### PR TITLE
Refactor/tracks persistence

### DIFF
--- a/src/ensembl/src/content/app/browser/Browser.tsx
+++ b/src/ensembl/src/content/app/browser/Browser.tsx
@@ -339,10 +339,7 @@ export const Browser: FunctionComponent<BrowserProps> = (
                 />
               </div>
             </animated.div>
-            <TrackPanel
-              browserRef={browserRef}
-              trackStates={trackStatesFromStorage}
-            />
+            <TrackPanel browserRef={browserRef} />
           </div>
         </section>
       )}

--- a/src/ensembl/src/content/app/browser/browser-image/BrowserImage.tsx
+++ b/src/ensembl/src/content/app/browser/browser-image/BrowserImage.tsx
@@ -26,7 +26,6 @@ import {
   updateBrowserNavStates,
   setChrLocation
 } from '../browserActions';
-import browserStorageService from '../browser-storage-service';
 
 import { ChrLocation } from '../browserState';
 

--- a/src/ensembl/src/content/app/browser/browser-storage-service.test.ts
+++ b/src/ensembl/src/content/app/browser/browser-storage-service.test.ts
@@ -78,12 +78,7 @@ describe('BrowserStorageService', () => {
         }
       };
 
-      browserStorageService.saveTrackStates(
-        'homo_sapiens38',
-        'Genes & transcripts',
-        'gene-pc-fwd',
-        ImageButtonStatus.INACTIVE
-      );
+      browserStorageService.saveTrackStates(toggledTrack);
 
       expect(mockStorageService.save).toHaveBeenCalledWith(
         StorageKeys.TRACK_STATES,

--- a/src/ensembl/src/content/app/browser/browser-storage-service.ts
+++ b/src/ensembl/src/content/app/browser/browser-storage-service.ts
@@ -72,24 +72,7 @@ export class BrowserStorageService {
     return this.storageService.get(StorageKeys.TRACK_STATES) || {};
   }
 
-  public saveTrackStates(
-    genomeId: string,
-    categoryName: string,
-    trackName: string,
-    trackStatus: ImageButtonStatus
-  ) {
-    const trackStates = this.getTrackStates();
-
-    if (!trackStates[genomeId]) {
-      trackStates[genomeId] = {};
-    }
-
-    if (!trackStates[genomeId][categoryName]) {
-      trackStates[genomeId][categoryName] = {};
-    }
-
-    trackStates[genomeId][categoryName][trackName] = trackStatus;
-
+  public saveTrackStates(trackStates: TrackStates) {
     this.storageService.save(StorageKeys.TRACK_STATES, trackStates);
   }
 

--- a/src/ensembl/src/content/app/browser/browserActions.ts
+++ b/src/ensembl/src/content/app/browser/browserActions.ts
@@ -1,4 +1,4 @@
-import { createAction } from 'typesafe-actions';
+import { createAction, createStandardAction } from 'typesafe-actions';
 import { Dispatch, ActionCreator, Action } from 'redux';
 import { ThunkAction } from 'redux-thunk';
 
@@ -8,12 +8,22 @@ import { BrowserNavStates, ChrLocation, CogList } from './browserState';
 import {
   getBrowserActiveGenomeId,
   getBrowserActiveEnsObjectId,
+  getBrowserTrackStates,
   getDefaultChrLocation,
   getChrLocation
 } from './browserSelectors';
 import { getBrowserAnalyticsObject } from 'src/analyticsHelper';
 import browserStorageService from './browser-storage-service';
 import { RootState } from 'src/store';
+import { ImageButtonStatus } from 'src/shared/image-button/ImageButton';
+import { TrackStates } from './track-panel/trackPanelConfig';
+
+export type UpdateTrackStatesPayload = {
+  genomeId: string;
+  categoryName: string;
+  trackId: string;
+  status: ImageButtonStatus; // FIXME: rework this part
+};
 
 export const updateBrowserActivated = createAction(
   'browser/update-browser-activated',
@@ -77,6 +87,28 @@ export const updateBrowserActiveEnsObjectIdAndSave: ActionCreator<
 
     browserStorageService.updateActiveEnsObjectId(updatedActiveEnsObjectId);
   };
+};
+
+export const updateTrackStates = createStandardAction(
+  'browser/update-tracks-state'
+)<TrackStates>();
+
+export const updateTrackStatesAndSave: ActionCreator<
+  ThunkAction<void, any, null, Action<string>>
+> = (payload: UpdateTrackStatesPayload) => (
+  dispatch: Dispatch,
+  getState: () => RootState
+) => {
+  const stateFragment = {
+    [payload.genomeId]: {
+      [payload.categoryName]: {
+        [payload.trackId]: payload.status
+      }
+    }
+  };
+
+  dispatch(updateTrackStates(stateFragment));
+  const trackStates = getBrowserTrackStates(getState());
 };
 
 export const toggleBrowserNav = createAction(

--- a/src/ensembl/src/content/app/browser/browserActions.ts
+++ b/src/ensembl/src/content/app/browser/browserActions.ts
@@ -109,6 +109,7 @@ export const updateTrackStatesAndSave: ActionCreator<
 
   dispatch(updateTrackStates(stateFragment));
   const trackStates = getBrowserTrackStates(getState());
+  browserStorageService.saveTrackStates(trackStates);
 };
 
 export const toggleBrowserNav = createAction(

--- a/src/ensembl/src/content/app/browser/browserActions.ts
+++ b/src/ensembl/src/content/app/browser/browserActions.ts
@@ -22,7 +22,7 @@ export type UpdateTrackStatesPayload = {
   genomeId: string;
   categoryName: string;
   trackId: string;
-  status: ImageButtonStatus; // FIXME: rework this part
+  status: ImageButtonStatus; // TODO: update types so that actions do not depend on ImageButton types
 };
 
 export const updateBrowserActivated = createAction(

--- a/src/ensembl/src/content/app/browser/browserReducer.ts
+++ b/src/ensembl/src/content/app/browser/browserReducer.ts
@@ -1,5 +1,6 @@
 import { combineReducers } from 'redux';
 import { ActionType, getType } from 'typesafe-actions';
+import merge from 'lodash/merge';
 
 import { RootAction } from 'src/objects';
 import * as browserActions from './browserActions';
@@ -54,6 +55,11 @@ export function browserEntity(
       return { ...state, activeGenomeId: action.payload };
     case getType(browserActions.updateBrowserActiveEnsObjectId):
       return { ...state, activeEnsObjectId: action.payload };
+    case getType(browserActions.updateTrackStates):
+      return {
+        ...state,
+        trackStates: merge({}, state.trackStates, action.payload)
+      };
     default:
       return state;
   }

--- a/src/ensembl/src/content/app/browser/browserSelectors.ts
+++ b/src/ensembl/src/content/app/browser/browserSelectors.ts
@@ -14,6 +14,9 @@ export const getBrowserActiveGenomeId = (state: RootState): string =>
 export const getBrowserActiveEnsObjectId = (state: RootState) =>
   state.browser.browserEntity.activeEnsObjectId;
 
+export const getBrowserTrackStates = (state: RootState) =>
+  state.browser.browserEntity.trackStates;
+
 export const getBrowserQueryParams = (
   state: RootState
 ): { [key: string]: string } => getQueryParamsMap(state.router.location.search);

--- a/src/ensembl/src/content/app/browser/browserState.ts
+++ b/src/ensembl/src/content/app/browser/browserState.ts
@@ -1,7 +1,10 @@
 import browserStorageService from './browser-storage-service';
 
+import { TrackStates } from './track-panel/trackPanelConfig';
+
 const activeGenomeId = browserStorageService.getActiveGenomeId();
 const activeEnsObjectId = browserStorageService.getActiveEnsObjectId();
+const trackStates = browserStorageService.getTrackStates();
 const chrLocation = browserStorageService.getChrLocation();
 const defaultChrLocation = browserStorageService.getDefaultChrLocation();
 
@@ -40,11 +43,13 @@ export const defaultBrowserState: BrowserState = {
 export type BrowserEntityState = Readonly<{
   activeGenomeId: string; // FIXME this should be nullable
   activeEnsObjectId: { [genomeId: string]: string }; // FIXME this should be nullable
+  trackStates: TrackStates;
 }>;
 
 export const defaultBrowserEntityState: BrowserEntityState = {
   activeGenomeId, // FIXME this can be null
-  activeEnsObjectId // FIXME this can be null
+  activeEnsObjectId, // FIXME this can be null
+  trackStates
 };
 
 export type BrowserNavState = Readonly<{

--- a/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
@@ -9,6 +9,10 @@ import Drawer from '../drawer/Drawer';
 import { RootState } from 'src/store';
 
 import {
+  updateTrackStatesAndSave,
+  UpdateTrackStatesPayload
+} from 'src/content/app/browser/browserActions';
+import {
   toggleTrackPanel,
   closeTrackPanelModal,
   openTrackPanelModal
@@ -71,6 +75,7 @@ type DispatchProps = {
   openTrackPanelModal: (trackPanelModalView: string) => void;
   toggleDrawer: (drawerOpened: boolean) => void;
   toggleTrackPanel: (trackPanelOpened?: boolean) => void;
+  updateTrackStates: (payload: UpdateTrackStatesPayload) => void;
 };
 
 type OwnProps = {
@@ -143,6 +148,7 @@ const TrackPanel: FunctionComponent<TrackPanelProps> = (
             trackStates={props.trackStates}
             genomeTrackCategories={props.genomeTrackCategories}
             updateDrawerView={props.changeDrawerView}
+            updateTrackStates={props.updateTrackStates}
           />
 
           {props.trackPanelModalOpened ? (
@@ -184,7 +190,8 @@ const mapDispatchToProps: DispatchProps = {
   closeTrackPanelModal,
   openTrackPanelModal,
   toggleDrawer,
-  toggleTrackPanel
+  toggleTrackPanel,
+  updateTrackStates: updateTrackStatesAndSave
 };
 
 export default connect(

--- a/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
@@ -28,7 +28,8 @@ import { getDrawerView, getDrawerOpened } from '../drawer/drawerSelectors';
 import {
   getBrowserActivated,
   getDefaultChrLocation,
-  getBrowserActiveGenomeId
+  getBrowserActiveGenomeId,
+  getBrowserTrackStates
 } from '../browserSelectors';
 import {
   getExampleEnsObjects,
@@ -42,7 +43,7 @@ import { BreakpointWidth } from 'src/global/globalConfig';
 import { TrackType, TrackStates } from './trackPanelConfig';
 
 import { GenomeTrackCategory } from 'src/genome/genomeTypes';
-import { getGenomeTrackCategories } from 'src/genome/genomeSelectors';
+import { getGenomeTrackCategoriesById } from 'src/genome/genomeSelectors';
 import {
   EnsObject,
   EnsObjectTrack,
@@ -67,6 +68,7 @@ type StateProps = {
   trackPanelModalOpened: boolean;
   trackPanelModalView: string;
   trackPanelOpened: boolean;
+  trackStates: TrackStates;
 };
 
 type DispatchProps = {
@@ -80,7 +82,6 @@ type DispatchProps = {
 
 type OwnProps = {
   browserRef: RefObject<HTMLDivElement>;
-  trackStates: TrackStates;
 };
 
 type TrackPanelProps = StateProps & DispatchProps & OwnProps;
@@ -165,25 +166,28 @@ const TrackPanel: FunctionComponent<TrackPanelProps> = (
   );
 };
 
-const mapStateToProps = (state: RootState): StateProps => ({
-  activeGenomeId: getBrowserActiveGenomeId(state),
-  breakpointWidth: getBreakpointWidth(state),
-  browserActivated: getBrowserActivated(state),
-  defaultChrLocation: getDefaultChrLocation(state),
-  drawerOpened: getDrawerOpened(state),
-  drawerView: getDrawerView(state),
-  ensObjectInfo: getEnsObjectInfo(state),
-  ensObjectTracks: getEnsObjectTracks(state),
-  exampleEnsObjects: getExampleEnsObjects(state),
-  launchbarExpanded: getLaunchbarExpanded(state),
-  selectedBrowserTab: getSelectedBrowserTab(state),
-  genomeTrackCategories: getGenomeTrackCategories(state)[
-    getBrowserActiveGenomeId(state)
-  ],
-  trackPanelModalOpened: getTrackPanelModalOpened(state),
-  trackPanelModalView: getTrackPanelModalView(state),
-  trackPanelOpened: getTrackPanelOpened(state)
-});
+const mapStateToProps = (state: RootState): StateProps => {
+  const activeGenomeId = getBrowserActiveGenomeId(state);
+
+  return {
+    activeGenomeId,
+    breakpointWidth: getBreakpointWidth(state),
+    browserActivated: getBrowserActivated(state),
+    defaultChrLocation: getDefaultChrLocation(state),
+    drawerOpened: getDrawerOpened(state),
+    drawerView: getDrawerView(state),
+    ensObjectInfo: getEnsObjectInfo(state),
+    ensObjectTracks: getEnsObjectTracks(state),
+    exampleEnsObjects: getExampleEnsObjects(state),
+    launchbarExpanded: getLaunchbarExpanded(state),
+    selectedBrowserTab: getSelectedBrowserTab(state),
+    genomeTrackCategories: getGenomeTrackCategoriesById(state, activeGenomeId),
+    trackPanelModalOpened: getTrackPanelModalOpened(state),
+    trackPanelModalView: getTrackPanelModalView(state),
+    trackPanelOpened: getTrackPanelOpened(state),
+    trackStates: getBrowserTrackStates(state)
+  };
+};
 
 const mapDispatchToProps: DispatchProps = {
   changeDrawerView,

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.tsx
@@ -1,10 +1,5 @@
-import React, {
-  FunctionComponent,
-  RefObject,
-  useCallback,
-  useState,
-  useEffect
-} from 'react';
+import React, { FunctionComponent, RefObject } from 'react';
+import get from 'lodash/get';
 
 import TrackPanelListItem from './TrackPanelListItem';
 
@@ -37,35 +32,28 @@ type TrackPanelListProps = {
 const TrackPanelList: FunctionComponent<TrackPanelListProps> = (
   props: TrackPanelListProps
 ) => {
-  const [currentTrackCategories, setCurrentTrackCategories] = useState<
-    GenomeTrackCategory[]
-  >([]);
+  const {
+    activeGenomeId,
+    selectedBrowserTab: selectedBrowserTabs,
+    genomeTrackCategories
+  } = props;
 
-  useEffect(() => {
-    const selectedBrowserTab =
-      props.selectedBrowserTab[props.activeGenomeId] || TrackType.GENOMIC;
-
-    if (props.genomeTrackCategories && props.genomeTrackCategories.length > 0) {
-      setCurrentTrackCategories(
-        props.genomeTrackCategories.filter((category: GenomeTrackCategory) =>
-          category.types.includes(selectedBrowserTab)
-        )
-      );
-    }
-  }, [props.selectedBrowserTab]);
-
-  const changeDrawerView = useCallback(
-    (currentTrack: string) => {
-      const { drawerView, toggleDrawer, updateDrawerView } = props;
-
-      updateDrawerView(currentTrack);
-
-      if (!drawerView) {
-        toggleDrawer(true);
-      }
-    },
-    [props.drawerView]
+  const selectedBrowserTab =
+    selectedBrowserTabs[activeGenomeId] || TrackType.GENOMIC;
+  const currentTrackCategories = genomeTrackCategories.filter(
+    (category: GenomeTrackCategory) =>
+      category.types.includes(selectedBrowserTab)
   );
+
+  const changeDrawerView = (currentTrack: string) => {
+    const { drawerView, toggleDrawer, updateDrawerView } = props;
+
+    updateDrawerView(currentTrack);
+
+    if (!drawerView) {
+      toggleDrawer(true);
+    }
+  };
 
   const getTrackPanelListClasses = () => {
     const heightClass: string = props.launchbarExpanded
@@ -101,13 +89,24 @@ const TrackPanelList: FunctionComponent<TrackPanelListProps> = (
     if (!track) {
       return;
     }
+    const { track_id } = track;
+    const defaultTrackStatus = getDefaultTrackStatus(
+      categoryName,
+      track.track_id
+    );
+
+    const trackStatus = get(
+      props.trackStates,
+      `${activeGenomeId}.${categoryName}.${track_id}`,
+      defaultTrackStatus
+    );
 
     return (
       <TrackPanelListItem
         activeGenomeId={props.activeGenomeId}
         browserRef={props.browserRef}
         categoryName={categoryName}
-        defaultTrackStatus={getDefaultTrackStatus(categoryName, track.track_id)}
+        trackStatus={trackStatus as ImageButtonStatus}
         drawerOpened={props.drawerOpened}
         drawerView={props.drawerView}
         key={track.track_id}

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.tsx
@@ -8,6 +8,7 @@ import React, {
 
 import TrackPanelListItem from './TrackPanelListItem';
 
+import { UpdateTrackStatesPayload } from 'src/content/app/browser/browserActions';
 import { TrackType, TrackStates } from '../trackPanelConfig';
 import { ChrLocation } from '../../browserState';
 
@@ -30,6 +31,7 @@ type TrackPanelListProps = {
   genomeTrackCategories: GenomeTrackCategory[];
   trackStates: TrackStates;
   updateDrawerView: (drawerView: string) => void;
+  updateTrackStates: (payload: UpdateTrackStatesPayload) => void;
 };
 
 const TrackPanelList: FunctionComponent<TrackPanelListProps> = (
@@ -111,6 +113,7 @@ const TrackPanelList: FunctionComponent<TrackPanelListProps> = (
         key={track.track_id}
         track={track}
         updateDrawerView={changeDrawerView}
+        updateTrackStates={props.updateTrackStates}
       >
         {track.child_tracks &&
           track.child_tracks.map((childTrack: EnsObjectTrack) =>

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.tsx
@@ -63,23 +63,9 @@ const TrackPanelList: FunctionComponent<TrackPanelListProps> = (
     return `${styles.trackPanelList} ${heightClass}`;
   };
 
-  const getDefaultTrackStatus = (categoryName: string, trackName: string) => {
-    let trackStatus = ImageButtonStatus.ACTIVE;
-
-    if (!props.trackStates[props.activeGenomeId]) {
-      return trackStatus;
-    }
-    const statesOfCategory =
-      props.trackStates[props.activeGenomeId][categoryName];
-
-    if (statesOfCategory && statesOfCategory[trackName]) {
-      trackStatus =
-        statesOfCategory[trackName] === 'active'
-          ? ImageButtonStatus.ACTIVE
-          : ImageButtonStatus.INACTIVE;
-    }
-
-    return trackStatus;
+  // TODO: get default track status properly if it can ever be inactive
+  const getDefaultTrackStatus = () => {
+    return ImageButtonStatus.ACTIVE;
   };
 
   const getTrackListItem = (
@@ -90,10 +76,7 @@ const TrackPanelList: FunctionComponent<TrackPanelListProps> = (
       return;
     }
     const { track_id } = track;
-    const defaultTrackStatus = getDefaultTrackStatus(
-      categoryName,
-      track.track_id
-    );
+    const defaultTrackStatus = getDefaultTrackStatus();
 
     const trackStatus = get(
       props.trackStates,
@@ -106,6 +89,7 @@ const TrackPanelList: FunctionComponent<TrackPanelListProps> = (
         activeGenomeId={props.activeGenomeId}
         browserRef={props.browserRef}
         categoryName={categoryName}
+        defaultTrackStatus={defaultTrackStatus as ImageButtonStatus}
         trackStatus={trackStatus as ImageButtonStatus}
         drawerOpened={props.drawerOpened}
         drawerView={props.drawerView}

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
@@ -31,6 +31,7 @@ type TrackPanelListItemProps = {
   categoryName: string;
   children?: ReactNode[];
   trackStatus: ImageButtonStatus;
+  defaultTrackStatus: ImageButtonStatus;
   drawerOpened: boolean;
   drawerView: string;
   track: EnsObjectTrack;
@@ -48,6 +49,13 @@ const TrackPanelListItem: FunctionComponent<TrackPanelListItemProps> = (
   const { activeGenomeId, browserRef, categoryName, drawerView, track } = props;
 
   const { trackStatus } = props;
+
+  useEffect(() => {
+    const { defaultTrackStatus } = props;
+    if (trackStatus !== defaultTrackStatus) {
+      updateGenomeBrowser(trackStatus);
+    }
+  }, []);
 
   useEffect(() => {
     const trackToggleStates = browserStorageService.getTrackListToggleStates();
@@ -113,8 +121,24 @@ const TrackPanelListItem: FunctionComponent<TrackPanelListItemProps> = (
   };
 
   const toggleTrack = () => {
+    const newStatus =
+      trackStatus === ImageButtonStatus.ACTIVE
+        ? ImageButtonStatus.INACTIVE
+        : ImageButtonStatus.ACTIVE;
+
+    updateGenomeBrowser(newStatus);
+
+    props.updateTrackStates({
+      genomeId: activeGenomeId,
+      categoryName,
+      trackId: track.track_id,
+      status: newStatus
+    });
+  };
+
+  const updateGenomeBrowser = (status: ImageButtonStatus) => {
     const currentTrackStatus =
-      trackStatus === ImageButtonStatus.ACTIVE ? 'off' : 'on';
+      status === ImageButtonStatus.ACTIVE ? 'on' : 'off';
 
     const trackEvent = new CustomEvent('bpane', {
       bubbles: true,
@@ -126,18 +150,6 @@ const TrackPanelListItem: FunctionComponent<TrackPanelListItemProps> = (
     if (browserRef.current) {
       browserRef.current.dispatchEvent(trackEvent);
     }
-
-    const newStatus =
-      trackStatus === ImageButtonStatus.ACTIVE
-        ? ImageButtonStatus.INACTIVE
-        : ImageButtonStatus.ACTIVE;
-
-    props.updateTrackStates({
-      genomeId: activeGenomeId,
-      categoryName,
-      trackId: track.track_id,
-      status: newStatus
-    });
   };
 
   return (

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
@@ -10,6 +10,7 @@ import React, {
 import get from 'lodash/get';
 
 import { TrackItemColour } from '../trackPanelConfig';
+import { UpdateTrackStatesPayload } from 'src/content/app/browser/browserActions';
 
 import chevronDownIcon from 'static/img/shared/chevron-down.svg';
 import chevronUpIcon from 'static/img/shared/chevron-up.svg';
@@ -34,6 +35,7 @@ type TrackPanelListItemProps = {
   drawerView: string;
   track: EnsObjectTrack;
   updateDrawerView: (drawerView: string) => void;
+  updateTrackStates: (payload: UpdateTrackStatesPayload) => void;
 };
 
 // delete this when there is a better place to put this
@@ -139,18 +141,19 @@ const TrackPanelListItem: FunctionComponent<TrackPanelListItemProps> = (
       browserRef.current.dispatchEvent(trackEvent);
     }
 
-    const newImageButtonStatus =
+    const newStatus =
       trackStatus === ImageButtonStatus.ACTIVE
         ? ImageButtonStatus.INACTIVE
         : ImageButtonStatus.ACTIVE;
 
-    browserStorageService.saveTrackStates(
-      activeGenomeId,
+    props.updateTrackStates({
+      genomeId: activeGenomeId,
       categoryName,
-      track.track_id,
-      newImageButtonStatus
-    );
-    setTrackStatus(newImageButtonStatus);
+      trackId: track.track_id,
+      status: newStatus
+    });
+
+    setTrackStatus(newStatus);
   };
 
   return (

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
@@ -30,7 +30,7 @@ type TrackPanelListItemProps = {
   browserRef: RefObject<HTMLDivElement>;
   categoryName: string;
   children?: ReactNode[];
-  defaultTrackStatus: ImageButtonStatus;
+  trackStatus: ImageButtonStatus;
   drawerOpened: boolean;
   drawerView: string;
   track: EnsObjectTrack;
@@ -45,23 +45,9 @@ const TrackPanelListItem: FunctionComponent<TrackPanelListItemProps> = (
   props: TrackPanelListItemProps
 ) => {
   const [expanded, setExpanded] = useState(true);
-  const [trackStatus, setTrackStatus] = useState(props.defaultTrackStatus);
   const { activeGenomeId, browserRef, categoryName, drawerView, track } = props;
 
-  // FIXME: rather reading trackstates from localStorage (multiple times!), they should be passed as props
-  // (and stored in redux store; localStorage should be used to store the relevant part of redux store between browser reloads)
-  useEffect(() => {
-    const trackStates = browserStorageService.getTrackStates();
-    const storedTrackStatus: ImageButtonStatus = get(
-      trackStates,
-      `${activeGenomeId}.${categoryName}.${track.track_id}`,
-      ImageButtonStatus.ACTIVE
-    ) as ImageButtonStatus;
-
-    if (storedTrackStatus && storedTrackStatus !== trackStatus) {
-      setTrackStatus(storedTrackStatus);
-    }
-  }, [props.activeGenomeId]);
+  const { trackStatus } = props;
 
   useEffect(() => {
     const trackToggleStates = browserStorageService.getTrackListToggleStates();
@@ -152,8 +138,6 @@ const TrackPanelListItem: FunctionComponent<TrackPanelListItemProps> = (
       trackId: track.track_id,
       status: newStatus
     });
-
-    setTrackStatus(newStatus);
   };
 
   return (

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelConfig.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelConfig.ts
@@ -26,9 +26,9 @@ export type TrackPanelIcons = {
 };
 
 export type TrackStates = {
-  [key: string]: {
-    [key: string]: {
-      [genomeId: string]: ImageButtonStatus;
+  [genomeId: string]: {
+    [categoryName: string]: {
+      [trackName: string]: ImageButtonStatus;
     };
   };
 };

--- a/src/ensembl/src/genome/genomeActions.ts
+++ b/src/ensembl/src/genome/genomeActions.ts
@@ -20,26 +20,17 @@ export const fetchGenomeInfoAsyncActions = createAsyncAction(
 
 export const fetchGenomeInfo: ActionCreator<
   ThunkAction<void, any, null, Action<string>>
-> = () => (dispatch: Dispatch, getState: () => RootState) => {
+> = (genomeId: string) => async (dispatch: Dispatch) => {
   try {
-    const genomeInfo: GenomeInfoData = getGenomeInfo(getState());
+    dispatch(fetchGenomeInfoAsyncActions.request());
+    const url = `/api/genome/info?genome_id=${genomeId}`;
+    const response = await apiService.fetch(url);
 
-    const committedSpecies = getCommittedSpecies(getState());
-
-    committedSpecies.map(async (species) => {
-      if (!genomeInfo[species.genome_id]) {
-        dispatch(fetchGenomeInfoAsyncActions.request());
-
-        const url = `/api/genome/info?genome_id=${species.genome_id}`;
-        const response = await apiService.fetch(url);
-
-        dispatch(
-          fetchGenomeInfoAsyncActions.success({
-            [species.genome_id]: response.genome_info[0]
-          })
-        );
-      }
-    });
+    dispatch(
+      fetchGenomeInfoAsyncActions.success({
+        [genomeId]: response.genome_info[0] // FIXME: Why the response is an array instead of an object keyed by genomeId?
+      })
+    );
   } catch (error) {
     dispatch(fetchGenomeInfoAsyncActions.failure(error));
   }

--- a/src/ensembl/src/genome/genomeSelectors.ts
+++ b/src/ensembl/src/genome/genomeSelectors.ts
@@ -13,6 +13,12 @@ export const getGenomeInfoFetchFailed = (state: RootState) =>
 export const getGenomeTrackCategories = (state: RootState) =>
   state.genome.genomeTrackCategories.genomeTrackCategoriesData;
 
+export const getGenomeTrackCategoriesById = (
+  state: RootState,
+  genomeId: string
+) =>
+  state.genome.genomeTrackCategories.genomeTrackCategoriesData[genomeId] || [];
+
 export const getGenomeTrackCategoriesFetching = (state: RootState) =>
   state.genome.genomeTrackCategories.genomeTrackCategoriesFetching;
 


### PR DESCRIPTION
## Type
- Improvement to existing feature

## Description
Read track states that have been saved in localStorage into redux store during initialization of the store, and pass them down as props to the components that need them. Do not read the values stored in localStorage directly from components.

## Views affected
Genome browser page

## Remains to be done in subsequent PRs
- move track expand status ([see here](https://github.com/Ensembl/ensembl-client/blob/dev/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx#L119-L125)) to redux as well
- throttle/debounce the call to genome browser to actually show/hide the respective track (it is an expensive operation, and is currently performed on the main thread)
- update types in such a way that we do not use ImageButtonStatus in the code that doesn't need to know about ImageButton (such as in actions, etc.)
- `fetchGenomeInfo` function in `genomeActions` — the way it relies now on the first item in the response array:
```
        dispatch(
          fetchGenomeInfoAsyncActions.success({
            [species.genome_id]: response.genome_info[0]
          })
        );

```
is bad. Either we should iterate over the response array and make sure the item in this array match the requested genomeId, or the response should be an object instead of an array, keyed by genomeId.