### PR TITLE
Remove condition upon environment from ZmenuContent (when showing links)

### DIFF
--- a/src/ensembl/src/content/app/browser/zmenu/ZmenuContent.tsx
+++ b/src/ensembl/src/content/app/browser/zmenu/ZmenuContent.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 
-import { isEnvironment, Environment } from 'src/shared/helpers/environment';
-
 import { changeFocusObject } from 'src/content/app/browser/browserActions';
 
 import styles from './Zmenu.scss';
@@ -85,16 +83,11 @@ const ZmenuContentBlock = (props: ZmenuContentBlockProps) => {
 const ZmenuContentItem = (props: ZmenuContentItemProps) => {
   const { text, markup, id } = props;
 
-  // FIXME: remove dependency on environment when ensObject api endpoint is ready
-  const shouldAddLink =
-    markup.includes(Markup.FOCUS) &&
-    isEnvironment([Environment.DEVELOPMENT, Environment.INTERNAL]);
-
   const className = classNames({
     [styles.markupLight]: markup.includes(Markup.LIGHT),
     [styles.markupStrong]: markup.includes(Markup.STRONG),
     [styles.markupEmphasis]: markup.includes(Markup.EMPHASIS),
-    [styles.markupFocus]: shouldAddLink
+    [styles.markupFocus]: markup.includes(Markup.FOCUS)
   });
 
   const handleClick = () => {
@@ -103,7 +96,7 @@ const ZmenuContentItem = (props: ZmenuContentItemProps) => {
 
   const itemProps = {
     className,
-    onClick: shouldAddLink ? handleClick : undefined
+    onClick: handleClick
   };
 
   return <span {...itemProps}>{text}</span>;


### PR DESCRIPTION
## Type
- Bug fix

## Description
Currently, the code in the dev branch doesn't show link to focus object in zmenu popup, because we disabled that behaviour previously (the feature not being ready yet) and forgot to enable it back again when merging https://github.com/Ensembl/ensembl-client/pull/123.

## Views affected
Genome browser.