### PR TITLE
Use ImageButton in HeaderButtons (in masthead)

### DIFF
--- a/src/ensembl/src/header/header-buttons/HeaderButtons.scss
+++ b/src/ensembl/src/header/header-buttons/HeaderButtons.scss
@@ -1,11 +1,15 @@
-.headerButtons {
-  button {
-    bottom: 1px;
-    display: inline-block;
-    height: 17px;
-    margin-left: 20px;
-    position: relative;
-    width: 17px;
-    vertical-align: middle;
+.buttonWrapper {
+  display: inline-block;
+  bottom: 1px;
+  height: 17px;
+  margin-left: 20px;
+  position: relative;
+  width: 17px;
+  vertical-align: middle;
+}
+
+.headerButtonDisabled {
+  svg {
+    fill: #7d8e9b;
   }
 }

--- a/src/ensembl/src/header/header-buttons/HeaderButtons.test.tsx
+++ b/src/ensembl/src/header/header-buttons/HeaderButtons.test.tsx
@@ -1,17 +1,20 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, ShallowWrapper } from 'enzyme';
 
 import { HeaderButtons } from './HeaderButtons';
+import ImageButton, {
+  ImageButtonStatus
+} from 'src/shared/image-button/ImageButton';
 
 describe('<HeaderButtons />', () => {
   let toggleLaunchbarFn: () => void;
   let toggleAccountFn: () => void;
-  let wrapper: any;
+  let shallowWrapper: ShallowWrapper;
 
   beforeEach(() => {
     toggleLaunchbarFn = jest.fn();
     toggleAccountFn = jest.fn();
-    wrapper = shallow(
+    shallowWrapper = shallow(
       <HeaderButtons
         toggleAccount={toggleAccountFn}
         toggleLaunchbar={toggleLaunchbarFn}
@@ -19,15 +22,23 @@ describe('<HeaderButtons />', () => {
     );
   });
 
-  test('calls toggleLaunchbar prop on launchbar button click', () => {
-    wrapper.find('.launchbarButton').simulate('click');
-
-    expect(toggleLaunchbarFn).toHaveBeenCalled();
+  test('contains button for toggling launchbar', () => {
+    const launchbarButton = shallowWrapper
+      .find(ImageButton)
+      .filterWhere(
+        (wrapper) => wrapper.prop('description') === 'Ensembl app launchbar'
+      );
+    expect(launchbarButton.prop('onClick')).toBe(toggleLaunchbarFn);
   });
 
-  test.skip('calls toggleAccount prop on account button click', () => {
-    wrapper.find('.accountButton').simulate('click');
-
-    expect(toggleAccountFn).toHaveBeenCalled();
+  test('contains disabled user account button', () => {
+    const launchbarButton = shallowWrapper
+      .find(ImageButton)
+      .filterWhere(
+        (wrapper) => wrapper.prop('description') === 'Ensembl account'
+      );
+    expect(launchbarButton.prop('buttonStatus')).toBe(
+      ImageButtonStatus.DISABLED
+    );
   });
 });

--- a/src/ensembl/src/header/header-buttons/HeaderButtons.tsx
+++ b/src/ensembl/src/header/header-buttons/HeaderButtons.tsx
@@ -3,8 +3,12 @@ import { connect } from 'react-redux';
 
 import { toggleAccount, toggleLaunchbar } from '../headerActions';
 
-import launchbarIcon from 'static/img/header/launchbar.svg';
-import userIcon from 'static/img/header/user-grey.svg';
+import ImageButton, {
+  ImageButtonStatus
+} from 'src/shared/image-button/ImageButton';
+
+import { ReactComponent as LaunchbarIcon } from 'static/img/header/launchbar.svg';
+import { ReactComponent as UserIcon } from 'static/img/header/user-grey.svg';
 
 import styles from './HeaderButtons.scss';
 
@@ -21,22 +25,29 @@ type HeaderButtonsProps = StateProps & DispatchProps & OwnProps;
 
 export const HeaderButtons: FunctionComponent<HeaderButtonsProps> = (props) => (
   <div className={styles.headerButtons}>
-    <button className="launchbarButton" onClick={props.toggleLaunchbar}>
-      <img
-        src={launchbarIcon}
-        alt="Toggle the Ensembl app launchbar"
-        title="Ensembl app launchbar"
+    <div className={styles.buttonWrapper}>
+      <ImageButton
+        image={LaunchbarIcon}
+        description="Ensembl app launchbar"
+        onClick={props.toggleLaunchbar}
       />
-    </button>
-    <button className="accountButton disabled">
-      <img
-        src={userIcon}
-        alt="Toggle the Ensembl account"
-        title="Ensembl account"
+    </div>
+    <div className={styles.buttonWrapper}>
+      <ImageButton
+        image={UserIcon}
+        description="Ensembl account"
+        buttonStatus={ImageButtonStatus.DISABLED}
+        classNames={{
+          [ImageButtonStatus.DISABLED]: styles.headerButtonDisabled
+        }}
       />
-    </button>
+    </div>
   </div>
 );
+
+// <button className="launchbarButton" >
+
+//      <button className="accountButton disabled"></button>
 
 const mapStateToProps = (): StateProps => ({});
 

--- a/src/ensembl/src/header/header-buttons/HeaderButtons.tsx
+++ b/src/ensembl/src/header/header-buttons/HeaderButtons.tsx
@@ -45,10 +45,6 @@ export const HeaderButtons: FunctionComponent<HeaderButtonsProps> = (props) => (
   </div>
 );
 
-// <button className="launchbarButton" >
-
-//      <button className="accountButton disabled"></button>
-
 const mapStateToProps = (): StateProps => ({});
 
 const mapDispatchToProps: DispatchProps = {

--- a/src/ensembl/src/header/launchbar/LaunchbarButton.tsx
+++ b/src/ensembl/src/header/launchbar/LaunchbarButton.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, memo } from 'react';
+import React, { FunctionComponent } from 'react';
 import { NavLink } from 'react-router-dom';
 import { withRouter, RouteComponentProps } from 'react-router';
 import ImageButton, {

--- a/src/ensembl/src/services/window-service.ts
+++ b/src/ensembl/src/services/window-service.ts
@@ -26,6 +26,23 @@ class WindowService implements WindowServiceInterface {
   public getLocation() {
     return window.location;
   }
+
+  // return viewport dimensions in the ClientRect format
+  public getDimensions() {
+    const width = window.innerWidth;
+    const height = window.innerHeight;
+
+    return {
+      x: 0,
+      y: 0,
+      width,
+      height,
+      top: 0,
+      left: 0,
+      right: width,
+      bottom: height
+    };
+  }
 }
 
 export default new WindowService();

--- a/src/ensembl/src/shared/tooltip/Tooltip.scss
+++ b/src/ensembl/src/shared/tooltip/Tooltip.scss
@@ -38,9 +38,6 @@ $fill-color: $ens-dark-grey;
 // It should also not cause change body dimensions (and cause sliders to appear),
 // hence it is placed in top left corned of the screen with position: fixed
 .tooltipInvisible {
-  position: fixed;
-  left: 0;
-  top: 0;
   visibility: hidden;
 }
 

--- a/src/ensembl/src/shared/tooltip/Tooltip.scss
+++ b/src/ensembl/src/shared/tooltip/Tooltip.scss
@@ -33,7 +33,14 @@ $fill-color: $ens-dark-grey;
   }
 }
 
+// Class applied to tooltip while the code is finding appropriate position for it.
+// The tooltip should be invisible, but have width and height required for calculations.
+// It should also not cause change body dimensions (and cause sliders to appear),
+// hence it is placed in top left corned of the screen with position: fixed
 .tooltipInvisible {
+  position: fixed;
+  left: 0;
+  top: 0;
   visibility: hidden;
 }
 

--- a/src/ensembl/src/shared/tooltip/Tooltip.scss
+++ b/src/ensembl/src/shared/tooltip/Tooltip.scss
@@ -35,10 +35,13 @@ $fill-color: $ens-dark-grey;
 
 // Class applied to tooltip while the code is finding appropriate position for it.
 // The tooltip should be invisible, but have width and height required for calculations.
-// It should also not cause change body dimensions (and cause sliders to appear),
-// hence it is placed in top left corned of the screen with position: fixed
+// It should also not change body dimensions (and cause sliders to appear);
+// hence it is placed in top left corner of the screen with position: fixed
 .tooltipInvisible {
   visibility: hidden;
+  position: fixed;
+  top: 0;
+  left: 0;
 }
 
 .tooltipTip {

--- a/src/ensembl/src/shared/tooltip/Tooltip.tsx
+++ b/src/ensembl/src/shared/tooltip/Tooltip.tsx
@@ -18,7 +18,7 @@ import styles from './Tooltip.scss';
 type Props = {
   position: Position;
   container?: HTMLElement | null;
-  autoAdjust: boolean; // try to adapt position so as not to extend beyond screen bounds
+  autoAdjust: boolean; // try to adjust tooltip position so as not to extend beyond screen bounds
   delay: number;
   children: ReactNode;
   onClose: () => void;
@@ -83,19 +83,30 @@ const Tooltip = (props: Props) => {
   }, []);
 
   useEffect(() => {
-    const node = tooltipElementRef.current;
-    const parentElement = node && node.parentElement;
-    if (!(node && parentElement)) {
+    if (isWaiting) {
       return;
     }
+
+    const tooltipElement = tooltipElementRef.current;
+    const parentElement = tooltipElement && tooltipElement.parentElement;
+
+    if (!(tooltipElement && parentElement)) {
+      return;
+    }
+
     parentRef.current = parentElement;
     setInlineStyles(getInlineStyles({ ...props, parentElement }));
 
-    if (isWaiting || !props.autoAdjust) {
-      return;
+    if (props.autoAdjust) {
+      adjustPosition(tooltipElement, parentElement);
     }
+  }, [isWaiting]);
 
-    const tooltipBoundingRect = node.getBoundingClientRect();
+  const adjustPosition = (
+    tooltipElement: HTMLDivElement,
+    parentElement: HTMLElement
+  ) => {
+    const tooltipBoundingRect = tooltipElement.getBoundingClientRect();
     const rootBoundingRect = props.container
       ? props.container.getBoundingClientRect()
       : windowService.getDimensions();
@@ -119,7 +130,7 @@ const Tooltip = (props: Props) => {
       })
     );
     setIsPositioning(false);
-  }, [isWaiting]);
+  };
 
   const className = classNames(
     styles.tooltip,

--- a/src/ensembl/src/shared/tooltip/Tooltip.tsx
+++ b/src/ensembl/src/shared/tooltip/Tooltip.tsx
@@ -81,6 +81,10 @@ const Tooltip = (props: Props) => {
   }, []);
 
   useEffect(() => {
+    if (isWaiting || !props.autoAdjust) {
+      return;
+    }
+
     const node = tooltipElementRef.current;
     const parentElement = node && node.parentElement;
     if (!(node && parentElement)) {
@@ -89,10 +93,6 @@ const Tooltip = (props: Props) => {
     parentRef.current = parentElement;
 
     setInlineStyles(getInlineStyles({ ...props, parentElement }));
-
-    if (!props.autoAdjust) {
-      return;
-    }
 
     const intersectionObserver = new IntersectionObserver(
       (entries) => {

--- a/src/ensembl/src/shared/tooltip/tooltip-helper.ts
+++ b/src/ensembl/src/shared/tooltip/tooltip-helper.ts
@@ -61,16 +61,22 @@ const adjustPosition = (params: FindOptimalPositionParams) => {
 const getPossiblePositions = (params: FindOptimalPositionParams) => {
   const { position } = params;
   if (topRow.includes(position)) {
-    return [...topRow, ...bottomRow];
+    return [...preferredFirst(topRow, position), ...bottomRow];
   } else if (bottomRow.includes(position)) {
-    return [...bottomRow, ...topRow];
+    return [...preferredFirst(bottomRow, position), ...topRow];
   } else if (leftSide.includes(position)) {
-    return [...leftSide, ...rightSide];
+    return [...preferredFirst(leftSide, position), ...rightSide];
   } else if (rightSide.includes(position)) {
-    return [...rightSide, ...leftSide];
+    return [...preferredFirst(rightSide, position), ...leftSide];
   } else {
     return [];
   }
+};
+
+const preferredFirst = (positions: Position[], preferredPosition: Position) => {
+  return [...positions].sort((position) =>
+    position === preferredPosition ? -1 : 0
+  );
 };
 
 const getTooltipOutOfBoundsArea = (

--- a/src/ensembl/src/shared/tooltip/tooltip-helper.ts
+++ b/src/ensembl/src/shared/tooltip/tooltip-helper.ts
@@ -73,7 +73,9 @@ const getPossiblePositions = (params: FindOptimalPositionParams) => {
   }
 };
 
-const getTooltipOutOfBoundsArea = (params: FindOptimalPositionParams) => {
+const getTooltipOutOfBoundsArea = (
+  params: FindOptimalPositionParams
+): number => {
   const {
     intersectionEntry: { boundingClientRect, rootBounds },
     anchorBoundingRect,
@@ -82,7 +84,7 @@ const getTooltipOutOfBoundsArea = (params: FindOptimalPositionParams) => {
 
   if (!rootBounds) {
     // shouldn't happen, but makes typescript happy
-    return position;
+    return 0;
   }
 
   const {
@@ -98,7 +100,11 @@ const getTooltipOutOfBoundsArea = (params: FindOptimalPositionParams) => {
 
   const { width, height } = boundingClientRect;
 
-  let predictedLeft, predictedRight, predictedTop, predictedBottom;
+  let predictedLeft = 0,
+    predictedRight = 0,
+    predictedTop = 0,
+    predictedBottom = 0;
+
   if (position === Position.TOP_LEFT) {
     predictedLeft =
       anchorCentreX - width + TIP_WIDTH / 2 + TIP_HORIZONTAL_OFFSET;
@@ -160,7 +166,10 @@ const getTooltipOutOfBoundsArea = (params: FindOptimalPositionParams) => {
   });
 };
 
-const calculateOverflowArea = (params) => {
+const calculateOverflowArea = (params: {
+  tooltip: ClientRect;
+  root: ClientRect;
+}) => {
   const {
     tooltip: {
       left: tooltipLeft,

--- a/src/ensembl/src/shared/tooltip/tooltip-helper.ts
+++ b/src/ensembl/src/shared/tooltip/tooltip-helper.ts
@@ -22,14 +22,7 @@ type FindOptimalPositionParams = {
 };
 
 export const findOptimalPosition = (params: FindOptimalPositionParams) => {
-  return adjustPosition(params);
-};
-
-const adjustPosition = (params: FindOptimalPositionParams) => {
   const possiblePositions = getPossiblePositions(params);
-  if (!possiblePositions.length) {
-    return params.position;
-  }
 
   return possiblePositions.reduce(
     (result, position) => {
@@ -66,6 +59,7 @@ const getPossiblePositions = (params: FindOptimalPositionParams) => {
 };
 
 const preferredFirst = (positions: Position[], preferredPosition: Position) => {
+  // sort the positions array in such a way that the preferred position is always the first
   return [...positions].sort((position) =>
     position === preferredPosition ? -1 : 0
   );

--- a/src/ensembl/src/shared/tooltip/tooltip-helper.ts
+++ b/src/ensembl/src/shared/tooltip/tooltip-helper.ts
@@ -1,3 +1,5 @@
+import bringToFront from 'src/shared/utils/bringToFront';
+
 import {
   TIP_WIDTH,
   TIP_HEIGHT,
@@ -46,23 +48,16 @@ export const findOptimalPosition = (params: FindOptimalPositionParams) => {
 const getPossiblePositions = (params: FindOptimalPositionParams) => {
   const { position } = params;
   if (topRow.includes(position)) {
-    return [...preferredFirst(topRow, position), ...bottomRow];
+    return [...bringToFront(topRow, position), ...bottomRow];
   } else if (bottomRow.includes(position)) {
-    return [...preferredFirst(bottomRow, position), ...topRow];
+    return [...bringToFront(bottomRow, position), ...topRow];
   } else if (leftSide.includes(position)) {
-    return [...preferredFirst(leftSide, position), ...rightSide];
+    return [...bringToFront(leftSide, position), ...rightSide];
   } else if (rightSide.includes(position)) {
-    return [...preferredFirst(rightSide, position), ...leftSide];
+    return [...bringToFront(rightSide, position), ...leftSide];
   } else {
     return [];
   }
-};
-
-const preferredFirst = (positions: Position[], preferredPosition: Position) => {
-  // sort the positions array in such a way that the preferred position is always the first
-  return [...positions].sort((position) =>
-    position === preferredPosition ? -1 : 0
-  );
 };
 
 const getTooltipOutOfBoundsArea = (

--- a/src/ensembl/src/shared/tooltip/tooltip-helper.ts
+++ b/src/ensembl/src/shared/tooltip/tooltip-helper.ts
@@ -15,21 +15,13 @@ const leftSide = [Position.LEFT_TOP, Position.LEFT_BOTTOM];
 const rightSide = [Position.RIGHT_TOP, Position.RIGHT_BOTTOM];
 
 type FindOptimalPositionParams = {
-  intersectionEntry: IntersectionObserverEntry;
+  tooltipBoundingRect: ClientRect;
+  rootBoundingRect: ClientRect;
   anchorBoundingRect: ClientRect;
   position: Position;
 };
 
 export const findOptimalPosition = (params: FindOptimalPositionParams) => {
-  const {
-    intersectionEntry: { isIntersecting }
-  } = params;
-  let { position } = params;
-
-  if (isIntersecting) {
-    return position;
-  }
-
   return adjustPosition(params);
 };
 
@@ -83,15 +75,13 @@ const getTooltipOutOfBoundsArea = (
   params: FindOptimalPositionParams
 ): number => {
   const {
-    intersectionEntry: { boundingClientRect, rootBounds },
+    tooltipBoundingRect,
+    rootBoundingRect,
     anchorBoundingRect,
     position
   } = params;
 
-  if (!rootBounds) {
-    // shouldn't happen, but makes typescript happy
-    return 0;
-  }
+  const { width, height } = tooltipBoundingRect;
 
   const {
     left: anchorLeft,
@@ -103,8 +93,6 @@ const getTooltipOutOfBoundsArea = (
   } = anchorBoundingRect;
   const anchorCentreX = anchorLeft + anchorWidth / 2;
   const anchorCentreY = anchorTop + anchorHeight / 2;
-
-  const { width, height } = boundingClientRect;
 
   let predictedLeft = 0,
     predictedRight = 0,
@@ -168,7 +156,7 @@ const getTooltipOutOfBoundsArea = (
 
   return calculateOverflowArea({
     tooltip: predictedTooltipRect,
-    root: rootBounds
+    root: rootBoundingRect
   });
 };
 
@@ -185,14 +173,7 @@ const calculateOverflowArea = (params: {
       width: tooltipWidth,
       height: tooltipHeight
     },
-    root: {
-      left: rootLeft,
-      right: rootRight,
-      top: rootTop,
-      bottom: rootBottom,
-      width: rootWidth,
-      height: rootHeight
-    }
+    root: { left: rootLeft, right: rootRight, top: rootTop, bottom: rootBottom }
   } = params;
 
   let deltaX = 0,

--- a/src/ensembl/src/shared/utils/bringToFront.ts
+++ b/src/ensembl/src/shared/utils/bringToFront.ts
@@ -1,0 +1,28 @@
+/* 
+  Given an array and a member of this array,
+  return a copy of the received array, where the received member
+  is guaranteed to be in the first place
+*/
+
+import findIndex from 'lodash/findIndex';
+import isEqual from 'lodash/isEqual';
+
+const bringToFront = <T>(elements: T[], promotedElement: T) => {
+  const promotedElementIndex = findIndex(elements, (element) =>
+    isEqual(element, promotedElement)
+  );
+
+  if (elements.length < 2 || promotedElementIndex === -1) {
+    // no need to do anything for short arrays or for arrays that do not include promoted element
+    return elements;
+  }
+
+  const newElements = [...elements];
+
+  newElements.splice(promotedElementIndex, 1); // remove promoted element from the array
+  newElements.unshift(promotedElement);
+
+  return newElements;
+};
+
+export default bringToFront;

--- a/src/ensembl/src/shared/utils/tests/bringToFront.test.ts
+++ b/src/ensembl/src/shared/utils/tests/bringToFront.test.ts
@@ -1,0 +1,51 @@
+import range from 'lodash/range';
+import random from 'lodash/random';
+import last from 'lodash/last';
+
+import bringToFront from '../bringToFront';
+
+describe('bringToFront', () => {
+  it('ensures a given member of an array is in its head', () => {
+    const minNumberOfMembers = 2;
+    const maxNumberOfMembers = 10000;
+    const numberOfMembers = random(minNumberOfMembers, maxNumberOfMembers);
+    const elements = range(numberOfMembers);
+    const chosenElementIndex = random(numberOfMembers - 1);
+    const chosenElement = elements[chosenElementIndex];
+
+    const withChosenFirst = bringToFront(elements, chosenElement);
+
+    expect(withChosenFirst.length).toBe(elements.length);
+    expect(withChosenFirst[0]).toBe(chosenElement);
+  });
+
+  describe('edge cases', () => {
+    it('returns empty array if passed an empty array', () => {
+      const element = 'foo';
+      expect(bringToFront([], element).length).toBe(0);
+    });
+
+    it('returns unchanged array if it contains a single element', () => {
+      const element = random(100);
+      const elements = [element];
+      expect(bringToFront(elements, element)).toEqual(elements);
+    });
+
+    it('returns unchanged array if it does not contain promoted element', () => {
+      const elements = range(10);
+      const missingElement = (last(elements) as number) + 1;
+      expect(bringToFront(elements, missingElement)).toEqual(elements);
+    });
+
+    it('can handle elements as objects', () => {
+      const buildElement = (number: number) => ({ number });
+      const elements = range(10).map(buildElement);
+      const lastElement = last(elements);
+
+      const newElements = bringToFront(elements, lastElement);
+
+      expect(newElements.length).toBe(elements.length);
+      expect(newElements[0]).toEqual(lastElement);
+    });
+  });
+});

--- a/src/ensembl/static/img/header/user-grey.svg
+++ b/src/ensembl/static/img/header/user-grey.svg
@@ -2,9 +2,6 @@
 <!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#7D8E9B;}
-</style>
 <g>
 	<path class="st0" d="M12,0C5.4,0,0,5.4,0,12s5.4,12,12,12s12-5.4,12-12S18.6,0,12,0z M12,1.4c5.8,0,10.6,4.7,10.6,10.6
 		c0,2-0.6,3.9-1.6,5.5c-0.5-1.8-4.4-3.2-9.2-3.2c-4.5,0-8.3,1.2-9.1,2.9c-0.9-1.6-1.4-3.3-1.4-5.3C1.4,6.2,6.2,1.4,12,1.4z"/>

--- a/src/ensembl/stories/shared-components/tooltip/positioningStory.tsx
+++ b/src/ensembl/stories/shared-components/tooltip/positioningStory.tsx
@@ -29,6 +29,7 @@ const Item = (props: ItemProps) => {
       Click me
       {showTooltip && (
         <Tooltip
+          delay={0}
           onClose={() => setShowTooltip(false)}
           position={props.position}
           container={props.container.current}

--- a/src/ensembl/stories/shared-components/tooltip/variantsStory.tsx
+++ b/src/ensembl/stories/shared-components/tooltip/variantsStory.tsx
@@ -24,7 +24,11 @@ const VariantsStory = () => {
           onClick={() => setVisibleId(Position.TOP_LEFT)}
         >
           {visibleId === Position.TOP_LEFT && (
-            <Tooltip onClose={handleClose} position={Position.TOP_LEFT}>
+            <Tooltip
+              delay={0}
+              onClose={handleClose}
+              position={Position.TOP_LEFT}
+            >
               TOP LEFT
             </Tooltip>
           )}
@@ -37,7 +41,11 @@ const VariantsStory = () => {
           onClick={() => setVisibleId(Position.TOP_RIGHT)}
         >
           {visibleId === Position.TOP_RIGHT && (
-            <Tooltip onClose={handleClose} position={Position.TOP_RIGHT}>
+            <Tooltip
+              delay={0}
+              onClose={handleClose}
+              position={Position.TOP_RIGHT}
+            >
               TOP RIGHT
             </Tooltip>
           )}
@@ -50,7 +58,11 @@ const VariantsStory = () => {
           onClick={() => setVisibleId(Position.RIGHT_TOP)}
         >
           {visibleId === Position.RIGHT_TOP && (
-            <Tooltip onClose={handleClose} position={Position.RIGHT_TOP}>
+            <Tooltip
+              delay={0}
+              onClose={handleClose}
+              position={Position.RIGHT_TOP}
+            >
               RIGHT TOP
             </Tooltip>
           )}
@@ -63,7 +75,11 @@ const VariantsStory = () => {
           onClick={() => setVisibleId(Position.RIGHT_BOTTOM)}
         >
           {visibleId === Position.RIGHT_BOTTOM && (
-            <Tooltip onClose={handleClose} position={Position.RIGHT_BOTTOM}>
+            <Tooltip
+              delay={0}
+              onClose={handleClose}
+              position={Position.RIGHT_BOTTOM}
+            >
               RIGHT BOTTOM
             </Tooltip>
           )}
@@ -76,7 +92,11 @@ const VariantsStory = () => {
           onClick={() => setVisibleId(Position.BOTTOM_LEFT)}
         >
           {visibleId === Position.BOTTOM_LEFT && (
-            <Tooltip onClose={handleClose} position={Position.BOTTOM_LEFT}>
+            <Tooltip
+              delay={0}
+              onClose={handleClose}
+              position={Position.BOTTOM_LEFT}
+            >
               BOTTOM LEFT
             </Tooltip>
           )}
@@ -89,7 +109,11 @@ const VariantsStory = () => {
           onClick={() => setVisibleId(Position.BOTTOM_RIGHT)}
         >
           {visibleId === Position.BOTTOM_RIGHT && (
-            <Tooltip onClose={handleClose} position={Position.BOTTOM_RIGHT}>
+            <Tooltip
+              delay={0}
+              onClose={handleClose}
+              position={Position.BOTTOM_RIGHT}
+            >
               BOTTOM RIGHT
             </Tooltip>
           )}
@@ -102,7 +126,11 @@ const VariantsStory = () => {
           onClick={() => setVisibleId(Position.LEFT_TOP)}
         >
           {visibleId === Position.LEFT_TOP && (
-            <Tooltip onClose={handleClose} position={Position.LEFT_TOP}>
+            <Tooltip
+              delay={0}
+              onClose={handleClose}
+              position={Position.LEFT_TOP}
+            >
               LEFT TOP
             </Tooltip>
           )}
@@ -115,7 +143,11 @@ const VariantsStory = () => {
           onClick={() => setVisibleId(Position.LEFT_BOTTOM)}
         >
           {visibleId === Position.LEFT_BOTTOM && (
-            <Tooltip onClose={handleClose} position={Position.LEFT_BOTTOM}>
+            <Tooltip
+              delay={0}
+              onClose={handleClose}
+              position={Position.LEFT_BOTTOM}
+            >
               LEFT BOTTOM
             </Tooltip>
           )}


### PR DESCRIPTION
## Type
- Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/projects/ENSWBSITES/issues/ENSWBSITES-287

## Description
This PR adds the tooltip to the image buttons in the masthead (a.k.a. Header).

![image](https://user-images.githubusercontent.com/6834224/62456431-4dbd9100-b770-11e9-8cab-4145743fce01.png)

While making this change, it became apparent that the tooltip positioning algorithm had the following problems:

1. If the algorithm could not find position for the tooltip in which it will not extend beyond container boundaries, it would fall back to the initial position. However, it is possible that one of the available positions for the tooltip would actually have been better than the initial position (i.e. in that position, the tooltip will leave its container boundaries only by a tiny margin). The updated algorithm calculates the area of the tooltip that will be out of container's bounds in a given position, and returns the position in which this area is the smallest.

2. The tooltip was relying on IntersectionObserver to figure out whether it remains within bounds of its container. It became obvious that IntersectionObserver was completely unnecessary for this task. Moreover, removing IntersectionObserver makes it possible to put the invisible tooltip in some arbitrary place on the screen (e.g. `position: fixed, top: 0, left: 0`) while its optimal position is being calculated; and thus be sure that the tooltip will not extend beyond the window boundaries and will not cause scrollbars to appear at this point.