### PR TITLE
Run typescript compiler to check types in Test CI job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,7 @@ Test:
   - npm ci
 
   script:
+  - npm run check-types
   - npm run test
 
   except:


### PR DESCRIPTION
## Type
- Improvement to existing feature

## Description
**Problem:** we use typescript as type checker with babel. When webpack builds a juvascript bundle and there are type errors, typescript will generate errors during the build process, due to which webpack will exit its job with a non-zero exit code, which counts as script error. 

To spot type errors before we attempt to build javascript bundle (and avoid the annoying situations when the tests pass, but the build fails because of type problems), this PR includes the type checking script (`npm run check-types`) in Gitlab CI Test job.