### PR TITLE
Send 'activity outside' action when user clicks anywhere outside z-menu

### DIFF
--- a/src/ensembl/src/content/app/browser/zmenu/Zmenu.tsx
+++ b/src/ensembl/src/content/app/browser/zmenu/Zmenu.tsx
@@ -1,10 +1,13 @@
-import React from 'react';
+import React, { useRef } from 'react';
+
+import browserMessagingService from 'src/content/app/browser/browser-messaging-service';
+import useOutsideClick from 'src/shared/hooks/useOutsideClick';
 
 import ZmenuContent from './ZmenuContent';
 
 import styles from './Zmenu.scss';
 
-import { ZmenuData, AnchorCoordinates } from './zmenu-types';
+import { ZmenuData, ZmenuAction, AnchorCoordinates } from './zmenu-types';
 
 const TIP_WIDTH = 18;
 const TIP_HEIGHT = 13;
@@ -35,6 +38,15 @@ type GetInlineStylesParams = {
 };
 
 const Zmenu = (props: Props) => {
+  const onOutsideClick = () =>
+    browserMessagingService.send('bpane-zmenu', {
+      id: props.id,
+      action: ZmenuAction.ACTIVITY_OUTSIDE
+    });
+  const zmenuRef = useRef<HTMLDivElement>(null);
+
+  useOutsideClick(zmenuRef, onOutsideClick);
+
   const direction = chooseDirection(props);
   const inlineStyles = getInlineStyles({
     direction,
@@ -45,6 +57,7 @@ const Zmenu = (props: Props) => {
     <div
       className={styles.zmenuWrapper}
       style={inlineStyles.body}
+      ref={zmenuRef}
       onMouseEnter={() => props.onEnter(props.id)}
       onMouseLeave={() => props.onLeave(props.id)}
     >

--- a/src/ensembl/src/content/app/browser/zmenu/zmenu-types.ts
+++ b/src/ensembl/src/content/app/browser/zmenu/zmenu-types.ts
@@ -25,6 +25,7 @@ export enum Markup {
 export enum ZmenuAction {
   CREATE = 'create_zmenu',
   DESTROY = 'destroy_zmenu',
+  ACTIVITY_OUTSIDE = 'zmenu_activity_outside',
   REPOSITION = 'update_zmenu_position',
   ENTER = 'zmenu-enter',
   LEAVE = 'zmenu-leave'
@@ -71,6 +72,13 @@ export type ZmenuDestroyPayload = {
 export type ZmenuEnterPayload = {
   id: string;
   action: ZmenuAction.ENTER;
+};
+
+// Sent from React to Genome browser
+// (on mouseleave, or on click outside)
+export type ZmenuOutsideActivityPayload = {
+  id: string;
+  action: ZmenuAction.ACTIVITY_OUTSIDE;
 };
 
 // Sent from React to Genome browser


### PR DESCRIPTION
## Type
- Improvement to existing feature

## Description
Zmenu needs to close when user clicks anywhere outside of it.
Currently, zmenu closes only when user click on some other point of genome browser image. This is because genome browser controls registers clicks and decides how to respond (e.g., it commands zmenu to close down). But since genome browser does not control area outside of its container, and since user can click anywhere on the screen, we need to delegate responsibility for listening of outside clicks to the zmenu itself, and when it registers an outside click it should notify genome browser of it, so that it can then send a command to close this zmenu.

## Views affected
Genome browser.