### PR TITLE
Use environment variables to configure the app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ built-storybook/
 package-lock.json
 bundle-report.html
 
+.env
 localhost.crt
 localhost.key

--- a/src/ensembl/.env.example
+++ b/src/ensembl/.env.example
@@ -1,0 +1,5 @@
+# Node environment
+NODE_ENV=development
+
+# Keys for external services
+GOOGLE_ANALYTICS_KEY="UA-58710484-17"

--- a/src/ensembl/config.js
+++ b/src/ensembl/config.js
@@ -1,0 +1,8 @@
+export default {
+  // environment
+  isDevelopment: process.env.NODE_ENV === 'development',
+  isProduction: process.env.NODE_ENV === 'production',
+
+  // keys for services
+  googleAnalyticsKey: process.env.GOOGLE_ANALYTICS_KEY
+};

--- a/src/ensembl/package.json
+++ b/src/ensembl/package.json
@@ -13,8 +13,9 @@
   "author": "EMBL-EBI",
   "license": "MIT",
   "scripts": {
-    "start": "npm run serve:dev",
-    "serve:dev": "webpack-dev-server --config ./webpack/webpack.config.dev.js",
+    "copy-dotenv": "test ! -f .env && (cp .env.example .env; echo '.env file created') || true",
+    "start": "npm install --no-save && npm run serve:dev",
+    "serve:dev": "npm run copy-dotenv && webpack-dev-server --config ./webpack/webpack.config.dev.js",
     "serve:prod": "node ./server.js",
     "build": "rimraf ./dist && webpack --config ./webpack/webpack.config.prod.js",
     "deploy": "node deploy",
@@ -44,6 +45,7 @@
   },
   "dependencies": {
     "classnames": "2.2.6",
+    "dotenv": "6.2.0",
     "foundation-sites": "6.5.3",
     "react": "16.8.1",
     "react-cookie": "^3.0.8",

--- a/src/ensembl/typings/config.d.ts
+++ b/src/ensembl/typings/config.d.ts
@@ -1,0 +1,4 @@
+declare module 'config' {
+  const config: { [key: string]: string };
+  export = config;
+}

--- a/src/ensembl/webpack/webpack.common.js
+++ b/src/ensembl/webpack/webpack.common.js
@@ -149,6 +149,7 @@ module.exports = (isDev, moduleRules, plugins) => ({
   resolve: {
     extensions: ['.tsx', '.ts', '.js', '.scss'],
     alias: {
+      config: path.resolve(__dirname, '../config.js'),
       src: path.join(__dirname, '../src'),
       tests: path.join(__dirname, '../tests'),
       static: path.join(__dirname, '../static')

--- a/src/ensembl/webpack/webpack.config.dev.js
+++ b/src/ensembl/webpack/webpack.config.dev.js
@@ -1,3 +1,5 @@
+const dotenv = require('dotenv').config();
+
 const webpack = require('webpack');
 const path = require('path');
 const StylelintWebpackPlugin = require('stylelint-webpack-plugin');
@@ -25,6 +27,11 @@ const plugins = [
   new StylelintWebpackPlugin({
     context: path.join(__dirname, '../src'),
     files: '**/*.scss'
+  }),
+
+  // make environment variables available on the client-side
+  new webpack.DefinePlugin({
+    'process.env': JSON.stringify(dotenv.parsed)
   })
 ];
 

--- a/src/ensembl/webpack/webpack.config.prod.js
+++ b/src/ensembl/webpack/webpack.config.prod.js
@@ -11,6 +11,13 @@ const WorkboxPlugin = require('workbox-webpack-plugin');
 const RobotstxtPlugin = require('robotstxt-webpack-plugin').default;
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 
+// copy from the environment the same variables that are declared in .env.example
+// NOTE: if no environment variable with corresponding key is present, the value from .env.example will be used
+const dotenv = require('dotenv').config({ path: path.resolve(__dirname, '../.env.example') });
+const getEnvironmentVariables = () => Object.keys(dotenv.parsed).reduce((result, key) => ({
+  [`process.env.${key}`]: JSON.stringify(process.env[key])
+}));
+
 // loaders specific to prod
 const moduleRules = [
   // loader for images
@@ -43,6 +50,11 @@ const moduleRules = [
 
 // plugins specific to prod
 const plugins = [
+  // make environment variables available on the client-side
+  new webpack.DefinePlugin({
+    ...getEnvironmentVariables()
+  }),
+
   // plugin to extract css from the webpack javascript build files
   new MiniCssExtractPlugin({
     filename: '[name].[contenthash].css',


### PR DESCRIPTION
- [x] Use the `.env` file to keep (sensitive) configuration variables 
- [x] Copy `.env` file locally from `.env.example` if the `.env` file is missing 
- [x] Use the `dotenv` package to read the `.env` file and make the values of environment variables available to the client-side js using `webpack.DefinePlugin`