### PR TITLE
Update workbox config to prevent caching of html files

### DIFF
--- a/src/ensembl/server.js
+++ b/src/ensembl/server.js
@@ -21,7 +21,7 @@ app.use(proxy({
 }));
 
 app.use(convert(history()));
-app.use(serve(path.join(__dirname, 'dist'), { br: true, gzip: false }));
+app.use(serve(path.join(__dirname, 'dist')));
 
 let protocol = 'http';
 

--- a/src/ensembl/webpack/webpack.config.prod.js
+++ b/src/ensembl/webpack/webpack.config.prod.js
@@ -103,7 +103,12 @@ const plugins = [
   new WorkboxPlugin.GenerateSW({
     swDest: '../service-worker.js', // save service worker in the root folder (/dist) instead of /dist/static
     clientsClaim: true,
-    skipWaiting: true
+    skipWaiting: true,
+    exclude: [/index.html/],
+    runtimeCaching: [{
+      urlPattern: ({ event }) => event.request.mode === 'navigate',
+      handler: 'NetworkOnly'
+    }]
   }),
 
   new RobotstxtPlugin()

--- a/src/ensembl/webpack/webpack.config.prod.js
+++ b/src/ensembl/webpack/webpack.config.prod.js
@@ -107,7 +107,7 @@ const plugins = [
     exclude: [/index.html$/, /\.gz$/, /\.br$/, /\.js\.map$/],
     runtimeCaching: [{
       urlPattern: ({ event }) => event.request.mode === 'navigate',
-      handler: 'NetworkOnly'
+      handler: 'NetworkFirst'
     }]
   }),
 

--- a/src/ensembl/webpack/webpack.config.prod.js
+++ b/src/ensembl/webpack/webpack.config.prod.js
@@ -104,7 +104,7 @@ const plugins = [
     swDest: '../service-worker.js', // save service worker in the root folder (/dist) instead of /dist/static
     clientsClaim: true,
     skipWaiting: true,
-    exclude: [/index.html/],
+    exclude: [/index.html$/, /\.gz$/, /\.br$/, /\.js\.map$/],
     runtimeCaching: [{
       urlPattern: ({ event }) => event.request.mode === 'navigate',
       handler: 'NetworkOnly'


### PR DESCRIPTION
## Type
- Bug fix

## JIRA ticket
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-296

## Description
- Update Workbox config so that it does not cache html files. (_See detailed description of the mechanism of the bug in the linked JIRA ticket._)
- Exclude compressed files and sourcemap files from the workbox-generated manifest
- Do not pass default options to koa-static in local production server config (both `br` option for serving brotli-compressed files if the browser can consume them and `gzip` option to serve gzipped files if the browser can consume them are `true` by default in koa-static).