### PR TITLE
Fix SpeciesSearchField tests

### DIFF
--- a/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.test.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.test.tsx
@@ -53,6 +53,12 @@ const defaultProps = {
 };
 
 describe('<SpeciesSearchField', () => {
+  let searchText: string;
+
+  beforeEach(() => {
+    searchText = faker.lorem.words();
+  });
+
   afterEach(() => {
     jest.resetAllMocks();
   });
@@ -65,8 +71,7 @@ describe('<SpeciesSearchField', () => {
     });
 
     test('does not show clear button for empty field', () => {
-      const props = { ...defaultProps, searchText: '' };
-      const wrapper = mount(<SpeciesSearchField {...props} />);
+      const wrapper = mount(<SpeciesSearchField {...defaultProps} />);
 
       expect(wrapper.find(ClearButton).length).toBe(0);
     });
@@ -75,7 +80,7 @@ describe('<SpeciesSearchField', () => {
       const matches = buildSearchMatchGroups();
       const props = {
         ...defaultProps,
-        searchText: faker.lorem.word(),
+        searchText,
         matches
       };
       const wrapper = mount(<SpeciesSearchField {...props} />);
@@ -95,7 +100,7 @@ describe('<SpeciesSearchField', () => {
       matches = buildSearchMatchGroups();
       const props = {
         ...defaultProps,
-        searchText: faker.lorem.word(),
+        searchText,
         matches
       };
       wrapper = mount(<SpeciesSearchField {...props} />);


### PR DESCRIPTION
## Type

- Bug fix

## Description
I forgot again that the faker method I used in tests (`faker.lorem.word`) can generate short words, which will be shorter that required to show the autosuggestion panel. So the tests that were trying to click things in autosuggestion panel were occasionally failing:

![Screenshot 2019-07-18 at 10 01 03](https://user-images.githubusercontent.com/6834224/61446338-d94cba80-a946-11e9-93fb-d98f35ced06f.png)
