### PR TITLE
Fix for browser tabs get hidden when track panel closed on large screens

### DIFF
--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.scss
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.scss
@@ -26,11 +26,7 @@
   flex-wrap: nowrap;
   font-size: 12px;
   margin: 0;
-  width: calc(100vw - 36px);
-
-  @include breakpoint(large) {
-    width: calc(100vw - 356px);
-  }
+  width: calc(100vw - 356px);
 
   label {
     color: $ens-dark-grey;
@@ -48,6 +44,10 @@
 
   &.browserInfoExpanded {
     width: calc(100vw - 36px);
+
+    @include breakpoint(large) {
+      width: calc(100vw - 356px);
+    }
   }
 
   &.browserInfoGreyed {

--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
@@ -126,13 +126,10 @@ export const BrowserBar: FunctionComponent<BrowserBarProps> = (
     props.toggleBrowserNav();
   };
 
-  const shouldShowBrowserTabs = () => {
-    return (
-      props.activeGenomeId &&
-      (props.isTrackPanelOpened ||
-        props.breakpointWidth === BreakpointWidth.LARGE)
-    );
-  };
+  const shouldShowBrowserTabs =
+    props.activeGenomeId &&
+    (props.isTrackPanelOpened ||
+      props.breakpointWidth === BreakpointWidth.LARGE);
 
   const className = classNames(styles.browserInfo, {
     [styles.browserInfoExpanded]: !props.isTrackPanelOpened,
@@ -175,7 +172,7 @@ export const BrowserBar: FunctionComponent<BrowserBarProps> = (
           )}
         </dl>
       </div>
-      {shouldShowBrowserTabs() && (
+      {shouldShowBrowserTabs && (
         <BrowserTabs
           closeDrawer={props.closeDrawer}
           ensObject={props.ensObject}

--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
@@ -127,15 +127,11 @@ export const BrowserBar: FunctionComponent<BrowserBarProps> = (
   };
 
   const shouldShowBrowserTabs = () => {
-    if (
+    return (
       props.activeGenomeId &&
       (props.isTrackPanelOpened ||
         props.breakpointWidth === BreakpointWidth.LARGE)
-    ) {
-      return true;
-    } else {
-      return false;
-    }
+    );
   };
 
   const className = classNames(styles.browserInfo, {

--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
@@ -23,8 +23,11 @@ import {
   getIsTrackPanelModalOpened,
   getIsTrackPanelOpened
 } from '../track-panel/trackPanelSelectors';
-import { selectBrowserTabAndSave } from '../track-panel/trackPanelActions';
-import { closeDrawer, toggleDrawer } from '../drawer/drawerActions';
+import {
+  selectBrowserTabAndSave,
+  toggleTrackPanel
+} from '../track-panel/trackPanelActions';
+import { closeDrawer } from '../drawer/drawerActions';
 import { RootState } from 'src/store';
 import { EnsObject } from 'src/ens-object/ensObjectTypes';
 
@@ -32,10 +35,14 @@ import BrowserReset from '../browser-reset/BrowserReset';
 import BrowserGenomeSelector from '../browser-genome-selector/BrowserGenomeSelector';
 import BrowserTabs from '../browser-tabs/BrowserTabs';
 
+import { getBreakpointWidth } from 'src/global/globalSelectors';
+import { BreakpointWidth } from 'src/global/globalConfig';
+
 import styles from './BrowserBar.scss';
 
 type StateProps = {
   activeGenomeId: string | null;
+  breakpointWidth: BreakpointWidth;
   browserActivated: boolean;
   browserNavOpened: boolean;
   chrLocation: ChrLocation | null;
@@ -53,8 +60,8 @@ type DispatchProps = {
   closeDrawer: () => void;
   selectBrowserTabAndSave: (selectedBrowserTab: TrackType) => void;
   toggleBrowserNav: () => void;
-  toggleDrawer: (isDrawerOpened: boolean) => void;
   toggleGenomeSelector: (genomeSelectorActive: boolean) => void;
+  toggleTrackPanel: (isTrackPanelOpened: boolean) => void;
 };
 
 type OwnProps = {
@@ -119,6 +126,18 @@ export const BrowserBar: FunctionComponent<BrowserBarProps> = (
     props.toggleBrowserNav();
   };
 
+  const shouldShowBrowserTabs = () => {
+    if (
+      props.activeGenomeId &&
+      (props.isTrackPanelOpened ||
+        props.breakpointWidth === BreakpointWidth.LARGE)
+    ) {
+      return true;
+    } else {
+      return false;
+    }
+  };
+
   const className = classNames(styles.browserInfo, {
     [styles.browserInfoExpanded]: !props.isTrackPanelOpened,
     [styles.browserInfoGreyed]: isDrawerOpened
@@ -160,7 +179,7 @@ export const BrowserBar: FunctionComponent<BrowserBarProps> = (
           )}
         </dl>
       </div>
-      {props.isTrackPanelOpened && props.activeGenomeId && (
+      {shouldShowBrowserTabs() && (
         <BrowserTabs
           closeDrawer={props.closeDrawer}
           ensObject={props.ensObject}
@@ -168,7 +187,9 @@ export const BrowserBar: FunctionComponent<BrowserBarProps> = (
           genomeSelectorActive={props.genomeSelectorActive}
           selectBrowserTabAndSave={props.selectBrowserTabAndSave}
           selectedBrowserTab={props.selectedBrowserTab}
+          toggleTrackPanel={props.toggleTrackPanel}
           isTrackPanelModalOpened={props.isTrackPanelModalOpened}
+          isTrackPanelOpened={props.isTrackPanelOpened}
         />
       )}
     </div>
@@ -226,6 +247,7 @@ export const BrowserNavigatorButton = (props: BrowserNavigatorButtonProps) => (
 
 const mapStateToProps = (state: RootState): StateProps => ({
   activeGenomeId: getBrowserActiveGenomeId(state),
+  breakpointWidth: getBreakpointWidth(state),
   browserActivated: getBrowserActivated(state),
   browserNavOpened: getBrowserNavOpened(state),
   chrLocation: getChrLocation(state),
@@ -243,8 +265,8 @@ const mapDispatchToProps: DispatchProps = {
   closeDrawer,
   selectBrowserTabAndSave,
   toggleBrowserNav,
-  toggleDrawer,
-  toggleGenomeSelector
+  toggleGenomeSelector,
+  toggleTrackPanel
 };
 
 export default connect(

--- a/src/ensembl/src/content/app/browser/browser-tabs/BrowserTabs.tsx
+++ b/src/ensembl/src/content/app/browser/browser-tabs/BrowserTabs.tsx
@@ -59,7 +59,7 @@ const BrowserTabs: FunctionComponent<BrowserTabsProps> = (
     });
 
   return (
-    <dl className={`${styles.browserTabs} show-for-large`}>
+    <dl className={`${styles.browserTabs}`}>
       {Object.values(TrackType).map((value: TrackType) => (
         <dd
           className={getBrowserTabClassNames(value)}

--- a/src/ensembl/src/content/app/browser/browser-tabs/BrowserTabs.tsx
+++ b/src/ensembl/src/content/app/browser/browser-tabs/BrowserTabs.tsx
@@ -1,7 +1,9 @@
 import React, { FunctionComponent } from 'react';
+import classNames from 'classnames';
 
 import { TrackType } from '../track-panel/trackPanelConfig';
 import { EnsObject } from 'src/ens-object/ensObjectTypes';
+
 import styles from './BrowserTabs.scss';
 
 type BrowserTabsProps = {
@@ -11,7 +13,9 @@ type BrowserTabsProps = {
   genomeSelectorActive: boolean;
   selectBrowserTabAndSave: (selectedBrowserTab: TrackType) => void;
   selectedBrowserTab: TrackType;
+  toggleTrackPanel: (isTrackPanelOpened: boolean) => void;
   isTrackPanelModalOpened: boolean;
+  isTrackPanelOpened: boolean;
 };
 
 const BrowserTabs: FunctionComponent<BrowserTabsProps> = (
@@ -22,6 +26,10 @@ const BrowserTabs: FunctionComponent<BrowserTabsProps> = (
       return;
     }
 
+    if (!props.isTrackPanelOpened) {
+      props.toggleTrackPanel(true);
+    }
+
     if (props.isDrawerOpened) {
       props.closeDrawer();
     }
@@ -29,33 +37,32 @@ const BrowserTabs: FunctionComponent<BrowserTabsProps> = (
     props.selectBrowserTabAndSave(value);
   };
 
-  const getBrowserTabClasses = (trackType: TrackType) => {
-    const {
-      isDrawerOpened,
-      selectedBrowserTab,
-      isTrackPanelModalOpened
-    } = props;
-    let classNames = styles.browserTab;
-
+  const isBrowserTabActive = (trackType: TrackType) => {
     if (
+      props.isTrackPanelOpened &&
       props.ensObject.genome_id &&
-      selectedBrowserTab === trackType &&
-      !isDrawerOpened &&
-      !isTrackPanelModalOpened
+      props.selectedBrowserTab === trackType &&
+      !props.isDrawerOpened &&
+      !props.isTrackPanelModalOpened
     ) {
-      classNames += ` ${styles.browserTabActive} ${styles.browserTabArrow}`;
-    } else if (!props.ensObject.genome_id) {
-      classNames = styles.browserTabDisabled;
+      return true;
+    } else {
+      return false;
     }
-
-    return classNames;
   };
+
+  const getBrowserTabClassNames = (trackType: TrackType) =>
+    classNames(styles.browserTab, {
+      [styles.browserTabActive]: isBrowserTabActive(trackType),
+      [styles.browserTabArrow]: isBrowserTabActive(trackType),
+      [styles.browserTabDisabled]: !props.ensObject.genome_id
+    });
 
   return (
     <dl className={`${styles.browserTabs} show-for-large`}>
       {Object.values(TrackType).map((value: TrackType) => (
         <dd
-          className={getBrowserTabClasses(value)}
+          className={getBrowserTabClassNames(value)}
           key={value}
           onClick={() => handleTabClick(value)}
         >

--- a/src/ensembl/src/content/app/browser/browser-tabs/BrowserTabs.tsx
+++ b/src/ensembl/src/content/app/browser/browser-tabs/BrowserTabs.tsx
@@ -37,22 +37,20 @@ const BrowserTabs: FunctionComponent<BrowserTabsProps> = (
     props.selectBrowserTabAndSave(value);
   };
 
-  const isBrowserTabActive = (trackType: TrackType) => {
-    return (
+  const getBrowserTabClassNames = (trackType: TrackType) => {
+    const isBrowserTabActive =
       props.isTrackPanelOpened &&
       props.ensObject.genome_id &&
       props.selectedBrowserTab === trackType &&
       !props.isDrawerOpened &&
-      !props.isTrackPanelModalOpened
-    );
-  };
+      !props.isTrackPanelModalOpened;
 
-  const getBrowserTabClassNames = (trackType: TrackType) =>
-    classNames(styles.browserTab, {
-      [styles.browserTabActive]: isBrowserTabActive(trackType),
-      [styles.browserTabArrow]: isBrowserTabActive(trackType),
+    return classNames(styles.browserTab, {
+      [styles.browserTabActive]: isBrowserTabActive,
+      [styles.browserTabArrow]: isBrowserTabActive,
       [styles.browserTabDisabled]: !props.ensObject.genome_id
     });
+  };
 
   return (
     <dl className={`${styles.browserTabs}`}>

--- a/src/ensembl/src/content/app/browser/browser-tabs/BrowserTabs.tsx
+++ b/src/ensembl/src/content/app/browser/browser-tabs/BrowserTabs.tsx
@@ -38,17 +38,13 @@ const BrowserTabs: FunctionComponent<BrowserTabsProps> = (
   };
 
   const isBrowserTabActive = (trackType: TrackType) => {
-    if (
+    return (
       props.isTrackPanelOpened &&
       props.ensObject.genome_id &&
       props.selectedBrowserTab === trackType &&
       !props.isDrawerOpened &&
       !props.isTrackPanelModalOpened
-    ) {
-      return true;
-    } else {
-      return false;
-    }
+    );
   };
 
   const getBrowserTabClassNames = (trackType: TrackType) =>


### PR DESCRIPTION
<!--
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This will normally be the development branch, so please ask your reviewer if you think it needs to go somewhere else. 
-->

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
<!--_Please provide the URL(s) for any JIRA issues related to this PR._-->
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-258

## Description
<!--
_Using one or more sentences, describe the proposed changes and the reason for making them._
-->
Fixes for:
- Browser tabs not shown when track panel closed on large screens
- Browser tabs not shown on smaller screens when track panel is open

The XD for this behaviour is: https://xd.adobe.com/view/8b709d74-78a9-47ee-78eb-54f65cd02054-fd41/?fullscreen

## Views affected
<!--
_List the website view(s) that you know are affected by this change._
_If possible please provide a relative or localhost URL that can be used to view the change._
-->
Genome browser

## Other effects
<!--
_List any other functionality that may be affected or which requires additional changes, such as saved configurations. Please add an explanation if, for example, no test is needed._
-->

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.
