### PR TITLE
Update webpack prod config

### DIFF
--- a/src/ensembl/webpack/webpack.config.prod.js
+++ b/src/ensembl/webpack/webpack.config.prod.js
@@ -68,8 +68,8 @@ const plugins = [
   // this is only temporarily until a better solution is found
   new CopyWebpackPlugin([
     {
-      from: path.join(__dirname, '../static/browser/browser.wasm'),
-      to: path.join(__dirname, '../dist/static/browser/browser.wasm')
+      from: path.join(__dirname, '../static/browser/browser*.wasm'),
+      to: path.join(__dirname, '../dist/static/browser/')
     }
   ]),
 

--- a/src/ensembl/webpack/webpack.config.prod.js
+++ b/src/ensembl/webpack/webpack.config.prod.js
@@ -95,6 +95,7 @@ const plugins = [
 
   // adds workbox library (from Google) support to enable service workers
   new WorkboxPlugin.GenerateSW({
+    swDest: '../service-worker.js', // save service worker in the root folder (/dist) instead of /dist/static
     clientsClaim: true,
     skipWaiting: true
   }),


### PR DESCRIPTION
## Type

- Bug fix

## Description
1. After https://github.com/Ensembl/ensembl-client/pull/105 added hash to the name of `browser.wasm` (to avoid the problem of caching outdated files), updating webpack config to use this change.
2. Updated webpack config to make sure service worker file sits in the root directory, so it can potentially intercept requests to any path:

> The scope of the service worker determines which files the service worker controls, in other words, from which path the service worker will intercept requests. The default scope is the location of the service worker file, and extends to all directories below. So if service-worker.js is located in the root directory, the service worker will control requests from all files at this domain.