### PR TITLE
Conditionally enable link to Genome Browser in Launchbar

### DIFF
--- a/src/ensembl/src/header/launchbar/Launchbar.test.tsx
+++ b/src/ensembl/src/header/launchbar/Launchbar.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { LaunchbarContent } from './Launchbar';
+
+import { createSelectedSpecies } from 'tests/fixtures/selected-species';
+
+const defaultProps = {
+  launchbarExpanded: true,
+  committedSpecies: []
+};
+
+describe('<LaunchbarContent />', () => {
+  it('disables Genome Browser button when there are no committed species', () => {
+    const shallowWrapper = shallow(<LaunchbarContent {...defaultProps} />);
+    const genomeBrowserButton = shallowWrapper.findWhere(
+      (wrapper) => wrapper.prop('app') === 'browser'
+    );
+
+    expect(genomeBrowserButton.prop('enabled')).toBe(false);
+  });
+
+  it('enables Genome Browser button when there are committed species', () => {
+    const props = {
+      ...defaultProps,
+      committedSpecies: [createSelectedSpecies()]
+    };
+    const shallowWrapper = shallow(<LaunchbarContent {...props} />);
+    const genomeBrowserButton = shallowWrapper.findWhere(
+      (wrapper) => wrapper.prop('app') === 'browser'
+    );
+
+    expect(genomeBrowserButton.prop('enabled')).toBe(true);
+  });
+});

--- a/src/ensembl/src/header/launchbar/Launchbar.test.tsx
+++ b/src/ensembl/src/header/launchbar/Launchbar.test.tsx
@@ -1,19 +1,24 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
-import { LaunchbarContent } from './Launchbar';
+import Launchbar from './Launchbar';
 
 import { createSelectedSpecies } from 'tests/fixtures/selected-species';
+
+jest.mock('react-slidedown', () => (props: any) => (
+  <div className="react-slidedown">{props.children}</div>
+));
+jest.mock('./LaunchbarButton', () => () => <div>Launchbar Button</div>);
 
 const defaultProps = {
   launchbarExpanded: true,
   committedSpecies: []
 };
 
