### PR TITLE
Remove 'ens-' prefix from colour variable names

### DIFF
--- a/src/ensembl/src/content/app/browser/Browser.scss
+++ b/src/ensembl/src/content/app/browser/Browser.scss
@@ -26,7 +26,7 @@
 }
 
 .browserOverlay {
-  background: $ens-white;
+  background: $white;
   height: 100%;
   opacity: 0.7;
   position: absolute;
@@ -45,7 +45,7 @@
 }
 
 .objectType {
-  color: $ens-grey;
+  color: $grey;
   margin-right: 15px;
   width: 60px;
   text-align: right;
@@ -53,5 +53,5 @@
 }
 
 .objectLabel {
-  color: $ens-blue;
+  color: $blue;
 }

--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.scss
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.scss
@@ -2,8 +2,8 @@
 
 .browserBar {
   display: flex;
-  background: $ens-light-grey;
-  box-shadow: 0 2px 3px $ens-grey;
+  background: $light-grey;
+  box-shadow: 0 2px 3px $grey;
   height: 32px;
   padding: 6px 0 3px 0;
   position: relative;
@@ -16,7 +16,7 @@
 
   button {
     &.selected {
-      background: $ens-white;
+      background: $white;
     }
   }
 }
@@ -29,7 +29,7 @@
   width: calc(100vw - 356px);
 
   label {
-    color: $ens-dark-grey;
+    color: $dark-grey;
     font-weight: $light;
   }
 
