### PR TITLE
Keep release version number in config and show it in header

### DIFF
--- a/src/ensembl/config.ts
+++ b/src/ensembl/config.ts
@@ -1,4 +1,7 @@
 export default {
+  // version number
+  version: '0.2.0',
+
   // environment
   isDevelopment: process.env.NODE_ENV === 'development',
   isProduction: process.env.NODE_ENV === 'production',

--- a/src/ensembl/src/header/Header.tsx
+++ b/src/ensembl/src/header/Header.tsx
@@ -1,6 +1,8 @@
 import React, { memo, FunctionComponent } from 'react';
 import { Link } from 'react-router-dom';
 
+import config from 'config';
+
 import HeaderButtons from './header-buttons/HeaderButtons';
 import LaunchbarContainer from './launchbar/LaunchbarContainer';
 import Account from './account/Account';
@@ -20,7 +22,7 @@ export const HomeLink = () => (
 );
 
 export const ReleaseVersion = () => (
-  <div className={styles.strapline}>Pre-release - March 2019</div>
+  <div className={styles.strapline}>Pre-release — version {config.version}</div>
 );
 
 export const Copyright = () => (


### PR DESCRIPTION
## Type
- Improvement to existing feature

Replaces https://github.com/Ensembl/ensembl-client/pull/78

## Description
Instead of showing the month of the release in the header:

![image](https://user-images.githubusercontent.com/6834224/60033845-44390780-96a1-11e9-9396-a1829af3e046.png)

we decided to show the version of the release:

![image](https://user-images.githubusercontent.com/6834224/60033902-62066c80-96a1-11e9-9bc3-d8b79ebccdf0.png)

The versions are numbered arbitrarily, but resemble semantic version numbers (first number is a very major release; second number is something more minor; third number is something entirely trivial).

## Alternative solutions
We could use package.json to keep the version number, which is what people do when publishing their packages as libraries. But since our website isn't a publishable library anyway, there doesn't seem to be any benefit to keeping the version number in package.json (while it will require extra lines of code for getting the version number from package.json in webpack, saving this number in environment variable and reading it back in config.js).