### PR TITLE
Use a more natural box-sizing (border-box instead of content-box) throughout

### DIFF
--- a/src/ensembl/src/styles/main.scss
+++ b/src/ensembl/src/styles/main.scss
@@ -6,6 +6,18 @@
 @include foundation-prototype-classes;
 @include foundation-visibility-classes;
 
+// apply a natural box layout model
+html {
+  box-sizing: border-box;
+}
+
+// inherit the natural box layout from html; allow box-sizing to easily change if necessary
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+}
+
 a {
   color: $ens-blue;
   text-decoration: none;


### PR DESCRIPTION
Apply `box-sizing: border-box` to all elements by first applying it to the html element and then making all other elements inherit this property from their parent (i.e., eventually, from html).

Selecting all elements is generally frowned upon from performance perspective, but for this case even such a hardcore performance nut as Paul Irish is [giving his thumbs up](https://www.paulirish.com/2012/box-sizing-border-box-ftw/).

The blessed approach, using inheritance, is borrowed from [CSS Tricks](https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/).