@@ -46,7 +46,7 @@
   }
 
   &.browserInfoGreyed {
-    color: $ens-dark-grey;
+    color: $dark-grey;
   }
 
   dd {

--- a/src/ensembl/src/content/app/browser/browser-genome-selector/BrowserGenomeSelector.scss
+++ b/src/ensembl/src/content/app/browser/browser-genome-selector/BrowserGenomeSelector.scss
@@ -30,10 +30,10 @@
 
 .chrCode {
   appearance: none;
-  background: $ens-dark-blue;
+  background: $dark-blue;
   border: none;
   border-radius: 0;
-  color: $ens-white;
+  color: $white;
   display: inline-block;
   font-weight: $bold;
   margin: 0 5px;
@@ -44,16 +44,16 @@
 }
 
 .chrRegion {
-  color: $ens-dark-blue;
+  color: $dark-blue;
   display: inline-block;
 }
 
 .browserGenomeSelectorDisabled {
   .chrCode {
-    background: $ens-dark-grey;
+    background: $dark-grey;
   }
 
   .chrRegion {
-    color: $ens-dark-grey;
+    color: $dark-grey;
   }
 }

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBar.scss
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBar.scss
@@ -2,7 +2,7 @@
 
 .browserNavBar {
   display: flex;
-  background: $ens-light-grey;
+  background: $light-grey;
   padding: 16px;
 
   @media #{$breakpoint-large} {

--- a/src/ensembl/src/content/app/browser/browser-reset/BrowserReset.scss
+++ b/src/ensembl/src/content/app/browser/browser-reset/BrowserReset.scss
@@ -14,7 +14,7 @@
 
 .imageButtonDisabled {
   svg {
-    fill: $ens-dark-grey;
+    fill: $dark-grey;
     cursor: default;
   }
   button {

--- a/src/ensembl/src/content/app/browser/drawer/Drawer.scss
+++ b/src/ensembl/src/content/app/browser/drawer/Drawer.scss
@@ -1,7 +1,7 @@
 @import 'src/styles/common';
 
 .drawer {
-  border-left: 1px solid $ens-light-grey;
+  border-left: 1px solid $light-grey;
   height: calc(100vh - 176px);
   width: calc(100vw - 397px);
 }

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBar.scss
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBar.scss
@@ -1,9 +1,9 @@
 @import 'src/styles/common';
 
 .trackPanelBar {
-  background: $ens-light-grey;
-  border-left: 1px solid $ens-grey;
-  border-right: 1px solid $ens-grey;
+  background: $light-grey;
+  border-left: 1px solid $grey;
+  border-right: 1px solid $grey;
   width: 36px;
 
   &.shorter {

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.scss
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.scss
@@ -7,7 +7,7 @@
   overflow: auto;
   padding: 15px;
   width: 320px;
-  background: $ens-white;
+  background: $white;
 
   &.shorter {
     height: calc(100vh - 177px);
@@ -18,8 +18,8 @@
   }
 
   h4 {
-    border-bottom: 1px solid $ens-grey;
-    color: $ens-grey;
+    border-bottom: 1px solid $grey;
+    color: $grey;
     font-size: 10px;
     padding-bottom: 2px;
   }

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.scss
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.scss
@@ -22,7 +22,7 @@
 
   &:hover,
   &.currentDrawerView {
-    background: $ens-light-blue;
+    background: $light-blue;
   }
 
   &.main {
@@ -41,7 +41,7 @@
     }
 
     .selectedInfo {
-      color: $ens-black;
+      color: $black;
       display: inline-block;
       font-size: 10px;
       font-weight: $normal;
@@ -65,18 +65,18 @@
     width: 11px;
 
     &.blue {
-      background: $ens-dark-blue;
-      border-color: $ens-dark-blue;
+      background: $dark-blue;
+      border-color: $dark-blue;
     }
 
     &.darkGrey {
-      background: $ens-dark-grey;
-      border-color: $ens-dark-grey;
+      background: $dark-grey;
+      border-color: $dark-grey;
     }
 
     &.grey {
-      background: $ens-grey;
-      border-color: $ens-grey;
+      background: $grey;
+      border-color: $grey;
     }
 
     &.white {

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/TrackPanelModal.scss
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/TrackPanelModal.scss
@@ -1,7 +1,7 @@
 @import 'src/styles/common';
 
 .trackPanelModal {
-  background: $ens-white;
+  background: $white;
   font-weight: $light;
   left: 36px;
   padding: 10px 20px;
@@ -46,7 +46,7 @@
   }
 
   dt {
-    color: $ens-dark-grey;
+    color: $dark-grey;
     font-size: 12px;
   }
 

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-tabs/TrackPanelTabs.scss
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-tabs/TrackPanelTabs.scss
@@ -11,7 +11,7 @@
 
 .trackPanelTab {
   button {
-    color: $ens-dark-blue;
+    color: $dark-blue;
   }
 }
 
@@ -23,7 +23,7 @@
 
 .trackPanelTabDisabled {
   button {
-    color: $ens-dark-grey;
+    color: $dark-grey;
     cursor: default;
   }
 }
@@ -31,9 +31,9 @@
   position: relative;
 
   &::after {
-    border: 6px solid $ens-grey;
-    border-color: transparent transparent $ens-light-grey $ens-light-grey;
-    box-shadow: -2px 2px 2px 0 $ens-grey;
+    border: 6px solid $grey;
+    border-color: transparent transparent $light-grey $light-grey;
+    box-shadow: -2px 2px 2px 0 $grey;
     box-sizing: border-box;
     content: '';
     height: 0;

--- a/src/ensembl/src/content/app/browser/zmenu/Zmenu.scss
+++ b/src/ensembl/src/content/app/browser/zmenu/Zmenu.scss
@@ -1,10 +1,10 @@
 @import 'src/styles/common';
 
-$zmenuBackgroundColor: $ens-black;
+$zmenuBackgroundColor: $black;
 
 .zmenuWrapper {
   position: absolute;
-  filter: drop-shadow(2px 2px 3px $ens-shadow-color);
+  filter: drop-shadow(2px 2px 3px $shadow-color);
 }
 
 .zmenu {
@@ -13,7 +13,7 @@ $zmenuBackgroundColor: $ens-black;
   flex-direction: column;
   justify-content: center;
   padding: 12px 20px;
-  color: $ens-white;
+  color: $white;
   background-color: $zmenuBackgroundColor;
   min-height: 40px;
   font-size: 13px;
@@ -58,5 +58,5 @@ $zmenuBackgroundColor: $ens-black;
 
 .markupFocus {
   cursor: pointer;
-  color: $ens-blue;
+  color: $blue;
 }

--- a/src/ensembl/src/content/app/custom-download/components/checkbox-grid/CheckboxGrid.scss
+++ b/src/ensembl/src/content/app/custom-download/components/checkbox-grid/CheckboxGrid.scss
@@ -7,7 +7,7 @@
 }
 
 .checkboxGridTitle {
-  color: $ens-grey;
+  color: $grey;
   margin-bottom: 10px;
   padding-left: 20px;
 }

--- a/src/ensembl/src/content/app/custom-download/components/content-builder/ContentBuilder.scss
+++ b/src/ensembl/src/content/app/custom-download/components/content-builder/ContentBuilder.scss
@@ -12,7 +12,7 @@
 
 .accordion {
   border: none;
-  border-top: 2px solid $ens-medium-light-grey;
+  border-top: 2px solid $medium-light-grey;
 }
 
 .accordionButton {

--- a/src/ensembl/src/content/app/custom-download/components/paste-or-upload/PasteOrUpload.scss
+++ b/src/ensembl/src/content/app/custom-download/components/paste-or-upload/PasteOrUpload.scss
@@ -2,7 +2,7 @@
 
 .pasteText,
 .uploadText {
-  color: $ens-blue;
+  color: $blue;
   cursor: pointer;
 }
 

--- a/src/ensembl/src/content/app/custom-download/containers/content/attributes-accordion/AttributesAccordion.scss
+++ b/src/ensembl/src/content/app/custom-download/containers/content/attributes-accordion/AttributesAccordion.scss
@@ -4,11 +4,11 @@
   padding-right: 15px;
   max-height: calc(100vh - 135px);
   overflow-y: auto;
-  background-color: $ens-white;
+  background-color: $white;
 }
 .dataSelectorHint {
   padding: 10px 40px 10px 15px;
-  color: $ens-dark-grey;
+  color: $dark-grey;
   position: relative;
 }
 
@@ -17,14 +17,14 @@
 }
 
 .permanentBlock {
-  background: $ens-light-grey;
+  background: $light-grey;
 }
 
 .accordionExpandedTitle {
-  color: $ens-dark-grey;
+  color: $dark-grey;
 
   > span {
-    color: $ens-black;
+    color: $black;
     font-weight: 700;
   }
 }

--- a/src/ensembl/src/content/app/custom-download/containers/content/attributes-accordion/sections/orthologues/Orthologues.scss
+++ b/src/ensembl/src/content/app/custom-download/containers/content/attributes-accordion/sections/orthologues/Orthologues.scss
@@ -14,35 +14,35 @@
   }
 
   input::placeholder {
-    color: $ens-medium-light-grey;
+    color: $medium-light-grey;
   }
 
   label {
     margin-right: 15px;
-    color: $ens-dark-grey;
+    color: $dark-grey;
   }
 
   .resultCounter {
     margin-left: 20px;
     span:first-of-type {
       font-weight: $bold;
-      color: $ens-black;
+      color: $black;
     }
 
     span:nth-of-type(2) {
-      color: $ens-medium-dark-grey;
+      color: $medium-dark-grey;
     }
 
     span:last-of-type {
       font-size: 12px;
       padding-left: 2px;
-      color: $ens-medium-dark-grey;
+      color: $medium-dark-grey;
     }
   }
 
   .bestMatchesFilter,
   .showAllFilter {
-    color: $ens-blue;
+    color: $blue;
     cursor: pointer;
     margin-left: 20px;
   }
@@ -54,5 +54,5 @@
 
 .speciesAttributesSectionTitle {
   margin: 20px 0 15px 30px;
-  color: $ens-dark-grey;
+  color: $dark-grey;
 }

--- a/src/ensembl/src/content/app/custom-download/containers/content/filter-accordion/FiltersAccordion.scss
+++ b/src/ensembl/src/content/app/custom-download/containers/content/filter-accordion/FiltersAccordion.scss
@@ -7,7 +7,7 @@
 }
 .filterHint {
   padding: 10px 40px 10px 15px;
-  color: $ens-dark-grey;
+  color: $dark-grey;
   position: relative;
 }
 
@@ -16,10 +16,10 @@
 }
 
 .accordionExpandedTitle {
-  color: $ens-grey;
+  color: $grey;
 
   > span {
-    color: $ens-black;
+    color: $black;
   }
 }
 

--- a/src/ensembl/src/content/app/custom-download/containers/content/preview-download/PreviewDownload.scss
+++ b/src/ensembl/src/content/app/custom-download/containers/content/preview-download/PreviewDownload.scss
@@ -20,8 +20,8 @@
 .previewDownloadHeader {
   border-collapse: collapse;
   min-width: 50%;
-  border-bottom: 2px solid $ens-grey;
-  color: $ens-grey;
+  border-bottom: 2px solid $grey;
+  color: $grey;
 
   td {
     padding: 8px 0 8px 8px;
@@ -37,7 +37,7 @@
 }
 
 .changeLink {
-  color: $ens-blue;
+  color: $blue;
   cursor: pointer;
   margin-top: 20px;
 }

--- a/src/ensembl/src/content/app/custom-download/containers/content/result-holder/ResultHolder.scss
+++ b/src/ensembl/src/content/app/custom-download/containers/content/result-holder/ResultHolder.scss
@@ -11,9 +11,9 @@
 
 .resultCard {
   min-height: 75px;
-  border: 1px solid $ens-grey;
+  border: 1px solid $grey;
   padding: 15px 5px;
-  background: $ens-white;
+  background: $white;
   margin-bottom: 5px;
   position: relative;
   display: block;
@@ -24,7 +24,7 @@
     clear: both;
     .lineHeader {
       text-align: right;
-      color: $ens-dark-grey;
+      color: $dark-grey;
       width: 25%;
       max-width: 200px;
       text-overflow: ellipsis;
@@ -33,7 +33,7 @@
     }
 
     .lineValue {
-      color: $ens-black;
+      color: $black;
       width: 75%;
       display: inline-block;
       padding-left: 5px;

--- a/src/ensembl/src/content/app/custom-download/containers/header/CustomDownloadHeader.scss
+++ b/src/ensembl/src/content/app/custom-download/containers/header/CustomDownloadHeader.scss
@@ -1,7 +1,7 @@
 @import 'src/styles/common';
 
 .wrapper {
-  background-color: $ens-light-grey;
+  background-color: $light-grey;
   height: 60px;
   position: relative;
 }
@@ -10,7 +10,7 @@
   position: absolute;
   top: 50%;
   left: 50px;
-  color: $ens-black;
+  color: $black;
   margin-top: -10px;
 
   span {
@@ -45,11 +45,11 @@
 
 .resultsLabel {
   font-size: 11px;
-  color: $ens-dark-grey;
+  color: $dark-grey;
 }
 .saveConfiguration {
   font-size: 11px;
-  color: $ens-dark-grey;
+  color: $dark-grey;
 }
 
 .backButton {
@@ -67,19 +67,19 @@
 }
 
 .downloadTypeLabel {
-  color: $ens-dark-grey;
+  color: $dark-grey;
 }
 
 .downloadTypeSelect {
   margin-left: 10px;
-  color: $ens-blue;
+  color: $blue;
   li {
-    color: $ens-medium-dark-grey;
+    color: $medium-dark-grey;
   }
 }
 
 .roundButtonInactive {
-  background-color: $ens-medium-dark-grey;
-  border-color: $ens-medium-dark-grey;
-  color: $ens-white;
+  background-color: $medium-dark-grey;
+  border-color: $medium-dark-grey;
+  color: $white;
 }

--- a/src/ensembl/src/content/app/custom-download/containers/pre-filters-panel/PreFilterPanel.scss
+++ b/src/ensembl/src/content/app/custom-download/containers/pre-filters-panel/PreFilterPanel.scss
@@ -1,14 +1,14 @@
 @import 'src/styles/common';
 
 .preFilterPanel {
-  background-color: $ens-light-grey;
+  background-color: $light-grey;
   height: 300px;
   box-shadow: 0 3px 5px $global-box-shadow;
 }
 
 .panelTitle {
   margin-left: 45px;
-  color: $ens-dark-grey;
+  color: $dark-grey;
   padding-top: 10px;
 }
 
@@ -22,23 +22,23 @@
 /* RoundButton extended styles*/
 .filterButtons {
   .inactive {
-    background-color: $ens-blue;
-    border: 1px solid $ens-blue;
-    color: $ens-white;
+    background-color: $blue;
+    border: 1px solid $blue;
+    color: $white;
     margin-left: 30px;
   }
 
   .active {
-    background-color: $ens-medium-dark-grey;
-    border: 1px solid $ens-medium-dark-grey;
-    color: $ens-white;
+    background-color: $medium-dark-grey;
+    border: 1px solid $medium-dark-grey;
+    color: $white;
     margin-left: 30px;
   }
 
   .disabled {
     background-color: transparent;
-    color: $ens-grey;
-    border: 1px solid $ens-grey;
+    color: $grey;
+    border: 1px solid $grey;
     cursor: default;
     margin-left: 30px;
   }

--- a/src/ensembl/src/content/app/species-selector/components/assembly-selector/AssemblySelector.scss
+++ b/src/ensembl/src/content/app/species-selector/components/assembly-selector/AssemblySelector.scss
@@ -1,6 +1,6 @@
 @import 'src/styles/common';
 
 .assemblySelectorLabel {
-  color: $ens-grey;
+  color: $grey;
   margin-right: 0.5em;
 }

--- a/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.scss
+++ b/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.scss
@@ -21,7 +21,7 @@ $button-gap: 1.4rem;
   display: inline-block;
   width: $button-width;
   height: $button-width;
-  background: $ens-blue;
+  background: $blue;
   padding: 3px;
   overflow: hidden; // <-- solely for IE11's sake; it seems that without this rule invisible parts of svg mignt be excaping the button and messing up layout
   cursor: pointer;
@@ -40,12 +40,12 @@ $button-gap: 1.4rem;
 }
 
 .popularSpeciesButtonSelected {
-  background: $ens-dark-grey;
+  background: $dark-grey;
 }
 
 .popularSpeciesButtonCommitted {
   background: white;
-  border: 1px solid $ens-blue;
+  border: 1px solid $blue;
 
   svg {
     fill: black;
@@ -59,6 +59,6 @@ $button-gap: 1.4rem;
 }
 
 .popularSpeciesButtonDisabled {
-  background: $ens-grey;
+  background: $grey;
   cursor: default;
 }

--- a/src/ensembl/src/content/app/species-selector/components/selected-species/SelectedSpecies.scss
+++ b/src/ensembl/src/content/app/species-selector/components/selected-species/SelectedSpecies.scss
@@ -8,7 +8,7 @@ $deleteButtonPadding: 8px 20px 8px 28px;
   position: relative;
   display: inline-block;
   padding: $selectedSpeciesPadding;
-  background-color: $ens-black;
+  background-color: $black;
   border-radius: $selectedSpeciesBorderRadius;
   line-height: 1;
   cursor: pointer;
@@ -36,7 +36,7 @@ $deleteButtonPadding: 8px 20px 8px 28px;
 }
 
 .selectedSpeciesDisabled {
-  background-color: $ens-grey;
+  background-color: $grey;
 }
 
 .selectedSpeciesOverlay {
@@ -48,7 +48,7 @@ $deleteButtonPadding: 8px 20px 8px 28px;
   height: 100%;
   line-height: 1;
   background: white;
-  border: 1px solid $ens-blue;
+  border: 1px solid $blue;
   border-radius: $selectedSpeciesBorderRadius;
   cursor: default;
 
@@ -64,7 +64,7 @@ $deleteButtonPadding: 8px 20px 8px 28px;
     padding: $selectedSpeciesPadding;
     padding-left: 15px;
     left: 0;
-    color: $ens-blue;
+    color: $blue;
   }
 
   .clearButtonContainer {

--- a/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.scss
+++ b/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.scss
@@ -10,19 +10,19 @@ $rightCornerWidth: 40px;
   width: 100%;
   max-width: 485px;
   height: 36px;
-  box-shadow: inset 2px 2px 4px -2px $ens-dark-grey;
+  box-shadow: inset 2px 2px 4px -2px $dark-grey;
   background: white;
 }
 
 .speciesSearchField {
   width: 100%;
-  background: $ens-white;
+  background: $white;
   padding-left: 18px;
   border: none;
 
   input {
     &::placeholder {
-      color: $ens-grey;
+      color: $grey;
     }
 
     &:focus {

--- a/src/ensembl/src/content/app/species-selector/components/species-search-match/SpeciesSearchMatch.scss
+++ b/src/ensembl/src/content/app/species-selector/components/species-search-match/SpeciesSearchMatch.scss
@@ -1,13 +1,13 @@
 @import 'src/styles/common';
 
 .speciesSearchMatch {
-  color: $ens-black;
+  color: $black;
   padding: 2px 24px;
   margin: 0 -23px;
   cursor: pointer;
 
   &:hover {
-    background-color: $ens-light-blue;
+    background-color: $light-blue;
   }
 }
 

--- a/src/ensembl/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.scss
+++ b/src/ensembl/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.scss
@@ -1,7 +1,7 @@
 @import 'src/styles/common';
 
 .main {
-  color: $ens-black;
+  color: $black;
   margin-left: 2em;
   line-height: 2.5em;
 }
@@ -13,5 +13,5 @@
 .genomeBrowserLinkContainer {
   margin-left: 1.2rem;
   display: inline-block;
-  color: $ens-blue;
+  color: $blue;
 }

--- a/src/ensembl/src/content/app/species-selector/components/strain-selector/StrainSelector.scss
+++ b/src/ensembl/src/content/app/species-selector/components/strain-selector/StrainSelector.scss
@@ -7,13 +7,13 @@
   transform: translateX(-60%);
   white-space: nowrap;
   display: inline-block;
-  color: $ens-white;
+  color: $white;
   font-size: 12px; // FIXME
   font-weight: 700;
   padding: 4px 6px;
-  background-color: $ens-blue;
+  background-color: $blue;
   border-radius: 4px;
-  box-shadow: 2px 2px 5px $ens-grey;
+  box-shadow: 2px 2px 5px $grey;
   cursor: pointer;
   user-select: none;
 }
@@ -27,11 +27,11 @@
 
 .strain {
   display: inline-block;
-  color: $ens-blue;
+  color: $blue;
   cursor: pointer;
 }
 
 .strainSelected {
-  color: $ens-grey;
+  color: $grey;
   cursor: default;
 }

--- a/src/ensembl/src/content/app/species-selector/containers/species-search-panel/SpeciesSearchPanel.scss
+++ b/src/ensembl/src/content/app/species-selector/containers/species-search-panel/SpeciesSearchPanel.scss
@@ -1,7 +1,7 @@
 @import 'src/styles/common';
 
 .speciesSearchPanel {
-  background-color: $ens-light-grey;
+  background-color: $light-grey;
   height: 235px;
   padding: 65px 40px;
   padding-left: $global-padding-left;

--- a/src/ensembl/src/content/home/Home.scss
+++ b/src/ensembl/src/content/home/Home.scss
@@ -2,7 +2,7 @@
 
 .home {
   h2 {
-    color: $ens-grey;
+    color: $grey;
     font-size: 14px;
     font-weight: $normal;
   }
@@ -11,8 +11,8 @@
 }
 
 .search {
-  background: $ens-light-grey;
-  box-shadow: 0 3px 5px $ens-medium-light-grey;
+  background: $light-grey;
+  box-shadow: 0 3px 5px $medium-light-grey;
   min-height: 235px;
   padding: 15px 60px;
 
@@ -22,8 +22,8 @@
 
   input[type='text'] {
     border: none;
-    box-shadow: inset 3px 3px 10px $ens-grey;
-    color: $ens-dark-grey;
+    box-shadow: inset 3px 3px 10px $grey;
+    color: $dark-grey;
     font-size: 14px;
     padding: 12px 20px;
     min-width: 300px;
@@ -31,7 +31,7 @@
   }
 
   button {
-    border: 1px solid $ens-grey;
+    border: 1px solid $grey;
     border-radius: 5px;
     margin-left: 15px;
     padding: 8px 24px;
@@ -53,7 +53,7 @@
   padding-top: 2%;
 
   h4 {
-    color: $ens-grey;
+    color: $grey;
     font-size: 13px;
     font-weight: $normal;
     margin-bottom: 30px;

--- a/src/ensembl/src/header/Header.scss
+++ b/src/ensembl/src/header/Header.scss
@@ -7,7 +7,7 @@
   align-items: center;
   color: $white;
   padding: 2px 20px;
-  background-color: $ens-black;
+  background-color: $black;
 }
 
 .homeLink {
@@ -16,7 +16,7 @@
   font-weight: $global-weight-bold;
 
   a {
-    color: $ens-white;
+    color: $white;
   }
 
   img {
@@ -39,6 +39,6 @@
   }
 
   a {
-    color: $ens-blue;
+    color: $blue;
   }
 }

--- a/src/ensembl/src/header/account/Account.scss
+++ b/src/ensembl/src/header/account/Account.scss
@@ -1,14 +1,14 @@
 @import 'src/styles/common';
 
 .account {
-  border-bottom: 1px solid $ens-grey;
+  border-bottom: 1px solid $grey;
   height: 300px;
   display: flex;
   align-items: center;
   justify-content: center;
 
   h2 {
-    color: $ens-grey;
+    color: $grey;
     text-align: center;
   }
 }

--- a/src/ensembl/src/header/launchbar/Launchbar.scss
+++ b/src/ensembl/src/header/launchbar/Launchbar.scss
@@ -3,8 +3,8 @@
 .launchbar {
   display: flex;
   justify-content: space-between;
-  border-bottom: 1px solid $ens-grey;
-  border-top: 1px solid $ens-grey;
+  border-bottom: 1px solid $grey;
+  border-top: 1px solid $grey;
   padding: 11px 6px;
   overflow-x: auto;
 }
@@ -32,7 +32,7 @@
   }
 
   &:not(:last-child) {
-    border-right: 1px solid $ens-grey;
+    border-right: 1px solid $grey;
   }
 }
 
@@ -40,7 +40,7 @@
   display: inline-block;
   height: 30px;
   width: 30px;
-  border: 1px solid $ens-blue;
+  border: 1px solid $blue;
   margin: 0 12px;
 
   img {
@@ -50,11 +50,11 @@
 }
 
 .launchbarButtonSelected {
-  border: 1px solid $ens-black;
+  border: 1px solid $black;
 }
 
 .launchbarButtonDisabled {
-  border: 1px solid $ens-grey;
+  border: 1px solid $grey;
 }
 
 .launchbarButtonImage {
@@ -62,22 +62,22 @@
     width: 30px;
     height: 30px;
     transform: scale(1.1);
-    fill: $ens-white;
-    background-color: $ens-blue;
+    fill: $white;
+    background-color: $blue;
   }
 }
 
 .launchbarButtonSelectedImage {
   svg {
-    fill: $ens-white;
-    background-color: $ens-black;
+    fill: $white;
+    background-color: $black;
   }
 }
 
 .launchbarButtonDisabledImage {
   svg {
-    fill: $ens-white;
-    background-color: $ens-grey;
+    fill: $white;
+    background-color: $grey;
   }
 }
 

--- a/src/ensembl/src/shared/components/accordion/css/Accordion.scss
+++ b/src/ensembl/src/shared/components/accordion/css/Accordion.scss
@@ -1,12 +1,12 @@
 @import 'src/styles/common';
 
 .accordionDefault {
-  border: 2px solid $ens-medium-light-grey;
+  border: 2px solid $medium-light-grey;
   border-radius: 2px;
 }
 
 .accordionItemDefault + .accordionItemDefault {
-  border-top: 2px solid $ens-medium-light-grey;
+  border-top: 2px solid $medium-light-grey;
 }
 
 .accordionButtonDefault {
@@ -29,7 +29,7 @@
   width: 10px;
   margin-right: 12px;
   transition: transform 0.2s linear, top 0.2s linear;
-  background-color: $ens-blue;
+  background-color: $blue;
 }
 
 .accordionButtonDefault:before {
@@ -57,7 +57,7 @@
 }
 
 .accordionPanelDefault {
-  background: $ens-light-grey;
+  background: $light-grey;
   animation: fadein 0.2s ease-in;
 }
 

--- a/src/ensembl/src/shared/components/app-bar/AppBar.scss
+++ b/src/ensembl/src/shared/components/app-bar/AppBar.scss
@@ -22,7 +22,7 @@
   top: 5px;
 
   a {
-    color: $ens-black;
+    color: $black;
     font-size: 12px;
     font-weight: $light;
   }

--- a/src/ensembl/src/shared/components/autosuggest-search-field/AutosuggestSearchField.scss
+++ b/src/ensembl/src/shared/components/autosuggest-search-field/AutosuggestSearchField.scss
@@ -14,8 +14,8 @@
   z-index: 1;
   padding: 18px 24px;
   background: white;
-  border: 1px solid $ens-grey;
-  box-shadow: 2px 2px 6px 0 $ens-grey;
+  border: 1px solid $grey;
+  box-shadow: 2px 2px 6px 0 $grey;
 }
 
 .autosuggestionPlateMatchGroup {
@@ -31,5 +31,5 @@
 }
 
 .autosuggestionPlateHighlightedItem {
-  background-color: $ens-light-blue;
+  background-color: $light-blue;
 }

--- a/src/ensembl/src/shared/components/badged-button/BadgedButton.scss
+++ b/src/ensembl/src/shared/components/badged-button/BadgedButton.scss
@@ -7,14 +7,14 @@
 
 .badgeDefault {
   position: absolute;
-  background-color: $ens-green;
+  background-color: $green;
   height: 26px;
   min-width: 26px;
   top: -13px;
   right: -13px;
   font-weight: 700;
   padding: 2px 0 0 0;
-  color: $ens-white;
+  color: $white;
   border-radius: 13px;
   text-align: center;
   cursor: pointer;

--- a/src/ensembl/src/shared/components/button/Button.scss
+++ b/src/ensembl/src/shared/components/button/Button.scss
@@ -1,22 +1,22 @@
 @import 'src/styles/common';
 
 .primaryButton {
-  background-color: $ens-green;
-  color: $ens-white;
+  background-color: $green;
+  color: $white;
   padding: 8px 18px;
   font-weight: $bold;
 }
 
 .primaryButtonDisabled {
   background-color: transparent;
-  color: $ens-grey;
-  border: 1px solid $ens-grey;
+  color: $grey;
+  border: 1px solid $grey;
   cursor: default;
 }
 
 .secondaryButton {
-  background-color: $ens-blue;
-  color: $ens-white;
+  background-color: $blue;
+  color: $white;
   font-weight: $bold;
 }
 

--- a/src/ensembl/src/shared/components/checkbox/Checkbox.scss
+++ b/src/ensembl/src/shared/components/checkbox/Checkbox.scss
@@ -9,8 +9,8 @@
   cursor: pointer;
   height: 15px;
   width: 15px;
-  border: 1px solid $ens-grey;
-  background-color: $ens-white;
+  border: 1px solid $grey;
+  background-color: $white;
   transition: background-color 0.1s ease-in-out;
   float: left;
   margin-top: 2px;
@@ -18,20 +18,20 @@
 
 .unchecked {
   cursor: pointer;
-  background-color: $ens-white;
+  background-color: $white;
 }
 
 .checked {
-  background-color: $ens-green;
+  background-color: $green;
 }
 
 .disabled {
-  background-color: $ens-light-grey;
+  background-color: $light-grey;
   cursor: default;
 }
 
 .defaultLabel {
-  color: $ens-black;
+  color: $black;
   line-height: 30px;
   font-size: 14px;
   padding-left: 8px;
@@ -46,6 +46,6 @@
   display: none;
 
   &:focus + div {
-    border: 1px solid $ens-dark-grey;
+    border: 1px solid $dark-grey;
   }
 }

--- a/src/ensembl/src/shared/components/clear-button/ClearButton.scss
+++ b/src/ensembl/src/shared/components/clear-button/ClearButton.scss
@@ -6,7 +6,7 @@
   align-items: center;
   width: 18px;
   height: 18px;
-  border: 2px solid $ens-blue;
+  border: 2px solid $blue;
   border-radius: 50%;
   cursor: pointer;
 
@@ -18,17 +18,17 @@
   svg {
     width: 66%;
     height: 66%;
-    fill: $ens-blue;
+    fill: $blue;
   }
 }
 
 .clearButtonInverted {
-  background-color: $ens-blue;
+  background-color: $blue;
   border: none;
 
   svg {
     width: 56%;
     height: 56%;
-    fill: $ens-white;
+    fill: $white;
   }
 }

--- a/src/ensembl/src/shared/components/error-screen/ErrorScreen.scss
+++ b/src/ensembl/src/shared/components/error-screen/ErrorScreen.scss
@@ -18,8 +18,8 @@ $generalErrorImagesTotalWidth: calc(
 }
 
 .errorLinkButton {
-  background-color: $ens-blue;
-  color: $ens-white;
+  background-color: $blue;
+  color: $white;
   font-weight: $bold;
   padding: 8px 18px;
   border-radius: 4px;

--- a/src/ensembl/src/shared/components/image-button/ImageButton.scss
+++ b/src/ensembl/src/shared/components/image-button/ImageButton.scss
@@ -18,7 +18,7 @@
 .disabled {
   cursor: not-allowed;
   svg {
-    fill: $ens-grey;
+    fill: $grey;
     opacity: 1;
   }
   &:before {
@@ -44,7 +44,7 @@
 
 .active {
   svg {
-    fill: $ens-dark-blue;
+    fill: $dark-blue;
   }
   &svg:hover {
     opacity: 0.8;
@@ -53,8 +53,8 @@
 
 .highlighted {
   svg {
-    fill: $ens-white;
-    background: $ens-dark-blue;
+    fill: $white;
+    background: $dark-blue;
   }
   &svg:hover {
     opacity: 0.8;
@@ -63,7 +63,7 @@
 
 .inactive {
   svg {
-    fill: $ens-grey;
+    fill: $grey;
   }
   &svg:hover {
     opacity: 0.8;

--- a/src/ensembl/src/shared/components/loader/Loader.scss
+++ b/src/ensembl/src/shared/components/loader/Loader.scss
@@ -2,8 +2,8 @@
 
 .circleLoader {
   display: inline-block;
-  border: 3px solid $ens-light-grey;
-  border-top-color: $ens-red;
+  border: 3px solid $light-grey;
+  border-top-color: $red;
   width: 40px;
   height: 40px;
   border-radius: 100%;

--- a/src/ensembl/src/shared/components/privacy-banner/PrivacyBanner.scss
+++ b/src/ensembl/src/shared/components/privacy-banner/PrivacyBanner.scss
@@ -3,7 +3,7 @@
 .privacyBanner {
   position: fixed;
   bottom: 0;
-  background: $ens-black;
+  background: $black;
   color: white;
   font-size: 13px;
   line-height: 2;
@@ -13,7 +13,7 @@
   z-index: 10000;
 
   button {
-    background: $ens-blue;
+    background: $blue;
     border-radius: 2px;
     color: white;
     font-weight: $bold;
@@ -22,7 +22,7 @@
   }
 
   a {
-    color: $ens-blue;
+    color: $blue;
     font-weight: $bold;
   }
 }

--- a/src/ensembl/src/shared/components/question-button/QuestionButton.scss
+++ b/src/ensembl/src/shared/components/question-button/QuestionButton.scss
@@ -7,13 +7,13 @@
   align-items: center;
   width: 18px;
   height: 18px;
-  border: 2px solid $ens-blue;
+  border: 2px solid $blue;
   border-radius: 50%;
 
   > svg {
     width: 70%;
     height: 70%;
-    fill: $ens-blue;
+    fill: $blue;
   }
 
   *[class*='tooltip'] {

--- a/src/ensembl/src/shared/components/round-button/RoundButton.scss
+++ b/src/ensembl/src/shared/components/round-button/RoundButton.scss
@@ -5,8 +5,8 @@
   padding: 6px 15px;
   min-width: 170px;
   position: relative;
-  border: 1px solid $ens-blue;
-  color: $ens-dark-blue;
+  border: 1px solid $blue;
+  color: $dark-blue;
 
   &:active,
   &:focus {
@@ -15,20 +15,20 @@
 }
 
 .active {
-  background-color: $ens-black;
-  border: 1px solid $ens-black;
-  color: $ens-white;
+  background-color: $black;
+  border: 1px solid $black;
+  color: $white;
 }
 
 .inactive {
-  background-color: $ens-blue;
-  border: 1px solid $ens-blue;
-  color: $ens-white;
+  background-color: $blue;
+  border: 1px solid $blue;
+  color: $white;
 }
 
 .disabled {
   background-color: transparent;
-  color: $ens-grey;
-  border: 1px solid $ens-grey;
+  color: $grey;
+  border: 1px solid $grey;
   cursor: default;
 }

--- a/src/ensembl/src/shared/components/search-field/SearchField.scss
+++ b/src/ensembl/src/shared/components/search-field/SearchField.scss
@@ -1,7 +1,7 @@
 @import 'src/styles/common';
 
 .searchField {
-  border: 1px solid $ens-grey;
+  border: 1px solid $grey;
   display: inline-flex;
   padding: 0 0.6em;
 }

--- a/src/ensembl/src/shared/components/select/Select.scss
+++ b/src/ensembl/src/shared/components/select/Select.scss
@@ -25,7 +25,7 @@ $optionsPanelLeftPadding: 14px;
   margin-left: 0.8em;
   height: 8px;
   width: 8px;
-  fill: $ens-blue;
+  fill: $blue;
 }
 
 .selectControl {
@@ -44,7 +44,7 @@ $optionsPanelLeftPadding: 14px;
   display: inline-block;
   min-width: 100%;
   padding: $optionsPanelTopPadding 0 34px 0;
-  box-shadow: 2px 2px 6px 0 $ens-grey;
+  box-shadow: 2px 2px 6px 0 $grey;
   white-space: nowrap;
   z-index: 1;
 
@@ -76,7 +76,7 @@ $optionsPanelLeftPadding: 14px;
 .scrollButtonBottom {
   position: absolute;
   left: 0;
-  background: $ens-white;
+  background: $white;
   width: 100%;
   text-align: center;
 }
@@ -97,7 +97,7 @@ $optionsPanelLeftPadding: 14px;
 }
 
 .optionsPanelHeader {
-  color: $ens-grey;
+  color: $grey;
   margin-bottom: 1em;
 }
 
@@ -114,5 +114,5 @@ $optionsPanelLeftPadding: 14px;
 }
 
 .optionHighlighted {
-  background-color: $ens-light-blue;
+  background-color: $light-blue;
 }

--- a/src/ensembl/src/shared/components/species-tab/SpeciesTab.scss
+++ b/src/ensembl/src/shared/components/species-tab/SpeciesTab.scss
@@ -3,7 +3,7 @@
 .speciesTab {
   display: inline-block;
   padding: 6px 20px;
-  border: 1px solid $ens-blue;
+  border: 1px solid $blue;
   border-radius: 20px;
   cursor: pointer;
   overflow: hidden;
@@ -31,12 +31,12 @@
 }
 
 .speciesTabActive {
-  background-color: $ens-black;
+  background-color: $black;
   border: none;
 
   .name,
   .assembly {
-    color: $ens-white;
+    color: $white;
   }
 }
 

--- a/src/ensembl/src/shared/components/tooltip/Tooltip.scss
+++ b/src/ensembl/src/shared/components/tooltip/Tooltip.scss
@@ -1,15 +1,15 @@
 @import 'src/styles/common';
 
-$fill-color: $ens-dark-grey;
+$fill-color: $dark-grey;
 
 .tooltip {
   position: absolute;
   background: $fill-color;
   padding: 6px 18px 8px;
-  box-shadow: 2px 2px 5px $ens-shadow-color;
+  box-shadow: 2px 2px 5px $shadow-color;
   width: max-content; // not supported in IE or non-webkit Edge
   cursor: default;
-  color: $ens-white;
+  color: $white;
   border-radius: 4px;
   font-size: 14px;
   z-index: 1000;
@@ -20,7 +20,7 @@ $fill-color: $ens-dark-grey;
   &[class*='left_centre'],
   &[class*='left_top'] {
     svg {
-      filter: drop-shadow(0px -3px 2px $ens-shadow-color);
+      filter: drop-shadow(0px -3px 2px $shadow-color);
     }
   }
 
@@ -28,7 +28,7 @@ $fill-color: $ens-dark-grey;
   &[class*='top_centre'],
   &[class*='top_right'] {
     svg {
-      filter: drop-shadow(0px -3px 2px $ens-shadow-color);
+      filter: drop-shadow(0px -3px 2px $shadow-color);
     }
   }
 }

--- a/src/ensembl/src/styles/_settings.scss
+++ b/src/ensembl/src/styles/_settings.scss
@@ -4,8 +4,9 @@
 $global-font-size: 14px;
 $global-lineheight: 1.5;
 $black: #17354e;
-$white: #fefefe;
-$body-background: $white;
+$white: #fff;
+$off-white: #fefefe;
+$body-background: $off-white;
 $body-font-color: $black;
 $body-font-family: Lato, 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;
 $body-antialiased: true;
@@ -17,43 +18,40 @@ $global-button-cursor: auto;
 
 // Colour Palette
 // ---------
+$shadow-color: rgba(0, 0, 0, 0.4);
 
-$ens-black: #17354e;
-$ens-shadow-color: rgba(0, 0, 0, 0.4);
+$light-blue: #e5f5ff; // text highlight
+$blue: #33adff; // blue on black
+$dark-blue: #0099ff; // blue on white
 
-$ens-light-blue: #e5f5ff; // text highlight
-$ens-blue: #33adff; // blue on black
-$ens-dark-blue: #0099ff; // blue on white
+$light-grey: #f1f2f4;
+$medium-light-grey: #d4d9de;
+$grey: #b7c0c8;
+$medium-dark-grey: #9aa7b1;
+$dark-grey: #6f8190;
 
-$ens-light-grey: #f1f2f4;
-$ens-medium-light-grey: #d4d9de;
-$ens-grey: #b7c0c8;
-$ens-medium-dark-grey: #9aa7b1;
-$ens-dark-grey: #6f8190;
+$red: #d90000;
 
-$ens-red: #d90000;
+$green: #47d147;
 
-$ens-green: #47d147;
 
-$ens-white: #fff;
-
-$global-box-shadow: $ens-medium-light-grey;
+$global-box-shadow: $medium-light-grey;
 
 /* stylelint-disable */
 :export {
-  ens-black: $ens-black;
-  ens-blue: $ens-blue;
-  ens-light-blue: $ens-light-blue;
-  ens-dark-blue: $ens-dark-blue;
-  ens-red: $ens-red;
-  ens-dark-grey: $ens-dark-grey;
-  ens-medium-dark-grey: $ens-medium-dark-grey;
-  ens-grey: $ens-grey;
-  ens-medium-light-grey: $ens-medium-light-grey;
-  ens-light-grey: $ens-light-grey;
-  ens-green: $ens-green;
-  ens-white: $ens-white;
-  ens-shadow-color: $ens-shadow-color;
+  black: $black;
+  blue: $blue;
+  light-blue: $light-blue;
+  dark-blue: $dark-blue;
+  red: $red;
+  dark-grey: $dark-grey;
+  medium-dark-grey: $medium-dark-grey;
+  grey: $grey;
+  medium-light-grey: $medium-light-grey;
+  light-grey: $light-grey;
+  green: $green;
+  white: $white;
+  shadow-color: $shadow-color;
 }
 /* stylelint-enable */
 

--- a/src/ensembl/src/styles/main.scss
+++ b/src/ensembl/src/styles/main.scss
@@ -10,11 +10,11 @@ body,
 }
 
 a {
-  color: $ens-dark-blue;
+  color: $dark-blue;
   text-decoration: none;
 
   &.inactive {
-    color: $ens-dark-grey;
+    color: $dark-grey;
   }
 }
 

--- a/src/ensembl/stories/design-primitives/colours/Colours.stories.tsx
+++ b/src/ensembl/stories/design-primitives/colours/Colours.stories.tsx
@@ -7,63 +7,63 @@ import variables from 'src/styles/_settings.scss';
 const colours = [
   {
     name: 'Ensembl black',
-    variableName: '$ens-black',
-    value: variables['ens-black']
+    variableName: '$black',
+    value: variables['black']
   },
   {
     name: 'Ensembl blue',
-    variableName: '$ens-blue',
-    value: variables['ens-blue']
+    variableName: '$blue',
+    value: variables['blue']
   },
   {
     name: 'Ensembl dark blue',
-    variableName: '$ens-dark-blue',
-    value: variables['ens-dark-blue']
+    variableName: '$dark-blue',
+    value: variables['dark-blue']
   },
   {
     name: 'Ensembl light blue',
-    variableName: '$ens-light-blue',
-    value: variables['ens-light-blue']
+    variableName: '$light-blue',
+    value: variables['light-blue']
   },
   {
     name: 'Ensembl red',
-    variableName: '$ens-red',
-    value: variables['ens-red']
+    variableName: '$red',
+    value: variables['red']
   },
   {
     name: 'Ensembl grey',
-    variableName: '$ens-grey',
-    value: variables['ens-grey']
+    variableName: '$grey',
+    value: variables['grey']
   },
   {
     name: 'Ensembl medium dark grey',
-    variableName: '$ens-medium-dark-grey',
-    value: variables['ens-medium-dark-grey']
+    variableName: '$medium-dark-grey',
+    value: variables['medium-dark-grey']
   },
   {
     name: 'Ensembl dark grey',
-    variableName: '$ens-dark-grey',
-    value: variables['ens-dark-grey']
+    variableName: '$dark-grey',
+    value: variables['dark-grey']
   },
   {
     name: 'Ensembl medium light grey',
-    variableName: '$ens-medium-light-grey',
-    value: variables['ens-medium-light-grey']
+    variableName: '$medium-light-grey',
+    value: variables['medium-light-grey']
   },
   {
     name: 'Ensembl light grey',
-    variableName: '$ens-light-grey',
-    value: variables['ens-light-grey']
+    variableName: '$light-grey',
+    value: variables['light-grey']
   },
   {
     name: 'Ensembl green',
-    variableName: '$ens-green',
-    value: variables['ens-green']
+    variableName: '$green',
+    value: variables['green']
   },
   {
     name: 'Ensembl white',
-    variableName: '$ens-white',
-    value: variables['ens-white']
+    variableName: '$white',
+    value: variables['white']
   }
 ];
 

--- a/src/ensembl/stories/shared-components/badged-button/BadgedButton.stories.scss
+++ b/src/ensembl/stories/shared-components/badged-button/BadgedButton.stories.scss
@@ -6,8 +6,8 @@
 
 .active {
   border: none;
-  background-color: $ens-dark-grey;
-  color: $ens-white;
+  background-color: $dark-grey;
+  color: $white;
 }
 
 .imageButtonWrapper {
@@ -17,5 +17,5 @@
 }
 
 .badge {
-  background-color: $ens-red;
+  background-color: $red;
 }

--- a/src/ensembl/stories/shared-components/button/Button.stories.scss
+++ b/src/ensembl/stories/shared-components/button/Button.stories.scss
@@ -5,5 +5,5 @@
 }
 
 .lightGreyWrapper {
-  background: $ens-light-grey;
+  background: $light-grey;
 }

--- a/src/ensembl/stories/shared-components/checkbox/Checkbox.stories.scss
+++ b/src/ensembl/stories/shared-components/checkbox/Checkbox.stories.scss
@@ -2,7 +2,7 @@
 
 .wrapper {
   padding: 20px;
-  background-color: $ens-light-grey;
+  background-color: $light-grey;
   width: 100%;
   height: 100%;
   position: absolute;

--- a/src/ensembl/stories/shared-components/image-button/ImageButton.stories.scss
+++ b/src/ensembl/stories/shared-components/image-button/ImageButton.stories.scss
@@ -37,7 +37,7 @@
 
   .codeContent {
     float: left;
-    background: $ens-light-grey;
+    background: $light-grey;
     padding: 10px;
     margin-top: 10px;
     height: 200px;

--- a/src/ensembl/stories/shared-components/round-button/RoundButton.stories.scss
+++ b/src/ensembl/stories/shared-components/round-button/RoundButton.stories.scss
@@ -6,6 +6,6 @@
 
 .active {
   border: none;
-  background-color: $ens-dark-grey;
-  color: $ens-white;
+  background-color: $dark-grey;
+  color: $white;
 }

--- a/src/ensembl/stories/shared-components/search-field/SearchField.stories.scss
+++ b/src/ensembl/stories/shared-components/search-field/SearchField.stories.scss
@@ -14,6 +14,6 @@
   height: 20px;
   width: 20px;
   border-width: 1px;
-  border-color: $ens-medium-light-grey;
-  border-top-color: $ens-red;
+  border-color: $medium-light-grey;
+  border-top-color: $red;
 }

--- a/src/ensembl/stories/shared-components/tooltip/Tooltip.stories.scss
+++ b/src/ensembl/stories/shared-components/tooltip/Tooltip.stories.scss
@@ -15,7 +15,7 @@
   margin-left: calc(100vw - 200px);
   width: 100px;
   height: 100px;
-  background-color: $ens-grey;
+  background-color: $grey;
   user-select: 'none';
   cursor: 'pointer';
 }
@@ -101,13 +101,13 @@
   position: relative;
   height: 600px;
   width: 600px;
-  background: $ens-light-grey;
+  background: $light-grey;
 }
 
 .positioningStoryItem {
   position: absolute;
   padding: 1.5em;
-  background: $ens-grey;
+  background: $grey;
 }
 
 .positioningStoryItemTopLeft {


### PR DESCRIPTION
<!--
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This will normally be the development branch, so please ask your reviewer if you think it needs to go somewhere else. 
-->

## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

(Not sure - really just a code cleanup.)

## Related JIRA Issue(s)
<!--_Please provide the URL(s) for any JIRA issues related to this PR._-->
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-205 (not directly relevant, but I want to make sure the CSS is clean before I start making major edits)

## Importance
<!-- Please explain briefly if this PR specifically needs more importance and also if there is any due date by which it needs to be merged. -->
This is only urgent in the sense that any new or updated components with colour variables in the CSS will be incompatible with this branch (see Complications, below).

## Description
<!--
_Using one or more sentences, describe the proposed changes and the reason for making them._
-->
I have removed the 'ens-' prefix from all the colour variable names. It made sense to use this prefix when we still used Foundation, to avoid name clashes, but now the longer names just make the CSS harder to read. There was also a potential confusion between $white (#fefefe) and $ens-white (#fff), which this PR fixes by renaming them $off-white and $white respectively.

## Views affected
<!--
_List the website view(s) that you know are affected by this change._
_If possible please provide a relative or localhost URL that can be used to view the change._
-->
All views - colours should be (and are) completely unchanged, as the code change is behind-the-scenes.

### Other effects
<!--
_List any other functionality that may be affected or which requires additional changes, such as saved configurations. Please add an explanation if, for example, no test is needed._
-->
No automated tests needed, as this only affects cosmetic CSS. Browser and Storybook have been visually checked for issues and none found so far.

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
<!--
_We appreciate this can be difficult but please highlight any views that you think might possibly be adversely affected by this change. For example a change to the services or app-level changes have potential for widespread consequences._
-->
If any new components are merged in from branches that don't have this update, they will appear as black. However this can be avoided (after this PR is merged) by merging dev into your branch and updating any CSS colours before submitting your PR.
