### PR TITLE
Automatically optimise WASM when building non-debug branch.

### DIFF
--- a/src/assets/browser/app/build/deploy.sh
+++ b/src/assets/browser/app/build/deploy.sh
@@ -27,6 +27,12 @@ echo "WASMHASH=$WASMHASH"
 WASMNAME="browser-$WASMHASH.wasm"
 JSNAME="browser.js"
 rm -f $DEST/*.js $DEST/*.wasm
-cp $SRC/target/deploy/hellostdweb.wasm $DEST/$WASMNAME
+
+if [ "$1" == "check" ] ; then
+  cp $SRC/target/deploy/hellostdweb.wasm $DEST/$WASMNAME
+else
+  wasm-opt -Os $SRC/target/deploy/hellostdweb.wasm -o $DEST/$WASMNAME
+fi
+ls -lh $DEST/$WASMNAME
 cp $SRC/target/deploy/hellostdweb.js $DEST/$JSNAME
 sed -i -e "s~\"hellostdweb.wasm\"~\"/static/browser/$WASMNAME\"~g" $DEST/$JSNAME


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [X] Improvement to existing feature

## Related JIRA Issue(s)
None

## Importance
Helps avoid common mistake when submitting code for PR.

## Description
Automatically run wasm optimiser when doing non-debug-build so that the person building doesn't need to remember to do so.

## Views affected
Genome browser build system (doesn't change genome browser WASM/JS)

### Other effects
None anticipated

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
None anticipated.