### PR TITLE
Add spinning loader

### DIFF
--- a/src/ensembl/src/shared/loader/Loader.scss
+++ b/src/ensembl/src/shared/loader/Loader.scss
@@ -1,0 +1,17 @@
+@import 'src/styles/common';
+
+.circleLoader {
+  display: inline-block;
+  border: 3px solid $ens-light-grey;
+  border-top-color: $ens-red;
+  width: 40px;
+  height: 40px;
+  border-radius: 100%;
+  animation: loader-spin 1.3s linear infinite;
+}
+
+@keyframes loader-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/ensembl/src/shared/loader/Loader.tsx
+++ b/src/ensembl/src/shared/loader/Loader.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import classNames from 'classnames';
+
+import styles from './Loader.scss';
+
+type Props = {
+  className?: string;
+};
+
+export const CircleLoader = (props: Props) => {
+  const className = classNames(styles.circleLoader, props.className);
+
+  return <div className={className} />;
+};

--- a/src/ensembl/src/styles/_settings.scss
+++ b/src/ensembl/src/styles/_settings.scss
@@ -109,6 +109,8 @@ $ens-light-grey: #f1f2f4;
 $ens-grey: #b7c0c8;
 $ens-dark-grey: #6f8190;
 
+$ens-red: #d90000;
+
 $ens-white: #fff;
 
 /* stylelint-disable */
@@ -117,6 +119,7 @@ $ens-white: #fff;
   ens-blue: $ens-blue;
   ens-light-blue: $ens-light-blue;
   ens-dark-blue: $ens-dark-blue;
+  ens-red: $ens-red;
   ens-dark-grey: $ens-dark-grey;
   ens-grey: $ens-grey;
   ens-light-grey: $ens-light-grey;

--- a/src/ensembl/src/styles/_settings.scss
+++ b/src/ensembl/src/styles/_settings.scss
@@ -106,7 +106,9 @@ $ens-blue: #33adff; // blue on black
 $ens-dark-blue: #0099ff; // blue on white
 
 $ens-light-grey: #f1f2f4;
+$ens-medium-light-grey: #d4d9de;
 $ens-grey: #b7c0c8;
+$ens-medium-dark-grey: #9aa7b1;
 $ens-dark-grey: #6f8190;
 
 $ens-red: #d90000;
@@ -121,7 +123,9 @@ $ens-white: #fff;
   ens-dark-blue: $ens-dark-blue;
   ens-red: $ens-red;
   ens-dark-grey: $ens-dark-grey;
+  ens-medium-dark-grey: $ens-medium-dark-grey;
   ens-grey: $ens-grey;
+  ens-medium-light-grey: $ens-medium-light-grey;
   ens-light-grey: $ens-light-grey;
   ens-white: $ens-white;
 }

