### PR TITLE
Add Select component

### DIFF
--- a/src/ensembl/src/shared/select/Select.scss
+++ b/src/ensembl/src/shared/select/Select.scss
@@ -65,12 +65,12 @@ $optionsPanelLeftPadding: 14px;
   overflow-y: auto;
   overflow-x: hidden;
 
-  // // hide the vertical scrollbar
-  // scrollbar-width: none; // for Firefox v64 and above; will probably become the standard
-  // &::-webkit-scrollbar {
-  //   display: none; // For Webkit-based browsers
-  // }
-  // -ms-overflow-style: none; // IE 10+
+  // hide the vertical scrollbar
+  scrollbar-width: none; // for Firefox v64 and above; will probably become the standard
+  &::-webkit-scrollbar {
+    display: none; // For Webkit-based browsers
+  }
+  -ms-overflow-style: none; // IE 10+
 }
 
 .scrollButtonTop,

--- a/src/ensembl/src/shared/select/Select.scss
+++ b/src/ensembl/src/shared/select/Select.scss
@@ -1,0 +1,36 @@
+@import 'src/styles/common';
+
+$optionsPanelTopPadding: 12px;
+$optionsPanelLeftPadding: 14px;
+
+.select {
+  position: relative;
+  display: inline-block;
+}
+
+.selectArrowhead {
+  margin-left: 0.8em;
+  height: 8px;
+  width: 8px;
+  fill: $ens-blue;
+}
+
+.selectClosed {
+  cursor: pointer;
+}
+
+.optionsPanel {
+  position: absolute;
+  left: -$optionsPanelLeftPadding;
+  top: -$optionsPanelTopPadding;
+  display: inline-block;
+  min-width: 100%;
+  padding: $optionsPanelTopPadding 22px 34px $optionsPanelLeftPadding;
+  box-shadow: 2px 2px 6px 0 $ens-grey;
+
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+  }
+}

--- a/src/ensembl/src/shared/select/Select.scss
+++ b/src/ensembl/src/shared/select/Select.scss
@@ -43,8 +43,7 @@ $optionsPanelLeftPadding: 14px;
   top: -$optionsPanelTopPadding;
   display: inline-block;
   min-width: 100%;
-  padding: $optionsPanelTopPadding $optionsPanelRightPadding 34px
-    $optionsPanelLeftPadding;
+  padding: $optionsPanelTopPadding 0 34px 0;
   box-shadow: 2px 2px 6px 0 $ens-grey;
   white-space: nowrap;
 
@@ -90,6 +89,13 @@ $optionsPanelLeftPadding: 14px;
   bottom: 0;
 }
 
