### PR TITLE
Browser Nav bar integration

### DIFF
--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBar.scss
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBar.scss
@@ -4,20 +4,8 @@
   display: flex;
   font-size: 12px;
   background: $light-grey;
-  padding: 16px;
+  padding: 16px 26px;
   position: relative;
-
-  @include for-desktop-up {
-    width: calc(100vw - 356px);
-  }
-
-  &.browserNavBarExpanded {
-    width: 100vw;
-  }
-
-  dd {
-    margin-left: 10px;
-  }
 
   form {
     display: inline-block;

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBar.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBar.test.tsx
@@ -4,7 +4,7 @@ import { render } from 'enzyme';
 jest.mock('./BrowserNavBarControls', () => () => (
   <div>BrowserNavBarControls</div>
 ));
-jest.mock('./BrowserNavBarMain', () => () => <div>BrowserNavBarControls</div>);
+jest.mock('./BrowserNavBarMain', () => () => <div>BrowserNavBarMain</div>);
 
 import { BrowserNavBar } from './BrowserNavBar';
 

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBar.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBar.test.tsx
@@ -1,46 +1,21 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from 'enzyme';
+
+jest.mock('./BrowserNavBarControls', () => () => (
+  <div>BrowserNavBarControls</div>
+));
+jest.mock('./BrowserNavBarMain', () => () => <div>BrowserNavBarControls</div>);
 
 import { BrowserNavBar } from './BrowserNavBar';
-import { BrowserNavStates, ChrLocation } from '../browserState';
-
-import styles from './BrowserNavBar.scss';
-
-const browserStates = [...Array(6)].map(() => false);
-const chrLocation: ChrLocation = ['13', 1, 114364328];
-const toggleRegionEditorActive: any = jest.fn();
-const toggleRegionFieldActive: any = jest.fn();
 
 describe('<BrowserNavBar />', () => {
-  test('renders with appropriate classes', () => {
-    expect(
-      shallow(
-        <BrowserNavBar
-          browserNavStates={browserStates as BrowserNavStates}
-          chrLocation={chrLocation}
-          genomeKaryotype={[]}
-          isTrackPanelOpened={true}
-          regionEditorActive={true}
-          regionFieldActive={false}
-          toggleRegionEditorActive={toggleRegionEditorActive}
-          toggleRegionFieldActive={toggleRegionFieldActive}
-        />
-      ).hasClass(styles.browserNavBarExpanded)
-    ).toBe(false);
+  describe('rendering', () => {
+    it('correctly interprets the "expanded" prop', () => {
+      const contractedBar = render(<BrowserNavBar expanded={false} />);
+      expect(contractedBar.hasClass('browserNavBarExpanded')).toBe(false);
 
-    expect(
-      shallow(
-        <BrowserNavBar
-          browserNavStates={browserStates as BrowserNavStates}
-          chrLocation={chrLocation}
-          genomeKaryotype={[]}
-          isTrackPanelOpened={false}
-          regionEditorActive={true}
-          regionFieldActive={false}
-          toggleRegionEditorActive={toggleRegionEditorActive}
-          toggleRegionFieldActive={toggleRegionFieldActive}
-        />
-      ).hasClass(styles.browserNavBarExpanded)
-    ).toBe(true);
+      const expandedBar = render(<BrowserNavBar expanded={true} />);
+      expect(expandedBar.hasClass('browserNavBarExpanded')).toBe(true);
+    });
   });
 });

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBar.tsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 
 import BrowserNavIcon from './BrowserNavIcon';
+import BrowserNavBarMain from './BrowserNavBarMain';
 import BrowserRegionEditor from '../browser-region-editor/BrowserRegionEditor';
 import BrowserRegionField from '../browser-region-field/BrowserRegionField';
 
@@ -69,12 +70,15 @@ export const BrowserNavBar = (props: BrowserNavBarProps) => {
           />
         ))}
       </dd>
-      <dd>{props.chrLocation ? <BrowserRegionField /> : null}</dd>
-      <dd>
-        {props.chrLocation && props.genomeKaryotype ? (
-          <BrowserRegionEditor />
-        ) : null}
-      </dd>
+      <BrowserNavBarMain />
+      {/*
+        <dd>{props.chrLocation ? <BrowserRegionField /> : null}</dd>
+        <dd>
+          {props.chrLocation && props.genomeKaryotype ? (
+            <BrowserRegionEditor />
+          ) : null}
+        </dd>
+        */}
     </dl>
   );
 };

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBar.tsx
@@ -2,30 +2,20 @@ import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 
-import BrowserNavIcon from './BrowserNavIcon';
+import BrowserNavBarControls from './BrowserNavBarControls';
 import BrowserNavBarMain from './BrowserNavBarMain';
 
 import { RootState } from 'src/store';
-import { browserNavConfig, BrowserNavItem } from '../browserConfig';
-import {
-  getBrowserNavStates,
-  getRegionEditorActive,
-  getRegionFieldActive
-} from '../browserSelectors';
 import {
   toggleRegionEditorActive,
   toggleRegionFieldActive
 } from '../browserActions';
 import { getIsTrackPanelOpened } from '../track-panel/trackPanelSelectors';
-import { BrowserNavStates } from '../browserState';
 
 import styles from './BrowserNavBar.scss';
 
 export type BrowserNavBarProps = {
-  browserNavStates: BrowserNavStates;
-  isTrackPanelOpened: boolean;
-  regionEditorActive: boolean;
-  regionFieldActive: boolean;
+  expanded: boolean;
   toggleRegionEditorActive: (regionEditorActive: boolean) => void;
   toggleRegionFieldActive: (regionFieldActive: boolean) => void;
 };
@@ -41,39 +31,20 @@ export const BrowserNavBar = (props: BrowserNavBarProps) => {
   );
   // FIXME: do something to the above
 
