### PR TITLE
Display date of the build instead of the hard-coded month

### DIFF
--- a/src/ensembl/config.ts
+++ b/src/ensembl/config.ts
@@ -8,5 +8,7 @@ export default {
   googleAnalyticsKey: process.env.GOOGLE_ANALYTICS_KEY,
 
   // Genesearch endpoint
-  genesearchAPIEndpoint: process.env.GENESEARCH_API_ENDPOINT
+  genesearchAPIEndpoint: process.env.GENESEARCH_API_ENDPOINT,
+
+  buildDate: process.env.BUILD_DATE
 };

--- a/src/ensembl/src/header/Header.tsx
+++ b/src/ensembl/src/header/Header.tsx
@@ -1,6 +1,8 @@
 import React, { memo, FunctionComponent } from 'react';
 import { Link } from 'react-router-dom';
 
+import config from 'config';
+
 import HeaderButtons from './header-buttons/HeaderButtons';
 import LaunchbarContainer from './launchbar/LaunchbarContainer';
 import Account from './account/Account';
@@ -19,9 +21,19 @@ export const HomeLink = () => (
   </div>
 );
 
-export const ReleaseVersion = () => (
-  <div className={styles.strapline}>Pre-release - March 2019</div>
-);
+export const ReleaseVersion = () => {
+  const buildDate = new Date(config.buildDate);
+  const dateOptions = {
+    month: 'long',
+    year: 'numeric',
+  };
+  const longDate = new Intl.DateTimeFormat('en-GB', dateOptions)
+    .format(buildDate);
+
+  return (
+    <div className={styles.strapline}>Pre-release – {longDate}</div>
+  );
+};
 
 export const Copyright = () => (
   <div className={styles.copyright}>

--- a/src/ensembl/static/html/template.html
+++ b/src/ensembl/static/html/template.html
@@ -13,7 +13,7 @@
 <body>
   <div id="ens-app"></div>
 
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=Object.assign%2CPromise%2Cfetch"></script>
+  <script src="https://polyfill.io/v3/polyfill.min.js?features=Object.assign%2CPromise%2Cfetch%2CIntl.~locale.en%2CIntersectionObserver"></script>
 </body>
 
 </html>

--- a/src/ensembl/webpack/webpack.config.dev.js
+++ b/src/ensembl/webpack/webpack.config.dev.js
@@ -31,7 +31,10 @@ const plugins = [
 
   // make environment variables available on the client-side
   new webpack.DefinePlugin({
-    'process.env': JSON.stringify(dotenv.parsed)
+    'process.env': JSON.stringify({
+      ...dotenv.parsed,
+      BUILD_DATE: new Date()
+    })
   })
 ];
 

--- a/src/ensembl/webpack/webpack.config.prod.js
+++ b/src/ensembl/webpack/webpack.config.prod.js
@@ -14,7 +14,8 @@ const RobotstxtPlugin = require('robotstxt-webpack-plugin');
 // NOTE: if no environment variable with corresponding key is present, the value from .env.example will be used
 const dotenv = require('dotenv').config({ path: path.resolve(__dirname, '../.env.example') });
 const getEnvironmentVariables = () => Object.keys(dotenv.parsed).reduce((result, key) => ({
-  [`process.env.${key}`]: JSON.stringify(process.env[key])
+  [`process.env.${key}`]: JSON.stringify(process.env[key]),
+  'process.env.BUILD_DATE': new Date()
 }));
 
 // loaders specific to prod


### PR DESCRIPTION
## Description
Save time of the build and show it in the `Month yyyy` format. Use browser’s Intl api for formatting the date. Add polyfill for Intl for (very) outdated browsers.

Also, add polyfill for IntersectionObserver that is already used in the dev branch (added there with the Tooltip component).

## Reference
[Discussion](https://genomes-ebi.slack.com/archives/CC2RKR525/p1561037429460300) on Slack
![image](https://user-images.githubusercontent.com/6834224/59885919-dfd22b80-93b4-11e9-9dea-3ab769cd255b.png)
