### PR TITLE
Custom Downloads  - Fix broken preview screen

### DIFF
--- a/src/ensembl/src/content/app/custom-download/containers/content/CustomDownloadContent.scss
+++ b/src/ensembl/src/content/app/custom-download/containers/content/CustomDownloadContent.scss
@@ -3,7 +3,7 @@
 .wrapper {
   position: relative;
   display: grid;
-  grid-template-columns: 40px calc(50% - 50px) 10px calc(50% - 40px) 40px;
+  grid-template-columns: 40px 1fr 10px 1fr 40px;
 
   &.default {
     height: calc(100vh - 220px);
@@ -30,7 +30,7 @@
 }
 
 .previewDownloadHolder {
-  grid-column-start: 1;
+  grid-column-start: 2;
   grid-column-end: 5;
 }
 

--- a/src/ensembl/src/content/app/custom-download/containers/content/CustomDownloadContent.scss
+++ b/src/ensembl/src/content/app/custom-download/containers/content/CustomDownloadContent.scss
@@ -29,6 +29,11 @@
   grid-column-end: 5;
 }
 
+.previewDownloadHolder {
+  grid-column-start: 1;
+  grid-column-end: 5;
+}
+
 .exampleDataPanel {
   top: 10px;
   left: calc(50% - 300px);

--- a/src/ensembl/src/content/app/custom-download/containers/content/CustomDownloadContent.tsx
+++ b/src/ensembl/src/content/app/custom-download/containers/content/CustomDownloadContent.tsx
@@ -58,7 +58,7 @@ const CustomDownloadContent = (props: Props) => {
         </>
       )}
       {props.showSummary && (
-        <div>
+        <div className={styles.previewDownloadHolder}>
           <PreviewDownload />
         </div>
       )}

--- a/src/ensembl/src/content/app/custom-download/containers/content/preview-download/PreviewDownload.scss
+++ b/src/ensembl/src/content/app/custom-download/containers/content/preview-download/PreviewDownload.scss
@@ -4,7 +4,7 @@
   border-collapse: collapse;
   width: calc(100vw - 140px);
   table-layout: fixed;
-  margin: 10px 70px 0;
+  margin-top: 10px;
 
   td {
     padding: 8px 0 8px 7px;


### PR DESCRIPTION
## Type

- [x] Bug fix

## Description
Fixes a bug that causes nothing to be displayed Preview Download screen, which was introduced in the PR https://github.com/Ensembl/ensembl-client/pull/174
![Screenshot 2019-10-18 at 13 13 19](https://user-images.githubusercontent.com/3085815/67093268-1ffdbb00-f1a9-11e9-8db3-af03420f5f7f.png)


## Views affected
Custom Downloads -> Preview download