### PR TITLE
Add index file for shared components

### DIFF
--- a/src/ensembl/src/shared/index.tsx
+++ b/src/ensembl/src/shared/index.tsx
@@ -1,0 +1,65 @@
+import {
+  Accordion,
+  AccordionItem,
+  AccordionItemButton,
+  AccordionItemHeading,
+  AccordionItemPanel,
+  AccordionItemState,
+  AccordionItemPermanentBlock
+} from './accordion';
+import Checkbox from './checkbox/Checkbox';
+import Input from './input/Input';
+import BadgedButton from 'src/shared/badged-button/BadgedButton';
+import Button, {
+  PrimaryButton,
+  SecondaryButton
+} from 'src/shared/button/Button';
+import RoundButton, {
+  RoundButtonStatus
+} from 'src/shared/round-button/RoundButton';
+import ImageButton, { ImageButtonStatus } from './image-button/ImageButton';
+import AutosuggestSearchField from './autosuggest-search-field/AutosuggestSearchField';
+import CloseButton from './close-button/CloseButton';
+import Dropdown from './dropdown/Dropdown';
+import { CircleLoader } from './loader/Loader';
+import QuestionButton from './question-button/QuestionButton';
+import SearchField from './search-field/SearchField';
+import SelectAdapter, {
+  Option,
+  OptionGroup,
+  GroupedOptionIndex
+} from './select/Select';
+import SpeciesTab from './species-tab/SpeciesTab';
+import SpeciesTabBar from './species-tab-bar/SpeciesTabBar';
+
+export {
+  Accordion,
+  AccordionItem,
+  AccordionItemButton,
+  AccordionItemHeading,
+  AccordionItemPanel,
+  AccordionItemState,
+  AccordionItemPermanentBlock,
+  AutosuggestSearchField,
+  Button,
+  BadgedButton,
+  CloseButton,
+  Checkbox,
+  Dropdown,
+  Input,
+  ImageButton,
+  ImageButtonStatus,
+  CircleLoader,
+  QuestionButton,
+  PrimaryButton,
+  SearchField,
+  SecondaryButton,
+  SelectAdapter,
+  Option,
+  OptionGroup,
+  GroupedOptionIndex,
+  SpeciesTab,
+  SpeciesTabBar,
+  RoundButton,
+  RoundButtonStatus
+};


### PR DESCRIPTION
Added an index file inside the shared components folder that makes the importing of components a little easier.

**For example:**
We can now use
`import Button from 'src/shared';`

instead of:
`import Button from 'src/shared/button/Button';`