### PR TITLE
Feature/species tabs

### DIFF
--- a/src/ensembl/src/shared/species-tab-bar/SpeciesTabBar.scss
+++ b/src/ensembl/src/shared/species-tab-bar/SpeciesTabBar.scss
@@ -1,3 +1,6 @@
 .speciesTabBar {
-  display: block; // FIXME
+  display: flex;
+  white-space: nowrap;
+  max-width: 100%;
+  overflow-x: hidden;
 }

--- a/src/ensembl/src/shared/species-tab-bar/SpeciesTabBar.scss
+++ b/src/ensembl/src/shared/species-tab-bar/SpeciesTabBar.scss
@@ -1,0 +1,3 @@
+.speciesTabBar {
+  display: block; // FIXME
+}

--- a/src/ensembl/src/shared/species-tab-bar/SpeciesTabBar.test.tsx
+++ b/src/ensembl/src/shared/species-tab-bar/SpeciesTabBar.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import times from 'lodash/times';
+import random from 'lodash/random';
+
+import SpeciesTabBar from 'src/shared/species-tab-bar/SpeciesTabBar';
+import SpeciesTab from 'src/shared/species-tab/SpeciesTab';
+
+import { createSelectedSpecies } from 'tests/fixtures/selected-species';
+
+const speciesList = times(5, () => createSelectedSpecies());
+const onTabSelect = jest.fn();
+
+const defaultProps = {
+  species: speciesList,
+  activeGenomeId: speciesList[0].genome_id,
+  onTabSelect
+};
+
+describe('SpeciesTabBar', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('renders species tabs', () => {
+    const wrapper = mount(<SpeciesTabBar {...defaultProps} />);
+    const tabs = wrapper.find(SpeciesTab);
+    expect(tabs.length).toBe(defaultProps.species.length);
+  });
+
+  it('indicates which of the tabs is active', () => {
+    const activeTabIndex = random(0, defaultProps.species.length - 1);
+    const activeTabData = defaultProps.species[activeTabIndex];
+    const activeGenomeId = activeTabData.genome_id;
+    const props = { ...defaultProps, activeGenomeId };
+    const wrapper = mount(<SpeciesTabBar {...props} />);
+    const activeTab = wrapper
+      .find(SpeciesTab)
+      .findWhere((tabWrapper) => tabWrapper.prop('isActive') === true);
+
+    expect(activeTab.length).toBe(1);
+    expect(activeTab.prop('species').genome_id).toBe(activeGenomeId);
+  });
+
+  it('calls onTabSelect when a non-active tab is clicked', () => {
+    // tests integration with the SpeciesTab component
+    // NOTE: as set in defaultProps, active tab is the first one (i.e. with an index of 0)
+    const newTabIndex = random(1, defaultProps.species.length - 1);
+    const newTabId = defaultProps.species[newTabIndex].genome_id;
+    const wrapper = mount(<SpeciesTabBar {...defaultProps} />);
+
+    const newTabWrapper = wrapper.find(SpeciesTab).at(newTabIndex);
+    newTabWrapper.simulate('click');
+
+    expect(onTabSelect).toHaveBeenCalledWith(newTabId);
+  });
+});

