### PR TITLE
Hotfix/species selector search field

### DIFF
--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorEpics.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorEpics.ts
@@ -21,6 +21,7 @@ export const fetchSpeciesSearchResultsEpic: Epic<Action, Action, RootState> = (
       isActionOf([
         speciesSelectorActions.fetchSpeciesSearchResults.request,
         speciesSelectorActions.setSelectedSpecies,
+        speciesSelectorActions.clearSearch,
         speciesSelectorActions.clearSearchResults
       ])
     ),

--- a/src/ensembl/src/shared/autosuggest-search-field/AutosuggestSearchField.tsx
+++ b/src/ensembl/src/shared/autosuggest-search-field/AutosuggestSearchField.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, ReactNode } from 'react';
 import classNames from 'classnames';
+import get from 'lodash/get';
 
 import SearchField from 'src/shared/search-field/SearchField';
 import AutosuggestionPanel, {
@@ -177,7 +178,15 @@ const AutosuggestSearchField = (props: Props) => {
       props.onSubmit(value);
     } else if (highlightedItemIndex) {
       const [groupIndex, itemIndex] = highlightedItemIndex;
-      const match = props.matchGroups[groupIndex].matches[itemIndex];
+      const match = get(
+        props.matchGroups,
+        `${groupIndex}.matches.${itemIndex}`
+      );
+
+      if (!match) {
+        return;
+      }
+
       props.onSelect(match.data);
 
       setHighlightedItemIndex(initialHighlightedItemIndex);


### PR DESCRIPTION
## Type

- Bug fix

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-295

## Importance
This is a hotfix (bugs currently in production)

## Description
Fixes for two bugs in SpeciesSelector:
- add null check to AutosuggestionSearchField upon pressing Enter (currently, AutosuggestionSearchField tries to submit the highlighted item; and if there is no such item — e.g. if a search returned no results — it throws an error (described in JIRA ticket)
- currently, if user enters 3 characters in SpeciesSearchField, then presses the clear search button (blue cross), then enters the same 3 characters, the field will not send request for search matches (because `fetchSpeciesSearchResultsEpic` will filter out the action with identical query in the `distinctUntilChanged` operator)

## Views affected
Species Selector