### PR TITLE
Prevent Sentry from recording ResizeObserver complaints

### DIFF
--- a/src/ensembl/src/services/error-service.ts
+++ b/src/ensembl/src/services/error-service.ts
@@ -24,7 +24,8 @@ class ErrorService implements ErrorServiceInterface {
   private initializeReportingService() {
     if (config.isProduction) {
       Sentry.init({
-        dsn: 'https://ab4205dce9c047588d30ddfaafd0655a@sentry.io/1507303'
+        dsn: 'https://ab4205dce9c047588d30ddfaafd0655a@sentry.io/1507303',
+        ignoreErrors: ['ResizeObserver loop limit exceeded']
       });
       this.isReportingServiceInitialized = true;
     }


### PR DESCRIPTION
## Type
- infrastructure

## Description
Sentry is getting errors that read as follows:

![image](https://user-images.githubusercontent.com/6834224/68044388-2030a700-fccf-11e9-8255-f84ffea45884.png)

As [discussed](https://stackoverflow.com/a/50387233/3925302) on Stack Overflow, or explained in this github comment: `https://github.com/WICG/ResizeObserver/issues/38#issuecomment-422126006`, this error is basically the browser complaining that ResizeObserver wasn't able to complete its work within an animation frame.

Since there doesn't seem to be much that we can do there, I think it's better to silence this error. Following the advice from https://github.com/WICG/ResizeObserver/issues/38#issuecomment-422126006.

[Sentry docs with this option described](https://docs.sentry.io/platforms/javascript/#decluttering-sentry)