### PR TITLE
Fix wasm build issues

### DIFF
--- a/src/assets/browser/app/build/deploy.sh
+++ b/src/assets/browser/app/build/deploy.sh
@@ -34,10 +34,10 @@ WASMNAME="browser-$WASMHASH.wasm"
 JSNAME="browser.js"
 rm -f $DEST/*.js $DEST/*.wasm
 
-if [ "$1" == "check" ] ; then
-  cp $SRC/target/deploy/hellostdweb.wasm $DEST/$WASMNAME
-else
+if [ "$1" != "check" ] && hash wasm-opt 2>/dev/null ; then
   wasm-opt -Os $SRC/target/deploy/hellostdweb.wasm -o $DEST/$WASMNAME
+else
+  cp $SRC/target/deploy/hellostdweb.wasm $DEST/$WASMNAME
 fi
 ls -lh $DEST/$WASMNAME
 cp $SRC/target/deploy/hellostdweb.js $DEST/$JSNAME

--- a/src/assets/browser/app/build/deploy.sh
+++ b/src/assets/browser/app/build/deploy.sh
@@ -21,7 +21,13 @@ cargo +nightly web deploy --target=wasm32-unknown-unknown --release
 
 echo "SRC=$SRC"
 echo "DEST=$DEST"
-WASMHASH=$(md5sum $SRC/target/deploy/hellostdweb.wasm | cut -f1 -d' ');
+
+if hash md5 2>/dev/null; then
+  WASMHASH=$(md5 $SRC/target/deploy/hellostdweb.wasm | cut -f4 -d' ')
+else
+  WASMHASH=$(md5sum $SRC/target/deploy/hellostdweb.wasm | cut -f1 -d' ')
+fi
+
 echo "WASMHASH=$WASMHASH"
 
 WASMNAME="browser-$WASMHASH.wasm"

--- a/src/assets/browser/app/build/env.sh
+++ b/src/assets/browser/app/build/env.sh
@@ -1,5 +1,11 @@
-#! /bin/bash
+if [ -n "$ZSH_VERSION" ]; then
+   SOURCE=${(%):-%x}
+else
+   SOURCE=$BASH_SOURCE
+fi
 
-BASE="$(cd "$(dirname "$BASH_SOURCE")"; pwd)"
+BASE="$(cd "$(dirname "$SOURCE")"; pwd)"
+
+echo "Adding $BASE/bin to path"
 export PATH="$BASE/bin:$PATH"
 


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Description
When I tried building the wasm file as per Dan's instructions, the md5 check failed as the command that is used for it (md5sum) does not exist in MacOS by default. So this PR, will check if md5 exists and use it, if not use md5sum (which is in Linux operating systems).

## Possible complications
This could probably not work, if both md5 and md5sum do not exist in the system.