-  const shouldNavIconBeEnabled = (index: number) => {
-    const { browserNavStates, regionEditorActive, regionFieldActive } = props;
-    const maxState = browserNavStates[index];
-    const regionInputsActive = regionEditorActive || regionFieldActive;
-
-    return !maxState && !regionInputsActive;
-  };
-
   const className = classNames(styles.browserNavBar, {
-    [styles.browserNavBarExpanded]: !props.isTrackPanelOpened
+    [styles.browserNavBarExpanded]: props.expanded
   });
 
   return (
-    <dl className={className}>
-      <dd>
-        {browserNavConfig.map((item: BrowserNavItem, index: number) => (
-          <BrowserNavIcon
-            key={item.name}
-            browserNavItem={item}
-            enabled={shouldNavIconBeEnabled(index)}
-          />
-        ))}
-      </dd>
+    <div className={className}>
+      <BrowserNavBarControls />
       <BrowserNavBarMain />
-    </dl>
+    </div>
   );
 };
 
 const mapStateToProps = (state: RootState) => ({
-  browserNavStates: getBrowserNavStates(state),
-  isTrackPanelOpened: getIsTrackPanelOpened(state),
-  regionEditorActive: getRegionEditorActive(state),
-  regionFieldActive: getRegionFieldActive(state)
+  expanded: !getIsTrackPanelOpened(state)
 });
 
 const mapDispatchToProps = {

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 
@@ -6,31 +6,15 @@ import BrowserNavBarControls from './BrowserNavBarControls';
 import BrowserNavBarMain from './BrowserNavBarMain';
 
 import { RootState } from 'src/store';
-import {
-  toggleRegionEditorActive,
-  toggleRegionFieldActive
-} from '../browserActions';
 import { getIsTrackPanelOpened } from '../track-panel/trackPanelSelectors';
 
 import styles from './BrowserNavBar.scss';
 
 export type BrowserNavBarProps = {
   expanded: boolean;
-  toggleRegionEditorActive: (regionEditorActive: boolean) => void;
-  toggleRegionFieldActive: (regionFieldActive: boolean) => void;
 };
 
 export const BrowserNavBar = (props: BrowserNavBarProps) => {
-  // the region editor and field style should be reset so that it won't be opaque when nav bar is opened again
-  useEffect(
-    () => () => {
-      props.toggleRegionEditorActive(false);
-      props.toggleRegionFieldActive(false);
-    },
-    []
-  );
-  // FIXME: do something to the above
-
   const className = classNames(styles.browserNavBar, {
     [styles.browserNavBarExpanded]: props.expanded
   });
@@ -47,12 +31,4 @@ const mapStateToProps = (state: RootState) => ({
   expanded: !getIsTrackPanelOpened(state)
 });
 
-const mapDispatchToProps = {
-  toggleRegionEditorActive,
-  toggleRegionFieldActive
-};
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(BrowserNavBar);
+export default connect(mapStateToProps)(BrowserNavBar);

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBar.tsx
@@ -4,14 +4,11 @@ import classNames from 'classnames';
 
 import BrowserNavIcon from './BrowserNavIcon';
 import BrowserNavBarMain from './BrowserNavBarMain';
-import BrowserRegionEditor from '../browser-region-editor/BrowserRegionEditor';
-import BrowserRegionField from '../browser-region-field/BrowserRegionField';
 
 import { RootState } from 'src/store';
 import { browserNavConfig, BrowserNavItem } from '../browserConfig';
 import {
   getBrowserNavStates,
-  getChrLocation,
   getRegionEditorActive,
   getRegionFieldActive
 } from '../browserSelectors';
@@ -20,16 +17,12 @@ import {
   toggleRegionFieldActive
 } from '../browserActions';
 import { getIsTrackPanelOpened } from '../track-panel/trackPanelSelectors';
-import { BrowserNavStates, ChrLocation } from '../browserState';
-import { getGenomeKaryotype } from 'src/shared/state/genome/genomeSelectors';
-import { GenomeKaryotypeItem } from 'src/shared/state/genome/genomeTypes';
+import { BrowserNavStates } from '../browserState';
 
 import styles from './BrowserNavBar.scss';
 
 export type BrowserNavBarProps = {
   browserNavStates: BrowserNavStates;
-  chrLocation: ChrLocation | null;
-  genomeKaryotype: GenomeKaryotypeItem[] | null;
   isTrackPanelOpened: boolean;
   regionEditorActive: boolean;
   regionFieldActive: boolean;
@@ -46,6 +39,7 @@ export const BrowserNavBar = (props: BrowserNavBarProps) => {
     },
     []
   );
+  // FIXME: do something to the above
 
   const shouldNavIconBeEnabled = (index: number) => {
     const { browserNavStates, regionEditorActive, regionFieldActive } = props;
@@ -71,22 +65,12 @@ export const BrowserNavBar = (props: BrowserNavBarProps) => {
         ))}
       </dd>
       <BrowserNavBarMain />
-      {/*
-        <dd>{props.chrLocation ? <BrowserRegionField /> : null}</dd>
-        <dd>
-          {props.chrLocation && props.genomeKaryotype ? (
-            <BrowserRegionEditor />
-          ) : null}
-        </dd>
-        */}
     </dl>
   );
 };
 
 const mapStateToProps = (state: RootState) => ({
   browserNavStates: getBrowserNavStates(state),
-  chrLocation: getChrLocation(state),
-  genomeKaryotype: getGenomeKaryotype(state),
   isTrackPanelOpened: getIsTrackPanelOpened(state),
   regionEditorActive: getRegionEditorActive(state),
   regionFieldActive: getRegionFieldActive(state)

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarControls.scss
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarControls.scss
@@ -1,0 +1,4 @@
+.browserNavBarControls {
+  display: flex;
+  align-items: center;
+}

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarControls.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarControls.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import faker from 'faker';
+import times from 'lodash/times';
+
+import BrowserNavIcon from './BrowserNavIcon';
+
+import { BrowserNavBarControls } from './BrowserNavBarControls';
+import { BrowserNavStates } from '../browserState';
+
+jest.mock('./BrowserNavIcon', () => () => <div>BrowserNavIcon</div>);
+
+const browserNavStates = times(6, faker.random.boolean) as BrowserNavStates;
+
+describe('BrowserNavBarControls', () => {
+  it('renders without errors', () => {
+    expect(() =>
+      mount(
+        <BrowserNavBarControls
+          browserNavStates={browserNavStates}
+          disabled={faker.random.boolean()}
+        />
+      )
+    ).not.toThrow();
+  });
+
+  it('disables all buttons if the disabled prop is set to true', () => {
+    const wrapper = mount(
+      <BrowserNavBarControls
+        browserNavStates={browserNavStates}
+        disabled={true}
+      />
+    );
+    const controlButtons = wrapper.find(BrowserNavIcon);
+    expect(controlButtons.length).toEqual(browserNavStates.length);
+    controlButtons.forEach((button) => {
+      expect(button.props().enabled).toBe(false);
+    });
+  });
+
+  it('disables buttons if corresponding actions are not possible', () => {
+    // browserNavStates are an array of booleans that indicate whether the button
+    // has already caused maximum corresponding effect, and will have no further effect if pressed
+    const wrapper = mount(
+      <BrowserNavBarControls
+        browserNavStates={browserNavStates}
+        disabled={false}
+      />
+    );
+    const controlButtons = wrapper.find(BrowserNavIcon);
+    controlButtons.forEach((button, index) => {
+      const hasCausedMaximumEffect = browserNavStates[index];
+      expect(button.props().enabled).toBe(!hasCausedMaximumEffect);
+    });
+  });
+});

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarControls.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarControls.test.tsx
@@ -34,7 +34,7 @@ describe('BrowserNavBarControls', () => {
     const controlButtons = wrapper.find(BrowserNavIcon);
     expect(controlButtons.length).toEqual(browserNavStates.length);
     controlButtons.forEach((button) => {
-      expect(button.props().enabled).toBe(false);
+      expect(button.prop('enabled')).toBe(false);
     });
   });
 
@@ -50,7 +50,7 @@ describe('BrowserNavBarControls', () => {
     const controlButtons = wrapper.find(BrowserNavIcon);
     controlButtons.forEach((button, index) => {
       const hasCausedMaximumEffect = browserNavStates[index];
-      expect(button.props().enabled).toBe(!hasCausedMaximumEffect);
+      expect(button.prop('enabled')).toBe(!hasCausedMaximumEffect);
     });
   });
 });

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarControls.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarControls.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import BrowserNavIcon from './BrowserNavIcon';
+
+import { RootState } from 'src/store';
+import { browserNavConfig, BrowserNavItem } from '../browserConfig';
+import {
+  getBrowserNavStates,
+  getRegionEditorActive,
+  getRegionFieldActive
+} from '../browserSelectors';
+import { BrowserNavStates } from '../browserState';
+
+type Props = {
+  browserNavStates: BrowserNavStates;
+  disabled: boolean;
+};
+
+export const BrowserNavBarControls = (props: Props) => {
+  const shouldEnableButton = (index: number) => {
+    const { browserNavStates, disabled } = props;
+    const isAtMaximum = browserNavStates[index];
+
+    return !disabled && !isAtMaximum;
+  };
+
+  return (
+    <div>
+      {browserNavConfig.map((item: BrowserNavItem, index: number) => (
+        <BrowserNavIcon
+          key={item.name}
+          browserNavItem={item}
+          enabled={shouldEnableButton(index)}
+        />
+      ))}
+    </div>
+  );
+};
+
+const mapStateToProps = (state: RootState) => {
+  const disabled = getRegionEditorActive(state) || getRegionFieldActive(state);
+
+  return {
+    browserNavStates: getBrowserNavStates(state),
+    disabled
+  };
+};
+
+export default connect(mapStateToProps)(BrowserNavBarControls);

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarControls.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarControls.tsx
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 
 import BrowserNavIcon from './BrowserNavIcon';
 
