### PR TITLE
Fix "not found" message for SpeciesSearchField

### DIFF
--- a/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.test.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.test.tsx
@@ -40,13 +40,14 @@ const buildSearchMatchGroups = (groups = 2): SearchMatches[] =>
 const onSearchChange = jest.fn();
 const onMatchSelected = jest.fn();
 const clearSelectedSearchResult = jest.fn();
-const clearSearchResults = jest.fn();
+const clearSearch = jest.fn();
 
 const defaultProps = {
   onSearchChange,
   onMatchSelected,
   clearSelectedSearchResult,
-  clearSearchResults,
+  clearSearch,
+  searchText: '',
   selectedItemText: null,
   matches: []
 };
@@ -63,16 +64,21 @@ describe('<SpeciesSearchField', () => {
       expect(wrapper.find(AutosuggestSearchField).length).toBe(1);
     });
 
+    test('does not show clear button for empty field', () => {
+      const props = { ...defaultProps, searchText: '' };
+      const wrapper = mount(<SpeciesSearchField {...props} />);
+
+      expect(wrapper.find(ClearButton).length).toBe(0);
+    });
+
     test('displays suggested matches', () => {
       const matches = buildSearchMatchGroups();
       const props = {
         ...defaultProps,
+        searchText: faker.lorem.word(),
         matches
       };
       const wrapper = mount(<SpeciesSearchField {...props} />);
-      // to update get a search string into the state of SpeciesSearchField
-      wrapper.find('input').simulate('change', { target: { value: 'foo' } });
-
       const expectedMatchedItemsNumber = flatten(matches).length;
 
       expect(wrapper.find(SpeciesSearchMatch).length).toBe(
@@ -89,15 +95,10 @@ describe('<SpeciesSearchField', () => {
       matches = buildSearchMatchGroups();
       const props = {
         ...defaultProps,
+        searchText: faker.lorem.word(),
         matches
       };
       wrapper = mount(<SpeciesSearchField {...props} />);
-      // to update get a search string into the state of SpeciesSearchField
-      wrapper.find('input').simulate('change', {
-        target: {
-          value: faker.lorem.words(2) // <-- 2 words to make sure the total number of characters is greater than the minimum required by SpeciesSearchField
-        }
-      });
     });
 
     test('triggers the onMatchSelected function when a match is clicked', () => {
@@ -112,12 +113,9 @@ describe('<SpeciesSearchField', () => {
       const clearButton = wrapper.find(ClearButton);
 
       clearButton.simulate('click');
-      wrapper.update();
 
       expect(clearSelectedSearchResult).toHaveBeenCalled();
-      expect(clearSearchResults).toHaveBeenCalled();
-      expect(wrapper.find('input').prop('value')).toBe(''); // input content was cleared
-      expect(wrapper.find(ClearButton).length).toBe(0); // clear button has disappeared
+      expect(clearSearch).toHaveBeenCalled();
     });
   });
 

--- a/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.test.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.test.tsx
@@ -129,18 +129,5 @@ describe('<SpeciesSearchField', () => {
       expect(messagePanel.length).toBe(1);
       expect(messagePanel.text()).toBe(NOT_FOUND_TEXT);
     });
-
-    test('does not show "not found" message when there are no matches but a species has been selected', () => {
-      /* example scenario:
-         - search for a non-existing species (SpeciesSearchField will receive empty array as a matches prop)
-         - select a species by clicking on a popular species button
-         - "not found" message should disappear
-      */
-      const props = { ...defaultProps, selectedItemText: faker.lorem.word() };
-      const wrapper = mount(<SpeciesSearchField {...props} />);
-      const messagePanel = wrapper.find('.autosuggestionPlate');
-
-      expect(messagePanel.length).toBe(0);
-    });
   });
 });

--- a/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.test.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.test.tsx
@@ -4,7 +4,7 @@ import faker from 'faker';
 import times from 'lodash/times';
 import flatten from 'lodash/flatten';
 
-import { SpeciesSearchField } from './SpeciesSearchField';
+import { SpeciesSearchField, NOT_FOUND_TEXT } from './SpeciesSearchField';
 import SpeciesSearchMatch from '../species-search-match/SpeciesSearchMatch';
 import ClearButton from 'src/shared/clear-button/ClearButton';
 
