### PR TITLE
Update Home page

### DIFF
--- a/src/ensembl/src/content/app/browser/browserActions.ts
+++ b/src/ensembl/src/content/app/browser/browserActions.ts
@@ -85,7 +85,7 @@ export const setDataFromUrlAndSave: ActionCreator<
     });
 };
 
-export const getDataForLastVisitedObjects: ActionCreator<
+export const fetchDataForLastVisitedObjects: ActionCreator<
   ThunkAction<void, any, null, Action<string>>
 > = () => async (dispatch, getState: () => RootState) => {
   const state = getState();

--- a/src/ensembl/src/content/app/browser/browserActions.ts
+++ b/src/ensembl/src/content/app/browser/browserActions.ts
@@ -85,6 +85,15 @@ export const setDataFromUrlAndSave: ActionCreator<
     });
 };
 
+export const getDataForLastVisitedObjects: ActionCreator<
+  ThunkAction<void, any, null, Action<string>>
+> = () => async (dispatch, getState: () => RootState) => {
+  const state = getState();
+  const activeEnsObjectIdsMap = getBrowserActiveEnsObjectIds(state);
+  const activeEnsObjectIds = Object.values(activeEnsObjectIdsMap);
+  activeEnsObjectIds.forEach((id) => dispatch(fetchEnsObject(id)));
+};
+
 export const updateBrowserActiveGenomeId = createStandardAction(
   'browser/update-active-genome-id'
 )<string>();

--- a/src/ensembl/src/content/home/Home.scss
+++ b/src/ensembl/src/content/home/Home.scss
@@ -22,12 +22,11 @@
 
   input[type='text'] {
     border: none;
-    box-shadow: inset 3px 3px 10px $grey;
-    color: $dark-grey;
-    font-size: 14px;
+    width: 100%;
+    max-width: 485px;
+    height: 36px;
+    box-shadow: inset 2px 2px 4px -2px $dark-grey;
     padding: 12px 20px;
-    min-width: 300px;
-    width: 30%;
 
     &::placeholder {
       color: $grey;
@@ -54,7 +53,6 @@
 
 .previouslyViewedItemAssemblyName {
   color: $medium-dark-grey;
-  // font-weight: bold;
   font-size: 11px;
   margin-left: 0.2em;
 }

--- a/src/ensembl/src/content/home/Home.scss
+++ b/src/ensembl/src/content/home/Home.scss
@@ -28,6 +28,10 @@
     padding: 12px 20px;
     min-width: 300px;
     width: 30%;
+
+    &::placeholder {
+      color: $grey;
+    }
   }
 
   button {
@@ -37,15 +41,22 @@
     padding: 8px 24px;
     text-transform: uppercase;
   }
-
-  .filter {
-    padding-top: 2%;
-  }
 }
 
 .previouslyViewed {
-  line-height: 2.5;
+  line-height: 2;
   padding: 15px 80px;
+}
+
+.previouslyViewedItem {
+  margin-left: 40px;
+}
+
+.previouslyViewedItemAssemblyName {
+  color: $medium-dark-grey;
+  // font-weight: bold;
+  font-size: 11px;
+  margin-left: 0.2em;
 }
 
 .siteMessage {
@@ -56,15 +67,17 @@
     color: $grey;
     font-size: 13px;
     font-weight: $normal;
-    margin-bottom: 30px;
+    margin-bottom: 0.8em;
   }
 
   p {
     font-size: 13px;
+    margin: 0;
+    line-height: 1.5;
   }
 
   .convoMessage {
-    margin-top: 30px;
+    margin-top: 1em;
   }
 }
 

--- a/src/ensembl/src/content/home/Home.tsx
+++ b/src/ensembl/src/content/home/Home.tsx
@@ -6,16 +6,18 @@ import upperFirst from 'lodash/upperFirst';
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import { RootState } from 'src/store';
 
+import { getDataForLastVisitedObjects } from 'src/content/app/browser/browserActions';
 import { fetchExampleEnsObjects } from 'src/ens-object/ensObjectActions';
