### PR TITLE
Fix focus object reset location

### DIFF
--- a/src/ensembl/src/content/app/browser/Browser.tsx
+++ b/src/ensembl/src/content/app/browser/Browser.tsx
@@ -190,10 +190,10 @@ export const Browser: FunctionComponent<BrowserProps> = (
       return;
     }
 
+    props.updateBrowserActiveEnsObjectIdAndSave(focus);
     dispatchBrowserLocation(parsedLocation);
     props.fetchEnsObject(focus, genomeId);
     props.fetchEnsObjectTracks(focus, genomeId);
-    props.updateBrowserActiveEnsObjectIdAndSave(focus);
   }, [props.browserQueryParams.focus]);
 
   useEffect(() => {

--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
@@ -220,12 +220,11 @@ export const BrowserNavigatorButton = (props: BrowserNavigatorButtonProps) => (
   </dd>
 );
 
-const mapStateToProps = (
-  state: RootState,
-  props: BrowserBarProps
-): StateProps => ({
+const mapStateToProps = (state: RootState): StateProps => ({
   activeGenomeId: getBrowserActiveGenomeId(state),
-  activeObjectId: getBrowserActiveEnsObjectId(state)[props.activeGenomeId],
+  activeObjectId: getBrowserActiveEnsObjectId(state)[
+    getBrowserActiveGenomeId(state)
+  ],
   browserActivated: getBrowserActivated(state),
   browserNavOpened: getBrowserNavOpened(state),
   chrLocation: getChrLocation(state),

--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
@@ -13,7 +13,8 @@ import {
   getBrowserActivated,
   getDefaultChrLocation,
   getGenomeSelectorActive,
-  getBrowserActiveGenomeId
+  getBrowserActiveGenomeId,
+  getBrowserActiveEnsObjectId
 } from '../browserSelectors';
 import { getDrawerOpened } from '../drawer/drawerSelectors';
 import { getEnsObjectInfo } from 'src/ens-object/ensObjectSelectors';
@@ -35,6 +36,7 @@ import styles from './BrowserBar.scss';
 
 type StateProps = {
   activeGenomeId: string;
+  activeObjectId: string;
   browserActivated: boolean;
   browserNavOpened: boolean;
   chrLocation: { [genomeId: string]: ChrLocation };
@@ -126,6 +128,7 @@ export const BrowserBar: FunctionComponent<BrowserBarProps> = (
         <dl className={styles.browserInfoLeft}>
           <BrowserReset
             activeGenomeId={props.activeGenomeId}
+            activeObjectId={props.activeObjectId}
             dispatchBrowserLocation={props.dispatchBrowserLocation}
             chrLocation={props.chrLocation}
             defaultChrLocation={props.defaultChrLocation}
@@ -217,8 +220,12 @@ export const BrowserNavigatorButton = (props: BrowserNavigatorButtonProps) => (
   </dd>
 );
 
-const mapStateToProps = (state: RootState): StateProps => ({
+const mapStateToProps = (
+  state: RootState,
+  props: BrowserBarProps
+): StateProps => ({
   activeGenomeId: getBrowserActiveGenomeId(state),
+  activeObjectId: getBrowserActiveEnsObjectId(state)[props.activeGenomeId],
   browserActivated: getBrowserActivated(state),
   browserNavOpened: getBrowserNavOpened(state),
   chrLocation: getChrLocation(state),

--- a/src/ensembl/src/content/app/browser/browser-reset/BrowserReset.scss
+++ b/src/ensembl/src/content/app/browser/browser-reset/BrowserReset.scss
@@ -12,7 +12,7 @@
   top: -3px;
 }
 
-.imageButtonInactive {
+.imageButtonDisabled {
   svg {
     fill: $ens-dark-grey;
     cursor: default;

--- a/src/ensembl/src/content/app/browser/browser-reset/BrowserReset.tsx
+++ b/src/ensembl/src/content/app/browser/browser-reset/BrowserReset.tsx
@@ -36,7 +36,7 @@ export const BrowserReset: FunctionComponent<BrowserResetProps> = (
     );
 
     if (chrLocationStr === defaultChrLocationStr || drawerOpened === true) {
-      return ImageButtonStatus.INACTIVE;
+      return ImageButtonStatus.DISABLED;
     }
 
     return ImageButtonStatus.ACTIVE;
@@ -58,7 +58,7 @@ export const BrowserReset: FunctionComponent<BrowserResetProps> = (
           description={'Reset browser image'}
           image={resetIcon}
           onClick={resetBrowser}
-          classNames={{ inactive: styles.imageButtonInactive }}
+          classNames={{ disabled: styles.imageButtonDisabled }}
         />
       </div>
     </dd>

--- a/src/ensembl/src/content/app/browser/browser-reset/BrowserReset.tsx
+++ b/src/ensembl/src/content/app/browser/browser-reset/BrowserReset.tsx
@@ -11,6 +11,7 @@ import { getChrLocationStr } from '../browserHelper';
 
 type BrowserResetProps = {
   activeGenomeId: string;
+  activeObjectId: string;
   chrLocation: { [genomeId: string]: ChrLocation };
   defaultChrLocation: { [genomeId: string]: ChrLocation };
   dispatchBrowserLocation: (chrLocation: ChrLocation) => void;

--- a/src/ensembl/src/content/app/browser/browser-reset/BrowserReset.tsx
+++ b/src/ensembl/src/content/app/browser/browser-reset/BrowserReset.tsx
@@ -23,6 +23,7 @@ export const BrowserReset: FunctionComponent<BrowserResetProps> = (
 ) => {
   const {
     activeGenomeId,
+    activeObjectId,
     chrLocation,
     defaultChrLocation,
     drawerOpened
@@ -31,7 +32,7 @@ export const BrowserReset: FunctionComponent<BrowserResetProps> = (
   const getResetIconStatus = (): ImageButtonStatus => {
     const chrLocationStr = getChrLocationStr(chrLocation[activeGenomeId]);
     const defaultChrLocationStr = getChrLocationStr(
-      defaultChrLocation[activeGenomeId]
+      defaultChrLocation[activeObjectId]
     );
 
     if (chrLocationStr === defaultChrLocationStr || drawerOpened === true) {
@@ -46,9 +47,7 @@ export const BrowserReset: FunctionComponent<BrowserResetProps> = (
       return;
     }
 
-    props.dispatchBrowserLocation(
-      props.defaultChrLocation[props.activeGenomeId]
-    );
+    props.dispatchBrowserLocation(props.defaultChrLocation[activeObjectId]);
   }, [chrLocation, drawerOpened]);
 
   return (

--- a/src/ensembl/src/content/app/browser/browserActions.ts
+++ b/src/ensembl/src/content/app/browser/browserActions.ts
@@ -161,7 +161,7 @@ export const changeBrowserLocation: ActionCreator<
 
     const currentDefaultChrLocation = getDefaultChrLocation(getState());
 
-    if (!currentDefaultChrLocation[activeObjectId]) {
+    if (activeObjectId && !currentDefaultChrLocation[activeObjectId]) {
       const updatedDefaultChrLocation = { ...currentDefaultChrLocation };
       updatedDefaultChrLocation[activeObjectId] = chrLocation;
       dispatch(updateDefaultChrLocation(updatedDefaultChrLocation));

--- a/src/ensembl/src/content/app/browser/browserActions.ts
+++ b/src/ensembl/src/content/app/browser/browserActions.ts
@@ -130,6 +130,7 @@ export const changeBrowserLocation: ActionCreator<
   return (dispatch: Dispatch, getState: () => RootState) => {
     const [chrCode, startBp, endBp] = chrLocation;
     const genomeId = getBrowserActiveGenomeId(getState());
+    const activeObjectId = getBrowserActiveEnsObjectId(getState())[genomeId];
 
     const stickEvent = new CustomEvent('bpane', {
       bubbles: true,
@@ -160,9 +161,9 @@ export const changeBrowserLocation: ActionCreator<
 
     const currentDefaultChrLocation = getDefaultChrLocation(getState());
 
-    if (!currentDefaultChrLocation[genomeId]) {
+    if (!currentDefaultChrLocation[activeObjectId]) {
       const updatedDefaultChrLocation = { ...currentDefaultChrLocation };
-      updatedDefaultChrLocation[genomeId] = chrLocation;
+      updatedDefaultChrLocation[activeObjectId] = chrLocation;
       dispatch(updateDefaultChrLocation(updatedDefaultChrLocation));
       browserStorageService.updateDefaultChrLocation(updatedDefaultChrLocation);
     }


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Importance
Required for June-alpha release

## Description
Reseting the location using the browser reset icon takes the wrong location from the store.

Steps to reproduce:
1) Load genome browser for a species
2) Select the example gene
3) Open the bookmark panel
4) Change the focus to a region
5) Click on the Browser reset icon
6) The location will be reset to the gene's default location, having the region as the focus
