### PR TITLE
Load all the config values from process.env during build time

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -67,7 +67,7 @@ Nginx:
   - cd ensembl-client-nginx
   - git checkout june-release
   - cd ..
-  - sed -i "s/<DEPLOYMNET_ENV>/${DEPLOYENV}/g" ensembl-client-nginx/config/conf.d/local.conf
+  - sed -i "s/<DEPLOYMENT_ENV>/${DEPLOYENV}/g" ensembl-client-nginx/config/conf.d/local.conf
   - docker build -t ${CONTAINER_IMAGE} -f ensembl-client-nginx/Dockerfile --no-cache .
   - echo "$GITLAB_REGISTRY_TOKEN" | docker login -u "$GITLAB_REGISTRY_USER" --password-stdin https://"$GITLAB_REGISTRY_URL"
   - docker push ${CONTAINER_IMAGE}

--- a/src/ensembl/src/services/analytics-service.ts
+++ b/src/ensembl/src/services/analytics-service.ts
@@ -3,15 +3,13 @@ import { AnalyticsType } from 'src/analyticsHelper';
 
 import config from 'config';
 
-const googleTrackingID = config.googleAnalyticsKey
-  ? config.googleAnalyticsKey
-  : '';
+const { googleAnalyticsKey = '' } = config;
 
 class AnalyticsTracking {
   private reactGA: typeof ReactGA;
 
   public constructor() {
-    ReactGA.initialize(googleTrackingID);
+    ReactGA.initialize(googleAnalyticsKey);
     this.reactGA = ReactGA;
   }
 

--- a/src/ensembl/src/services/analytics-service.ts
+++ b/src/ensembl/src/services/analytics-service.ts
@@ -1,8 +1,10 @@
 import ReactGA from 'react-ga';
 import { AnalyticsType } from 'src/analyticsHelper';
 
-const googleTrackingID = process.env.GOOGLE_ANALYTICS_KEY
-  ? process.env.GOOGLE_ANALYTICS_KEY
+import config from 'config';
+
+const googleTrackingID = config.googleAnalyticsKey
+  ? config.googleAnalyticsKey
   : '';
 
 class AnalyticsTracking {

--- a/src/ensembl/webpack/webpack.config.prod.js
+++ b/src/ensembl/webpack/webpack.config.prod.js
@@ -13,10 +13,10 @@ const RobotstxtPlugin = require('robotstxt-webpack-plugin');
 // copy from the environment the same variables that are declared in .env.example
 // NOTE: if no environment variable with corresponding key is present, the value from .env.example will be used
 const dotenv = require('dotenv').config({ path: path.resolve(__dirname, '../.env.example') });
-const environmentVariables = {};
-Object.keys(dotenv.parsed).map((key) => (
-  environmentVariables[`process.env.${key}`] = JSON.stringify(process.env[key])
-));
+const getEnvironmentVariables = () => Object.keys(dotenv.parsed).reduce((result, key) => ({
+  ...result,
+  [`process.env.${key}`]: JSON.stringify(process.env[key])
+}));
 
 
 
@@ -55,7 +55,7 @@ const moduleRules = [
 const plugins = [
   // make environment variables available on the client-side
   new webpack.DefinePlugin({
-    ...environmentVariables
+    ...getEnvironmentVariables()
   }),
 
   // plugin to extract css from the webpack javascript build files

--- a/src/ensembl/webpack/webpack.config.prod.js
+++ b/src/ensembl/webpack/webpack.config.prod.js
@@ -13,9 +13,12 @@ const RobotstxtPlugin = require('robotstxt-webpack-plugin');
 // copy from the environment the same variables that are declared in .env.example
 // NOTE: if no environment variable with corresponding key is present, the value from .env.example will be used
 const dotenv = require('dotenv').config({ path: path.resolve(__dirname, '../.env.example') });
-const getEnvironmentVariables = () => Object.keys(dotenv.parsed).reduce((result, key) => ({
-  [`process.env.${key}`]: JSON.stringify(process.env[key])
-}));
+const environmentVariables = {};
+Object.keys(dotenv.parsed).map((key) => (
+  environmentVariables[`process.env.${key}`] = JSON.stringify(process.env[key])
+));
+
+
 
 // loaders specific to prod
 const moduleRules = [
@@ -52,7 +55,7 @@ const moduleRules = [
 const plugins = [
   // make environment variables available on the client-side
   new webpack.DefinePlugin({
-    ...getEnvironmentVariables()
+    ...environmentVariables
   }),
 
   // plugin to extract css from the webpack javascript build files

--- a/src/ensembl/webpack/webpack.config.prod.js
+++ b/src/ensembl/webpack/webpack.config.prod.js
@@ -16,7 +16,7 @@ const dotenv = require('dotenv').config({ path: path.resolve(__dirname, '../.env
 const getEnvironmentVariables = () => Object.keys(dotenv.parsed).reduce((result, key) => ({
   ...result,
   [`process.env.${key}`]: JSON.stringify(process.env[key])
-}));
+}), {});
 
 
 


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Importance
Required for June-alpha release

## Description
Fixed the webpack config for prod that was considering only the last value specified in the .env file, ignoring the rest.

## Views affected
- Google analytics tracking
- Custom download