-import { RootState } from 'src/store';
 import { browserNavConfig, BrowserNavItem } from '../browserConfig';
 import {
   getBrowserNavStates,
@@ -11,6 +10,10 @@ import {
   getRegionFieldActive
 } from '../browserSelectors';
 import { BrowserNavStates } from '../browserState';
+
+import { RootState } from 'src/store';
+
+import styles from './BrowserNavBarControls.scss';
 
 type Props = {
   browserNavStates: BrowserNavStates;
@@ -26,7 +29,7 @@ export const BrowserNavBarControls = (props: Props) => {
   };
 
   return (
-    <div>
+    <div className={styles.browserNavBarControls}>
       {browserNavConfig.map((item: BrowserNavItem, index: number) => (
         <BrowserNavIcon
           key={item.name}

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.scss
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.scss
@@ -1,3 +1,5 @@
+@import 'src/styles/common';
+
 .browserNavBarMain {
   display: flex;
   align-items: center;
@@ -9,12 +11,23 @@
 }
 
 .contentSwitcherArea {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
   flex: 0 0 auto;
   width: 100px;
-  text-align: right;
 }
 
 .contentSwitcher {
-  color: blue;
+  display: inline-block;
+  color: $blue;
   cursor: pointer;
+
+  svg {
+    height: 20px;
+  }
+}
+
+.contentSwitcherClose {
+  font-size: 0;
 }

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.scss
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.scss
@@ -1,13 +1,21 @@
 @import 'src/styles/common';
 
 .browserNavBarMain {
+  padding-left: 50px;
   display: flex;
   align-items: center;
   flex-grow: 1;
 }
 
 .content {
+  display: flex;
   flex-grow: 1;
+}
+
+.contentChromosomeNavigator {
+  flex-grow: 1;
+  max-width: 1400px;
+  margin: auto;
 }
 
 .contentSwitcherArea {

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.scss
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.scss
@@ -37,5 +37,5 @@
 }
 
 .contentSwitcherClose {
-  font-size: 0;
+  font-size: 0; // to make the height of this container be defined exclusively by the height of its content
 }

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.scss
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.scss
@@ -32,7 +32,7 @@
   cursor: pointer;
 
   svg {
-    height: 20px;
+    height: 16px;
   }
 }
 

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.scss
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.scss
@@ -1,0 +1,20 @@
+.browserNavBarMain {
+  display: flex;
+  align-items: center;
+  flex-grow: 1;
+}
+
+.content {
+  flex-grow: 1;
+}
+
+.contentSwitcherArea {
+  flex: 0 0 auto;
+  width: 100px;
+  text-align: right;
+}
+
+.contentSwitcher {
+  color: blue;
+  cursor: pointer;
+}

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { mount } from 'enzyme';
+
+import BrowserNavBarMain, {
+  Content as BrowserNavBarMainContent
+} from './BrowserNavBarMain';
+
+import ChromosomeNavigator from 'src/content/app/browser/chromosome-navigator/ChromosomeNavigator';
+import BrowserNavBarRegionSwitcher from './BrowserNavBarRegionSwitcher';
+
+jest.mock(
+  'src/content/app/browser/chromosome-navigator/ChromosomeNavigator',
+  () => () => <div>ChromosomeNavigator</div>
+);
+jest.mock('./BrowserNavBarRegionSwitcher', () => () => (
+  <div>BrowserNavBarRegionSwitcher</div>
+));
+
+describe('BrowserNavBarMain', () => {
+  describe('rendering', () => {
+    it('renders without errors', () => {
+      expect(() => mount(<BrowserNavBarMain />)).not.toThrow();
+    });
+  });
+
+  describe('behaviour', () => {
+    it('renders chromosome visualization by default', () => {
+      const wrapper = mount(<BrowserNavBarMain />);
+      expect(wrapper.find(ChromosomeNavigator).length).toBe(1);
+      expect(wrapper.find(BrowserNavBarRegionSwitcher).length).toBe(0);
+    });
+
+    it('renders RegionSwitcher when user clicks on Change', () => {
+      const wrapper = mount(<BrowserNavBarMain />);
+      const changeButton = wrapper.find('.contentSwitcher');
+      act(() => {
+        changeButton.simulate('click');
+      });
+      wrapper.update();
+      expect(wrapper.find(ChromosomeNavigator).length).toBe(0);
+      expect(wrapper.find(BrowserNavBarRegionSwitcher).length).toBe(1);
+    });
+
+    it('renders chromosome visualization when user closes RegionSwitcher', () => {
+      const wrapper = mount(<BrowserNavBarMain />);
+      const changeButton = wrapper.find('.contentSwitcher');
+      act(() => {
+        changeButton.simulate('click');
+      });
+      wrapper.update();
+
+      const closeButton = wrapper.find('.contentSwitcherClose');
+      act(() => {
+        closeButton.simulate('click');
+      });
+      wrapper.update();
+
+      expect(wrapper.find(ChromosomeNavigator).length).toBe(1);
+      expect(wrapper.find(BrowserNavBarRegionSwitcher).length).toBe(0);
+    });
+  });
+});

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.test.tsx
@@ -34,10 +34,7 @@ describe('BrowserNavBarMain', () => {
     it('renders RegionSwitcher when user clicks on Change', () => {
       const wrapper = mount(<BrowserNavBarMain />);
       const changeButton = wrapper.find('.contentSwitcher');
-      act(() => {
-        changeButton.simulate('click');
-      });
-      wrapper.update();
+      changeButton.simulate('click');
       expect(wrapper.find(ChromosomeNavigator).length).toBe(0);
       expect(wrapper.find(BrowserNavBarRegionSwitcher).length).toBe(1);
     });
@@ -45,16 +42,10 @@ describe('BrowserNavBarMain', () => {
     it('renders chromosome visualization when user closes RegionSwitcher', () => {
       const wrapper = mount(<BrowserNavBarMain />);
       const changeButton = wrapper.find('.contentSwitcher');
-      act(() => {
-        changeButton.simulate('click');
-      });
-      wrapper.update();
+      changeButton.simulate('click');
 
       const closeButton = wrapper.find('.contentSwitcherClose');
-      act(() => {
-        closeButton.simulate('click');
-      });
-      wrapper.update();
+      closeButton.simulate('click');
 
       expect(wrapper.find(ChromosomeNavigator).length).toBe(1);
       expect(wrapper.find(BrowserNavBarRegionSwitcher).length).toBe(0);

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 
 import BrowserNavBarMain from './BrowserNavBarMain';

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.test.tsx
@@ -2,9 +2,7 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 
-import BrowserNavBarMain, {
-  Content as BrowserNavBarMainContent
-} from './BrowserNavBarMain';
+import BrowserNavBarMain from './BrowserNavBarMain';
 
 import ChromosomeNavigator from 'src/content/app/browser/chromosome-navigator/ChromosomeNavigator';
 import BrowserNavBarRegionSwitcher from './BrowserNavBarRegionSwitcher';
@@ -18,37 +16,29 @@ jest.mock('./BrowserNavBarRegionSwitcher', () => () => (
 ));
 
 describe('BrowserNavBarMain', () => {
-  describe('rendering', () => {
-    it('renders without errors', () => {
-      expect(() => mount(<BrowserNavBarMain />)).not.toThrow();
-    });
+  it('renders chromosome visualization by default', () => {
+    const wrapper = mount(<BrowserNavBarMain />);
+    expect(wrapper.find(ChromosomeNavigator).length).toBe(1);
+    expect(wrapper.find(BrowserNavBarRegionSwitcher).length).toBe(0);
   });
 
-  describe('behaviour', () => {
-    it('renders chromosome visualization by default', () => {
-      const wrapper = mount(<BrowserNavBarMain />);
-      expect(wrapper.find(ChromosomeNavigator).length).toBe(1);
-      expect(wrapper.find(BrowserNavBarRegionSwitcher).length).toBe(0);
-    });
+  it('renders RegionSwitcher when user clicks on Change', () => {
+    const wrapper = mount(<BrowserNavBarMain />);
+    const changeButton = wrapper.find('.contentSwitcher');
+    changeButton.simulate('click');
+    expect(wrapper.find(ChromosomeNavigator).length).toBe(0);
+    expect(wrapper.find(BrowserNavBarRegionSwitcher).length).toBe(1);
+  });
 
-    it('renders RegionSwitcher when user clicks on Change', () => {
-      const wrapper = mount(<BrowserNavBarMain />);
-      const changeButton = wrapper.find('.contentSwitcher');
-      changeButton.simulate('click');
-      expect(wrapper.find(ChromosomeNavigator).length).toBe(0);
-      expect(wrapper.find(BrowserNavBarRegionSwitcher).length).toBe(1);
-    });
+  it('renders chromosome visualization when user closes RegionSwitcher', () => {
+    const wrapper = mount(<BrowserNavBarMain />);
+    const changeButton = wrapper.find('.contentSwitcher');
+    changeButton.simulate('click');
 
-    it('renders chromosome visualization when user closes RegionSwitcher', () => {
-      const wrapper = mount(<BrowserNavBarMain />);
-      const changeButton = wrapper.find('.contentSwitcher');
-      changeButton.simulate('click');
+    const closeButton = wrapper.find('.contentSwitcherClose');
+    closeButton.simulate('click');
 
-      const closeButton = wrapper.find('.contentSwitcherClose');
-      closeButton.simulate('click');
-
-      expect(wrapper.find(ChromosomeNavigator).length).toBe(1);
-      expect(wrapper.find(BrowserNavBarRegionSwitcher).length).toBe(0);
-    });
+    expect(wrapper.find(ChromosomeNavigator).length).toBe(1);
+    expect(wrapper.find(BrowserNavBarRegionSwitcher).length).toBe(0);
   });
 });

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
+import classNames from 'classnames';
 
 import ChromosomeNavigator from 'src/content/app/browser/chromosome-navigator/ChromosomeNavigator';
 import BrowserNavBarRegionSwitcher from './BrowserNavBarRegionSwitcher';
+import { ReactComponent as CloseIcon } from 'static/img/shared/close.svg';
 
 import styles from './BrowserNavBarMain.scss';
 
@@ -11,13 +13,9 @@ enum Content {
 }
 
 const BrowserNavBarMain = () => {
-  const [view, changeView] = useState<Content>(Content.REGION_SWITCHER);
+  const [view, changeView] = useState<Content>(Content.CHROMOSOME);
 
-  const onChangeViewClick = () => {
-    const newView =
-      view === Content.CHROMOSOME
-        ? Content.REGION_SWITCHER
-        : Content.CHROMOSOME;
+  const onChangeViewClick = (newView: Content) => {
     changeView(newView);
   };
 
@@ -30,11 +28,37 @@ const BrowserNavBarMain = () => {
           <BrowserNavBarRegionSwitcher />
         )}
       </div>
-      <div className={styles.contentSwitcherArea}>
-        <span className={styles.contentSwitcher} onClick={onChangeViewClick}>
-          Change
-        </span>
-      </div>
+      <ContentSwitcher currentView={view} onSwitch={onChangeViewClick} />
+    </div>
+  );
+};
+
+type ContentSwitcherProps = {
+  currentView: Content;
+  onSwitch: (view: Content) => void;
+};
+
+const ContentSwitcher = (props: ContentSwitcherProps) => {
+  const switcherContent =
+    props.currentView === Content.CHROMOSOME ? 'Change' : <CloseIcon />;
+
+  const handleClick = () => {
+    const newView =
+      props.currentView === Content.CHROMOSOME
+        ? Content.REGION_SWITCHER
+        : Content.CHROMOSOME;
+    props.onSwitch(newView);
+  };
+
+  const contentSwitcherStyles = classNames(styles.contentSwitcher, {
+    [styles.contentSwitcherClose]: props.currentView === Content.REGION_SWITCHER
+  });
+
+  return (
+    <div className={styles.contentSwitcherArea}>
+      <span className={contentSwitcherStyles} onClick={handleClick}>
+        {switcherContent}
+      </span>
     </div>
   );
 };

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.tsx
@@ -1,7 +1,42 @@
 import React, { useState } from 'react';
 
+import ChromosomeNavigator from 'src/content/app/browser/chromosome-navigator/ChromosomeNavigator';
+import BrowserNavBarRegionSwitcher from './BrowserNavBarRegionSwitcher';
+
+import styles from './BrowserNavBarMain.scss';
+
+enum Content {
+  CHROMOSOME,
+  REGION_SWITCHER
+}
+
 const BrowserNavBarMain = () => {
-  return <div>Main</div>;
+  const [view, changeView] = useState<Content>(Content.REGION_SWITCHER);
+
+  const onChangeViewClick = () => {
+    const newView =
+      view === Content.CHROMOSOME
+        ? Content.REGION_SWITCHER
+        : Content.CHROMOSOME;
+    changeView(newView);
+  };
+
+  return (
+    <div className={styles.browserNavBarMain}>
+      <div className={styles.content}>
+        {view === Content.CHROMOSOME ? (
+          <ChromosomeNavigator />
+        ) : (
+          <BrowserNavBarRegionSwitcher />
+        )}
+      </div>
+      <div className={styles.contentSwitcherArea}>
+        <span className={styles.contentSwitcher} onClick={onChangeViewClick}>
+          Change
+        </span>
+      </div>
+    </div>
+  );
 };
 
 export default BrowserNavBarMain;

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.tsx
@@ -6,9 +6,8 @@ import BrowserNavBarRegionSwitcher from './BrowserNavBarRegionSwitcher';
 import { ReactComponent as CloseIcon } from 'static/img/shared/close.svg';
 
 import styles from './BrowserNavBarMain.scss';
-import style from 'react-syntax-highlighter/dist/styles/prism/xonokai';
 
-enum Content {
+export enum Content {
   CHROMOSOME,
   REGION_SWITCHER
 }

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.tsx
@@ -6,6 +6,7 @@ import BrowserNavBarRegionSwitcher from './BrowserNavBarRegionSwitcher';
 import { ReactComponent as CloseIcon } from 'static/img/shared/close.svg';
 
 import styles from './BrowserNavBarMain.scss';
+import style from 'react-syntax-highlighter/dist/styles/prism/xonokai';
 
 enum Content {
   CHROMOSOME,
@@ -23,7 +24,9 @@ const BrowserNavBarMain = () => {
     <div className={styles.browserNavBarMain}>
       <div className={styles.content}>
         {view === Content.CHROMOSOME ? (
-          <ChromosomeNavigator />
+          <div className={styles.contentChromosomeNavigator}>
+            <ChromosomeNavigator />
+          </div>
         ) : (
           <BrowserNavBarRegionSwitcher />
         )}

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.tsx
@@ -7,7 +7,7 @@ import { ReactComponent as CloseIcon } from 'static/img/shared/close.svg';
 
 import styles from './BrowserNavBarMain.scss';
 
-export enum Content {
+enum Content {
   CHROMOSOME,
   REGION_SWITCHER
 }

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.tsx
@@ -15,7 +15,7 @@ export enum Content {
 const BrowserNavBarMain = () => {
   const [view, changeView] = useState<Content>(Content.CHROMOSOME);
 
-  const onChangeViewClick = (newView: Content) => {
+  const handleViewChange = (newView: Content) => {
     changeView(newView);
   };
 
@@ -30,7 +30,7 @@ const BrowserNavBarMain = () => {
           <BrowserNavBarRegionSwitcher />
         )}
       </div>
-      <ContentSwitcher currentView={view} onSwitch={onChangeViewClick} />
+      <ContentSwitcher currentView={view} onSwitch={handleViewChange} />
     </div>
   );
 };

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.tsx
@@ -1,0 +1,7 @@
+import React, { useState } from 'react';
+
+const BrowserNavBarMain = () => {
+  return <div>Main</div>;
+};
+
+export default BrowserNavBarMain;

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarRegionSwitcher.scss
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarRegionSwitcher.scss
@@ -1,3 +1,5 @@
 .regionSwitcher {
   display: flex;
+  flex-grow: 1;
+  justify-content: flex-end;
 }

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarRegionSwitcher.scss
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarRegionSwitcher.scss
@@ -1,0 +1,3 @@
+.regionSwitcher {
+  display: flex;
+}

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarRegionSwitcher.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarRegionSwitcher.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { BrowserNavBarRegionSwitcher } from './BrowserNavBarRegionSwitcher';
+
+import BrowserRegionEditor from '../browser-region-editor/BrowserRegionEditor';
+import BrowserRegionField from '../browser-region-field/BrowserRegionField';
+
+jest.mock(
+  'src/content/app/browser/browser-region-editor/BrowserRegionEditor',
+  () => () => <div>BrowserRegionEditor</div>
+);
+jest.mock(
+  'src/content/app/browser/browser-region-field/BrowserRegionField',
+  () => () => <div>BrowserRegionField</div>
+);
+
+const props = {
+  toggleRegionEditorActive: jest.fn(),
+  toggleRegionFieldActive: jest.fn()
+};
+
+describe('BrowserNavBarRegionSwitcher', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('renders correctly', () => {
+    const wrapper = mount(<BrowserNavBarRegionSwitcher {...props} />);
+
+    expect(wrapper.find(BrowserRegionEditor).length).toBe(1);
+    expect(wrapper.find(BrowserRegionField).length).toBe(1);
+  });
+
+  it('calls cleanup functions on unmount', () => {
+    const wrapper = mount(<BrowserNavBarRegionSwitcher {...props} />);
+
+    expect(props.toggleRegionEditorActive).not.toHaveBeenCalled();
+    expect(props.toggleRegionFieldActive).not.toHaveBeenCalled();
+
+    wrapper.unmount();
+
+    expect(props.toggleRegionEditorActive).toHaveBeenCalledWith(false);
+    expect(props.toggleRegionFieldActive).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarRegionSwitcher.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarRegionSwitcher.tsx
@@ -1,13 +1,31 @@
-import React, { useState } from 'react';
+import React, { useEffect } from 'react';
+import { connect } from 'react-redux';
 
 import BrowserRegionEditor from '../browser-region-editor/BrowserRegionEditor';
 import BrowserRegionField from '../browser-region-field/BrowserRegionField';
 
-import { RootState } from 'src/store';
+import {
+  toggleRegionEditorActive,
+  toggleRegionFieldActive
+} from '../browserActions';
 
 import styles from './BrowserNavBarRegionSwitcher.scss';
 
-const BrowserNavBarRegionSwitcher = () => {
+type Props = {
+  toggleRegionEditorActive: (isActive: boolean) => void;
+  toggleRegionFieldActive: (isActive: boolean) => void;
+};
+
+export const BrowserNavBarRegionSwitcher = (props: Props) => {
+  // cleanup on unmount
+  useEffect(
+    () => () => {
+      props.toggleRegionEditorActive(false);
+      props.toggleRegionFieldActive(false);
+    },
+    []
+  );
+
   return (
     <div className={styles.regionSwitcher}>
       <div className={styles.regionFieldWrapper}>
@@ -20,4 +38,12 @@ const BrowserNavBarRegionSwitcher = () => {
   );
 };
 
-export default BrowserNavBarRegionSwitcher;
+const mapDispatchToProps = {
+  toggleRegionEditorActive,
+  toggleRegionFieldActive
+};
+
+export default connect(
+  null,
+  mapDispatchToProps
+)(BrowserNavBarRegionSwitcher);

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarRegionSwitcher.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarRegionSwitcher.tsx
@@ -1,0 +1,23 @@
+import React, { useState } from 'react';
+
+import BrowserRegionEditor from '../browser-region-editor/BrowserRegionEditor';
+import BrowserRegionField from '../browser-region-field/BrowserRegionField';
+
+import { RootState } from 'src/store';
+
+import styles from './BrowserNavBarRegionSwitcher.scss';
+
+const BrowserNavBarRegionSwitcher = () => {
+  return (
+    <div className={styles.regionSwitcher}>
+      <div className={styles.regionFieldWrapper}>
+        <BrowserRegionField />
+      </div>
+      <div className={styles.regionEditorWrapper}>
+        <BrowserRegionEditor />
+      </div>
+    </div>
+  );
+};
+
+export default BrowserNavBarRegionSwitcher;

--- a/src/ensembl/src/content/app/browser/browser-region-editor/BrowserRegionEditor.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-region-editor/BrowserRegionEditor.test.tsx
@@ -12,16 +12,12 @@ import Tooltip from 'src/shared/components/tooltip/Tooltip';
 import Overlay from 'src/shared/components/overlay/Overlay';
 
 import { createGenomeKaryotype } from 'tests/fixtures/genomes';
-import {
-  getCommaSeparatedNumber,
-  getNumberWithoutCommas
-} from 'src/shared/helpers/numberFormatter';
+import { getCommaSeparatedNumber } from 'src/shared/helpers/numberFormatter';
 import {
   createChrLocationValues,
   createRegionValidationMessages
 } from 'tests/fixtures/browser';
 import * as browserHelper from '../browserHelper';
-import { ChrLocation } from '../browserState';
 
 jest.mock('src/shared/components/overlay/Overlay', () => () => (
   <div>Overlay</div>

--- a/src/ensembl/src/content/app/browser/chromosome-navigator/ChromosomeNavigator.test.tsx
+++ b/src/ensembl/src/content/app/browser/chromosome-navigator/ChromosomeNavigator.test.tsx
@@ -101,8 +101,8 @@ describe('Chromosome Navigator', () => {
         which is the second tuple of coordinates in the points prop
       */
       const bracketX = bracket
-        .props()
-        .points.split(' ')[1]
+        .prop('points')
+        .split(' ')[1]
         .split(',')[0];
       expect(parseInt(bracketX, 10)).toBe(position);
     };
@@ -112,10 +112,10 @@ describe('Chromosome Navigator', () => {
       assertions.forEach((assertion: any, index: number) => {
         const { x, width } = assertion;
         if (x !== undefined) {
-          expect(areas.at(index).props().x).toBe(x);
+          expect(areas.at(index).prop('x')).toBe(x);
         }
         if (width !== undefined) {
-          expect(areas.at(index).props().width).toBe(width);
+          expect(areas.at(index).prop('width')).toBe(width);
         }
       });
     };
@@ -227,8 +227,8 @@ describe('Chromosome Navigator', () => {
       positions.forEach((position: number, index: number) => {
         const transform = pointers
           .at(index)
-          .props()
-          .transform.match(/translate\((\d+)\)/)[1];
+          .prop('transform')
+          .match(/translate\((\d+)\)/)[1];
         const actualPosition = parseInt(transform, 10);
         expect(isApproximatelyEqual(position, actualPosition)).toBe(true);
       });
@@ -307,7 +307,7 @@ describe('Chromosome Navigator', () => {
       assertions.forEach((assertion: any, index: number) => {
         const { x, text } = assertion;
         if (x !== undefined) {
-          expect(labels.at(index).props().x).toBe(x);
+          expect(labels.at(index).prop('x')).toBe(x);
         }
         if (text !== undefined) {
           const actualText = labels.at(index).text();

--- a/src/ensembl/src/content/app/browser/chromosome-navigator/ChromosomeNavigator.tsx
+++ b/src/ensembl/src/content/app/browser/chromosome-navigator/ChromosomeNavigator.tsx
@@ -12,7 +12,7 @@ import {
   getDefaultChrLocation
 } from 'src/content/app/browser/browserSelectors';
 
-import { getKaryotypeItemLength } from 'src/genome/genomeSelectors';
+import { getKaryotypeItemLength } from 'src/shared/state/genome/genomeSelectors';
 
 import * as centromeres from 'src/shared/data/centromeres';
 

--- a/src/ensembl/src/content/app/browser/chromosome-navigator/ChromosomeNavigator.tsx
+++ b/src/ensembl/src/content/app/browser/chromosome-navigator/ChromosomeNavigator.tsx
@@ -1,5 +1,3 @@
-// TODO: think about the name; perhaps something like MiniMap is a better option?
-
 import React from 'react';
 import { connect } from 'react-redux';
 import useResizeObserver from 'use-resize-observer';

--- a/src/ensembl/src/content/app/browser/chromosome-navigator/ChromosomeNavigator.tsx
+++ b/src/ensembl/src/content/app/browser/chromosome-navigator/ChromosomeNavigator.tsx
@@ -9,11 +9,14 @@ import * as constants from './chromosomeNavigatorConstants';
 import { calculateStyles } from './chromosomeNavigatorHelper';
 
 import {
+  getBrowserActiveGenomeId,
   getActualChrLocation,
   getDefaultChrLocation
 } from 'src/content/app/browser/browserSelectors';
 
 import { getKaryotypeItemLength } from 'src/genome/genomeSelectors';
+
+import * as centromeres from 'src/shared/data/centromeres';
 
 import { RootState } from 'src/store';
 
@@ -123,12 +126,20 @@ const mapStateToProps = (state: RootState) => {
   const length =
     (chromosomeName && getKaryotypeItemLength(chromosomeName, state)) || 0;
 
+  // the code below is naughty: we are going to peek at the string that represents genome id
+  // — something which we are not supposed to do
+  const genomeId = getBrowserActiveGenomeId(state);
+  let centromere;
+  if (chromosomeName && genomeId && genomeId.startsWith('homo_sapiens')) {
+    centromere = centromeres.humanCentromeres[chromosomeName] || null;
+  }
+
   return {
     length,
     viewportStart: start,
     viewportEnd: end,
     focusRegion,
-    centromere: null // FIXME
+    centromere
   };
 };
 

--- a/src/ensembl/src/content/app/browser/chromosome-navigator/ChromosomeNavigator.tsx
+++ b/src/ensembl/src/content/app/browser/chromosome-navigator/ChromosomeNavigator.tsx
@@ -1,11 +1,21 @@
 // TODO: think about the name; perhaps something like MiniMap is a better option?
 
 import React from 'react';
+import { connect } from 'react-redux';
 import useResizeObserver from 'use-resize-observer';
 
 import * as constants from './chromosomeNavigatorConstants';
 
 import { calculateStyles } from './chromosomeNavigatorHelper';
+
+import {
+  getActualChrLocation,
+  getDefaultChrLocation
+} from 'src/content/app/browser/browserSelectors';
+
+import { getKaryotypeItemLength } from 'src/genome/genomeSelectors';
+
+import { RootState } from 'src/store';
 
 import styles from './ChromosomeNavigator.scss';
 
@@ -27,7 +37,7 @@ export type ChromosomeNavigatorProps = WrapperProps & {
   containerWidth: number; // width of the container, in pixels
 };
 
-const ChromosomeNavigatorWrapper = (props: WrapperProps) => {
+export const ChromosomeNavigatorWrapper = (props: WrapperProps) => {
   const [containerRef, containerWidth] = useResizeObserver();
 
   return (
@@ -35,7 +45,7 @@ const ChromosomeNavigatorWrapper = (props: WrapperProps) => {
       ref={containerRef as React.RefObject<HTMLDivElement>}
       className={styles.chromosomeNavigator}
     >
-      {containerWidth ? (
+      {containerWidth && props.length ? (
         <ChromosomeNavigator {...{ ...props, containerWidth }} />
       ) : null}
     </div>
@@ -100,4 +110,26 @@ export const ChromosomeNavigator = (props: ChromosomeNavigatorProps) => {
   );
 };
 
-export default ChromosomeNavigatorWrapper;
+const mapStateToProps = (state: RootState) => {
+  const [chromosomeName = null, start = 0, end = 0] =
+    getActualChrLocation(state) || [];
+  const defaultChrLocation = getDefaultChrLocation(state);
+  const focusRegion = defaultChrLocation
+    ? {
+        start: defaultChrLocation[1],
+        end: defaultChrLocation[2]
+      }
+    : null;
+  const length =
+    (chromosomeName && getKaryotypeItemLength(chromosomeName, state)) || 0;
+
+  return {
+    length,
+    viewportStart: start,
+    viewportEnd: end,
+    focusRegion,
+    centromere: null // FIXME
+  };
+};
+
+export default connect(mapStateToProps)(ChromosomeNavigatorWrapper);

--- a/src/ensembl/src/content/app/browser/chromosome-navigator/ChromosomeNavigator.tsx
+++ b/src/ensembl/src/content/app/browser/chromosome-navigator/ChromosomeNavigator.tsx
@@ -126,10 +126,10 @@ const mapStateToProps = (state: RootState) => {
   const length =
     (chromosomeName && getKaryotypeItemLength(chromosomeName, state)) || 0;
 
-  // the code below is naughty: we are going to peek at the string that represents genome id
-  // — something which we are not supposed to do
+  // the code below is naughty and temporary (see ENSWBSITES-385):
+  // we are peeking at the string that represents genome id — something which we are not supposed to do
   const genomeId = getBrowserActiveGenomeId(state);
-  let centromere;
+  let centromere = null;
   if (chromosomeName && genomeId && genomeId.startsWith('homo_sapiens')) {
     centromere = centromeres.humanCentromeres[chromosomeName] || null;
   }

--- a/src/ensembl/src/content/app/browser/chromosome-navigator/chromosomeNavigatorConstants.ts
+++ b/src/ensembl/src/content/app/browser/chromosome-navigator/chromosomeNavigatorConstants.ts
@@ -1,7 +1,7 @@
 export const TOTAL_HEIGHT = 20;
 
 export const STICK_HEIGHT = 4;
-export const STICK_MARGIN_TOP = 10;
+export const STICK_MARGIN_TOP = 12;
 
 export const CENTROMERE_RADIUS = 2;
 export const CENTROMERE_CENTRE_Y = STICK_MARGIN_TOP + CENTROMERE_RADIUS;
@@ -14,5 +14,5 @@ export const POINTER_ARROWHEAD_WIDTH = 10;
 export const POINTER_ARROWHEAD_HEIGHT = 8;
 export const POINTER_LINE_LENGTH = 8;
 
-export const LABEL_TOP_MARGIN = 0;
+export const LABEL_TOP_MARGIN = STICK_MARGIN_TOP - 8;
 export const MIN_DISTANCE_BETWEEN_LABELS = 10;

--- a/src/ensembl/src/shared/data/centromeres.ts
+++ b/src/ensembl/src/shared/data/centromeres.ts
@@ -1,0 +1,115 @@
+/*
+
+This file exists due to two reasons:
+1) Designer wants chromosome idiograms to contain visual representation of centromere
+2) But we only have centromere locations for human
+
+That's why we agreed to hard-code centromere locations for human on the front end.
+
+*/
+
+type CentromereLocations = {
+  [name: string]: {
+    start: number;
+    end: number;
+  };
+};
+
+export const humanCentromeres: CentromereLocations = {
+  1: {
+    start: 122026460,
+    end: 125184587
+  },
+  2: {
+    start: 92188146,
+    end: 94090557
+  },
+  3: {
+    start: 90772459,
+    end: 93655574
+  },
+  4: {
+    start: 49708101,
+    end: 51743951
+  },
+  5: {
+    start: 46485901,
+    end: 50059807
+  },
+  6: {
+    start: 58553889,
+    end: 59829934
+  },
+  7: {
+    start: 58169654,
+    end: 60828234
+  },
+  8: {
+    start: 44033745,
+    end: 45877265
+  },
+  9: {
+    start: 43236168,
+    end: 45518558
+  },
+  10: {
+    start: 39686683,
+    end: 41593521
+  },
+  11: {
+    start: 51078349,
+    end: 54425074
+  },
+  12: {
+    start: 34769408,
+    end: 37185252
+  },
+  13: {
+    start: 16000001,
+    end: 18051248
+  },
+  14: {
+    start: 16000001,
+    end: 18173523
+  },
+  15: {
+    start: 17000001,
+    end: 19725254
+  },
+  16: {
+    start: 36311159,
+    end: 38280682
+  },
+  17: {
+    start: 22813680,
+    end: 26885980
+  },
+  18: {
+    start: 15460900,
+    end: 20861206
+  },
+  19: {
+    start: 24498981,
+    end: 27190874
+  },
+  20: {
+    start: 26436233,
+    end: 30038348
+  },
+  21: {
+    start: 10864561,
+    end: 12915808
+  },
+  22: {
+    start: 12954789,
+    end: 15054318
+  },
+  X: {
+    start: 58605580,
+    end: 62412542
+  },
+  Y: {
+    start: 10316945,
+    end: 10544039
+  }
+};

--- a/src/ensembl/src/shared/state/genome/genomeSelectors.ts
+++ b/src/ensembl/src/shared/state/genome/genomeSelectors.ts
@@ -41,6 +41,16 @@ export const getGenomeKaryotype = (state: RootState) => {
     : null;
 };
 
+export const getKaryotypeItemLength = (name: string, state: RootState) => {
+  const karyotype = getGenomeKaryotype(state);
+  if (!karyotype) {
+    return null;
+  }
+
+  const karyotypeItem = karyotype.find((item) => item.name === name);
+  return karyotypeItem ? karyotypeItem.length : null;
+};
+
 export const getGenomeKaryotypeFetching = (state: RootState) =>
   state.genome.genomeKaryotype.genomeKaryotypeFetching;
 

--- a/src/ensembl/stories/genome-browser/chromosome-navigator/ChromosomeNavigator.stories.tsx
+++ b/src/ensembl/stories/genome-browser/chromosome-navigator/ChromosomeNavigator.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 
-import ChromosomeNavigator from 'src/content/app/browser/chromosome-navigator/ChromosomeNavigator';
+import { ChromosomeNavigatorWrapper as ChromosomeNavigator } from 'src/content/app/browser/chromosome-navigator/ChromosomeNavigator';
 
 import styles from './ChromosomeNavigator.stories.scss';
 


### PR DESCRIPTION
## Type
- New feature
- Refactoring

## Related JIRA Issue(s)
ENSWBSITES-403

## Description

### New functionality
Chromosome navigator component is included in browser navigation bar, alongside the fields that change browser location.

### Code refactoring
The composition of BrowserNavBar component has changed:

**before:**
![Untitled Diagram](https://user-images.githubusercontent.com/6834224/68195541-f2897d80-ffae-11e9-9611-4d2f4249f8c8.png)

**after:**
![Untitled Diagram (1)](https://user-images.githubusercontent.com/6834224/68195557-f87f5e80-ffae-11e9-849d-e3b8aa918bb4.png)

### Styles
Directions from Andrea:

1) Region switcher elements should be aligned to the right, next to the close icon
![Untitled Diagram](https://user-images.githubusercontent.com/6834224/68206270-42bf0a80-ffc4-11e9-9cd8-60623bb4c897.png)

2) Chromosome idiogram should have a max-width (say, 1400px) and be positioned in the centre of the available space
![Untitled Diagram (1)](https://user-images.githubusercontent.com/6834224/68206280-49e61880-ffc4-11e9-8052-0bbe3a5f90ce.png)


## Views affected
Genome browser page