@@ -118,6 +118,29 @@ describe('<SpeciesSearchField', () => {
       expect(clearSearchResults).toHaveBeenCalled();
       expect(wrapper.find('input').prop('value')).toBe(''); // input content was cleared
       expect(wrapper.find(ClearButton).length).toBe(0); // clear button has disappeared
+    });
+  });
+
+  describe('no matches found', () => {
+    test('shows "not found" message', () => {
+      const wrapper = mount(<SpeciesSearchField {...defaultProps} />);
+      const messagePanel = wrapper.find('.autosuggestionPlate');
+
+      expect(messagePanel.length).toBe(1);
+      expect(messagePanel.text()).toBe(NOT_FOUND_TEXT);
+    });
+
+    test('does not show "not found" message when there are no matches but a species has been selected', () => {
+      /* example scenario:
+         - search for a non-existing species (SpeciesSearchField will receive empty array as a matches prop)
+         - select a species by clicking on a popular species button
+         - "not found" message should disappear
+      */
+      const props = { ...defaultProps, selectedItemText: faker.lorem.word() };
+      const wrapper = mount(<SpeciesSearchField {...props} />);
+      const messagePanel = wrapper.find('.autosuggestionPlate');
+
+      expect(messagePanel.length).toBe(0);
     });
   });
 });

