### PR TITLE
Add production server for both HTTP and HTTPS

### DIFF
--- a/src/ensembl/package.json
+++ b/src/ensembl/package.json
@@ -17,6 +17,7 @@
     "start": "npm install --no-save && npm run serve:dev",
     "serve:dev": "npm run copy-dotenv && webpack-dev-server --config ./webpack/webpack.config.dev.js",
     "serve:prod": "node ./server.js",
+    "serve:prod:secure": "node ./server.js -p https",
     "build": "rimraf ./dist && webpack --config ./webpack/webpack.config.prod.js",
     "deploy": "node deploy",
     "certify": "node setup-ssl",

--- a/src/ensembl/server.js
+++ b/src/ensembl/server.js
@@ -12,16 +12,24 @@ const app = new Koa();
 app.use(convert(history()));
 app.use(serve(path.join(__dirname, 'dist'), { br: true, gzip: false }));
 
-// const server = https.createServer(
-//   {
-//     key: fs.readFileSync('localhost.key'),
-//     cert: fs.readFileSync('localhost.crt')
-//   },
-//   app.callback()
-// );
+let protocol = 'http';
 
-// server.listen(3000);
+if (process.argv[2] === '-p') {
+  protocol = process.argv[3];
+}
 
-app.listen(3000);
+if (protocol.toLowerCase() === 'https') {
+  https
+    .createServer(
+      {
+        key: fs.readFileSync('localhost.key'),
+        cert: fs.readFileSync('localhost.crt')
+      },
+      app.callback()
+    )
+    .listen(3000);
+} else {
+  app.listen(3000);
+}
 
-console.log('Running on https://localhost:3000');
+console.log(`Running on ${protocol}://localhost:3000`);


### PR DESCRIPTION
This PR should get rid of the need to always run on HTTPS which will not work for users who haven't run the `certify` command beforehand.