### PR TITLE
Add browser storage and preserve selected species

### DIFF
--- a/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.tsx
@@ -5,7 +5,7 @@ import {
   hasCurrentSpecies,
   canCommitSpecies
 } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
-import { commitSelectedSpecies } from 'src/content/app/species-selector/state/speciesSelectorActions';
+import { commitSelectedSpeciesAndSave } from 'src/content/app/species-selector/state/speciesSelectorActions';
 
 import { PrimaryButton } from 'src/shared/button/Button';
 
@@ -39,7 +39,7 @@ const mapStateToProps = (state: RootState) => ({
 });
 
 const mapDispatchToProps = {
-  onCommit: commitSelectedSpecies
+  onCommit: commitSelectedSpeciesAndSave
 };
 
 export default connect(

--- a/src/ensembl/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { getCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 import {
   toggleSpeciesUse,
-  deleteSpecies
+  deleteSpeciesAndSave
 } from 'src/content/app/species-selector/state/speciesSelectorActions';
 
 import SelectedSpecies from 'src/content/app/species-selector/components/selected-species/SelectedSpecies';
@@ -64,7 +64,7 @@ const mapStateToProps = (state: RootState) => ({
 
 const mapDispatchToProps = {
   toggleSpeciesUse,
-  onSpeciesDelete: deleteSpecies
+  onSpeciesDelete: deleteSpeciesAndSave
 };
 
 export default connect(

--- a/src/ensembl/src/content/app/species-selector/services/species-selector-storage-service.test.ts
+++ b/src/ensembl/src/content/app/species-selector/services/species-selector-storage-service.test.ts
@@ -1,0 +1,67 @@
+import {
+  SpeciesSelectorStorageService,
+  StorageKeys
+} from './species-selector-storage-service';
+
+import { createSelectedSpecies } from 'tests/fixtures/selected-species';
+
+const mockStorageService = {
+  get: jest.fn(),
+  save: jest.fn(),
+  update: jest.fn(),
+  remove: jest.fn(),
+  clearAll: jest.fn()
+};
+
+describe('SpeciesSelectorStorageService', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('.getSelectedSpecies()', () => {
+    it('gets saved selected species from storage service', () => {
+      const savedSpecies = [createSelectedSpecies()];
+      jest
+        .spyOn(mockStorageService, 'get')
+        .mockImplementation(() => savedSpecies);
+      const speciesSelectorStorageService = new SpeciesSelectorStorageService(
+        mockStorageService
+      );
+      const result = speciesSelectorStorageService.getSelectedSpecies();
+
+      expect(mockStorageService.get).toHaveBeenCalledWith(
+        StorageKeys.SELECTED_SPECIES
+      );
+      expect(result).toEqual(savedSpecies);
+
+      mockStorageService.get.mockRestore();
+    });
+
+    it('returns an empty array if there are no saved species', () => {
+      jest.spyOn(mockStorageService, 'get').mockImplementation(() => null);
+      const speciesSelectorStorageService = new SpeciesSelectorStorageService(
+        mockStorageService
+      );
+      const result = speciesSelectorStorageService.getSelectedSpecies();
+
+      expect(result).toEqual([]);
+
+      mockStorageService.get.mockRestore();
+    });
+  });
+
+  describe('.saveSelectedSpecies()', () => {
+    it('saves selected species via storage service', () => {
+      const speciesSelectorStorageService = new SpeciesSelectorStorageService(
+        mockStorageService
+      );
+      const selectedSpecies = [createSelectedSpecies()];
+      speciesSelectorStorageService.saveSelectedSpecies(selectedSpecies);
+
+      expect(mockStorageService.save).toHaveBeenCalledWith(
+        StorageKeys.SELECTED_SPECIES,
+        selectedSpecies
+      );
+    });
+  });
+});

--- a/src/ensembl/src/content/app/species-selector/services/species-selector-storage-service.ts
+++ b/src/ensembl/src/content/app/species-selector/services/species-selector-storage-service.ts
@@ -1,0 +1,29 @@
+import storageService, {
+  StorageServiceInterface
+} from 'src/services/storage-service';
+
+import { CommittedItem } from 'src/content/app/species-selector/types/species-search';
+
+export enum StorageKeys {
+  SELECTED_SPECIES = 'speciesSelector.selectedSpecies'
+}
+
+// named export is for testing purposes
+// for development, use default export
+export class SpeciesSelectorStorageService {
+  private storageService: StorageServiceInterface;
+
+  public constructor(storageService: StorageServiceInterface) {
+    this.storageService = storageService;
+  }
+
+  public getSelectedSpecies(): CommittedItem[] {
+    return this.storageService.get(StorageKeys.SELECTED_SPECIES) || [];
+  }
+
+  public saveSelectedSpecies(species: CommittedItem[]) {
+    this.storageService.save(StorageKeys.SELECTED_SPECIES, species);
+  }
+}
+
+export default new SpeciesSelectorStorageService(storageService);

--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorActions.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorActions.ts
@@ -1,4 +1,6 @@
 import { createStandardAction, createAsyncAction } from 'typesafe-actions';
+import { ActionCreator, Action } from 'redux';
+import { ThunkAction } from 'redux-thunk';
 
 // import apiService from 'src/services/api-service';
 
@@ -42,7 +44,9 @@ export const clearSelectedSearchResult = createStandardAction(
   'species_selector/clear_search_result'
 )();
 
-export const fetchStrains = (genomeId: string) => async (dispatch: any) => {
+export const fetchStrains: ActionCreator<
+  ThunkAction<void, any, null, Action<string>>
+> = (genomeId: string) => async (dispatch) => {
   try {
     dispatch(fetchStrainsAsyncActions.request());
 
@@ -56,7 +60,9 @@ export const fetchStrains = (genomeId: string) => async (dispatch: any) => {
   }
 };
 
-export const fetchAssemblies = (genomeId: string) => async (dispatch: any) => {
+export const fetchAssemblies: ActionCreator<
+  ThunkAction<void, any, null, Action<string>>
+> = (genomeId: string) => async (dispatch) => {
   try {
     dispatch(fetchAssembliesAsyncActions.request());
 
@@ -72,9 +78,9 @@ export const fetchAssemblies = (genomeId: string) => async (dispatch: any) => {
   }
 };
 
-export const handleSelectedSearchResult = (match: SearchMatch) => (
-  dispatch: any
-) => {
+export const handleSelectedSearchResult: ActionCreator<
+  ThunkAction<void, any, null, Action<string>>
+> = (match: SearchMatch) => (dispatch) => {
   dispatch(setSelectedSearchResult(match));
   const { genome_id, common_name } = match;
 
@@ -91,12 +97,9 @@ export const commitSelectedSpecies = createStandardAction(
   'species_selector/commit_selected_species'
 )();
 
-// FIXME: try types as described here:
-// https://gist.github.com/seansean11/196c436988c1fdf4b22cde308c492fe5
-export const commitSelectedSpeciesAndSave = () => (
-  dispatch: any,
-  getState: any
-) => {
+export const commitSelectedSpeciesAndSave: ActionCreator<
+  ThunkAction<void, any, null, Action<string>>
+> = () => (dispatch, getState) => {
   dispatch(commitSelectedSpecies());
   const committedSpecies = getCommittedSpecies(getState());
   speciesSelectorStorageService.saveSelectedSpecies(committedSpecies);
@@ -110,12 +113,9 @@ export const deleteSpecies = createStandardAction(
   'species_selector/delete_species'
 )<string>();
 
-// FIXME: try types as described here:
-// https://gist.github.com/seansean11/196c436988c1fdf4b22cde308c492fe5
-export const deleteSpeciesAndSave = (genomeId: string) => (
-  dispatch: any,
-  getState: any
-) => {
+export const deleteSpeciesAndSave: ActionCreator<
+  ThunkAction<void, any, null, Action<string>>
+> = (genomeId: string) => (dispatch, getState) => {
   dispatch(deleteSpecies(genomeId));
   const committedSpecies = getCommittedSpecies(getState());
   speciesSelectorStorageService.saveSelectedSpecies(committedSpecies);

--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorActions.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorActions.ts
@@ -2,6 +2,10 @@ import { createStandardAction, createAsyncAction } from 'typesafe-actions';
 
 // import apiService from 'src/services/api-service';
 
+import storageService from 'src/services/storage-service';
+
+import { getCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
+
 import {
   SearchMatch,
   SearchMatches,
@@ -87,6 +91,17 @@ export const commitSelectedSpecies = createStandardAction(
   'species_selector/commit_selected_species'
 )();
 
+// FIXME: try types as described here:
+// https://gist.github.com/seansean11/196c436988c1fdf4b22cde308c492fe5
+export const commitSelectedSpeciesAndSave = () => (
+  dispatch: any,
+  getState: any
+) => {
+  dispatch(commitSelectedSpecies());
+  const committedSpecies = getCommittedSpecies(getState());
+  storageService.save('speciesSelector.selectedSpecies', committedSpecies);
+};
+
 export const toggleSpeciesUse = createStandardAction(
   'species_selector/toggle_species_use'
 )<string>();
@@ -94,6 +109,17 @@ export const toggleSpeciesUse = createStandardAction(
 export const deleteSpecies = createStandardAction(
   'species_selector/delete_species'
 )<string>();
+
+// FIXME: try types as described here:
+// https://gist.github.com/seansean11/196c436988c1fdf4b22cde308c492fe5
+export const deleteSpeciesAndSave = (genomeId: string) => (
+  dispatch: any,
+  getState: any
+) => {
+  dispatch(deleteSpecies(genomeId));
+  const committedSpecies = getCommittedSpecies(getState());
+  storageService.save('speciesSelector.selectedSpecies', committedSpecies);
+};
 
 export const changeAssembly = createStandardAction(
   'species_selector/change_assembly'

--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorActions.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorActions.ts
@@ -2,7 +2,7 @@ import { createStandardAction, createAsyncAction } from 'typesafe-actions';
 
 // import apiService from 'src/services/api-service';
 
-import storageService from 'src/services/storage-service';
+import speciesSelectorStorageService from 'src/content/app/species-selector/services/species-selector-storage-service';
 
 import { getCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 
@@ -99,7 +99,7 @@ export const commitSelectedSpeciesAndSave = () => (
 ) => {
   dispatch(commitSelectedSpecies());
   const committedSpecies = getCommittedSpecies(getState());
-  storageService.save('speciesSelector.selectedSpecies', committedSpecies);
+  speciesSelectorStorageService.saveSelectedSpecies(committedSpecies);
 };
 
 export const toggleSpeciesUse = createStandardAction(
@@ -118,7 +118,7 @@ export const deleteSpeciesAndSave = (genomeId: string) => (
 ) => {
   dispatch(deleteSpecies(genomeId));
   const committedSpecies = getCommittedSpecies(getState());
-  storageService.save('speciesSelector.selectedSpecies', committedSpecies);
+  speciesSelectorStorageService.saveSelectedSpecies(committedSpecies);
 };
 
 export const changeAssembly = createStandardAction(

--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorState.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorState.ts
@@ -1,3 +1,5 @@
+import speciesSelectorStorageService from 'src/content/app/species-selector/services/species-selector-storage-service';
+
 import { LoadingState } from 'src/content/app/species-selector/types/loading-state';
 import {
   SearchMatches,
@@ -33,6 +35,8 @@ export type SpeciesSelectorState = {
   committedItems: CommittedItem[];
 };
 
+const storedSelectedSpecies = speciesSelectorStorageService.getSelectedSpecies();
+
 const initialState: SpeciesSelectorState = {
   loadingStates: {
     search: LoadingState.NOT_REQUESTED
@@ -45,7 +49,7 @@ const initialState: SpeciesSelectorState = {
     results: []
   },
   currentItem: null,
-  committedItems: []
+  committedItems: storedSelectedSpecies || []
 };
 
 export default initialState;

--- a/src/ensembl/src/services/storage-service.ts
+++ b/src/ensembl/src/services/storage-service.ts
@@ -9,12 +9,12 @@ export enum StorageType {
 }
 
 type PrimitiveValue = string | number | boolean | null | undefined;
-type ArrayValue = PrimitiveValue[];
+type ArrayValue = PrimitiveValue[] | ObjectValue[];
 type ObjectValue = {
   [key: string]: PrimitiveValue | ArrayValue | ObjectValue;
 };
 
-type ValueForSaving = PrimitiveValue | ArrayValue | ObjectValue;
+type ValueForSaving = PrimitiveValue | ArrayValue | ArrayValue[] | ObjectValue;
 
 type options = {
   storage: StorageType;

--- a/src/ensembl/src/services/storage-service.ts
+++ b/src/ensembl/src/services/storage-service.ts
@@ -20,13 +20,21 @@ type options = {
   storage: StorageType;
 };
 
+export interface StorageServiceInterface {
+  get: (key: string, options?: options) => any;
+  save: (key: string, value: ValueForSaving, options?: options) => void;
+  update: (key: string, fragment: ObjectValue, options?: options) => void;
+  remove: (key: string, options?: options) => void;
+  clearAll: () => void;
+}
+
 const defaultOptions: options = {
   storage: StorageType.LOCAL_STORAGE
 };
 
 // named export is for testing;
 // for development, use default export
-export class StorageService {
+export class StorageService implements StorageServiceInterface {
   private localStorage: Storage;
   private sessionStorage: Storage;
 

--- a/src/ensembl/src/services/storage-service.ts
+++ b/src/ensembl/src/services/storage-service.ts
@@ -1,18 +1,20 @@
-import windowService from 'src/services/window-service';
+import windowService, {
+  WindowServiceInterface
+} from 'src/services/window-service';
 import merge from 'lodash/merge';
 
-enum StorageType {
+export enum StorageType {
   LOCAL_STORAGE = 'localstorage',
   SESSION_STORAGE = 'sessionstorage'
 }
 
 type PrimitiveValue = string | number | boolean | null | undefined;
+type ArrayValue = PrimitiveValue[];
+type ObjectValue = {
+  [key: string]: PrimitiveValue | ArrayValue | ObjectValue;
+};
 
-type ObjectValue =
-  | PrimitiveValue[]
-  | { [key: string]: PrimitiveValue | ObjectValue };
-
-type ValueForSaving = PrimitiveValue | ObjectValue;
+type ValueForSaving = PrimitiveValue | ArrayValue | ObjectValue;
 
 type options = {
   storage: StorageType;
@@ -22,11 +24,13 @@ const defaultOptions: options = {
   storage: StorageType.LOCAL_STORAGE
 };
 
-class StorageService {
+// named export is for testing;
+// for development, use default export
+export class StorageService {
   private localStorage: Storage;
   private sessionStorage: Storage;
 
-  public constructor() {
+  public constructor(windowService: WindowServiceInterface) {
     this.localStorage = windowService.getLocalStorage();
     this.sessionStorage = windowService.getSessionStorage();
   }
@@ -49,11 +53,7 @@ class StorageService {
   }
 
   // intended only for updating part of the saved object
-  public update(
-    key: string,
-    fragment: { [key: string]: ObjectValue },
-    options = defaultOptions
-  ) {
+  public update(key: string, fragment: ObjectValue, options = defaultOptions) {
     const storedData = this.get(key, options);
     if (storedData) {
       this.save(key, merge(storedData, fragment), options);
@@ -73,4 +73,4 @@ class StorageService {
   }
 }
 
-export default new StorageService();
+export default new StorageService(windowService);

--- a/src/ensembl/src/services/tests/storage-service.test.ts
+++ b/src/ensembl/src/services/tests/storage-service.test.ts
@@ -1,0 +1,60 @@
+import storageService from 'src/services/storage-service';
+import windowService from 'src/services/window-service';
+
+jest.mock('src/services/window-service', () => ({
+  getLocalStorage: jest.fn(),
+  getSessionStorage: jest.fn()
+}));
+
+const mockLocalStorage: any = {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+  clear: jest.fn()
+};
+
+const mockSessionStorage: any = {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+  clear: jest.fn()
+};
+
+describe('storageService', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(windowService, 'getLocalStorage')
+      .mockImplementation(() => mockLocalStorage);
+    jest
+      .spyOn(windowService, 'getSessionStorage')
+      .mockImplementation(() => mockSessionStorage);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('using local sotrage', () => {
+    // This is the default behaviour of storageService
+
+    describe('.get', () => {
+      it('gets data from local storage if the data exists', () => {
+        const key = 'foo';
+        const storedValue = 'something';
+
+        jest
+          .spyOn(mockLocalStorage, 'getItem')
+          .mockImplementation(() => JSON.stringify(storedValue));
+
+        const result = storageService.get(key);
+
+        expect(mockLocalStorage.getItem).toHaveBeenCalledWith(key);
+        expect(result).toBe(storedValue);
+      });
+
+      it('returns null if nothing is stored under provided key', () => {
+        jest.spyOn(mockLocalStorage, 'getItem').mockImplementation(() => null);
+      });
+    });
+  });
+});

--- a/src/ensembl/src/services/tests/storage-service.test.ts
+++ b/src/ensembl/src/services/tests/storage-service.test.ts
@@ -1,10 +1,6 @@
-import storageService from 'src/services/storage-service';
-import windowService from 'src/services/window-service';
-
-jest.mock('src/services/window-service', () => ({
-  getLocalStorage: jest.fn(),
-  getSessionStorage: jest.fn()
-}));
+import { StorageService, StorageType } from 'src/services/storage-service';
+import { WindowServiceInterface } from 'src/services/window-service';
+import faker from 'faker';
 
 const mockLocalStorage: any = {
   getItem: jest.fn(),
@@ -20,41 +16,215 @@ const mockSessionStorage: any = {
   clear: jest.fn()
 };
 
-describe('storageService', () => {
-  beforeEach(() => {
-    jest
-      .spyOn(windowService, 'getLocalStorage')
-      .mockImplementation(() => mockLocalStorage);
-    jest
-      .spyOn(windowService, 'getSessionStorage')
-      .mockImplementation(() => mockSessionStorage);
-  });
+const mockWindowService: WindowServiceInterface = {
+  getLocalStorage: () => mockLocalStorage,
+  getSessionStorage: () => mockSessionStorage
+};
 
+describe('storageService', () => {
   afterEach(() => {
     jest.resetAllMocks();
   });
 
-  describe('using local sotrage', () => {
+  describe('using local storage', () => {
     // This is the default behaviour of storageService
 
-    describe('.get', () => {
+    describe('.get()', () => {
       it('gets data from local storage if the data exists', () => {
-        const key = 'foo';
-        const storedValue = 'something';
+        const key = faker.lorem.word();
+        const storedValue = faker.lorem.words();
 
         jest
           .spyOn(mockLocalStorage, 'getItem')
           .mockImplementation(() => JSON.stringify(storedValue));
 
+        const storageService = new StorageService(mockWindowService);
         const result = storageService.get(key);
 
         expect(mockLocalStorage.getItem).toHaveBeenCalledWith(key);
         expect(result).toBe(storedValue);
+
+        mockLocalStorage.getItem.mockRestore();
       });
 
       it('returns null if nothing is stored under provided key', () => {
+        const key = faker.lorem.word();
         jest.spyOn(mockLocalStorage, 'getItem').mockImplementation(() => null);
+
+        const storageService = new StorageService(mockWindowService);
+        const result = storageService.get(key);
+
+        expect(mockLocalStorage.getItem).toHaveBeenCalledWith(key);
+        expect(result).toBe(null);
+
+        mockLocalStorage.getItem.mockRestore();
       });
+    });
+
+    describe('.save()', () => {
+      it('saves JSON-stringified value in local storage', () => {
+        const key = faker.lorem.word();
+        const value = faker.lorem.words();
+
+        const storageService = new StorageService(mockWindowService);
+        storageService.save(key, value);
+
+        const [passedKey, passedValue] = mockLocalStorage.setItem.mock.calls[0];
+
+        expect(passedKey).toBe(key);
+        expect(passedValue).toBe(JSON.stringify(value));
+      });
+    });
+
+    describe('.update()', () => {
+      it('saves an updated object under the same key', () => {
+        const key = faker.lorem.word();
+        const key1 = faker.lorem.word();
+        const key2 = faker.lorem.word();
+        const value1 = faker.lorem.words();
+        const value2 = faker.lorem.words();
+        const value3 = faker.lorem.words();
+        const obj = { [key1]: value1 };
+        const updateObj = { [key1]: value3, [key2]: value2 };
+
+        jest
+          .spyOn(mockLocalStorage, 'getItem')
+          .mockImplementation(() => JSON.stringify(obj));
+
+        const storageService = new StorageService(mockWindowService);
+        storageService.update(key, updateObj);
+
+        const [passedKey, passedValue] = mockLocalStorage.setItem.mock.calls[0];
+
+        expect(passedKey).toBe(key);
+        expect(passedValue).toBe(JSON.stringify(updateObj));
+
+        mockLocalStorage.getItem.mockRestore();
+      });
+    });
+
+    describe('.remove()', () => {
+      it('removes value stored under provided key', () => {
+        const key = faker.lorem.word();
+
+        const storageService = new StorageService(mockWindowService);
+        storageService.remove(key);
+
+        expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(key);
+      });
+    });
+  });
+
+  describe('using session storage', () => {
+    // Session storage will be used if the appropriate option is provided
+
+    describe('.get()', () => {
+      it('gets data from session storage if the data exists', () => {
+        const key = faker.lorem.word();
+        const storedValue = faker.lorem.words();
+
+        jest
+          .spyOn(mockSessionStorage, 'getItem')
+          .mockImplementation(() => JSON.stringify(storedValue));
+
+        const storageService = new StorageService(mockWindowService);
+        const result = storageService.get(key, {
+          storage: StorageType.SESSION_STORAGE
+        });
+
+        expect(mockSessionStorage.getItem).toHaveBeenCalledWith(key);
+        expect(result).toBe(storedValue);
+
+        mockSessionStorage.getItem.mockRestore();
+      });
+
+      it('returns null if nothing is stored under provided key', () => {
+        const key = faker.lorem.word();
+        jest
+          .spyOn(mockSessionStorage, 'getItem')
+          .mockImplementation(() => null);
+
+        const storageService = new StorageService(mockWindowService);
+        const result = storageService.get(key, {
+          storage: StorageType.SESSION_STORAGE
+        });
+
+        expect(mockSessionStorage.getItem).toHaveBeenCalledWith(key);
+        expect(result).toBe(null);
+
+        mockSessionStorage.getItem.mockRestore();
+      });
+    });
+
+    describe('.save()', () => {
+      it('saves JSON-stringified value in session storage', () => {
+        const key = faker.lorem.word();
+        const value = faker.lorem.words();
+
+        const storageService = new StorageService(mockWindowService);
+        storageService.save(key, value, {
+          storage: StorageType.SESSION_STORAGE
+        });
+
+        const [
+          passedKey,
+          passedValue
+        ] = mockSessionStorage.setItem.mock.calls[0];
+
+        expect(passedKey).toBe(key);
+        expect(passedValue).toBe(JSON.stringify(value));
+      });
+    });
+
+    describe('.update()', () => {
+      it('saves an updated object under the same key', () => {
+        const key = faker.lorem.word();
+        const key1 = faker.lorem.word();
+        const key2 = faker.lorem.word();
+        const value1 = faker.lorem.words();
+        const value2 = faker.lorem.words();
+        const value3 = faker.lorem.words();
+        const obj = { [key1]: value1 };
+        const updateObj = { [key1]: value3, [key2]: value2 };
+
+        jest
+          .spyOn(mockSessionStorage, 'getItem')
+          .mockImplementation(() => JSON.stringify(obj));
+
+        const storageService = new StorageService(mockWindowService);
+        storageService.update(key, updateObj, {
+          storage: StorageType.SESSION_STORAGE
+        });
+
+        const [
+          passedKey,
+          passedValue
+        ] = mockSessionStorage.setItem.mock.calls[0];
+
+        expect(passedKey).toBe(key);
+        expect(passedValue).toBe(JSON.stringify(updateObj));
+      });
+    });
+
+    describe('.remove()', () => {
+      it('removes value stored under provided key', () => {
+        const key = faker.lorem.word();
+
+        const storageService = new StorageService(mockWindowService);
+        storageService.remove(key, { storage: StorageType.SESSION_STORAGE });
+
+        expect(mockSessionStorage.removeItem).toHaveBeenCalledWith(key);
+      });
+    });
+  });
+
+  describe('clearAll', () => {
+    it('clears both localStorage and sessionStorage', () => {
+      const storageService = new StorageService(mockWindowService);
+      storageService.clearAll();
+
+      expect(mockLocalStorage.clear).toHaveBeenCalled();
+      expect(mockSessionStorage.clear).toHaveBeenCalled();
     });
   });
 });

--- a/src/ensembl/src/services/window-service.ts
+++ b/src/ensembl/src/services/window-service.ts
@@ -1,0 +1,16 @@
+/**
+ * This is a simple service whose purpose is to return objects from the window object.
+ * This is helpful for mocking elements of the browser API during tests.
+ */
+
+class WindowService {
+  public getLocalStorage() {
+    return window.localStorage;
+  }
+
+  public getSessionStorage() {
+    return window.sessionStorage;
+  }
+}
+
+export default new WindowService();

--- a/src/ensembl/src/services/window-service.ts
+++ b/src/ensembl/src/services/window-service.ts
@@ -3,6 +3,11 @@
  * This is helpful for mocking elements of the browser API during tests.
  */
 
+export interface WindowServiceInterface {
+  getLocalStorage: () => Storage;
+  getSessionStorage: () => Storage;
+}
+
 class WindowService {
   public getLocalStorage() {
     return window.localStorage;

--- a/src/ensembl/src/services/window-service.ts
+++ b/src/ensembl/src/services/window-service.ts
@@ -8,7 +8,7 @@ export interface WindowServiceInterface {
   getSessionStorage: () => Storage;
 }
 
-class WindowService {
+class WindowService implements WindowServiceInterface {
   public getLocalStorage() {
     return window.localStorage;
   }


### PR DESCRIPTION
This PR adds the storage service for keeping client-side data either in local storage or in session storage. It also uses this storage service for storing selected species between browser reloads.

Related JIRA ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-72