### PR TITLE
Fix cropping of the tooltip by the launchbar

### DIFF
--- a/src/ensembl/src/header/launchbar/Launchbar.scss
+++ b/src/ensembl/src/header/launchbar/Launchbar.scss
@@ -6,7 +6,10 @@
   border-bottom: 1px solid $grey;
   border-top: 1px solid $grey;
   padding: 11px 6px;
-  overflow-x: auto;
+
+  @media screen and (max-width: 700px) {
+    overflow-x: auto;
+  }
 }
 
 .categoriesWrapper {


### PR DESCRIPTION
## Type
- Bug fix

## Description
**Problem:** tooltip is not visible while hovering over a launchbar item (only the end of the tip can be seen):

![image](https://user-images.githubusercontent.com/6834224/64699145-0f686f80-d49c-11e9-8f5b-e4df3e0cfd0c.png)

**Cause:** the launchbar element currently has an `overflow-x: auto` CSS rule. Perversely, this does not let the absolutely positioned tooltip leave the container.

Here's [reproduction](https://jsfiddle.net/ax5qwbhv/2/) of this problem in a playground (notice how the red square cannot leave the yellow container).

One temporary solution is to add a media query, so that overflow-x is added only at the screen size that will need it. This solution will allow us to release the code for this sprint; and then think of a better solution (if one exists).

## Views affected
All