### PR TITLE
Update tslint rules

### DIFF
--- a/src/ensembl/tslint.json
+++ b/src/ensembl/tslint.json
@@ -7,6 +7,7 @@
   "rules": {
     "interface-name": [true, "never-prefix"],
     "interface-over-type-literal": false,
+    "jsx-no-lambda": false,
     "jsx-no-multiline-js": false,
     "jsx-self-close": false,
     "max-line-length": [true, 160],
@@ -19,12 +20,15 @@
         "static",
         "enzyme",
         "enzyme-adapter-react-16",
-        "jest-fetch-mock"
+        "jest-fetch-mock",
+        "tests",
+        "@storybook"
       ]
     ],
     "no-namespace": false,
-    "no-submodule-imports": [true, "src", "static"],
+    "no-submodule-imports": [true, "src", "static", "tests", "lodash", "rjxs"],
     "no-var-requires": false,
+    "object-literal-sort-keys": false,
     "ordered-imports": false,
     "quotemark": [true, "single", "jsx-double"],
     "semicolon": [true, "always"],


### PR DESCRIPTION
Some updates for the linter:

`"jsx-no-lambda": false` — because its performance impact is negligible, and sometimes there is no way around creating functions during render

`"object-literal-sort-keys": false` — because semantic grouping of object properties may, at least in some cases, be more appropriate than the alphabetic one. Another relevant example is that is is more natural to list `start` and `end` properties in that order, rather than the opposite (which would be the case with alphabetical sorting)

Extended list of exceptions for "no-implicit-dependencies" and "no-submodule-imports" (although I would prefer to just switch "no-submodule-imports" to false).