--- a/src/ensembl/src/shared/species-tab-bar/SpeciesTabBar.tsx
+++ b/src/ensembl/src/shared/species-tab-bar/SpeciesTabBar.tsx
@@ -17,6 +17,7 @@ const SpeciesTabBar = (props: Props) => {
     <div className={styles.speciesTabBar}>
       {props.species.map((species) => (
         <SpeciesTab
+          key={species.genome_id}
           species={species}
           isActive={species.genome_id === props.activeGenomeId}
           onActivate={props.onTabSelect}

--- a/src/ensembl/src/shared/species-tab-bar/SpeciesTabBar.tsx
+++ b/src/ensembl/src/shared/species-tab-bar/SpeciesTabBar.tsx
@@ -9,6 +9,7 @@ import { CommittedItem } from 'src/content/app/species-selector/types/species-se
 type Props = {
   species: CommittedItem[]; // list of species
   activeGenomeId: string; // id of the species that is currently active
+  onTabSelect: (genomeId: string) => void;
 };
 
 const SpeciesTabBar = (props: Props) => {
@@ -18,6 +19,7 @@ const SpeciesTabBar = (props: Props) => {
         <SpeciesTab
           species={species}
           isActive={species.genome_id === props.activeGenomeId}
+          onActivate={props.onTabSelect}
         />
       ))}
     </div>

--- a/src/ensembl/src/shared/species-tab-bar/SpeciesTabBar.tsx
+++ b/src/ensembl/src/shared/species-tab-bar/SpeciesTabBar.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import SpeciesTab from 'src/shared/species-tab/SpeciesTab';
+
+import styles from './SpeciesTabBar.scss';
+
+import { CommittedItem } from 'src/content/app/species-selector/types/species-search';
+
+type Props = {
+  species: CommittedItem[]; // list of species
+  activeGenomeId: string; // id of the species that is currently active
+};
+
+const SpeciesTabBar = (props: Props) => {
+  return (
+    <div className={styles.speciesTabBar}>
+      {props.species.map((species) => (
+        <SpeciesTab
+          species={species}
+          isActive={species.genome_id === props.activeGenomeId}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default SpeciesTabBar;

--- a/src/ensembl/src/shared/species-tab/SpeciesTab.scss
+++ b/src/ensembl/src/shared/species-tab/SpeciesTab.scss
@@ -11,6 +11,7 @@ $speciesTabPadding: 6px 20px;
   cursor: pointer;
   overflow: hidden;
   line-height: 1;
+  user-select: none;
   text-overflow: ellipsis;
   flex-grow: 0;
   flex-shrink: 1;

--- a/src/ensembl/src/shared/species-tab/SpeciesTab.scss
+++ b/src/ensembl/src/shared/species-tab/SpeciesTab.scss
@@ -9,6 +9,10 @@ $speciesTabPadding: 6px 20px;
   border: 1px solid $ens-blue;
   border-radius: $speciesTabBorderRadius;
   cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 1;
+  flex-basis: 100%;
 
   &:not(:last-child) {
     margin-right: 1em;
@@ -27,6 +31,7 @@ $speciesTabPadding: 6px 20px;
 
 .speciesTabActive {
   background-color: $ens-black;
+  border: none;
 
   .name,
   .assembly {
@@ -35,4 +40,6 @@ $speciesTabPadding: 6px 20px;
 }
 
 .speciesTabFullSize {
+  flex-shrink: 0;
+  flex-basis: auto;
 }

--- a/src/ensembl/src/shared/species-tab/SpeciesTab.scss
+++ b/src/ensembl/src/shared/species-tab/SpeciesTab.scss
@@ -1,13 +1,10 @@
 @import 'src/styles/common';
 
-$speciesTabBorderRadius: 20px;
-$speciesTabPadding: 6px 20px;
-
 .speciesTab {
   display: inline-block;
-  padding: $speciesTabPadding;
+  padding: 6px 20px;
   border: 1px solid $ens-blue;
-  border-radius: $speciesTabBorderRadius;
+  border-radius: 20px;
   cursor: pointer;
   overflow: hidden;
   line-height: 1;

--- a/src/ensembl/src/shared/species-tab/SpeciesTab.scss
+++ b/src/ensembl/src/shared/species-tab/SpeciesTab.scss
@@ -10,9 +10,12 @@ $speciesTabPadding: 6px 20px;
   border-radius: $speciesTabBorderRadius;
   cursor: pointer;
   overflow: hidden;
+  line-height: 1;
   text-overflow: ellipsis;
+  flex-grow: 0;
   flex-shrink: 1;
-  flex-basis: 100%;
+  flex-basis: auto;
+  transition: flex-shrink 200ms;
 
   &:not(:last-child) {
     margin-right: 1em;

--- a/src/ensembl/src/shared/species-tab/SpeciesTab.scss
+++ b/src/ensembl/src/shared/species-tab/SpeciesTab.scss
@@ -1,0 +1,38 @@
+@import 'src/styles/common';
+
+$speciesTabBorderRadius: 20px;
+$speciesTabPadding: 6px 20px;
+
+.speciesTab {
+  display: inline-block;
+  padding: $speciesTabPadding;
+  border: 1px solid $ens-blue;
+  border-radius: $speciesTabBorderRadius;
+  cursor: pointer;
+
+  &:not(:last-child) {
+    margin-right: 1em;
+  }
+
+  .name {
+    font-size: 14px;
+    font-weight: $bold;
+    margin-right: 0.5rem;
+  }
+
+  .assembly {
+    font-size: 11px;
+  }
+}
+
+.speciesTabActive {
+  background-color: $ens-black;
+
+  .name,
+  .assembly {
+    color: $ens-white;
+  }
+}
+
+.speciesTabFullSize {
+}

--- a/src/ensembl/src/shared/species-tab/SpeciesTab.test.tsx
+++ b/src/ensembl/src/shared/species-tab/SpeciesTab.test.tsx
@@ -7,12 +7,19 @@ import { createSelectedSpecies } from 'tests/fixtures/selected-species';
 
 import SpeciesTab from './SpeciesTab';
 
+const onActivate = jest.fn();
+
 const defaultProps = {
   species: createSelectedSpecies(),
-  isActive: true
+  isActive: true,
+  onActivate
 };
 
 describe('<SpeciesTab />', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   it('displays species’ common name (if present) and assembly name', () => {
     const commonName = faker.lorem.words();
     const props = set('species.common_name', commonName, defaultProps);
@@ -72,5 +79,21 @@ describe('<SpeciesTab />', () => {
     expect(renderedInactiveTab.render().hasClass('speciesTabFullSize')).toBe(
       false
     );
+  });
+
+  it('calls the onActivate prop when clicked if inactive', () => {
+    const props = { ...defaultProps, isActive: false };
+    const wrapper = mount(<SpeciesTab {...props} />);
+    wrapper.simulate('click');
+
+    expect(onActivate).toHaveBeenCalledWith(defaultProps.species.genome_id);
+  });
+
+  it('does not call the onActivate prop when clicked if already active', () => {
+    // with defaultProps, the tab is active
+    const wrapper = mount(<SpeciesTab {...defaultProps} />);
+    wrapper.simulate('click');
+
+    expect(onActivate).not.toHaveBeenCalled();
   });
 });

--- a/src/ensembl/src/shared/species-tab/SpeciesTab.test.tsx
+++ b/src/ensembl/src/shared/species-tab/SpeciesTab.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render, mount } from 'enzyme';
+import faker from 'faker';
+import set from 'lodash/fp/set';
+
+import { createSelectedSpecies } from 'tests/fixtures/selected-species';
+
+import SpeciesTab from './SpeciesTab';
+
+const defaultProps = {
+  species: createSelectedSpecies(),
+  isActive: true
+};
+
+describe('<SpeciesTab />', () => {
+  it('displays species’ common name (if present) and assembly name', () => {
+    const commonName = faker.lorem.words();
+    const props = set('species.common_name', commonName, defaultProps);
+    const wrapper = render(<SpeciesTab {...props} />);
+    const nameElement = wrapper.find(`.name`);
+    const assemblyElement = wrapper.find(`.assembly`);
+
+    expect(nameElement.text()).toMatch(commonName);
+    expect(assemblyElement.text()).toMatch(props.species.assembly_name);
+  });
+
+  it('displays species’ scientific name (if species does not have a common name), and assembly name', () => {
+    const wrapper = render(<SpeciesTab {...defaultProps} />);
+    const nameElement = wrapper.find(`.name`);
+    const assemblyElement = wrapper.find(`.assembly`);
+
+    expect(nameElement.text()).toMatch(defaultProps.species.scientific_name);
+    expect(assemblyElement.text()).toMatch(defaultProps.species.assembly_name);
+  });
+
+  it('uses appropriate classes', () => {
+    const inactiveProps = { ...defaultProps, isActive: false };
+
+    const renderedInactiveTab = mount(<SpeciesTab {...inactiveProps} />);
+    const renderedActiveTab = mount(<SpeciesTab {...defaultProps} />);
+
+    expect(renderedInactiveTab.render().hasClass('speciesTabActive')).toBe(
+      false
+    );
+    expect(renderedActiveTab.render().hasClass('speciesTabActive')).toBe(true);
+
+    expect(renderedInactiveTab.render().hasClass('speciesTabFullSize')).toBe(
+      false
+    );
+    expect(renderedActiveTab.render().hasClass('speciesTabFullSize')).toBe(
+      true
+    );
+
+    // simulate hover
+    renderedInactiveTab.simulate('mouseenter');
+    renderedInactiveTab.update();
+
+    expect(renderedInactiveTab.render().hasClass('speciesTabActive')).toBe(
+      false
+    );
+    expect(renderedInactiveTab.render().hasClass('speciesTabFullSize')).toBe(
+      true
+    );
+
+    // simulate mouse leave
+    renderedInactiveTab.simulate('mouseleave');
+    renderedInactiveTab.update();
+
+    expect(renderedInactiveTab.render().hasClass('speciesTabActive')).toBe(
+      false
+    );
+    expect(renderedInactiveTab.render().hasClass('speciesTabFullSize')).toBe(
+      false
+    );
+  });
+});

--- a/src/ensembl/src/shared/species-tab/SpeciesTab.tsx
+++ b/src/ensembl/src/shared/species-tab/SpeciesTab.tsx
@@ -8,16 +8,28 @@ import { CommittedItem } from 'src/content/app/species-selector/types/species-se
 type Props = {
   species: CommittedItem;
   isActive: boolean;
+  onActivate: (genomeId: string) => void;
 };
 
 const SpeciesTab = (props: Props) => {
   const [isHovering, setIsHovering] = useState(false);
 
-  const { common_name, scientific_name, assembly_name } = props.species;
+  const {
+    genome_id,
+    common_name,
+    scientific_name,
+    assembly_name
+  } = props.species;
 
   const toggleHoverState = (newHoverState: boolean) => {
     if (newHoverState !== isHovering && !props.isActive) {
       setIsHovering(newHoverState);
+    }
+  };
+
+  const handleClick = () => {
+    if (!props.isActive) {
+      props.onActivate(genome_id);
     }
   };
 
@@ -34,6 +46,7 @@ const SpeciesTab = (props: Props) => {
       className={className}
       onMouseEnter={() => toggleHoverState(true)}
       onMouseLeave={() => toggleHoverState(false)}
+      onClick={handleClick}
     >
       <span className={styles.name}>{displayName}</span>
       <span className={styles.assembly}>{assembly_name}</span>

--- a/src/ensembl/src/shared/species-tab/SpeciesTab.tsx
+++ b/src/ensembl/src/shared/species-tab/SpeciesTab.tsx
@@ -22,7 +22,7 @@ const SpeciesTab = (props: Props) => {
   } = props.species;
 
   const toggleHoverState = (newHoverState: boolean) => {
-    if (newHoverState !== isHovering && !props.isActive) {
+    if (newHoverState !== isHovering) {
       setIsHovering(newHoverState);
     }
   };

--- a/src/ensembl/src/shared/species-tab/SpeciesTab.tsx
+++ b/src/ensembl/src/shared/species-tab/SpeciesTab.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import classNames from 'classnames';
+
+import styles from './SpeciesTab.scss';
+
+import { CommittedItem } from 'src/content/app/species-selector/types/species-search';
+
+type Props = {
+  species: CommittedItem;
+  isActive: boolean;
+};
+
+const SpeciesTab = (props: Props) => {
+  const [isHovering, setIsHovering] = useState(false);
+
+  const { common_name, scientific_name, assembly_name } = props.species;
+
+  const toggleHoverState = (newHoverState: boolean) => {
+    if (newHoverState !== isHovering && !props.isActive) {
+      setIsHovering(newHoverState);
+    }
+  };
+
+  const displayName = common_name || scientific_name;
+  const isFullSize = props.isActive || isHovering;
+
+  const className = classNames(styles.speciesTab, {
+    [styles.speciesTabActive]: props.isActive,
+    [styles.speciesTabFullSize]: isFullSize
+  });
+
+  return (
+    <div
+      className={className}
+      onMouseEnter={() => toggleHoverState(true)}
+      onMouseLeave={() => toggleHoverState(false)}
+    >
+      <span className={styles.name}>{displayName}</span>
+      <span className={styles.assembly}>{assembly_name}</span>
+    </div>
+  );
+};
+
+export default SpeciesTab;

--- a/src/ensembl/stories/shared-components/index.ts
+++ b/src/ensembl/stories/shared-components/index.ts
@@ -12,3 +12,4 @@ import './loader/Loader.stories';
 import './checkbox/Checkbox.stories';
 import './round-button/RoundButton.stories';
 import './badged-button/BadgedButton.stories';
+import './species-tab-bar/SpeciesTabBar.stories';

--- a/src/ensembl/stories/shared-components/species-tab-bar/SpeciesTabBar.stories.scss
+++ b/src/ensembl/stories/shared-components/species-tab-bar/SpeciesTabBar.stories.scss
@@ -1,0 +1,3 @@
+.wrapper {
+  padding: 80px 40px;
+}

--- a/src/ensembl/stories/shared-components/species-tab-bar/SpeciesTabBar.stories.scss
+++ b/src/ensembl/stories/shared-components/species-tab-bar/SpeciesTabBar.stories.scss
@@ -1,3 +1,4 @@
 .wrapper {
   padding: 80px 40px;
+  width: 100vw;
 }

--- a/src/ensembl/stories/shared-components/species-tab-bar/SpeciesTabBar.stories.tsx
+++ b/src/ensembl/stories/shared-components/species-tab-bar/SpeciesTabBar.stories.tsx
@@ -1,0 +1,23 @@
+import React, { useState } from 'react';
+import { storiesOf } from '@storybook/react';
+
+import speciesData from './speciesData';
+
+import styles from './SpeciesTabBar.stories.scss';
+
+import SpeciesTabBar from 'src/shared/species-tab-bar/SpeciesTabBar';
+
+const Wrapper = () => {
+  const activeGenomeId = speciesData[0].genome_id;
+
+  return (
+    <div className={styles.wrapper}>
+      <SpeciesTabBar species={speciesData} activeGenomeId={activeGenomeId} />
+    </div>
+  );
+};
+
+storiesOf('Components|Shared Components/SpeciesTabBar', module).add(
+  'default',
+  () => <Wrapper />
+);

--- a/src/ensembl/stories/shared-components/species-tab-bar/SpeciesTabBar.stories.tsx
+++ b/src/ensembl/stories/shared-components/species-tab-bar/SpeciesTabBar.stories.tsx
@@ -8,11 +8,20 @@ import styles from './SpeciesTabBar.stories.scss';
 import SpeciesTabBar from 'src/shared/species-tab-bar/SpeciesTabBar';
 
 const Wrapper = () => {
-  const activeGenomeId = speciesData[0].genome_id;
+  const [activeGenomeId, setActiveGenomeId] = useState(
+    speciesData[0].genome_id
+  );
+  const onTabSelect = (genomeId: string) => {
+    setActiveGenomeId(genomeId);
+  };
 
   return (
     <div className={styles.wrapper}>
-      <SpeciesTabBar species={speciesData} activeGenomeId={activeGenomeId} />
+      <SpeciesTabBar
+        species={speciesData}
+        activeGenomeId={activeGenomeId}
+        onTabSelect={onTabSelect}
+      />
     </div>
   );
 };

--- a/src/ensembl/stories/shared-components/species-tab-bar/SpeciesTabBar.stories.tsx
+++ b/src/ensembl/stories/shared-components/species-tab-bar/SpeciesTabBar.stories.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 
 import speciesData from './speciesData';
+import juneSpeciesData from './juneSpeciesData';
 
 import SpeciesTabBar from 'src/shared/species-tab-bar/SpeciesTabBar';
 
@@ -34,4 +35,5 @@ const Wrapper = (props: WrapperProps) => {
 
 storiesOf('Components|Shared Components/SpeciesTabBar', module)
   .add('few species', () => <Wrapper species={speciesData.slice(0, 3)} />)
+  .add('more species', () => <Wrapper species={juneSpeciesData} />)
   .add('multiple species', () => <Wrapper species={speciesData} />);

--- a/src/ensembl/stories/shared-components/species-tab-bar/SpeciesTabBar.stories.tsx
+++ b/src/ensembl/stories/shared-components/species-tab-bar/SpeciesTabBar.stories.tsx
@@ -3,11 +3,17 @@ import { storiesOf } from '@storybook/react';
 
 import speciesData from './speciesData';
 
-import styles from './SpeciesTabBar.stories.scss';
-
 import SpeciesTabBar from 'src/shared/species-tab-bar/SpeciesTabBar';
 
-const Wrapper = () => {
+import styles from './SpeciesTabBar.stories.scss';
+
+import { CommittedItem } from 'src/content/app/species-selector/types/species-search';
+
+type WrapperProps = {
+  species: CommittedItem[];
+};
+
+const Wrapper = (props: WrapperProps) => {
   const [activeGenomeId, setActiveGenomeId] = useState(
     speciesData[0].genome_id
   );
@@ -18,7 +24,7 @@ const Wrapper = () => {
   return (
     <div className={styles.wrapper}>
       <SpeciesTabBar
-        species={speciesData}
+        species={props.species}
         activeGenomeId={activeGenomeId}
         onTabSelect={onTabSelect}
       />
@@ -26,7 +32,6 @@ const Wrapper = () => {
   );
 };
 
-storiesOf('Components|Shared Components/SpeciesTabBar', module).add(
-  'default',
-  () => <Wrapper />
-);
+storiesOf('Components|Shared Components/SpeciesTabBar', module)
+  .add('few species', () => <Wrapper species={speciesData.slice(0, 3)} />)
+  .add('multiple species', () => <Wrapper species={speciesData} />);

--- a/src/ensembl/stories/shared-components/species-tab-bar/juneSpeciesData.ts
+++ b/src/ensembl/stories/shared-components/species-tab-bar/juneSpeciesData.ts
@@ -1,0 +1,60 @@
+// this is a limited set of species expected to be added with the June release
+
+export default [
+  {
+    genome_id: 'homo_sapiens38',
+    reference_genome_id: null,
+    common_name: 'Human',
+    scientific_name: 'Homo sapiens',
+    assembly_name: 'GRCh38',
+    isEnabled: true
+  },
+  {
+    genome_id: 'homo_sapiens37',
+    reference_genome_id: null,
+    common_name: 'Human',
+    scientific_name: 'Homo sapiens',
+    assembly_name: 'GRCh37',
+    isEnabled: true
+  },
+  {
+    genome_id: 'triticum_aestivum',
+    reference_genome_id: null,
+    common_name: 'Wheat',
+    scientific_name: 'Triticum aestivum',
+    assembly_name: 'IWGSC',
+    isEnabled: true
+  },
+  {
+    genome_id: 'escherichia_coli',
+    reference_genome_id: null,
+    common_name: null,
+    scientific_name: 'Escherichia coli str. K-12 substr. MG1655',
+    assembly_name: 'ASM584v2',
+    isEnabled: true
+  },
+  {
+    genome_id: 'saccharomyces_cerevisiae',
+    reference_genome_id: null,
+    common_name: null,
+    scientific_name: 'Saccharomyces cerevisiae',
+    assembly_name: 'R64-1-1',
+    isEnabled: true
+  },
+  {
+    genome_id: 'caenorhabditis_elegans',
+    reference_genome_id: null,
+    common_name: null,
+    scientific_name: 'Caenorhabditis elegans',
+    assembly_name: 'WBcel235',
+    isEnabled: true
+  },
+  {
+    genome_id: 'plasmodium_falciparum',
+    reference_genome_id: null,
+    common_name: null,
+    scientific_name: 'Plasmodium falciparum',
+    assembly_name: 'EPr1',
+    isEnabled: true
+  }
+];

--- a/src/ensembl/stories/shared-components/species-tab-bar/speciesData.ts
+++ b/src/ensembl/stories/shared-components/species-tab-bar/speciesData.ts
@@ -1,0 +1,90 @@
+export default [
+  {
+    genome_id: 'homo_sapiens38',
+    reference_genome_id: null,
+    common_name: 'Human',
+    scientific_name: 'Homo sapiens',
+    assembly_name: 'GRCh38',
+    isEnabled: true
+  },
+  {
+    genome_id: 'homo_sapiens37',
+    reference_genome_id: null,
+    common_name: 'Human',
+    scientific_name: 'Homo sapiens',
+    assembly_name: 'GRCh37',
+    isEnabled: true
+  },
+  {
+    genome_id: 'bifidobacterium_longum_subsp_longum_cect_7347',
+    reference_genome_id: null,
+    common_name: null,
+    scientific_name: 'Bifidobacterium longum subsp. longum CECT 7347',
+    assembly_name: 'ASM105055v1',
+    isEnabled: true
+  },
+  {
+    genome_id: 'bifidobacterium_longum_subsp_longum_cect_7347',
+    reference_genome_id: null,
+    common_name: null,
+    scientific_name: 'Arabidopsis thaliana',
+    assembly_name: 'TAIR10',
+    isEnabled: true
+  },
+  {
+    genome_id: 'drosophila_melanogaster',
+    reference_genome_id: null,
+    common_name: null,
+    scientific_name: 'Drosophila melanogaster',
+    assembly_name: 'BDGP6.22',
+    isEnabled: true
+  },
+  {
+    genome_id: 'drosophila_yakuba',
+    reference_genome_id: null,
+    common_name: null,
+    scientific_name: 'Drosophila yakuba',
+    assembly_name: 'dyak_caf1',
+    isEnabled: true
+  },
+  {
+    genome_id: 'caenorhabditis_elegans',
+    reference_genome_id: null,
+    common_name: null,
+    scientific_name: 'Caenorhabditis elegans',
+    assembly_name: 'WBcel235',
+    isEnabled: true
+  },
+  {
+    genome_id: 'mus_musculus',
+    reference_genome_id: null,
+    common_name: 'Mouse',
+    scientific_name: 'Mus musculus',
+    assembly_name: 'GRCm38.p6',
+    isEnabled: true
+  },
+  {
+    genome_id: 'canis_lupus_familiaris',
+    reference_genome_id: null,
+    common_name: 'Dog',
+    scientific_name: 'Canis lupus familiaris',
+    assembly_name: 'GRCm38.p6',
+    isEnabled: true
+  },
+  {
+    genome_id: 'zea_mays',
+    reference_genome_id: null,
+    common_name: 'Maize',
+    scientific_name: 'Zea mays',
+    assembly_name: 'B73_RefGen_v4',
+    isEnabled: true
+  },
+  {
+    genome_id: 'escherichia_coli',
+    reference_genome_id: null,
+    common_name: null,
+    scientific_name: 'Escherichia coli O157:H7 str. EDL933',
+    assembly_name: 'ASM666v1',
+    isEnabled: true
+  }
+];

--- a/src/ensembl/stories/shared-components/species-tab-bar/speciesData.ts
+++ b/src/ensembl/stories/shared-components/species-tab-bar/speciesData.ts
@@ -24,7 +24,7 @@ export default [
     isEnabled: true
   },
   {
-    genome_id: 'bifidobacterium_longum_subsp_longum_cect_7347',
+    genome_id: 'arabidopsis_thaliana',
     reference_genome_id: null,
     common_name: null,
     scientific_name: 'Arabidopsis thaliana',


### PR DESCRIPTION
This PR adds a header bar that shows a list of selected species and treats them as tabs (i.e. clicking on a species item will "activate" it, which will be accompanied by some change in the interface). The view that needs this bar the most at the moment is Genome Browser.

### Technical implementation and problems
The current implementation of required behaviour (a single line of tabs that adapt to the width of the screen) is done with CSS only (using flexbox). The problem with this approach is that instead of making all tabs the same width in cases where their collective width is larger than the width of the container, tabs are shrunk by the same fraction (which is how flexbox apparently works). This results in some tabs being wider and other tabs being shorter. While we (Andrea and me) recognise this defect, we agree that it is acceptable to have this header behaviour until we come up with a better one.

The current behaviour of the header can be observed in the [deployed storybook](https://ensembl.github.io/ensembl-client/storybook/index.html?path=/story/components-shared-components-speciestabbar--multiple-species).

See also [design mockup](https://xd.adobe.com/view/b0b60cbe-c41f-45e3-4e8e-3fd73d0090d5-c687/screen/aa57f3ec-6c3b-4729-8090-e3d139792a30/species-selector-8-on/) to get a picture of designer's thinking.