### PR TITLE
Remove refs from Browser component

### DIFF
--- a/src/ensembl/src/content/app/browser/Browser.tsx
+++ b/src/ensembl/src/content/app/browser/Browser.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useRef, useEffect, useState } from 'react';
+import React, { FunctionComponent, useEffect, useState } from 'react';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { replace, Replace } from 'connected-react-router';
@@ -102,7 +102,6 @@ type BrowserProps = RouteComponentProps<MatchParams> &
 export const Browser: FunctionComponent<BrowserProps> = (
   props: BrowserProps
 ) => {
-  const browserRef: React.RefObject<HTMLDivElement> = useRef(null);
   const [trackStatesFromStorage, setTrackStatesFromStorage] = useState<
     TrackStates
   >({});
@@ -276,15 +275,12 @@ export const Browser: FunctionComponent<BrowserProps> = (
           >
             <animated.div style={trackAnimation}>
               <div className={styles.browserImageWrapper} onClick={closeTrack}>
-                {props.browserNavOpened &&
-                !isDrawerOpened &&
-                browserRef.current ? (
+                {props.browserActivated &&
+                props.browserNavOpened &&
+                !isDrawerOpened ? (
                   <BrowserNavBar />
                 ) : null}
-                <BrowserImage
-                  browserRef={browserRef}
-                  trackStates={trackStatesFromStorage}
-                />
+                <BrowserImage trackStates={trackStatesFromStorage} />
               </div>
             </animated.div>
             <TrackPanel />

--- a/src/ensembl/src/content/app/browser/Browser.tsx
+++ b/src/ensembl/src/content/app/browser/Browser.tsx
@@ -106,7 +106,6 @@ export const Browser: FunctionComponent<BrowserProps> = (
   const [trackStatesFromStorage, setTrackStatesFromStorage] = useState<
     TrackStates
   >({});
-  const lastGenomeIdRef = useRef(props.activeGenomeId);
 
   const { isDrawerOpened, closeDrawer } = props;
 
@@ -115,25 +114,9 @@ export const Browser: FunctionComponent<BrowserProps> = (
     const { focus = null, location = null } = props.browserQueryParams;
     const chrLocation = location ? getChrLocationFromStr(location) : null;
 
-    const lastGenomeId = lastGenomeIdRef.current;
-
-    /*
-      before committing url changes to redux:
-      - make sure we don't already have these same values in redux store;
-      - if we already have these values, it's possible that this is because
-        the user is switching back to a previously viewed species;
-        so check whether the genome id has changed from the previous render
-        (that's the reason for lastGenomeIdRef here)
-
-      TODO: after both genome browser and browser chrome are updated so that
-      we do not update url location while moving or zooming the image; we can
-      remove the genomeId === lastGenomeId check in the if-statement below
-      and move dispatchBrowserLocation(genomeId, chrLocation) above the if-statement
-    */
     if (
       !genomeId ||
-      (genomeId === lastGenomeId &&
-        genomeId === props.activeGenomeId &&
+      (genomeId === props.activeGenomeId &&
         focus === props.activeEnsObjectId &&
         isEqual(chrLocation, props.chrLocation))
     ) {
@@ -153,7 +136,6 @@ export const Browser: FunctionComponent<BrowserProps> = (
     } else if (focus) {
       props.changeFocusObject(focus);
     }
-    lastGenomeIdRef.current = genomeId;
   };
 
   const dispatchBrowserLocation = (

--- a/src/ensembl/src/content/app/browser/Browser.tsx
+++ b/src/ensembl/src/content/app/browser/Browser.tsx
@@ -244,9 +244,12 @@ export const Browser: FunctionComponent<BrowserProps> = (
     return launchbarExpanded ? styles.shorter : styles.taller;
   };
 
-  const BrowserBarNode = (
+  const browserBar = (
     <BrowserBar dispatchBrowserLocation={dispatchBrowserLocation} />
   );
+
+  const shouldShowNavBar =
+    props.browserActivated && props.browserNavOpened && !isDrawerOpened;
 
   return props.activeGenomeId ? (
     <>
@@ -258,13 +261,13 @@ export const Browser: FunctionComponent<BrowserProps> = (
 
       {!props.browserQueryParams.focus && (
         <section className={styles.browser}>
-          {BrowserBarNode}
+          {browserBar}
           <ExampleObjectLinks {...props} />
         </section>
       )}
       {props.browserQueryParams.focus && (
         <section className={styles.browser}>
-          {BrowserBarNode}
+          {browserBar}
           {props.genomeSelectorActive && (
             <div className={styles.browserOverlay} />
           )}
@@ -275,11 +278,7 @@ export const Browser: FunctionComponent<BrowserProps> = (
           >
             <animated.div style={trackAnimation}>
               <div className={styles.browserImageWrapper} onClick={closeTrack}>
-                {props.browserActivated &&
-                props.browserNavOpened &&
-                !isDrawerOpened ? (
-                  <BrowserNavBar />
-                ) : null}
+                {shouldShowNavBar && <BrowserNavBar />}
                 <BrowserImage trackStates={trackStatesFromStorage} />
               </div>
             </animated.div>

--- a/src/ensembl/src/content/app/browser/BrowserCogList.tsx
+++ b/src/ensembl/src/content/app/browser/BrowserCogList.tsx
@@ -14,6 +14,8 @@ import {
   getBrowserActivated,
   getBrowserCogList,
   getBrowserCogTrackList,
+  getTrackConfigNames,
+  getTrackConfigLabel,
   getBrowserSelectedCog
 } from './browserSelectors';
 
@@ -23,6 +25,8 @@ type BrowserCogListProps = {
   browserActivated: boolean;
   browserCogList: number;
   browserCogTrackList: CogList;
+  trackConfigNames: any; // FIXME
+  trackConfigLabel: any; // FIXME
   selectedCog: any;
   updateCogList: (cogList: number) => void;
   updateCogTrackList: (track_y: CogList) => void;
@@ -54,6 +58,37 @@ const BrowserCogList = (props: BrowserCogListProps) => {
 
     return () => subscription.unsubscribe();
   }, []);
+
+  useEffect(() => {
+    if (props.browserCogTrackList) {
+      const ons: string[] = [];
+      const offs: string[] = [];
+
+      /* what the frontend and backend call labels and names is flipped */
+      Object.keys(props.browserCogTrackList).forEach((name) => {
+        /* undefined means not seen means on for names */
+        if (props.trackConfigNames[name]) {
+          ons.push(`${name}:label`);
+        } else {
+          offs.push(`${name}:label`);
+        }
+        /* undefined means not seen means off for labels */
+        if (props.trackConfigLabel[name] !== false) {
+          ons.push(`${name}:names`);
+        } else {
+          offs.push(`${name}:names`);
+        }
+      });
+      browserMessagingService.send('bpane', {
+        off: offs,
+        on: ons
+      });
+    }
+  }, [
+    props.trackConfigNames,
+    props.trackConfigLabel,
+    props.browserCogTrackList
+  ]);
 
   const cogs = Object.entries(browserCogTrackList).map(([name, pos]) => {
     const posStyle = { top: pos + 'px' };
@@ -88,6 +123,8 @@ const mapStateToProps = (state: RootState) => ({
   browserActivated: getBrowserActivated(state),
   browserCogList: getBrowserCogList(state),
   browserCogTrackList: getBrowserCogTrackList(state),
+  trackConfigLabel: getTrackConfigLabel(state),
+  trackConfigNames: getTrackConfigNames(state),
   selectedCog: getBrowserSelectedCog(state)
 });
 

--- a/src/ensembl/src/content/app/browser/BrowserCogList.tsx
+++ b/src/ensembl/src/content/app/browser/BrowserCogList.tsx
@@ -25,8 +25,8 @@ type BrowserCogListProps = {
   browserActivated: boolean;
   browserCogList: number;
   browserCogTrackList: CogList;
-  trackConfigNames: any; // FIXME
-  trackConfigLabel: any; // FIXME
+  trackConfigNames: { [key: string]: boolean };
+  trackConfigLabel: { [key: string]: boolean };
   selectedCog: any;
   updateCogList: (cogList: number) => void;
   updateCogTrackList: (track_y: CogList) => void;

--- a/src/ensembl/src/content/app/browser/BrowserCogList.tsx
+++ b/src/ensembl/src/content/app/browser/BrowserCogList.tsx
@@ -41,6 +41,7 @@ type BpaneScrollPayload = {
 const BrowserCogList = (props: BrowserCogListProps) => {
   const { browserCogTrackList } = props;
   const listenBpaneScroll = (payload: BpaneScrollPayload) => {
+    console.log('payload', payload);
     const { delta_y, track_y } = payload;
     if (delta_y !== undefined) {
       props.updateCogList(delta_y);
@@ -64,19 +65,21 @@ const BrowserCogList = (props: BrowserCogListProps) => {
       const ons: string[] = [];
       const offs: string[] = [];
 
-      /* what the frontend and backend call labels and names is flipped */
       Object.keys(props.browserCogTrackList).forEach((name) => {
-        /* undefined means not seen means on for names */
+        // TODO: notice how we generate strings with suffix ":label" for track names,
+        // and strings with suffix ":names" for track label? That's because the frontend code
+        // and the backend code refer to these things by opposite terms. We will need to unify
+        // the terminology at some point.
         if (props.trackConfigNames[name]) {
           ons.push(`${name}:label`);
         } else {
-          offs.push(`${name}:label`);
+          offs.push(`${name}:label`); // by default, track names are not shown
         }
-        /* undefined means not seen means off for labels */
+
         if (props.trackConfigLabel[name] !== false) {
           ons.push(`${name}:names`);
         } else {
-          offs.push(`${name}:names`);
+          offs.push(`${name}:names`); // by default, track label is not shown
         }
       });
       browserMessagingService.send('bpane', {

--- a/src/ensembl/src/content/app/browser/BrowserCogList.tsx
+++ b/src/ensembl/src/content/app/browser/BrowserCogList.tsx
@@ -41,7 +41,6 @@ type BpaneScrollPayload = {
 const BrowserCogList = (props: BrowserCogListProps) => {
   const { browserCogTrackList } = props;
   const listenBpaneScroll = (payload: BpaneScrollPayload) => {
-    console.log('payload', payload);
     const { delta_y, track_y } = payload;
     if (delta_y !== undefined) {
       props.updateCogList(delta_y);

--- a/src/ensembl/src/content/app/browser/browser-image/BrowserImage.tsx
+++ b/src/ensembl/src/content/app/browser/browser-image/BrowserImage.tsx
@@ -75,7 +75,7 @@ const parseLocation = (location: ChrLocation) => {
 export const BrowserImage: FunctionComponent<BrowserImageProps> = (
   props: BrowserImageProps
 ) => {
-  const browserRef: React.RefObject<HTMLDivElement> = useRef(null);
+  const browserRef = useRef<HTMLDivElement>(null);
   const listenBpaneOut = useCallback((payload: BpaneOutPayload) => {
     const ensObjectId = payload.focus;
     const navIconStates = payload.bumper as BrowserNavStates;

--- a/src/ensembl/src/content/app/browser/browser-image/BrowserImage.tsx
+++ b/src/ensembl/src/content/app/browser/browser-image/BrowserImage.tsx
@@ -120,16 +120,12 @@ export const BrowserImage: FunctionComponent<BrowserImageProps> = (
   }, []);
 
   useEffect(() => {
-    const currentEl: HTMLDivElement = props.browserRef
-      .current as HTMLDivElement;
     props.activateBrowser();
 
     return function cleanup() {
-      if (currentEl && currentEl.ownerDocument) {
-        props.updateBrowserActivated(false);
-      }
+      props.updateBrowserActivated(false);
     };
-  }, [props.browserRef]);
+  }, []);
 
   useEffect(() => {
     if (props.browserCogTrackList) {
@@ -137,35 +133,28 @@ export const BrowserImage: FunctionComponent<BrowserImageProps> = (
       const offs: string[] = [];
 
       /* what the frontend and backend call labels and names is flipped */
-      Object.keys(props.browserCogTrackList).map((name) => {
+      Object.keys(props.browserCogTrackList).forEach((name) => {
         /* undefined means not seen means on for names */
         if (props.trackConfigNames[name]) {
-          ons.push(name + ':label');
+          ons.push(`${name}:label`);
         } else {
-          offs.push(name + ':label');
+          offs.push(`${name}:label`);
         }
         /* undefined means not seen means off for labels */
         if (props.trackConfigLabel[name] !== false) {
-          ons.push(name + ':names');
+          ons.push(`${name}:names`);
         } else {
-          offs.push(name + ':names');
+          offs.push(`${name}:names`);
         }
       });
-      const stateEvent = new CustomEvent('bpane', {
-        bubbles: true,
-        detail: {
-          off: offs,
-          on: ons
-        }
+      browserMessagingService.send('bpane', {
+        off: offs,
+        on: ons
       });
-      if (props.browserRef.current) {
-        props.browserRef.current.dispatchEvent(stateEvent);
-      }
     }
   }, [
     props.trackConfigNames,
     props.trackConfigLabel,
-    props.browserRef,
     props.browserCogTrackList
   ]);
 

--- a/src/ensembl/src/content/app/browser/browser-image/BrowserImage.tsx
+++ b/src/ensembl/src/content/app/browser/browser-image/BrowserImage.tsx
@@ -1,6 +1,6 @@
 import React, {
   FunctionComponent,
-  RefObject,
+  useRef,
   useEffect,
   useCallback
 } from 'react';
@@ -56,7 +56,6 @@ type DispatchProps = {
 };
 
 type OwnProps = {
-  browserRef: RefObject<HTMLDivElement>;
   trackStates: TrackStates;
 };
 
@@ -80,6 +79,7 @@ const parseLocation = (location: ChrLocation) => {
 export const BrowserImage: FunctionComponent<BrowserImageProps> = (
   props: BrowserImageProps
 ) => {
+  const browserRef: React.RefObject<HTMLDivElement> = useRef(null);
   const listenBpaneOut = useCallback((payload: BpaneOutPayload) => {
     const ensObjectId = payload.focus;
     const navIconStates = payload.bumper as BrowserNavStates;
@@ -169,10 +169,10 @@ export const BrowserImage: FunctionComponent<BrowserImageProps> = (
         <div
           id={BROWSER_CONTAINER_ID}
           className={getBrowserImageClasses(props.browserNavOpened)}
-          ref={props.browserRef}
+          ref={browserRef}
         />
         <BrowserCogList />
-        <ZmenuController browserRef={props.browserRef} />
+        <ZmenuController browserRef={browserRef} />
       </div>
     </>
   );

--- a/src/ensembl/src/content/app/browser/browser-image/BrowserImage.tsx
+++ b/src/ensembl/src/content/app/browser/browser-image/BrowserImage.tsx
@@ -13,8 +13,6 @@ import { ZmenuController } from 'src/content/app/browser/zmenu';
 
 import browserMessagingService from 'src/content/app/browser/browser-messaging-service';
 import {
-  getTrackConfigNames,
-  getTrackConfigLabel,
   getBrowserCogTrackList,
   getBrowserNavOpened,
   getBrowserActivated
@@ -40,8 +38,6 @@ import { BROWSER_CONTAINER_ID } from '../browser-constants';
 type StateProps = {
   browserCogTrackList: CogList;
   browserNavOpened: boolean;
-  trackConfigNames: any;
-  trackConfigLabel: any;
   browserActivated: boolean;
 };
 
@@ -127,37 +123,6 @@ export const BrowserImage: FunctionComponent<BrowserImageProps> = (
     };
   }, []);
 
-  useEffect(() => {
-    if (props.browserCogTrackList) {
-      const ons: string[] = [];
-      const offs: string[] = [];
-
-      /* what the frontend and backend call labels and names is flipped */
-      Object.keys(props.browserCogTrackList).forEach((name) => {
-        /* undefined means not seen means on for names */
-        if (props.trackConfigNames[name]) {
-          ons.push(`${name}:label`);
-        } else {
-          offs.push(`${name}:label`);
-        }
-        /* undefined means not seen means off for labels */
-        if (props.trackConfigLabel[name] !== false) {
-          ons.push(`${name}:names`);
-        } else {
-          offs.push(`${name}:names`);
-        }
-      });
-      browserMessagingService.send('bpane', {
-        off: offs,
-        on: ons
-      });
-    }
-  }, [
-    props.trackConfigNames,
-    props.trackConfigLabel,
-    props.browserCogTrackList
-  ]);
-
   return (
     <>
       {!props.browserActivated && (
@@ -191,8 +156,6 @@ function getBrowserImageClasses(browserNavOpened: boolean): string {
 const mapStateToProps = (state: RootState): StateProps => ({
   browserCogTrackList: getBrowserCogTrackList(state),
   browserNavOpened: getBrowserNavOpened(state),
-  trackConfigLabel: getTrackConfigLabel(state),
-  trackConfigNames: getTrackConfigNames(state),
   browserActivated: getBrowserActivated(state)
 });
 


### PR DESCRIPTION
## Type
- refactoring

## Related JIRA Issue(s)
ENSWBSITES-174

## Description
The task description says "Check why useRef is used in the Browser.tsx and remove it if it’s not required".

`useRef` was used for 2 purposes in the Browser component:

1) to hold reference to the html element into which genome browser renders the canvas element, and
2) to get reference to the last value of active genome id coming from the props

Regarding the first usage, it is still relevant (some React components, such as zmenu, may need to be able to access the wrapper around canvas directly to calculate the dimensions of the canvas), but the ref itself can be moved from `Browser` to `BrowserImage`.
Second usage seems to be redundant at the moment.

**Note:** `BrowserImage` contained code that communicated with genome browser using the old mechanism (sending custom events via a DOM element) to tell genome browser stuff about cogs. I've changed the communication method to the new one (via browser-messaging-service) and moved this code to `BrowserCogList` component.

## Views affected
Genome browser screen.