+.optionsPanelHeader,
+.option {
+  margin: 0 1px 0 1px;
+  padding: 0 calc(#{$optionsPanelRightPadding} - 1px) 0
+    calc(#{$optionsPanelLeftPadding} - 1px);
+}
+
 .optionsPanelHeader {
   color: $ens-grey;
   margin-bottom: 1em;
@@ -97,9 +103,6 @@ $optionsPanelLeftPadding: 14px;
 
 .option {
   cursor: pointer;
-  margin-left: -$optionsPanelLeftPadding;
-  // margin-right: -$optionsPanelRightPadding;
-  padding: 0 $optionsPanelRightPadding 0 $optionsPanelLeftPadding;
 }
 
 .optionHighlighted {

--- a/src/ensembl/src/shared/select/Select.scss
+++ b/src/ensembl/src/shared/select/Select.scss
@@ -1,6 +1,7 @@
 @import 'src/styles/common';
 
 $optionsPanelTopPadding: 12px;
+$optionsPanelRightPadding: 22px;
 $optionsPanelLeftPadding: 14px;
 
 .select {
@@ -25,7 +26,8 @@ $optionsPanelLeftPadding: 14px;
   top: -$optionsPanelTopPadding;
   display: inline-block;
   min-width: 100%;
-  padding: $optionsPanelTopPadding 22px 34px $optionsPanelLeftPadding;
+  padding: $optionsPanelTopPadding $optionsPanelRightPadding 34px
+    $optionsPanelLeftPadding;
   box-shadow: 2px 2px 6px 0 $ens-grey;
   white-space: nowrap;
 
@@ -34,4 +36,15 @@ $optionsPanelLeftPadding: 14px;
     padding: 0;
     list-style-type: none;
   }
+}
+
+.option {
+  cursor: pointer;
+  margin-left: -$optionsPanelLeftPadding;
+  margin-right: -$optionsPanelRightPadding;
+  padding: 0 $optionsPanelRightPadding 0 $optionsPanelLeftPadding;
+}
+
+.optionHighlighted {
+  background-color: $ens-light-blue;
 }

--- a/src/ensembl/src/shared/select/Select.scss
+++ b/src/ensembl/src/shared/select/Select.scss
@@ -28,11 +28,11 @@ $optionsPanelLeftPadding: 14px;
   fill: $ens-blue;
 }
 
-.selectClosed {
+.selectControl {
   cursor: pointer;
 }
 
-.selectClosedInvisible {
+.selectControlInvisible {
   visibility: hidden;
 }
 

--- a/src/ensembl/src/shared/select/Select.scss
+++ b/src/ensembl/src/shared/select/Select.scss
@@ -98,7 +98,7 @@ $optionsPanelLeftPadding: 14px;
 .option {
   cursor: pointer;
   margin-left: -$optionsPanelLeftPadding;
-  margin-right: -$optionsPanelRightPadding;
+  // margin-right: -$optionsPanelRightPadding;
   padding: 0 $optionsPanelRightPadding 0 $optionsPanelLeftPadding;
 }
 

--- a/src/ensembl/src/shared/select/Select.scss
+++ b/src/ensembl/src/shared/select/Select.scss
@@ -27,6 +27,7 @@ $optionsPanelLeftPadding: 14px;
   min-width: 100%;
   padding: $optionsPanelTopPadding 22px 34px $optionsPanelLeftPadding;
   box-shadow: 2px 2px 6px 0 $ens-grey;
+  white-space: nowrap;
 
   ul {
     margin: 0;

--- a/src/ensembl/src/shared/select/Select.scss
+++ b/src/ensembl/src/shared/select/Select.scss
@@ -47,13 +47,47 @@ $optionsPanelLeftPadding: 14px;
     $optionsPanelLeftPadding;
   box-shadow: 2px 2px 6px 0 $ens-grey;
   white-space: nowrap;
-  overflow: auto;
 
   ul {
     margin: 0;
     padding: 0;
     list-style-type: none;
   }
+}
+
+.optionsListContainer {
+  height: calc(100% - 35px);
+  position: relative;
+}
+
+.optionsList {
+  height: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
+
+  // // hide the vertical scrollbar
+  // scrollbar-width: none; // for Firefox v64 and above; will probably become the standard
+  // &::-webkit-scrollbar {
+  //   display: none; // For Webkit-based browsers
+  // }
+  // -ms-overflow-style: none; // IE 10+
+}
+
+.scrollButtonTop,
+.scrollButtonBottom {
+  position: absolute;
+  left: 0;
+  background: $ens-white;
+  width: 100%;
+  text-align: center;
+}
+
+.scrollButtonTop {
+  top: 0;
+}
+
+.scrollButtonBottom {
+  bottom: 0;
 }
 
 .optionsPanelHeader {

--- a/src/ensembl/src/shared/select/Select.scss
+++ b/src/ensembl/src/shared/select/Select.scss
@@ -20,6 +20,10 @@ $optionsPanelLeftPadding: 14px;
   cursor: pointer;
 }
 
+.selectClosedInvisible {
+  visibility: hidden;
+}
+
 .optionsPanel {
   position: absolute;
   left: -$optionsPanelLeftPadding;
@@ -36,6 +40,11 @@ $optionsPanelLeftPadding: 14px;
     padding: 0;
     list-style-type: none;
   }
+}
+
+.optionsPanelHeader {
+  color: $ens-grey;
+  margin-bottom: 1em;
 }
 
 .option {

--- a/src/ensembl/src/shared/select/Select.scss
+++ b/src/ensembl/src/shared/select/Select.scss
@@ -48,9 +48,8 @@ $optionsPanelLeftPadding: 14px;
   white-space: nowrap;
 
   ul {
-    margin: 0;
-    padding: 0;
     list-style-type: none;
+    padding: 0;
   }
 }
 
@@ -99,6 +98,14 @@ $optionsPanelLeftPadding: 14px;
 .optionsPanelHeader {
   color: $ens-grey;
   margin-bottom: 1em;
+}
+
+.optionsGroup:first-child {
+  margin: 0;
+}
+
+.optionsGroup:not(:first-child) {
+  margin: 1em 0 0 0;
 }
 
 .option {

--- a/src/ensembl/src/shared/select/Select.scss
+++ b/src/ensembl/src/shared/select/Select.scss
@@ -7,6 +7,18 @@ $optionsPanelLeftPadding: 14px;
 .select {
   position: relative;
   display: inline-block;
+
+  &:focus {
+    outline: auto;
+    outline-style: dotted;
+    outline-width: 2px;
+  }
+}
+
+.selectOpen {
+  &:focus {
+    outline: none;
+  }
 }
 
 .selectArrowhead {
@@ -26,6 +38,7 @@ $optionsPanelLeftPadding: 14px;
 
 .optionsPanel {
   position: absolute;
+  background-color: white;
   left: -$optionsPanelLeftPadding;
   top: -$optionsPanelTopPadding;
   display: inline-block;
@@ -34,6 +47,7 @@ $optionsPanelLeftPadding: 14px;
     $optionsPanelLeftPadding;
   box-shadow: 2px 2px 6px 0 $ens-grey;
   white-space: nowrap;
+  overflow: auto;
 
   ul {
     margin: 0;

--- a/src/ensembl/src/shared/select/Select.test.tsx
+++ b/src/ensembl/src/shared/select/Select.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import faker from 'faker';
+import times from 'lodash/times';
+import { mount } from 'enzyme';
+
+import Select from './Select';
+import SelectOptionsPanel from './SelectOptionsPanel';
+
+const createOption = (isSelected: boolean = false) => ({
+  value: faker.random.uuid(),
+  label: faker.random.words(5),
+  isSelected
+});
+
+const createOptionGroup = (number: number = 5) => {
+  const options = times(number, () => createOption());
+  return {
+    options
+  };
+};
+
+const defaultProps = {
+  optionGroups: [createOptionGroup()]
+};
+
+describe('<Select />', () => {
+  let wrapper: any;
+
+  beforeEach(() => {
+    wrapper = mount(<Select {...defaultProps} />);
+  });
+
+  test('is closed by default', () => {
+    expect(wrapper.find('.selectClosed').length).toBe(1);
+  });
+
+  test('opens options panel on click', async () => {
+    const closedSelect = wrapper.find('.selectClosed');
+    closedSelect.simulate('click');
+
+    wrapper.update();
+
+    // the element visible during closed state is still there
+    expect(wrapper.find('.selectClosed').length).toBe(1);
+    expect(wrapper.find(SelectOptionsPanel).length).toBe(1);
+  });
+});

--- a/src/ensembl/src/shared/select/Select.test.tsx
+++ b/src/ensembl/src/shared/select/Select.test.tsx
@@ -38,18 +38,18 @@ describe('<Select />', () => {
     });
 
     test('is closed by default', () => {
-      expect(wrapper.find('.selectClosed').length).toBe(1);
+      expect(wrapper.find('.selectControl').length).toBe(1);
       expect(wrapper.find(SelectOptionsPanel).length).toBe(0);
     });
 
     test('opens options panel on click', async () => {
-      const closedSelect = wrapper.find('.selectClosed');
-      closedSelect.simulate('click');
+      const selectControl = wrapper.find('.selectControl');
+      selectControl.simulate('click');
 
       wrapper.update();
 
       // the element visible during closed state is still there
-      expect(wrapper.find('.selectClosedInvisible').length).toBe(1);
+      expect(wrapper.find('.selectControlInvisible').length).toBe(1);
       expect(wrapper.find(SelectOptionsPanel).length).toBe(1);
     });
   });
@@ -64,8 +64,8 @@ describe('<Select />', () => {
       wrapper = mount(<Select {...defaultProps} />);
 
       // open the select
-      const closedSelect = wrapper.find('.selectClosed');
-      closedSelect.simulate('click');
+      const selectControl = wrapper.find('.selectControl');
+      selectControl.simulate('click');
       wrapper.update();
 
       const optionGroups = wrapper.find('ul');
@@ -86,8 +86,8 @@ describe('<Select />', () => {
       wrapper = mount(<Select {...defaultProps} />);
 
       // open the select
-      const closedSelect = wrapper.find('.selectClosed');
-      closedSelect.simulate('click');
+      const selectControl = wrapper.find('.selectControl');
+      selectControl.simulate('click');
       wrapper.update();
 
       const optionGroups = wrapper.find('ul');
@@ -115,8 +115,8 @@ describe('<Select />', () => {
       wrapper = mount(<Select {...defaultProps} />);
 
       // open the select
-      const closedSelect = wrapper.find('.selectClosed');
-      closedSelect.simulate('click');
+      const selectControl = wrapper.find('.selectControl');
+      selectControl.simulate('click');
       wrapper.update();
 
       // choose a random option

--- a/src/ensembl/src/shared/select/Select.test.tsx
+++ b/src/ensembl/src/shared/select/Select.test.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import faker from 'faker';
 import times from 'lodash/times';
+import random from 'lodash/random';
+import find from 'lodash/find';
+import get from 'lodash/get';
 import { mount } from 'enzyme';
 
 import Select from './Select';
@@ -19,29 +22,116 @@ const createOptionGroup = (number: number = 5) => {
   };
 };
 
-const defaultProps = {
-  optionGroups: [createOptionGroup()]
-};
+const onSelect = jest.fn();
 
 describe('<Select />', () => {
   let wrapper: any;
 
-  beforeEach(() => {
-    wrapper = mount(<Select {...defaultProps} />);
+  describe('basic functionality', () => {
+    const defaultProps = {
+      optionGroups: [createOptionGroup()],
+      onSelect
+    };
+
+    beforeEach(() => {
+      wrapper = mount(<Select {...defaultProps} />);
+    });
+
+    test('is closed by default', () => {
+      expect(wrapper.find('.selectClosed').length).toBe(1);
+      expect(wrapper.find(SelectOptionsPanel).length).toBe(0);
+    });
+
+    test('opens options panel on click', async () => {
+      const closedSelect = wrapper.find('.selectClosed');
+      closedSelect.simulate('click');
+
+      wrapper.update();
+
+      // the element visible during closed state is still there
+      expect(wrapper.find('.selectClosedInvisible').length).toBe(1);
+      expect(wrapper.find(SelectOptionsPanel).length).toBe(1);
+    });
   });
 
-  test('is closed by default', () => {
-    expect(wrapper.find('.selectClosed').length).toBe(1);
+  describe('when passed a list of options', () => {
+    const defaultProps = {
+      options: times(5, () => createOption()),
+      onSelect
+    };
+
+    test('shows the list of options', () => {
+      wrapper = mount(<Select {...defaultProps} />);
+
+      // open the select
+      const closedSelect = wrapper.find('.selectClosed');
+      closedSelect.simulate('click');
+      wrapper.update();
+
+      const optionGroups = wrapper.find('ul');
+      const options = wrapper.find('li');
+
+      expect(optionGroups.length).toBe(1);
+      expect(options.length).toBe(defaultProps.options.length);
+    });
   });
 
-  test('opens options panel on click', async () => {
-    const closedSelect = wrapper.find('.selectClosed');
-    closedSelect.simulate('click');
+  describe('when passed a list of option groups', () => {
+    const defaultProps = {
+      optionGroups: times(3, () => createOptionGroup()),
+      onSelect
+    };
 
-    wrapper.update();
+    test('shows the list of groups of options', () => {
+      wrapper = mount(<Select {...defaultProps} />);
 
-    // the element visible during closed state is still there
-    expect(wrapper.find('.selectClosed').length).toBe(1);
-    expect(wrapper.find(SelectOptionsPanel).length).toBe(1);
+      // open the select
+      const closedSelect = wrapper.find('.selectClosed');
+      closedSelect.simulate('click');
+      wrapper.update();
+
+      const optionGroups = wrapper.find('ul');
+      const options = wrapper.find('li');
+
+      const expectedOptionsNumber = defaultProps.optionGroups.reduce(
+        (sum, group) => {
+          return sum + group.options.length;
+        },
+        0
+      );
+
+      expect(optionGroups.length).toBe(defaultProps.optionGroups.length);
+      expect(options.length).toBe(expectedOptionsNumber);
+    });
+  });
+
+  describe('clicking on an option', () => {
+    const defaultProps = {
+      options: times(5, () => createOption()),
+      onSelect
+    };
+
+    test('calls onSelect and passes it the option value', () => {
+      wrapper = mount(<Select {...defaultProps} />);
+
+      // open the select
+      const closedSelect = wrapper.find('.selectClosed');
+      closedSelect.simulate('click');
+      wrapper.update();
+
+      // choose a random option
+      const options = wrapper.find('li');
+      const optionIndex = random(options.length - 1);
+      const option = options.at(optionIndex);
+      const optionText = option.text();
+      option.simulate('click');
+
+      const expectedValue = get(
+        find(defaultProps.options, ({ label }) => label === optionText),
+        'value'
+      );
+
+      expect(onSelect).toHaveBeenCalledWith(expectedValue);
+    });
   });
 });

--- a/src/ensembl/src/shared/select/Select.tsx
+++ b/src/ensembl/src/shared/select/Select.tsx
@@ -48,11 +48,11 @@ type CommonProps = {
 };
 
 type OptionsSelectProps = CommonProps & OptionsSpecificProps;
-type OptionGroupssSelectProps = CommonProps & OptionGroupsSpecificProps;
+type OptionGroupsSelectProps = CommonProps & OptionGroupsSpecificProps;
 
-type SelectAdapterProps = OptionsSelectProps | OptionGroupssSelectProps;
+type SelectAdapterProps = OptionsSelectProps | OptionGroupsSelectProps;
 
-type SelectProps = OptionGroupssSelectProps & { placeholder: string };
+type SelectProps = OptionGroupsSelectProps & { placeholder: string };
 
 // TODO: think of a better name for this component?
 const ClosedSelect = (props: ClosedSelectProps) => {
@@ -158,8 +158,8 @@ Select.defaultProps = {
 // the purpose of the adapter is to unify props
 // to be consumed by the Select component
 const SelectAdapter = (props: SelectAdapterProps) => {
-  if ((props as OptionGroupssSelectProps).optionGroups) {
-    return <Select {...props as OptionGroupssSelectProps} />;
+  if ((props as OptionGroupsSelectProps).optionGroups) {
+    return <Select {...props as OptionGroupsSelectProps} />;
   } else {
     const { options, title, ...otherProps } = props as OptionsSelectProps;
     const optionGroups = [

--- a/src/ensembl/src/shared/select/Select.tsx
+++ b/src/ensembl/src/shared/select/Select.tsx
@@ -92,7 +92,7 @@ const Select = (props: SelectProps) => {
       {isOpen && (
         <SelectOptionsPanel
           optionGroups={props.optionGroups}
-          onSelect={(thing) => console.log('thing', thing)}
+          onSelect={handleSelect}
           onClose={closePanel}
         />
       )}

--- a/src/ensembl/src/shared/select/Select.tsx
+++ b/src/ensembl/src/shared/select/Select.tsx
@@ -1,7 +1,5 @@
 import React, { useState, useEffect } from 'react';
 
-import useDeepCompareEffect from 'src/shared/hooks/useDeepCompareEffect';
-
 import {
   findSelectedIndexForOptions,
   findSelectedIndexForOptionGroups,
@@ -30,7 +28,8 @@ export type GroupedOptionIndex = [
 ];
 
 type ClosedSelectProps = {
-  label: React.ReactNode;
+  selectedOption: Option | null;
+  placeholder: string;
   onClick: () => void;
 };
 
@@ -45,6 +44,7 @@ type OptionGroupsSpecificProps = {
 
 type CommonProps = {
   onSelect: (value: any) => void;
+  placeholder: string;
 };
 
 type OptionsSelectProps = CommonProps & OptionsSpecificProps;
@@ -63,7 +63,7 @@ const arrowHead = (
 const ClosedSelect = (props: ClosedSelectProps) => {
   return (
     <span className={styles.selectClosed} onClick={props.onClick}>
-      {props.label}
+      {props.selectedOption ? props.selectedOption.label : props.placeholder}
       {arrowHead}
     </span>
   );
@@ -90,7 +90,11 @@ const Select = (props: SelectProps) => {
 
   return (
     <div className={styles.select}>
-      <ClosedSelect label="hello?" onClick={openPanel} />
+      <ClosedSelect
+        selectedOption={selectedOption}
+        onClick={openPanel}
+        placeholder={props.placeholder}
+      />
       {isOpen && (
         <SelectOptionsPanel
           optionGroups={optionGroups}
@@ -100,6 +104,10 @@ const Select = (props: SelectProps) => {
       )}
     </div>
   );
+};
+
+Select.defaultProps = {
+  placeholder: 'Select'
 };
 
 // the purpose of the adapter is to unify props

--- a/src/ensembl/src/shared/select/Select.tsx
+++ b/src/ensembl/src/shared/select/Select.tsx
@@ -27,7 +27,6 @@ export type GroupedOptionIndex = [
 ];
 
 type ClosedSelectProps = {
-  // <-- TODO: think of a better name
   isOpen: boolean;
   selectedOption: Option | null;
   placeholder: string;
@@ -45,7 +44,7 @@ type OptionGroupsSpecificProps = {
 
 type CommonProps = {
   onSelect: (value: any) => void;
-  placeholder: string;
+  placeholder?: string;
 };
 
 type OptionsSelectProps = CommonProps & OptionsSpecificProps;
@@ -53,8 +52,9 @@ type OptionGroupssSelectProps = CommonProps & OptionGroupsSpecificProps;
 
 type SelectAdapterProps = OptionsSelectProps | OptionGroupssSelectProps;
 
-type SelectProps = OptionGroupssSelectProps;
+type SelectProps = OptionGroupssSelectProps & { placeholder: string };
 
+// TODO: think of a better name for this component?
 const ClosedSelect = (props: ClosedSelectProps) => {
   const className = props.isOpen
     ? styles.selectClosedInvisible

--- a/src/ensembl/src/shared/select/Select.tsx
+++ b/src/ensembl/src/shared/select/Select.tsx
@@ -75,6 +75,17 @@ const Select = (props: SelectProps) => {
     setIsOpen(true);
   };
 
+  const closePanel = () => {
+    setIsOpen(false);
+  };
+
+  const handleSelect = (optionIndex: GroupedOptionIndex) => {
+    const [groupdIndex, itemIndex] = optionIndex;
+    const selectedOption = optionGroups[groupdIndex].options[itemIndex];
+    props.onSelect(selectedOption.value);
+    setIsOpen(false);
+  };
+
   return (
     <div className={styles.select}>
       <ClosedSelect label="hello?" onClick={openPanel} />
@@ -82,6 +93,7 @@ const Select = (props: SelectProps) => {
         <SelectOptionsPanel
           optionGroups={props.optionGroups}
           onSelect={(thing) => console.log('thing', thing)}
+          onClose={closePanel}
         />
       )}
     </div>

--- a/src/ensembl/src/shared/select/Select.tsx
+++ b/src/ensembl/src/shared/select/Select.tsx
@@ -94,7 +94,7 @@ const Select = (props: SelectProps) => {
   const handleBlur = () => {
     focusRef.current = false;
     if (isOpen) {
-      setIsOpen(false);
+      closePanel();
     }
   };
 
@@ -109,17 +109,17 @@ const Select = (props: SelectProps) => {
     }
 
     if (event.keyCode === keyCodes.ENTER) {
-      setIsOpen(true);
+      openPanel();
     } else if (event.keyCode === keyCodes.ESC) {
-      setIsOpen(false);
+      closePanel();
     }
   };
 
   const handleSelect = (optionIndex: GroupedOptionIndex) => {
-    const [groupdIndex, itemIndex] = optionIndex;
-    const selectedOption = optionGroups[groupdIndex].options[itemIndex];
+    const [groupIndex, itemIndex] = optionIndex;
+    const selectedOption = optionGroups[groupIndex].options[itemIndex];
     props.onSelect(selectedOption.value);
-    setIsOpen(false);
+    closePanel();
   };
 
   const headerText = selectedOption ? selectedOption.label : props.placeholder;
@@ -159,16 +159,15 @@ Select.defaultProps = {
 const SelectAdapter = (props: SelectAdapterProps) => {
   if ((props as OptionGroupsSelectProps).optionGroups) {
     return <Select {...props as OptionGroupsSelectProps} />;
-  } else {
-    const { options, title, ...otherProps } = props as OptionsSelectProps;
-    const optionGroups = [
-      {
-        title,
-        options
-      }
-    ];
-    return <Select optionGroups={optionGroups} {...otherProps} />;
   }
+  const { options, title, ...otherProps } = props as OptionsSelectProps;
+  const optionGroups = [
+    {
+      title,
+      options
+    }
+  ];
+  return <Select optionGroups={optionGroups} {...otherProps} />;
 };
 
 export default SelectAdapter;

--- a/src/ensembl/src/shared/select/Select.tsx
+++ b/src/ensembl/src/shared/select/Select.tsx
@@ -2,8 +2,9 @@ import React, { useState, useEffect } from 'react';
 
 import {
   findSelectedIndexForOptions,
-  findSelectedIndexForOptionGroups
-} from './select-helpers';
+  findSelectedIndexForOptionGroups,
+  splitFromSelected
+} from './helpers/select-helpers';
 
 import SelectOptionsPanel from './SelectOptionsPanel';
 
@@ -68,6 +69,7 @@ const ClosedSelect = (props: ClosedSelectProps) => {
 
 const Select = (props: SelectProps) => {
   const [isOpen, setIsOpen] = useState(false);
+  const [selectedOption, optionGroups] = splitFromSelected(props.optionGroups);
 
   const openPanel = () => {
     setIsOpen(true);

--- a/src/ensembl/src/shared/select/Select.tsx
+++ b/src/ensembl/src/shared/select/Select.tsx
@@ -28,6 +28,8 @@ export type GroupedOptionIndex = [
 ];
 
 type ClosedSelectProps = {
+  // <-- TODO: think of a better name
+  isOpen: boolean;
   selectedOption: Option | null;
   placeholder: string;
   onClick: () => void;
@@ -61,8 +63,11 @@ const arrowHead = (
 );
 
 const ClosedSelect = (props: ClosedSelectProps) => {
+  const className = props.isOpen
+    ? styles.selectClosedInvisible
+    : styles.selectClosed;
   return (
-    <span className={styles.selectClosed} onClick={props.onClick}>
+    <span className={className} onClick={props.onClick}>
       {props.selectedOption ? props.selectedOption.label : props.placeholder}
       {arrowHead}
     </span>
@@ -88,9 +93,12 @@ const Select = (props: SelectProps) => {
     setIsOpen(false);
   };
 
+  const headerText = selectedOption ? selectedOption.label : props.placeholder;
+
   return (
     <div className={styles.select}>
       <ClosedSelect
+        isOpen={isOpen}
         selectedOption={selectedOption}
         onClick={openPanel}
         placeholder={props.placeholder}
@@ -98,6 +106,7 @@ const Select = (props: SelectProps) => {
       {isOpen && (
         <SelectOptionsPanel
           optionGroups={optionGroups}
+          header={headerText}
           onSelect={handleSelect}
           onClose={closePanel}
         />

--- a/src/ensembl/src/shared/select/Select.tsx
+++ b/src/ensembl/src/shared/select/Select.tsx
@@ -81,8 +81,8 @@ const Select = (props: SelectProps) => {
   );
 };
 
-// the sole purpose of this component is to unify props
-// and transform OptionsSpecificProps into OptionGroupsSpecificProps
+// the purpose of the adapter is to unify props
+// to be consumed by the Select component
 const SelectAdapter = (props: SelectAdapterProps) => {
   if ((props as OptionGroupssSelectProps).optionGroups) {
     return <Select {...props as OptionGroupssSelectProps} />;

--- a/src/ensembl/src/shared/select/Select.tsx
+++ b/src/ensembl/src/shared/select/Select.tsx
@@ -1,5 +1,10 @@
 import React, { useState, useEffect } from 'react';
 
+import {
+  findSelectedIndexForOptions,
+  findSelectedIndexForOptionGroups
+} from './select-helpers';
+
 import SelectOptionsPanel from './SelectOptionsPanel';
 
 import styles from './Select.scss';
@@ -16,7 +21,7 @@ export type OptionGroup = {
   options: Option[];
 };
 
-export type OptionIndex = [
+export type GroupedOptionIndex = [
   number, // index of option group
   number // index of the option within a group
 ];
@@ -26,10 +31,25 @@ type ClosedSelectProps = {
   onClick: () => void;
 };
 
-type Props = {
+type OptionsSpecificProps = {
+  options: Option[];
+  title?: string;
+};
+
+type OptionGroupsSpecificProps = {
   optionGroups: OptionGroup[];
+};
+
+type CommonProps = {
   onSelect: (value: any) => void;
 };
+
+type OptionsSelectProps = CommonProps & OptionsSpecificProps;
+type OptionGroupssSelectProps = CommonProps & OptionGroupsSpecificProps;
+
+type SelectAdapterProps = OptionsSelectProps | OptionGroupssSelectProps;
+
+type SelectProps = OptionGroupssSelectProps;
 
 const arrowHead = (
   <svg className={styles.selectArrowhead} focusable="false" viewBox="0 0 8 8">
@@ -46,7 +66,7 @@ const ClosedSelect = (props: ClosedSelectProps) => {
   );
 };
 
-const Select = (props: Props) => {
+const Select = (props: SelectProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const openPanel = () => {
@@ -61,4 +81,21 @@ const Select = (props: Props) => {
   );
 };
 
-export default Select;
+// the sole purpose of this component is to unify props
+// and transform OptionsSpecificProps into OptionGroupsSpecificProps
+const SelectAdapter = (props: SelectAdapterProps) => {
+  if ((props as OptionGroupssSelectProps).optionGroups) {
+    return <Select {...props as OptionGroupssSelectProps} />;
+  } else {
+    const { options, title, ...otherProps } = props as OptionsSelectProps;
+    const optionGroups = [
+      {
+        title,
+        options
+      }
+    ];
+    return <Select optionGroups={optionGroups} {...otherProps} />;
+  }
+};
+
+export default SelectAdapter;

--- a/src/ensembl/src/shared/select/Select.tsx
+++ b/src/ensembl/src/shared/select/Select.tsx
@@ -5,6 +5,7 @@ import { splitFromSelected } from './helpers/select-helpers';
 import * as keyCodes from 'src/shared/constants/keyCodes';
 
 import SelectOptionsPanel from './SelectOptionsPanel';
+import SelectArrowhead from './SelectArrowhead';
 
 import styles from './Select.scss';
 
@@ -54,12 +55,6 @@ type SelectAdapterProps = OptionsSelectProps | OptionGroupssSelectProps;
 
 type SelectProps = OptionGroupssSelectProps;
 
-const arrowHead = (
-  <svg className={styles.selectArrowhead} focusable="false" viewBox="0 0 8 8">
-    <polygon points="0,0 8,0 4,8" />
-  </svg>
-);
-
 const ClosedSelect = (props: ClosedSelectProps) => {
   const className = props.isOpen
     ? styles.selectClosedInvisible
@@ -67,7 +62,7 @@ const ClosedSelect = (props: ClosedSelectProps) => {
   return (
     <span className={className} onClick={props.onClick}>
       {props.selectedOption ? props.selectedOption.label : props.placeholder}
-      {arrowHead}
+      <SelectArrowhead />
     </span>
   );
 };
@@ -104,7 +99,6 @@ const Select = (props: SelectProps) => {
     }
   };
 
-  console.log('isOpen?', isOpen);
   const handleKeyPress = (event: KeyboardEvent) => {
     if (
       !(
@@ -145,7 +139,7 @@ const Select = (props: SelectProps) => {
         onClick={openPanel}
         placeholder={props.placeholder}
       />
-      {isOpen && (
+      {!isOpen && (
         <SelectOptionsPanel
           optionGroups={optionGroups}
           header={headerText}

--- a/src/ensembl/src/shared/select/Select.tsx
+++ b/src/ensembl/src/shared/select/Select.tsx
@@ -26,7 +26,7 @@ export type GroupedOptionIndex = [
   number // index of the option within a group
 ];
 
-type ClosedSelectProps = {
+type SelectControlProps = {
   isOpen: boolean;
   selectedOption: Option | null;
   placeholder: string;
@@ -54,11 +54,10 @@ type SelectAdapterProps = OptionsSelectProps | OptionGroupsSelectProps;
 
 type SelectProps = OptionGroupsSelectProps & { placeholder: string };
 
-// TODO: think of a better name for this component?
-const ClosedSelect = (props: ClosedSelectProps) => {
+const SelectControl = (props: SelectControlProps) => {
   const className = props.isOpen
-    ? styles.selectClosedInvisible
-    : styles.selectClosed;
+    ? styles.selectControlInvisible
+    : styles.selectControl;
   return (
     <span className={className} onClick={props.onClick}>
       {props.selectedOption ? props.selectedOption.label : props.placeholder}
@@ -133,7 +132,7 @@ const Select = (props: SelectProps) => {
       onFocus={handleFocus}
       onBlur={handleBlur}
     >
-      <ClosedSelect
+      <SelectControl
         isOpen={isOpen}
         selectedOption={selectedOption}
         onClick={openPanel}

--- a/src/ensembl/src/shared/select/Select.tsx
+++ b/src/ensembl/src/shared/select/Select.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 
+import useDeepCompareEffect from 'src/shared/hooks/useDeepCompareEffect';
+
 import {
   findSelectedIndexForOptions,
   findSelectedIndexForOptionGroups,
@@ -91,7 +93,7 @@ const Select = (props: SelectProps) => {
       <ClosedSelect label="hello?" onClick={openPanel} />
       {isOpen && (
         <SelectOptionsPanel
-          optionGroups={props.optionGroups}
+          optionGroups={optionGroups}
           onSelect={handleSelect}
           onClose={closePanel}
         />

--- a/src/ensembl/src/shared/select/Select.tsx
+++ b/src/ensembl/src/shared/select/Select.tsx
@@ -78,7 +78,12 @@ const Select = (props: SelectProps) => {
   return (
     <div className={styles.select}>
       <ClosedSelect label="hello?" onClick={openPanel} />
-      {isOpen && <SelectOptionsPanel optionGroups={props.optionGroups} />}
+      {isOpen && (
+        <SelectOptionsPanel
+          optionGroups={props.optionGroups}
+          onSelect={(thing) => console.log('thing', thing)}
+        />
+      )}
     </div>
   );
 };

--- a/src/ensembl/src/shared/select/Select.tsx
+++ b/src/ensembl/src/shared/select/Select.tsx
@@ -1,0 +1,64 @@
+import React, { useState, useEffect } from 'react';
+
+import SelectOptionsPanel from './SelectOptionsPanel';
+
+import styles from './Select.scss';
+
+export type Option = {
+  value: any;
+  label: React.ReactNode;
+  isSelected: boolean;
+  isDisabled?: boolean;
+};
+
+export type OptionGroup = {
+  title?: string;
+  options: Option[];
+};
+
+export type OptionIndex = [
+  number, // index of option group
+  number // index of the option within a group
+];
+
+type ClosedSelectProps = {
+  label: React.ReactNode;
+  onClick: () => void;
+};
+
+type Props = {
+  optionGroups: OptionGroup[];
+  selectedIndex?: OptionIndex;
+};
+
+const arrowHead = (
+  <svg className={styles.selectArrowhead} focusable="false" viewBox="0 0 8 8">
+    <polygon points="0,0 8,0 4,8" />
+  </svg>
+);
+
+const ClosedSelect = (props: ClosedSelectProps) => {
+  return (
+    <span className={styles.selectClosed} onClick={props.onClick}>
+      {props.label}
+      {arrowHead}
+    </span>
+  );
+};
+
+const Select = (props: Props) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const openPanel = () => {
+    setIsOpen(true);
+  };
+
+  return (
+    <div className={styles.select}>
+      <ClosedSelect label="hello?" onClick={openPanel} />
+      {isOpen && <SelectOptionsPanel optionGroups={props.optionGroups} />}
+    </div>
+  );
+};
+
+export default Select;

--- a/src/ensembl/src/shared/select/Select.tsx
+++ b/src/ensembl/src/shared/select/Select.tsx
@@ -28,7 +28,7 @@ type ClosedSelectProps = {
 
 type Props = {
   optionGroups: OptionGroup[];
-  selectedIndex?: OptionIndex;
+  onSelect: (value: any) => void;
 };
 
 const arrowHead = (

--- a/src/ensembl/src/shared/select/Select.tsx
+++ b/src/ensembl/src/shared/select/Select.tsx
@@ -139,7 +139,7 @@ const Select = (props: SelectProps) => {
         onClick={openPanel}
         placeholder={props.placeholder}
       />
-      {!isOpen && (
+      {isOpen && (
         <SelectOptionsPanel
           optionGroups={optionGroups}
           header={headerText}

--- a/src/ensembl/src/shared/select/SelectArrowhead.tsx
+++ b/src/ensembl/src/shared/select/SelectArrowhead.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import styles from './Select.scss';
+
+export enum Direction {
+  UP = 'up',
+  DOWN = 'down'
+}
+
+type Props = {
+  direction: Direction;
+};
+
+const SelectArrowhead = (props: Props) => {
+  const points =
+    props.direction === Direction.DOWN ? '0,0 8,0 4,8' : '0,8 8,8 4,0';
+
+  return (
+    <svg className={styles.selectArrowhead} focusable="false" viewBox="0 0 8 8">
+      <polygon points={points} />
+    </svg>
+  );
+};
+
+SelectArrowhead.defaultProps = {
+  direction: Direction.DOWN
+};
+
+export default SelectArrowhead;

--- a/src/ensembl/src/shared/select/SelectOptionsPanel.tsx
+++ b/src/ensembl/src/shared/select/SelectOptionsPanel.tsx
@@ -1,0 +1,36 @@
+import React, { useState, useEffect } from 'react';
+
+import { Option, OptionGroup } from './Select';
+
+import styles from './Select.scss';
+
+type Props = {
+  optionGroups: OptionGroup[];
+};
+
+const SelectOption = (props: Option) => {
+  return <li>{props.label}</li>;
+};
+
+const SelectOptionGroup = (props: OptionGroup) => {
+  return (
+    <ul>
+      {props.title && <div>{props.title}</div>}
+      {props.options.map((option, index) => (
+        <SelectOption {...option} key={index} />
+      ))}
+    </ul>
+  );
+};
+
+const SelectOptionsPanel = (props: Props) => {
+  return (
+    <div className={styles.optionsPanel}>
+      {props.optionGroups.map((optionGroup, index) => (
+        <SelectOptionGroup {...optionGroup} key={index} />
+      ))}
+    </div>
+  );
+};
+
+export default SelectOptionsPanel;

--- a/src/ensembl/src/shared/select/SelectOptionsPanel.tsx
+++ b/src/ensembl/src/shared/select/SelectOptionsPanel.tsx
@@ -77,13 +77,10 @@ const highlightedItemReducer = (
 };
 
 const SelectOptionsPanel = (props: Props) => {
-  const [shouldShowTopScrollButton, setShouldShowTopScrollButton] = useState(
+  const [shouldShowTopScrollButton, showTopScrollButton] = useState(false);
+  const [shouldShowBottomScrollButton, showBottomScrollButton] = useState(
     false
   );
-  const [
-    shouldShowBottomScrollButton,
-    setShouldShowBottomScrollButton
-  ] = useState(false);
   const [highlightedItemIndex, dispatch] = useReducer(
     highlightedItemReducer,
     null
@@ -165,7 +162,7 @@ const SelectOptionsPanel = (props: Props) => {
       !getPanelScrollStatus(optionsListRef.current as HTMLDivElement)
         .isScrolledToBottom
     ) {
-      setShouldShowBottomScrollButton(true);
+      showBottomScrollButton(true);
     }
   }, []);
 
@@ -182,16 +179,16 @@ const SelectOptionsPanel = (props: Props) => {
       optionsListRef.current as HTMLDivElement
     );
     if (!isScrolledToTop && !shouldShowTopScrollButton) {
-      setShouldShowTopScrollButton(true);
+      showTopScrollButton(true);
     }
     if (isScrolledToTop && shouldShowTopScrollButton) {
-      setShouldShowTopScrollButton(false);
+      showTopScrollButton(false);
     }
     if (!isScrolledToBottom && !shouldShowBottomScrollButton) {
-      setShouldShowBottomScrollButton(true);
+      showBottomScrollButton(true);
     }
     if (isScrolledToBottom && shouldShowBottomScrollButton) {
-      setShouldShowBottomScrollButton(false);
+      showBottomScrollButton(false);
     }
   };
 

--- a/src/ensembl/src/shared/select/SelectOptionsPanel.tsx
+++ b/src/ensembl/src/shared/select/SelectOptionsPanel.tsx
@@ -45,7 +45,7 @@ type OptionProps = Option & {
 
 type Props = {
   optionGroups: OptionGroup[];
-  selectedOption: Option | null;
+  header: React.ReactNode;
   onSelect: (index: GroupedOptionIndex) => void;
   onClose: () => void;
 };
@@ -97,7 +97,11 @@ const SelectOptionsPanel = (props: Props) => {
 
   const handleClickOutside = (event: MouseEvent | TouchEvent) => {
     const { target } = event;
-    if (target !== elementRef.current) {
+    if (
+      elementRef.current &&
+      elementRef.current !== target &&
+      !elementRef.current.contains(target as Node)
+    ) {
       props.onClose();
     }
   };
@@ -127,6 +131,7 @@ const SelectOptionsPanel = (props: Props) => {
 
   return (
     <div className={styles.optionsPanel} ref={elementRef}>
+      <div className={styles.optionsPanelHeader}>{props.header}</div>
       {props.optionGroups.map((optionGroup, index) => {
         const [groupIndex, itemIndex] = highlightedItemIndex || [null, null];
         const otherProps =

--- a/src/ensembl/src/shared/select/SelectOptionsPanel.tsx
+++ b/src/ensembl/src/shared/select/SelectOptionsPanel.tsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect } from 'react';
 
-import { Option, OptionGroup } from './Select';
+import { Option, OptionGroup, GroupedOptionIndex } from './Select';
 
 import styles from './Select.scss';
 
 type Props = {
   optionGroups: OptionGroup[];
+  selectedOption: Option | null;
+  onSelect: (index: GroupedOptionIndex) => void;
 };
 
 const SelectOption = (props: Option) => {

--- a/src/ensembl/src/shared/select/SelectOptionsPanel.tsx
+++ b/src/ensembl/src/shared/select/SelectOptionsPanel.tsx
@@ -125,6 +125,10 @@ const SelectOptionsPanel = (props: Props) => {
 
     // scroll option into view after the state gets updated
     setTimeout(() => {
+      if (!optionsListRef.current) {
+        // keypress has caused the options panel to close
+        return;
+      }
       window.requestAnimationFrame(() => {
         scrollOptionIntoView({
           container: optionsListRef.current as HTMLDivElement,
@@ -184,12 +188,6 @@ const SelectOptionsPanel = (props: Props) => {
     const { isScrolledToTop, isScrolledToBottom } = getPanelScrollStatus(
       optionsListRef.current as HTMLDivElement
     );
-    console.log(
-      'isScrolledToBottom',
-      isScrolledToBottom,
-      'shouldShowBottomScrollButton',
-      shouldShowBottomScrollButton
-    );
     if (!isScrolledToTop && !shouldShowTopScrollButton) {
       setShouldShowTopScrollButton(true);
     }
@@ -200,7 +198,6 @@ const SelectOptionsPanel = (props: Props) => {
       setShouldShowBottomScrollButton(true);
     }
     if (isScrolledToBottom && shouldShowBottomScrollButton) {
-      console.log('should be false?');
       setShouldShowBottomScrollButton(false);
     }
   };

--- a/src/ensembl/src/shared/select/SelectOptionsPanel.tsx
+++ b/src/ensembl/src/shared/select/SelectOptionsPanel.tsx
@@ -30,14 +30,17 @@ type HighlightAction =
 
 type OptionGroupProps = OptionGroup & {
   highlightedItemIndex?: number;
+  groupIndex: number;
   onItemHover: () => void;
   onItemClick: () => void;
 };
 
 type OptionProps = Option & {
+  groupIndex: number;
+  itemIndex: number;
   isHighlighed: boolean;
-  onHover: () => void;
-  onClick: () => void;
+  onHover: (index: GroupedOptionIndex) => void;
+  onClick: (index: GroupedOptionIndex) => void;
 };
 
 type Props = {
@@ -97,11 +100,11 @@ const SelectOptionsPanel = (props: Props) => {
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, []);
 
-  const handleItemHover = () => {
-    console.log('hovering');
+  const handleItemHover = (index: GroupedOptionIndex) => {
+    dispatch({ type: HighlightActionType.SET, payload: index });
   };
 
-  const handleItemClick = () => {
+  const handleItemClick = (index: GroupedOptionIndex) => {
     console.log('clicked!');
   };
 
@@ -117,6 +120,7 @@ const SelectOptionsPanel = (props: Props) => {
         return (
           <SelectOptionGroup
             {...optionGroup}
+            groupIndex={index}
             onItemHover={handleItemHover}
             onItemClick={handleItemClick}
             {...otherProps}
@@ -135,6 +139,8 @@ const SelectOptionGroup = (props: OptionGroupProps) => {
       {props.options.map((option, index) => (
         <SelectOption
           {...option}
+          groupIndex={props.groupIndex}
+          itemIndex={index}
           isHighlighed={index === props.highlightedItemIndex}
           onHover={props.onItemHover}
           onClick={props.onItemClick}
@@ -149,12 +155,13 @@ const SelectOption = (props: OptionProps) => {
   const className = classNames(styles.option, {
     [styles.optionHighlighted]: props.isHighlighed
   });
+  const optionIndex = [props.groupIndex, props.itemIndex] as GroupedOptionIndex;
+
+  const onHover = () => props.onHover(optionIndex);
+  const onClick = () => props.onClick(optionIndex);
+
   return (
-    <li
-      className={className}
-      onMouseEnter={props.onHover}
-      onClick={props.onClick}
-    >
+    <li className={className} onMouseEnter={onHover} onClick={onClick}>
       {props.label}
     </li>
   );

--- a/src/ensembl/src/shared/select/SelectOptionsPanel.tsx
+++ b/src/ensembl/src/shared/select/SelectOptionsPanel.tsx
@@ -30,18 +30,13 @@ import styles from './Select.scss';
 enum HighlightActionType {
   NEXT = 'next',
   PREVIOUS = 'previous',
-  SET = 'set',
-  SUBMIT = 'submit'
+  SET = 'set'
 }
 type HighlightedItemState = GroupedOptionIndex | null;
 type HighlightAction =
   | { type: HighlightActionType.NEXT; payload: OptionGroup[] }
   | { type: HighlightActionType.PREVIOUS; payload: OptionGroup[] }
-  | { type: HighlightActionType.SET; payload: GroupedOptionIndex }
-  | {
-      type: HighlightActionType.SUBMIT;
-      payload: (index: GroupedOptionIndex) => void;
-    };
+  | { type: HighlightActionType.SET; payload: GroupedOptionIndex };
 
 type OptionGroupProps = OptionGroup & {
   highlightedItemIndex?: number;
@@ -76,9 +71,6 @@ const highlightedItemReducer = (
       return getPreviousItemIndex(state, action.payload);
     case HighlightActionType.SET:
       return action.payload;
-    case HighlightActionType.SUBMIT:
-      // side effect! and fallthrough to default! boo!
-      state && action.payload(state);
     default:
       return state;
   }
@@ -120,7 +112,8 @@ const SelectOptionsPanel = (props: Props) => {
     } else if (event.keyCode === keyCodes.DOWN) {
       dispatch({ type: HighlightActionType.NEXT, payload: props.optionGroups });
     } else if (event.keyCode === keyCodes.ENTER) {
-      dispatch({ type: HighlightActionType.SUBMIT, payload: props.onSelect });
+      highlightedItemIndexRef.current &&
+        props.onSelect(highlightedItemIndexRef.current);
     }
 
     // scroll option into view after the state gets updated

--- a/src/ensembl/src/shared/select/SelectOptionsPanel.tsx
+++ b/src/ensembl/src/shared/select/SelectOptionsPanel.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useReducer, useRef } from 'react';
+import React, { useEffect, useLayoutEffect, useReducer, useRef } from 'react';
 import classNames from 'classnames';
 
 import {
   getNextItemIndex,
-  getPreviousItemIndex
+  getPreviousItemIndex,
+  setOptionsPanelHeight
 } from './helpers/select-helpers';
 
 import * as keyCodes from 'src/shared/constants/keyCodes';
@@ -75,6 +76,7 @@ const SelectOptionsPanel = (props: Props) => {
     null
   );
   const elementRef = useRef<HTMLDivElement | null>(null);
+  const optionsListRef = useRef<HTMLDivElement | null>(null);
 
   const handleKeyDown = (event: KeyboardEvent) => {
     if (![keyCodes.UP, keyCodes.DOWN, keyCodes.ENTER].includes(event.keyCode)) {
@@ -121,6 +123,10 @@ const SelectOptionsPanel = (props: Props) => {
     };
   });
 
+  useLayoutEffect(() => {
+    setOptionsPanelHeight(elementRef);
+  });
+
   const handleItemHover = (index: GroupedOptionIndex) => {
     dispatch({ type: HighlightActionType.SET, payload: index });
   };
@@ -132,24 +138,26 @@ const SelectOptionsPanel = (props: Props) => {
   return (
     <div className={styles.optionsPanel} ref={elementRef}>
       <div className={styles.optionsPanelHeader}>{props.header}</div>
-      {props.optionGroups.map((optionGroup, index) => {
-        const [groupIndex, itemIndex] = highlightedItemIndex || [null, null];
-        const otherProps =
-          index === groupIndex
-            ? { highlightedItemIndex: itemIndex as number }
-            : {};
+      <div ref={optionsListRef}>
+        {props.optionGroups.map((optionGroup, index) => {
+          const [groupIndex, itemIndex] = highlightedItemIndex || [null, null];
+          const otherProps =
+            index === groupIndex
+              ? { highlightedItemIndex: itemIndex as number }
+              : {};
 
-        return (
-          <SelectOptionGroup
-            {...optionGroup}
-            groupIndex={index}
-            onItemHover={handleItemHover}
-            onItemClick={handleItemClick}
-            {...otherProps}
-            key={index}
-          />
-        );
-      })}
+          return (
+            <SelectOptionGroup
+              {...optionGroup}
+              groupIndex={index}
+              onItemHover={handleItemHover}
+              onItemClick={handleItemClick}
+              {...otherProps}
+              key={index}
+            />
+          );
+        })}
+      </div>
     </div>
   );
 };

--- a/src/ensembl/src/shared/select/SelectOptionsPanel.tsx
+++ b/src/ensembl/src/shared/select/SelectOptionsPanel.tsx
@@ -278,7 +278,7 @@ const SelectOptionsPanel = (props: Props) => {
 
 const SelectOptionGroup = (props: OptionGroupProps) => {
   return (
-    <ul>
+    <ul className={styles.optionsGroup}>
       {props.title && <div>{props.title}</div>}
       {props.options.map((option, index) => (
         <SelectOption

--- a/src/ensembl/src/shared/select/SelectOptionsPanel.tsx
+++ b/src/ensembl/src/shared/select/SelectOptionsPanel.tsx
@@ -76,8 +76,6 @@ const SelectOptionsPanel = (props: Props) => {
   );
   const elementRef = useRef<HTMLDivElement | null>(null);
 
-  const getHighlightedItemIndex = () => highlightedItemIndex;
-
   const handleKeyDown = (event: KeyboardEvent) => {
     if (![keyCodes.UP, keyCodes.DOWN, keyCodes.ENTER].includes(event.keyCode)) {
       return;
@@ -124,7 +122,7 @@ const SelectOptionsPanel = (props: Props) => {
   };
 
   const handleItemClick = (index: GroupedOptionIndex) => {
-    console.log('clicked!');
+    props.onSelect(index);
   };
 
   return (

--- a/src/ensembl/src/shared/select/SelectOptionsPanel.tsx
+++ b/src/ensembl/src/shared/select/SelectOptionsPanel.tsx
@@ -11,7 +11,9 @@ import {
   getNextItemIndex,
   getPreviousItemIndex,
   setOptionsPanelHeight,
-  getPanelScrollStatus
+  getPanelScrollStatus,
+  scrollDown,
+  scrollUp
 } from './helpers/select-helpers';
 
 import * as keyCodes from 'src/shared/constants/keyCodes';
@@ -95,6 +97,7 @@ const SelectOptionsPanel = (props: Props) => {
   );
   const elementRef = useRef<HTMLDivElement | null>(null);
   const optionsListRef = useRef<HTMLDivElement | null>(null);
+  const scrollRef = useRef(0);
 
   const handleKeyDown = (event: KeyboardEvent) => {
     if (![keyCodes.UP, keyCodes.DOWN, keyCodes.ENTER].includes(event.keyCode)) {
@@ -168,6 +171,22 @@ const SelectOptionsPanel = (props: Props) => {
     }
   };
 
+  const startScrollDown = () => {
+    scrollDown(optionsListRef.current as HTMLDivElement, scrollRef);
+  };
+
+  const stopScrollDown = () => {
+    window.cancelAnimationFrame(scrollRef.current);
+  };
+
+  const startScrollUp = () => {
+    scrollUp(optionsListRef.current as HTMLDivElement, scrollRef);
+  };
+
+  const stopScrollUp = () => {
+    window.cancelAnimationFrame(scrollRef.current);
+  };
+
   return (
     <div
       className={styles.optionsPanel}
@@ -177,7 +196,13 @@ const SelectOptionsPanel = (props: Props) => {
       <div className={styles.optionsPanelHeader}>{props.header}</div>
       <div className={styles.optionsListContainer}>
         {shouldShowTopScrollButton && (
-          <div className={styles.scrollButtonTop}>
+          <div
+            className={styles.scrollButtonTop}
+            onMouseEnter={startScrollUp}
+            onTouchStart={startScrollUp}
+            onMouseLeave={stopScrollUp}
+            onTouchEnd={stopScrollUp}
+          >
             <SelectArrowhead direction={ArrowheadDirection.UP} />
           </div>
         )}
@@ -205,7 +230,13 @@ const SelectOptionsPanel = (props: Props) => {
           })}
         </div>
         {shouldShowBottomScrollButton && (
-          <div className={styles.scrollButtonBottom}>
+          <div
+            className={styles.scrollButtonBottom}
+            onMouseEnter={startScrollDown}
+            onTouchStart={startScrollDown}
+            onMouseLeave={stopScrollDown}
+            onTouchEnd={stopScrollDown}
+          >
             <SelectArrowhead />
           </div>
         )}

--- a/src/ensembl/src/shared/select/helpers/select-helpers.spec.ts
+++ b/src/ensembl/src/shared/select/helpers/select-helpers.spec.ts
@@ -1,0 +1,77 @@
+import faker from 'faker';
+import random from 'lodash/random';
+import times from 'lodash/times';
+
+import { Option, OptionGroup } from '../Select';
+
+import {
+  findSelectedIndexForOptions,
+  findSelectedIndexForOptionGroups
+} from './select-helpers';
+
+const buildOption = (): Option => ({
+  value: faker.random.number(),
+  label: faker.lorem.words(),
+  isSelected: false
+});
+
+const buildOptionGroup = (options: Option[]): OptionGroup => ({
+  options
+});
+
+describe('findSelectedIndexForOptions', () => {
+  let numberOfOptions;
+  let options: Option[];
+  let selectedOptionIndex: number;
+
+  beforeEach(() => {
+    numberOfOptions = 10;
+    options = times(numberOfOptions, () => buildOption());
+    selectedOptionIndex = random(numberOfOptions);
+  });
+
+  test('finds index of selected option in an array of options', () => {
+    options[selectedOptionIndex].isSelected = true;
+
+    expect(findSelectedIndexForOptions(options)).toBe(selectedOptionIndex);
+  });
+
+  test('returns -1 if none of the options in the array is selected', () => {
+    expect(findSelectedIndexForOptions(options)).toBe(-1);
+  });
+});
+
+describe('findSelectedIndexForOptionGroups', () => {
+  let numberOfOptionGroups: number;
+  let numberOfOptionsPerGroup: number;
+  let optionGroups: OptionGroup[];
+  let selectedOptionIndex: [number, number];
+
+  beforeEach(() => {
+    numberOfOptionGroups = 5;
+    numberOfOptionsPerGroup = 10;
+
+    optionGroups = times(numberOfOptionGroups, () => {
+      const options = times(numberOfOptionsPerGroup, () => buildOption());
+      return buildOptionGroup(options);
+    });
+
+    selectedOptionIndex = [
+      random(numberOfOptionGroups),
+      random(numberOfOptionsPerGroup)
+    ];
+  });
+
+  test('finds index of selected option in an array of option groups', () => {
+    const [groupIndex, optionIndex] = selectedOptionIndex;
+    optionGroups[groupIndex].options[optionIndex].isSelected = true;
+
+    expect(findSelectedIndexForOptionGroups(optionGroups)).toEqual(
+      selectedOptionIndex
+    );
+  });
+
+  test('returns -1 if none of the options is selected', () => {
+    expect(findSelectedIndexForOptionGroups(optionGroups)).toEqual(-1);
+  });
+});

--- a/src/ensembl/src/shared/select/helpers/select-helpers.spec.ts
+++ b/src/ensembl/src/shared/select/helpers/select-helpers.spec.ts
@@ -5,7 +5,6 @@ import times from 'lodash/times';
 import { Option, OptionGroup } from '../Select';
 
 import {
-  findSelectedIndexForOptions,
   findSelectedIndexForOptionGroups,
   splitFromSelected
 } from './select-helpers';
@@ -18,28 +17,6 @@ const buildOption = (): Option => ({
 
 const buildOptionGroup = (options: Option[]): OptionGroup => ({
   options
-});
-
-describe('findSelectedIndexForOptions', () => {
-  let numberOfOptions;
-  let options: Option[];
-  let selectedOptionIndex: number;
-
-  beforeEach(() => {
-    numberOfOptions = 10;
-    options = times(numberOfOptions, () => buildOption());
-    selectedOptionIndex = random(numberOfOptions - 1);
-  });
-
-  test('finds index of selected option in an array of options', () => {
-    options[selectedOptionIndex].isSelected = true;
-
-    expect(findSelectedIndexForOptions(options)).toBe(selectedOptionIndex);
-  });
-
-  test('returns -1 if none of the options in the array is selected', () => {
-    expect(findSelectedIndexForOptions(options)).toBe(-1);
-  });
 });
 
 describe('findSelectedIndexForOptionGroups', () => {

--- a/src/ensembl/src/shared/select/helpers/select-helpers.spec.ts
+++ b/src/ensembl/src/shared/select/helpers/select-helpers.spec.ts
@@ -6,7 +6,8 @@ import { Option, OptionGroup } from '../Select';
 
 import {
   findSelectedIndexForOptions,
-  findSelectedIndexForOptionGroups
+  findSelectedIndexForOptionGroups,
+  splitFromSelected
 } from './select-helpers';
 
 const buildOption = (): Option => ({
@@ -27,7 +28,7 @@ describe('findSelectedIndexForOptions', () => {
   beforeEach(() => {
     numberOfOptions = 10;
     options = times(numberOfOptions, () => buildOption());
-    selectedOptionIndex = random(numberOfOptions);
+    selectedOptionIndex = random(numberOfOptions - 1);
   });
 
   test('finds index of selected option in an array of options', () => {
@@ -57,13 +58,15 @@ describe('findSelectedIndexForOptionGroups', () => {
     });
 
     selectedOptionIndex = [
-      random(numberOfOptionGroups),
-      random(numberOfOptionsPerGroup)
+      random(numberOfOptionGroups - 1),
+      random(numberOfOptionsPerGroup - 1)
     ];
   });
 
   test('finds index of selected option in an array of option groups', () => {
+    selectedOptionIndex = [4, 0]; // TODO: find out why this fails
     const [groupIndex, optionIndex] = selectedOptionIndex;
+
     optionGroups[groupIndex].options[optionIndex].isSelected = true;
 
     expect(findSelectedIndexForOptionGroups(optionGroups)).toEqual(
@@ -73,5 +76,45 @@ describe('findSelectedIndexForOptionGroups', () => {
 
   test('returns -1 if none of the options is selected', () => {
     expect(findSelectedIndexForOptionGroups(optionGroups)).toEqual(-1);
+  });
+});
+
+describe('splitFromSelected', () => {
+  let numberOfOptionGroups: number;
+  let numberOfOptionsPerGroup: number;
+  let optionGroups: OptionGroup[];
+  let selectedOptionIndex: [number, number];
+
+  beforeEach(() => {
+    numberOfOptionGroups = 5;
+    numberOfOptionsPerGroup = 10;
+
+    optionGroups = times(numberOfOptionGroups, () => {
+      const options = times(numberOfOptionsPerGroup, () => buildOption());
+      return buildOptionGroup(options);
+    });
+
+    selectedOptionIndex = [
+      random(numberOfOptionGroups - 1),
+      random(numberOfOptionsPerGroup - 1)
+    ];
+  });
+
+  test('finds index of selected option in an array of option groups', () => {
+    const [groupIndex, optionIndex] = selectedOptionIndex;
+    optionGroups[groupIndex].options[optionIndex].isSelected = true;
+
+    const [selectedOption, withoutSelected] = splitFromSelected(optionGroups);
+
+    expect(selectedOption).toEqual(
+      optionGroups[groupIndex].options[optionIndex]
+    );
+    expect(withoutSelected[groupIndex].options.length).toBe(
+      numberOfOptionsPerGroup - 1
+    );
+  });
+
+  test('returns unmodified option groups if no option is selected', () => {
+    // TODO: write test
   });
 });

--- a/src/ensembl/src/shared/select/helpers/select-helpers.ts
+++ b/src/ensembl/src/shared/select/helpers/select-helpers.ts
@@ -116,6 +116,24 @@ export const setOptionsPanelHeight = (
   const { top: panelTop, height: panelHeight } = panel.getBoundingClientRect();
 
   if (panelTop + panelHeight > windowHeight) {
-    panel.style.height = `${windowHeight - panelTop}px`;
+    const bottomOffset = 10;
+    panel.style.height = `${windowHeight - panelTop - bottomOffset}px`;
   }
+};
+
+export const getPanelScrollStatus = (panel: HTMLDivElement) => {
+  console.log(
+    'panel.scrollTop',
+    panel.scrollTop,
+    'panel.scrollHeight',
+    panel.scrollHeight,
+    'panel.clientHeight',
+    panel.clientHeight,
+    panel.scrollTop === panel.scrollHeight - panel.clientHeight
+  );
+  return {
+    isScrolledToTop: panel.scrollTop === 0,
+    isScrolledToBottom:
+      panel.scrollTop === panel.scrollHeight - panel.clientHeight
+  };
 };

--- a/src/ensembl/src/shared/select/helpers/select-helpers.ts
+++ b/src/ensembl/src/shared/select/helpers/select-helpers.ts
@@ -1,12 +1,7 @@
 import cloneDeep from 'lodash/cloneDeep';
-import range from 'lodash/range';
 import isEqual from 'lodash/isEqual';
 
 import { Option, OptionGroup, GroupedOptionIndex } from '../Select';
-
-export const findSelectedIndexForOptions = (options: Option[]) => {
-  return options.findIndex(({ isSelected }) => isSelected);
-};
 
 export const findSelectedIndexForOptionGroups = (
   optionGroups: OptionGroup[]
@@ -196,7 +191,6 @@ export const scrollOptionIntoView = ({
     containerRect.bottom
   ) {
     container.scrollTop = container.scrollTop + currentOptionElementRect.height;
-    // container.scrollTop = currentOptionElement.offsetTop - container.scrollHeight + currentOptionElementRect.height;
   } else if (
     currentOptionElementRect.top <
     containerRect.top + currentOptionElementRect.height

--- a/src/ensembl/src/shared/select/helpers/select-helpers.ts
+++ b/src/ensembl/src/shared/select/helpers/select-helpers.ts
@@ -1,3 +1,5 @@
+import cloneDeep from 'lodash/cloneDeep';
+
 import { Option, OptionGroup } from '../Select';
 
 export const findSelectedIndexForOptions = (options: Option[]) => {
@@ -7,7 +9,7 @@ export const findSelectedIndexForOptions = (options: Option[]) => {
 export const findSelectedIndexForOptionGroups = (
   optionGroups: OptionGroup[]
 ) => {
-  for (let groupIndex = 0; groupIndex < optionGroups.length - 1; groupIndex++) {
+  for (let groupIndex = 0; groupIndex < optionGroups.length; groupIndex++) {
     const group = optionGroups[groupIndex];
     for (
       let optionIndex = 0;
@@ -22,4 +24,21 @@ export const findSelectedIndexForOptionGroups = (
   }
 
   return -1;
+};
+
+export const splitFromSelected = (
+  optionGroups: OptionGroup[]
+): [Option, OptionGroup[]] | [null, OptionGroup[]] => {
+  const position = findSelectedIndexForOptionGroups(optionGroups);
+
+  if (!Array.isArray(position)) {
+    // no option selected; return unmodified option groups
+    return [null, optionGroups];
+  }
+
+  const [groupIndex, optionIndex] = position;
+  const selectedOption = optionGroups[groupIndex].options[optionIndex];
+  const withoutSelected = cloneDeep(optionGroups);
+  withoutSelected[groupIndex].options.splice(optionIndex, 1);
+  return [selectedOption, withoutSelected];
 };

--- a/src/ensembl/src/shared/select/helpers/select-helpers.ts
+++ b/src/ensembl/src/shared/select/helpers/select-helpers.ts
@@ -106,6 +106,8 @@ export const getPreviousItemIndex = (
   }
 };
 
+// check whether the options panel fits the allotted portion of the window,
+// and if it does not, assign a height to it
 export const setOptionsPanelHeight = (
   elementRef: React.MutableRefObject<HTMLDivElement | null>
 ) => {
@@ -118,8 +120,11 @@ export const setOptionsPanelHeight = (
   const { top: panelTop, height: panelHeight } = panel.getBoundingClientRect();
 
   if (panelTop + panelHeight > windowHeight) {
+    const minHeight = 300;
     const bottomOffset = 10;
-    panel.style.height = `${windowHeight - panelTop - bottomOffset}px`;
+    const distanceToWindowEdge = windowHeight - panelTop - bottomOffset;
+    const panelHeight = Math.max(distanceToWindowEdge, minHeight);
+    panel.style.height = `${panelHeight}px`;
   }
 };
 

--- a/src/ensembl/src/shared/select/helpers/select-helpers.ts
+++ b/src/ensembl/src/shared/select/helpers/select-helpers.ts
@@ -124,13 +124,6 @@ export const setOptionsPanelHeight = (
 };
 
 export const getPanelScrollStatus = (panel: HTMLDivElement) => {
-  console.log(
-    'panel.scrollTop === panel.scrollHeight - panel.clientHeight',
-    panel.scrollTop,
-    panel.scrollHeight,
-    panel.clientHeight,
-    panel.scrollTop === panel.scrollHeight - panel.clientHeight
-  );
   return {
     isScrolledToTop: panel.scrollTop === 0,
     isScrolledToBottom:

--- a/src/ensembl/src/shared/select/helpers/select-helpers.ts
+++ b/src/ensembl/src/shared/select/helpers/select-helpers.ts
@@ -1,6 +1,6 @@
 import cloneDeep from 'lodash/cloneDeep';
 
-import { Option, OptionGroup } from '../Select';
+import { Option, OptionGroup, GroupedOptionIndex } from '../Select';
 
 export const findSelectedIndexForOptions = (options: Option[]) => {
   return options.findIndex(({ isSelected }) => isSelected);
@@ -41,4 +41,65 @@ export const splitFromSelected = (
   const withoutSelected = cloneDeep(optionGroups);
   withoutSelected[groupIndex].options.splice(optionIndex, 1);
   return [selectedOption, withoutSelected];
+};
+
+export const getNextItemIndex = (
+  currentIndex: GroupedOptionIndex | null,
+  optionGroups: OptionGroup[]
+): GroupedOptionIndex | null => {
+  const [groupIndex, itemIndex] = currentIndex || [null, null];
+  const currentGroup =
+    typeof groupIndex === 'number' ? optionGroups[groupIndex] : null;
+  const firstItemIndex: GroupedOptionIndex = [0, 0];
+
+  if (currentIndex === null) {
+    return firstItemIndex;
+  } else if (
+    currentGroup &&
+    typeof itemIndex === 'number' &&
+    itemIndex < currentGroup.options.length - 1
+  ) {
+    // move to the next item in the group
+    return [groupIndex, itemIndex + 1] as GroupedOptionIndex;
+  } else if (groupIndex === optionGroups.length - 1) {
+    // this is the last item in the last group;
+    // cycle back to the first item in the list
+    return firstItemIndex;
+  } else if (typeof groupIndex === 'number') {
+    // move to the next group in the list
+    return [groupIndex + 1, 0];
+  } else {
+    return null; // should never happen, but makes Typescript happy
+  }
+};
+
+export const getPreviousItemIndex = (
+  currentIndex: GroupedOptionIndex | null,
+  optionGroups: OptionGroup[]
+): GroupedOptionIndex | null => {
+  const [groupIndex, itemIndex] = currentIndex || [null, null];
+  const lastGroupIndex = optionGroups.length - 1;
+  const lastGroupItemIndex = optionGroups[lastGroupIndex].options.length - 1;
+  const lastItemIndex: GroupedOptionIndex = [
+    lastGroupIndex,
+    lastGroupItemIndex
+  ];
+
+  if (currentIndex === null) {
+    return lastItemIndex;
+  } else if (typeof itemIndex === 'number' && itemIndex > 0) {
+    // move to the previous item
+    return [groupIndex, itemIndex - 1] as GroupedOptionIndex;
+  } else if (groupIndex === 0) {
+    // this is the first item in the first group;
+    // cycle back to the last item in the last group
+    return lastItemIndex;
+  } else if (typeof groupIndex === 'number') {
+    // move to the last item in the previous group
+    const previousGroupIndex = groupIndex - 1;
+    const lastItemIndex = optionGroups[previousGroupIndex].options.length - 1;
+    return [previousGroupIndex, lastItemIndex];
+  } else {
+    return null; // should never happen, but makes Typescript happy
+  }
 };

--- a/src/ensembl/src/shared/select/helpers/select-helpers.ts
+++ b/src/ensembl/src/shared/select/helpers/select-helpers.ts
@@ -1,0 +1,25 @@
+import { Option, OptionGroup } from '../Select';
+
+export const findSelectedIndexForOptions = (options: Option[]) => {
+  return options.findIndex(({ isSelected }) => isSelected);
+};
+
+export const findSelectedIndexForOptionGroups = (
+  optionGroups: OptionGroup[]
+) => {
+  for (let groupIndex = 0; groupIndex < optionGroups.length - 1; groupIndex++) {
+    const group = optionGroups[groupIndex];
+    for (
+      let optionIndex = 0;
+      optionIndex < group.options.length;
+      optionIndex++
+    ) {
+      const option = group.options[optionIndex];
+      if (option.isSelected) {
+        return [groupIndex, optionIndex];
+      }
+    }
+  }
+
+  return -1;
+};

--- a/src/ensembl/src/shared/select/helpers/select-helpers.ts
+++ b/src/ensembl/src/shared/select/helpers/select-helpers.ts
@@ -103,3 +103,19 @@ export const getPreviousItemIndex = (
     return null; // should never happen, but makes Typescript happy
   }
 };
+
+export const setOptionsPanelHeight = (
+  elementRef: React.MutableRefObject<HTMLDivElement | null>
+) => {
+  const panel = elementRef.current;
+  if (!panel) {
+    return;
+  }
+
+  const windowHeight = window.innerHeight;
+  const { top: panelTop, height: panelHeight } = panel.getBoundingClientRect();
+
+  if (panelTop + panelHeight > windowHeight) {
+    panel.style.height = `${windowHeight - panelTop}px`;
+  }
+};

--- a/src/ensembl/src/shared/select/helpers/select-helpers.ts
+++ b/src/ensembl/src/shared/select/helpers/select-helpers.ts
@@ -1,4 +1,6 @@
 import cloneDeep from 'lodash/cloneDeep';
+import range from 'lodash/range';
+import isEqual from 'lodash/isEqual';
 
 import { Option, OptionGroup, GroupedOptionIndex } from '../Select';
 
@@ -122,6 +124,13 @@ export const setOptionsPanelHeight = (
 };
 
 export const getPanelScrollStatus = (panel: HTMLDivElement) => {
+  console.log(
+    'panel.scrollTop === panel.scrollHeight - panel.clientHeight',
+    panel.scrollTop,
+    panel.scrollHeight,
+    panel.clientHeight,
+    panel.scrollTop === panel.scrollHeight - panel.clientHeight
+  );
   return {
     isScrolledToTop: panel.scrollTop === 0,
     isScrolledToBottom:
@@ -153,4 +162,47 @@ export const scrollUp = (
     }
   };
   window.requestAnimationFrame(scroll);
+};
+
+type ScrollOptionIntoViewArgs = {
+  container: HTMLDivElement;
+  currentIndex: GroupedOptionIndex;
+  optionGroups: OptionGroup[];
+  selector: string; // CSS selector for option elements
+};
+export const scrollOptionIntoView = ({
+  container,
+  currentIndex,
+  optionGroups,
+  selector
+}: ScrollOptionIntoViewArgs) => {
+  const lastGroupIndex = optionGroups.length - 1;
+  const lastItemIndex = [
+    lastGroupIndex,
+    optionGroups[lastGroupIndex].options.length - 1
+  ];
+  const currentOptionElement = container.querySelector(selector);
+  if (!currentOptionElement) {
+    return;
+  }
+
+  const containerRect = container.getBoundingClientRect();
+  const currentOptionElementRect = currentOptionElement.getBoundingClientRect();
+
+  if (isEqual(currentIndex, [0, 0]) && container.scrollTop !== 0) {
+    container.scrollTop = 0;
+  } else if (isEqual(currentIndex, lastItemIndex)) {
+    container.scrollTop = container.scrollHeight - container.clientHeight;
+  } else if (
+    currentOptionElementRect.bottom + currentOptionElementRect.height >
+    containerRect.bottom
+  ) {
+    container.scrollTop = container.scrollTop + currentOptionElementRect.height;
+    // container.scrollTop = currentOptionElement.offsetTop - container.scrollHeight + currentOptionElementRect.height;
+  } else if (
+    currentOptionElementRect.top <
+    containerRect.top + currentOptionElementRect.height
+  ) {
+    container.scrollTop = container.scrollTop - currentOptionElementRect.height;
+  }
 };

--- a/src/ensembl/src/shared/select/helpers/select-helpers.ts
+++ b/src/ensembl/src/shared/select/helpers/select-helpers.ts
@@ -122,18 +122,35 @@ export const setOptionsPanelHeight = (
 };
 
 export const getPanelScrollStatus = (panel: HTMLDivElement) => {
-  console.log(
-    'panel.scrollTop',
-    panel.scrollTop,
-    'panel.scrollHeight',
-    panel.scrollHeight,
-    'panel.clientHeight',
-    panel.clientHeight,
-    panel.scrollTop === panel.scrollHeight - panel.clientHeight
-  );
   return {
     isScrolledToTop: panel.scrollTop === 0,
     isScrolledToBottom:
       panel.scrollTop === panel.scrollHeight - panel.clientHeight
   };
+};
+
+export const scrollDown = (
+  panel: HTMLDivElement,
+  ref: React.MutableRefObject<number>
+) => {
+  const scroll = () => {
+    panel.scrollTop = panel.scrollTop + 10;
+    if (panel.scrollTop + panel.clientHeight < panel.scrollHeight) {
+      ref.current = window.requestAnimationFrame(scroll);
+    }
+  };
+  window.requestAnimationFrame(scroll);
+};
+
+export const scrollUp = (
+  panel: HTMLDivElement,
+  ref: React.MutableRefObject<number>
+) => {
+  const scroll = () => {
+    panel.scrollTop = panel.scrollTop - 10;
+    if (panel.scrollTop > 0) {
+      ref.current = window.requestAnimationFrame(scroll);
+    }
+  };
+  window.requestAnimationFrame(scroll);
 };

--- a/src/ensembl/stories/shared-components/index.ts
+++ b/src/ensembl/stories/shared-components/index.ts
@@ -1,6 +1,7 @@
 import './button/Button.stories';
 import './close-button/CloseButton.stories';
 import './question-button/QuestionButton.stories';
+import './select/Select.stories';
 import './dropdown/Dropdown.stories';
 import './input/Input.stories';
 import './accordion/Accordion.stories';

--- a/src/ensembl/stories/shared-components/select/Select.stories.scss
+++ b/src/ensembl/stories/shared-components/select/Select.stories.scss
@@ -1,0 +1,3 @@
+.defaultWrapper {
+  padding: 40px;
+}

--- a/src/ensembl/stories/shared-components/select/Select.stories.tsx
+++ b/src/ensembl/stories/shared-components/select/Select.stories.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import times from 'lodash/times';
+// import { action } from '@storybook/addon-actions';
+
+import Select from 'src/shared/select/Select';
+
+import styles from './Select.stories.scss';
+
+const createSimpleOption = (number: number) => ({
+  value: number,
+  label: `option ${number}`,
+  isSelected: false
+});
+
+const crreateSimpleOptions = (number: number) => {
+  const options = times(number, (time) => createSimpleOption(time + 1));
+  return {
+    options
+  };
+};
+
+// const Wrapper = (props: any) => {
+//   const [value, setValue] = useState('');
+//   const { searchField: SearchField, ...otherProps } = props;
+
+//   return (
+//     <div className={styles.searchFieldWrapper}>
+//       <SearchField value={value} onChange={setValue} {...otherProps} />
+//     </div>
+//   );
+// };
+
+storiesOf('Components|Shared Components/Select', module).add('default', () => (
+  <div className={styles.defaultWrapper}>
+    <Select optionGroups={[crreateSimpleOptions(5)]} />
+  </div>
+));

--- a/src/ensembl/stories/shared-components/select/Select.stories.tsx
+++ b/src/ensembl/stories/shared-components/select/Select.stories.tsx
@@ -23,7 +23,7 @@ const WrapperForOptions = (props: any) => {
   const onSelect = (selectedValue: number) => {
     action(`selected: ${selectedValue}`)();
 
-    const updatedOptions = options.options.map((option: Option) => ({
+    const updatedOptions = options.map((option: Option) => ({
       ...option,
       isSelected: option.value === selectedValue
     }));
@@ -43,12 +43,13 @@ const WrapperForOptionGroups = (props: any) => {
   const onSelect = (selectedValue: number) => {
     action(`selected: ${selectedValue}`)();
 
-    const updatedOptionGroups = optionGroups.map((group: OptionGroup) =>
-      group.options.map((option) => ({
+    const updatedOptionGroups = optionGroups.map((group: OptionGroup) => ({
+      ...group,
+      options: group.options.map((option) => ({
         ...option,
         isSelected: option.value === selectedValue
       }))
-    );
+    }));
 
     setOptionGroups(updatedOptionGroups);
   };

--- a/src/ensembl/stories/shared-components/select/Select.stories.tsx
+++ b/src/ensembl/stories/shared-components/select/Select.stories.tsx
@@ -25,14 +25,10 @@ const Wrapper = (props: any) => {
 
   const onSelect = (selectedValue: number) => {
     action(`selected: ${selectedValue}`)();
-    const updatedOptions = options.options.map((option) =>
-      option.value === selectedValue
-        ? {
-            ...option,
-            isSelected: true
-          }
-        : option
-    );
+    const updatedOptions = options.options.map((option) => ({
+      ...option,
+      isSelected: option.value === selectedValue
+    }));
     setOptions({
       ...options,
       options: updatedOptions

--- a/src/ensembl/stories/shared-components/select/Select.stories.tsx
+++ b/src/ensembl/stories/shared-components/select/Select.stories.tsx
@@ -3,11 +3,11 @@ import { storiesOf } from '@storybook/react';
 import times from 'lodash/times';
 import { action } from '@storybook/addon-actions';
 
-import Select from 'src/shared/select/Select';
+import Select, { Option } from 'src/shared/select/Select';
 
 import styles from './Select.stories.scss';
 
-const createSimpleOption = (number: number) => ({
+const createSimpleOption = (number: number): Option => ({
   value: number,
   label: `option ${number}`,
   isSelected: false
@@ -21,7 +21,7 @@ const createSimpleOptions = (number: number) => {
 };
 
 const Wrapper = (props: any) => {
-  const [options, setOptions] = useState(createSimpleOptions(5));
+  const [options, setOptions] = useState(props.options);
 
   const onSelect = (selectedValue: number) => {
     action(`selected: ${selectedValue}`)();
@@ -42,6 +42,16 @@ const Wrapper = (props: any) => {
   );
 };
 
-storiesOf('Components|Shared Components/Select', module).add('default', () => (
-  <Wrapper />
-));
+storiesOf('Components|Shared Components/Select', module)
+  .add('default', () => <Wrapper options={createSimpleOptions(5)} />)
+  .add('long list of options', () => {
+    const options = createSimpleOptions(50);
+    const longOption = {
+      value: 'long option value',
+      label: 'this is some ridiculously long text for an option',
+      isSelected: false
+    };
+    options.options.splice(10, 0, longOption);
+
+    return <Wrapper options={options} />;
+  });

--- a/src/ensembl/stories/shared-components/select/Select.stories.tsx
+++ b/src/ensembl/stories/shared-components/select/Select.stories.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import times from 'lodash/times';
 import { action } from '@storybook/addon-actions';
 
-import Select, { Option } from 'src/shared/select/Select';
+import Select, { Option, OptionGroup } from 'src/shared/select/Select';
 
 import styles from './Select.stories.scss';
 
@@ -14,36 +14,54 @@ const createSimpleOption = (number: number): Option => ({
 });
 
 const createSimpleOptions = (number: number) => {
-  const options = times(number, (time) => createSimpleOption(time + 1));
-  return {
-    options
-  };
+  return times(number, (time) => createSimpleOption(time + 1));
 };
 
-const Wrapper = (props: any) => {
+const WrapperForOptions = (props: any) => {
   const [options, setOptions] = useState(props.options);
 
   const onSelect = (selectedValue: number) => {
     action(`selected: ${selectedValue}`)();
-    const updatedOptions = options.options.map((option) => ({
+
+    const updatedOptions = options.options.map((option: Option) => ({
       ...option,
       isSelected: option.value === selectedValue
     }));
-    setOptions({
-      ...options,
-      options: updatedOptions
-    });
+    setOptions(updatedOptions);
   };
 
   return (
     <div className={styles.defaultWrapper}>
-      <Select optionGroups={[options]} onSelect={onSelect} />
+      <Select options={options} onSelect={onSelect} />
+    </div>
+  );
+};
+
+const WrapperForOptionGroups = (props: any) => {
+  const [optionGroups, setOptionGroups] = useState(props.optionGroups);
+
+  const onSelect = (selectedValue: number) => {
+    action(`selected: ${selectedValue}`)();
+
+    const updatedOptionGroups = optionGroups.map((group: OptionGroup) =>
+      group.options.map((option) => ({
+        ...option,
+        isSelected: option.value === selectedValue
+      }))
+    );
+
+    setOptionGroups(updatedOptionGroups);
+  };
+
+  return (
+    <div className={styles.defaultWrapper}>
+      <Select optionGroups={optionGroups} onSelect={onSelect} />
     </div>
   );
 };
 
 storiesOf('Components|Shared Components/Select', module)
-  .add('default', () => <Wrapper options={createSimpleOptions(5)} />)
+  .add('default', () => <WrapperForOptions options={createSimpleOptions(5)} />)
   .add('long list of options', () => {
     const options = createSimpleOptions(50);
     const longOption = {
@@ -51,7 +69,19 @@ storiesOf('Components|Shared Components/Select', module)
       label: 'this is some ridiculously long text for an option',
       isSelected: false
     };
-    options.options.splice(10, 0, longOption);
+    options.splice(10, 0, longOption);
 
-    return <Wrapper options={options} />;
+    return <WrapperForOptions options={options} />;
+  })
+  .add('groups of options', () => {
+    const options1 = createSimpleOptions(2);
+    const options2 = createSimpleOptions(3);
+    const options3 = createSimpleOptions(4);
+    const optionGroups = [
+      { options: options1 },
+      { options: options2 },
+      { options: options3 }
+    ];
+
+    return <WrapperForOptionGroups optionGroups={optionGroups} />;
   });

--- a/src/ensembl/stories/shared-components/select/Select.stories.tsx
+++ b/src/ensembl/stories/shared-components/select/Select.stories.tsx
@@ -5,6 +5,8 @@ import { action } from '@storybook/addon-actions';
 
 import Select, { Option, OptionGroup } from 'src/shared/select/Select';
 
+import selectNotes from './select.md';
+
 import styles from './Select.stories.scss';
 
 const createSimpleOption = (number: number): Option => ({
@@ -62,7 +64,11 @@ const WrapperForOptionGroups = (props: any) => {
 };
 
 storiesOf('Components|Shared Components/Select', module)
-  .add('default', () => <WrapperForOptions options={createSimpleOptions(5)} />)
+  .add(
+    'default',
+    () => <WrapperForOptions options={createSimpleOptions(5)} />,
+    { notes: selectNotes }
+  )
   .add('long list of options', () => {
     const options = createSimpleOptions(50);
     const longOption = {

--- a/src/ensembl/stories/shared-components/select/Select.stories.tsx
+++ b/src/ensembl/stories/shared-components/select/Select.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import times from 'lodash/times';
 // import { action } from '@storybook/addon-actions';
@@ -13,26 +13,38 @@ const createSimpleOption = (number: number) => ({
   isSelected: false
 });
 
-const crreateSimpleOptions = (number: number) => {
+const createSimpleOptions = (number: number) => {
   const options = times(number, (time) => createSimpleOption(time + 1));
   return {
     options
   };
 };
 
-// const Wrapper = (props: any) => {
-//   const [value, setValue] = useState('');
-//   const { searchField: SearchField, ...otherProps } = props;
+const Wrapper = (props: any) => {
+  const [options, setOptions] = useState(createSimpleOptions(5));
 
-//   return (
-//     <div className={styles.searchFieldWrapper}>
-//       <SearchField value={value} onChange={setValue} {...otherProps} />
-//     </div>
-//   );
-// };
+  const onSelect = (selectedValue: number) => {
+    const updatedOptions = options.options.map((option) =>
+      option.value === selectedValue
+        ? {
+            ...option,
+            isSelected: true
+          }
+        : option
+    );
+    setOptions({
+      ...options,
+      options: updatedOptions
+    });
+  };
+
+  return (
+    <div className={styles.defaultWrapper}>
+      <Select optionGroups={[options]} onSelect={onSelect} />
+    </div>
+  );
+};
 
 storiesOf('Components|Shared Components/Select', module).add('default', () => (
-  <div className={styles.defaultWrapper}>
-    <Select optionGroups={[crreateSimpleOptions(5)]} />
-  </div>
+  <Wrapper />
 ));

--- a/src/ensembl/stories/shared-components/select/Select.stories.tsx
+++ b/src/ensembl/stories/shared-components/select/Select.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import times from 'lodash/times';
-// import { action } from '@storybook/addon-actions';
+import { action } from '@storybook/addon-actions';
 
 import Select from 'src/shared/select/Select';
 
@@ -24,6 +24,7 @@ const Wrapper = (props: any) => {
   const [options, setOptions] = useState(createSimpleOptions(5));
 
   const onSelect = (selectedValue: number) => {
+    action(`selected: ${selectedValue}`)();
     const updatedOptions = options.options.map((option) =>
       option.value === selectedValue
         ? {

--- a/src/ensembl/stories/shared-components/select/select.md
+++ b/src/ensembl/stories/shared-components/select/select.md
@@ -1,0 +1,9 @@
+# Select
+
+Select component tries to replicate and extend the functionality of the native browser `select` element, styling it as specified in the design guideline.
+
+## Behaviour
+- Accepts either `options`, or groups of `options` (groups are separated visually in the options dropdown).
+- Upon selecting an option, calls the `onSelect` handler passing to it the value of the `value` field of the selected option object.
+- Allows navigation using keyboard (`enter` opens the dropdown with options, `up` and `down` arrow keys cycle between the options).
+- If the list of options is too tall to fit the space between the `select` element and the bottom border of the window, its height is adjusted to fit the allotted space. In such a case, the options panel shows areas (marked with up and down arrows) that initiate scrolling up or down when moused over. Taking the cursor away from these areas stops scrolling. Cycling between the options using arrow keys should also work; and each change of the option should scroll the newly highlighted option into view.


### PR DESCRIPTION
**Component's behaviour:**
- [x] Can accept an array of options or an array of groups of options
- [x] Selected option is sorted to the top of the list and is not selectable any longer
- [x] Select options can be navigated using arrow keys (as well as, obviously, by hovering/clicking with a mouse). Pressing `enter` will submit the current option. The current option is highlighted.
- [x] If the options list is too tall and does not fit the part of the screen to the bottom of the closed select element, the options list will be scrollable. Native scrollbars will be hidden, but the list will show up and down arrows indicating that there are more options than what is currently visible. Mousing over an arrow will start scrolling in the direction where the arrow is pointing. Leaving the mouse from the arrow will stop scrolling.
- [x] Make sure that, when navigating the options using the keyboard, the highlighted option is always visible (i.e. when an option is selected using the keyboard, it always gets scrolled into view if needed).

[Design reference](https://xd.adobe.com/view/46903a85-c5d9-43ad-6bb2-9b7e3a2b098e-30a1/screen/a43c11b6-baeb-4db9-851e-5a3068f18685/label-list-8)

**TODO (for subsequent pull requests):**
- Disable `onMouseEnter` for options when the user is navigating the options using keyboard (probably — debounce all onMouseEnters within, say, half a second after a key press). This should solve the current problem when an option under the cursor gets highlighted immediately after keyboard navigation causes the options list panel to scroll.
- Extend keyboard-based behaviour (open the options panel when pressing `down` or `space` key; confirm selection by pressing the `space` key) 
- Add appropriate behaviour for disabled options (making use of the `isDisabled` filed in the option data structure)?
- Find an option when the user starts typing in its text (there should be a brief interval within which every subsequent keypress is treated as being a part of the same string that begins a word, and after which a new keypress will be treated as starting a new string)