--- a/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx
@@ -93,6 +93,10 @@ export const SpeciesSearchField = (props: Props) => {
     ? RightCornerStatus.EMPTY
     : RightCornerStatus.INFO;
 
+  const isNotFound = Boolean(
+    !props.selectedItemText && props.matches && props.matches.length === 0
+  );
+
   return (
     <AutosuggestSearchField
       search={props.selectedItemText || search}
@@ -103,7 +107,7 @@ export const SpeciesSearchField = (props: Props) => {
       matchGroups={matchGroups}
       searchFieldClassName={styles.speciesSearchField}
       canShowSuggestions={canShowSuggesions}
-      notFound={Boolean(props.matches && props.matches.length === 0)}
+      notFound={isNotFound}
       notFoundText="Sorry, we have no data for this species"
       onFocus={() => setIsFocused(true)}
       onBlur={() => setIsFocused(false)}

--- a/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx
@@ -94,9 +94,7 @@ export const SpeciesSearchField = (props: Props) => {
     ? RightCornerStatus.EMPTY
     : RightCornerStatus.INFO;
 
-  const isNotFound = Boolean(
-    !props.selectedItemText && props.matches && props.matches.length === 0
-  );
+  const isNotFound = Boolean(props.matches && props.matches.length === 0);
 
   return (
     <AutosuggestSearchField

--- a/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx
@@ -28,6 +28,7 @@ import { RootState } from 'src/store';
 import styles from './SpeciesSearchField.scss';
 
 const MINIMUM_SEARCH_LENGTH = 3;
+export const NOT_FOUND_TEXT = 'Sorry, we have no data for this species';
 
 type Props = {
   onSearchChange: (search: string) => void;
@@ -108,7 +109,7 @@ export const SpeciesSearchField = (props: Props) => {
       searchFieldClassName={styles.speciesSearchField}
       canShowSuggestions={canShowSuggesions}
       notFound={isNotFound}
-      notFoundText="Sorry, we have no data for this species"
+      notFoundText={NOT_FOUND_TEXT}
       onFocus={() => setIsFocused(true)}
       onBlur={() => setIsFocused(false)}
       rightCorner={<RightCorner status={rightCornerStatus} clear={clear} />}

--- a/src/ensembl/src/content/app/species-selector/constants/speciesSelectorConstants.ts
+++ b/src/ensembl/src/content/app/species-selector/constants/speciesSelectorConstants.ts
@@ -1,0 +1,1 @@
+export const MINIMUM_SEARCH_LENGTH = 3;

--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorActions.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorActions.ts
@@ -6,7 +6,11 @@ import apiService from 'src/services/api-service';
 
 import speciesSelectorStorageService from 'src/content/app/species-selector/services/species-selector-storage-service';
 
-import { getCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
+import {
+  getSelectedItem,
+  getCommittedSpecies,
+  getSearchText
+} from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 
 import {
   SearchMatch,
@@ -15,6 +19,38 @@ import {
   Assembly,
   PopularSpecies
 } from 'src/content/app/species-selector/types/species-search';
+
+import { MINIMUM_SEARCH_LENGTH } from 'src/content/app/species-selector/constants/speciesSelectorConstants';
+
+import { RootState } from 'src/store';
+
+export const setSearchText = createStandardAction(
+  'species_selector/set_search_text'
+)<string>();
+
+export const updateSearch: ActionCreator<
+  ThunkAction<void, any, null, Action<string>>
+> = (text: string) => (dispatch, getState: () => RootState) => {
+  console.log('update');
+  const state = getState();
+  const selectedItem = getSelectedItem(state);
+  const previousText = getSearchText(state);
+  if (selectedItem) {
+    dispatch(clearSelectedSearchResult());
+  }
+
+  const trimmedText = text.trim();
+  if (text.length < previousText.length) {
+    // user is deleting their input; clear search results
+    dispatch(clearSearchResults());
+  }
+
+  if (trimmedText.length >= MINIMUM_SEARCH_LENGTH) {
+    dispatch(fetchSpeciesSearchResults.request(trimmedText));
+  }
+
+  dispatch(setSearchText(text));
+};
 
 export const fetchSpeciesSearchResults = createAsyncAction(
   'species_selector/species_search_request',
@@ -44,6 +80,10 @@ export const fetchAssembliesAsyncActions = createAsyncAction(
 export const setSelectedSpecies = createStandardAction(
   'species_selector/species_selected'
 )<SearchMatch | PopularSpecies>();
+
+export const clearSearch = createStandardAction(
+  'species_selector/clear_search'
+)();
 
 export const clearSearchResults = createStandardAction(
   'species_selector/clear_search_results'

--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorEpics.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorEpics.ts
@@ -17,7 +17,9 @@ export const fetchSpeciesSearchResultsEpic: Epic<Action, Action, RootState> = (
     filter(
       isActionOf([
         speciesSelectorActions.fetchSpeciesSearchResults.request,
-        speciesSelectorActions.clearSearchResults
+        speciesSelectorActions.setSelectedSpecies,
+        speciesSelectorActions.clearSearchResults,
+        speciesSelectorActions.commitSelectedSpecies
       ])
     ),
     distinctUntilChanged(

--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorReducer.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorReducer.ts
@@ -52,10 +52,21 @@ export default function speciesSelectorReducer(
   action: ActionType<typeof speciesSelectorActions>
 ): SpeciesSelectorState {
   switch (action.type) {
+    case getType(speciesSelectorActions.setSearchText):
+      return {
+        ...state,
+        search: {
+          ...state.search,
+          text: action.payload
+        }
+      };
     case getType(speciesSelectorActions.fetchSpeciesSearchResults.success):
       return {
         ...state,
-        search: action.payload
+        search: {
+          ...state.search,
+          ...action.payload
+        }
       };
     case getType(speciesSelectorActions.setSelectedSpecies):
       return {
@@ -131,10 +142,15 @@ export default function speciesSelectorReducer(
           (item) => item.genome_id !== action.payload
         )
       };
-    case getType(speciesSelectorActions.clearSearchResults):
+    case getType(speciesSelectorActions.clearSearch):
       return {
         ...state,
         search: initialState.search
+      };
+    case getType(speciesSelectorActions.clearSearchResults):
+      return {
+        ...state,
+        search: { ...state.search, results: initialState.search.results }
       };
     case getType(speciesSelectorActions.clearSelectedSearchResult):
       return {

--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorReducer.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorReducer.ts
@@ -60,7 +60,8 @@ export default function speciesSelectorReducer(
     case getType(speciesSelectorActions.setSelectedSpecies):
       return {
         ...state,
-        currentItem: buildCurrentItem(action.payload)
+        currentItem: buildCurrentItem(action.payload),
+        search: initialState.search
       };
     // TODO: wait for strains
     // case getType(speciesSelectorActions.fetchStrainsAsyncActions.success):

--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorSelectors.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorSelectors.ts
@@ -3,8 +3,14 @@ import get from 'lodash/get';
 import { RootState } from 'src/store';
 import { CommittedItem } from 'src/content/app/species-selector/types/species-search';
 
+export const getSearchText = (state: RootState) =>
+  state.speciesSelector.search.text;
+
 export const getSearchResults = (state: RootState) =>
   state.speciesSelector.search.results;
+
+export const getSelectedItem = (state: RootState) =>
+  state.speciesSelector.currentItem;
 
 export const getSelectedItemText = (state: RootState): string | null => {
   const commonName = get(

--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorState.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorState.ts
@@ -29,6 +29,7 @@ export type SpeciesSelectorState = {
     isSelectingAssembly: boolean;
   };
   search: {
+    text: string;
     results: SearchMatches[] | null;
   };
   currentItem: CurrentItem | null;
@@ -47,6 +48,7 @@ const initialState: SpeciesSelectorState = {
     isSelectingAssembly: false
   },
   search: {
+    text: '',
     results: null
   },
   currentItem: null,


### PR DESCRIPTION
## Type

- Bug fix

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-241

## Description
Currently, the following scenario results in incorrect behaviour:
- search for a non-existing species
- see the "Sorry, we have no data for this species" message
- select a species by clicking on a popular species button
- see the name of the species added in the search field
- _(bug)_ notice that the "Sorry we have no data..." message is still showing

This PR fixes the bug.

## Views affected
Species selector screen