### PR TITLE
Remove IE11-specific code

### DIFF
--- a/src/ensembl/package.json
+++ b/src/ensembl/package.json
@@ -163,7 +163,8 @@
     "workbox-webpack-plugin": "4.3.1"
   },
   "browserslist": [
-    "last 2 versions",
-    "ie > 10"
+    "> 1% and last 2 versions",
+    "not dead",
+    "not ie 11"
   ]
 }

--- a/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.scss
+++ b/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.scss
@@ -23,7 +23,6 @@ $button-gap: 1.4rem;
   height: $button-width;
   background: $blue;
   padding: 3px;
-  overflow: hidden; // <-- solely for IE11's sake; it seems that without this rule invisible parts of svg mignt be excaping the button and messing up layout
   cursor: pointer;
 
   svg {

--- a/src/ensembl/src/shared/components/tooltip/Tooltip.tsx
+++ b/src/ensembl/src/shared/components/tooltip/Tooltip.tsx
@@ -169,8 +169,8 @@ const getInlineStyles = (params: Props & { parentElement: HTMLElement }) => {
       return {
         bodyStyles: {
           left: '50%',
-          transform: `translateX(-100%) translateX(${TIP_HORIZONTAL_OFFSET}px) translateX(${TIP_WIDTH /
-            2}px)`,
+          transform: `translateX(calc(${TIP_HORIZONTAL_OFFSET}px + ${TIP_WIDTH /
+            2}px - 100%))`,
           bottom: `${parentHeight + TIP_HEIGHT}px`
         },
         tipStyles: {
@@ -221,7 +221,7 @@ const getInlineStyles = (params: Props & { parentElement: HTMLElement }) => {
         bodyStyles: {
           left: `-${TIP_HEIGHT}px`,
           top: `50%`,
-          transform: `translateX(-100%) translateY(-100%) translateY(${TIP_HORIZONTAL_OFFSET}px)`
+          transform: `translateX(-100%) translateY(calc(-100% + ${TIP_HORIZONTAL_OFFSET}px))`
         },
         tipStyles: {
           left: 'calc(100% - 1px)',
@@ -235,7 +235,7 @@ const getInlineStyles = (params: Props & { parentElement: HTMLElement }) => {
         bodyStyles: {
           left: 0,
           top: '50%',
-          transform: `translateX(-100%) translateX(-${TIP_HEIGHT}px) translateY(-${TIP_HORIZONTAL_OFFSET}px)`
+          transform: `translateX(calc(-100% - ${TIP_HEIGHT}px)) translateY(-${TIP_HORIZONTAL_OFFSET}px)`
         },
         tipStyles: {
           left: 'calc(100% - 1px)',

--- a/src/ensembl/webpack/webpack.common.js
+++ b/src/ensembl/webpack/webpack.common.js
@@ -35,13 +35,6 @@ module.exports = (isDev, moduleRules, plugins) => ({
         exclude: /node_modules/
       },
 
-      // these libraries are distributed in a way that does not support IE11, and so require compilation
-      {
-        test: /.js$/,
-        loader: 'babel-loader',
-        include: /react-spring/
-      },
-
       // the loaders for styling
       // there are two sets of them: for global and component styles
       // a scss file will first be loaded via sass loader and transpiled


### PR DESCRIPTION
# Description
Now that it is agreed that we do not support IE11, we should remove code transforms required for IE11 to work:

- explicitly exclude IE11 in browserslist field in package.json (the simple `last 2 versions` rule will still include IE11, because it is, technically, the last version of the IE line)
- remove explicit babel transform of `react-spring` (was needed because react-spring started packaging the library in a way that does not support IE11)

## Benefits
Small reduction in file sizes:

before (total size: 1012179 bytes):
```
-rw-r--r--  1 andrey  EBI\Domain Users   12872 29 Oct 14:31 ./dist/static/1.fd9afb449a39d088e862.js
-rw-r--r--  1 andrey  EBI\Domain Users   78139 29 Oct 14:31 ./dist/static/4.080b8405d290c664db85.js
-rw-r--r--  1 andrey  EBI\Domain Users  102267 29 Oct 14:31 ./dist/static/5.8f2ef17cf59f9201735c.js
-rw-r--r--  1 andrey  EBI\Domain Users   28234 29 Oct 14:31 ./dist/static/6.fe8fdffa6fff6d40e74d.js
-rw-r--r--  1 andrey  EBI\Domain Users    1663 29 Oct 14:31 ./dist/static/7.41d6f480557ea6913dee.js
-rw-r--r--  1 andrey  EBI\Domain Users  131746 29 Oct 14:31 ./dist/static/index.fa914f2bbe819a04a2ca.js
-rw-r--r--  1 andrey  EBI\Domain Users    7928 29 Oct 14:31 ./dist/static/precache-manifest.43ce61d49eda664410c28c901892753f.js
-rw-r--r--  1 andrey  EBI\Domain Users    3420 29 Oct 14:31 ./dist/static/runtime~index.b15be8914c4736b15741.js
-rw-r--r--  1 andrey  EBI\Domain Users  645910 29 Oct 14:31 ./dist/static/vendors.c9d7e2665525036dcea9.js
```

after (total size: 958564 bytes):
```
-rw-r--r--  1 andrey  EBI\Domain Users  112716  1 Nov 18:31 ./dist/static/3.580cd81367b8b2c040f6.js
-rw-r--r--  1 andrey  EBI\Domain Users   78159  1 Nov 18:31 ./dist/static/4.ab916f9cd9cb27e9787e.js
-rw-r--r--  1 andrey  EBI\Domain Users   31125  1 Nov 18:31 ./dist/static/5.48d622f2742e324c5b00.js
-rw-r--r--  1 andrey  EBI\Domain Users     294  1 Nov 18:31 ./dist/static/6.f1864c671ae3c18bb914.js
-rw-r--r--  1 andrey  EBI\Domain Users  111489  1 Nov 18:31 ./dist/static/index.050866eabc246eeb6505.js
-rw-r--r--  1 andrey  EBI\Domain Users    7534  1 Nov 18:31 ./dist/static/precache-manifest.2934d74e6a3ae1fb7ad58369065cdb94.js
-rw-r--r--  1 andrey  EBI\Domain Users    3366  1 Nov 18:31 ./dist/static/runtime~index.e3c9c0763ba6653c23b7.js
-rw-r--r--  1 andrey  EBI\Domain Users  613881  1 Nov 18:31 ./dist/static/vendors.22ca20110245f38d2110.js
```

The names of the files are different, and the distribution of code between files is different, but the total size of the built javascript files is about 50kB smaller after the removal of support for IE11.

## Discussion
There are a couple of places left where CSS was explicitly written to support IE11:
- in PopularSpeciesButton ([link](https://github.com/Ensembl/ensembl-client/blob/dev/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.scss#L26))
- in Tooltip ([link](https://github.com/Ensembl/ensembl-client/blob/dev/src/ensembl/src/shared/components/tooltip/Tooltip.tsx#L158-L160))

Not sure whether to update these styles or to leave them as they are.