### PR TITLE
Fix initialization of track panel state

### DIFF
--- a/src/ensembl/src/content/app/browser/browserActions.ts
+++ b/src/ensembl/src/content/app/browser/browserActions.ts
@@ -94,17 +94,6 @@ export const fetchDataForLastVisitedObjects: ActionCreator<
   activeEnsObjectIds.forEach((id) => dispatch(fetchEnsObject(id)));
 };
 
-export const updateBrowserActiveGenomeId = createStandardAction(
-  'browser/update-active-genome-id'
-)<string>();
-
-export const updateBrowserActiveGenomeIdAndSave: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (activeGenomeId: string) => (dispatch) => {
-  dispatch(updateBrowserActiveGenomeId(activeGenomeId));
-  browserStorageService.saveActiveGenomeId(activeGenomeId);
-};
-
 export const updateBrowserActiveEnsObjectIds = createStandardAction(
   'browser/update-active-ens-object-ids'
 )<{ [objectId: string]: string }>();

--- a/src/ensembl/src/content/app/browser/browserReducer.ts
+++ b/src/ensembl/src/content/app/browser/browserReducer.ts
@@ -47,8 +47,6 @@ export function browserEntity(
       }
       return newState;
     }
-    case getType(browserActions.updateBrowserActiveGenomeId):
-      return { ...state, activeGenomeId: action.payload };
     case getType(browserActions.updateBrowserActiveEnsObjectIds):
       return { ...state, activeEnsObjectIds: action.payload };
     case getType(browserActions.updateTrackStates):

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelReducer.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelReducer.ts
@@ -15,10 +15,11 @@ export default function trackPanel(
     | ActionType<typeof browserActions>
 ): TrackPanelState {
   switch (action.type) {
-    case getType(browserActions.updateBrowserActiveGenomeId):
+    case getType(browserActions.setDataFromUrl):
+      const { activeGenomeId } = action.payload;
       return {
         ...state,
-        [action.payload]: getTrackPanelStateForGenome(action.payload)
+        [activeGenomeId]: getTrackPanelStateForGenome(activeGenomeId)
       };
     case getType(trackPanelActions.updateTrackPanelForGenome):
       return {

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
@@ -21,7 +21,7 @@ export const defaultTrackPanelStateForGenome: TrackPanelStateForGenome = {
   selectedTrackPanelTab: TrackSet.GENOMIC,
   trackPanelModalView: '',
   highlightedTrackId: '',
-  isTrackPanelOpened: false,
+  isTrackPanelOpened: true,
   collapsedTrackIds: []
 };
 


### PR DESCRIPTION
## Type
- Bug fix

## Description
This PR fixes a bug introduced in https://github.com/Ensembl/ensembl-client/pull/158 and manifesting as follows: when the user first visits genome browser page, the track panel is closed.

Causes of the bug:

- Track panel reducer was listening to the `updateBrowserActiveGenomeId` action, but our code does not use this action any longer. Instead active genome id in the redux state is updated with the `setDataFromUrl`; so trackPanel reducer should be listening to this action.
- The initial value for whether the track is opened should be `true` (panel should be opened).

## Views affected
Genome browser page