### PR TITLE
Change default track config state for track labels to true

### DIFF
--- a/src/ensembl/src/content/app/browser/browser-track-config/BrowserTrackConfig.tsx
+++ b/src/ensembl/src/content/app/browser/browser-track-config/BrowserTrackConfig.tsx
@@ -61,8 +61,7 @@ const BrowserTrackConfig: FunctionComponent<BrowserTrackConfigProps> = (
 
   const selectedCog = props.selectedCog || '';
 
-  const shouldShowTrackName =
-    trackConfigNames[selectedCog] !== false ? true : false;
+  const shouldShowTrackName = trackConfigNames[selectedCog] || false;
   const shouldShowTrackLabels =
     trackConfigLabel[selectedCog] !== false ? true : false;
 

--- a/src/ensembl/src/content/app/browser/browser-track-config/BrowserTrackConfig.tsx
+++ b/src/ensembl/src/content/app/browser/browser-track-config/BrowserTrackConfig.tsx
@@ -61,8 +61,10 @@ const BrowserTrackConfig: FunctionComponent<BrowserTrackConfigProps> = (
 
   const selectedCog = props.selectedCog || '';
 
-  const shouldShowTrackName = trackConfigNames[selectedCog] || false;
-  const shouldShowTrackLabels = trackConfigLabel[selectedCog] || false;
+  const shouldShowTrackName =
+    trackConfigNames[selectedCog] !== false ? true : false;
+  const shouldShowTrackLabels =
+    trackConfigLabel[selectedCog] !== false ? true : false;
 
   const ref = useRef(null);
   useOutsideClick(ref, props.onClose);

--- a/src/ensembl/src/content/app/browser/browser-track-config/BrowserTrackConfig.tsx
+++ b/src/ensembl/src/content/app/browser/browser-track-config/BrowserTrackConfig.tsx
@@ -63,7 +63,7 @@ const BrowserTrackConfig: FunctionComponent<BrowserTrackConfigProps> = (
 
   const shouldShowTrackName = trackConfigNames[selectedCog] || false;
   const shouldShowTrackLabels =
-    trackConfigLabel[selectedCog] !== false ? true : false;
+    selectedCog in trackConfigLabel ? trackConfigLabel[selectedCog] : true;
 
   const ref = useRef(null);
   useOutsideClick(ref, props.onClose);


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-388

## Importance
Sprint 2019-6

## Description
The initial state of the labels and names field within the track config should be set to true instead of false.

## Views affected
Browser -> Track Config
