### PR TITLE
Get nginx june-release config

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,7 +63,7 @@ Nginx:
   script:
   - apk update && apk add git
   - git clone --depth 1 https://github.com/Ensembl/ensembl-2020-static-assests.git
-  - git clone --depth 1 https://gitlab.ebi.ac.uk/kamal/ensembl-client-nginx.git
+  - git clone https://gitlab.ebi.ac.uk/kamal/ensembl-client-nginx.git
   - cd ensembl-client-nginx
   - git checkout june-release
   - cd ..


### PR DESCRIPTION
## Description

When cloning repository with the nginx config file, make sure all branches are cloned, so that we can select the one required for the June release.