### PR TITLE
Refactor trackPanel state and update TrackPanelListItem

### DIFF
--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.test.tsx
@@ -61,7 +61,6 @@ describe('<BrowserBar />', () => {
     isTrackPanelOpened: false,
     isFocusObjectInDefaultPosition: true,
     closeDrawer: jest.fn(),
-    selectTrackPanelTabAndSave: jest.fn(),
     toggleTrackPanel: jest.fn(),
     changeFocusObject: jest.fn()
   };

--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
@@ -32,7 +32,7 @@ import {
   getIsTrackPanelOpened
 } from '../track-panel/trackPanelSelectors';
 import {
-  selectTrackPanelTabAndSave,
+  selectTrackPanelTab,
   toggleTrackPanel
 } from '../track-panel/trackPanelActions';
 import { closeDrawer } from '../drawer/drawerActions';
@@ -67,7 +67,7 @@ type StateProps = {
 
 type DispatchProps = {
   closeDrawer: () => void;
-  selectTrackPanelTabAndSave: (selectedTrackPanelTab: TrackSet) => void;
+  selectTrackPanelTab: (selectedTrackPanelTab: TrackSet) => void;
   toggleBrowserNav: () => void;
   toggleGenomeSelector: (genomeSelectorActive: boolean) => void;
   toggleTrackPanel: (isTrackPanelOpened: boolean) => void;
@@ -188,7 +188,7 @@ export const BrowserBar: FunctionComponent<BrowserBarProps> = (
           ensObject={props.ensObject}
           isDrawerOpened={props.isDrawerOpened}
           genomeSelectorActive={props.genomeSelectorActive}
-          selectTrackPanelTabAndSave={props.selectTrackPanelTabAndSave}
+          selectTrackPanelTab={props.selectTrackPanelTab}
           selectedTrackPanelTab={props.selectedTrackPanelTab}
           toggleTrackPanel={props.toggleTrackPanel}
           isTrackPanelModalOpened={props.isTrackPanelModalOpened}
@@ -265,7 +265,7 @@ const mapStateToProps = (state: RootState): StateProps => ({
 
 const mapDispatchToProps: DispatchProps = {
   closeDrawer,
-  selectTrackPanelTabAndSave,
+  selectTrackPanelTab,
   toggleBrowserNav,
   toggleGenomeSelector,
   toggleTrackPanel,

--- a/src/ensembl/src/content/app/browser/browser-storage-service.test.ts
+++ b/src/ensembl/src/content/app/browser/browser-storage-service.test.ts
@@ -87,33 +87,34 @@ describe('BrowserStorageService', () => {
     });
   });
 
-  describe('.getTrackListToggleStates()', () => {
-    it('gets saved track list toggle states from storage service', () => {
+  describe('.getTrackPanels()', () => {
+    it('gets saved track panels configuration from storage service', () => {
+      const mockTrackPanels = { foo: 'doesnt really matter' };
       jest
         .spyOn(mockStorageService, 'get')
-        .mockImplementation(() => trackListToggleStates);
+        .mockImplementation(() => mockTrackPanels);
 
       const browserStorageService = new BrowserStorageService(
         mockStorageService
       );
 
-      const result = browserStorageService.getTrackListToggleStates();
+      const result = browserStorageService.getTrackPanels();
 
       expect(mockStorageService.get).toHaveBeenCalledWith(
-        StorageKeys.TRACK_LIST_TOGGLE_STATES
+        StorageKeys.TRACK_PANELS
       );
-      expect(result).toEqual(trackListToggleStates);
+      expect(result).toEqual(mockTrackPanels);
 
       mockStorageService.get.mockRestore();
     });
 
-    it('returns an empty object if there are no saved track list toggle states', () => {
+    it('returns an empty object if there are no saved track panel configurations', () => {
       jest.spyOn(mockStorageService, 'get').mockImplementation(() => null);
 
       const browserStorageService = new BrowserStorageService(
         mockStorageService
       );
-      const result = browserStorageService.getTrackListToggleStates();
+      const result = browserStorageService.getTrackPanels();
 
       expect(result).toEqual({});
 
@@ -121,72 +122,18 @@ describe('BrowserStorageService', () => {
     });
   });
 
-  describe('.updateTrackListToggleStates()', () => {
-    it('updates track list toggle states via storage service', () => {
+  describe('.updateTrackPanels()', () => {
+    it('updates stored track panel configurations', () => {
+      const mockTrackPanels = { foo: {} };
       const browserStorageService = new BrowserStorageService(
         mockStorageService
       );
 
-      const toggledTrackState = { homo_sapiens38: { 'gene-feat': true } };
-
-      browserStorageService.updateTrackListToggleStates(toggledTrackState);
+      browserStorageService.updateTrackPanels(mockTrackPanels);
 
       expect(mockStorageService.update).toHaveBeenCalledWith(
-        StorageKeys.TRACK_LIST_TOGGLE_STATES,
-        toggledTrackState
-      );
-    });
-  });
-
-  describe('.getSelectedTrackPanelTab()', () => {
-    it('gets saved selected browser tab from storage service', () => {
-      jest
-        .spyOn(mockStorageService, 'get')
-        .mockImplementation(() => SELECTED_TRACK_PANEL_TAB);
-
-      const browserStorageService = new BrowserStorageService(
-        mockStorageService
-      );
-
-      const result = browserStorageService.getSelectedTrackPanelTab();
-
-      expect(mockStorageService.get).toHaveBeenCalledWith(
-        StorageKeys.SELECTED_TRACK_PANEL_TAB
-      );
-      expect(result).toEqual(SELECTED_TRACK_PANEL_TAB);
-
-      mockStorageService.get.mockRestore();
-    });
-
-    it('returns "GENOMIC" if there is no saved selected browser tab', () => {
-      jest.spyOn(mockStorageService, 'get').mockImplementation(() => null);
-
-      const browserStorageService = new BrowserStorageService(
-        mockStorageService
-      );
-      const result = browserStorageService.getSelectedTrackPanelTab();
-
-      expect(result).toEqual({});
-
-      mockStorageService.get.mockRestore();
-    });
-  });
-
-  describe('.updateSelectedTrackPanelTab()', () => {
-    it('updates selected browser tab via storage service', () => {
-      const browserStorageService = new BrowserStorageService(
-        mockStorageService
-      );
-
-      browserStorageService.updateSelectedTrackPanelTab({
-        homo_sapiens38: TrackSet.EXPRESSION
-      });
-
-      expect(mockStorageService.update).toHaveBeenCalledWith(
-        StorageKeys.SELECTED_TRACK_PANEL_TAB,
-        {
-          homo_sapiens38: TrackSet.EXPRESSION
-        }
+        StorageKeys.TRACK_PANELS,
+        mockTrackPanels
       );
     });
   });

--- a/src/ensembl/src/content/app/browser/browser-storage-service.ts
+++ b/src/ensembl/src/content/app/browser/browser-storage-service.ts
@@ -1,12 +1,12 @@
 import storageService, {
   StorageServiceInterface
 } from 'src/services/storage-service';
-import {
-  TrackStates,
-  TrackSet,
-  TrackToggleStates
-} from './track-panel/trackPanelConfig';
+import { TrackStates, TrackSet } from './track-panel/trackPanelConfig';
 import { ChrLocations } from './browserState';
+import {
+  TrackPanelState,
+  TrackPanelStateForGenome
+} from 'src/content/app/browser/track-panel/trackPanelState';
 
 export enum StorageKeys {
   ACTIVE_GENOME_ID = 'browser.activeGenomeId',
@@ -14,7 +14,8 @@ export enum StorageKeys {
   CHR_LOCATION = 'browser.chrLocation',
   DEFAULT_CHR_LOCATION = 'browser.defaultChrLocation',
   TRACK_STATES = 'browser.trackStates',
-  TRACK_LIST_TOGGLE_STATES = 'browser.trackListToggleStates',
+  TRACK_PANELS = 'browser.trackPanels',
+  COLLAPSED_TRACK_IDS = 'browser.collapsedTrackIds',
   SELECTED_TRACK_PANEL_TAB = 'browser.selectedTrackPanelTab'
 }
 
@@ -25,7 +26,7 @@ export class BrowserStorageService {
     this.storageService = storageService;
   }
 
-  public getActiveGenomeId(): string {
+  public getActiveGenomeId(): string | null {
     return this.storageService.get(StorageKeys.ACTIVE_GENOME_ID);
   }
 
@@ -62,23 +63,22 @@ export class BrowserStorageService {
     this.storageService.save(StorageKeys.TRACK_STATES, trackStates);
   }
 
-  public getTrackListToggleStates() {
-    return this.storageService.get(StorageKeys.TRACK_LIST_TOGGLE_STATES) || {};
+  public getCollapsedTrackIds() {
+    return this.storageService.get(StorageKeys.COLLAPSED_TRACK_IDS) || {};
   }
 
-  public updateTrackListToggleStates(toggleState: {
-    [genomeId: string]: TrackToggleStates;
+  public updateCollapsedTrackIds(idsPerGenome: {
+    [genomeId: string]: string[];
   }) {
-    this.storageService.update(
-      StorageKeys.TRACK_LIST_TOGGLE_STATES,
-      toggleState
-    );
+    this.storageService.update(StorageKeys.COLLAPSED_TRACK_IDS, idsPerGenome);
   }
 
+  // FIXME delete
   public getSelectedTrackPanelTab(): { [genomeId: string]: TrackSet } {
     return this.storageService.get(StorageKeys.SELECTED_TRACK_PANEL_TAB) || {};
   }
 
+  // FIXME delete
   public updateSelectedTrackPanelTab(selectedTrackPanelTabForGenome: {
     [genomeId: string]: TrackSet;
   }) {
@@ -86,6 +86,16 @@ export class BrowserStorageService {
       StorageKeys.SELECTED_TRACK_PANEL_TAB,
       selectedTrackPanelTabForGenome
     );
+  }
+
+  public getTrackPanels(): { [genomeId: string]: Partial<TrackPanelState> } {
+    return this.storageService.get(StorageKeys.TRACK_PANELS) || {};
+  }
+
+  public updateTrackPanels(trackPanels: {
+    [genomeId: string]: Partial<TrackPanelStateForGenome>;
+  }): void {
+    this.storageService.update(StorageKeys.TRACK_PANELS, trackPanels);
   }
 }
 

--- a/src/ensembl/src/content/app/browser/browser-storage-service.ts
+++ b/src/ensembl/src/content/app/browser/browser-storage-service.ts
@@ -1,7 +1,7 @@
 import storageService, {
   StorageServiceInterface
 } from 'src/services/storage-service';
-import { TrackStates, TrackSet } from './track-panel/trackPanelConfig';
+import { TrackStates } from './track-panel/trackPanelConfig';
 import { ChrLocations } from './browserState';
 import {
   TrackPanelState,
@@ -71,21 +71,6 @@ export class BrowserStorageService {
     [genomeId: string]: string[];
   }) {
     this.storageService.update(StorageKeys.COLLAPSED_TRACK_IDS, idsPerGenome);
-  }
-
-  // FIXME delete
-  public getSelectedTrackPanelTab(): { [genomeId: string]: TrackSet } {
-    return this.storageService.get(StorageKeys.SELECTED_TRACK_PANEL_TAB) || {};
-  }
-
-  // FIXME delete
-  public updateSelectedTrackPanelTab(selectedTrackPanelTabForGenome: {
-    [genomeId: string]: TrackSet;
-  }) {
-    this.storageService.update(
-      StorageKeys.SELECTED_TRACK_PANEL_TAB,
-      selectedTrackPanelTabForGenome
-    );
   }
 
   public getTrackPanels(): { [genomeId: string]: Partial<TrackPanelState> } {

--- a/src/ensembl/src/content/app/browser/browser-storage-service.ts
+++ b/src/ensembl/src/content/app/browser/browser-storage-service.ts
@@ -15,7 +15,6 @@ export enum StorageKeys {
   DEFAULT_CHR_LOCATION = 'browser.defaultChrLocation',
   TRACK_STATES = 'browser.trackStates',
   TRACK_PANELS = 'browser.trackPanels',
-  COLLAPSED_TRACK_IDS = 'browser.collapsedTrackIds',
   SELECTED_TRACK_PANEL_TAB = 'browser.selectedTrackPanelTab'
 }
 
@@ -61,16 +60,6 @@ export class BrowserStorageService {
 
   public saveTrackStates(trackStates: TrackStates) {
     this.storageService.save(StorageKeys.TRACK_STATES, trackStates);
-  }
-
-  public getCollapsedTrackIds() {
-    return this.storageService.get(StorageKeys.COLLAPSED_TRACK_IDS) || {};
-  }
-
-  public updateCollapsedTrackIds(idsPerGenome: {
-    [genomeId: string]: string[];
-  }) {
-    this.storageService.update(StorageKeys.COLLAPSED_TRACK_IDS, idsPerGenome);
   }
 
   public getTrackPanels(): { [genomeId: string]: Partial<TrackPanelState> } {

--- a/src/ensembl/src/content/app/browser/browserReducer.ts
+++ b/src/ensembl/src/content/app/browser/browserReducer.ts
@@ -17,6 +17,7 @@ import {
   BrowserEntityState,
   defaultBrowserEntityState
 } from './browserState';
+import trackPanelReducer from 'src/content/app/browser/track-panel/trackPanelReducer';
 
 export function browserInfo(
   state: BrowserState = defaultBrowserState,
@@ -165,5 +166,6 @@ export default combineReducers({
   browserEntity,
   browserLocation,
   browserNav,
-  trackConfig
+  trackConfig,
+  trackPanel: trackPanelReducer
 });

--- a/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
@@ -8,7 +8,6 @@ import TrackPanelModal from './track-panel-modal/TrackPanelModal';
 import Drawer from '../drawer/Drawer';
 import { RootState } from 'src/store';
 
-import { toggleTrackPanel } from './trackPanelActions';
 import {
   getIsTrackPanelOpened,
   getIsTrackPanelModalOpened,
@@ -42,19 +41,10 @@ type TrackPanelProps = {
   selectedTrackPanelTab: TrackSet;
   genomeTrackCategories: GenomeTrackCategory[];
   trackStates: TrackStates;
-  toggleTrackPanel: (isTrackPanelOpened?: boolean) => void;
 };
 
 const TrackPanel = (props: TrackPanelProps) => {
   const { isDrawerOpened } = props;
-
-  useEffect(() => {
-    if (props.breakpointWidth !== BreakpointWidth.LARGE) {
-      props.toggleTrackPanel(false);
-    } else {
-      props.toggleTrackPanel(true);
-    }
-  }, [props.breakpointWidth, props.toggleTrackPanel]);
 
   const [trackAnimation, setTrackAnimation] = useSpring(() => ({
     config: { tension: 280, friction: 45 },
@@ -112,11 +102,4 @@ const mapStateToProps = (state: RootState) => {
   };
 };
 
-const mapDispatchToProps = {
-  toggleTrackPanel
-};
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(TrackPanel);
+export default connect(mapStateToProps)(TrackPanel);

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
@@ -39,7 +39,20 @@ import { ReactComponent as Ellipsis } from 'static/img/track-panel/ellipsis.svg'
 
 import styles from './TrackPanelListItem.scss';
 
-type Props = {
+type OwnProps = {
+  categoryName: string;
+  children?: ReactNode[];
+  trackStatus: ImageButtonStatus;
+  defaultTrackStatus: ImageButtonStatus;
+  track: EnsObjectTrack;
+};
+
+type PropsFromRedux = {
+  activeGenomeId: string | null;
+  isDrawerOpened: boolean;
+  drawerView: string;
+  highlightedTrackId: string;
+  isCollapsed: boolean;
   changeDrawerView: (drawerView: string) => void;
   toggleDrawer: (isDrawerOpened: boolean) => void;
   updateTrackStates: (payload: UpdateTrackStatesPayload) => void;
@@ -47,17 +60,9 @@ type Props = {
     trackId: string;
     isCollapsed: boolean;
   }) => void;
-  categoryName: string;
-  children?: ReactNode[];
-  trackStatus: ImageButtonStatus;
-  defaultTrackStatus: ImageButtonStatus;
-  track: EnsObjectTrack;
-  highlightedTrackId: string;
-  isCollapsed: boolean;
-  activeGenomeId: string | null;
-  isDrawerOpened: boolean;
-  drawerView: string;
 };
+
+type Props = OwnProps & PropsFromRedux;
 
 const TrackPanelListItem = (props: Props) => {
   const {
@@ -209,8 +214,7 @@ const TrackPanelListItem = (props: Props) => {
   );
 };
 
-// FIXME: ownProps
-const mapStateToProps = (state: RootState, ownProps: any) => ({
+const mapStateToProps = (state: RootState, ownProps: OwnProps) => ({
   activeGenomeId: getBrowserActiveGenomeId(state),
   isDrawerOpened: getIsDrawerOpened(state),
   drawerView: getDrawerView(state),

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
@@ -1,9 +1,12 @@
 import React, { MouseEvent, ReactNode, useState, useEffect } from 'react';
 import { connect } from 'react-redux';
-import { RootState } from 'src/store';
 import classNames from 'classnames';
 
+import { RootState } from 'src/store';
+
 import analyticsTracking from 'src/services/analytics-service';
+import browserMessagingService from 'src/content/app/browser/browser-messaging-service';
+
 import ImageButton, {
   ImageButtonStatus
 } from 'src/shared/components/image-button/ImageButton';
@@ -13,14 +16,18 @@ import {
   TrackItemColourKey,
   TrackId
 } from '../trackPanelConfig';
+
 import {
   updateTrackStatesAndSave,
   UpdateTrackStatesPayload
 } from 'src/content/app/browser/browserActions';
+import { updateCollapsedTrackIds } from 'src/content/app/browser/track-panel/trackPanelActions';
 import { changeDrawerView, toggleDrawer } from '../../drawer/drawerActions';
-import browserMessagingService from 'src/content/app/browser/browser-messaging-service';
-import { gethighlightedTrackId } from 'src/content/app/browser/track-panel/trackPanelSelectors';
-import browserStorageService from '../../browser-storage-service';
+
+import {
+  getHighlightedTrackId,
+  isTrackCollapsed
+} from 'src/content/app/browser/track-panel/trackPanelSelectors';
 import { EnsObjectTrack } from 'src/ens-object/ensObjectTypes';
 import { getIsDrawerOpened, getDrawerView } from '../../drawer/drawerSelectors';
 import { getBrowserActiveGenomeId } from '../../browserSelectors';
@@ -36,19 +43,23 @@ type Props = {
   changeDrawerView: (drawerView: string) => void;
   toggleDrawer: (isDrawerOpened: boolean) => void;
   updateTrackStates: (payload: UpdateTrackStatesPayload) => void;
+  updateCollapsedTrackIds: (payload: {
+    trackId: string;
+    isCollapsed: boolean;
+  }) => void;
   categoryName: string;
   children?: ReactNode[];
   trackStatus: ImageButtonStatus;
   defaultTrackStatus: ImageButtonStatus;
   track: EnsObjectTrack;
   highlightedTrackId: string;
+  isCollapsed: boolean;
   activeGenomeId: string | null;
   isDrawerOpened: boolean;
   drawerView: string;
 };
 
 const TrackPanelListItem = (props: Props) => {
-  const [expanded, setExpanded] = useState(true);
   const {
     activeGenomeId,
     categoryName,
@@ -62,19 +73,6 @@ const TrackPanelListItem = (props: Props) => {
     const { defaultTrackStatus } = props;
     if (trackStatus !== defaultTrackStatus) {
       updateGenomeBrowser(trackStatus);
-    }
-  }, []);
-
-  useEffect(() => {
-    const trackToggleStates = browserStorageService.getTrackListToggleStates();
-
-    if (
-      activeGenomeId &&
-      track.child_tracks &&
-      trackToggleStates[activeGenomeId] &&
-      trackToggleStates[activeGenomeId][track.track_id] !== undefined
-    ) {
-      setExpanded(trackToggleStates[activeGenomeId][track.track_id]);
     }
   }, []);
 
@@ -123,11 +121,9 @@ const TrackPanelListItem = (props: Props) => {
   };
 
   const toggleExpand = () => {
-    setExpanded(!expanded);
-
-    browserStorageService.updateTrackListToggleStates({
-      [activeGenomeId as string]: { [track.track_id]: !expanded }
-    });
+    const { track_id: trackId } = props.track;
+    const { isCollapsed } = props;
+    props.updateCollapsedTrackIds({ trackId, isCollapsed: !isCollapsed });
   };
 
   const toggleTrack = () => {
@@ -185,8 +181,8 @@ const TrackPanelListItem = (props: Props) => {
           {track.child_tracks && (
             <button onClick={toggleExpand} className={styles.expandBtn}>
               <img
-                src={expanded ? chevronUpIcon : chevronDownIcon}
-                alt={expanded ? 'collapse' : 'expand'}
+                src={props.isCollapsed ? chevronDownIcon : chevronUpIcon}
+                alt={props.isCollapsed ? 'expand' : 'collapse'}
               />
             </button>
           )}
@@ -208,19 +204,22 @@ const TrackPanelListItem = (props: Props) => {
           />
         </div>
       </dd>
-      {expanded && props.children}
+      {!props.isCollapsed && props.children}
     </>
   );
 };
 
-const mapStateToProps = (state: RootState) => ({
+// FIXME: ownProps
+const mapStateToProps = (state: RootState, ownProps: any) => ({
   activeGenomeId: getBrowserActiveGenomeId(state),
   isDrawerOpened: getIsDrawerOpened(state),
   drawerView: getDrawerView(state),
-  highlightedTrackId: gethighlightedTrackId(state)
+  highlightedTrackId: getHighlightedTrackId(state),
+  isCollapsed: isTrackCollapsed(state, ownProps.track.track_id)
 });
 
 const mapDispatchToProps = {
+  updateCollapsedTrackIds,
   changeDrawerView,
   toggleDrawer,
   updateTrackStates: updateTrackStatesAndSave

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-tabs/TrackPanelTabs.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-tabs/TrackPanelTabs.tsx
@@ -11,7 +11,7 @@ type TrackPanelTabsProps = {
   ensObject: EnsObject;
   isDrawerOpened: boolean;
   genomeSelectorActive: boolean;
-  selectTrackPanelTabAndSave: (selectedTrackPanelTab: TrackSet) => void;
+  selectTrackPanelTab: (selectedTrackPanelTab: TrackSet) => void;
   selectedTrackPanelTab: TrackSet;
   toggleTrackPanel: (isTrackPanelOpened: boolean) => void;
   isTrackPanelModalOpened: boolean;
@@ -32,7 +32,7 @@ const TrackPanelTabs = (props: TrackPanelTabsProps) => {
       props.closeDrawer();
     }
 
-    props.selectTrackPanelTabAndSave(value);
+    props.selectTrackPanelTab(value);
   };
 
   const getTrackPanelTabClassNames = (trackSet: TrackSet) => {

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.test.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.test.ts
@@ -1,0 +1,59 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import faker from 'faker';
+
+import browserStorageService from 'src/content/app/browser/browser-storage-service';
+
+import * as trackPanelActions from './trackPanelActions';
+import {
+  pickPersistentTrackPanelProperties,
+  TrackPanelStateForGenome
+} from './trackPanelState';
+import { TrackSet } from './trackPanelConfig';
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+const trackPanelProperties: TrackPanelStateForGenome = {
+  isTrackPanelModalOpened: faker.random.boolean(),
+  selectedTrackPanelTab: TrackSet.GENOMIC,
+  trackPanelModalView: faker.lorem.word(),
+  highlightedTrackId: faker.lorem.word(),
+  isTrackPanelOpened: faker.random.boolean(),
+  collapsedTrackIds: [faker.lorem.word()]
+};
+
+describe('track panel actions', () => {
+  beforeEach(() => {
+    jest.spyOn(browserStorageService, 'updateTrackPanels');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('updateTrackPanelForGenome', () => {
+    it('saves a subset of track panel properties every time it‘s called', () => {
+      const store = mockStore({});
+      const genomeId = faker.random.word();
+
+      store.dispatch(
+        trackPanelActions.updateTrackPanelForGenome({
+          activeGenomeId: genomeId,
+          data: trackPanelProperties
+        })
+      );
+
+      expect(browserStorageService.updateTrackPanels).toHaveBeenCalledTimes(1);
+
+      const storedPayload = (browserStorageService.updateTrackPanels as any)
+        .mock.calls[0][0];
+      const storedData = storedPayload[genomeId];
+
+      const allowedProperties = pickPersistentTrackPanelProperties(
+        trackPanelProperties
+      );
+      expect(storedData).toEqual(allowedProperties);
+    });
+  });
+});

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
@@ -49,8 +49,7 @@ export const toggleTrackPanel: ActionCreator<
   );
 };
 
-// FIXME name
-export const selectTrackPanelTabAndSave: ActionCreator<
+export const selectTrackPanelTab: ActionCreator<
   ThunkAction<void, any, null, Action<string>>
 > = (selectedTrackPanelTab: TrackSet) => (
   dispatch,

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
@@ -1,4 +1,4 @@
-import { createAction, createStandardAction } from 'typesafe-actions';
+import { createAction } from 'typesafe-actions';
 import { ThunkAction } from 'redux-thunk';
 import { Action, ActionCreator } from 'redux';
 import uniq from 'lodash/uniq';
@@ -49,6 +49,7 @@ export const toggleTrackPanel: ActionCreator<
   );
 };
 
+// FIXME name
 export const selectTrackPanelTabAndSave: ActionCreator<
   ThunkAction<void, any, null, Action<string>>
 > = (selectedTrackPanelTab: TrackSet) => (
@@ -60,10 +61,6 @@ export const selectTrackPanelTabAndSave: ActionCreator<
   if (!activeGenomeId) {
     return;
   }
-
-  browserStorageService.updateSelectedTrackPanelTab({
-    [activeGenomeId]: selectedTrackPanelTab
-  });
 
   analyticsTracking.trackEvent({
     category: 'track_panel_tab',

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelConfig.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelConfig.ts
@@ -37,10 +37,6 @@ export type TrackStates = {
   };
 };
 
-export type TrackToggleStates = {
-  [key: string]: boolean;
-};
-
 export enum TrackId {
   GENE = 'track:gene-feat'
 }

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelReducer.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelReducer.ts
@@ -1,17 +1,30 @@
 import { ActionType, getType } from 'typesafe-actions';
 
-import { TrackPanelState, defaultTrackPanelState } from './trackPanelState';
+import {
+  getInitialTrackPanelState,
+  getTrackPanelStateForGenome,
+  TrackPanelState
+} from './trackPanelState';
+import * as browserActions from 'src/content/app/browser/browserActions';
 import * as trackPanelActions from './trackPanelActions';
 
 export default function trackPanel(
-  state: TrackPanelState = defaultTrackPanelState,
-  action: ActionType<typeof trackPanelActions>
+  state: TrackPanelState = getInitialTrackPanelState(),
+  action:
+    | ActionType<typeof trackPanelActions>
+    | ActionType<typeof browserActions>
 ): TrackPanelState {
   switch (action.type) {
+    case getType(browserActions.updateBrowserActiveGenomeId):
+      return {
+        ...state,
+        [action.payload]: getTrackPanelStateForGenome(action.payload)
+      };
     case getType(trackPanelActions.updateTrackPanelForGenome):
       return {
         ...state,
         [action.payload.activeGenomeId]: {
+          ...state[action.payload.activeGenomeId],
           ...action.payload.data
         }
       };

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelSelectors.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelSelectors.ts
@@ -4,11 +4,10 @@ import { defaultTrackPanelStateForGenome } from './trackPanelState';
 
 export const getActiveTrackPanel = (state: RootState) => {
   const activeGenomeId = getBrowserActiveGenomeId(state);
-  const activeTrackPanel = activeGenomeId && state.trackPanel[activeGenomeId];
+  const activeTrackPanel =
+    activeGenomeId && state.browser.trackPanel[activeGenomeId];
 
-  return activeGenomeId && activeTrackPanel
-    ? state.trackPanel[activeGenomeId]
-    : defaultTrackPanelStateForGenome;
+  return activeTrackPanel || defaultTrackPanelStateForGenome;
 };
 
 export const getIsTrackPanelModalOpened = (state: RootState) =>
@@ -23,5 +22,10 @@ export const getSelectedTrackPanelTab = (state: RootState) =>
 export const getIsTrackPanelOpened = (state: RootState) =>
   getActiveTrackPanel(state).isTrackPanelOpened;
 
-export const gethighlightedTrackId = (state: RootState) =>
+export const getHighlightedTrackId = (state: RootState) =>
   getActiveTrackPanel(state).highlightedTrackId;
+
+export const isTrackCollapsed = (state: RootState, trackId: string) => {
+  const trackPanel = getActiveTrackPanel(state);
+  return trackPanel.collapsedTrackIds.includes(trackId);
+};

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
@@ -7,6 +7,7 @@ export type TrackPanelStateForGenome = Readonly<{
   selectedTrackPanelTab: TrackSet;
   trackPanelModalView: string;
   highlightedTrackId: string;
+  collapsedTrackIds: string[];
 }>;
 
 export type TrackPanelState = Readonly<{
@@ -20,7 +21,8 @@ export const defaultTrackPanelStateForGenome: TrackPanelStateForGenome = {
   selectedTrackPanelTab: TrackSet.GENOMIC,
   trackPanelModalView: '',
   highlightedTrackId: '',
-  isTrackPanelOpened: false
+  isTrackPanelOpened: false,
+  collapsedTrackIds: []
 };
 
 export const defaultTrackPanelState: TrackPanelState = Object.keys(

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
@@ -1,3 +1,5 @@
+import pick from 'lodash/pick';
+
 import { TrackSet } from './trackPanelConfig';
 import browserStorageService from '../browser-storage-service';
 
@@ -14,8 +16,6 @@ export type TrackPanelState = Readonly<{
   [genomeId: string]: TrackPanelStateForGenome;
 }>;
 
-const selectedTrackPanelTabFromStorage = browserStorageService.getSelectedTrackPanelTab();
-
 export const defaultTrackPanelStateForGenome: TrackPanelStateForGenome = {
   isTrackPanelModalOpened: false,
   selectedTrackPanelTab: TrackSet.GENOMIC,
@@ -25,15 +25,29 @@ export const defaultTrackPanelStateForGenome: TrackPanelStateForGenome = {
   collapsedTrackIds: []
 };
 
-export const defaultTrackPanelState: TrackPanelState = Object.keys(
-  selectedTrackPanelTabFromStorage
-).reduce(
-  (state: TrackPanelState, genomeId: string) => ({
-    ...state,
-    [genomeId]: {
-      ...defaultTrackPanelStateForGenome,
-      selectedTrackPanelTab: selectedTrackPanelTabFromStorage[genomeId]
-    }
-  }),
-  {}
-);
+export const getInitialTrackPanelState = (): TrackPanelState => {
+  const genomeId = browserStorageService.getActiveGenomeId();
+  return genomeId ? { [genomeId]: getTrackPanelStateForGenome(genomeId) } : {};
+};
+
+export const getTrackPanelStateForGenome = (
+  genomeId: string
+): TrackPanelStateForGenome => {
+  const storedTrackPanel =
+    browserStorageService.getTrackPanels()[genomeId] || {};
+  return {
+    ...defaultTrackPanelStateForGenome,
+    ...storedTrackPanel
+  };
+};
+
+export const pickPersistentTrackPanelProperties = (
+  trackPanel: Partial<TrackPanelStateForGenome>
+) => {
+  const persistentProperties = [
+    'selectedTrackPanelTab',
+    'isTrackPanelOpened',
+    'collapsedTrackIds'
+  ];
+  return pick(trackPanel, persistentProperties);
+};

--- a/src/ensembl/src/root/rootReducer.ts
+++ b/src/ensembl/src/root/rootReducer.ts
@@ -8,7 +8,6 @@ import customDownload from '../content/app/custom-download/state/customDownloadR
 import global from '../global/globalReducer';
 import header from '../header/headerReducer';
 import ensObjects from '../ens-object/ensObjectReducer';
-import trackPanel from '../content/app/browser/track-panel/trackPanelReducer';
 import speciesSelector from '../content/app/species-selector/state/speciesSelectorReducer';
 
 const rootReducer = (history: any) =>
@@ -21,7 +20,6 @@ const rootReducer = (history: any) =>
     global,
     header,
     router: connectRouter(history),
-    trackPanel,
     speciesSelector
   });
 


### PR DESCRIPTION
## Type
- Bug fix
- Refactoring

## Related JIRA Issue(s)
ENSWBSITES-176

## Description
This PR is trying to solve the following problems:

1. **Bug.** Steps to reproduce:
- select 2 species
- go to genome browser
- view an example object for both species
- refresh browser
- switch from one species to the other
- notice that track panel collapses when doing so
_(the reason is, at this point, there is no track panel configuration for the other species in the redux state)_

2. Andrea's Instructions on which parts of track panel state should be preserved between browser sessions (unique per species):
- whether the track panel is open or closed
- which track panel tab is active
- which tracks in the track panel are expanded or collapsed

3. Code structure
Currently, the TrackPanelListItem component is trying to directly store data about whether it's expanded or collapsed, and read this data from local storage upon mounting. I am moving this logic to redux.

## Views affected
Genome browser