-describe('<LaunchbarContent />', () => {
+describe('<Launchbar />', () => {
   it('disables Genome Browser button when there are no committed species', () => {
-    const shallowWrapper = shallow(<LaunchbarContent {...defaultProps} />);
-    const genomeBrowserButton = shallowWrapper.findWhere(
+    const wrapper = mount(<Launchbar {...defaultProps} />);
+    const genomeBrowserButton = wrapper.findWhere(
       (wrapper) => wrapper.prop('app') === 'browser'
     );
 
@@ -25,8 +30,8 @@ describe('<LaunchbarContent />', () => {
       ...defaultProps,
       committedSpecies: [createSelectedSpecies()]
     };
-    const shallowWrapper = shallow(<LaunchbarContent {...props} />);
-    const genomeBrowserButton = shallowWrapper.findWhere(
+    const wrapper = mount(<Launchbar {...props} />);
+    const genomeBrowserButton = wrapper.findWhere(
       (wrapper) => wrapper.prop('app') === 'browser'
     );
 

--- a/src/ensembl/src/header/launchbar/Launchbar.tsx
+++ b/src/ensembl/src/header/launchbar/Launchbar.tsx
@@ -25,7 +25,7 @@ export const getCategoryClass = (separator: boolean): string => {
   return separator ? 'border' : '';
 };
 
-export const LaunchbarContent = (props: LaunchbarProps) => (
+const LaunchbarContent = (props: LaunchbarProps) => (
   <div className={styles.launchbar}>
     <div className={styles.categoriesWrapper}>
       <div className={styles.categories}>

--- a/src/ensembl/src/header/launchbar/Launchbar.tsx
+++ b/src/ensembl/src/header/launchbar/Launchbar.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import SlideDown from 'react-slidedown';
+
+import { getCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 
 import ensemblIcon from 'static/img/launchbar/ensembl-logo.png'; // <-- note it's a png
 
@@ -14,15 +17,19 @@ import LaunchbarButton from './LaunchbarButton';
 
 import styles from './Launchbar.scss';
 
+import { RootState } from 'src/store';
+import { CommittedItem } from 'src/content/app/species-selector/types/species-search';
+
 type LaunchbarProps = {
   launchbarExpanded: boolean;
+  committedSpecies: CommittedItem[];
 };
 
 export const getCategoryClass = (separator: boolean): string => {
   return separator ? 'border' : '';
 };
 
-const LaunchbarContent = () => (
+const LaunchbarContent = (props: LaunchbarProps) => (
   <div className={styles.launchbar}>
     <div className={styles.categoriesWrapper}>
       <div className={styles.categories}>
@@ -45,7 +52,7 @@ const LaunchbarContent = () => (
             app="browser"
             description="Genome browser"
             icon={BrowserIcon}
-            enabled={true}
+            enabled={props.committedSpecies.length > 0}
           />
         </div>
         <div className={styles.category}>
@@ -89,9 +96,13 @@ const LaunchbarContent = () => (
 const Launchbar = (props: LaunchbarProps) => {
   return (
     <SlideDown transitionOnAppear={false}>
-      {props.launchbarExpanded ? <LaunchbarContent /> : null}
+      {props.launchbarExpanded ? <LaunchbarContent {...props} /> : null}
     </SlideDown>
   );
 };
 
-export default Launchbar;
+const mapStateToProps = (state: RootState) => ({
+  committedSpecies: getCommittedSpecies(state)
+});
+
+export default connect(mapStateToProps)(Launchbar);

--- a/src/ensembl/src/header/launchbar/Launchbar.tsx
+++ b/src/ensembl/src/header/launchbar/Launchbar.tsx
@@ -1,8 +1,5 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import SlideDown from 'react-slidedown';
-
-import { getCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 
 import ensemblIcon from 'static/img/launchbar/ensembl-logo.png'; // <-- note it's a png
 
@@ -17,7 +14,6 @@ import LaunchbarButton from './LaunchbarButton';
 
 import styles from './Launchbar.scss';
 
-import { RootState } from 'src/store';
 import { CommittedItem } from 'src/content/app/species-selector/types/species-search';
 
 type LaunchbarProps = {
@@ -101,8 +97,4 @@ const Launchbar = (props: LaunchbarProps) => {
   );
 };
 
-const mapStateToProps = (state: RootState) => ({
-  committedSpecies: getCommittedSpecies(state)
-});
-
-export default connect(mapStateToProps)(Launchbar);
+export default Launchbar;

--- a/src/ensembl/src/header/launchbar/Launchbar.tsx
+++ b/src/ensembl/src/header/launchbar/Launchbar.tsx
@@ -25,7 +25,7 @@ export const getCategoryClass = (separator: boolean): string => {
   return separator ? 'border' : '';
 };
 
-const LaunchbarContent = (props: LaunchbarProps) => (
+export const LaunchbarContent = (props: LaunchbarProps) => (
   <div className={styles.launchbar}>
     <div className={styles.categoriesWrapper}>
       <div className={styles.categories}>

--- a/src/ensembl/src/header/launchbar/LaunchbarContainer.tsx
+++ b/src/ensembl/src/header/launchbar/LaunchbarContainer.tsx
@@ -1,12 +1,17 @@
 import React, { FunctionComponent, memo } from 'react';
 import { connect } from 'react-redux';
 
-import { RootState } from 'src/store';
+import { getCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
+
 import Launchbar from './Launchbar';
 import { getLaunchbarExpanded } from '../headerSelectors';
 
+import { RootState } from 'src/store';
+import { CommittedItem } from 'src/content/app/species-selector/types/species-search';
+
 type StateProps = {
   launchbarExpanded: boolean;
+  committedSpecies: CommittedItem[];
 };
 
 type OwnProps = {};
@@ -18,7 +23,8 @@ export const LaunchbarContainer: FunctionComponent<
 > = memo((props) => <Launchbar {...props} />);
 
 const mapStateToProps = (state: RootState): StateProps => ({
-  launchbarExpanded: getLaunchbarExpanded(state)
+  launchbarExpanded: getLaunchbarExpanded(state),
+  committedSpecies: getCommittedSpecies(state)
 });
 
 export default connect(mapStateToProps)(LaunchbarContainer);


### PR DESCRIPTION
### Description
According to mockups ([link](https://xd.adobe.com/view/38482aac-ac76-4d51-57e7-35bd3d85a424-4e79/screen/0ad947a2-5309-4ea3-8d68-6455893d0fca/ss-human-selected)), the launchbar button that leads to Genome Browser should be enabled only if at least one species has been selected.