### PR TITLE
Add @svgr/webpack loader for svg's

### DIFF
--- a/src/ensembl/package.json
+++ b/src/ensembl/package.json
@@ -64,6 +64,8 @@
     "@babel/preset-env": "7.3.1",
     "@babel/preset-react": "7.0.0",
     "@babel/preset-typescript": "7.1.0",
+    "@storybook/react": "4.1.12",
+    "@svgr/webpack": "4.1.0",
     "@types/enzyme": "3.1.17",
     "@types/enzyme-adapter-react-16": "1.0.3",
     "@types/jest": "23.3.14",

--- a/src/ensembl/webpack/webpack.common.js
+++ b/src/ensembl/webpack/webpack.common.js
@@ -97,6 +97,13 @@ module.exports = (isDev, moduleRules, plugins) => ({
         ]
       },
 
+      // use file-loader on svg's (to be able to require them as a path to the image),
+      // but also use @svgr/webpack to be able to require svg's directly as React components
+      {
+        test: /\.svg$/,
+        use: ['@svgr/webpack', 'file-loader'],
+      },
+
       // loaders specific to dev/prod
       ...moduleRules
     ]

--- a/src/ensembl/webpack/webpack.config.dev.js
+++ b/src/ensembl/webpack/webpack.config.dev.js
@@ -6,7 +6,7 @@ const StylelintWebpackPlugin = require('stylelint-webpack-plugin');
 const moduleRules = [
   // this is the loader that will make webpack load file formats that are not supported by other loaders
   {
-    test: /\.(woff|woff2|eot|ttf|otf|svg|gif|png|jpe?g)$/,
+    test: /\.(woff|woff2|eot|ttf|otf|gif|png|jpe?g)$/,
     loader: 'file-loader',
     options: {
       // the file path and name that webpack will use to store these files

--- a/src/ensembl/webpack/webpack.config.prod.js
+++ b/src/ensembl/webpack/webpack.config.prod.js
@@ -17,7 +17,7 @@ const moduleRules = [
   // image loader should compress the images
   // then file loader takes over to copy the images into the dist folder
   {
-    test: /static\/img\/.*\.(svg|gif|png|jpe?g)$/i,
+    test: /static\/img\/.*\.(gif|png|jpe?g)$/i,
     use: [
       {
         loader: 'file-loader',


### PR DESCRIPTION
[@svgr/webpack](https://www.npmjs.com/package/@svgr/webpack) loader, in combination with `file-loader`, makes it possible to import either the path to an svg (as a default import):

`import someSvgUrl from './some-icon.svg'`

or a React component transformed from an svg (as a named import, always called `ReactComponent`, so should be renamed during import):

`import { ReactComponent as Icon } from './icon.svg'`

Checked the browser behaviour after this commit — everything seems to be working fine.