### PR TITLE
Handle clicks only on focusable parts of zmenu content

### DIFF
--- a/src/ensembl/src/content/app/browser/zmenu/ZmenuContent.tsx
+++ b/src/ensembl/src/content/app/browser/zmenu/ZmenuContent.tsx
@@ -82,12 +82,13 @@ const ZmenuContentBlock = (props: ZmenuContentBlockProps) => {
 
 const ZmenuContentItem = (props: ZmenuContentItemProps) => {
   const { text, markup, id } = props;
+  const isFocusable = markup.includes(Markup.FOCUS);
 
   const className = classNames({
     [styles.markupLight]: markup.includes(Markup.LIGHT),
     [styles.markupStrong]: markup.includes(Markup.STRONG),
     [styles.markupEmphasis]: markup.includes(Markup.EMPHASIS),
-    [styles.markupFocus]: markup.includes(Markup.FOCUS)
+    [styles.markupFocus]: isFocusable
   });
 
   const handleClick = () => {
@@ -96,7 +97,7 @@ const ZmenuContentItem = (props: ZmenuContentItemProps) => {
 
   const itemProps = {
     className,
-    onClick: handleClick
+    ...(isFocusable && { onClick: handleClick })
   };
 
   return <span {...itemProps}>{text}</span>;


### PR DESCRIPTION
## Type
- Bug fix

## Related JIRA Issue(s)
ENSWBSITES-317

## Description
Fixes the bug when clicking on text outside the link to a focus object in a zmenu also caused changing the focus object.

## Views affected
Genome Browser screen