### PR TITLE
Separate home and genome browser coordinates with commas

### DIFF
--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
@@ -27,6 +27,7 @@ import { selectBrowserTabAndSave } from '../track-panel/trackPanelActions';
 import { closeDrawer, toggleDrawer } from '../drawer/drawerActions';
 import { RootState } from 'src/store';
 import { EnsObject } from 'src/ens-object/ensObjectTypes';
+import { getCommaSeparatedNumber } from 'src/shared/helpers/numberFormatter';
 
 import BrowserReset from '../browser-reset/BrowserReset';
 import BrowserGenomeSelector from '../browser-genome-selector/BrowserGenomeSelector';
@@ -207,7 +208,9 @@ export const BrowserInfo = ({ ensObject }: BrowserInfoProps) => {
           <dd className={styles.ensObjectLabel}>
             <label>Region: </label>
             <span className={styles.value}>
-              {`${ensObject.location.chromosome}:${ensObject.location.start}:${ensObject.location.end}`}
+              {`${ensObject.location.chromosome}:${getCommaSeparatedNumber(
+                ensObject.location.start
+              )}:${getCommaSeparatedNumber(ensObject.location.end)}`}
             </span>
           </dd>
         </>

--- a/src/ensembl/src/content/app/browser/browser-genome-selector/BrowserGenomeSelector.tsx
+++ b/src/ensembl/src/content/app/browser/browser-genome-selector/BrowserGenomeSelector.tsx
@@ -8,12 +8,13 @@ import React, {
 import classNames from 'classnames';
 
 import { ChrLocation } from '../browserState';
+import { getChrLocationStr } from '../browserHelper';
+import { getCommaSeparatedNumber } from 'src/shared/helpers/numberFormatter';
 
 import applyIcon from 'static/img/shared/apply.svg';
 import clearIcon from 'static/img/shared/clear.svg';
 
 import styles from './BrowserGenomeSelector.scss';
-import { getChrLocationStr } from '../browserHelper';
 
 type BrowserGenomeSelectorProps = {
   activeGenomeId: string | null;
@@ -117,9 +118,9 @@ const BrowserGenomeSelector: FunctionComponent<BrowserGenomeSelectorProps> = (
           <div className={styles.chrCode}>{chrCode}</div>
           {displayChrRegion ? (
             <div className={styles.chrRegion}>
-              <span>{chrStart}</span>
+              <span>{getCommaSeparatedNumber(chrStart)}</span>
               <span className={styles.chrSeparator}> - </span>
-              <span>{chrEnd}</span>
+              <span>{getCommaSeparatedNumber(chrEnd)}</span>
             </div>
           ) : null}
         </div>

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
@@ -11,6 +11,7 @@ import { getGenomeInfo } from 'src/genome/genomeSelectors';
 import { fetchExampleEnsObjects } from 'src/ens-object/ensObjectActions';
 import { getExampleEnsObjects } from 'src/ens-object/ensObjectSelectors';
 import * as urlFor from 'src/shared/helpers/urlHelper';
+import { getCommaSeparatedNumber } from 'src/shared/helpers/numberFormatter';
 
 import upperFirst from 'lodash/upperFirst';
 
@@ -31,6 +32,18 @@ type OwnProps = {};
 type TrackPanelBookmarksProps = StateProps & DispatchProps & OwnProps;
 
 export const TrackPanelBookmarks = (props: TrackPanelBookmarksProps) => {
+  const getExampleObjLabel = (exampleObject: EnsObject) => {
+    if (exampleObject.object_type === 'gene') {
+      return exampleObject.label;
+    } else {
+      const { chromosome, start, end } = exampleObject.location;
+
+      return `${chromosome}:${getCommaSeparatedNumber(
+        start
+      )}:${getCommaSeparatedNumber(end)}`;
+    }
+  };
+
   const getPreviouslyViewed = () => {
     return props.exampleEnsObjects.map((exampleObject) => {
       const locationStr = `${exampleObject.location.chromosome}:${exampleObject.location.start}-${exampleObject.location.end}`;
@@ -43,7 +56,8 @@ export const TrackPanelBookmarks = (props: TrackPanelBookmarksProps) => {
       return (
         <dd key={exampleObject.ensembl_object_id}>
           <Link to={path}>
-            {upperFirst(exampleObject.object_type)}: {exampleObject.label}
+            {upperFirst(exampleObject.object_type)}:{' '}
+            {getExampleObjLabel(exampleObject)}
           </Link>
         </dd>
       );

--- a/src/ensembl/src/content/home/Home.tsx
+++ b/src/ensembl/src/content/home/Home.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
+import upperFirst from 'lodash/upperFirst';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import { RootState } from 'src/store';
@@ -13,9 +14,9 @@ import { getCommittedSpecies } from '../app/species-selector/state/speciesSelect
 import { CommittedItem } from '../app/species-selector/types/species-search';
 
 import { fetchGenomeInfo } from 'src/genome/genomeActions';
-import upperFirst from 'lodash/upperFirst';
-
+import { getCommaSeparatedNumber } from 'src/shared/helpers/numberFormatter';
 import { GenomeInfoData } from 'src/genome/genomeTypes';
+
 import styles from './Home.scss';
 
 type StateProps = {
@@ -51,6 +52,18 @@ const Home: FunctionComponent<HomeProps> = (props: HomeProps) => {
     }
   }, [props.exampleEnsObjects]);
 
+  const getExampleObjLabel = (exampleObject: EnsObject) => {
+    if (exampleObject.object_type === 'gene') {
+      return exampleObject.label;
+    } else {
+      const { chromosome, start, end } = exampleObject.location;
+
+      return `${chromosome}:${getCommaSeparatedNumber(
+        start
+      )}:${getCommaSeparatedNumber(end)}`;
+    }
+  };
+
   const getPreviouslyViewed = () => {
     return props.activeSpecies.map((species) => {
       if (props.exampleEnsObjects.length) {
@@ -67,7 +80,7 @@ const Home: FunctionComponent<HomeProps> = (props: HomeProps) => {
               <Link to={path}>
                 {`${species.common_name} ${upperFirst(
                   exampleObject.object_type
-                )}: ${exampleObject.label}`}
+                )}: ${getExampleObjLabel(exampleObject)}`}
               </Link>
             </dd>
           );

--- a/src/ensembl/src/shared/helpers/numberFormatter.ts
+++ b/src/ensembl/src/shared/helpers/numberFormatter.ts
@@ -2,6 +2,6 @@
     Formats the input number to comma separated representation
     eg: 10000 -> 10,000
 */
-export const getCommaSeparatedNumber = (input: number): string => {
+export const getCommaSeparatedNumber = (input: number | string): string => {
   return input.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 };

--- a/src/ensembl/src/shared/helpers/numberFormatter.ts
+++ b/src/ensembl/src/shared/helpers/numberFormatter.ts
@@ -2,6 +2,6 @@
     Formats the input number to comma separated representation
     eg: 10000 -> 10,000
 */
-export const getCommaSeparatedNumber = (input: number | string): string => {
+export const getCommaSeparatedNumber = (input: number) => {
   return input.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 };


### PR DESCRIPTION
<!--
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This will normally be the development branch, so please ask your reviewer if you think it needs to go somewhere else. 
-->

## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-214

## Description
The coordinates in the UI don't use comma separators for big numbers. This makes it difficult to read, so commas have been added to them. However, the input field numbers are not separated by commas.

## Views affected
Home and Genome Browser

## Other effects
<!--
_List any other functionality that may be affected or which requires additional changes, such as saved configurations. Please add an explanation if, for example, no test is needed._
-->

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.
