### PR TITLE
Fix state of tracks in browser app

### DIFF
--- a/src/ensembl/src/content/app/browser/Browser.tsx
+++ b/src/ensembl/src/content/app/browser/Browser.tsx
@@ -3,7 +3,8 @@ import React, {
   useCallback,
   useRef,
   useEffect,
-  Fragment
+  Fragment,
+  useState
 } from 'react';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { connect } from 'react-redux';
@@ -44,6 +45,8 @@ import { toggleDrawer } from './drawer/drawerActions';
 import styles from './Browser.scss';
 
 import 'static/browser/browser.js';
+import browserStorageService from './browser-storage-service';
+import { TrackStates } from './track-panel/trackPanelConfig';
 
 type StateProps = {
   browserActivated: boolean;
@@ -84,12 +87,19 @@ export const Browser: FunctionComponent<BrowserProps> = (
   props: BrowserProps
 ) => {
   const browserRef: React.RefObject<HTMLDivElement> = useRef(null);
+  const [trackStatesFromStorage, setTrackStatesFromStorage] = useState<
+    TrackStates
+  >({});
 
   const dispatchBrowserLocation = (chrLocation: ChrLocation) => {
     if (browserRef.current) {
       props.changeBrowserLocation(chrLocation, browserRef.current);
     }
   };
+
+  useEffect(() => {
+    setTrackStatesFromStorage(browserStorageService.getTrackStates());
+  }, []);
 
   useEffect(() => {
     const { stableId } = props.match.params;
@@ -146,9 +156,15 @@ export const Browser: FunctionComponent<BrowserProps> = (
             browserRef.current ? (
               <BrowserNavBar browserElement={browserRef.current} />
             ) : null}
-            <BrowserImage browserRef={browserRef} />
+            <BrowserImage
+              browserRef={browserRef}
+              trackStates={trackStatesFromStorage}
+            />
           </div>
-          <TrackPanel browserRef={browserRef} />
+          <TrackPanel
+            browserRef={browserRef}
+            trackStates={trackStatesFromStorage}
+          />
           {props.drawerOpened && <Drawer />}
         </div>
       </Fragment>

--- a/src/ensembl/src/content/app/browser/BrowserCogList.scss
+++ b/src/ensembl/src/content/app/browser/BrowserCogList.scss
@@ -4,7 +4,6 @@
   top: 18px;
   bottom: 16px;
   position: absolute;
-  top: 18px;
   overflow: hidden;
 }
 

--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
@@ -21,7 +21,7 @@ import {
   getTrackPanelModalOpened,
   getTrackPanelOpened
 } from '../track-panel/trackPanelSelectors';
-import { selectBrowserTab } from '../track-panel/trackPanelActions';
+import { selectBrowserTabAndSave } from '../track-panel/trackPanelActions';
 import { toggleDrawer } from '../drawer/drawerActions';
 import { RootState } from 'src/store';
 
@@ -45,7 +45,7 @@ type StateProps = {
 };
 
 type DispatchProps = {
-  selectBrowserTab: (selectedBrowserTab: TrackType) => void;
+  selectBrowserTabAndSave: (selectedBrowserTab: TrackType) => void;
   toggleBrowserNav: () => void;
   toggleDrawer: (drawerOpened: boolean) => void;
   toggleGenomeSelector: (genomeSelectorActive: boolean) => void;
@@ -153,7 +153,7 @@ export const BrowserBar: FunctionComponent<BrowserBarProps> = (
         <BrowserTabs
           drawerOpened={props.drawerOpened}
           genomeSelectorActive={props.genomeSelectorActive}
-          selectBrowserTab={props.selectBrowserTab}
+          selectBrowserTabAndSave={props.selectBrowserTabAndSave}
           selectedBrowserTab={props.selectedBrowserTab}
           toggleDrawer={props.toggleDrawer}
           trackPanelModalOpened={props.trackPanelModalOpened}
@@ -209,7 +209,7 @@ const mapStateToProps = (state: RootState): StateProps => ({
 });
 
 const mapDispatchToProps: DispatchProps = {
-  selectBrowserTab,
+  selectBrowserTabAndSave,
   toggleBrowserNav,
   toggleDrawer,
   toggleGenomeSelector

--- a/src/ensembl/src/content/app/browser/browser-image/BrowserImage.tsx
+++ b/src/ensembl/src/content/app/browser/browser-image/BrowserImage.tsx
@@ -23,6 +23,7 @@ import {
   updateChrLocation
 } from '../browserActions';
 import { RootState } from 'src/store';
+import { TrackStates } from '../track-panel/trackPanelConfig';
 
 type StateProps = {
   browserCogTrackList: CogList;
@@ -41,6 +42,7 @@ type DispatchProps = {
 
 type OwnProps = {
   browserRef: RefObject<HTMLDivElement>;
+  trackStates: TrackStates;
 };
 
 type BrowserImageProps = StateProps & DispatchProps & OwnProps;

--- a/src/ensembl/src/content/app/browser/browser-storage-service.test.ts
+++ b/src/ensembl/src/content/app/browser/browser-storage-service.test.ts
@@ -1,0 +1,193 @@
+import { BrowserStorageService, StorageKeys } from './browser-storage-service';
+import { ImageButtonStatus } from 'src/shared/image-button/ImageButton';
+import { TrackType } from './track-panel/trackPanelConfig';
+
+const mockStorageService = {
+  get: jest.fn(),
+  save: jest.fn(),
+  update: jest.fn(),
+  remove: jest.fn(),
+  clearAll: jest.fn()
+};
+
+const trackStates = {
+  main: {
+    'gene-feat': 'active'
+  },
+  Assembly: {
+    gc: 'inactive'
+  }
+};
+
+const trackListToggleStates = {
+  'gene-feat': false
+};
+
+const SELECTED_BROWSER_TAB = TrackType.VARIATION;
+
+describe('BrowserStorageService', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('.getTrackStates()', () => {
+    it('gets saved track states from storage service', () => {
+      jest
+        .spyOn(mockStorageService, 'get')
+        .mockImplementation(() => trackStates);
+
+      const browserStorageService = new BrowserStorageService(
+        mockStorageService
+      );
+
+      const result = browserStorageService.getTrackStates();
+
+      expect(mockStorageService.get).toHaveBeenCalledWith(
+        StorageKeys.TRACK_STATES
+      );
+      expect(result).toEqual(trackStates);
+
+      mockStorageService.get.mockRestore();
+    });
+
+    it('returns an empty object if there are no saved track states', () => {
+      jest.spyOn(mockStorageService, 'get').mockImplementation(() => null);
+
+      const browserStorageService = new BrowserStorageService(
+        mockStorageService
+      );
+      const result = browserStorageService.getTrackStates();
+
+      expect(result).toEqual({});
+
+      mockStorageService.get.mockRestore();
+    });
+  });
+
+  describe('.saveTrackStates()', () => {
+    it('saves track states via storage service', () => {
+      const browserStorageService = new BrowserStorageService(
+        mockStorageService
+      );
+
+      const toggledTrack = {
+        'Genes & transcripts': {
+          'gene-pc-fwd': 'inactive'
+        }
+      };
+
+      browserStorageService.saveTrackStates(
+        'Genes & transcripts',
+        'gene-pc-fwd',
+        ImageButtonStatus.INACTIVE
+      );
+
+      expect(mockStorageService.save).toHaveBeenCalledWith(
+        StorageKeys.TRACK_STATES,
+        toggledTrack
+      );
+    });
+  });
+
+  describe('.getTrackListToggleStates()', () => {
+    it('gets saved track list toggle states from storage service', () => {
+      jest
+        .spyOn(mockStorageService, 'get')
+        .mockImplementation(() => trackListToggleStates);
+
+      const browserStorageService = new BrowserStorageService(
+        mockStorageService
+      );
+
+      const result = browserStorageService.getTrackListToggleStates();
+
+      expect(mockStorageService.get).toHaveBeenCalledWith(
+        StorageKeys.TRACK_LIST_TOGGLE_STATES
+      );
+      expect(result).toEqual(trackListToggleStates);
+
+      mockStorageService.get.mockRestore();
+    });
+
+    it('returns an empty object if there are no saved track list toggle states', () => {
+      jest.spyOn(mockStorageService, 'get').mockImplementation(() => null);
+
+      const browserStorageService = new BrowserStorageService(
+        mockStorageService
+      );
+      const result = browserStorageService.getTrackListToggleStates();
+
+      expect(result).toEqual({});
+
+      mockStorageService.get.mockRestore();
+    });
+  });
+
+  describe('.updateTrackListTogglestates()', () => {
+    it('updates track list toggle states via storage service', () => {
+      const browserStorageService = new BrowserStorageService(
+        mockStorageService
+      );
+
+      const toggledTrackState = {
+        'gene-feat': true
+      };
+
+      browserStorageService.updateTrackListToggleStates(toggledTrackState);
+
+      expect(mockStorageService.update).toHaveBeenCalledWith(
+        StorageKeys.TRACK_LIST_TOGGLE_STATES,
+        toggledTrackState
+      );
+    });
+  });
+
+  describe('.getSelectedBrowserTab()', () => {
+    it('gets saved selected browser tab from storage service', () => {
+      jest
+        .spyOn(mockStorageService, 'get')
+        .mockImplementation(() => SELECTED_BROWSER_TAB);
+
+      const browserStorageService = new BrowserStorageService(
+        mockStorageService
+      );
+
+      const result = browserStorageService.getSelectedBrowserTab();
+
+      expect(mockStorageService.get).toHaveBeenCalledWith(
+        StorageKeys.SELECTED_BROWSER_TAB
+      );
+      expect(result).toEqual(SELECTED_BROWSER_TAB);
+
+      mockStorageService.get.mockRestore();
+    });
+
+    it('returns "GENOMIC" if there is no saved selected browser tab', () => {
+      jest.spyOn(mockStorageService, 'get').mockImplementation(() => null);
+
+      const browserStorageService = new BrowserStorageService(
+        mockStorageService
+      );
+      const result = browserStorageService.getSelectedBrowserTab();
+
+      expect(result).toEqual(TrackType.GENOMIC);
+
+      mockStorageService.get.mockRestore();
+    });
+  });
+
+  describe('.saveSelectedBrowserTab()', () => {
+    it('saves selected browser tab via storage service', () => {
+      const browserStorageService = new BrowserStorageService(
+        mockStorageService
+      );
+
+      browserStorageService.saveSelectedBrowserTab(TrackType.EXPRESSION);
+
+      expect(mockStorageService.save).toHaveBeenCalledWith(
+        StorageKeys.SELECTED_BROWSER_TAB,
+        TrackType.EXPRESSION
+      );
+    });
+  });
+});

--- a/src/ensembl/src/content/app/browser/browser-storage-service.ts
+++ b/src/ensembl/src/content/app/browser/browser-storage-service.ts
@@ -25,7 +25,7 @@ export class BrowserStorageService {
     return this.storageService.get(StorageKeys.TRACK_STATES) || {};
   }
 
-  public saveTrackState(
+  public saveTrackStates(
     categoryName: string,
     trackName: string,
     trackStatus: ImageButtonStatus

--- a/src/ensembl/src/content/app/browser/browser-storage-service.ts
+++ b/src/ensembl/src/content/app/browser/browser-storage-service.ts
@@ -10,7 +10,7 @@ import { ImageButtonStatus } from 'src/shared/image-button/ImageButton';
 
 export enum StorageKeys {
   TRACK_STATES = 'browser.trackStates',
-  TRACK_TOGGLE_STATES = 'browser.trackToggleStates',
+  TRACK_LIST_TOGGLE_STATES = 'browser.trackListToggleStates',
   SELECTED_TAB = 'browser.selectedBrowserTab'
 }
 
@@ -41,12 +41,15 @@ export class BrowserStorageService {
     this.storageService.save(StorageKeys.TRACK_STATES, trackStates);
   }
 
-  public getTrackToggleStates(): TrackToggleStates {
-    return this.storageService.get(StorageKeys.TRACK_TOGGLE_STATES) || {};
+  public getTrackListToggleStates(): TrackToggleStates {
+    return this.storageService.get(StorageKeys.TRACK_LIST_TOGGLE_STATES) || {};
   }
 
-  public updateTrackToggleStates(toggleState: TrackToggleStates) {
-    this.storageService.update(StorageKeys.TRACK_TOGGLE_STATES, toggleState);
+  public updateTrackListToggleStates(toggleState: TrackToggleStates) {
+    this.storageService.update(
+      StorageKeys.TRACK_LIST_TOGGLE_STATES,
+      toggleState
+    );
   }
 
   public getSelectedBrowserTab(): TrackType {

--- a/src/ensembl/src/content/app/browser/browser-storage-service.ts
+++ b/src/ensembl/src/content/app/browser/browser-storage-service.ts
@@ -1,11 +1,16 @@
 import storageService, {
   StorageServiceInterface
 } from 'src/services/storage-service';
-import { TrackStates, TrackType } from './track-panel/trackPanelConfig';
+import {
+  TrackStates,
+  TrackType,
+  TrackToggleStates
+} from './track-panel/trackPanelConfig';
 import { ImageButtonStatus } from 'src/shared/image-button/ImageButton';
 
 export enum StorageKeys {
   TRACK_STATES = 'browser.trackStates',
+  TRACK_TOGGLE_STATES = 'browser.trackToggleStates',
   SELECTED_TAB = 'browser.selectedBrowserTab'
 }
 
@@ -34,6 +39,14 @@ export class BrowserStorageService {
     trackStates[categoryName][trackName] = trackStatus;
 
     this.storageService.save(StorageKeys.TRACK_STATES, trackStates);
+  }
+
+  public getTrackToggleStates(): TrackToggleStates {
+    return this.storageService.get(StorageKeys.TRACK_TOGGLE_STATES) || {};
+  }
+
+  public updateTrackToggleStates(toggleState: TrackToggleStates) {
+    this.storageService.update(StorageKeys.TRACK_TOGGLE_STATES, toggleState);
   }
 
   public getSelectedBrowserTab(): TrackType {

--- a/src/ensembl/src/content/app/browser/browser-storage-service.ts
+++ b/src/ensembl/src/content/app/browser/browser-storage-service.ts
@@ -1,0 +1,39 @@
+import storageService, {
+  StorageServiceInterface
+} from 'src/services/storage-service';
+import { TrackStates } from './track-panel/trackPanelConfig';
+import { ImageButtonStatus } from 'src/shared/image-button/ImageButton';
+
+export enum StorageKeys {
+  TRACK_STATES = 'browser.trackStates'
+}
+
+export class BrowserStorageService {
+  private storageService: StorageServiceInterface;
+
+  public constructor(storageService: StorageServiceInterface) {
+    this.storageService = storageService;
+  }
+
+  public getTrackStates(): TrackStates {
+    return this.storageService.get(StorageKeys.TRACK_STATES) || {};
+  }
+
+  public saveTrackState(
+    categoryName: string,
+    trackName: string,
+    trackStatus: ImageButtonStatus
+  ) {
+    const trackStates = this.getTrackStates();
+
+    if (!trackStates[categoryName]) {
+      trackStates[categoryName] = {};
+    }
+
+    trackStates[categoryName][trackName] = trackStatus;
+
+    this.storageService.save(StorageKeys.TRACK_STATES, trackStates);
+  }
+}
+
+export default new BrowserStorageService(storageService);

--- a/src/ensembl/src/content/app/browser/browser-storage-service.ts
+++ b/src/ensembl/src/content/app/browser/browser-storage-service.ts
@@ -11,7 +11,7 @@ import { ImageButtonStatus } from 'src/shared/image-button/ImageButton';
 export enum StorageKeys {
   TRACK_STATES = 'browser.trackStates',
   TRACK_LIST_TOGGLE_STATES = 'browser.trackListToggleStates',
-  SELECTED_TAB = 'browser.selectedBrowserTab'
+  SELECTED_BROWSER_TAB = 'browser.selectedBrowserTab'
 }
 
 export class BrowserStorageService {
@@ -54,12 +54,13 @@ export class BrowserStorageService {
 
   public getSelectedBrowserTab(): TrackType {
     return (
-      this.storageService.get(StorageKeys.SELECTED_TAB) || TrackType.GENOMIC
+      this.storageService.get(StorageKeys.SELECTED_BROWSER_TAB) ||
+      TrackType.GENOMIC
     );
   }
 
   public saveSelectedBrowserTab(selectedTab: TrackType) {
-    this.storageService.save(StorageKeys.SELECTED_TAB, selectedTab);
+    this.storageService.save(StorageKeys.SELECTED_BROWSER_TAB, selectedTab);
   }
 }
 

--- a/src/ensembl/src/content/app/browser/browser-storage-service.ts
+++ b/src/ensembl/src/content/app/browser/browser-storage-service.ts
@@ -1,11 +1,12 @@
 import storageService, {
   StorageServiceInterface
 } from 'src/services/storage-service';
-import { TrackStates } from './track-panel/trackPanelConfig';
+import { TrackStates, TrackType } from './track-panel/trackPanelConfig';
 import { ImageButtonStatus } from 'src/shared/image-button/ImageButton';
 
 export enum StorageKeys {
-  TRACK_STATES = 'browser.trackStates'
+  TRACK_STATES = 'browser.trackStates',
+  SELECTED_TAB = 'browser.selectedBrowserTab'
 }
 
 export class BrowserStorageService {
@@ -33,6 +34,16 @@ export class BrowserStorageService {
     trackStates[categoryName][trackName] = trackStatus;
 
     this.storageService.save(StorageKeys.TRACK_STATES, trackStates);
+  }
+
+  public getSelectedBrowserTab(): TrackType {
+    return (
+      this.storageService.get(StorageKeys.SELECTED_TAB) || TrackType.GENOMIC
+    );
+  }
+
+  public saveSelectedBrowserTab(selectedTab: TrackType) {
+    this.storageService.save(StorageKeys.SELECTED_TAB, selectedTab);
   }
 }
 

--- a/src/ensembl/src/content/app/browser/browser-tabs/BrowserTabs.tsx
+++ b/src/ensembl/src/content/app/browser/browser-tabs/BrowserTabs.tsx
@@ -7,7 +7,7 @@ import styles from './BrowserTabs.scss';
 type BrowserTabsProps = {
   drawerOpened: boolean;
   genomeSelectorActive: boolean;
-  selectBrowserTab: (selectedBrowserTab: TrackType) => void;
+  selectBrowserTabAndSave: (selectedBrowserTab: TrackType) => void;
   selectedBrowserTab: TrackType;
   toggleDrawer: (drawerOpened: boolean) => void;
   trackPanelModalOpened: boolean;
@@ -50,7 +50,7 @@ const BrowserTabs: FunctionComponent<BrowserTabsProps> = (
           props.toggleDrawer(false);
         }
 
-        props.selectBrowserTab(value);
+        props.selectBrowserTabAndSave(value);
       };
     });
 

--- a/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
@@ -38,7 +38,7 @@ import { getLaunchbarExpanded } from 'src/header/headerSelectors';
 import { getBreakpointWidth } from 'src/global/globalSelectors';
 import { ChrLocation } from '../browserState';
 import { BreakpointWidth } from 'src/global/globalConfig';
-import { TrackType, TrackPanelCategory } from './trackPanelConfig';
+import { TrackType, TrackPanelCategory, TrackStates } from './trackPanelConfig';
 
 import styles from './TrackPanel.scss';
 
@@ -68,6 +68,7 @@ type DispatchProps = {
 
 type OwnProps = {
   browserRef: RefObject<HTMLDivElement>;
+  trackStates: TrackStates;
 };
 
 type TrackPanelProps = StateProps & DispatchProps & OwnProps;
@@ -110,6 +111,7 @@ const TrackPanel: FunctionComponent<TrackPanelProps> = (
                 selectedBrowserTab={props.selectedBrowserTab}
                 toggleDrawer={props.toggleDrawer}
                 trackCategories={props.trackCategories}
+                trackStates={props.trackStates}
                 updateDrawerView={props.changeDrawerView}
               />
               {props.trackPanelModalOpened ? (

--- a/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
@@ -38,7 +38,7 @@ import { getLaunchbarExpanded } from 'src/header/headerSelectors';
 import { getBreakpointWidth } from 'src/global/globalSelectors';
 import { ChrLocation } from '../browserState';
 import { BreakpointWidth } from 'src/global/globalConfig';
-import { TrackType } from './trackPanelConfig';
+import { TrackType, TrackPanelCategory } from './trackPanelConfig';
 
 import styles from './TrackPanel.scss';
 
@@ -52,7 +52,7 @@ type StateProps = {
   exampleEnsObjects: any;
   launchbarExpanded: boolean;
   selectedBrowserTab: TrackType;
-  trackCategories: [];
+  trackCategories: TrackPanelCategory[];
   trackPanelModalOpened: boolean;
   trackPanelModalView: string;
   trackPanelOpened: boolean;

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.tsx
@@ -26,14 +26,16 @@ type TrackPanelListProps = {
   ensObjectInfo: any;
   selectedBrowserTab: TrackType;
   toggleDrawer: (drawerOpened: boolean) => void;
-  trackCategories: [];
+  trackCategories: TrackPanelCategory[];
   updateDrawerView: (drawerView: string) => void;
 };
 
 const TrackPanelList: FunctionComponent<TrackPanelListProps> = (
   props: TrackPanelListProps
 ) => {
-  const [currentTrackCategories, setCurrentTrackCategories] = useState([]);
+  const [currentTrackCategories, setCurrentTrackCategories] = useState<
+    TrackPanelCategory[]
+  >([]);
 
   useEffect(() => {
     if (props.trackCategories.length > 0) {

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.tsx
@@ -11,11 +11,13 @@ import TrackPanelListItem from './TrackPanelListItem';
 import {
   TrackPanelCategory,
   TrackPanelItem,
-  TrackType
+  TrackType,
+  TrackStates
 } from '../trackPanelConfig';
 import { ChrLocation } from '../../browserState';
 
 import styles from './TrackPanelList.scss';
+import { ImageButtonStatus } from 'src/shared/image-button/ImageButton';
 
 type TrackPanelListProps = {
   browserRef: RefObject<HTMLDivElement>;
@@ -27,6 +29,7 @@ type TrackPanelListProps = {
   selectedBrowserTab: TrackType;
   toggleDrawer: (drawerOpened: boolean) => void;
   trackCategories: TrackPanelCategory[];
+  trackStates: TrackStates;
   updateDrawerView: (drawerView: string) => void;
 };
 
@@ -105,7 +108,22 @@ const TrackPanelList: FunctionComponent<TrackPanelListProps> = (
     };
   };
 
-  const getTrackListItem = (track: TrackPanelItem | null) => {
+  const getDefaultTrackStatus = (categoryName: string, trackName: string) => {
+    const statesOfCategory = props.trackStates[categoryName];
+
+    let defaultTrackStatus = ImageButtonStatus.ACTIVE;
+
+    if (statesOfCategory && statesOfCategory[trackName]) {
+      defaultTrackStatus = statesOfCategory[trackName];
+    }
+
+    return defaultTrackStatus;
+  };
+
+  const getTrackListItem = (
+    categoryName: string,
+    track: TrackPanelItem | null
+  ) => {
     if (!track) {
       return;
     }
@@ -113,6 +131,8 @@ const TrackPanelList: FunctionComponent<TrackPanelListProps> = (
     return (
       <TrackPanelListItem
         browserRef={props.browserRef}
+        categoryName={categoryName}
+        defaultTrackStatus={getDefaultTrackStatus(categoryName, track.name)}
         drawerOpened={props.drawerOpened}
         drawerView={props.drawerView}
         key={track.id}
@@ -121,7 +141,7 @@ const TrackPanelList: FunctionComponent<TrackPanelListProps> = (
       >
         {track.childTrackList &&
           track.childTrackList.map((childTrack: TrackPanelItem) =>
-            getTrackListItem(childTrack)
+            getTrackListItem(categoryName, childTrack)
           )}
       </TrackPanelListItem>
     );
@@ -130,7 +150,7 @@ const TrackPanelList: FunctionComponent<TrackPanelListProps> = (
   return (
     <div className={getTrackPanelListClasses()}>
       <section>
-        <dl>{getTrackListItem(getMainTracks())}</dl>
+        <dl>{getTrackListItem('main', getMainTracks())}</dl>
       </section>
       {currentTrackCategories.map((category: TrackPanelCategory) => (
         <section key={category.name}>
@@ -138,7 +158,7 @@ const TrackPanelList: FunctionComponent<TrackPanelListProps> = (
           <dl>
             {category.trackList.length ? (
               category.trackList.map((track: TrackPanelItem) =>
-                getTrackListItem(track)
+                getTrackListItem(category.name, track)
               )
             ) : (
               <dd className={styles.emptyListMsg}>No data available</dd>

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
@@ -45,7 +45,7 @@ const TrackPanelListItem: FunctionComponent<TrackPanelListItemProps> = (
   const { browserRef, categoryName, drawerView, track } = props;
 
   useEffect(() => {
-    const trackToggleStates = browserStorageService.getTrackToggleStates();
+    const trackToggleStates = browserStorageService.getTrackListToggleStates();
 
     if (track.childTrackList && trackToggleStates[track.name] !== undefined) {
       setExpanded(trackToggleStates[`${track.name}`]);
@@ -98,7 +98,7 @@ const TrackPanelListItem: FunctionComponent<TrackPanelListItemProps> = (
   const toggleExpand = () => {
     setExpanded(!expanded);
 
-    browserStorageService.updateTrackToggleStates({
+    browserStorageService.updateTrackListToggleStates({
       [`${track.name}`]: !expanded
     });
   };

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
@@ -124,7 +124,7 @@ const TrackPanelListItem: FunctionComponent<TrackPanelListItemProps> = (
         : ImageButtonStatus.ACTIVE;
 
     setTrackStatus(newImageButtonStatus);
-    browserStorageService.saveTrackState(
+    browserStorageService.saveTrackStates(
       categoryName,
       track.name,
       newImageButtonStatus

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
@@ -5,7 +5,8 @@ import React, {
   ReactNode,
   RefObject,
   useState,
-  useCallback
+  useCallback,
+  useEffect
 } from 'react';
 
 import { TrackItemColour, TrackPanelItem } from '../trackPanelConfig';
@@ -42,6 +43,14 @@ const TrackPanelListItem: FunctionComponent<TrackPanelListItemProps> = (
   const [expanded, setExpanded] = useState(true);
   const [trackStatus, setTrackStatus] = useState(props.defaultTrackStatus);
   const { browserRef, categoryName, drawerView, track } = props;
+
+  useEffect(() => {
+    const trackToggleStates = browserStorageService.getTrackToggleStates();
+
+    if (track.childTrackList && trackToggleStates[track.name] !== undefined) {
+      setExpanded(trackToggleStates[`${track.name}`]);
+    }
+  }, []);
 
   const getListItemClasses = useCallback((): string => {
     let classNames: string = styles.listItem;
@@ -88,6 +97,10 @@ const TrackPanelListItem: FunctionComponent<TrackPanelListItemProps> = (
 
   const toggleExpand = () => {
     setExpanded(!expanded);
+
+    browserStorageService.updateTrackToggleStates({
+      [`${track.name}`]: !expanded
+    });
   };
 
   const toggleTrack = () => {

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
@@ -20,10 +20,13 @@ import styles from './TrackPanelListItem.scss';
 import ImageButton, {
   ImageButtonStatus
 } from 'src/shared/image-button/ImageButton';
+import browserStorageService from '../../browser-storage-service';
 
 type TrackPanelListItemProps = {
   browserRef: RefObject<HTMLDivElement>;
+  categoryName: string;
   children?: ReactNode[];
+  defaultTrackStatus: ImageButtonStatus;
   drawerOpened: boolean;
   drawerView: string;
   track: TrackPanelItem;
@@ -37,9 +40,8 @@ const TrackPanelListItem: FunctionComponent<TrackPanelListItemProps> = (
   props: TrackPanelListItemProps
 ) => {
   const [expanded, setExpanded] = useState(true);
-  const [trackStatus, setTrackStatus] = useState(ImageButtonStatus.ACTIVE);
-
-  const { browserRef, drawerView, track } = props;
+  const [trackStatus, setTrackStatus] = useState(props.defaultTrackStatus);
+  const { browserRef, categoryName, drawerView, track } = props;
 
   const getListItemClasses = useCallback((): string => {
     let classNames: string = styles.listItem;
@@ -103,11 +105,17 @@ const TrackPanelListItem: FunctionComponent<TrackPanelListItemProps> = (
       browserRef.current.dispatchEvent(trackEvent);
     }
 
-    if (trackStatus === ImageButtonStatus.ACTIVE) {
-      setTrackStatus(ImageButtonStatus.INACTIVE);
-      return;
-    }
-    setTrackStatus(ImageButtonStatus.ACTIVE);
+    const newImageButtonStatus =
+      trackStatus === ImageButtonStatus.ACTIVE
+        ? ImageButtonStatus.INACTIVE
+        : ImageButtonStatus.ACTIVE;
+
+    setTrackStatus(newImageButtonStatus);
+    browserStorageService.saveTrackState(
+      categoryName,
+      track.name,
+      newImageButtonStatus
+    );
   };
 
   return (

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
@@ -2,6 +2,7 @@ import { createAction } from 'typesafe-actions';
 
 import { TrackType } from './trackPanelConfig';
 import { getTrackPanelAnalyticsObject } from 'src/analyticsHelper';
+import browserStorageService from '../browser-storage-service';
 
 export const toggleTrackPanel = createAction(
   'track-panel/toggle-track-panel',
@@ -14,10 +15,13 @@ export const toggleTrackPanel = createAction(
   }
 );
 
-export const selectBrowserTab = createAction(
+export const selectBrowserTabAndSave = createAction(
   'select-browser-tab',
   (resolve) => {
-    return (selectedBrowserTab: TrackType) => resolve(selectedBrowserTab);
+    return (selectedBrowserTab: TrackType) => {
+      browserStorageService.saveSelectedBrowserTab(selectedBrowserTab);
+      return resolve(selectedBrowserTab);
+    };
   }
 );
 

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelConfig.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelConfig.ts
@@ -1,3 +1,5 @@
+import { ImageButtonStatus } from 'src/shared/image-button/ImageButton';
+
 export enum TrackItemColour {
   BLUE = 'blue',
   DARK_GREY = 'darkGrey',
@@ -38,4 +40,10 @@ export type TrackPanelIcon = {
 
 export type TrackPanelIcons = {
   [key: string]: TrackPanelIcon;
+};
+
+export type TrackStates = {
+  [key: string]: {
+    [key: string]: ImageButtonStatus;
+  };
 };

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelConfig.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelConfig.ts
@@ -47,3 +47,7 @@ export type TrackStates = {
     [key: string]: ImageButtonStatus;
   };
 };
+
+export type TrackToggleStates = {
+  [key: string]: boolean;
+};

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelReducer.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelReducer.ts
@@ -28,7 +28,7 @@ export default function trackPanel(
         trackPanelModalOpened: false,
         trackPanelModalView: ''
       };
-    case getType(trackPanelActions.selectBrowserTab):
+    case getType(trackPanelActions.selectBrowserTabAndSave):
       return {
         ...state,
         selectedBrowserTab: action.payload,

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
@@ -1,4 +1,7 @@
 import { TrackType } from './trackPanelConfig';
+import browserStorageService from '../browser-storage-service';
+
+const selectedBrowserTab = browserStorageService.getSelectedBrowserTab();
 
 export type TrackPanelState = Readonly<{
   selectedBrowserTab: TrackType;
@@ -8,7 +11,7 @@ export type TrackPanelState = Readonly<{
 }>;
 
 export const defaultTrackPanelState: TrackPanelState = {
-  selectedBrowserTab: TrackType.GENOMIC,
+  selectedBrowserTab: selectedBrowserTab || TrackType.GENOMIC,
   trackPanelModalOpened: false,
   trackPanelModalView: '',
   trackPanelOpened: true

--- a/src/ensembl/src/ens-object/ensObjectActions.ts
+++ b/src/ensembl/src/ens-object/ensObjectActions.ts
@@ -1,13 +1,14 @@
 import { createAsyncAction } from 'typesafe-actions';
 import { Dispatch } from 'redux';
 
+import { EnsObject } from './ensObjectTypes';
 import apiService from 'src/services/api-service';
 
 export const fetchEnsObject = createAsyncAction(
   'ens-object/fetch_ens_object_request',
   'ens-object/fetch_ens_object_success',
   'ens-object/fetch_ens_object_failure'
-)<string, {}, Error>();
+)<string, EnsObject, Error>();
 
 export const fetchEnsObjectData = (ensObjectId: string) => async (
   dispatch: Dispatch
@@ -16,7 +17,7 @@ export const fetchEnsObjectData = (ensObjectId: string) => async (
     dispatch(fetchEnsObject.request(ensObjectId));
 
     const url = `/browser/get_object_info/${ensObjectId}`;
-    const response = await apiService.fetch(url);
+    const response: EnsObject = await apiService.fetch(url);
     dispatch(fetchEnsObject.success(response));
   } catch (error) {
     dispatch(fetchEnsObject.failure(error));

--- a/src/ensembl/src/ens-object/ensObjectReducer.ts
+++ b/src/ensembl/src/ens-object/ensObjectReducer.ts
@@ -3,16 +3,16 @@ import { combineReducers } from 'redux';
 
 import * as objectActions from './ensObjectActions';
 import {
+  CurrentEnsObjectState,
+  defaultCurrentEnsObjectState,
   ExampleEnsObjectState,
-  defaultExampleEnsObjectState,
-  EnsObjectInfoState,
-  defaultEnsObjectInfoState
+  defaultExampleEnsObjectState
 } from './ensObjectState';
 
-function ensObjectInfo(
-  state: EnsObjectInfoState = defaultEnsObjectInfoState,
+function currentEnsObject(
+  state: CurrentEnsObjectState = defaultCurrentEnsObjectState,
   action: ActionType<typeof objectActions>
-): EnsObjectInfoState {
+): CurrentEnsObjectState {
   switch (action.type) {
     case getType(objectActions.fetchEnsObject.failure):
       return { ...state, ensObjectFetchFailed: true };
@@ -23,19 +23,12 @@ function ensObjectInfo(
         ensObjectFetching: true
       };
     case getType(objectActions.fetchEnsObject.success):
-      type Payload = {
-        object_info: {};
-        track_categories: [];
-      };
-
-      const json = action.payload as Payload;
-
       return {
         ...state,
-        ensObject: json.object_info,
+        ensObjectInfo: action.payload.object_info,
         ensObjectFetchFailed: false,
         ensObjectFetching: false,
-        trackCategories: json.track_categories
+        trackCategories: action.payload.track_categories
       };
     default:
       return state;
@@ -74,6 +67,6 @@ function exampleEnsObjects(
 }
 
 export default combineReducers({
-  ensObjectInfo,
+  currentEnsObject,
   exampleEnsObjects
 });

--- a/src/ensembl/src/ens-object/ensObjectSelectors.ts
+++ b/src/ensembl/src/ens-object/ensObjectSelectors.ts
@@ -1,16 +1,18 @@
 import { RootState } from '../store';
+import { EnsObjectInfo } from './ensObjectTypes';
+import { TrackPanelCategory } from 'src/content/app/browser/track-panel/trackPanelConfig';
 
 export const getEnsObjectFetchFailed = (state: RootState) =>
-  state.ensObject.ensObjectInfo.ensObjectFetchFailed;
+  state.ensObject.currentEnsObject.ensObjectFetchFailed;
 
 export const getEnsObjectFetching = (state: RootState) =>
-  state.ensObject.ensObjectInfo.ensObjectFetching;
+  state.ensObject.currentEnsObject.ensObjectFetching;
 
-export const getEnsObjectInfo = (state: RootState) =>
-  state.ensObject.ensObjectInfo.ensObject;
+export const getEnsObjectInfo = (state: RootState): EnsObjectInfo =>
+  state.ensObject.currentEnsObject.ensObjectInfo as EnsObjectInfo;
 
-export const getTrackCategories = (state: RootState): [] =>
-  state.ensObject.ensObjectInfo.trackCategories;
+export const getTrackCategories = (state: RootState): TrackPanelCategory[] =>
+  state.ensObject.currentEnsObject.trackCategories as TrackPanelCategory[];
 
 export const getExampleEnsObjectsFetchFailed = (state: RootState) =>
   state.ensObject.exampleEnsObjects.exampleEnsObjectsFetchFailed;

--- a/src/ensembl/src/ens-object/ensObjectState.ts
+++ b/src/ensembl/src/ens-object/ensObjectState.ts
@@ -1,12 +1,15 @@
-export type EnsObjectInfoState = Readonly<{
-  ensObject: object;
+import { EnsObject } from './ensObjectTypes';
+import { TrackPanelCategory } from 'src/content/app/browser/track-panel/trackPanelConfig';
+
+export type CurrentEnsObjectState = Readonly<{
+  ensObjectInfo: EnsObject | {};
   ensObjectFetchFailed: boolean;
   ensObjectFetching: boolean;
-  trackCategories: [];
+  trackCategories: TrackPanelCategory[] | [];
 }>;
 
-export const defaultEnsObjectInfoState: EnsObjectInfoState = {
-  ensObject: {},
+export const defaultCurrentEnsObjectState: CurrentEnsObjectState = {
+  ensObjectInfo: {},
   ensObjectFetchFailed: false,
   ensObjectFetching: false,
   trackCategories: []

--- a/src/ensembl/src/ens-object/ensObjectTypes.ts
+++ b/src/ensembl/src/ens-object/ensObjectTypes.ts
@@ -1,0 +1,35 @@
+import { TrackPanelCategory } from 'src/content/app/browser/track-panel/trackPanelConfig';
+
+export type Assembly = {
+  name: string;
+  patch: string;
+};
+
+export enum Strand {
+  FORWARD = 'forward',
+  REVERSE = 'reverse'
+}
+
+export type AssociatedObject = {
+  obj_symbol?: string;
+  obj_type: string;
+  selected_info: string;
+  spliced_length: number;
+  stable_id: string;
+};
+
+export type EnsObjectInfo = {
+  assembly: Assembly;
+  associated_object: AssociatedObject;
+  bio_type: string;
+  obj_symbol: string;
+  obj_type: string;
+  spliced_length: number;
+  stable_id: string;
+  strand: Strand;
+};
+
+export type EnsObject = {
+  object_info: EnsObjectInfo;
+  track_categories: TrackPanelCategory[];
+};


### PR DESCRIPTION
This PR fixes the browser tracks not being saved when navigated away from the browser app. Also, the following are persisted via web storage:

- Track list tabs
- Track list groups

TODO:

- [ ] Write tests

The related JIRA ticket is: https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-83