### PR TITLE
Fix zmenu styles

### DIFF
--- a/src/ensembl/src/content/app/browser/zmenu/Zmenu.scss
+++ b/src/ensembl/src/content/app/browser/zmenu/Zmenu.scss
@@ -9,9 +9,6 @@ $zmenuBackgroundColor: $ens-black;
 
 .zmenu {
   position: relative;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
   padding: 12px 20px;
   color: $ens-white;
   background-color: $zmenuBackgroundColor;
@@ -36,6 +33,7 @@ $zmenuBackgroundColor: $ens-black;
 
 .zmenuContentLine {
   display: block;
+  white-space: nowrap;
 }
 
 .zmenuContentBlock {


### PR DESCRIPTION
## Type
- Bug fix

## Related JIRA Issue(s)
ENSWBSITES-317

## Description
Problem with zmenu styles that we are currently seeing:

If zmenu opens far enough from the right border of browser image, it is displayed correctly:

![image](https://user-images.githubusercontent.com/6834224/64168299-1f040a80-ce43-11e9-957e-8a950ca2217f.png)

But if it opens close to the right border, its lines tend to wrap to wrap producing a taller and narrower zmenu:

![image](https://user-images.githubusercontent.com/6834224/64168785-3263a580-ce44-11e9-8a2b-2ea61df5d933.png)


I am not entirely sure why this is happening, but one way to stop it from happening is by preventing lines from wrapping.


## Views affected
Genome browser
