### PR TITLE
Update genome selector location when browser location changes

### DIFF
--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
@@ -135,7 +135,7 @@ export const BrowserBar: FunctionComponent<BrowserBarProps> = (
           <BrowserGenomeSelector
             browserActivated={props.browserActivated}
             dispatchBrowserLocation={props.dispatchBrowserLocation}
-            defaultChrLocation={props.defaultChrLocation}
+            chrLocation={props.chrLocation}
             drawerOpened={props.drawerOpened}
             genomeSelectorActive={props.genomeSelectorActive}
             toggleGenomeSelector={props.toggleGenomeSelector}

--- a/src/ensembl/src/content/app/browser/browser-genome-selector/BrowserGenomeSelector.tsx
+++ b/src/ensembl/src/content/app/browser/browser-genome-selector/BrowserGenomeSelector.tsx
@@ -16,7 +16,7 @@ import { getChrLocationStr } from '../browserHelper';
 
 type BrowserGenomeSelectorProps = {
   browserActivated: boolean;
-  defaultChrLocation: ChrLocation;
+  chrLocation: ChrLocation;
   dispatchBrowserLocation: (chrLocation: ChrLocation) => void;
   drawerOpened: boolean;
   genomeSelectorActive: boolean;
@@ -26,12 +26,12 @@ type BrowserGenomeSelectorProps = {
 const BrowserGenomeSelector: FunctionComponent<BrowserGenomeSelectorProps> = (
   props: BrowserGenomeSelectorProps
 ) => {
-  const chrLocationStr = getChrLocationStr(props.defaultChrLocation);
+  const chrLocationStr = getChrLocationStr(props.chrLocation);
 
   const [chrLocationPlaceholder, setChrLocationPlaceholder] = useState('');
   const [chrLocationInput, setChrLocationInput] = useState('');
 
-  const [chrCode, chrStart, chrEnd] = props.defaultChrLocation;
+  const [chrCode, chrStart, chrEnd] = props.chrLocation;
   const displayChrRegion = chrStart === 0 && chrEnd === 0 ? false : true;
 
   useEffect(() => {


### PR DESCRIPTION
This PR fixes the genome selector in the browser bar to update the browser location whenever the user navigates through the browser.