### PR TITLE
Remove useless scrollbars in the drawer

### DIFF
--- a/src/ensembl/src/content/app/browser/drawer/Drawer.scss
+++ b/src/ensembl/src/content/app/browser/drawer/Drawer.scss
@@ -7,8 +7,8 @@
 }
 
 .drawerView {
-  margin-top: 20px;
-  overflow: scroll;
+  margin-top: 40px;
+  overflow-y: auto;
 
   h2 {
     @include flex;

--- a/src/ensembl/src/content/app/browser/drawer/Drawer.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/Drawer.tsx
@@ -80,7 +80,7 @@ const Drawer: FunctionComponent<DrawerProps> = (props: DrawerProps) => {
       <button className={styles.closeButton} onClick={closeDrawer}>
         <img src={closeIcon} alt="close drawer" />
       </button>
-      <div className={styles.drawerView}>{getDrawerViewComponent()}</div>
+      {getDrawerViewComponent()}
     </section>
   );
 };

--- a/src/ensembl/webpack/webpack.config.dev.js
+++ b/src/ensembl/webpack/webpack.config.dev.js
@@ -72,7 +72,7 @@ const devConfig = {
         secure: false
       },
       '/browser': {
-        target: 'http://localhost:4000',
+        target: 'https://staging-2020.ensembl.org',
         changeOrigin: true,
         secure: false
       }


### PR DESCRIPTION
## Type
- Bug fix

## Description
The content of the drawer has a useless (and duplicate!) scrollbar, which is invisible on a Mac, but obvious on Windows or Linux:

![image](https://user-images.githubusercontent.com/6834224/60468156-a8833a80-9c50-11e9-8ae7-209fbe83a30e.png)

After the fix:

![image](https://user-images.githubusercontent.com/6834224/60468166-b20ca280-9c50-11e9-9b4f-ba21ba71e0c1.png)

## Views affected
Genome browser page (open drawer)

## Notice
Layout of drawer views does not make much sense (`clearfix` class, `label` elements, definition list elements) and will have to be updated, but that’s the task for another PR.