### PR TITLE
Get gene description from the API response

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -141,34 +141,6 @@ Nginx:internal:
   dependencies:
   - Test_N_Build:internal
 
-Deploy:internal:
-  stage: deploy
-  image: alpine
-  before_script:
-  - mkdir -p /etc/deploy
-  - echo ${EMBASSY_KUBECONFIG} | base64 -d > ${KUBECONFIG}
-
-  script:
-  - apk update && apk add --no-cache curl git
-  - curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
-  - chmod +x ./kubectl
-  - mv ./kubectl /usr/local/bin/kubectl
-  - git clone https://gitlab.ebi.ac.uk/kamal/ensembl-client-caas-deploy.git
-  - cd ensembl-client-caas-deploy
-  - git checkout refactor-manifest
-  - cd ..
-  - sed -i "s/<VERSION>/${CI_COMMIT_SHORT_SHA}-internal/g" ensembl-client-caas-deploy/ensembl_client_deployment.yaml
-  - sed -i "s/<DEPLOYMNET_ENV>/internal/g" ensembl-client-caas-deploy/ensembl_client_deployment.yaml
-  - cat ensembl-client-caas-deploy/ensembl_client_deployment.yaml
-  - kubectl config view
-  - kubectl config use-context ens-dev-ctx
-  - kubectl apply -f ensembl-client-caas-deploy/ensembl_client_deployment.yaml
-
-  only:
-  - master
-
-  dependencies:
-  - Nginx:internal
 
 Staging:
   stage: deploy
@@ -225,3 +197,33 @@ Live:
 
   dependencies:
   - Nginx
+
+
+Deploy:internal:
+  stage: deploy
+  image: alpine
+  before_script:
+  - mkdir -p /etc/deploy
+  - echo ${EMBASSY_KUBECONFIG} | base64 -d > ${KUBECONFIG}
+
+  script:
+  - apk update && apk add --no-cache curl git
+  - curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+  - chmod +x ./kubectl
+  - mv ./kubectl /usr/local/bin/kubectl
+  - git clone https://gitlab.ebi.ac.uk/kamal/ensembl-client-caas-deploy.git
+  - cd ensembl-client-caas-deploy
+  - git checkout refactor-manifest
+  - cd ..
+  - sed -i "s/<VERSION>/${CI_COMMIT_SHORT_SHA}-internal/g" ensembl-client-caas-deploy/ensembl_client_deployment.yaml
+  - sed -i "s/<DEPLOYMNET_ENV>/internal/g" ensembl-client-caas-deploy/ensembl_client_deployment.yaml
+  - cat ensembl-client-caas-deploy/ensembl_client_deployment.yaml
+  - kubectl config view
+  - kubectl config use-context ens-dev-ctx
+  - kubectl apply -f ensembl-client-caas-deploy/ensembl_client_deployment.yaml
+
+  only:
+  - master
+
+  dependencies:
+  - Nginx:internal

--- a/src/ensembl/src/content/app/browser/Browser.tsx
+++ b/src/ensembl/src/content/app/browser/Browser.tsx
@@ -158,8 +158,8 @@ export const Browser: FunctionComponent<BrowserProps> = (
       ) {
         changeSelectedSpecies(activeGenomeId);
       } else {
-        if (props.committedSpecies[0]) {
-          changeSelectedSpecies(props.committedSpecies[0].genome_id);
+        if (committedSpecies[0]) {
+          changeSelectedSpecies(committedSpecies[0].genome_id);
         }
       }
     }

