### PR TITLE
Fix saving of committed species in localStorage when a new species is added

### DIFF
--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorActions.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorActions.ts
@@ -246,7 +246,7 @@ export const commitSelectedSpeciesAndSave: ActionCreator<
   dispatch(updateCommittedSpecies(newCommittedSpecies));
   dispatch(clearSelectedSearchResult());
 
-  speciesSelectorStorageService.saveSelectedSpecies(committedSpecies);
+  speciesSelectorStorageService.saveSelectedSpecies(newCommittedSpecies);
 };
 
 export const toggleSpeciesUseAndSave: ActionCreator<


### PR DESCRIPTION
## Type
- Bug fix

## Importance
This is a hotfix (bug currently in production)

## Description
**Bug:** In Species Selector, if a new species is added, it is not saved in local storage (and is lost during browser refresh).

## Views affected
Species Selector