### PR TITLE
Fix IE11-related issues

### DIFF
--- a/src/ensembl/package.json
+++ b/src/ensembl/package.json
@@ -160,5 +160,9 @@
     "webpack-dev-server": "3.7.2",
     "webpack-manifest-plugin": "2.0.4",
     "workbox-webpack-plugin": "4.3.1"
-  }
+  },
+  "browserslist": [
+    "last 2 versions",
+    "ie > 10"
+  ]
 }

--- a/src/ensembl/src/header/launchbar/Launchbar.scss
+++ b/src/ensembl/src/header/launchbar/Launchbar.scss
@@ -51,8 +51,8 @@
   }
 
   img {
-    max-width: 100%;
-    max-height: 100%;
+    max-width: 30px;
+    max-height: 30px;
   }
 }
 

--- a/src/ensembl/src/header/launchbar/Launchbar.scss
+++ b/src/ensembl/src/header/launchbar/Launchbar.scss
@@ -43,8 +43,8 @@
   margin: 0 12px;
 
   svg {
-    width: 100%;
-    height: 100%;
+    width: 30px;
+    height: 30px;
     transform: scale(1.1);
     fill: $ens-white;
     background-color: $ens-blue;

--- a/src/ensembl/src/services/observable-api-service.ts
+++ b/src/ensembl/src/services/observable-api-service.ts
@@ -1,18 +1,10 @@
 import { of } from 'rxjs';
-import { fromFetch } from 'rxjs/fetch';
-import { switchMap, catchError } from 'rxjs/operators';
+import { ajax } from 'rxjs/ajax';
+import { map, catchError } from 'rxjs/operators';
 
 export const fetch = (url: string) =>
-  fromFetch(url).pipe(
-    switchMap((response) => {
-      if (response.ok) {
-        // OK return data
-        return response.json();
-      } else {
-        // Server is returning a status requiring the client to try something else.
-        return of({ error: true, message: `Error ${response.status}` });
-      }
-    }),
+  ajax(url).pipe(
+    map((ajaxResponse) => ajaxResponse.response),
     catchError((err) => {
       // Network or other error, handle appropriately
       return of({ error: true, message: err.message });

--- a/src/ensembl/src/shared/autosuggest-search-field/AutosuggestSearchField.scss
+++ b/src/ensembl/src/shared/autosuggest-search-field/AutosuggestSearchField.scss
@@ -9,7 +9,7 @@
   position: absolute;
   left: 0;
   bottom: 0;
-  transform: translateY(calc(100% + 1px));
+  transform: translateY(100%) translateY(1px);
   width: 100%;
   z-index: 1;
   padding: 18px 24px;

--- a/src/ensembl/src/shared/privacy-banner/PrivacyBanner.scss
+++ b/src/ensembl/src/shared/privacy-banner/PrivacyBanner.scss
@@ -1,14 +1,14 @@
 @import 'src/styles/common';
 
 .privacyBanner {
-  background: $ens-black;
+  position: fixed;
   bottom: 0;
+  background: $ens-black;
   color: white;
   font-size: 14px;
   height: 104px;
   line-height: 2;
   padding: 10px;
-  position: absolute;
   text-align: center;
   width: 100%;
   z-index: 10000;

--- a/src/ensembl/src/shared/search-field/SearchField.scss
+++ b/src/ensembl/src/shared/search-field/SearchField.scss
@@ -3,17 +3,17 @@
 .searchField {
   border: 1px solid $ens-grey;
   display: inline-flex;
-  justify-content: space-between;
   padding: 0 0.6em;
 }
 
 .searchFieldRightCorner {
   display: flex;
   align-items: center;
-  flex-basis: 0;
+  flex: 0 0 auto;
   margin-left: 0.6em;
 }
 
 .searchFieldInput {
+  flex-grow: 1;
   border: none;
 }

--- a/src/ensembl/webpack/webpack.common.js
+++ b/src/ensembl/webpack/webpack.common.js
@@ -35,12 +35,11 @@ module.exports = (isDev, moduleRules, plugins) => ({
         exclude: /node_modules/
       },
 
-      // this will create source maps for the typescript code
+      // these libraries are distributed in a way that does not support IE11, and so require compilation
       {
         test: /.js$/,
-        exclude: /node_modules/,
-        loader: 'source-map-loader',
-        enforce: 'pre'
+        loader: 'babel-loader',
+        include: /react-spring/
       },
 
       // the loaders for styling


### PR DESCRIPTION
## Type
- Bug fix

## Description
Fix problems with IE11

**1. Javascript-related issues:**

- our build contains code that's too modern for IE11 (because react-spring distributes its bundle this way, and we do not transpile node_modules with babel-loader):

![image](https://user-images.githubusercontent.com/6834224/60283272-b5c2c100-9900-11e9-9aa3-0c3d98fbaf62.png)

- rxjs used a fetch method that was aborted with the modern AbortController; that's not supported by IE11 (and even more recent browsers)  

**2. CSS-related issues:**

- blown up launchbar (seen as a huge rectangle in the top part of the screenshot below) — the height value did not propagate to svg icons, so setting their height to 100% didn't help):

![image](https://user-images.githubusercontent.com/6834224/60265056-93b74780-98dc-11e9-9111-e472f3c6e14e.png)

same goes for the ensembl icon:

![image](https://user-images.githubusercontent.com/6834224/60265608-0ffe5a80-98de-11e9-9f85-17bb5c89735d.png)

- broken right-hand-side corner of species search field:

![image](https://user-images.githubusercontent.com/6834224/60268249-e9432280-98e3-11e9-8e4e-110f210c0292.png)

- broken positioning of autosuggestion panel (it appears on top of the search field instead of right below it), because IE11 does not support the `calc` function inside of `transform: translate`:

![image](https://user-images.githubusercontent.com/6834224/60282309-8ca13100-98fe-11e9-87f0-26020fc83204.png)

- incorrect position of the privacy banner (not fixed to the bottom of the page):

![image](https://user-images.githubusercontent.com/6834224/60428503-db95e180-9bf0-11e9-8b59-9cf98dcd753d.png)


## Views affected
- launchbar: all
- species search field — species selector screen