-import { EnsObject } from 'src/ens-object/ensObjectTypes';
 import { getExampleEnsObjects } from 'src/ens-object/ensObjectSelectors';
 import { getGenomeInfo } from 'src/genome/genomeSelectors';
 import { getCommittedSpecies } from '../app/species-selector/state/speciesSelectorSelectors';
-import { CommittedItem } from '../app/species-selector/types/species-search';
-
 import { fetchGenomeInfo } from 'src/genome/genomeActions';
 import { getFormattedLocation } from 'src/shared/helpers/regionFormatter';
+import { getPreviouslyViewedGenomeBrowserObjects } from 'src/content/home/homePageSelectors';
+
+import { EnsObject } from 'src/ens-object/ensObjectTypes';
 import { GenomeInfoData } from 'src/genome/genomeTypes';
+import { CommittedItem } from '../app/species-selector/types/species-search';
 
 import styles from './Home.scss';
 
@@ -37,13 +39,15 @@ type HomeProps = StateProps & DispatchProps & OwnProps;
 
 const Home: FunctionComponent<HomeProps> = (props: HomeProps) => {
   const [showPreviouslyViewed, toggleShowPreviouslyViewed] = useState(false);
+  console.log('props', props);
 
   useEffect(() => {
     props.fetchGenomeInfo();
   }, [props.activeSpecies]);
 
   useEffect(() => {
-    props.fetchExampleEnsObjects();
+    props.getDataForLastVisitedObjects();
+    // props.fetchExampleEnsObjects();
   }, [props.genomeInfo]);
 
   useEffect(() => {
@@ -142,12 +146,16 @@ const mapStateToProps = (state: RootState) => ({
   activeSpecies: getCommittedSpecies(state),
   exampleEnsObjects: getExampleEnsObjects(state),
   totalSelectedSpecies: getCommittedSpecies(state).length,
-  genomeInfo: getGenomeInfo(state)
+  genomeInfo: getGenomeInfo(state),
+  previouslyViewedGenomeBrowserObjects: getPreviouslyViewedGenomeBrowserObjects(
+    state
+  )
 });
 
 const mapDispatchToProps = {
   fetchExampleEnsObjects,
-  fetchGenomeInfo
+  fetchGenomeInfo,
+  getDataForLastVisitedObjects
 };
 
 export default connect(

--- a/src/ensembl/src/content/home/Home.tsx
+++ b/src/ensembl/src/content/home/Home.tsx
@@ -1,17 +1,15 @@
-import React, { FunctionComponent, useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import { RootState } from 'src/store';
 
-import { getDataForLastVisitedObjects } from 'src/content/app/browser/browserActions';
-import { fetchExampleEnsObjects } from 'src/ens-object/ensObjectActions';
+import { fetchDataForLastVisitedObjects } from 'src/content/app/browser/browserActions';
 import { getExampleEnsObjects } from 'src/ens-object/ensObjectSelectors';
 import { getGenomeInfo } from 'src/genome/genomeSelectors';
 import { getCommittedSpecies } from '../app/species-selector/state/speciesSelectorSelectors';
 import { fetchGenomeInfo } from 'src/genome/genomeActions';
-import { getFormattedLocation } from 'src/shared/helpers/regionFormatter';
 import {
   getPreviouslyViewedGenomeBrowserObjects,
   PreviouslyViewedGenomeBrowserObjects
@@ -23,44 +21,28 @@ import { CommittedItem } from '../app/species-selector/types/species-search';
 
 import styles from './Home.scss';
 
-type StateProps = {
+type Props = {
   activeSpecies: CommittedItem[];
   exampleEnsObjects: EnsObject[];
   genomeInfo: GenomeInfoData;
   totalSelectedSpecies: number;
   previouslyViewedGenomeBrowserObjects: PreviouslyViewedGenomeBrowserObjects;
-};
-
-type DispatchProps = {
-  fetchExampleEnsObjects: () => void;
   fetchGenomeInfo: () => void;
+  fetchDataForLastVisitedObjects: () => void;
 };
-
-type OwnProps = {};
-
-type HomeProps = StateProps & DispatchProps & OwnProps;
 
 type PreviouslyViewedProps = {
   previouslyViewedGenomeBrowserObjects: PreviouslyViewedGenomeBrowserObjects;
 };
 
-const Home: FunctionComponent<HomeProps> = (props: HomeProps) => {
-  const [showPreviouslyViewed, toggleShowPreviouslyViewed] = useState(false);
-
+const Home = (props: Props) => {
   useEffect(() => {
     props.fetchGenomeInfo();
   }, [props.activeSpecies]);
 
   useEffect(() => {
-    props.getDataForLastVisitedObjects();
-    // props.fetchExampleEnsObjects();
+    props.fetchDataForLastVisitedObjects();
   }, [props.genomeInfo]);
-
-  useEffect(() => {
-    if (Object.keys(props.exampleEnsObjects).length > 0) {
-      toggleShowPreviouslyViewed(true);
-    }
-  }, [props.exampleEnsObjects]);
 
   return (
     <div className={styles.home}>
@@ -146,9 +128,8 @@ const mapStateToProps = (state: RootState) => ({
 });
 
 const mapDispatchToProps = {
-  fetchExampleEnsObjects,
   fetchGenomeInfo,
-  getDataForLastVisitedObjects
+  fetchDataForLastVisitedObjects
 };
 
 export default connect(

--- a/src/ensembl/src/content/home/Home.tsx
+++ b/src/ensembl/src/content/home/Home.tsx
@@ -6,16 +6,13 @@ import * as urlFor from 'src/shared/helpers/urlHelper';
 import { RootState } from 'src/store';
 
 import { fetchDataForLastVisitedObjects } from 'src/content/app/browser/browserActions';
-import { getExampleEnsObjects } from 'src/ens-object/ensObjectSelectors';
 import { getGenomeInfo } from 'src/genome/genomeSelectors';
 import { getCommittedSpecies } from '../app/species-selector/state/speciesSelectorSelectors';
-import { fetchGenomeInfo } from 'src/genome/genomeActions';
 import {
   getPreviouslyViewedGenomeBrowserObjects,
   PreviouslyViewedGenomeBrowserObjects
 } from 'src/content/home/homePageSelectors';
 
-import { EnsObject } from 'src/ens-object/ensObjectTypes';
 import { GenomeInfoData } from 'src/genome/genomeTypes';
 import { CommittedItem } from '../app/species-selector/types/species-search';
 
@@ -23,11 +20,8 @@ import styles from './Home.scss';
 
 type Props = {
   activeSpecies: CommittedItem[];
-  exampleEnsObjects: EnsObject[];
   genomeInfo: GenomeInfoData;
-  totalSelectedSpecies: number;
   previouslyViewedGenomeBrowserObjects: PreviouslyViewedGenomeBrowserObjects;
-  fetchGenomeInfo: () => void;
   fetchDataForLastVisitedObjects: () => void;
 };
 
@@ -37,16 +31,14 @@ type PreviouslyViewedProps = {
 
 const Home = (props: Props) => {
   useEffect(() => {
-    props.fetchGenomeInfo();
-  }, [props.activeSpecies]);
-
-  useEffect(() => {
     props.fetchDataForLastVisitedObjects();
-  }, [props.genomeInfo]);
+  }, []);
+
+  const totalSelectedSpecies = props.activeSpecies.length;
 
   return (
     <div className={styles.home}>
-      {!props.totalSelectedSpecies && (
+      {!totalSelectedSpecies && (
         <>
           <span className={styles.speciesSelectorBannerText}>
             7 species now available
@@ -119,8 +111,6 @@ const PreviouslyViewed = (props: PreviouslyViewedProps) => {
 
 const mapStateToProps = (state: RootState) => ({
   activeSpecies: getCommittedSpecies(state),
-  exampleEnsObjects: getExampleEnsObjects(state),
-  totalSelectedSpecies: getCommittedSpecies(state).length,
   genomeInfo: getGenomeInfo(state),
   previouslyViewedGenomeBrowserObjects: getPreviouslyViewedGenomeBrowserObjects(
     state
@@ -128,7 +118,6 @@ const mapStateToProps = (state: RootState) => ({
 });
 
 const mapDispatchToProps = {
-  fetchGenomeInfo,
   fetchDataForLastVisitedObjects
 };
 

--- a/src/ensembl/src/content/home/Home.tsx
+++ b/src/ensembl/src/content/home/Home.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
-import upperFirst from 'lodash/upperFirst';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import { RootState } from 'src/store';
@@ -13,7 +12,10 @@ import { getGenomeInfo } from 'src/genome/genomeSelectors';
 import { getCommittedSpecies } from '../app/species-selector/state/speciesSelectorSelectors';
 import { fetchGenomeInfo } from 'src/genome/genomeActions';
 import { getFormattedLocation } from 'src/shared/helpers/regionFormatter';
-import { getPreviouslyViewedGenomeBrowserObjects } from 'src/content/home/homePageSelectors';
+import {
+  getPreviouslyViewedGenomeBrowserObjects,
+  PreviouslyViewedGenomeBrowserObjects
+} from 'src/content/home/homePageSelectors';
 
 import { EnsObject } from 'src/ens-object/ensObjectTypes';
 import { GenomeInfoData } from 'src/genome/genomeTypes';
@@ -26,6 +28,7 @@ type StateProps = {
   exampleEnsObjects: EnsObject[];
   genomeInfo: GenomeInfoData;
   totalSelectedSpecies: number;
+  previouslyViewedGenomeBrowserObjects: PreviouslyViewedGenomeBrowserObjects;
 };
 
 type DispatchProps = {
@@ -37,9 +40,12 @@ type OwnProps = {};
 
 type HomeProps = StateProps & DispatchProps & OwnProps;
 
+type PreviouslyViewedProps = {
+  previouslyViewedGenomeBrowserObjects: PreviouslyViewedGenomeBrowserObjects;
+};
+
 const Home: FunctionComponent<HomeProps> = (props: HomeProps) => {
   const [showPreviouslyViewed, toggleShowPreviouslyViewed] = useState(false);
-  console.log('props', props);
 
   useEffect(() => {
     props.fetchGenomeInfo();
@@ -55,39 +61,6 @@ const Home: FunctionComponent<HomeProps> = (props: HomeProps) => {
       toggleShowPreviouslyViewed(true);
     }
   }, [props.exampleEnsObjects]);
-
-  const getExampleObjLabel = (exampleObject: EnsObject) => {
-    if (exampleObject.object_type === 'gene') {
-      return exampleObject.label;
-    } else {
-      return getFormattedLocation(exampleObject.location);
-    }
-  };
-
-  const getPreviouslyViewed = () => {
-    return props.activeSpecies.map((species) => {
-      if (props.exampleEnsObjects.length) {
-        return props.exampleEnsObjects.map((exampleObject) => {
-          const location = `${exampleObject.location.chromosome}:${exampleObject.location.start}-${exampleObject.location.end}`;
-          const path = urlFor.browser({
-            genomeId: species.genome_id,
-            focus: exampleObject.object_id,
-            location
-          });
-
-          return (
-            <dd key={exampleObject.object_id}>
-              <Link to={path}>
-                {`${species.common_name} ${upperFirst(
-                  exampleObject.object_type
-                )}: ${getExampleObjLabel(exampleObject)}`}
-              </Link>
-            </dd>
-          );
-        });
-      }
-    });
-  };
 
   return (
     <div className={styles.home}>
@@ -108,18 +81,13 @@ const Home: FunctionComponent<HomeProps> = (props: HomeProps) => {
         <h2>Find</h2>
         <p>
           <input type="text" placeholder="Name, symbol or ID" disabled={true} />
-          {/* <button disabled={true}>Go</button> */}
         </p>
-        <div className={styles.filter}>
-          <h2>Refine results</h2>
-        </div>
       </section>
-      {showPreviouslyViewed && (
-        <section className={styles.previouslyViewed}>
-          <h2>Previously viewed</h2>
-          {getPreviouslyViewed()}
-        </section>
-      )}
+      <PreviouslyViewed
+        previouslyViewedGenomeBrowserObjects={
+          props.previouslyViewedGenomeBrowserObjects
+        }
+      />
       <section className={styles.siteMessage}>
         <h4>Using the site</h4>
         <p>
@@ -139,6 +107,31 @@ const Home: FunctionComponent<HomeProps> = (props: HomeProps) => {
         <p>helpdesk@ensembl.org</p>
       </section>
     </div>
+  );
+};
+
+const PreviouslyViewed = (props: PreviouslyViewedProps) => {
+  if (props.previouslyViewedGenomeBrowserObjects.areLoading) {
+    return null;
+  }
+
+  const previouslyViewedLinks = props.previouslyViewedGenomeBrowserObjects.objects.map(
+    (object, index) => (
+      <div key={index} className={styles.previouslyViewedItem}>
+        <Link to={object.link}>{object.speciesName}</Link>
+        <span className={styles.previouslyViewedItemAssemblyName}>
+          {' '}
+          {object.assemblyName}
+        </span>
+      </div>
+    )
+  );
+
+  return (
+    <section className={styles.previouslyViewed}>
+      <h2>Previously viewed</h2>
+      {previouslyViewedLinks}
+    </section>
   );
 };
 

--- a/src/ensembl/src/content/home/homePageSelectors.ts
+++ b/src/ensembl/src/content/home/homePageSelectors.ts
@@ -1,0 +1,46 @@
+import * as urlFor from 'src/shared/helpers/urlHelper';
+import { getChrLocationStr } from 'src/content/app/browser/browserHelper';
+
+import {
+  getBrowserActiveEnsObjectIds,
+  getAllChrLocations
+} from 'src/content/app/browser/browserSelectors';
+import { getEnsObjectById } from 'src/ens-object/ensObjectSelectors';
+import { getCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
+
+import { RootState } from 'src/store';
+import { EnsObject } from 'src/ens-object/ensObjectTypes';
+
+export const getPreviouslyViewedGenomeBrowserObjects = (state: RootState) => {
+  const ensObjectIdsMap = getBrowserActiveEnsObjectIds(state);
+  const chrLocations = getAllChrLocations(state);
+  const committedSpecies = getCommittedSpecies(state);
+
+  const genomeIds = Object.keys(ensObjectIdsMap);
+
+  const ensObjectMap: { [genomeId: string]: EnsObject } = Object.keys(
+    ensObjectIdsMap
+  ).reduce((result, genomeId) => {
+    const ensObjectId = ensObjectIdsMap[genomeId];
+    const ensObject = getEnsObjectById(state, ensObjectId);
+    if (!ensObject) {
+      return result;
+    } else {
+      return {
+        ...result,
+        [genomeId]: ensObject
+      };
+    }
+  }, {});
+
+  console.log('ensObjectMap', ensObjectMap);
+
+  return Object.keys(ensObjectMap).map((id) => ({
+    ensObjectLabel: ensObjectMap[id].label,
+    link: urlFor.browser({
+      genomeId: id,
+      focus: ensObjectMap[id].object_id,
+      location: getChrLocationStr(chrLocations[id])
+    })
+  }));
+};

--- a/src/ensembl/src/content/home/homePageSelectors.ts
+++ b/src/ensembl/src/content/home/homePageSelectors.ts
@@ -5,42 +5,90 @@ import {
   getBrowserActiveEnsObjectIds,
   getAllChrLocations
 } from 'src/content/app/browser/browserSelectors';
-import { getEnsObjectById } from 'src/ens-object/ensObjectSelectors';
+import {
+  getEnsObjectById,
+  getEnsObjectLoadingStatus
+} from 'src/ens-object/ensObjectSelectors';
 import { getCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
+import { LoadingState } from 'src/shared/types/loading-state';
 
 import { RootState } from 'src/store';
 import { EnsObject } from 'src/ens-object/ensObjectTypes';
 
-export const getPreviouslyViewedGenomeBrowserObjects = (state: RootState) => {
+export type PreviouslyViewedGenomeBrowserObject = {
+  speciesName: string;
+  assemblyName: string;
+  link: string;
+};
+
+export type PreviouslyViewedGenomeBrowserObjects = {
+  areLoading: boolean;
+  objects: PreviouslyViewedGenomeBrowserObject[];
+};
+
+export const getPreviouslyViewedGenomeBrowserObjects = (
+  state: RootState
+): PreviouslyViewedGenomeBrowserObjects => {
   const ensObjectIdsMap = getBrowserActiveEnsObjectIds(state);
   const chrLocations = getAllChrLocations(state);
   const committedSpecies = getCommittedSpecies(state);
 
   const genomeIds = Object.keys(ensObjectIdsMap);
 
-  const ensObjectMap: { [genomeId: string]: EnsObject } = Object.keys(
-    ensObjectIdsMap
-  ).reduce((result, genomeId) => {
+  const ensObjectMap: {
+    [genomeId: string]: {
+      speciesName: string;
+      assemblyName: string;
+      ensObjectId: string;
+    };
+  } = Object.keys(ensObjectIdsMap).reduce((result, genomeId) => {
     const ensObjectId = ensObjectIdsMap[genomeId];
     const ensObject = getEnsObjectById(state, ensObjectId);
-    if (!ensObject) {
+    const species = committedSpecies.find(
+      (species) => species.genome_id === genomeId
+    );
+
+    if (!ensObject || !species) {
       return result;
     } else {
+      const speciesName = species.common_name || species.scientific_name;
+      const assemblyName = species.assembly_name;
+      const ensObjectId = ensObject.object_id;
       return {
         ...result,
-        [genomeId]: ensObject
+        [genomeId]: {
+          speciesName,
+          assemblyName,
+          ensObjectId
+        }
       };
     }
   }, {});
 
-  console.log('ensObjectMap', ensObjectMap);
+  const areLoading: boolean = Object.keys(ensObjectIdsMap).reduce(
+    (result: boolean, genomeId) => {
+      const ensObjectId = ensObjectIdsMap[genomeId];
+      const ensObjectLoadingStatus = getEnsObjectLoadingStatus(
+        state,
+        ensObjectId
+      );
+      return result || ensObjectLoadingStatus === LoadingState.LOADING;
+    },
+    false
+  );
 
-  return Object.keys(ensObjectMap).map((id) => ({
-    ensObjectLabel: ensObjectMap[id].label,
+  const previouslyViewedObjects = Object.keys(ensObjectMap).map((id) => ({
+    speciesName: ensObjectMap[id].speciesName,
+    assemblyName: ensObjectMap[id].assemblyName,
     link: urlFor.browser({
       genomeId: id,
-      focus: ensObjectMap[id].object_id,
+      focus: ensObjectMap[id].ensObjectId,
       location: getChrLocationStr(chrLocations[id])
     })
   }));
+
+  return {
+    areLoading,
+    objects: previouslyViewedObjects
+  };
 };

--- a/src/ensembl/src/content/home/homePageSelectors.ts
+++ b/src/ensembl/src/content/home/homePageSelectors.ts
@@ -13,7 +13,6 @@ import { getCommittedSpecies } from 'src/content/app/species-selector/state/spec
 import { LoadingState } from 'src/shared/types/loading-state';
 
 import { RootState } from 'src/store';
-import { EnsObject } from 'src/ens-object/ensObjectTypes';
 
 export type PreviouslyViewedGenomeBrowserObject = {
   speciesName: string;
@@ -32,8 +31,6 @@ export const getPreviouslyViewedGenomeBrowserObjects = (
   const ensObjectIdsMap = getBrowserActiveEnsObjectIds(state);
   const chrLocations = getAllChrLocations(state);
   const committedSpecies = getCommittedSpecies(state);
-
-  const genomeIds = Object.keys(ensObjectIdsMap);
 
   const ensObjectMap: {
     [genomeId: string]: {

--- a/src/ensembl/src/content/home/homePageSelectors.ts
+++ b/src/ensembl/src/content/home/homePageSelectors.ts
@@ -62,17 +62,14 @@ export const getPreviouslyViewedGenomeBrowserObjects = (
     }
   }, {});
 
-  const areLoading: boolean = Object.keys(ensObjectIdsMap).reduce(
-    (result: boolean, genomeId) => {
-      const ensObjectId = ensObjectIdsMap[genomeId];
-      const ensObjectLoadingStatus = getEnsObjectLoadingStatus(
-        state,
-        ensObjectId
-      );
-      return result || ensObjectLoadingStatus === LoadingState.LOADING;
-    },
-    false
-  );
+  const areLoading: boolean = Object.keys(ensObjectIdsMap).some((genomeId) => {
+    const ensObjectId = ensObjectIdsMap[genomeId];
+    const ensObjectLoadingStatus = getEnsObjectLoadingStatus(
+      state,
+      ensObjectId
+    );
+    return ensObjectLoadingStatus === LoadingState.LOADING;
+  });
 
   const previouslyViewedObjects = Object.keys(ensObjectMap).map((id) => ({
     speciesName: ensObjectMap[id].speciesName,

--- a/src/ensembl/src/shared/components/app-bar/AppBar.scss
+++ b/src/ensembl/src/shared/components/app-bar/AppBar.scss
@@ -3,7 +3,6 @@
 .appBar {
   font-size: 12px;
   padding: 8px 20px;
-  width: 100%;
   min-height: 80px;
 
   .appBarTop {
@@ -11,8 +10,10 @@
   }
 
   .appBarBottom {
-    display: flex;
+    display: grid;
     margin-left: 2em;
+    max-width: 100%;
+    grid-template-columns: minmax(80%, 1fr) minmax(100px, auto);
   }
 }
 
@@ -20,6 +21,7 @@
   flex: 0 1 auto;
   position: relative;
   top: 5px;
+  margin-left: 2em;
 
   a {
     color: $black;

--- a/src/ensembl/src/shared/components/species-tab-bar/SpeciesTabBar.scss
+++ b/src/ensembl/src/shared/components/species-tab-bar/SpeciesTabBar.scss
@@ -1,10 +1,11 @@
 .speciesTabBar {
-  flex: 1 1 auto;
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
 }
 
 .addSpeciesLink {
   display: inline-block;
   font-size: 11px;
   position: relative;
-  bottom: 8px;
 }

--- a/src/ensembl/src/shared/components/species-tab/SpeciesTab.scss
+++ b/src/ensembl/src/shared/components/species-tab/SpeciesTab.scss
@@ -10,6 +10,7 @@
   line-height: 1;
   user-select: none;
   text-overflow: ellipsis;
+  white-space: nowrap;
   flex-grow: 0;
   flex-shrink: 1;
   flex-basis: auto;

--- a/src/ensembl/stories/shared-components/species-tab-bar/SpeciesTabBar.stories.tsx
+++ b/src/ensembl/stories/shared-components/species-tab-bar/SpeciesTabBar.stories.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
+import { MemoryRouter } from 'react-router';
 
 import speciesData from './speciesData';
 import juneSpeciesData from './juneSpeciesData';
@@ -23,13 +24,15 @@ const Wrapper = (props: WrapperProps) => {
   };
 
   return (
-    <div className={styles.wrapper}>
-      <SpeciesTabBar
-        species={props.species}
-        activeGenomeId={activeGenomeId}
-        onTabSelect={onTabSelect}
-      />
-    </div>
+    <MemoryRouter>
+      <div className={styles.wrapper}>
+        <SpeciesTabBar
+          species={props.species}
+          activeGenomeId={activeGenomeId}
+          onTabSelect={onTabSelect}
+        />
+      </div>
+    </MemoryRouter>
   );
 };
 


### PR DESCRIPTION
## Type
- bug fix
- Improvement to existing feature

## Related JIRA Issue(s)
ENSWBSITES-224
ENSWBSITES-186

## Description
This PR does two things:

1) Shows a list of previously viewed genomes on the Home page. Clicking on the link to a genome will take the user to the last location where they were in Genome Browser when viewing this species.
_(Also, some Home page styles were updated, as directed by Andrea. And removed the request for genome info on the home page, which was both failing and unnecessary)_

2) Fixes the AppBar for Genome Browser (when there is not enough space for all species tabs, they do not wrap to the next line, but instead shrink to fit the available space). Also, fixes the SpeciesTabBar component in the Storybook (which broke, because we added the Link component from react-router to SpeciesTabBar).

## Views affected
- Home page
- Genome browser
- Storybook (Shared components / SpeciesTabBar)