### PR TITLE
Add overflow-x: scroll to launchbar

### DIFF
--- a/src/ensembl/src/header/launchbar/Launchbar.scss
+++ b/src/ensembl/src/header/launchbar/Launchbar.scss
@@ -6,6 +6,7 @@
   border-bottom: 1px solid $ens-grey;
   border-top: 1px solid $ens-grey;
   padding: 11px 6px;
+  overflow-x: scroll;
 }
 
 .categoriesWrapper {


### PR DESCRIPTION
## Type
- Bug fix

## Description
If you visit the home page on a mobile device, you will see this|:

![image](https://user-images.githubusercontent.com/6834224/63040672-d4cfdf00-bebd-11e9-8aab-ce32947692b5.png)

Actually, you would see this, but the screen will be horizontally scrollable:

![image](https://user-images.githubusercontent.com/6834224/63040718-f0d38080-bebd-11e9-9e7e-58e8ff938e62.png)

Notice that the privacy banner also extends beyond the right border of the screen, and that there is some strange empty vertical space between privacy banner and the text:

![image](https://user-images.githubusercontent.com/6834224/63040772-1f515b80-bebe-11e9-996d-6d1ced2c46ce.png)

This is another look at this empty space. I have no idea where it is coming from, but it is caused by some launchbar elements extending beyond the right border of the screen:

![image](https://user-images.githubusercontent.com/6834224/63040892-68a1ab00-bebe-11e9-8839-962a6a45b62e.png)

When the launchbar element receives `overflow-x: scroll`, the weird vertical spacing goes away, and the width of the page becomes reasonable as well:

![image](https://user-images.githubusercontent.com/6834224/63040948-938bff00-bebe-11e9-9ec3-2ea50760484e.png)


## Views affected
- definitely Home page
- possibly other screens as well (because all screens contain the launchbar)