### PR TITLE
Fix toggling of species use status

### DIFF
--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorActions.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorActions.ts
@@ -249,7 +249,7 @@ export const toggleSpeciesUseAndSave: ActionCreator<
   });
 
   dispatch(updateCommittedSpecies(updatedCommittedSpecies));
-  speciesSelectorStorageService.saveSelectedSpecies(committedSpecies);
+  speciesSelectorStorageService.saveSelectedSpecies(updatedCommittedSpecies);
 };
 
 export const deleteSpeciesAndSave: ActionCreator<

--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorSelectors.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorSelectors.ts
@@ -1,4 +1,5 @@
 import get from 'lodash/get';
+import find from 'lodash/find';
 
 import { RootState } from 'src/store';
 import { CommittedItem } from 'src/content/app/species-selector/types/species-search';
@@ -60,6 +61,16 @@ export const canCommitSpecies = (state: RootState) => {
 
 export const getCommittedSpecies = (state: RootState): CommittedItem[] => {
   return state.speciesSelector.committedItems;
+};
+
+export const getCommittedSpeciesById = (
+  state: RootState,
+  genomeId: string
+): CommittedItem | null => {
+  const allCommittedSpecies = getCommittedSpecies(state);
+  return (
+    find(allCommittedSpecies, ({ genome_id }) => genomeId === genome_id) || null
+  );
 };
 
 export const getEnabledCommittedSpecies = (state: RootState) => {

--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorSelectors.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorSelectors.ts
@@ -69,7 +69,8 @@ export const getCommittedSpeciesById = (
 ): CommittedItem | null => {
   const allCommittedSpecies = getCommittedSpecies(state);
   return (
-    find(allCommittedSpecies, ({ genome_id }) => genomeId === genome_id) || null
+    find(allCommittedSpecies, (species) => genomeId === species.genome_id) ||
+    null
   );
 };
 


### PR DESCRIPTION
## Type
- Bug fix

## Description
Fixes regression introduced in https://github.com/Ensembl/ensembl-client/pull/113, which breaks toggling between using and not using selected species.

## Views affected
Species Selector