### PR TITLE
Do not show disabled species on genome browser screen

### DIFF
--- a/src/ensembl/src/content/app/browser/browserState.ts
+++ b/src/ensembl/src/content/app/browser/browserState.ts
@@ -38,13 +38,13 @@ export const defaultBrowserState: BrowserState = {
 };
 
 export type BrowserEntityState = Readonly<{
-  activeGenomeId: string;
-  activeEnsObjectId: { [genomeId: string]: string };
+  activeGenomeId: string; // FIXME this should be nullable
+  activeEnsObjectId: { [genomeId: string]: string }; // FIXME this should be nullable
 }>;
 
 export const defaultBrowserEntityState: BrowserEntityState = {
-  activeGenomeId,
-  activeEnsObjectId
+  activeGenomeId, // FIXME this can be null
+  activeEnsObjectId // FIXME this can be null
 };
 
 export type BrowserNavState = Readonly<{

--- a/src/ensembl/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 
 import { getCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 import {
-  toggleSpeciesUse,
+  toggleSpeciesUseAndSave,
   deleteSpeciesAndSave
 } from 'src/content/app/species-selector/state/speciesSelectorActions';
 import * as urlFor from 'src/shared/helpers/urlHelper';
@@ -74,7 +74,7 @@ const mapStateToProps = (state: RootState) => ({
 });
 
 const mapDispatchToProps = {
-  toggleSpeciesUse,
+  toggleSpeciesUse: toggleSpeciesUseAndSave,
   onSpeciesDelete: deleteSpeciesAndSave
 };
 

--- a/src/ensembl/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
@@ -48,6 +48,8 @@ export const SpeciesSelectorAppBar = (props: Props) => {
 };
 
 const SelectedSpeciesList = (props: Props) => {
+  const shouldLinkToGenomeBrowser =
+    props.selectedSpecies.filter(({ isEnabled }) => isEnabled).length > 0;
   return (
     <>
       {props.selectedSpecies.map((species) => (
@@ -58,13 +60,11 @@ const SelectedSpeciesList = (props: Props) => {
           onRemove={props.onSpeciesDelete}
         />
       ))}
-      <div className={styles.genomeBrowserLinkContainer}>
-        <Link
-          to={urlFor.browser({ genomeId: props.selectedSpecies[0].genome_id })}
-        >
-          View in Genome Browser
-        </Link>
-      </div>
+      {shouldLinkToGenomeBrowser && (
+        <div className={styles.genomeBrowserLinkContainer}>
+          <Link to={urlFor.browser()}>View in Genome Browser</Link>
+        </div>
+      )}
     </>
   );
 };

--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorActions.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorActions.ts
@@ -134,6 +134,14 @@ export const toggleSpeciesUse = createStandardAction(
   'species_selector/toggle_species_use'
 )<string>();
 
+export const toggleSpeciesUseAndSave: ActionCreator<
+  ThunkAction<void, any, null, Action<string>>
+> = (genomeId: string) => (dispatch, getState) => {
+  dispatch(toggleSpeciesUse(genomeId));
+  const committedSpecies = getCommittedSpecies(getState());
+  speciesSelectorStorageService.saveSelectedSpecies(committedSpecies);
+};
+
 export const deleteSpecies = createStandardAction(
   'species_selector/delete_species'
 )<string>();

--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorSelectors.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorSelectors.ts
@@ -55,6 +55,10 @@ export const getCommittedSpecies = (state: RootState) => {
   return state.speciesSelector.committedItems;
 };
 
+export const getEnabledCommittedSpecies = (state: RootState) => {
+  return getCommittedSpecies(state).filter(({ isEnabled }) => isEnabled);
+};
+
 export const getPopularSpecies = (state: RootState) => {
   return state.speciesSelector.popularSpecies;
 };

--- a/src/ensembl/src/header/launchbar/LaunchbarContainer.tsx
+++ b/src/ensembl/src/header/launchbar/LaunchbarContainer.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, memo } from 'react';
 import { connect } from 'react-redux';
 
-import { getCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
+import { getEnabledCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 
 import Launchbar from './Launchbar';
 import { getLaunchbarExpanded } from '../headerSelectors';
@@ -24,7 +24,7 @@ export const LaunchbarContainer: FunctionComponent<
 
 const mapStateToProps = (state: RootState): StateProps => ({
   launchbarExpanded: getLaunchbarExpanded(state),
-  committedSpecies: getCommittedSpecies(state)
+  committedSpecies: getEnabledCommittedSpecies(state)
 });
 
 export default connect(mapStateToProps)(LaunchbarContainer);

--- a/src/ensembl/src/shared/species-tab-bar/SpeciesTabBar.tsx
+++ b/src/ensembl/src/shared/species-tab-bar/SpeciesTabBar.tsx
@@ -6,7 +6,7 @@ import SpeciesTab from 'src/shared/species-tab/SpeciesTab';
 
 import { CommittedItem } from 'src/content/app/species-selector/types/species-search';
 import { RootState } from 'src/store';
-import { getCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
+import { getEnabledCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 
 import styles from './SpeciesTabBar.scss';
 
@@ -40,7 +40,7 @@ export const SpeciesTabBar = (props: SpeciesTabBarProps) => {
 };
 
 const mapStateToProps = (state: RootState) => ({
-  species: getCommittedSpecies(state)
+  species: getEnabledCommittedSpecies(state)
 });
 
 export default connect(mapStateToProps)(SpeciesTabBar);


### PR DESCRIPTION
## Type
- Bug fix
- New feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-154

## Description
- [x]  Exclude species that have been marked with "do not use" from the list of species shown on the genome browser screen
- [x] Persist the data regarding whether to use or not to use particular species

## Views affected
Genome browser screen (/app/browser).