### PR TITLE
Extract a generic Status type, from which ImageButtonStatus is derived

### DIFF
--- a/src/ensembl/src/content/app/browser/browser-reset/BrowserReset.tsx
+++ b/src/ensembl/src/content/app/browser/browser-reset/BrowserReset.tsx
@@ -7,6 +7,7 @@ import ImageButton, {
 
 import styles from './BrowserReset.scss';
 import { EnsObject } from 'src/ens-object/ensObjectTypes';
+import { Status } from 'src/shared/types/status';
 
 type BrowserResetProps = {
   focusObject: EnsObject | null;
@@ -23,9 +24,7 @@ export const BrowserReset: FunctionComponent<BrowserResetProps> = (
   }
 
   const getResetIconStatus = (): ImageButtonStatus => {
-    return props.isActive
-      ? ImageButtonStatus.ACTIVE
-      : ImageButtonStatus.DISABLED;
+    return props.isActive ? Status.ACTIVE : Status.DISABLED;
   };
 
   const handleClick = () => {

--- a/src/ensembl/src/content/app/browser/browser-storage-service.test.ts
+++ b/src/ensembl/src/content/app/browser/browser-storage-service.test.ts
@@ -1,5 +1,5 @@
 import { BrowserStorageService, StorageKeys } from './browser-storage-service';
-import { ImageButtonStatus } from 'src/shared/components/image-button/ImageButton';
+import { Status } from 'src/shared/types/status';
 
 const mockStorageService = {
   get: jest.fn(),
@@ -66,7 +66,7 @@ describe('BrowserStorageService', () => {
       const toggledTrack = {
         homo_sapiens38: {
           'Genes & transcripts': {
-            'gene-pc-fwd': ImageButtonStatus.INACTIVE
+            'gene-pc-fwd': Status.INACTIVE
           }
         }
       };

--- a/src/ensembl/src/content/app/browser/browser-storage-service.test.ts
+++ b/src/ensembl/src/content/app/browser/browser-storage-service.test.ts
@@ -1,5 +1,6 @@
 import { BrowserStorageService, StorageKeys } from './browser-storage-service';
 import { Status } from 'src/shared/types/status';
+import { TrackActivityStatus } from 'src/content/app/browser/track-panel/trackPanelConfig';
 
 const mockStorageService = {
   get: jest.fn(),
@@ -66,7 +67,7 @@ describe('BrowserStorageService', () => {
       const toggledTrack = {
         homo_sapiens38: {
           'Genes & transcripts': {
-            'gene-pc-fwd': Status.INACTIVE
+            'gene-pc-fwd': Status.INACTIVE as TrackActivityStatus
           }
         }
       };

--- a/src/ensembl/src/content/app/browser/browserActions.ts
+++ b/src/ensembl/src/content/app/browser/browserActions.ts
@@ -37,7 +37,7 @@ export type UpdateTrackStatesPayload = {
   genomeId: string;
   categoryName: string;
   trackId: string;
-  status: TrackActivityStatus; // TODO: update types so that actions do not depend on ImageButton types
+  status: TrackActivityStatus;
 };
 
 export type ParsedUrlPayload = {

--- a/src/ensembl/src/content/app/browser/browserActions.ts
+++ b/src/ensembl/src/content/app/browser/browserActions.ts
@@ -6,17 +6,13 @@ import isEqual from 'lodash/isEqual';
 
 import config from 'config';
 import * as urlFor from 'src/shared/helpers/urlHelper';
+import { getChrLocationStr } from './browserHelper';
 
 import browserMessagingService from 'src/content/app/browser/browser-messaging-service';
+import browserStorageService from './browser-storage-service';
 
 import { fetchEnsObject } from 'src/ens-object/ensObjectActions';
 
-import {
-  BrowserNavStates,
-  ChrLocation,
-  CogList,
-  ChrLocations
-} from './browserState';
 import {
   getBrowserActiveGenomeId,
   getBrowserActiveEnsObjectId,
@@ -25,18 +21,23 @@ import {
   getChrLocation,
   getBrowserMessageCount
 } from './browserSelectors';
-import { getChrLocationStr } from './browserHelper';
-import browserStorageService from './browser-storage-service';
-import { RootState } from 'src/store';
-import { ImageButtonStatus } from 'src/shared/components/image-button/ImageButton';
-import { TrackStates } from './track-panel/trackPanelConfig';
 import { BROWSER_CONTAINER_ID } from './browser-constants';
+
+import {
+  BrowserNavStates,
+  ChrLocation,
+  CogList,
+  ChrLocations
+} from './browserState';
+import { TrackStates } from './track-panel/trackPanelConfig';
+import { RootState } from 'src/store';
+import { TrackActivityStatus } from 'src/content/app/browser/track-panel/trackPanelConfig';
 
 export type UpdateTrackStatesPayload = {
   genomeId: string;
   categoryName: string;
   trackId: string;
-  status: ImageButtonStatus; // TODO: update types so that actions do not depend on ImageButton types
+  status: TrackActivityStatus; // TODO: update types so that actions do not depend on ImageButton types
 };
 
 export type ParsedUrlPayload = {

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBarIcon.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBarIcon.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { TrackPanelBarItem } from './trackPanelBarConfig';
-import ImageButton, {
-  ImageButtonStatus
-} from 'src/shared/components/image-button/ImageButton';
+import ImageButton from 'src/shared/components/image-button/ImageButton';
+
+import { Status } from 'src/shared/types/status';
 
 import styles from './TrackPanelBarIcon.scss';
 
@@ -46,8 +46,8 @@ const TrackPanelBarIcon = (props: TrackPanelBarIconProps) => {
     const { iconConfig, trackPanelModalView } = props;
 
     return iconConfig.name === trackPanelModalView && props.isTrackPanelOpened
-      ? ImageButtonStatus.HIGHLIGHTED
-      : ImageButtonStatus.ACTIVE;
+      ? Status.HIGHLIGHTED
+      : Status.ACTIVE;
   };
 
   return (

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.tsx
@@ -2,9 +2,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import get from 'lodash/get';
 
-import TrackPanelListItem from './TrackPanelListItem';
-import { ImageButtonStatus } from 'src/shared/components/image-button/ImageButton';
-
 import {
   UpdateTrackStatesPayload,
   updateTrackStatesAndSave
@@ -23,6 +20,11 @@ import {
 } from '../../browserSelectors';
 import { getSelectedTrackPanelTab } from '../trackPanelSelectors';
 import { getGenomeTrackCategoriesById } from 'src/genome/genomeSelectors';
+
+import TrackPanelListItem from './TrackPanelListItem';
+
+import { TrackActivityStatus } from 'src/content/app/browser/track-panel/trackPanelConfig';
+import { Status } from 'src/shared/types/status';
 
 import styles from './TrackPanelList.scss';
 
@@ -61,8 +63,8 @@ const TrackPanelList = (props: TrackPanelListProps) => {
   };
 
   // TODO: get default track status properly if it can ever be inactive
-  const getDefaultTrackStatus = () => {
-    return ImageButtonStatus.ACTIVE;
+  const getDefaultTrackStatus = (): TrackActivityStatus => {
+    return Status.ACTIVE;
   };
 
   const getTrackListItem = (
@@ -80,13 +82,13 @@ const TrackPanelList = (props: TrackPanelListProps) => {
       props.trackStates,
       `${activeGenomeId}.${categoryName}.${track_id}`,
       defaultTrackStatus
-    );
+    ) as TrackActivityStatus;
 
     return (
       <TrackPanelListItem
         categoryName={categoryName}
-        defaultTrackStatus={defaultTrackStatus as ImageButtonStatus}
-        trackStatus={trackStatus as ImageButtonStatus}
+        defaultTrackStatus={defaultTrackStatus}
+        trackStatus={trackStatus}
         key={track.track_id}
         track={track}
       >

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
@@ -14,7 +14,8 @@ import ImageButton, {
 import {
   TrackItemColour,
   TrackItemColourKey,
-  TrackId
+  TrackId,
+  TrackActivityStatus
 } from '../trackPanelConfig';
 
 import {
@@ -37,13 +38,15 @@ import chevronUpIcon from 'static/img/shared/chevron-up.svg';
 import { ReactComponent as Eye } from 'static/img/track-panel/eye.svg';
 import { ReactComponent as Ellipsis } from 'static/img/track-panel/ellipsis.svg';
 
+import { Status } from 'src/shared/types/status';
+
 import styles from './TrackPanelListItem.scss';
 
 type OwnProps = {
   categoryName: string;
   children?: ReactNode[];
-  trackStatus: ImageButtonStatus;
-  defaultTrackStatus: ImageButtonStatus;
+  trackStatus: TrackActivityStatus;
+  defaultTrackStatus: TrackActivityStatus;
   track: EnsObjectTrack;
 };
 
@@ -133,9 +136,7 @@ const TrackPanelListItem = (props: Props) => {
 
   const toggleTrack = () => {
     const newStatus =
-      trackStatus === ImageButtonStatus.ACTIVE
-        ? ImageButtonStatus.INACTIVE
-        : ImageButtonStatus.ACTIVE;
+      trackStatus === Status.ACTIVE ? Status.INACTIVE : Status.ACTIVE;
 
     updateGenomeBrowser(newStatus);
 
@@ -148,8 +149,7 @@ const TrackPanelListItem = (props: Props) => {
   };
 
   const updateGenomeBrowser = (status: ImageButtonStatus) => {
-    const currentTrackStatus =
-      status === ImageButtonStatus.ACTIVE ? 'on' : 'off';
+    const currentTrackStatus = status === Status.ACTIVE ? 'on' : 'off';
 
     const payload = {
       [currentTrackStatus]: `${track.track_id}`
@@ -194,7 +194,7 @@ const TrackPanelListItem = (props: Props) => {
         </label>
         <div className={styles.ellipsisHolder}>
           <ImageButton
-            buttonStatus={ImageButtonStatus.ACTIVE}
+            buttonStatus={Status.ACTIVE}
             description={`Go to ${track.label}`}
             onClick={drawerViewButtonHandler}
             image={Ellipsis}

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelConfig.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelConfig.ts
@@ -1,4 +1,4 @@
-import { ImageButtonStatus } from 'src/shared/components/image-button/ImageButton';
+import { Status } from 'src/shared/types/status';
 
 export enum TrackItemColour {
   BLUE = 'blue',
@@ -8,6 +8,8 @@ export enum TrackItemColour {
 }
 
 export type TrackItemColourKey = keyof typeof TrackItemColour;
+
+export type TrackActivityStatus = Status.ACTIVE | Status.INACTIVE;
 
 export enum TrackSet {
   GENOMIC = 'Genomic',
@@ -32,7 +34,7 @@ export type TrackPanelIcons = {
 export type TrackStates = {
   [genomeId: string]: {
     [categoryName: string]: {
-      [trackName: string]: ImageButtonStatus;
+      [trackName: string]: TrackActivityStatus;
     };
   };
 };

--- a/src/ensembl/src/content/app/custom-download/containers/content/attributes-accordion/AttributesAccordion.tsx
+++ b/src/ensembl/src/content/app/custom-download/containers/content/attributes-accordion/AttributesAccordion.tsx
@@ -19,9 +19,7 @@ import {
 } from 'src/content/app/custom-download/state/attributes/attributesActions';
 import { Orthologues } from './sections';
 import { setShowExampleData } from 'src/content/app/custom-download/state/customDownloadActions';
-import ImageButton, {
-  ImageButtonStatus
-} from 'src/shared/components/image-button/ImageButton';
+import ImageButton from 'src/shared/components/image-button/ImageButton';
 import { ReactComponent as ResetIcon } from 'static/img/shared/trash.svg';
 import JSONValue from 'src/shared/types/JSON';
 import AttributesAccordionSection from 'src/content/app/custom-download/containers/content/attributes-accordion/sections/AttributesAccordionSection';
@@ -29,6 +27,8 @@ import {
   getAttributesAccordionExpandedPanels,
   getSelectedAttributes
 } from 'src/content/app/custom-download/state/attributes/attributesSelector';
+
+import { Status } from 'src/shared/types/status';
 
 import styles from './AttributesAccordion.scss';
 
@@ -122,7 +122,7 @@ const AttributesAccordion = (props: Props) => {
         </span>
         <span className={styles.resetIcon} onClick={onReset}>
           <ImageButton
-            buttonStatus={ImageButtonStatus.ACTIVE}
+            buttonStatus={Status.ACTIVE}
             description={'Reset attributes'}
             image={ResetIcon}
           />

--- a/src/ensembl/src/content/app/custom-download/containers/content/filter-accordion/FiltersAccordion.tsx
+++ b/src/ensembl/src/content/app/custom-download/containers/content/filter-accordion/FiltersAccordion.tsx
@@ -12,9 +12,7 @@ import {
 } from 'src/shared/components/accordion';
 
 import JSONValue from 'src/shared/types/JSON';
-import ImageButton, {
-  ImageButtonStatus
-} from 'src/shared/components/image-button/ImageButton';
+import ImageButton from 'src/shared/components/image-button/ImageButton';
 import BadgedButton from 'src/shared/components/badged-button/BadgedButton';
 import { getCommaSeparatedNumber } from 'src/shared/helpers/numberFormatter';
 import { ReactComponent as ResetIcon } from 'static/img/shared/trash.svg';
@@ -29,6 +27,8 @@ import {
   getSelectedFilters
 } from 'src/content/app/custom-download/state/filters/filtersSelector';
 import { getPreviewResult } from 'src/content/app/custom-download/state/customDownloadSelectors';
+
+import { Status } from 'src/shared/types/status';
 
 import styles from './FiltersAccordion.scss';
 
@@ -118,7 +118,7 @@ const FiltersAccordion = (props: FiltersAccordionProps) => {
 
         <span className={styles.resetIcon} onClick={props.resetSelectedFilters}>
           <ImageButton
-            buttonStatus={ImageButtonStatus.ACTIVE}
+            buttonStatus={Status.ACTIVE}
             description={'Reset filters'}
             image={ResetIcon}
           />

--- a/src/ensembl/src/header/header-buttons/HeaderButtons.test.tsx
+++ b/src/ensembl/src/header/header-buttons/HeaderButtons.test.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 
 import { HeaderButtons } from './HeaderButtons';
-import ImageButton, {
-  ImageButtonStatus
-} from 'src/shared/components/image-button/ImageButton';
+import ImageButton from 'src/shared/components/image-button/ImageButton';
+
+import { Status } from 'src/shared/types/status';
 
 describe('<HeaderButtons />', () => {
   let toggleLaunchbarFn: () => void;
@@ -37,8 +37,6 @@ describe('<HeaderButtons />', () => {
       .filterWhere(
         (wrapper) => wrapper.prop('description') === 'Ensembl account'
       );
-    expect(launchbarButton.prop('buttonStatus')).toBe(
-      ImageButtonStatus.DISABLED
-    );
+    expect(launchbarButton.prop('buttonStatus')).toBe(Status.DISABLED);
   });
 });

--- a/src/ensembl/src/header/header-buttons/HeaderButtons.tsx
+++ b/src/ensembl/src/header/header-buttons/HeaderButtons.tsx
@@ -3,12 +3,12 @@ import { connect } from 'react-redux';
 
 import { toggleAccount, toggleLaunchbar } from '../headerActions';
 
-import ImageButton, {
-  ImageButtonStatus
-} from 'src/shared/components/image-button/ImageButton';
+import ImageButton from 'src/shared/components/image-button/ImageButton';
 
 import { ReactComponent as LaunchbarIcon } from 'static/img/header/launchbar.svg';
 import { ReactComponent as UserIcon } from 'static/img/header/user-grey.svg';
+
+import { Status } from 'src/shared/types/status';
 
 import styles from './HeaderButtons.scss';
 
@@ -36,9 +36,9 @@ export const HeaderButtons: FunctionComponent<HeaderButtonsProps> = (props) => (
       <ImageButton
         image={UserIcon}
         description="Ensembl account"
-        buttonStatus={ImageButtonStatus.DISABLED}
+        buttonStatus={Status.DISABLED}
         classNames={{
-          [ImageButtonStatus.DISABLED]: styles.headerButtonDisabled
+          [Status.DISABLED]: styles.headerButtonDisabled
         }}
       />
     </div>

--- a/src/ensembl/src/header/launchbar/LaunchbarButton.tsx
+++ b/src/ensembl/src/header/launchbar/LaunchbarButton.tsx
@@ -5,6 +5,8 @@ import ImageButton, {
   ImageButtonStatus
 } from 'src/shared/components/image-button/ImageButton';
 
+import { Status } from 'src/shared/types/status';
+
 import styles from './Launchbar.scss';
 
 type LaunchbarButtonProps = {
@@ -27,9 +29,9 @@ const LaunchbarButton: FunctionComponent<LaunchbarButtonProps> = (
   const imageButton = (
     <ImageButton
       classNames={{
-        [ImageButtonStatus.DEFAULT]: styles.launchbarButtonImage,
-        [ImageButtonStatus.ACTIVE]: styles.launchbarButtonSelectedImage,
-        [ImageButtonStatus.DISABLED]: styles.launchbarButtonDisabledImage
+        [Status.DEFAULT]: styles.launchbarButtonImage,
+        [Status.ACTIVE]: styles.launchbarButtonSelectedImage,
+        [Status.DISABLED]: styles.launchbarButtonDisabledImage
       }}
       buttonStatus={imageButtonStatus}
       description={props.description}
@@ -62,11 +64,11 @@ const getImageButtonStatus = ({
   isActive: boolean;
 }): ImageButtonStatus => {
   if (isDisabled) {
-    return ImageButtonStatus.DISABLED;
+    return Status.DISABLED;
   } else if (isActive) {
-    return ImageButtonStatus.ACTIVE;
+    return Status.ACTIVE;
   } else {
-    return ImageButtonStatus.DEFAULT;
+    return Status.DEFAULT;
   }
 };
 

--- a/src/ensembl/src/shared/components/image-button/ImageButton.test.tsx
+++ b/src/ensembl/src/shared/components/image-button/ImageButton.test.tsx
@@ -8,6 +8,8 @@ import ImageHolder from './ImageHolder';
 
 import Tooltip from 'src/shared/components/tooltip/Tooltip';
 
+import { Status } from 'src/shared/types/status';
+
 jest.mock(
   'src/shared/components/tooltip/Tooltip',
   () => ({ children }: { children: any }) => (
@@ -26,7 +28,7 @@ describe('<ImageButton />', () => {
     it('has a buttonStatus set by default', () => {
       const wrapper = mount(<ImageButton />);
 
-      expect(wrapper.prop('buttonStatus')).toEqual(ImageButtonStatus.DEFAULT);
+      expect(wrapper.prop('buttonStatus')).toEqual(Status.DEFAULT);
     });
   });
 
@@ -71,17 +73,13 @@ describe('<ImageButton />', () => {
 
   describe('prop classNames', () => {
     it('always has the default className applied', () => {
-      const wrapper = mount(
-        <ImageButton buttonStatus={ImageButtonStatus.ACTIVE} />
-      );
+      const wrapper = mount(<ImageButton buttonStatus={Status.ACTIVE} />);
 
       expect(wrapper.find(ImageHolder).find('div.default')).toHaveLength(1);
     });
 
     it('applies the respective className depending on the button status', () => {
-      const wrapper = mount(
-        <ImageButton buttonStatus={ImageButtonStatus.ACTIVE} />
-      );
+      const wrapper = mount(<ImageButton buttonStatus={Status.ACTIVE} />);
 
       expect(wrapper.find(ImageHolder).find('div.active')).toHaveLength(1);
     });
@@ -102,10 +100,7 @@ describe('<ImageButton />', () => {
 
     it('does not call the onClick prop when clicked if the status is disabled', () => {
       const wrapper = mount(
-        <ImageButton
-          onClick={onClick}
-          buttonStatus={ImageButtonStatus.DISABLED}
-        />
+        <ImageButton onClick={onClick} buttonStatus={Status.DISABLED} />
       );
 
       wrapper.simulate('click');

--- a/src/ensembl/src/shared/components/image-button/ImageButton.tsx
+++ b/src/ensembl/src/shared/components/image-button/ImageButton.tsx
@@ -8,13 +8,14 @@ import Tooltip from 'src/shared/components/tooltip/Tooltip';
 
 import imageButtonStyles from './ImageButton.scss';
 
-export enum ImageButtonStatus {
-  ACTIVE = 'active',
-  INACTIVE = 'inactive',
-  DISABLED = 'disabled',
-  DEFAULT = 'default',
-  HIGHLIGHTED = 'highlighted'
-}
+import { Status } from 'src/shared/types/status';
+
+export type ImageButtonStatus =
+  | Status.ACTIVE
+  | Status.INACTIVE
+  | Status.DISABLED
+  | Status.DEFAULT
+  | Status.HIGHLIGHTED;
 
 type Props = {
   buttonStatus: ImageButtonStatus;
@@ -32,9 +33,7 @@ const ImageButton = (props: Props) => {
   };
 
   const buttonProps =
-    props.buttonStatus === ImageButtonStatus.DISABLED
-      ? {}
-      : { onClick: handleClick };
+    props.buttonStatus === Status.DISABLED ? {} : { onClick: handleClick };
 
   const { classNames, ...rest } = props;
 
@@ -59,7 +58,7 @@ const ImageButton = (props: Props) => {
 };
 
 ImageButton.defaultProps = {
-  buttonStatus: ImageButtonStatus.DEFAULT,
+  buttonStatus: Status.DEFAULT,
   description: '',
   image: ''
 };

--- a/src/ensembl/src/shared/types/status.ts
+++ b/src/ensembl/src/shared/types/status.ts
@@ -1,0 +1,16 @@
+/*
+  This file contains the Status enumerable type.
+  The Status type does not correspond to any single thing,
+  but rather serves as a collection of various possible statuses
+  that various things may have.
+*/
+
+// To developer: for easier checking of which statuses are available,
+// please add new variants to the enum in the alphabetical order
+export enum Status {
+  ACTIVE = 'active',
+  DISABLED = 'disabled',
+  DEFAULT = 'default',
+  HIGHLIGHTED = 'highlighted',
+  INACTIVE = 'inactive'
+}

--- a/src/ensembl/stories/shared-components/badged-button/BadgedButton.stories.tsx
+++ b/src/ensembl/stories/shared-components/badged-button/BadgedButton.stories.tsx
@@ -7,9 +7,9 @@ import BadgedButton from 'src/shared/components/badged-button/BadgedButton';
 import { SecondaryButton } from 'src/shared/components/button/Button';
 import { ReactComponent as DownloadIcon } from 'static/img/track-panel/download.svg';
 import styles from './BadgedButton.stories.scss';
-import ImageButton, {
-  ImageButtonStatus
-} from 'src/shared/components/image-button/ImageButton';
+import ImageButton from 'src/shared/components/image-button/ImageButton';
+
+import { Status } from 'src/shared/types/status';
 
 const onClick = action('button-click');
 
@@ -32,7 +32,7 @@ storiesOf('Components|Shared Components/BadgedButton', module)
     <div className={styles.imageButtonWrapper}>
       <BadgedButton badgeContent={':)'}>
         <ImageButton
-          buttonStatus={ImageButtonStatus.HIGHLIGHTED}
+          buttonStatus={Status.HIGHLIGHTED}
           description={'enable/disable'}
           image={DownloadIcon}
           onClick={onClick}
@@ -44,7 +44,7 @@ storiesOf('Components|Shared Components/BadgedButton', module)
     <div className={styles.imageButtonWrapper}>
       <BadgedButton badgeContent={':)'} className={styles.badge}>
         <ImageButton
-          buttonStatus={ImageButtonStatus.HIGHLIGHTED}
+          buttonStatus={Status.HIGHLIGHTED}
           description={'enable/disable'}
           image={DownloadIcon}
           onClick={onClick}

--- a/src/ensembl/stories/shared-components/image-button/ImageButtonParent.stories.tsx
+++ b/src/ensembl/stories/shared-components/image-button/ImageButtonParent.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
-import ImageButton, {
-  ImageButtonStatus
-} from 'src/shared/components/image-button/ImageButton';
+import ImageButton from 'src/shared/components/image-button/ImageButton';
+
+import { Status } from 'src/shared/types/status';
 
 import classNames from 'classnames';
 type Props = {
@@ -14,18 +14,18 @@ type Props = {
 import styles from './ImageButton.stories.scss';
 
 const ImageButtonParent = (props: Props) => {
-  const [buttonStatus, setVisible] = useState(ImageButtonStatus.DEFAULT);
+  const [buttonStatus, setVisible] = useState(Status.DEFAULT);
 
   const toggleImage = () => {
     switch (buttonStatus) {
-      case ImageButtonStatus.DEFAULT:
-        return setVisible(ImageButtonStatus.ACTIVE);
-      case ImageButtonStatus.ACTIVE:
-        return setVisible(ImageButtonStatus.INACTIVE);
-      case ImageButtonStatus.INACTIVE:
-        return setVisible(ImageButtonStatus.HIGHLIGHTED);
+      case Status.DEFAULT:
+        return setVisible(Status.ACTIVE);
+      case Status.ACTIVE:
+        return setVisible(Status.INACTIVE);
+      case Status.INACTIVE:
+        return setVisible(Status.HIGHLIGHTED);
       default:
-        return setVisible(ImageButtonStatus.DEFAULT);
+        return setVisible(Status.DEFAULT);
     }
   };
 
@@ -67,56 +67,56 @@ const ImageButtonParent = (props: Props) => {
         <div className={classNames(styles.imageCard)}>
           <div className={classNames(styles.imageHolder)}>
             <ImageButton
-              buttonStatus={ImageButtonStatus.ACTIVE}
+              buttonStatus={Status.ACTIVE}
               description={'enable/disable'}
               image={props.image}
               classNames={computedStyles}
             />
           </div>
           <div className={classNames(styles.imageDescription)}>
-            {ImageButtonStatus.ACTIVE}
+            {Status.ACTIVE}
           </div>
         </div>
 
         <div className={classNames(styles.imageCard)}>
           <div className={classNames(styles.imageHolder)}>
             <ImageButton
-              buttonStatus={ImageButtonStatus.INACTIVE}
+              buttonStatus={Status.INACTIVE}
               description={'enable/disable'}
               image={props.image}
               classNames={computedStyles}
             />
           </div>
           <div className={classNames(styles.imageDescription)}>
-            {ImageButtonStatus.INACTIVE}
+            {Status.INACTIVE}
           </div>
         </div>
 
         <div className={classNames(styles.imageCard)}>
           <div className={classNames(styles.imageHolder)}>
             <ImageButton
-              buttonStatus={ImageButtonStatus.HIGHLIGHTED}
+              buttonStatus={Status.HIGHLIGHTED}
               description={'enable/disable'}
               image={props.image}
               classNames={computedStyles}
             />
           </div>
           <div className={classNames(styles.imageDescription)}>
-            {ImageButtonStatus.HIGHLIGHTED}
+            {Status.HIGHLIGHTED}
           </div>
         </div>
 
         <div className={classNames(styles.imageCard)}>
           <div className={classNames(styles.imageHolder)}>
             <ImageButton
-              buttonStatus={ImageButtonStatus.DISABLED}
+              buttonStatus={Status.DISABLED}
               description={'enable/disable'}
               image={props.image}
               classNames={computedStyles}
             />
           </div>
           <div className={classNames(styles.imageDescription)}>
-            {ImageButtonStatus.DISABLED}
+            {Status.DISABLED}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Type
- refactoring

## Description
(alternative to https://github.com/Ensembl/ensembl-client/pull/156)

**Purpose:**
We are currently abusing ImageButtonStatus for defining statuses of things that are not directly related to the image button (e.g. browser tracks). This PR introduces a new Status type (that serves as a collection of all possible types for various things), from which other, more specific statuses, are derived.

Supersedes [this PR](https://github.com/Ensembl/ensembl-client/pull/156), which offered a different approach to solving the same problem.

**Discussion**
The unfortunate consequence of this implementation is that typescript may complain about the Status enum being too broad a type for a specific case, and thus will require some additional coaxing to type-check correctly. For example, declaring this variable:

```typescript
      const toggledTrack = {
        homo_sapiens38: {
          'Genes & transcripts': {
            'gene-pc-fwd': Status.INACTIVE
          }
        }
      };
```
and then passing it to a function that expected the 'gene-pc-fwd' field to be TrackPanelActivity type resulted in error:

![image](https://user-images.githubusercontent.com/6834224/67223138-a07d1f80-f426-11e9-9be2-b75031292f4e.png)

But on the other hand, even the approach with constants mentioned in the other PR will also require the same disambiguation of the type.