### PR TITLE
Do not lower-case gene location info in BrowserBar

### DIFF
--- a/src/ensembl/src/content/app/browser/Browser.tsx
+++ b/src/ensembl/src/content/app/browser/Browser.tsx
@@ -99,6 +99,7 @@ type BrowserProps = RouteComponentProps<MatchParams> &
 export const Browser: FunctionComponent<BrowserProps> = (
   props: BrowserProps
 ) => {
+  console.log('Hello world!');
   const browserRef: React.RefObject<HTMLDivElement> = useRef(null);
   const [trackStatesFromStorage, setTrackStatesFromStorage] = useState<
     TrackStates

--- a/src/ensembl/src/content/app/browser/Browser.tsx
+++ b/src/ensembl/src/content/app/browser/Browser.tsx
@@ -99,7 +99,6 @@ type BrowserProps = RouteComponentProps<MatchParams> &
 export const Browser: FunctionComponent<BrowserProps> = (
   props: BrowserProps
 ) => {
-  console.log('Hello world!');
   const browserRef: React.RefObject<HTMLDivElement> = useRef(null);
   const [trackStatesFromStorage, setTrackStatesFromStorage] = useState<
     TrackStates

--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.scss
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.scss
@@ -34,12 +34,7 @@
   }
 
   .value {
-    color: $ens-black;
     margin: 0 3px;
-  }
-
-  .nonLabelValue {
-    text-transform: lowercase;
   }
 
   &.browserInfoExpanded {
@@ -51,10 +46,7 @@
   }
 
   &.browserInfoGreyed {
-    .value,
-    .nonLabelValue {
-      color: $ens-dark-grey;
-    }
+    color: $ens-dark-grey;
   }
 
   dd {

--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
@@ -213,7 +213,7 @@ export const BrowserInfo = ({ ensObject }: BrowserInfoProps) => {
           <dd className={`show-for-large ${styles.nonLabelValue}`}>
             {ensObject.strand} strand
           </dd>
-          <dd className={`show-for-large ${styles.nonLabelValue}`}>
+          <dd className={`show-for-large`}>
             {getFormattedLocation(ensObject.location)}
           </dd>
         </>

--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
@@ -207,12 +207,10 @@ export const BrowserInfo = ({ ensObject }: BrowserInfoProps) => {
               {getDisplayStableId(ensObject)}
             </span>
           </dd>
-          <dd className={`show-for-large ${styles.nonLabelValue}`}>
-            {ensObject.bio_type}
+          <dd className={`show-for-large`}>
+            {ensObject.bio_type && ensObject.bio_type.toLowerCase()}
           </dd>
-          <dd className={`show-for-large ${styles.nonLabelValue}`}>
-            {ensObject.strand} strand
-          </dd>
+          <dd className={`show-for-large`}>{ensObject.strand} strand</dd>
           <dd className={`show-for-large`}>
             {getFormattedLocation(ensObject.location)}
           </dd>


### PR DESCRIPTION
## Type
- Bug fix

## Description
**Bug**: letters in chromosome name in browser bar get lower-cased (although the case is actually significant):

**Example:** region of a wheat gene; expecting chromosome to be 3D, but instead it shows up as 3d

![image](https://user-images.githubusercontent.com/6834224/62233637-ddee8580-b3c0-11e9-8595-b684c97bff39.png)

**Cause**: the `nonLabelValue` CSS class has the rule `text-transform: lowercase`.