### PR TITLE
Fix docker daemon error for GitLab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,7 @@ variables:
   KUBECONTEXT: ens-dev-ctx
   DEPLOYENV: dev
   ENVIRONMENT: production
+  DOCKER_TLS_CERTDIR: ""
 
 Test:
   image: node:10.16.0


### PR DESCRIPTION
## Type

- [x ] Bug fix

## Description
gitlab CICD failing with error Cannot connect to the Docker daemon at tcp://docker:2375. Is the docker daemon running?

The solution is here https://gitlab.com/gitlab-org/gitlab-ce/issues/64959
