### PR TITLE
Fix edge case for species search match

### DIFF
--- a/src/ensembl/src/content/app/species-selector/components/species-search-match/SpeciesSearchMatch.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-search-match/SpeciesSearchMatch.tsx
@@ -166,7 +166,7 @@ const splitMatch = ({ string, matchedSubstrings }: SplitterProps) => {
       ];
     } else if (
       index === array.length - 1 &&
-      currentEndIndex < string.length - 1
+      currentEndIndex <= string.length - 1
     ) {
       // if there is unmatched trailing portion of the string, add it to the list of substrings
       result = [


### PR DESCRIPTION
## Type
- Bug fix

## Description
Fix species search match for cases when all but one last letter of a field is selected

**Before** (notice the missing "n" in the end of the word "Human"): 
![image](https://user-images.githubusercontent.com/6834224/61251846-8ced5900-a753-11e9-9951-66f6b48f3c55.png)

**After:**
![image](https://user-images.githubusercontent.com/6834224/61251895-b27a6280-a753-11e9-9157-bbfe10385bc2.png)


## Views affected
Species Selector