--- a/src/ensembl/src/content/app/browser/Browser.tsx
+++ b/src/ensembl/src/content/app/browser/Browser.tsx
@@ -158,7 +158,9 @@ export const Browser: FunctionComponent<BrowserProps> = (
       ) {
         changeSelectedSpecies(activeGenomeId);
       } else {
-        changeSelectedSpecies(props.committedSpecies[0].genome_id);
+        if (props.committedSpecies[0]) {
+          changeSelectedSpecies(props.committedSpecies[0].genome_id);
+        }
       }
     }
     setTrackStatesFromStorage(browserStorageService.getTrackStates());

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerGene.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerGene.tsx
@@ -11,21 +11,13 @@ const DrawerGene: FunctionComponent<DrawerGeneProps> = (
 ) => {
   const { ensObjectInfo } = props;
 
-  let geneSymbol = ensObjectInfo.label;
-  let geneStableId = ensObjectInfo.stable_id;
-
-  if (ensObjectInfo.obj_type === 'transcript') {
-    geneSymbol = ensObjectInfo.associated_object.label;
-    geneStableId = ensObjectInfo.associated_object.stable_id;
-  }
-
   return (
     <dl className={styles.drawerView}>
       <dd className="clearfix">
         <label htmlFor="">Gene</label>
         <div className={styles.details}>
           <p>
-            <span className={styles.mainDetail}>{geneSymbol}</span>
+            <span className={styles.mainDetail}>{ensObjectInfo.label}</span>
           </p>
         </div>
       </dd>
@@ -33,21 +25,13 @@ const DrawerGene: FunctionComponent<DrawerGeneProps> = (
       <dd className="clearfix">
         <label htmlFor="">Stable ID</label>
         <div className={styles.details}>
-          <p>{geneStableId}</p>
+          <p>{ensObjectInfo.stable_id}</p>
         </div>
       </dd>
 
       <dd className="clearfix">
         <label htmlFor="">Description</label>
-        <div className={styles.details}>
-          <p>DNA repair associated</p>
-          <p>This gene is part of the GENCODE Comprehensive gene set</p>
-          <p>
-            <a href="https://www.gencodegenes.org">
-              https://www.gencodegenes.org/
-            </a>
-          </p>
-        </div>
+        <div className={styles.details}>{ensObjectInfo.description}</div>
       </dd>
     </dl>
   );

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerGene.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerGene.tsx
@@ -1,9 +1,11 @@
 import React, { FunctionComponent } from 'react';
 
+import { EnsObject } from 'src/ens-object/ensObjectTypes';
+
 import styles from '../Drawer.scss';
 
 type DrawerGeneProps = {
-  ensObjectInfo: any;
+  ensObjectInfo: EnsObject;
 };
 
 const DrawerGene: FunctionComponent<DrawerGeneProps> = (
@@ -31,7 +33,9 @@ const DrawerGene: FunctionComponent<DrawerGeneProps> = (
 
       <dd className="clearfix">
         <label htmlFor="">Description</label>
-        <div className={styles.details}>{ensObjectInfo.description}</div>
+        <div className={styles.details}>
+          {ensObjectInfo.description || '--'}
+        </div>
       </dd>
     </dl>
   );

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerTranscript.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerTranscript.tsx
@@ -46,7 +46,9 @@ const DrawerTranscript: FunctionComponent<DrawerTranscriptProps> = (
 
       <dd className="clearfix">
         <label htmlFor="">Description</label>
-        <div className={styles.details}>{ensObjectTrack.description}</div>
+        <div className={styles.details}>
+          {ensObjectTrack.description || '--'}
+        </div>
       </dd>
     </dl>
   );

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerTranscript.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerTranscript.tsx
@@ -17,10 +17,6 @@ const DrawerTranscript: FunctionComponent<DrawerTranscriptProps> = (
   if (!ensObjectTrack) {
     return null;
   }
-  const transcriptStableId = ensObjectInfo.stable_id;
-  const additionalInfo = ensObjectTrack.additional_info;
-  const geneSymbol = ensObjectInfo.label;
-  const geneStableId = ensObjectInfo.stable_id;
 
   return (
     <dl className={styles.drawerView}>
@@ -28,8 +24,10 @@ const DrawerTranscript: FunctionComponent<DrawerTranscriptProps> = (
         <label htmlFor="">Transcript</label>
         <div className={styles.details}>
           <p>
-            <span className={styles.mainDetail}>{transcriptStableId}</span>
-            <span className={styles.secondaryDetail}>{additionalInfo}</span>
+            <span className={styles.mainDetail}>{ensObjectInfo.stable_id}</span>
+            <span className={styles.secondaryDetail}>
+              {ensObjectTrack.additional_info}
+            </span>
           </p>
         </div>
       </dd>
@@ -38,37 +36,17 @@ const DrawerTranscript: FunctionComponent<DrawerTranscriptProps> = (
         <label htmlFor="">Gene</label>
         <div className={styles.details}>
           <p>
-            <span>{geneSymbol}</span>
-            <span className={styles.secondaryDetail}>{geneStableId}</span>
+            <span>{ensObjectInfo.label}</span>
+            <span className={styles.secondaryDetail}>
+              {ensObjectInfo.stable_id}
+            </span>
           </p>
         </div>
       </dd>
 
       <dd className="clearfix">
         <label htmlFor="">Description</label>
-        <div className={styles.details}>
-          {additionalInfo === 'MANE Select' ? (
-            <>
-              <p>
-                MANE Select transcripts match GRCh38 and are 100% identical
-                between Ensembl-GENCODE and RefSeq for 5' UTR, CDS, splicing and
-                3' UTR.
-              </p>
-              <p>
-                The MANE project (Matched Annotation from NCBI and EMBL-EBI) is
-                collaboration betwen Ensembl-GENCODE and RefSeq to select a
-                default transcript per human protein coding locus that is
-                representative of biology, and is well-supported, expressed and
-                conserved.
-              </p>
-            </>
-          ) : (
-            <p>
-              The Selected transcript is defined as either the longest CDS (if
-              the gene has translated transcripts) or the longest cDNA
-            </p>
-          )}
-        </div>
+        <div className={styles.details}>{ensObjectTrack.description}</div>
       </dd>
     </dl>
   );

--- a/src/ensembl/src/ens-object/ensObjectTypes.ts
+++ b/src/ensembl/src/ens-object/ensObjectTypes.ts
@@ -24,6 +24,7 @@ export type EnsObjectTrack = {
   ensembl_object_id?: string;
   support_level?: string | null;
   track_id: string;
+  description: string;
 };
 
 export type EnsObjectResponse = {

--- a/src/ensembl/src/ens-object/ensObjectTypes.ts
+++ b/src/ensembl/src/ens-object/ensObjectTypes.ts
@@ -14,6 +14,7 @@ export type EnsObject = {
   spliced_length: number | null;
   stable_id: string | null;
   strand: string | null;
+  description: string | null;
 };
 
 export type EnsObjectTrack = {
@@ -24,7 +25,7 @@ export type EnsObjectTrack = {
   ensembl_object_id?: string;
   support_level?: string | null;
   track_id: string;
-  description: string;
+  description: string | null;
 };
 
 export type EnsObjectResponse = {


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-185

## Importance
June-alpha hotfix

## Description
- Getting the gene description from the API response to display within the drawer.
- Fixed a minor issue with the browser that throws an error when we directly hit the URL app/browser/ without having any species selected.
- Reordered CICD pipelines as per Kamal's request

## Views affected
1) Browser -> TrackPanel -> Drawer
2) Browser