--- a/src/ensembl/stories/design-primitives/colours/Colours.stories.tsx
+++ b/src/ensembl/stories/design-primitives/colours/Colours.stories.tsx
@@ -26,6 +26,11 @@ const colours = [
     value: variables['ens-light-blue']
   },
   {
+    name: 'Ensembl red',
+    variableName: '$ens-red',
+    value: variables['ens-red']
+  },
+  {
     name: 'Ensembl grey',
     variableName: '$ens-grey',
     value: variables['ens-grey']

--- a/src/ensembl/stories/design-primitives/colours/Colours.stories.tsx
+++ b/src/ensembl/stories/design-primitives/colours/Colours.stories.tsx
@@ -56,8 +56,8 @@ storiesOf('Design Primitives|Colours', module).add(
   'colour palette',
   () => (
     <>
-      {colours.map((colourData) => (
-        <ColourCard {...colourData} />
+      {colours.map((colourData, index) => (
+        <ColourCard key={index} {...colourData} />
       ))}
     </>
   ),

--- a/src/ensembl/stories/design-primitives/colours/Colours.stories.tsx
+++ b/src/ensembl/stories/design-primitives/colours/Colours.stories.tsx
@@ -36,9 +36,19 @@ const colours = [
     value: variables['ens-grey']
   },
   {
+    name: 'Ensembl medium dark grey',
+    variableName: '$ens-medium-dark-grey',
+    value: variables['ens-medium-dark-grey']
+  },
+  {
     name: 'Ensembl dark grey',
     variableName: '$ens-dark-grey',
     value: variables['ens-dark-grey']
+  },
+  {
+    name: 'Ensembl medium light grey',
+    variableName: '$ens-medium-light-grey',
+    value: variables['ens-medium-light-grey']
   },
   {
     name: 'Ensembl light grey',

--- a/src/ensembl/stories/shared-components/index.ts
+++ b/src/ensembl/stories/shared-components/index.ts
@@ -4,3 +4,4 @@ import './dropdown/Dropdown.stories';
 import './input/Input.stories';
 import './search-field/SearchField.stories';
 import './autosuggest-search-field/AutosuggestSearchField.stories';
+import './loader/Loader.stories';

--- a/src/ensembl/stories/shared-components/loader/Loader.stories.scss
+++ b/src/ensembl/stories/shared-components/loader/Loader.stories.scss
@@ -1,0 +1,6 @@
+.fullPageWrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}

--- a/src/ensembl/stories/shared-components/loader/Loader.stories.tsx
+++ b/src/ensembl/stories/shared-components/loader/Loader.stories.tsx
@@ -1,0 +1,15 @@
+import React, { useState } from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { CircleLoader } from 'src/shared/loader/Loader';
+
+import styles from './Loader.stories.scss';
+
+storiesOf('Components|Shared Components/Loader', module).add(
+  'full-page',
+  () => (
+    <div className={styles.fullPageWrapper}>
+      <CircleLoader />
+    </div>
+  )
+);

--- a/src/ensembl/stories/shared-components/search-field/SearchField.stories.scss
+++ b/src/ensembl/stories/shared-components/search-field/SearchField.stories.scss
@@ -1,3 +1,5 @@
+@import 'src/styles/common';
+
 .searchFieldWrapper {
   padding: 40px;
 }
@@ -6,4 +8,12 @@
   height: 36px;
   width: 300px;
   align-items: center;
+}
+
+.circleLoader {
+  height: 20px;
+  width: 20px;
+  border-width: 1px;
+  border-color: $ens-grey;
+  border-top-color: $ens-red;
 }

--- a/src/ensembl/stories/shared-components/search-field/SearchField.stories.scss
+++ b/src/ensembl/stories/shared-components/search-field/SearchField.stories.scss
@@ -14,6 +14,6 @@
   height: 20px;
   width: 20px;
   border-width: 1px;
-  border-color: $ens-grey;
+  border-color: $ens-medium-light-grey;
   border-top-color: $ens-red;
 }

--- a/src/ensembl/stories/shared-components/search-field/SearchField.stories.tsx
+++ b/src/ensembl/stories/shared-components/search-field/SearchField.stories.tsx
@@ -4,6 +4,7 @@ import { action } from '@storybook/addon-actions';
 
 import SearchField from 'src/shared/search-field/SearchField';
 import QuestionButton from 'src/shared/question-button/QuestionButton';
+import { CircleLoader } from 'src/shared/loader/Loader';
 
 import styles from './SearchField.stories.scss';
 
@@ -18,13 +19,18 @@ const Wrapper = (props: any) => {
   );
 };
 
-storiesOf('Components|Shared Components/SearchField', module).add(
-  'default',
-  () => (
+storiesOf('Components|Shared Components/SearchField', module)
+  .add('default', () => (
     <Wrapper
       searchField={SearchField}
       className={styles.searchField}
       rightCorner={<QuestionButton onHover={action('question-button-hover')} />}
     />
-  )
-);
+  ))
+  .add('with loader', () => (
+    <Wrapper
+      searchField={SearchField}
+      className={styles.searchField}
+      rightCorner={<CircleLoader className={styles.circleLoader} />}
+    />
+  ));


### PR DESCRIPTION
Tested on [Codepen](https://codepen.io/anon/pen/MxRGzg)

Currently, there is just one variation of a Loader component (CircleLoader) that will have to be styled appropriately to fit a particular context (as in the story for SearchField, where it is inserted into the right corner of the field).

_I don't especially like this approach, but it feels slightly more robust design-wise than scaling an svg (which may result in fractional line widths; don't know how well browsers are at displaying that)._