### PR TITLE
Fix switching between ensembl objects

### DIFF
--- a/src/ensembl/src/content/app/browser/Browser.tsx
+++ b/src/ensembl/src/content/app/browser/Browser.tsx
@@ -182,16 +182,15 @@ export const Browser: FunctionComponent<BrowserProps> = (
   }, [props.genomeInfo]);
 
   useEffect(() => {
-    const { focus } = props.browserQueryParams;
+    const { focus, location } = props.browserQueryParams;
     const { genomeId } = props.match.params;
-    let location = props.chrLocation[genomeId];
-    if (!location && props.browserQueryParams.location) {
-      location = getChrLocationFromStr(props.browserQueryParams.location);
-    }
-    if (!location || !focus) {
+    const parsedLocation = location && getChrLocationFromStr(location);
+
+    if (!parsedLocation || !focus) {
       return;
     }
-    dispatchBrowserLocation(location);
+
+    dispatchBrowserLocation(parsedLocation);
     props.fetchEnsObject(focus, genomeId);
     props.fetchEnsObjectTracks(focus, genomeId);
     props.updateBrowserActiveEnsObjectIdAndSave(focus);


### PR DESCRIPTION
## Type
- Bug fix

## Description
**Bug 1. Genome browser code does not receive correct chromosome and location when user changes the focus object**

Steps to reproduce:
- Select human
- Go to genome browser and choose to view BRCA2
- In the right-hand sidebar (track panel bar) click on the bookmark icon
- Change from gene object to region object
- Notice that genome browser did not respond. If you console log the event sent to the browser, you will see that it received the wrong chromosome (13 instead of 17) and wrong coordinates

## Possible complications
Don’t know why the previous version of code used location from the browser state (props.chrLocation[genomeId]). Will this bugfix break things?