### PR TITLE
Add CSS rule to preserve colors in print

### DIFF
--- a/src/ensembl/src/styles/main.scss
+++ b/src/ensembl/src/styles/main.scss
@@ -52,3 +52,9 @@ img {
   display: table;
   clear: both;
 }
+
+@media print {
+  body {
+    color-adjust: exact;
+  }
+}


### PR DESCRIPTION
## Type
- Bug fix

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-168

## Description
Currently, an attempt to print a page (any page) of the site will show a mostly empty page:

![Screenshot 2019-06-27 at 09 44 46](https://user-images.githubusercontent.com/6834224/60252952-1a5f2b00-98c3-11e9-9c04-5e9ccdf76c8b.png)

The reason for this is that Safari and Chrome — probably in a good-intentioned effort to save the planet — use economy mode when printing, which means they do not print background colours. Since many of our items have some background colour (and some have white content on a darkly-coloured background), ignoring background colour results in a mostly blank page.

This should be solved by adding an extra CSS rule for webkit-based browsers (as suggested [here](https://css-tricks.com/almanac/properties/c/color-adjust/)):

**Result:**

![Screenshot 2019-06-27 at 09 45 18](https://user-images.githubusercontent.com/6834224/60254291-95294580-98c5-11e9-99c5-1cad58fe1d57.png)


## Note
This will not solve the [problem](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-169) of printing the contents of Genome Browser canvas.
