### PR TITLE
Fix no description for focus genes

### DIFF
--- a/src/ensembl/src/content/app/browser/drawer/Drawer.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/Drawer.tsx
@@ -18,7 +18,7 @@ import DrawerGC from './drawer-views/DrawerGC';
 
 import closeIcon from 'static/img/track-panel/close.svg';
 
-import { get, find } from 'lodash';
+import { find } from 'lodash';
 import styles from './Drawer.scss';
 import SnpIndels from './drawer-views/SnpIndels';
 

--- a/src/ensembl/src/content/app/browser/drawer/Drawer.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/Drawer.tsx
@@ -18,7 +18,7 @@ import DrawerGC from './drawer-views/DrawerGC';
 
 import closeIcon from 'static/img/track-panel/close.svg';
 
-import { find } from 'lodash';
+import find from 'lodash/find';
 import styles from './Drawer.scss';
 import SnpIndels from './drawer-views/SnpIndels';
 

--- a/src/ensembl/src/content/app/browser/drawer/Drawer.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/Drawer.tsx
@@ -4,7 +4,10 @@ import { connect } from 'react-redux';
 import { RootState } from 'src/store';
 import { toggleDrawer } from './drawerActions';
 import { getDrawerView } from './drawerSelectors';
-import { getEnsObjectInfo } from 'src/ens-object/ensObjectSelectors';
+import {
+  getEnsObjectInfo,
+  getEnsObjectTracks
+} from 'src/ens-object/ensObjectSelectors';
 
 import DrawerGene from './drawer-views/DrawerGene';
 import DrawerTranscript from './drawer-views/DrawerTranscript';
@@ -15,12 +18,16 @@ import DrawerGC from './drawer-views/DrawerGC';
 
 import closeIcon from 'static/img/track-panel/close.svg';
 
+import { get, find } from 'lodash';
 import styles from './Drawer.scss';
 import SnpIndels from './drawer-views/SnpIndels';
 
+import { EnsObject, EnsObjectTrack } from 'src/ens-object/ensObjectTypes';
+
 type StateProps = {
   drawerView: string;
-  ensObjectInfo: any;
+  ensObjectInfo: EnsObject;
+  ensObjectTracks: EnsObjectTrack;
 };
 
 type DispatchProps = {
@@ -32,12 +39,23 @@ type OwnProps = {};
 type DrawerProps = StateProps & DispatchProps & OwnProps;
 
 const Drawer: FunctionComponent<DrawerProps> = (props: DrawerProps) => {
+  const getTrackDetails = () => {
+    const childTracks = props.ensObjectTracks['child_tracks'];
+
+    return find(childTracks, { track_id: props.drawerView });
+  };
+
   const getDrawerViewComponent = () => {
     switch (props.drawerView) {
-      case 'gene':
+      case 'gene-feat':
         return <DrawerGene ensObjectInfo={props.ensObjectInfo} />;
-      case 'transcript':
-        return <DrawerTranscript ensObjectInfo={props.ensObjectInfo} />;
+      case 'gene-feat-1':
+        return (
+          <DrawerTranscript
+            ensObjectInfo={props.ensObjectInfo}
+            ensObjectTrack={getTrackDetails()}
+          />
+        );
       case 'gene-pc-fwd':
         return <ProteinCodingGenes forwardStrand={true} />;
       case 'gene-other-fwd':
@@ -69,7 +87,8 @@ const Drawer: FunctionComponent<DrawerProps> = (props: DrawerProps) => {
 
 const mapStateToProps = (state: RootState): StateProps => ({
   drawerView: getDrawerView(state),
-  ensObjectInfo: getEnsObjectInfo(state)
+  ensObjectInfo: getEnsObjectInfo(state),
+  ensObjectTracks: getEnsObjectTracks(state)
 });
 
 const mapDispatchToProps: DispatchProps = {

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerGene.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerGene.tsx
@@ -11,11 +11,11 @@ const DrawerGene: FunctionComponent<DrawerGeneProps> = (
 ) => {
   const { ensObjectInfo } = props;
 
-  let geneSymbol = ensObjectInfo.obj_symbol;
+  let geneSymbol = ensObjectInfo.label;
   let geneStableId = ensObjectInfo.stable_id;
 
   if (ensObjectInfo.obj_type === 'transcript') {
-    geneSymbol = ensObjectInfo.associated_object.obj_symbol;
+    geneSymbol = ensObjectInfo.associated_object.label;
     geneStableId = ensObjectInfo.associated_object.stable_id;
   }
 

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerTranscript.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerTranscript.tsx
@@ -1,27 +1,26 @@
 import React, { FunctionComponent } from 'react';
 
+import { EnsObject, EnsObjectTrack } from 'src/ens-object/ensObjectTypes';
+
 import styles from '../Drawer.scss';
 
 type DrawerTranscriptProps = {
-  ensObjectInfo: any;
+  ensObjectInfo: EnsObject;
+  ensObjectTrack: EnsObjectTrack | undefined;
 };
 
 const DrawerTranscript: FunctionComponent<DrawerTranscriptProps> = (
   props: DrawerTranscriptProps
 ) => {
-  const { ensObjectInfo } = props;
+  const { ensObjectInfo, ensObjectTrack } = props;
 
-  let transcriptStableId = ensObjectInfo.associated_object.stable_id;
-  let selectedInfo = ensObjectInfo.associated_object.selected_info;
-  let geneSymbol = ensObjectInfo.obj_symbol;
-  let geneStableId = ensObjectInfo.stable_id;
-
-  if (ensObjectInfo.obj_type === 'transcript') {
-    transcriptStableId = ensObjectInfo.stable_id;
-    selectedInfo = ensObjectInfo.selected_info;
-    geneSymbol = ensObjectInfo.associated_object.obj_symbol;
-    geneStableId = ensObjectInfo.associated_object.stable_id;
+  if (!ensObjectTrack) {
+    return null;
   }
+  const transcriptStableId = ensObjectInfo.stable_id;
+  const additionalInfo = ensObjectTrack.additional_info;
+  const geneSymbol = ensObjectInfo.label;
+  const geneStableId = ensObjectInfo.stable_id;
 
   return (
     <dl className={styles.drawerView}>
@@ -30,7 +29,7 @@ const DrawerTranscript: FunctionComponent<DrawerTranscriptProps> = (
         <div className={styles.details}>
           <p>
             <span className={styles.mainDetail}>{transcriptStableId}</span>
-            <span className={styles.secondaryDetail}>{selectedInfo}</span>
+            <span className={styles.secondaryDetail}>{additionalInfo}</span>
           </p>
         </div>
       </dd>
@@ -48,7 +47,7 @@ const DrawerTranscript: FunctionComponent<DrawerTranscriptProps> = (
       <dd className="clearfix">
         <label htmlFor="">Description</label>
         <div className={styles.details}>
-          {selectedInfo === 'MANE Select' ? (
+          {additionalInfo === 'MANE Select' ? (
             <>
               <p>
                 MANE Select transcripts match GRCh38 and are 100% identical


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-185

## Importance
June-alpha hotfix

## Description
Fixed the issue with the focus description not being displayed in the drawer.

## Views affected
Browser Chrome - > Trackpanel -> Drawer
