### PR TITLE
Remove RobotstxtPlugin from webpack

### DIFF
--- a/src/ensembl/robots-txt.config.js
+++ b/src/ensembl/robots-txt.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   policy: [{ userAgent: '*', disallow: '/' }],
-  host: 'http://2020.ensembl.org'
+  host: process.env.DEPLOYENV === 'prod' ? '2020.ensembl.org' : process.env.DEPLOYENV + '-2020.ensembl.org'
 };

--- a/src/ensembl/robots-txt.config.js
+++ b/src/ensembl/robots-txt.config.js
@@ -1,4 +1,3 @@
 module.exports = {
-  policy: [{ userAgent: '*', disallow: '/' }],
-  host: ( (!process.env.DEPLOYENV || process.env.DEPLOYENV === 'prod') ? '' : process.env.DEPLOYENV + '-') + '2020.ensembl.org'
+  policy: [{ userAgent: '*', disallow: '/' }]
 };

--- a/src/ensembl/robots-txt.config.js
+++ b/src/ensembl/robots-txt.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   policy: [{ userAgent: '*', disallow: '/' }],
-  host: process.env.DEPLOYENV === 'prod' ? '2020.ensembl.org' : process.env.DEPLOYENV + '-2020.ensembl.org'
+  host: (process.env.DEPLOYENV === 'prod' ? '' : process.env.DEPLOYENV + '-') + '2020.ensembl.org'
 };

--- a/src/ensembl/robots-txt.config.js
+++ b/src/ensembl/robots-txt.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   policy: [{ userAgent: '*', disallow: '/' }],
-  host: (process.env.DEPLOYENV === 'prod' ? '' : process.env.DEPLOYENV + '-') + '2020.ensembl.org'
+  host: ( (!process.env.DEPLOYENV || process.env.DEPLOYENV === 'prod') ? '' : process.env.DEPLOYENV + '-') + '2020.ensembl.org'
 };

--- a/src/ensembl/webpack/webpack.config.prod.js
+++ b/src/ensembl/webpack/webpack.config.prod.js
@@ -111,7 +111,9 @@ const plugins = [
     }]
   }),
 
-  new RobotstxtPlugin()
+  new RobotstxtPlugin({
+    filePath: '../robots.txt'
+  })
 ];
 
 // prod specific configuration


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-376

## Description
Updated the webpack configuration to create the robots.txt file in the path `dist/` instead of `dist/static/`

## Views affected
/robots.txt & /static/robots.txt
