### PR TITLE
Fix browser bar genome selector

### DIFF
--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
@@ -142,6 +142,7 @@ export const BrowserBar: FunctionComponent<BrowserBarProps> = (
           <BrowserGenomeSelector
             activeGenomeId={props.activeGenomeId}
             browserActivated={props.browserActivated}
+            activeObjectId={props.activeObjectId}
             dispatchBrowserLocation={props.dispatchBrowserLocation}
             chrLocation={props.chrLocation}
             drawerOpened={props.drawerOpened}

--- a/src/ensembl/src/content/app/browser/browser-genome-selector/BrowserGenomeSelector.tsx
+++ b/src/ensembl/src/content/app/browser/browser-genome-selector/BrowserGenomeSelector.tsx
@@ -16,6 +16,7 @@ import { getChrLocationStr } from '../browserHelper';
 
 type BrowserGenomeSelectorProps = {
   activeGenomeId: string;
+  activeObjectId: string;
   browserActivated: boolean;
   chrLocation: BrowserChrLocation;
   dispatchBrowserLocation: (chrLocation: ChrLocation) => void;
@@ -27,7 +28,7 @@ type BrowserGenomeSelectorProps = {
 const BrowserGenomeSelector: FunctionComponent<BrowserGenomeSelectorProps> = (
   props: BrowserGenomeSelectorProps
 ) => {
-  const chrLocationForGenome = props.chrLocation[props.activeGenomeId] || [
+  const chrLocationForGenome = props.chrLocation[props.activeObjectId] || [
     '',
     0,
     0


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Importance
June-alpha hotfix

## Description
Fixed the issue with chromosome location displayed in the browserbar.

