### PR TITLE
Add script for building docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 node_modules/
 dist/
 coverage/
-built-storybook/
+built-docs/
 
 *.log
 .DS_Store

--- a/src/ensembl/README.md
+++ b/src/ensembl/README.md
@@ -20,7 +20,7 @@ There are several script commands that have been baked into the NPM configuratio
 - `npm run lint:scripts` - Runs TSLint to check code errors in TypeScript and React. Also, suggests improvements to the code.
 - `npm run lint:styles` - Does the same as above through `stylelint` for the SASS code.
 - `npm run storybook` - Starts the Storybook application
-- `npm run deploy-storybook` — Builds the Storybook application and deploys it to Github Pages ([link](https://ensembl.github.io/ensembl-client))
+- `npm run deploy-docs` — Builds the Storybook application and deploys it, along with the docs on Genome browser, to Github Pages ([link](https://ensembl.github.io/ensembl-client))
 - `npm run check-types` – Runs typescript compiler to check for type correctness
 - `npm jest` - Runs `jest`in non-verbose mode.
 - `npm test` - Runs `jest` to check whether the unit tests pass in verbose mode.

--- a/src/ensembl/deploy-docs.sh
+++ b/src/ensembl/deploy-docs.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# prepare directories
+BUILD_DIR="built-docs"
+if [ -d "$BUILD_DIR" ]; then rm -rf $BUILD_DIR; fi
+mkdir -p "$BUILD_DIR" "$BUILD_DIR/storybook" "$BUILD_DIR/genome-browser"
+
+# build storybook in respective folder
+build-storybook -o "$BUILD_DIR/storybook"
+
+# copy pre-built docs for genome browser in respective folder
+cp -r ../assets/browser/app/doc/manual/site/ "$BUILD_DIR/genome-browser"
+
+# copy landing page to the root docs build folder
+cp static/html/docs-main.html "$BUILD_DIR/index.html"
+
+# deploy the folder with built docs to github-pages
+gh-pages -d "$BUILD_DIR"

--- a/src/ensembl/deploy-docs.sh
+++ b/src/ensembl/deploy-docs.sh
@@ -9,7 +9,7 @@ mkdir -p "$BUILD_DIR" "$BUILD_DIR/storybook" "$BUILD_DIR/genome-browser"
 build-storybook -o "$BUILD_DIR/storybook"
 
 # copy pre-built docs for genome browser in respective folder
-cp -r ../assets/browser/app/doc/manual/site/ "$BUILD_DIR/genome-browser"
+cp -a ../assets/browser/app/doc/manual/site/. "$BUILD_DIR/genome-browser"
 
 # copy landing page to the root docs build folder
 cp static/html/docs-main.html "$BUILD_DIR/index.html"

--- a/src/ensembl/package.json
+++ b/src/ensembl/package.json
@@ -25,7 +25,7 @@
     "lint:scripts": "tslint -c tslint.json 'src/**/*.{ts,tsx}' -t codeFrame --force",
     "lint:styles": "stylelint 'src/styles/**/*.scss'",
     "storybook": "start-storybook -p 9001 -c .storybook",
-    "deploy-storybook": "build-storybook -o built-storybook && gh-pages -d built-storybook",
+    "deploy-docs": "./deploy-docs.sh",
     "check-types": "tsc",
     "jest": "jest",
     "test": "jest --verbose",

--- a/src/ensembl/static/html/docs-main.html
+++ b/src/ensembl/static/html/docs-main.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>Ensembl developer documentation</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <base href="/">
+
+  <style>
+    main {
+      max-width: 800px;
+      margin: auto;
+    }
+
+    h1 {
+      text-align: center;
+    }
+
+    ul {
+      display: inline-block;
+      list-style: none;
+      text-align: left;
+    }
+
+    ul li {
+      margin-bottom: 0.5em;
+      font-size: 24px;
+    }
+
+    a:visited {color: blue;}
+
+    .toc {
+      text-align: center;
+    }
+  </style>
+</head>
+
+<body>
+  <main>
+    <h1>Ensembl developer documentation</h1>
+    <section class="toc">
+      <ul>
+        <li>
+          <a href="genome-browser/index.html">Genome browser</a>
+        </li>
+        <li>
+          <a href="storybook/index.html">UI patterns and components</a>
+        </li>
+      </ul>
+    </section>
+  </main>
+</body>
+
+</html>

--- a/src/ensembl/static/html/docs-main.html
+++ b/src/ensembl/static/html/docs-main.html
@@ -42,10 +42,10 @@
     <section class="toc">
       <ul>
         <li>
-          <a href="genome-browser/index.html">Genome browser</a>
+          <a href="ensembl-client/genome-browser/index.html">Genome browser</a>
         </li>
         <li>
-          <a href="storybook/index.html">UI patterns and components</a>
+          <a href="ensembl-client/storybook/index.html">UI patterns and components</a>
         </li>
       </ul>
     </section>


### PR DESCRIPTION
Include both documentation and Storybook in the documentation build that is deployed to github-pages. 