### PR TITLE
Fix flaky tests of SpeciesSearchField

### DIFF
--- a/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.test.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.test.tsx
@@ -93,9 +93,11 @@ describe('<SpeciesSearchField', () => {
       };
       wrapper = mount(<SpeciesSearchField {...props} />);
       // to update get a search string into the state of SpeciesSearchField
-      wrapper
-        .find('input')
-        .simulate('change', { target: { value: faker.lorem.word() } });
+      wrapper.find('input').simulate('change', {
+        target: {
+          value: faker.lorem.words(2) // <-- 2 words to make sure the total number of characters is greater than the minimum required by SpeciesSearchField
+        }
+      });
     });
 
     test('triggers the onMatchSelected function when a match is clicked', () => {


### PR DESCRIPTION
## Type
Bug fix

## Description
A test for SpeciesSearchField was failing once in every while for no apparent reason:

![image](https://user-images.githubusercontent.com/6834224/59754077-4f44ff80-927d-11e9-88b8-0a0a604d3610.png)

During investigation, it turned out that the random generator of search strings could produce a short two-letter string, which was not long enough for the field to open the autosuggestion panel that the test was trying to access.

## Alternative solutions
We could actually remove the check for the length of the SpeciesSearchField content ([link to code](https://github.com/Ensembl/ensembl-client/blob/dev/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx#L78)), which will also make the test pass. The reason for possible removal of that check is that every time the search field gets a string shorter than 3 characters, it sends an action to clear search results ([link to code](https://github.com/Ensembl/ensembl-client/blob/dev/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx#L67)), so there won't be anything to display in the autosuggestion panel anyway. So currently this check is redundant. But we can leave it in place as an extra precaution.