### PR TITLE
Update hard-coded track ids in the Drawer component

### DIFF
--- a/src/ensembl/src/content/app/browser/drawer/Drawer.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/Drawer.tsx
@@ -33,8 +33,6 @@ const Drawer = (props: DrawerProps) => {
     return null;
   }
 
-  console.log('ensObject', ensObject);
-
   const getDrawerViewComponent = () => {
     switch (drawerView) {
       case 'track:gene-feat':


### PR DESCRIPTION
## Type
- Bug fix

## Related JIRA Issue(s)
ENSWBSITES-335

## Description
**Bug:** the drawer is empty, both for genes and transcripts:

![image](https://user-images.githubusercontent.com/6834224/64794358-44e08c00-d574-11e9-9deb-1587e7cdcfa7.png)

**Cause:**
Track ids used for deciding what to show in the drawer are hard-coded. When the server switched to the new pattern for track ids, it broke the drawer.

## Views affected
Genome browser