### PR TITLE
Make track panel state of species indepedent

### DIFF
--- a/src/ensembl/src/content/app/browser/BrowserCogList.tsx
+++ b/src/ensembl/src/content/app/browser/BrowserCogList.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 
 import browserMessagingService from 'src/content/app/browser/browser-messaging-service';
@@ -19,31 +19,22 @@ import {
 
 import styles from './BrowserCogList.scss';
 
-type StateProps = {
+type BrowserCogListProps = {
   browserActivated: boolean;
   browserCogList: number;
   browserCogTrackList: CogList;
   selectedCog: any;
-};
-
-type DispatchProps = {
   updateCogList: (cogList: number) => void;
   updateCogTrackList: (track_y: CogList) => void;
   updateSelectedCog: (index: string) => void;
 };
-
-type OwnProps = {};
-
-type BrowserCogListProps = StateProps & DispatchProps & OwnProps;
 
 type BpaneScrollPayload = {
   delta_y?: number;
   track_y?: CogList;
 };
 
-const BrowserCogList: FunctionComponent<BrowserCogListProps> = (
-  props: BrowserCogListProps
-) => {
+const BrowserCogList = (props: BrowserCogListProps) => {
   const { browserCogTrackList } = props;
   const listenBpaneScroll = (payload: BpaneScrollPayload) => {
     const { delta_y, track_y } = payload;
@@ -93,14 +84,14 @@ const BrowserCogList: FunctionComponent<BrowserCogListProps> = (
   ) : null;
 };
 
-const mapStateToProps = (state: RootState): StateProps => ({
+const mapStateToProps = (state: RootState) => ({
   browserActivated: getBrowserActivated(state),
   browserCogList: getBrowserCogList(state),
   browserCogTrackList: getBrowserCogTrackList(state),
   selectedCog: getBrowserSelectedCog(state)
 });
 
-const mapDispatchToProps: DispatchProps = {
+const mapDispatchToProps = {
   updateCogList,
   updateCogTrackList,
   updateSelectedCog

--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.test.tsx
@@ -12,7 +12,7 @@ import { BreakpointWidth } from 'src/global/globalConfig';
 
 import BrowserReset from 'src/content/app/browser/browser-reset/BrowserReset';
 import BrowserGenomeSelector from 'src/content/app/browser/browser-genome-selector/BrowserGenomeSelector';
-import BrowserTabs from 'src/content/app/browser/browser-tabs/BrowserTabs';
+import TrackPanelTabs from '../track-panel/track-panel-tabs/TrackPanelTabs';
 
 import { ChrLocation } from '../browserState';
 import { TrackSet } from '../track-panel/trackPanelConfig';
@@ -26,13 +26,13 @@ jest.mock(
   'src/content/app/browser/browser-genome-selector/BrowserGenomeSelector',
   () => () => <div>BrowserGenomeSelector</div>
 );
-jest.mock('src/content/app/browser/browser-tabs/BrowserTabs', () => () => (
+jest.mock('../track-panel/track-panel-tabs/TrackPanelTabs', () => () => (
   <div>BrowserReset</div>
 ));
 
 describe('<BrowserBar />', () => {
   const dispatchBrowserLocation: any = jest.fn();
-  const selectBrowserTab: any = jest.fn();
+  const selectTrackPanelTab: any = jest.fn();
   const toggleBrowserNav: any = jest.fn();
   const toggleDrawer: any = jest.fn();
   const toggleGenomeSelector: any = jest.fn();
@@ -48,11 +48,11 @@ describe('<BrowserBar />', () => {
     drawerOpened: false,
     genomeSelectorActive: false,
     ensObject: createEnsObject(),
-    selectedBrowserTab: TrackSet.GENOMIC,
+    selectedTrackPanelTab: TrackSet.GENOMIC,
     trackPanelModalOpened: false,
     trackPanelOpened: false,
     dispatchBrowserLocation,
-    selectBrowserTab,
+    selectTrackPanelTab,
     toggleBrowserNav,
     toggleDrawer,
     toggleGenomeSelector,
@@ -60,7 +60,7 @@ describe('<BrowserBar />', () => {
     isTrackPanelModalOpened: false,
     isTrackPanelOpened: false,
     closeDrawer: jest.fn(),
-    selectBrowserTabAndSave: jest.fn(),
+    selectTrackPanelTabAndSave: jest.fn(),
     toggleTrackPanel: jest.fn()
   };
 
@@ -133,23 +133,23 @@ describe('<BrowserBar />', () => {
       expect(renderedBrowserBar.find(BrowserNavigatorButton).length).toBe(0);
     });
 
-    test('shows BrowserTabs if TrackPanel is open', () => {
+    test('shows TrackPanelTabs if TrackPanel is open', () => {
       const renderedBrowserBar = mount(
         renderBrowserBar({ isTrackPanelOpened: true })
       );
-      expect(renderedBrowserBar.find(BrowserTabs).length).toBe(1);
+      expect(renderedBrowserBar.find(TrackPanelTabs).length).toBe(1);
     });
 
-    test('shows BrowserTabs on a wide display even if TrackPanel is closed', () => {
+    test('shows TrackPanelTabs on a wide display even if TrackPanel is closed', () => {
       const renderedBrowserBar = mount(renderBrowserBar());
-      expect(renderedBrowserBar.find(BrowserTabs).length).toBe(1);
+      expect(renderedBrowserBar.find(TrackPanelTabs).length).toBe(1);
     });
 
-    test('hides BrowserTabs on small if TrackPanel is closed', () => {
+    test('hides TrackPanelTabs on small if TrackPanel is closed', () => {
       const renderedBrowserBar = mount(
         renderBrowserBar({ breakpointWidth: BreakpointWidth.MEDIUM })
       );
-      expect(renderedBrowserBar.find(BrowserTabs).length).toBe(0);
+      expect(renderedBrowserBar.find(TrackPanelTabs).length).toBe(0);
     });
   });
 });

--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.test.tsx
@@ -15,7 +15,7 @@ import BrowserGenomeSelector from 'src/content/app/browser/browser-genome-select
 import BrowserTabs from 'src/content/app/browser/browser-tabs/BrowserTabs';
 
 import { ChrLocation } from '../browserState';
-import { TrackType } from '../track-panel/trackPanelConfig';
+import { TrackSet } from '../track-panel/trackPanelConfig';
 
 import { createEnsObject } from 'tests/fixtures/ens-object';
 
@@ -48,7 +48,7 @@ describe('<BrowserBar />', () => {
     drawerOpened: false,
     genomeSelectorActive: false,
     ensObject: createEnsObject(),
-    selectedBrowserTab: TrackType.GENOMIC,
+    selectedBrowserTab: TrackSet.GENOMIC,
     trackPanelModalOpened: false,
     trackPanelOpened: false,
     dispatchBrowserLocation,

--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 
 import { browserInfoConfig, BrowserInfoItem } from '../browserConfig';
-import { TrackType } from '../track-panel/trackPanelConfig';
+import { TrackSet } from '../track-panel/trackPanelConfig';
 
 import { getDisplayStableId } from 'src/ens-object/ensObjectHelpers';
 import { getFormattedLocation } from 'src/shared/helpers/regionFormatter';
@@ -56,12 +56,12 @@ type StateProps = {
   isTrackPanelOpened: boolean;
   genomeSelectorActive: boolean;
   ensObject: EnsObject | null;
-  selectedBrowserTab: TrackType;
+  selectedBrowserTab: TrackSet;
 };
 
 type DispatchProps = {
   closeDrawer: () => void;
-  selectBrowserTabAndSave: (selectedBrowserTab: TrackType) => void;
+  selectBrowserTabAndSave: (selectedBrowserTab: TrackSet) => void;
   toggleBrowserNav: () => void;
   toggleGenomeSelector: (genomeSelectorActive: boolean) => void;
   toggleTrackPanel: (isTrackPanelOpened: boolean) => void;

--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
@@ -22,12 +22,12 @@ import {
 } from '../browserSelectors';
 import { getIsDrawerOpened } from '../drawer/drawerSelectors';
 import {
-  getSelectedBrowserTab,
+  getSelectedTrackPanelTab,
   getIsTrackPanelModalOpened,
   getIsTrackPanelOpened
 } from '../track-panel/trackPanelSelectors';
 import {
-  selectBrowserTabAndSave,
+  selectTrackPanelTabAndSave,
   toggleTrackPanel
 } from '../track-panel/trackPanelActions';
 import { closeDrawer } from '../drawer/drawerActions';
@@ -36,7 +36,7 @@ import { EnsObject } from 'src/ens-object/ensObjectTypes';
 
 import BrowserReset from '../browser-reset/BrowserReset';
 import BrowserGenomeSelector from '../browser-genome-selector/BrowserGenomeSelector';
-import BrowserTabs from '../browser-tabs/BrowserTabs';
+import TrackPanelTabs from '../track-panel/track-panel-tabs/TrackPanelTabs';
 
 import { getBreakpointWidth } from 'src/global/globalSelectors';
 import { BreakpointWidth } from 'src/global/globalConfig';
@@ -56,12 +56,12 @@ type StateProps = {
   isTrackPanelOpened: boolean;
   genomeSelectorActive: boolean;
   ensObject: EnsObject | null;
-  selectedBrowserTab: TrackSet;
+  selectedTrackPanelTab: TrackSet;
 };
 
 type DispatchProps = {
   closeDrawer: () => void;
-  selectBrowserTabAndSave: (selectedBrowserTab: TrackSet) => void;
+  selectTrackPanelTabAndSave: (selectedTrackPanelTab: TrackSet) => void;
   toggleBrowserNav: () => void;
   toggleGenomeSelector: (genomeSelectorActive: boolean) => void;
   toggleTrackPanel: (isTrackPanelOpened: boolean) => void;
@@ -129,7 +129,7 @@ export const BrowserBar: FunctionComponent<BrowserBarProps> = (
     props.toggleBrowserNav();
   };
 
-  const shouldShowBrowserTabs =
+  const shouldShowTrackPanelTabs =
     props.activeGenomeId &&
     (props.isTrackPanelOpened ||
       props.breakpointWidth === BreakpointWidth.LARGE);
@@ -175,14 +175,14 @@ export const BrowserBar: FunctionComponent<BrowserBarProps> = (
           )}
         </dl>
       </div>
-      {shouldShowBrowserTabs && (
-        <BrowserTabs
+      {shouldShowTrackPanelTabs && (
+        <TrackPanelTabs
           closeDrawer={props.closeDrawer}
           ensObject={props.ensObject}
           isDrawerOpened={props.isDrawerOpened}
           genomeSelectorActive={props.genomeSelectorActive}
-          selectBrowserTabAndSave={props.selectBrowserTabAndSave}
-          selectedBrowserTab={props.selectedBrowserTab}
+          selectTrackPanelTabAndSave={props.selectTrackPanelTabAndSave}
+          selectedTrackPanelTab={props.selectedTrackPanelTab}
           toggleTrackPanel={props.toggleTrackPanel}
           isTrackPanelModalOpened={props.isTrackPanelModalOpened}
           isTrackPanelOpened={props.isTrackPanelOpened}
@@ -254,12 +254,12 @@ const mapStateToProps = (state: RootState): StateProps => ({
   isDrawerOpened: getIsDrawerOpened(state),
   isTrackPanelModalOpened: getIsTrackPanelModalOpened(state),
   isTrackPanelOpened: getIsTrackPanelOpened(state),
-  selectedBrowserTab: getSelectedBrowserTab(state)
+  selectedTrackPanelTab: getSelectedTrackPanelTab(state)
 });
 
 const mapDispatchToProps: DispatchProps = {
   closeDrawer,
-  selectBrowserTabAndSave,
+  selectTrackPanelTabAndSave,
   toggleBrowserNav,
   toggleGenomeSelector,
   toggleTrackPanel

--- a/src/ensembl/src/content/app/browser/browser-storage-service.test.ts
+++ b/src/ensembl/src/content/app/browser/browser-storage-service.test.ts
@@ -1,6 +1,6 @@
 import { BrowserStorageService, StorageKeys } from './browser-storage-service';
 import { ImageButtonStatus } from 'src/shared/image-button/ImageButton';
-import { TrackType } from './track-panel/trackPanelConfig';
+import { TrackSet } from './track-panel/trackPanelConfig';
 
 const mockStorageService = {
   get: jest.fn(),
@@ -23,7 +23,7 @@ const trackListToggleStates = {
   'gene-feat': false
 };
 
-const SELECTED_BROWSER_TAB = TrackType.VARIATION;
+const SELECTED_BROWSER_TAB = TrackSet.VARIATION;
 
 describe('BrowserStorageService', () => {
   afterEach(() => {
@@ -179,13 +179,13 @@ describe('BrowserStorageService', () => {
       );
 
       browserStorageService.updateSelectedBrowserTab({
-        homo_sapiens38: TrackType.EXPRESSION
+        homo_sapiens38: TrackSet.EXPRESSION
       });
 
       expect(mockStorageService.update).toHaveBeenCalledWith(
         StorageKeys.SELECTED_BROWSER_TAB,
         {
-          homo_sapiens38: TrackType.EXPRESSION
+          homo_sapiens38: TrackSet.EXPRESSION
         }
       );
     });

--- a/src/ensembl/src/content/app/browser/browser-storage-service.test.ts
+++ b/src/ensembl/src/content/app/browser/browser-storage-service.test.ts
@@ -23,7 +23,7 @@ const trackListToggleStates = {
   'gene-feat': false
 };
 
-const SELECTED_BROWSER_TAB = TrackSet.VARIATION;
+const SELECTED_TRACK_PANEL_TAB = TrackSet.VARIATION;
 
 describe('BrowserStorageService', () => {
   afterEach(() => {
@@ -138,22 +138,22 @@ describe('BrowserStorageService', () => {
     });
   });
 
-  describe('.getSelectedBrowserTab()', () => {
+  describe('.getSelectedTrackPanelTab()', () => {
     it('gets saved selected browser tab from storage service', () => {
       jest
         .spyOn(mockStorageService, 'get')
-        .mockImplementation(() => SELECTED_BROWSER_TAB);
+        .mockImplementation(() => SELECTED_TRACK_PANEL_TAB);
 
       const browserStorageService = new BrowserStorageService(
         mockStorageService
       );
 
-      const result = browserStorageService.getSelectedBrowserTab();
+      const result = browserStorageService.getSelectedTrackPanelTab();
 
       expect(mockStorageService.get).toHaveBeenCalledWith(
-        StorageKeys.SELECTED_BROWSER_TAB
+        StorageKeys.SELECTED_TRACK_PANEL_TAB
       );
-      expect(result).toEqual(SELECTED_BROWSER_TAB);
+      expect(result).toEqual(SELECTED_TRACK_PANEL_TAB);
 
       mockStorageService.get.mockRestore();
     });
@@ -164,7 +164,7 @@ describe('BrowserStorageService', () => {
       const browserStorageService = new BrowserStorageService(
         mockStorageService
       );
-      const result = browserStorageService.getSelectedBrowserTab();
+      const result = browserStorageService.getSelectedTrackPanelTab();
 
       expect(result).toEqual({});
 
@@ -172,18 +172,18 @@ describe('BrowserStorageService', () => {
     });
   });
 
-  describe('.updateSelectedBrowserTab()', () => {
+  describe('.updateSelectedTrackPanelTab()', () => {
     it('updates selected browser tab via storage service', () => {
       const browserStorageService = new BrowserStorageService(
         mockStorageService
       );
 
-      browserStorageService.updateSelectedBrowserTab({
+      browserStorageService.updateSelectedTrackPanelTab({
         homo_sapiens38: TrackSet.EXPRESSION
       });
 
       expect(mockStorageService.update).toHaveBeenCalledWith(
-        StorageKeys.SELECTED_BROWSER_TAB,
+        StorageKeys.SELECTED_TRACK_PANEL_TAB,
         {
           homo_sapiens38: TrackSet.EXPRESSION
         }

--- a/src/ensembl/src/content/app/browser/browser-storage-service.ts
+++ b/src/ensembl/src/content/app/browser/browser-storage-service.ts
@@ -75,7 +75,7 @@ export class BrowserStorageService {
     );
   }
 
-  public getSelectedBrowserTab() {
+  public getSelectedBrowserTab(): { [genomeId: string]: TrackType } {
     return this.storageService.get(StorageKeys.SELECTED_BROWSER_TAB) || {};
   }
 

--- a/src/ensembl/src/content/app/browser/browser-storage-service.ts
+++ b/src/ensembl/src/content/app/browser/browser-storage-service.ts
@@ -3,7 +3,7 @@ import storageService, {
 } from 'src/services/storage-service';
 import {
   TrackStates,
-  TrackType,
+  TrackSet,
   TrackToggleStates
 } from './track-panel/trackPanelConfig';
 import { ChrLocations } from './browserState';
@@ -75,12 +75,12 @@ export class BrowserStorageService {
     );
   }
 
-  public getSelectedBrowserTab(): { [genomeId: string]: TrackType } {
+  public getSelectedBrowserTab(): { [genomeId: string]: TrackSet } {
     return this.storageService.get(StorageKeys.SELECTED_BROWSER_TAB) || {};
   }
 
   public updateSelectedBrowserTab(selectedBrowserTabForGenome: {
-    [genomeId: string]: TrackType;
+    [genomeId: string]: TrackSet;
   }) {
     this.storageService.update(
       StorageKeys.SELECTED_BROWSER_TAB,

--- a/src/ensembl/src/content/app/browser/browser-storage-service.ts
+++ b/src/ensembl/src/content/app/browser/browser-storage-service.ts
@@ -15,7 +15,7 @@ export enum StorageKeys {
   DEFAULT_CHR_LOCATION = 'browser.defaultChrLocation',
   TRACK_STATES = 'browser.trackStates',
   TRACK_LIST_TOGGLE_STATES = 'browser.trackListToggleStates',
-  SELECTED_BROWSER_TAB = 'browser.selectedBrowserTab'
+  SELECTED_TRACK_PANEL_TAB = 'browser.selectedTrackPanelTab'
 }
 
 export class BrowserStorageService {
@@ -75,16 +75,16 @@ export class BrowserStorageService {
     );
   }
 
-  public getSelectedBrowserTab(): { [genomeId: string]: TrackSet } {
-    return this.storageService.get(StorageKeys.SELECTED_BROWSER_TAB) || {};
+  public getSelectedTrackPanelTab(): { [genomeId: string]: TrackSet } {
+    return this.storageService.get(StorageKeys.SELECTED_TRACK_PANEL_TAB) || {};
   }
 
-  public updateSelectedBrowserTab(selectedBrowserTabForGenome: {
+  public updateSelectedTrackPanelTab(selectedTrackPanelTabForGenome: {
     [genomeId: string]: TrackSet;
   }) {
     this.storageService.update(
-      StorageKeys.SELECTED_BROWSER_TAB,
-      selectedBrowserTabForGenome
+      StorageKeys.SELECTED_TRACK_PANEL_TAB,
+      selectedTrackPanelTabForGenome
     );
   }
 }

--- a/src/ensembl/src/content/app/browser/browser-tabs/BrowserTabs.tsx
+++ b/src/ensembl/src/content/app/browser/browser-tabs/BrowserTabs.tsx
@@ -1,7 +1,7 @@
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 
-import { TrackType } from '../track-panel/trackPanelConfig';
+import { TrackSet } from '../track-panel/trackPanelConfig';
 import { EnsObject } from 'src/ens-object/ensObjectTypes';
 
 import styles from './BrowserTabs.scss';
@@ -11,17 +11,15 @@ type BrowserTabsProps = {
   ensObject: EnsObject;
   isDrawerOpened: boolean;
   genomeSelectorActive: boolean;
-  selectBrowserTabAndSave: (selectedBrowserTab: TrackType) => void;
-  selectedBrowserTab: TrackType;
+  selectBrowserTabAndSave: (selectedBrowserTab: TrackSet) => void;
+  selectedBrowserTab: TrackSet;
   toggleTrackPanel: (isTrackPanelOpened: boolean) => void;
   isTrackPanelModalOpened: boolean;
   isTrackPanelOpened: boolean;
 };
 
-const BrowserTabs: FunctionComponent<BrowserTabsProps> = (
-  props: BrowserTabsProps
-) => {
-  const handleTabClick = (value: TrackType) => {
+const BrowserTabs = (props: BrowserTabsProps) => {
+  const handleTabClick = (value: TrackSet) => {
     if (props.genomeSelectorActive || !props.ensObject.genome_id) {
       return;
     }
@@ -37,11 +35,11 @@ const BrowserTabs: FunctionComponent<BrowserTabsProps> = (
     props.selectBrowserTabAndSave(value);
   };
 
-  const getBrowserTabClassNames = (trackType: TrackType) => {
+  const getBrowserTabClassNames = (trackSet: TrackSet) => {
     const isBrowserTabActive =
       props.isTrackPanelOpened &&
       props.ensObject.genome_id &&
-      props.selectedBrowserTab === trackType &&
+      props.selectedBrowserTab === trackSet &&
       !props.isDrawerOpened &&
       !props.isTrackPanelModalOpened;
 
@@ -54,7 +52,7 @@ const BrowserTabs: FunctionComponent<BrowserTabsProps> = (
 
   return (
     <dl className={`${styles.browserTabs}`}>
-      {Object.values(TrackType).map((value: TrackType) => (
+      {Object.values(TrackSet).map((value: TrackSet) => (
         <dd
           className={getBrowserTabClassNames(value)}
           key={value}

--- a/src/ensembl/src/content/app/browser/browserReducer.ts
+++ b/src/ensembl/src/content/app/browser/browserReducer.ts
@@ -5,12 +5,9 @@ import pickBy from 'lodash/pickBy';
 
 import { RootAction } from 'src/objects';
 import * as browserActions from './browserActions';
-import * as drawerActions from './drawer/drawerActions';
-import * as trackPanelActions from './track-panel/trackPanelActions';
 import {
   BrowserState,
   defaultBrowserState,
-  BrowserOpenState,
   BrowserLocationState,
   defaultBrowserLocationState,
   BrowserNavState,
@@ -28,20 +25,6 @@ export function browserInfo(
   switch (action.type) {
     case getType(browserActions.updateBrowserActivated):
       return { ...state, browserActivated: action.payload };
-    case getType(trackPanelActions.toggleTrackPanelForGenome):
-      return {
-        ...state,
-        browserOpenState: action.payload
-          ? BrowserOpenState.SEMI_EXPANDED
-          : BrowserOpenState.EXPANDED
-      };
-    case getType(drawerActions.toggleDrawerForGenome):
-      return {
-        ...state,
-        browserOpenState: action.payload
-          ? BrowserOpenState.COLLAPSED
-          : BrowserOpenState.SEMI_EXPANDED
-      };
     default:
       return state;
   }

--- a/src/ensembl/src/content/app/browser/browserReducer.ts
+++ b/src/ensembl/src/content/app/browser/browserReducer.ts
@@ -28,7 +28,7 @@ export function browserInfo(
   switch (action.type) {
     case getType(browserActions.updateBrowserActivated):
       return { ...state, browserActivated: action.payload };
-    case getType(trackPanelActions.toggleTrackPanel):
+    case getType(trackPanelActions.toggleTrackPanelForGenome):
       return {
         ...state,
         browserOpenState: action.payload

--- a/src/ensembl/src/content/app/browser/browserSelectors.ts
+++ b/src/ensembl/src/content/app/browser/browserSelectors.ts
@@ -1,6 +1,5 @@
 import { RootState } from 'src/store';
 import {
-  BrowserOpenState,
   BrowserNavStates,
   CogList,
   ChrLocation,
@@ -12,9 +11,6 @@ import { getEnsObjectById } from 'src/ens-object/ensObjectSelectors';
 
 export const getBrowserActivated = (state: RootState): boolean =>
   state.browser.browserInfo.browserActivated;
-
-export const getBrowserOpenState = (state: RootState): BrowserOpenState =>
-  state.browser.browserInfo.browserOpenState;
 
 export const getBrowserActiveGenomeId = (state: RootState) =>
   state.browser.browserEntity.activeGenomeId;

--- a/src/ensembl/src/content/app/browser/browserState.ts
+++ b/src/ensembl/src/content/app/browser/browserState.ts
@@ -7,12 +7,6 @@ const activeEnsObjectIds = browserStorageService.getActiveEnsObjectIds();
 const trackStates = browserStorageService.getTrackStates();
 const chrLocations = browserStorageService.getChrLocation();
 
-export enum BrowserOpenState {
-  EXPANDED = 'expanded',
-  SEMI_EXPANDED = 'semiExpanded',
-  COLLAPSED = 'collapsed'
-}
-
 // states are top, right, bottom, left (TRBL) and minus (zoom out) and plus (zoom in)
 export type BrowserNavStates = [
   boolean,
@@ -33,12 +27,10 @@ export type CogList = {
 
 export type BrowserState = Readonly<{
   browserActivated: boolean;
-  browserOpenState: BrowserOpenState;
 }>;
 
 export const defaultBrowserState: BrowserState = {
-  browserActivated: false,
-  browserOpenState: BrowserOpenState.SEMI_EXPANDED
+  browserActivated: false
 };
 
 export type BrowserEntityState = Readonly<{

--- a/src/ensembl/src/content/app/browser/drawer/Drawer.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/Drawer.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 
 import { RootState } from 'src/store';
@@ -20,20 +20,13 @@ import SnpIndels from './drawer-views/SnpIndels';
 
 import { EnsObject } from 'src/ens-object/ensObjectTypes';
 
-type StateProps = {
+type DrawerProps = {
   drawerView: string;
   ensObject: EnsObject | null;
-};
-
-type DispatchProps = {
   closeDrawer: () => void;
 };
 
-type OwnProps = {};
-
-type DrawerProps = StateProps & DispatchProps & OwnProps;
-
-const Drawer: FunctionComponent<DrawerProps> = (props: DrawerProps) => {
+const Drawer = (props: DrawerProps) => {
   const { ensObject, drawerView } = props;
 
   if (!ensObject) {
@@ -73,7 +66,7 @@ const Drawer: FunctionComponent<DrawerProps> = (props: DrawerProps) => {
   );
 };
 
-const mapStateToProps = (state: RootState): StateProps => ({
+const mapStateToProps = (state: RootState) => ({
   drawerView: getDrawerView(state),
   ensObject: getBrowserActiveEnsObject(state)
 });

--- a/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { useSpring, animated } from 'react-spring';
 
@@ -31,7 +31,7 @@ import { EnsObject } from 'src/ens-object/ensObjectTypes';
 
 import styles from './TrackPanel.scss';
 
-type StateProps = {
+type TrackPanelProps = {
   activeGenomeId: string | null;
   breakpointWidth: BreakpointWidth;
   browserActivated: boolean;
@@ -42,19 +42,10 @@ type StateProps = {
   selectedBrowserTab: TrackType;
   genomeTrackCategories: GenomeTrackCategory[];
   trackStates: TrackStates;
-};
-
-type DispatchProps = {
   toggleTrackPanel: (isTrackPanelOpened?: boolean) => void;
 };
 
-type OwnProps = {};
-
-type TrackPanelProps = StateProps & DispatchProps & OwnProps;
-
-const TrackPanel: FunctionComponent<TrackPanelProps> = (
-  props: TrackPanelProps
-) => {
+const TrackPanel = (props: TrackPanelProps) => {
   const { isDrawerOpened } = props;
 
   useEffect(() => {
@@ -102,7 +93,7 @@ const TrackPanel: FunctionComponent<TrackPanelProps> = (
   ) : null;
 };
 
-const mapStateToProps = (state: RootState): StateProps => {
+const mapStateToProps = (state: RootState) => {
   const activeGenomeId = getBrowserActiveGenomeId(state);
 
   return {
@@ -121,7 +112,7 @@ const mapStateToProps = (state: RootState): StateProps => {
   };
 };
 
-const mapDispatchToProps: DispatchProps = {
+const mapDispatchToProps = {
   toggleTrackPanel
 };
 

--- a/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
@@ -12,7 +12,7 @@ import { toggleTrackPanel } from './trackPanelActions';
 import {
   getIsTrackPanelOpened,
   getIsTrackPanelModalOpened,
-  getSelectedBrowserTab
+  getSelectedTrackPanelTab
 } from './trackPanelSelectors';
 import { getIsDrawerOpened } from '../drawer/drawerSelectors';
 import {
@@ -39,7 +39,7 @@ type TrackPanelProps = {
   activeEnsObject: EnsObject | null;
   isTrackPanelModalOpened: boolean;
   isTrackPanelOpened: boolean;
-  selectedBrowserTab: TrackSet;
+  selectedTrackPanelTab: TrackSet;
   genomeTrackCategories: GenomeTrackCategory[];
   trackStates: TrackStates;
   toggleTrackPanel: (isTrackPanelOpened?: boolean) => void;
@@ -103,7 +103,7 @@ const mapStateToProps = (state: RootState) => {
     isDrawerOpened: getIsDrawerOpened(state),
     activeEnsObject: getBrowserActiveEnsObject(state),
     isTrackPanelModalOpened: getIsTrackPanelModalOpened(state),
-    selectedBrowserTab: getSelectedBrowserTab(state),
+    selectedTrackPanelTab: getSelectedTrackPanelTab(state),
     genomeTrackCategories: activeGenomeId
       ? getGenomeTrackCategoriesById(state, activeGenomeId)
       : [],

--- a/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
@@ -23,7 +23,7 @@ import {
 } from '../browserSelectors';
 import { getBreakpointWidth } from 'src/global/globalSelectors';
 import { BreakpointWidth } from 'src/global/globalConfig';
-import { TrackType, TrackStates } from './trackPanelConfig';
+import { TrackSet, TrackStates } from './trackPanelConfig';
 
 import { GenomeTrackCategory } from 'src/genome/genomeTypes';
 import { getGenomeTrackCategoriesById } from 'src/genome/genomeSelectors';
@@ -39,7 +39,7 @@ type TrackPanelProps = {
   activeEnsObject: EnsObject | null;
   isTrackPanelModalOpened: boolean;
   isTrackPanelOpened: boolean;
-  selectedBrowserTab: TrackType;
+  selectedBrowserTab: TrackSet;
   genomeTrackCategories: GenomeTrackCategory[];
   trackStates: TrackStates;
   toggleTrackPanel: (isTrackPanelOpened?: boolean) => void;

--- a/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
@@ -8,34 +8,19 @@ import TrackPanelModal from './track-panel-modal/TrackPanelModal';
 import Drawer from '../drawer/Drawer';
 import { RootState } from 'src/store';
 
-import {
-  updateTrackStatesAndSave,
-  UpdateTrackStatesPayload
-} from 'src/content/app/browser/browserActions';
-import {
-  toggleTrackPanel,
-  closeTrackPanelModal,
-  openTrackPanelModal
-} from './trackPanelActions';
-import {
-  toggleDrawer,
-  changeDrawerView,
-  closeDrawer
-} from '../drawer/drawerActions';
+import { toggleTrackPanel } from './trackPanelActions';
 import {
   getIsTrackPanelOpened,
   getIsTrackPanelModalOpened,
-  getTrackPanelModalView,
   getSelectedBrowserTab
 } from './trackPanelSelectors';
-import { getDrawerView, getIsDrawerOpened } from '../drawer/drawerSelectors';
+import { getIsDrawerOpened } from '../drawer/drawerSelectors';
 import {
   getBrowserActivated,
   getBrowserActiveGenomeId,
   getBrowserActiveEnsObject,
   getBrowserTrackStates
 } from '../browserSelectors';
-import { getLaunchbarExpanded } from 'src/header/headerSelectors';
 import { getBreakpointWidth } from 'src/global/globalSelectors';
 import { BreakpointWidth } from 'src/global/globalConfig';
 import { TrackType, TrackStates } from './trackPanelConfig';
@@ -51,25 +36,16 @@ type StateProps = {
   breakpointWidth: BreakpointWidth;
   browserActivated: boolean;
   isDrawerOpened: boolean;
-  drawerView: string;
-  ensObject: EnsObject | null;
+  activeEnsObject: EnsObject | null;
   isTrackPanelModalOpened: boolean;
   isTrackPanelOpened: boolean;
-  launchbarExpanded: boolean;
   selectedBrowserTab: TrackType;
   genomeTrackCategories: GenomeTrackCategory[];
-  trackPanelModalView: string;
   trackStates: TrackStates;
 };
 
 type DispatchProps = {
-  changeDrawerView: (drawerView: string) => void;
-  closeDrawer: () => void;
-  closeTrackPanelModal: () => void;
-  openTrackPanelModal: (trackPanelModalView: string) => void;
-  toggleDrawer: (isDrawerOpened: boolean) => void;
   toggleTrackPanel: (isTrackPanelOpened?: boolean) => void;
-  updateTrackStates: (payload: UpdateTrackStatesPayload) => void;
 };
 
 type OwnProps = {};
@@ -114,41 +90,11 @@ const TrackPanel: FunctionComponent<TrackPanelProps> = (
 
   return props.activeGenomeId ? (
     <animated.div style={trackAnimation}>
-      {props.browserActivated && props.ensObject ? (
+      {props.browserActivated && props.activeEnsObject ? (
         <div className={styles.trackPanel}>
-          <TrackPanelBar
-            activeGenomeId={props.activeGenomeId}
-            closeDrawer={props.closeDrawer}
-            closeTrackPanelModal={props.closeTrackPanelModal}
-            isDrawerOpened={props.isDrawerOpened}
-            launchbarExpanded={props.launchbarExpanded}
-            openTrackPanelModal={props.openTrackPanelModal}
-            toggleTrackPanel={props.toggleTrackPanel}
-            isTrackPanelModalOpened={props.isTrackPanelModalOpened}
-            trackPanelModalView={props.trackPanelModalView}
-            isTrackPanelOpened={props.isTrackPanelOpened}
-          />
-          <TrackPanelList
-            activeGenomeId={props.activeGenomeId}
-            isDrawerOpened={props.isDrawerOpened}
-            drawerView={props.drawerView}
-            launchbarExpanded={props.launchbarExpanded}
-            ensObject={props.ensObject}
-            selectedBrowserTab={props.selectedBrowserTab}
-            toggleDrawer={props.toggleDrawer}
-            trackStates={props.trackStates}
-            genomeTrackCategories={props.genomeTrackCategories}
-            updateDrawerView={props.changeDrawerView}
-            updateTrackStates={props.updateTrackStates}
-          />
-
-          {props.isTrackPanelModalOpened ? (
-            <TrackPanelModal
-              closeTrackPanelModal={props.closeTrackPanelModal}
-              launchbarExpanded={props.launchbarExpanded}
-              trackPanelModalView={props.trackPanelModalView}
-            />
-          ) : null}
+          <TrackPanelBar />
+          <TrackPanelList />
+          {props.isTrackPanelModalOpened ? <TrackPanelModal /> : null}
           {isDrawerOpened && <Drawer />}
         </div>
       ) : null}
@@ -164,11 +110,8 @@ const mapStateToProps = (state: RootState): StateProps => {
     breakpointWidth: getBreakpointWidth(state),
     browserActivated: getBrowserActivated(state),
     isDrawerOpened: getIsDrawerOpened(state),
-    drawerView: getDrawerView(state),
-    ensObject: getBrowserActiveEnsObject(state),
+    activeEnsObject: getBrowserActiveEnsObject(state),
     isTrackPanelModalOpened: getIsTrackPanelModalOpened(state),
-    trackPanelModalView: getTrackPanelModalView(state),
-    launchbarExpanded: getLaunchbarExpanded(state),
     selectedBrowserTab: getSelectedBrowserTab(state),
     genomeTrackCategories: activeGenomeId
       ? getGenomeTrackCategoriesById(state, activeGenomeId)
@@ -179,13 +122,7 @@ const mapStateToProps = (state: RootState): StateProps => {
 };
 
 const mapDispatchToProps: DispatchProps = {
-  changeDrawerView,
-  closeDrawer,
-  closeTrackPanelModal,
-  openTrackPanelModal,
-  toggleDrawer,
-  toggleTrackPanel,
-  updateTrackStates: updateTrackStatesAndSave
+  toggleTrackPanel
 };
 
 export default connect(

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBar.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBar.tsx
@@ -1,6 +1,22 @@
 import React, { FunctionComponent, useCallback } from 'react';
+import { connect } from 'react-redux';
 
 import { trackPanelBarConfig, TrackPanelBarItem } from './trackPanelBarConfig';
+import { getBrowserActiveGenomeId } from '../../browserSelectors';
+import { getIsDrawerOpened } from '../../drawer/drawerSelectors';
+import {
+  getIsTrackPanelModalOpened,
+  getIsTrackPanelOpened,
+  getTrackPanelModalView
+} from '../trackPanelSelectors';
+import { RootState } from 'src/store';
+import { getLaunchbarExpanded } from 'src/header/headerSelectors';
+import {
+  toggleTrackPanel,
+  closeTrackPanelModal,
+  openTrackPanelModal
+} from '../trackPanelActions';
+import { closeDrawer } from '../../drawer/drawerActions';
 
 import TrackPanelBarIcon from './TrackPanelBarIcon';
 
@@ -9,18 +25,25 @@ import chevronRightIcon from 'static/img/shared/chevron-right.svg';
 
 import styles from './TrackPanelBar.scss';
 
-type TrackPanelBarProps = {
-  activeGenomeId: string;
-  closeDrawer: () => void;
-  closeTrackPanelModal: () => void;
+type StateProps = {
+  activeGenomeId: string | null;
   isDrawerOpened: boolean;
   isTrackPanelModalOpened: boolean;
   isTrackPanelOpened: boolean;
   launchbarExpanded: boolean;
-  openTrackPanelModal: (trackPanelModalView: string) => void;
-  toggleTrackPanel: (isTrackPanelOpened?: boolean) => void;
   trackPanelModalView: string;
 };
+
+type DispatchProps = {
+  closeDrawer: () => void;
+  closeTrackPanelModal: () => void;
+  openTrackPanelModal: (trackPanelModalView: string) => void;
+  toggleTrackPanel: (isTrackPanelOpened?: boolean) => void;
+};
+
+type OwnProps = {};
+
+type TrackPanelBarProps = StateProps & DispatchProps & OwnProps;
 
 const TrackPanelBar: FunctionComponent<TrackPanelBarProps> = (
   props: TrackPanelBarProps
@@ -74,4 +97,23 @@ const TrackPanelBar: FunctionComponent<TrackPanelBarProps> = (
   );
 };
 
-export default TrackPanelBar;
+const mapStateToProps = (state: RootState): StateProps => ({
+  activeGenomeId: getBrowserActiveGenomeId(state),
+  isDrawerOpened: getIsDrawerOpened(state),
+  isTrackPanelModalOpened: getIsTrackPanelModalOpened(state),
+  isTrackPanelOpened: getIsTrackPanelOpened(state),
+  launchbarExpanded: getLaunchbarExpanded(state),
+  trackPanelModalView: getTrackPanelModalView(state)
+});
+
+const mapDispatchToProps: DispatchProps = {
+  closeDrawer,
+  closeTrackPanelModal,
+  openTrackPanelModal,
+  toggleTrackPanel
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(TrackPanelBar);

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBar.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBar.tsx
@@ -29,9 +29,14 @@ const TrackPanelBar: FunctionComponent<TrackPanelBarProps> = (
     if (props.isDrawerOpened) {
       props.closeDrawer();
     } else {
-      props.toggleTrackPanel();
+      props.toggleTrackPanel(!props.isTrackPanelOpened);
     }
-  }, [props.isDrawerOpened, props.closeDrawer, props.toggleTrackPanel]);
+  }, [
+    props.isDrawerOpened,
+    props.closeDrawer,
+    props.toggleTrackPanel,
+    props.isTrackPanelOpened
+  ]);
 
   const getClassNames = () => {
     const heightClass: string = props.launchbarExpanded

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBar.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBar.tsx
@@ -65,6 +65,7 @@ const TrackPanelBar: FunctionComponent<TrackPanelBarProps> = (
             closeTrackPanelModal={props.closeTrackPanelModal}
             openTrackPanelModal={props.openTrackPanelModal}
             isTrackPanelModalOpened={props.isTrackPanelModalOpened}
+            isTrackPanelOpened={props.isTrackPanelOpened}
             trackPanelModalView={props.trackPanelModalView}
           />
         ))}

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBar.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBar.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useCallback } from 'react';
+import React, { useCallback } from 'react';
 import { connect } from 'react-redux';
 
 import { trackPanelBarConfig, TrackPanelBarItem } from './trackPanelBarConfig';
@@ -25,29 +25,20 @@ import chevronRightIcon from 'static/img/shared/chevron-right.svg';
 
 import styles from './TrackPanelBar.scss';
 
-type StateProps = {
+type TrackPanelBarProps = {
   activeGenomeId: string | null;
   isDrawerOpened: boolean;
   isTrackPanelModalOpened: boolean;
   isTrackPanelOpened: boolean;
   launchbarExpanded: boolean;
   trackPanelModalView: string;
-};
-
-type DispatchProps = {
   closeDrawer: () => void;
   closeTrackPanelModal: () => void;
   openTrackPanelModal: (trackPanelModalView: string) => void;
   toggleTrackPanel: (isTrackPanelOpened?: boolean) => void;
 };
 
-type OwnProps = {};
-
-type TrackPanelBarProps = StateProps & DispatchProps & OwnProps;
-
-const TrackPanelBar: FunctionComponent<TrackPanelBarProps> = (
-  props: TrackPanelBarProps
-) => {
+const TrackPanelBar = (props: TrackPanelBarProps) => {
   const moveTrackPanel = useCallback(() => {
     if (props.isDrawerOpened) {
       props.closeDrawer();
@@ -97,7 +88,7 @@ const TrackPanelBar: FunctionComponent<TrackPanelBarProps> = (
   );
 };
 
-const mapStateToProps = (state: RootState): StateProps => ({
+const mapStateToProps = (state: RootState) => ({
   activeGenomeId: getBrowserActiveGenomeId(state),
   isDrawerOpened: getIsDrawerOpened(state),
   isTrackPanelModalOpened: getIsTrackPanelModalOpened(state),
@@ -106,7 +97,7 @@ const mapStateToProps = (state: RootState): StateProps => ({
   trackPanelModalView: getTrackPanelModalView(state)
 });
 
-const mapDispatchToProps: DispatchProps = {
+const mapDispatchToProps = {
   closeDrawer,
   closeTrackPanelModal,
   openTrackPanelModal,

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBarIcon.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBarIcon.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useState, useCallback, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { TrackPanelBarItem } from './trackPanelBarConfig';
 import ImageButton, {
   ImageButtonStatus
@@ -14,7 +14,7 @@ type TrackPanelBarIconProps = {
   trackPanelModalView: string;
 };
 
-const TrackPanelBarIcon = memo((props: TrackPanelBarIconProps) => {
+const TrackPanelBarIcon = (props: TrackPanelBarIconProps) => {
   const [toggleState, setToggleState] = useState(false);
 
   useEffect(() => {
@@ -23,7 +23,7 @@ const TrackPanelBarIcon = memo((props: TrackPanelBarIconProps) => {
     }
   }, [props.isTrackPanelModalOpened]);
 
-  const toggleModalView = useCallback(() => {
+  const toggleModalView = () => {
     if (!props.isTrackPanelOpened) {
       return;
     }
@@ -37,7 +37,7 @@ const TrackPanelBarIcon = memo((props: TrackPanelBarIconProps) => {
     }
 
     setToggleState(newToggleState);
-  }, [props.iconConfig.name, props.isTrackPanelOpened, toggleState]);
+  };
 
   const getViewIconStatus = () => {
     const { iconConfig, trackPanelModalView } = props;
@@ -57,6 +57,6 @@ const TrackPanelBarIcon = memo((props: TrackPanelBarIconProps) => {
       />
     </dt>
   );
-});
+};
 
 export default TrackPanelBarIcon;

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBarIcon.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBarIcon.tsx
@@ -15,6 +15,7 @@ type TrackPanelBarIconProps = {
   closeTrackPanelModal: () => void;
   iconConfig: TrackPanelBarItem;
   isTrackPanelModalOpened: boolean;
+  isTrackPanelOpened: boolean;
   openTrackPanelModal: (trackPanelModalView: string) => void;
   trackPanelModalView: string;
 };
@@ -30,16 +31,20 @@ const TrackPanelBarIcon: FunctionComponent<TrackPanelBarIconProps> = memo(
     }, [props.isTrackPanelModalOpened]);
 
     const toggleModalView = useCallback(() => {
+      if (!props.isTrackPanelOpened) {
+        return;
+      }
+
       const newToggleState = !toggleState;
 
-      if (newToggleState === true) {
+      if (newToggleState) {
         props.openTrackPanelModal(props.iconConfig.name);
       } else {
         props.closeTrackPanelModal();
       }
 
       setToggleState(newToggleState);
-    }, [props.iconConfig.name, toggleState]);
+    }, [props.iconConfig.name, props.isTrackPanelOpened, toggleState]);
 
     const getViewIconStatus = () => {
       const { iconConfig, trackPanelModalView } = props;

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBarIcon.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBarIcon.tsx
@@ -1,10 +1,4 @@
-import React, {
-  FunctionComponent,
-  memo,
-  useState,
-  useCallback,
-  useEffect
-} from 'react';
+import React, { memo, useState, useCallback, useEffect } from 'react';
 import { TrackPanelBarItem } from './trackPanelBarConfig';
 import ImageButton, {
   ImageButtonStatus
@@ -20,51 +14,49 @@ type TrackPanelBarIconProps = {
   trackPanelModalView: string;
 };
 
-const TrackPanelBarIcon: FunctionComponent<TrackPanelBarIconProps> = memo(
-  (props: TrackPanelBarIconProps) => {
-    const [toggleState, setToggleState] = useState(false);
+const TrackPanelBarIcon = memo((props: TrackPanelBarIconProps) => {
+  const [toggleState, setToggleState] = useState(false);
 
-    useEffect(() => {
-      if (!props.isTrackPanelModalOpened) {
-        setToggleState(false);
-      }
-    }, [props.isTrackPanelModalOpened]);
+  useEffect(() => {
+    if (!props.isTrackPanelModalOpened) {
+      setToggleState(false);
+    }
+  }, [props.isTrackPanelModalOpened]);
 
-    const toggleModalView = useCallback(() => {
-      if (!props.isTrackPanelOpened) {
-        return;
-      }
+  const toggleModalView = useCallback(() => {
+    if (!props.isTrackPanelOpened) {
+      return;
+    }
 
-      const newToggleState = !toggleState;
+    const newToggleState = !toggleState;
 
-      if (newToggleState) {
-        props.openTrackPanelModal(props.iconConfig.name);
-      } else {
-        props.closeTrackPanelModal();
-      }
+    if (newToggleState) {
+      props.openTrackPanelModal(props.iconConfig.name);
+    } else {
+      props.closeTrackPanelModal();
+    }
 
-      setToggleState(newToggleState);
-    }, [props.iconConfig.name, props.isTrackPanelOpened, toggleState]);
+    setToggleState(newToggleState);
+  }, [props.iconConfig.name, props.isTrackPanelOpened, toggleState]);
 
-    const getViewIconStatus = () => {
-      const { iconConfig, trackPanelModalView } = props;
+  const getViewIconStatus = () => {
+    const { iconConfig, trackPanelModalView } = props;
 
-      return iconConfig.name === trackPanelModalView
-        ? ImageButtonStatus.HIGHLIGHTED
-        : ImageButtonStatus.ACTIVE;
-    };
+    return iconConfig.name === trackPanelModalView
+      ? ImageButtonStatus.HIGHLIGHTED
+      : ImageButtonStatus.ACTIVE;
+  };
 
-    return (
-      <dt className={styles.barIcon}>
-        <ImageButton
-          buttonStatus={getViewIconStatus()}
-          description={props.iconConfig.description}
-          onClick={toggleModalView}
-          image={props.iconConfig.icon}
-        />
-      </dt>
-    );
-  }
-);
+  return (
+    <dt className={styles.barIcon}>
+      <ImageButton
+        buttonStatus={getViewIconStatus()}
+        description={props.iconConfig.description}
+        onClick={toggleModalView}
+        image={props.iconConfig.icon}
+      />
+    </dt>
+  );
+});
 
 export default TrackPanelBarIcon;

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.tsx
@@ -21,7 +21,7 @@ import {
   getBrowserTrackStates,
   getBrowserActiveGenomeId
 } from '../../browserSelectors';
-import { getSelectedBrowserTab } from '../trackPanelSelectors';
+import { getSelectedTrackPanelTab } from '../trackPanelSelectors';
 import { getGenomeTrackCategoriesById } from 'src/genome/genomeSelectors';
 
 import styles from './TrackPanelList.scss';
@@ -32,7 +32,7 @@ type TrackPanelListProps = {
   drawerView: string;
   launchbarExpanded: boolean;
   activeEnsObject: EnsObject | null;
-  selectedBrowserTab: TrackSet;
+  selectedTrackPanelTab: TrackSet;
   genomeTrackCategories: GenomeTrackCategory[];
   trackStates: TrackStates;
   toggleDrawer: (isDrawerOpened: boolean) => void;
@@ -44,12 +44,12 @@ const TrackPanelList = (props: TrackPanelListProps) => {
   const {
     activeGenomeId,
     activeEnsObject,
-    selectedBrowserTab,
+    selectedTrackPanelTab,
     genomeTrackCategories
   } = props;
   const currentTrackCategories = genomeTrackCategories.filter(
     (category: GenomeTrackCategory) =>
-      category.types.includes(selectedBrowserTab)
+      category.types.includes(selectedTrackPanelTab)
   );
 
   const getTrackPanelListClasses = () => {
@@ -133,7 +133,7 @@ const mapStateToProps = (state: RootState) => {
     drawerView: getDrawerView(state),
     launchbarExpanded: getLaunchbarExpanded(state),
     activeEnsObject: getBrowserActiveEnsObject(state),
-    selectedBrowserTab: getSelectedBrowserTab(state),
+    selectedTrackPanelTab: getSelectedTrackPanelTab(state),
     genomeTrackCategories: activeGenomeId
       ? getGenomeTrackCategoriesById(state, activeGenomeId)
       : [],

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.tsx
@@ -10,7 +10,7 @@ import {
   updateTrackStatesAndSave
 } from 'src/content/app/browser/browserActions';
 import { toggleDrawer, changeDrawerView } from '../../drawer/drawerActions';
-import { TrackType, TrackStates } from '../trackPanelConfig';
+import { TrackSet, TrackStates } from '../trackPanelConfig';
 import { GenomeTrackCategory } from 'src/genome/genomeTypes';
 import { EnsObjectTrack, EnsObject } from 'src/ens-object/ensObjectTypes';
 import { RootState } from 'src/store';
@@ -32,7 +32,7 @@ type TrackPanelListProps = {
   drawerView: string;
   launchbarExpanded: boolean;
   activeEnsObject: EnsObject | null;
-  selectedBrowserTab: TrackType;
+  selectedBrowserTab: TrackSet;
   genomeTrackCategories: GenomeTrackCategory[];
   trackStates: TrackStates;
   toggleDrawer: (isDrawerOpened: boolean) => void;

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.tsx
@@ -1,48 +1,65 @@
 import React, { FunctionComponent } from 'react';
+import { connect } from 'react-redux';
 import get from 'lodash/get';
 
 import TrackPanelListItem from './TrackPanelListItem';
-
-import { UpdateTrackStatesPayload } from 'src/content/app/browser/browserActions';
-import { TrackType, TrackStates } from '../trackPanelConfig';
-
-import styles from './TrackPanelList.scss';
 import { ImageButtonStatus } from 'src/shared/image-button/ImageButton';
+
+import {
+  UpdateTrackStatesPayload,
+  updateTrackStatesAndSave
+} from 'src/content/app/browser/browserActions';
+import { toggleDrawer, changeDrawerView } from '../../drawer/drawerActions';
+import { TrackType, TrackStates } from '../trackPanelConfig';
 import { GenomeTrackCategory } from 'src/genome/genomeTypes';
 import { EnsObjectTrack, EnsObject } from 'src/ens-object/ensObjectTypes';
+import { RootState } from 'src/store';
+import { getDrawerView, getIsDrawerOpened } from '../../drawer/drawerSelectors';
+import { getLaunchbarExpanded } from 'src/header/headerSelectors';
+import {
+  getBrowserActiveEnsObject,
+  getBrowserTrackStates,
+  getBrowserActiveGenomeId
+} from '../../browserSelectors';
+import { getSelectedBrowserTab } from '../trackPanelSelectors';
+import { getGenomeTrackCategoriesById } from 'src/genome/genomeSelectors';
 
-type TrackPanelListProps = {
-  activeGenomeId: string;
+import styles from './TrackPanelList.scss';
+
+type StateProps = {
+  activeGenomeId: string | null;
   isDrawerOpened: boolean;
   drawerView: string;
   launchbarExpanded: boolean;
-  ensObject: EnsObject;
+  activeEnsObject: EnsObject | null;
   selectedBrowserTab: TrackType;
-  toggleDrawer: (isDrawerOpened: boolean) => void;
   genomeTrackCategories: GenomeTrackCategory[];
   trackStates: TrackStates;
-  updateDrawerView: (drawerView: string) => void;
+};
+
+type DispatchProps = {
+  toggleDrawer: (isDrawerOpened: boolean) => void;
+  changeDrawerView: (drawerView: string) => void;
   updateTrackStates: (payload: UpdateTrackStatesPayload) => void;
 };
+
+type OwnProps = {};
+
+type TrackPanelListProps = StateProps & DispatchProps & OwnProps;
 
 const TrackPanelList: FunctionComponent<TrackPanelListProps> = (
   props: TrackPanelListProps
 ) => {
-  const { activeGenomeId, selectedBrowserTab, genomeTrackCategories } = props;
+  const {
+    activeGenomeId,
+    activeEnsObject,
+    selectedBrowserTab,
+    genomeTrackCategories
+  } = props;
   const currentTrackCategories = genomeTrackCategories.filter(
     (category: GenomeTrackCategory) =>
       category.types.includes(selectedBrowserTab)
   );
-
-  const changeDrawerView = (currentTrack: string) => {
-    const { drawerView, toggleDrawer, updateDrawerView } = props;
-
-    updateDrawerView(currentTrack);
-
-    if (!drawerView) {
-      toggleDrawer(true);
-    }
-  };
 
   const getTrackPanelListClasses = () => {
     const heightClass: string = props.launchbarExpanded
@@ -64,6 +81,7 @@ const TrackPanelList: FunctionComponent<TrackPanelListProps> = (
     if (!track) {
       return;
     }
+
     const { track_id } = track;
     const defaultTrackStatus = getDefaultTrackStatus();
 
@@ -75,16 +93,11 @@ const TrackPanelList: FunctionComponent<TrackPanelListProps> = (
 
     return (
       <TrackPanelListItem
-        activeGenomeId={props.activeGenomeId}
         categoryName={categoryName}
         defaultTrackStatus={defaultTrackStatus as ImageButtonStatus}
         trackStatus={trackStatus as ImageButtonStatus}
-        isDrawerOpened={props.isDrawerOpened}
-        drawerView={props.drawerView}
         key={track.track_id}
         track={track}
-        updateDrawerView={changeDrawerView}
-        updateTrackStates={props.updateTrackStates}
       >
         {track.child_tracks &&
           track.child_tracks.map((childTrack: EnsObjectTrack) =>
@@ -96,9 +109,11 @@ const TrackPanelList: FunctionComponent<TrackPanelListProps> = (
 
   return (
     <div className={getTrackPanelListClasses()}>
-      {props.ensObject.object_type === 'region' ? null : (
+      {activeEnsObject && activeEnsObject.object_type === 'region' ? null : (
         <section>
-          <dl>{getTrackListItem('main', props.ensObject.track)}</dl>
+          <dl>
+            {getTrackListItem('main', activeEnsObject && activeEnsObject.track)}
+          </dl>
         </section>
       )}
       {currentTrackCategories.map((category: GenomeTrackCategory) => (
@@ -119,4 +134,29 @@ const TrackPanelList: FunctionComponent<TrackPanelListProps> = (
   );
 };
 
-export default TrackPanelList;
+const mapStateToProps = (state: RootState): StateProps => {
+  const activeGenomeId = getBrowserActiveGenomeId(state);
+  return {
+    activeGenomeId,
+    isDrawerOpened: getIsDrawerOpened(state),
+    drawerView: getDrawerView(state),
+    launchbarExpanded: getLaunchbarExpanded(state),
+    activeEnsObject: getBrowserActiveEnsObject(state),
+    selectedBrowserTab: getSelectedBrowserTab(state),
+    genomeTrackCategories: activeGenomeId
+      ? getGenomeTrackCategoriesById(state, activeGenomeId)
+      : [],
+    trackStates: getBrowserTrackStates(state)
+  };
+};
+
+const mapDispatchToProps: DispatchProps = {
+  changeDrawerView,
+  toggleDrawer,
+  updateTrackStates: updateTrackStatesAndSave
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(TrackPanelList);

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import get from 'lodash/get';
 
@@ -26,7 +26,7 @@ import { getGenomeTrackCategoriesById } from 'src/genome/genomeSelectors';
 
 import styles from './TrackPanelList.scss';
 
-type StateProps = {
+type TrackPanelListProps = {
   activeGenomeId: string | null;
   isDrawerOpened: boolean;
   drawerView: string;
@@ -35,21 +35,12 @@ type StateProps = {
   selectedBrowserTab: TrackType;
   genomeTrackCategories: GenomeTrackCategory[];
   trackStates: TrackStates;
-};
-
-type DispatchProps = {
   toggleDrawer: (isDrawerOpened: boolean) => void;
   changeDrawerView: (drawerView: string) => void;
   updateTrackStates: (payload: UpdateTrackStatesPayload) => void;
 };
 
-type OwnProps = {};
-
-type TrackPanelListProps = StateProps & DispatchProps & OwnProps;
-
-const TrackPanelList: FunctionComponent<TrackPanelListProps> = (
-  props: TrackPanelListProps
-) => {
+const TrackPanelList = (props: TrackPanelListProps) => {
   const {
     activeGenomeId,
     activeEnsObject,
@@ -134,7 +125,7 @@ const TrackPanelList: FunctionComponent<TrackPanelListProps> = (
   );
 };
 
-const mapStateToProps = (state: RootState): StateProps => {
+const mapStateToProps = (state: RootState) => {
   const activeGenomeId = getBrowserActiveGenomeId(state);
   return {
     activeGenomeId,
@@ -150,7 +141,7 @@ const mapStateToProps = (state: RootState): StateProps => {
   };
 };
 
-const mapDispatchToProps: DispatchProps = {
+const mapDispatchToProps = {
   changeDrawerView,
   toggleDrawer,
   updateTrackStates: updateTrackStatesAndSave

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
@@ -1,10 +1,4 @@
-import React, {
-  FunctionComponent,
-  MouseEvent,
-  ReactNode,
-  useState,
-  useEffect
-} from 'react';
+import React, { MouseEvent, ReactNode, useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 
@@ -32,19 +26,13 @@ import { ReactComponent as Ellipsis } from 'static/img/track-panel/ellipsis.svg'
 
 import styles from './TrackPanelListItem.scss';
 
-type StateProps = {
+type TrackPanelListItemProps = {
   activeGenomeId: string | null;
   isDrawerOpened: boolean;
   drawerView: string;
-};
-
-type DispatchProps = {
   changeDrawerView: (drawerView: string) => void;
   toggleDrawer: (isDrawerOpened: boolean) => void;
   updateTrackStates: (payload: UpdateTrackStatesPayload) => void;
-};
-
-type OwnProps = {
   categoryName: string;
   children?: ReactNode[];
   trackStatus: ImageButtonStatus;
@@ -52,14 +40,10 @@ type OwnProps = {
   track: EnsObjectTrack;
 };
 
-type TrackPanelListItemProps = StateProps & DispatchProps & OwnProps;
-
 // delete this when there is a better place to put this
 const trackPrefix = 'track:';
 
-const TrackPanelListItem: FunctionComponent<TrackPanelListItemProps> = (
-  props: TrackPanelListItemProps
-) => {
+const TrackPanelListItem = (props: TrackPanelListItemProps) => {
   const [expanded, setExpanded] = useState(true);
   const {
     activeGenomeId,
@@ -215,13 +199,13 @@ const TrackPanelListItem: FunctionComponent<TrackPanelListItemProps> = (
   );
 };
 
-const mapStateToProps = (state: RootState): StateProps => ({
+const mapStateToProps = (state: RootState) => ({
   activeGenomeId: getBrowserActiveGenomeId(state),
   isDrawerOpened: getIsDrawerOpened(state),
   drawerView: getDrawerView(state)
 });
 
-const mapDispatchToProps: DispatchProps = {
+const mapDispatchToProps = {
   changeDrawerView,
   toggleDrawer,
   updateTrackStates: updateTrackStatesAndSave

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/TrackPanelModal.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/TrackPanelModal.tsx
@@ -1,5 +1,5 @@
-import React, { FunctionComponent } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import React from 'react';
+import { connect } from 'react-redux';
 
 import TrackPanelSearch from './modal-views/TrackPanelSearch';
 import TracksManager from './modal-views/TracksManager';
@@ -17,18 +17,22 @@ import closeIcon from 'static/img/track-panel/close.svg';
 
 import styles from './TrackPanelModal.scss';
 
-const TrackPanelModal: FunctionComponent = () => {
-  const { launchbarExpanded, trackPanelModalView } = useSelector(
-    (state: RootState) => ({
-      launchbarExpanded: getLaunchbarExpanded(state),
-      trackPanelModalView: getTrackPanelModalView(state)
-    })
-  );
+type StateProps = {
+  launchbarExpanded: boolean;
+  trackPanelModalView: string;
+};
 
-  const dispatch = useDispatch();
+type DispatchProps = {
+  closeTrackPanelModal: () => void;
+};
 
+type OwnProps = {};
+
+type TrackPanelModalProps = StateProps & DispatchProps & OwnProps;
+
+const TrackPanelModal = (props: TrackPanelModalProps) => {
   const getTrackPanelModalClasses = () => {
-    const heightClass: string = launchbarExpanded
+    const heightClass: string = props.launchbarExpanded
       ? styles.shorter
       : styles.taller;
 
@@ -36,7 +40,7 @@ const TrackPanelModal: FunctionComponent = () => {
   };
 
   const getModalView = () => {
-    switch (trackPanelModalView) {
+    switch (props.trackPanelModalView) {
       case 'search':
         return <TrackPanelSearch />;
       case 'tracks-manager':
@@ -57,7 +61,7 @@ const TrackPanelModal: FunctionComponent = () => {
   return (
     <section className={getTrackPanelModalClasses()}>
       <button
-        onClick={() => dispatch(closeTrackPanelModal())}
+        onClick={props.closeTrackPanelModal}
         className={styles.closeButton}
       >
         <img src={closeIcon} alt="Close track panel modal" />
@@ -67,4 +71,16 @@ const TrackPanelModal: FunctionComponent = () => {
   );
 };
 
-export default TrackPanelModal;
+const mapStateToProps = (state: RootState): StateProps => ({
+  launchbarExpanded: getLaunchbarExpanded(state),
+  trackPanelModalView: getTrackPanelModalView(state)
+});
+
+const mapDispatchToProps: DispatchProps = {
+  closeTrackPanelModal
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(TrackPanelModal);

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/TrackPanelModal.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/TrackPanelModal.tsx
@@ -1,6 +1,5 @@
 import React, { FunctionComponent } from 'react';
-
-import closeIcon from 'static/img/track-panel/close.svg';
+import { useSelector, useDispatch } from 'react-redux';
 
 import TrackPanelSearch from './modal-views/TrackPanelSearch';
 import TracksManager from './modal-views/TracksManager';
@@ -9,19 +8,27 @@ import PersonalData from './modal-views/PersonalData';
 import TrackPanelShare from './modal-views/TrackPanelShare';
 import TrackPanelDownloads from './modal-views/TrackPanelDownloads';
 
+import { getLaunchbarExpanded } from 'src/header/headerSelectors';
+import { getTrackPanelModalView } from '../trackPanelSelectors';
+import { closeTrackPanelModal } from '../trackPanelActions';
+import { RootState } from 'src/store';
+
+import closeIcon from 'static/img/track-panel/close.svg';
+
 import styles from './TrackPanelModal.scss';
 
-type TrackPanelModalProps = {
-  closeTrackPanelModal: () => void;
-  launchbarExpanded: boolean;
-  trackPanelModalView: string;
-};
+const TrackPanelModal: FunctionComponent = () => {
+  const { launchbarExpanded, trackPanelModalView } = useSelector(
+    (state: RootState) => ({
+      launchbarExpanded: getLaunchbarExpanded(state),
+      trackPanelModalView: getTrackPanelModalView(state)
+    })
+  );
 
-const TrackPanelModal: FunctionComponent<TrackPanelModalProps> = (
-  props: TrackPanelModalProps
-) => {
+  const dispatch = useDispatch();
+
   const getTrackPanelModalClasses = () => {
-    const heightClass: string = props.launchbarExpanded
+    const heightClass: string = launchbarExpanded
       ? styles.shorter
       : styles.taller;
 
@@ -29,7 +36,7 @@ const TrackPanelModal: FunctionComponent<TrackPanelModalProps> = (
   };
 
   const getModalView = () => {
-    switch (props.trackPanelModalView) {
+    switch (trackPanelModalView) {
       case 'search':
         return <TrackPanelSearch />;
       case 'tracks-manager':
@@ -50,7 +57,7 @@ const TrackPanelModal: FunctionComponent<TrackPanelModalProps> = (
   return (
     <section className={getTrackPanelModalClasses()}>
       <button
-        onClick={props.closeTrackPanelModal}
+        onClick={() => dispatch(closeTrackPanelModal())}
         className={styles.closeButton}
       >
         <img src={closeIcon} alt="Close track panel modal" />

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/TrackPanelModal.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/TrackPanelModal.tsx
@@ -17,18 +17,11 @@ import closeIcon from 'static/img/track-panel/close.svg';
 
 import styles from './TrackPanelModal.scss';
 
-type StateProps = {
+type TrackPanelModalProps = {
   launchbarExpanded: boolean;
   trackPanelModalView: string;
-};
-
-type DispatchProps = {
   closeTrackPanelModal: () => void;
 };
-
-type OwnProps = {};
-
-type TrackPanelModalProps = StateProps & DispatchProps & OwnProps;
 
 const TrackPanelModal = (props: TrackPanelModalProps) => {
   const getTrackPanelModalClasses = () => {
@@ -71,12 +64,12 @@ const TrackPanelModal = (props: TrackPanelModalProps) => {
   );
 };
 
-const mapStateToProps = (state: RootState): StateProps => ({
+const mapStateToProps = (state: RootState) => ({
   launchbarExpanded: getLaunchbarExpanded(state),
   trackPanelModalView: getTrackPanelModalView(state)
 });
 
-const mapDispatchToProps: DispatchProps = {
+const mapDispatchToProps = {
   closeTrackPanelModal
 };
 

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/PersonalData.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/PersonalData.tsx
@@ -1,6 +1,6 @@
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 
-const PersonalData: FunctionComponent = () => {
+const PersonalData = () => {
   return (
     <section className="personaData">
       <h3>Personal Data</h3>

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
@@ -17,19 +17,12 @@ import upperFirst from 'lodash/upperFirst';
 
 import styles from '../TrackPanelModal.scss';
 
-type StateProps = {
+type TrackPanelBookmarksProps = {
   activeGenomeId: string | null;
   genomeInfo: GenomeInfoData;
   exampleEnsObjects: EnsObject[];
-};
-
-type DispatchProps = {
   fetchExampleEnsObjects: (objectId: string) => void;
 };
-
-type OwnProps = {};
-
-type TrackPanelBookmarksProps = StateProps & DispatchProps & OwnProps;
 
 export const TrackPanelBookmarks = (props: TrackPanelBookmarksProps) => {
   const getExampleObjLabel = (exampleObject: EnsObject) => {

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelDownloads.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelDownloads.tsx
@@ -1,6 +1,6 @@
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 
-const TrackPanelDownloads: FunctionComponent = () => {
+const TrackPanelDownloads = () => {
   return (
     <section className="trackPanelDownloads">
       <h3>Downloads</h3>

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelSearch.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelSearch.tsx
@@ -1,6 +1,6 @@
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 
-const TrackPanelSearch: FunctionComponent = () => {
+const TrackPanelSearch = () => {
   return (
     <section className="trackPanelSearch">
       <h3>Search</h3>

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelShare.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelShare.tsx
@@ -1,6 +1,6 @@
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 
-const TrackPanelShare: FunctionComponent = () => {
+const TrackPanelShare = () => {
   return (
     <section className="trackPanelShare">
       <h3>Share</h3>

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TracksManager.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TracksManager.tsx
@@ -1,6 +1,6 @@
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 
-const TracksManager: FunctionComponent = () => {
+const TracksManager = () => {
   return (
     <section className="tracksManager">
       <h3>Tracks Manager</h3>

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-tabs/TrackPanelTabs.scss
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-tabs/TrackPanelTabs.scss
@@ -1,6 +1,6 @@
 @import 'src/styles/common';
 
-.browserTabs {
+.trackPanelTabs {
   @include flex;
   font-size: 13px;
   justify-content: space-between;
@@ -9,25 +9,25 @@
   width: 312px;
 }
 
-.browserTab {
+.trackPanelTab {
   button {
     color: $ens-dark-blue;
   }
 }
 
-.browserTabActive {
+.trackPanelTabActive {
   button {
     color: inherit;
   }
 }
 
-.browserTabDisabled {
+.trackPanelTabDisabled {
   button {
     color: $ens-dark-grey;
     cursor: default;
   }
 }
-.browserTabArrow {
+.trackPanelTabArrow {
   position: relative;
 
   &::after {

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-tabs/TrackPanelTabs.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-tabs/TrackPanelTabs.tsx
@@ -1,24 +1,24 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { TrackSet } from '../track-panel/trackPanelConfig';
+import { TrackSet } from '../trackPanelConfig';
 import { EnsObject } from 'src/ens-object/ensObjectTypes';
 
-import styles from './BrowserTabs.scss';
+import styles from './TrackPanelTabs.scss';
 
-type BrowserTabsProps = {
+type TrackPanelTabsProps = {
   closeDrawer: () => void;
   ensObject: EnsObject;
   isDrawerOpened: boolean;
   genomeSelectorActive: boolean;
-  selectBrowserTabAndSave: (selectedBrowserTab: TrackSet) => void;
-  selectedBrowserTab: TrackSet;
+  selectTrackPanelTabAndSave: (selectedTrackPanelTab: TrackSet) => void;
+  selectedTrackPanelTab: TrackSet;
   toggleTrackPanel: (isTrackPanelOpened: boolean) => void;
   isTrackPanelModalOpened: boolean;
   isTrackPanelOpened: boolean;
 };
 
-const BrowserTabs = (props: BrowserTabsProps) => {
+const TrackPanelTabs = (props: TrackPanelTabsProps) => {
   const handleTabClick = (value: TrackSet) => {
     if (props.genomeSelectorActive || !props.ensObject.genome_id) {
       return;
@@ -32,29 +32,29 @@ const BrowserTabs = (props: BrowserTabsProps) => {
       props.closeDrawer();
     }
 
-    props.selectBrowserTabAndSave(value);
+    props.selectTrackPanelTabAndSave(value);
   };
 
-  const getBrowserTabClassNames = (trackSet: TrackSet) => {
-    const isBrowserTabActive =
+  const getTrackPanelTabClassNames = (trackSet: TrackSet) => {
+    const isTrackPanelTabActive =
       props.isTrackPanelOpened &&
       props.ensObject.genome_id &&
-      props.selectedBrowserTab === trackSet &&
+      props.selectedTrackPanelTab === trackSet &&
       !props.isDrawerOpened &&
       !props.isTrackPanelModalOpened;
 
-    return classNames(styles.browserTab, {
-      [styles.browserTabActive]: isBrowserTabActive,
-      [styles.browserTabArrow]: isBrowserTabActive,
-      [styles.browserTabDisabled]: !props.ensObject.genome_id
+    return classNames(styles.trackPanelTab, {
+      [styles.trackPanelTabActive]: isTrackPanelTabActive,
+      [styles.trackPanelTabArrow]: isTrackPanelTabActive,
+      [styles.trackPanelTabDisabled]: !props.ensObject.genome_id
     });
   };
 
   return (
-    <dl className={`${styles.browserTabs}`}>
+    <dl className={`${styles.trackPanelTabs}`}>
       {Object.values(TrackSet).map((value: TrackSet) => (
         <dd
-          className={getBrowserTabClassNames(value)}
+          className={getTrackPanelTabClassNames(value)}
           key={value}
           onClick={() => handleTabClick(value)}
         >
@@ -65,4 +65,4 @@ const BrowserTabs = (props: BrowserTabsProps) => {
   );
 };
 
-export default BrowserTabs;
+export default TrackPanelTabs;

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
@@ -1,18 +1,20 @@
 import { createAction } from 'typesafe-actions';
 import { ThunkAction } from 'redux-thunk';
 import { Action, ActionCreator } from 'redux';
+import { batch } from 'react-redux';
 
 import { RootState } from 'src/store';
 import { TrackType } from './trackPanelConfig';
 import browserStorageService from '../browser-storage-service';
 import { getBrowserActiveGenomeId } from '../browserSelectors';
-import { batch } from 'react-redux';
 
 export const toggleTrackPanelForGenome = createAction(
   'track-panel/toggle-track-panel',
   (resolve) => {
-    return (isTrackPanelOpenedForGenome: { [genomeId: string]: boolean }) =>
-      resolve(isTrackPanelOpenedForGenome);
+    return (isTrackPanelOpenedForGenome: {
+      activeGenomeId: string;
+      isTrackPanelOpened: boolean;
+    }) => resolve(isTrackPanelOpenedForGenome);
   }
 );
 
@@ -27,7 +29,8 @@ export const toggleTrackPanel: ActionCreator<
 
   dispatch(
     toggleTrackPanelForGenome({
-      [activeGenomeId]: isTrackPanelOpened
+      activeGenomeId: activeGenomeId,
+      isTrackPanelOpened
     })
   );
 };
@@ -35,7 +38,10 @@ export const toggleTrackPanel: ActionCreator<
 export const selectBrowserTab = createAction(
   'track-panel/select-browser-tab',
   (resolve) => {
-    return (selectedBrowserTabForGenome: { [genomeId: string]: TrackType }) => {
+    return (selectedBrowserTabForGenome: {
+      activeGenomeId: string;
+      selectedBrowserTab: TrackType;
+    }) => {
       return resolve(selectedBrowserTabForGenome);
     };
   }
@@ -53,14 +59,17 @@ export const selectBrowserTabAndSave: ActionCreator<
     return;
   }
 
-  const selectedBrowserTabForGenome = {
+  browserStorageService.updateSelectedBrowserTab({
     [activeGenomeId]: selectedBrowserTab
-  };
-
-  browserStorageService.updateSelectedBrowserTab(selectedBrowserTabForGenome);
+  });
 
   batch(() => {
-    dispatch(selectBrowserTab(selectedBrowserTabForGenome));
+    dispatch(
+      selectBrowserTab({
+        activeGenomeId,
+        selectedBrowserTab
+      })
+    );
     dispatch(closeTrackPanelModal());
   });
 };
@@ -68,16 +77,20 @@ export const selectBrowserTabAndSave: ActionCreator<
 export const changeTrackPanelModalViewForGenome = createAction(
   'track-panel/change-track-panel-modal-view',
   (resolve) => {
-    return (trackPanelModalView: { [genomeId: string]: string }) =>
-      resolve(trackPanelModalView);
+    return (trackPanelModalViewForGenome: {
+      activeGenomeId: string;
+      trackPanelModalView: string;
+    }) => resolve(trackPanelModalViewForGenome);
   }
 );
 
 export const toggleTrackPanelModalForGenome = createAction(
   'track-panel/toggle-track-panel-modal',
   (resolve) => {
-    return (isTrackPanelModalOpenForGenome: { [genomeId: string]: boolean }) =>
-      resolve(isTrackPanelModalOpenForGenome);
+    return (isTrackPanelModalOpenForGenome: {
+      activeGenomeId: string;
+      isTrackPanelModalOpened: boolean;
+    }) => resolve(isTrackPanelModalOpenForGenome);
   }
 );
 
@@ -93,13 +106,15 @@ export const openTrackPanelModal: ActionCreator<
   batch(() => {
     dispatch(
       toggleTrackPanelModalForGenome({
-        [activeGenomeId]: true
+        activeGenomeId,
+        isTrackPanelModalOpened: true
       })
     );
 
     dispatch(
       changeTrackPanelModalViewForGenome({
-        [activeGenomeId]: trackPanelModalView
+        activeGenomeId: activeGenomeId,
+        trackPanelModalView
       })
     );
   });
@@ -117,13 +132,15 @@ export const closeTrackPanelModal: ActionCreator<
   batch(() => {
     dispatch(
       toggleTrackPanelModalForGenome({
-        [activeGenomeId]: false
+        activeGenomeId,
+        isTrackPanelModalOpened: false
       })
     );
 
     dispatch(
       changeTrackPanelModalViewForGenome({
-        [activeGenomeId]: ''
+        activeGenomeId,
+        trackPanelModalView: ''
       })
     );
   });

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
@@ -29,7 +29,7 @@ export const toggleTrackPanel: ActionCreator<
 
   dispatch(
     toggleTrackPanelForGenome({
-      activeGenomeId: activeGenomeId,
+      activeGenomeId,
       isTrackPanelOpened
     })
   );
@@ -70,6 +70,7 @@ export const selectBrowserTabAndSave: ActionCreator<
         selectedBrowserTab
       })
     );
+
     dispatch(closeTrackPanelModal());
   });
 };
@@ -113,7 +114,7 @@ export const openTrackPanelModal: ActionCreator<
 
     dispatch(
       changeTrackPanelModalViewForGenome({
-        activeGenomeId: activeGenomeId,
+        activeGenomeId,
         trackPanelModalView
       })
     );

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
@@ -3,7 +3,7 @@ import { ThunkAction } from 'redux-thunk';
 import { Action, ActionCreator } from 'redux';
 
 import { RootState } from 'src/store';
-import { TrackType } from './trackPanelConfig';
+import { TrackSet } from './trackPanelConfig';
 import browserStorageService from '../browser-storage-service';
 import { getBrowserActiveGenomeId } from '../browserSelectors';
 import { getActiveTrackPanel } from './trackPanelSelectors';
@@ -35,10 +35,7 @@ export const toggleTrackPanel: ActionCreator<
 
 export const selectBrowserTabAndSave: ActionCreator<
   ThunkAction<void, any, null, Action<string>>
-> = (selectedBrowserTab: TrackType) => (
-  dispatch,
-  getState: () => RootState
-) => {
+> = (selectedBrowserTab: TrackSet) => (dispatch, getState: () => RootState) => {
   const activeGenomeId = getBrowserActiveGenomeId(getState());
 
   if (!activeGenomeId) {

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
@@ -33,17 +33,20 @@ export const toggleTrackPanel: ActionCreator<
   );
 };
 
-export const selectBrowserTabAndSave: ActionCreator<
+export const selectTrackPanelTabAndSave: ActionCreator<
   ThunkAction<void, any, null, Action<string>>
-> = (selectedBrowserTab: TrackSet) => (dispatch, getState: () => RootState) => {
+> = (selectedTrackPanelTab: TrackSet) => (
+  dispatch,
+  getState: () => RootState
+) => {
   const activeGenomeId = getBrowserActiveGenomeId(getState());
 
   if (!activeGenomeId) {
     return;
   }
 
-  browserStorageService.updateSelectedBrowserTab({
-    [activeGenomeId]: selectedBrowserTab
+  browserStorageService.updateSelectedTrackPanelTab({
+    [activeGenomeId]: selectedTrackPanelTab
   });
 
   dispatch(
@@ -51,7 +54,7 @@ export const selectBrowserTabAndSave: ActionCreator<
       activeGenomeId,
       data: {
         ...getActiveTrackPanel(getState()),
-        selectedBrowserTab,
+        selectedTrackPanelTab,
         isTrackPanelModalOpened: false,
         trackPanelModalView: ''
       }

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelConfig.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelConfig.ts
@@ -9,13 +9,13 @@ export enum TrackItemColour {
 
 export type TrackItemColourKey = keyof typeof TrackItemColour;
 
-export enum TrackType {
+export enum TrackSet {
   GENOMIC = 'Genomic',
   VARIATION = 'Variation',
   EXPRESSION = 'Expression'
 }
 
-export type TrackTypeKey = keyof typeof TrackType;
+export type TrackSetKey = keyof typeof TrackSet;
 
 export type TrackPanelIcon = {
   description: string;

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelReducer.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelReducer.ts
@@ -7,39 +7,12 @@ export default function trackPanel(
   state: TrackPanelState = defaultTrackPanelState,
   action: ActionType<typeof trackPanelActions>
 ): TrackPanelState {
-  const activeGenomeId = action.payload && action.payload.activeGenomeId;
-
   switch (action.type) {
-    case getType(trackPanelActions.toggleTrackPanelForGenome):
+    case getType(trackPanelActions.updateTrackPanelForGenome):
       return {
         ...state,
-        [activeGenomeId]: {
-          ...state[activeGenomeId],
-          isTrackPanelOpened: action.payload.isTrackPanelOpened
-        }
-      };
-    case getType(trackPanelActions.toggleTrackPanelModalForGenome):
-      return {
-        ...state,
-        [activeGenomeId]: {
-          ...state[activeGenomeId],
-          isTrackPanelModalOpened: action.payload.isTrackPanelModalOpened
-        }
-      };
-    case getType(trackPanelActions.changeTrackPanelModalViewForGenome):
-      return {
-        ...state,
-        [activeGenomeId]: {
-          ...state[activeGenomeId],
-          trackPanelModalView: action.payload.trackPanelModalView
-        }
-      };
-    case getType(trackPanelActions.selectBrowserTab):
-      return {
-        ...state,
-        [activeGenomeId]: {
-          ...state[activeGenomeId],
-          selectedBrowserTab: action.payload.selectedBrowserTab
+        [action.payload.activeGenomeId]: {
+          ...action.payload.data
         }
       };
     default:

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelReducer.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelReducer.ts
@@ -7,7 +7,6 @@ export default function trackPanel(
   state: TrackPanelState = defaultTrackPanelState,
   action: ActionType<typeof trackPanelActions>
 ): TrackPanelState {
-  // check if action payload is not undefined to assign activeGenomeId
   const activeGenomeId = action.payload && action.payload.activeGenomeId;
 
   switch (action.type) {

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelReducer.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelReducer.ts
@@ -7,36 +7,39 @@ export default function trackPanel(
   state: TrackPanelState = defaultTrackPanelState,
   action: ActionType<typeof trackPanelActions>
 ): TrackPanelState {
+  // check if action payload is not undefined to assign activeGenomeId
+  const activeGenomeId = action.payload && action.payload.activeGenomeId;
+
   switch (action.type) {
     case getType(trackPanelActions.toggleTrackPanelForGenome):
       return {
         ...state,
-        [action.payload.activeGenomeId]: {
-          ...state[action.payload.activeGenomeId],
+        [activeGenomeId]: {
+          ...state[activeGenomeId],
           isTrackPanelOpened: action.payload.isTrackPanelOpened
         }
       };
     case getType(trackPanelActions.toggleTrackPanelModalForGenome):
       return {
         ...state,
-        [action.payload.activeGenomeId]: {
-          ...state[action.payload.activeGenomeId],
+        [activeGenomeId]: {
+          ...state[activeGenomeId],
           isTrackPanelModalOpened: action.payload.isTrackPanelModalOpened
         }
       };
     case getType(trackPanelActions.changeTrackPanelModalViewForGenome):
       return {
         ...state,
-        [action.payload.activeGenomeId]: {
-          ...state[action.payload.activeGenomeId],
+        [activeGenomeId]: {
+          ...state[activeGenomeId],
           trackPanelModalView: action.payload.trackPanelModalView
         }
       };
     case getType(trackPanelActions.selectBrowserTab):
       return {
         ...state,
-        [action.payload.activeGenomeId]: {
-          ...state[action.payload.activeGenomeId],
+        [activeGenomeId]: {
+          ...state[activeGenomeId],
           selectedBrowserTab: action.payload.selectedBrowserTab
         }
       };

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelReducer.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelReducer.ts
@@ -11,25 +11,34 @@ export default function trackPanel(
     case getType(trackPanelActions.toggleTrackPanelForGenome):
       return {
         ...state,
-        isTrackPanelOpened: { ...state.isTrackPanelOpened, ...action.payload }
+        [action.payload.activeGenomeId]: {
+          ...state[action.payload.activeGenomeId],
+          isTrackPanelOpened: action.payload.isTrackPanelOpened
+        }
       };
     case getType(trackPanelActions.toggleTrackPanelModalForGenome):
       return {
         ...state,
-        isTrackPanelModalOpened: {
-          ...state.isTrackPanelModalOpened,
-          ...action.payload
+        [action.payload.activeGenomeId]: {
+          ...state[action.payload.activeGenomeId],
+          isTrackPanelModalOpened: action.payload.isTrackPanelModalOpened
         }
       };
     case getType(trackPanelActions.changeTrackPanelModalViewForGenome):
       return {
         ...state,
-        trackPanelModalView: { ...state.trackPanelModalView, ...action.payload }
+        [action.payload.activeGenomeId]: {
+          ...state[action.payload.activeGenomeId],
+          trackPanelModalView: action.payload.trackPanelModalView
+        }
       };
     case getType(trackPanelActions.selectBrowserTab):
       return {
         ...state,
-        selectedBrowserTab: { ...state.selectedBrowserTab, ...action.payload }
+        [action.payload.activeGenomeId]: {
+          ...state[action.payload.activeGenomeId],
+          selectedBrowserTab: action.payload.selectedBrowserTab
+        }
       };
     default:
       return state;

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelReducer.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelReducer.ts
@@ -8,38 +8,28 @@ export default function trackPanel(
   action: ActionType<typeof trackPanelActions>
 ): TrackPanelState {
   switch (action.type) {
-    case getType(trackPanelActions.toggleTrackPanel):
-      const isTrackPanelOpened =
-        action.payload === undefined
-          ? !state.isTrackPanelOpened
-          : action.payload;
-
+    case getType(trackPanelActions.toggleTrackPanelForGenome):
       return {
         ...state,
-        isTrackPanelOpened
+        isTrackPanelOpened: { ...state.isTrackPanelOpened, ...action.payload }
       };
-    case getType(trackPanelActions.openTrackPanelModal):
+    case getType(trackPanelActions.toggleTrackPanelModalForGenome):
       return {
         ...state,
-        isTrackPanelModalOpened: true,
-        trackPanelModalView: action.payload
+        isTrackPanelModalOpened: {
+          ...state.isTrackPanelModalOpened,
+          ...action.payload
+        }
       };
-    case getType(trackPanelActions.closeTrackPanelModal):
+    case getType(trackPanelActions.changeTrackPanelModalViewForGenome):
       return {
         ...state,
-        isTrackPanelModalOpened: false,
-        trackPanelModalView: ''
+        trackPanelModalView: { ...state.trackPanelModalView, ...action.payload }
       };
     case getType(trackPanelActions.selectBrowserTab):
       return {
         ...state,
-        selectedBrowserTab: Object.assign(
-          {},
-          state.selectedBrowserTab,
-          action.payload
-        ),
-        isTrackPanelModalOpened: false,
-        trackPanelModalView: ''
+        selectedBrowserTab: { ...state.selectedBrowserTab, ...action.payload }
       };
     default:
       return state;

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelSelectors.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelSelectors.ts
@@ -1,40 +1,30 @@
 import { RootState } from 'src/store';
 import { getBrowserActiveGenomeId } from '../browserSelectors';
 import { TrackType } from './trackPanelConfig';
+import { TrackPanelStateForGenome } from './trackPanelState';
 
-const getTrackPanelStateForGenome = (state: RootState) => {
+const getTrackPanelStateProp = (
+  state: RootState,
+  prop: keyof TrackPanelStateForGenome
+) => {
   const activeGenomeId = getBrowserActiveGenomeId(state);
   const trackPanelStateForGenome = activeGenomeId
     ? state.trackPanel[activeGenomeId]
     : null;
 
-  return trackPanelStateForGenome || null;
+  return trackPanelStateForGenome ? trackPanelStateForGenome[prop] : null;
 };
 
-export const getIsTrackPanelModalOpened = (state: RootState) => {
-  const trackPanelStateForGenome = getTrackPanelStateForGenome(state);
-  return trackPanelStateForGenome
-    ? trackPanelStateForGenome['isTrackPanelModalOpened']
-    : false;
-};
+export const getIsTrackPanelModalOpened = (state: RootState) =>
+  (getTrackPanelStateProp(state, 'isTrackPanelModalOpened') as boolean) ||
+  false;
 
-export const getTrackPanelModalView = (state: RootState) => {
-  const trackPanelStateForGenome = getTrackPanelStateForGenome(state);
-  return trackPanelStateForGenome
-    ? trackPanelStateForGenome['trackPanelModalView']
-    : '';
-};
+export const getTrackPanelModalView = (state: RootState) =>
+  (getTrackPanelStateProp(state, 'trackPanelModalView') as string) || '';
 
-export const getSelectedBrowserTab = (state: RootState) => {
-  const trackPanelStateForGenome = getTrackPanelStateForGenome(state);
-  return trackPanelStateForGenome
-    ? trackPanelStateForGenome['selectedBrowserTab']
-    : TrackType.GENOMIC;
-};
+export const getSelectedBrowserTab = (state: RootState) =>
+  (getTrackPanelStateProp(state, 'selectedBrowserTab') as TrackType) ||
+  TrackType.GENOMIC;
 
-export const getIsTrackPanelOpened = (state: RootState) => {
-  const trackPanelStateForGenome = getTrackPanelStateForGenome(state);
-  return trackPanelStateForGenome
-    ? trackPanelStateForGenome['isTrackPanelOpened']
-    : false;
-};
+export const getIsTrackPanelOpened = (state: RootState) =>
+  (getTrackPanelStateProp(state, 'isTrackPanelOpened') as boolean) || false;

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelSelectors.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelSelectors.ts
@@ -2,11 +2,24 @@ import { RootState } from 'src/store';
 import { getBrowserActiveGenomeId } from '../browserSelectors';
 import { TrackType } from './trackPanelConfig';
 
-export const getIsTrackPanelModalOpened = (state: RootState) =>
-  state.trackPanel.isTrackPanelModalOpened;
+export const getIsTrackPanelModalOpened = (state: RootState) => {
+  const activeGenomeId = getBrowserActiveGenomeId(state);
 
-export const getTrackPanelModalView = (state: RootState) =>
-  state.trackPanel.trackPanelModalView;
+  return (
+    (activeGenomeId &&
+      state.trackPanel.isTrackPanelModalOpened[activeGenomeId]) ||
+    false
+  );
+};
+
+export const getTrackPanelModalView = (state: RootState) => {
+  const activeGenomeId = getBrowserActiveGenomeId(state);
+
+  return (
+    (activeGenomeId && state.trackPanel.trackPanelModalView[activeGenomeId]) ||
+    ''
+  );
+};
 
 export const getSelectedBrowserTab = (state: RootState) => {
   const activeGenomeId = getBrowserActiveGenomeId(state);
@@ -17,5 +30,11 @@ export const getSelectedBrowserTab = (state: RootState) => {
   );
 };
 
-export const getIsTrackPanelOpened = (state: RootState) =>
-  state.trackPanel.isTrackPanelOpened;
+export const getIsTrackPanelOpened = (state: RootState) => {
+  const activeGenomeId = getBrowserActiveGenomeId(state);
+
+  return (
+    (activeGenomeId && state.trackPanel.isTrackPanelOpened[activeGenomeId]) ||
+    false
+  );
+};

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelSelectors.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelSelectors.ts
@@ -1,30 +1,22 @@
 import { RootState } from 'src/store';
 import { getBrowserActiveGenomeId } from '../browserSelectors';
-import { TrackType } from './trackPanelConfig';
-import { TrackPanelStateForGenome } from './trackPanelState';
+import { defaultTrackPanelStateForGenome } from './trackPanelState';
 
-const getTrackPanelStateProp = (
-  state: RootState,
-  prop: keyof TrackPanelStateForGenome
-) => {
+export const getActiveTrackPanel = (state: RootState) => {
   const activeGenomeId = getBrowserActiveGenomeId(state);
-  const trackPanelStateForGenome = activeGenomeId
+  return activeGenomeId
     ? state.trackPanel[activeGenomeId]
-    : null;
-
-  return trackPanelStateForGenome ? trackPanelStateForGenome[prop] : null;
+    : defaultTrackPanelStateForGenome;
 };
 
 export const getIsTrackPanelModalOpened = (state: RootState) =>
-  (getTrackPanelStateProp(state, 'isTrackPanelModalOpened') as boolean) ||
-  false;
+  getActiveTrackPanel(state).isTrackPanelModalOpened;
 
 export const getTrackPanelModalView = (state: RootState) =>
-  (getTrackPanelStateProp(state, 'trackPanelModalView') as string) || '';
+  getActiveTrackPanel(state).trackPanelModalView;
 
 export const getSelectedBrowserTab = (state: RootState) =>
-  (getTrackPanelStateProp(state, 'selectedBrowserTab') as TrackType) ||
-  TrackType.GENOMIC;
+  getActiveTrackPanel(state).selectedBrowserTab;
 
 export const getIsTrackPanelOpened = (state: RootState) =>
-  (getTrackPanelStateProp(state, 'isTrackPanelOpened') as boolean) || false;
+  getActiveTrackPanel(state).isTrackPanelOpened;

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelSelectors.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelSelectors.ts
@@ -4,7 +4,9 @@ import { defaultTrackPanelStateForGenome } from './trackPanelState';
 
 export const getActiveTrackPanel = (state: RootState) => {
   const activeGenomeId = getBrowserActiveGenomeId(state);
-  return activeGenomeId
+  const activeTrackPanel = activeGenomeId && state.trackPanel[activeGenomeId];
+
+  return activeGenomeId && activeTrackPanel
     ? state.trackPanel[activeGenomeId]
     : defaultTrackPanelStateForGenome;
 };

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelSelectors.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelSelectors.ts
@@ -17,8 +17,8 @@ export const getIsTrackPanelModalOpened = (state: RootState) =>
 export const getTrackPanelModalView = (state: RootState) =>
   getActiveTrackPanel(state).trackPanelModalView;
 
-export const getSelectedBrowserTab = (state: RootState) =>
-  getActiveTrackPanel(state).selectedBrowserTab;
+export const getSelectedTrackPanelTab = (state: RootState) =>
+  getActiveTrackPanel(state).selectedTrackPanelTab;
 
 export const getIsTrackPanelOpened = (state: RootState) =>
   getActiveTrackPanel(state).isTrackPanelOpened;

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelSelectors.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelSelectors.ts
@@ -2,39 +2,39 @@ import { RootState } from 'src/store';
 import { getBrowserActiveGenomeId } from '../browserSelectors';
 import { TrackType } from './trackPanelConfig';
 
-export const getIsTrackPanelModalOpened = (state: RootState) => {
+const getTrackPanelStateForGenome = (state: RootState) => {
   const activeGenomeId = getBrowserActiveGenomeId(state);
+  const trackPanelStateForGenome = activeGenomeId
+    ? state.trackPanel[activeGenomeId]
+    : null;
 
-  return (
-    (activeGenomeId &&
-      state.trackPanel.isTrackPanelModalOpened[activeGenomeId]) ||
-    false
-  );
+  return trackPanelStateForGenome || null;
+};
+
+export const getIsTrackPanelModalOpened = (state: RootState) => {
+  const trackPanelStateForGenome = getTrackPanelStateForGenome(state);
+  return trackPanelStateForGenome
+    ? trackPanelStateForGenome['isTrackPanelModalOpened']
+    : false;
 };
 
 export const getTrackPanelModalView = (state: RootState) => {
-  const activeGenomeId = getBrowserActiveGenomeId(state);
-
-  return (
-    (activeGenomeId && state.trackPanel.trackPanelModalView[activeGenomeId]) ||
-    ''
-  );
+  const trackPanelStateForGenome = getTrackPanelStateForGenome(state);
+  return trackPanelStateForGenome
+    ? trackPanelStateForGenome['trackPanelModalView']
+    : '';
 };
 
 export const getSelectedBrowserTab = (state: RootState) => {
-  const activeGenomeId = getBrowserActiveGenomeId(state);
-
-  return (
-    (activeGenomeId && state.trackPanel.selectedBrowserTab[activeGenomeId]) ||
-    TrackType.GENOMIC
-  );
+  const trackPanelStateForGenome = getTrackPanelStateForGenome(state);
+  return trackPanelStateForGenome
+    ? trackPanelStateForGenome['selectedBrowserTab']
+    : TrackType.GENOMIC;
 };
 
 export const getIsTrackPanelOpened = (state: RootState) => {
-  const activeGenomeId = getBrowserActiveGenomeId(state);
-
-  return (
-    (activeGenomeId && state.trackPanel.isTrackPanelOpened[activeGenomeId]) ||
-    false
-  );
+  const trackPanelStateForGenome = getTrackPanelStateForGenome(state);
+  return trackPanelStateForGenome
+    ? trackPanelStateForGenome['isTrackPanelOpened']
+    : false;
 };

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
@@ -14,7 +14,6 @@ export type TrackPanelState = Readonly<{
 
 const selectedBrowserTabFromStorage = browserStorageService.getSelectedBrowserTab();
 
-// create the default state using the stored selected browser tab object
 export const defaultTrackPanelState: TrackPanelState = Object.keys(
   selectedBrowserTabFromStorage
 ).reduce(

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
@@ -1,10 +1,10 @@
-import { TrackType } from './trackPanelConfig';
+import { TrackSet } from './trackPanelConfig';
 import browserStorageService from '../browser-storage-service';
 
 export type TrackPanelStateForGenome = Readonly<{
   isTrackPanelModalOpened: boolean;
   isTrackPanelOpened: boolean;
-  selectedBrowserTab: TrackType;
+  selectedBrowserTab: TrackSet;
   trackPanelModalView: string;
 }>;
 
@@ -17,7 +17,7 @@ const selectedBrowserTabFromStorage = browserStorageService.getSelectedBrowserTa
 export const defaultTrackPanelStateForGenome: TrackPanelStateForGenome = {
   isTrackPanelModalOpened: false,
   isTrackPanelOpened: false,
-  selectedBrowserTab: TrackType.GENOMIC,
+  selectedBrowserTab: TrackSet.GENOMIC,
   trackPanelModalView: ''
 };
 

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
@@ -4,7 +4,7 @@ import browserStorageService from '../browser-storage-service';
 export type TrackPanelStateForGenome = Readonly<{
   isTrackPanelModalOpened: boolean;
   isTrackPanelOpened: boolean;
-  selectedBrowserTab: TrackSet;
+  selectedTrackPanelTab: TrackSet;
   trackPanelModalView: string;
 }>;
 
@@ -12,23 +12,23 @@ export type TrackPanelState = Readonly<{
   [genomeId: string]: TrackPanelStateForGenome;
 }>;
 
-const selectedBrowserTabFromStorage = browserStorageService.getSelectedBrowserTab();
+const selectedTrackPanelTabFromStorage = browserStorageService.getSelectedTrackPanelTab();
 
 export const defaultTrackPanelStateForGenome: TrackPanelStateForGenome = {
   isTrackPanelModalOpened: false,
   isTrackPanelOpened: false,
-  selectedBrowserTab: TrackSet.GENOMIC,
+  selectedTrackPanelTab: TrackSet.GENOMIC,
   trackPanelModalView: ''
 };
 
 export const defaultTrackPanelState: TrackPanelState = Object.keys(
-  selectedBrowserTabFromStorage
+  selectedTrackPanelTabFromStorage
 ).reduce(
   (state: TrackPanelState, genomeId: string) => ({
     ...state,
     [genomeId]: {
       ...defaultTrackPanelStateForGenome,
-      selectedBrowserTab: selectedBrowserTabFromStorage[genomeId]
+      selectedTrackPanelTab: selectedTrackPanelTabFromStorage[genomeId]
     }
   }),
   {}

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
@@ -1,13 +1,15 @@
 import { TrackType } from './trackPanelConfig';
 import browserStorageService from '../browser-storage-service';
 
+export type TrackPanelStateForGenome = Readonly<{
+  isTrackPanelModalOpened: boolean;
+  isTrackPanelOpened: boolean;
+  selectedBrowserTab: TrackType;
+  trackPanelModalView: string;
+}>;
+
 export type TrackPanelState = Readonly<{
-  [genomeId: string]: {
-    isTrackPanelModalOpened: boolean;
-    isTrackPanelOpened: boolean;
-    selectedBrowserTab: TrackType;
-    trackPanelModalView: string;
-  };
+  [genomeId: string]: TrackPanelStateForGenome;
 }>;
 
 const selectedBrowserTabFromStorage = browserStorageService.getSelectedBrowserTab();

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
@@ -1,18 +1,29 @@
 import { TrackType } from './trackPanelConfig';
 import browserStorageService from '../browser-storage-service';
 
-const selectedBrowserTab = browserStorageService.getSelectedBrowserTab();
-
 export type TrackPanelState = Readonly<{
-  isTrackPanelModalOpened: { [genomeId: string]: boolean };
-  isTrackPanelOpened: { [genomeId: string]: boolean };
-  selectedBrowserTab: { [genomeId: string]: TrackType };
-  trackPanelModalView: { [genomeId: string]: string };
+  [genomeId: string]: {
+    isTrackPanelModalOpened: boolean;
+    isTrackPanelOpened: boolean;
+    selectedBrowserTab: TrackType;
+    trackPanelModalView: string;
+  };
 }>;
 
-export const defaultTrackPanelState: TrackPanelState = {
-  isTrackPanelModalOpened: {},
-  isTrackPanelOpened: {},
-  selectedBrowserTab,
-  trackPanelModalView: {}
-};
+const selectedBrowserTabFromStorage = browserStorageService.getSelectedBrowserTab();
+
+// create the default state using the stored selected browser tab object
+export const defaultTrackPanelState: TrackPanelState = Object.keys(
+  selectedBrowserTabFromStorage
+).reduce(
+  (state: TrackPanelState, genomeId: string) => ({
+    ...state,
+    [genomeId]: {
+      selectedBrowserTab: selectedBrowserTabFromStorage[genomeId],
+      isTrackPanelModalOpened: false,
+      isTrackPanelOpened: false,
+      trackPanelModalView: ''
+    }
+  }),
+  {}
+);

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
@@ -14,16 +14,21 @@ export type TrackPanelState = Readonly<{
 
 const selectedBrowserTabFromStorage = browserStorageService.getSelectedBrowserTab();
 
+export const defaultTrackPanelStateForGenome: TrackPanelStateForGenome = {
+  isTrackPanelModalOpened: false,
+  isTrackPanelOpened: false,
+  selectedBrowserTab: TrackType.GENOMIC,
+  trackPanelModalView: ''
+};
+
 export const defaultTrackPanelState: TrackPanelState = Object.keys(
   selectedBrowserTabFromStorage
 ).reduce(
   (state: TrackPanelState, genomeId: string) => ({
     ...state,
     [genomeId]: {
-      selectedBrowserTab: selectedBrowserTabFromStorage[genomeId],
-      isTrackPanelModalOpened: false,
-      isTrackPanelOpened: false,
-      trackPanelModalView: ''
+      ...defaultTrackPanelStateForGenome,
+      selectedBrowserTab: selectedBrowserTabFromStorage[genomeId]
     }
   }),
   {}

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
@@ -4,15 +4,15 @@ import browserStorageService from '../browser-storage-service';
 const selectedBrowserTab = browserStorageService.getSelectedBrowserTab();
 
 export type TrackPanelState = Readonly<{
-  isTrackPanelModalOpened: boolean;
-  isTrackPanelOpened: boolean;
+  isTrackPanelModalOpened: { [genomeId: string]: boolean };
+  isTrackPanelOpened: { [genomeId: string]: boolean };
   selectedBrowserTab: { [genomeId: string]: TrackType };
-  trackPanelModalView: string;
+  trackPanelModalView: { [genomeId: string]: string };
 }>;
 
 export const defaultTrackPanelState: TrackPanelState = {
-  isTrackPanelModalOpened: false,
-  isTrackPanelOpened: true,
+  isTrackPanelModalOpened: {},
+  isTrackPanelOpened: {},
   selectedBrowserTab,
-  trackPanelModalView: ''
+  trackPanelModalView: {}
 };

--- a/src/ensembl/src/genome/genomeTypes.ts
+++ b/src/ensembl/src/genome/genomeTypes.ts
@@ -1,5 +1,5 @@
 import { EnsObjectTrack } from 'src/ens-object/ensObjectTypes';
-import { TrackType } from 'src/content/app/browser/track-panel/trackPanelConfig';
+import { TrackSet } from 'src/content/app/browser/track-panel/trackPanelConfig';
 
 export type GenomeInfo = {
   genome_id: string;
@@ -18,7 +18,7 @@ export type GenomeTrackCategory = {
   label: string;
   track_category_id: string;
   track_list: EnsObjectTrack[];
-  types: TrackType[];
+  types: TrackSet[];
 };
 
 export type GenomeInfoResponse = {


### PR DESCRIPTION
<!--
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This will normally be the development branch, so please ask your reviewer if you think it needs to go somewhere else. 
-->

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-276

## Description
The genome browser for a species should display the track panel just as how the user left it before going to a different view. The track panel open/close state and the track panel modal state is made independent with this PR.

## Views affected
Genome Browser

## Other effects

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.
