### PR TITLE
Fix tooltip width for Safari

### DIFF
--- a/src/ensembl/src/shared/components/tooltip/Tooltip.scss
+++ b/src/ensembl/src/shared/components/tooltip/Tooltip.scss
@@ -8,6 +8,7 @@ $fill-color: $dark-grey;
   padding: 6px 18px 8px;
   box-shadow: 2px 2px 5px $shadow-color;
   width: max-content; // not supported in IE or non-webkit Edge
+  box-sizing: content-box; // Safari doesn't seem to respect "width: max-content" if box-sizing is border-box
   cursor: default;
   color: $white;
   border-radius: 4px;


### PR DESCRIPTION
## Type
- Bug fix

## Related JIRA Issue(s)
ENSWBSITES-423

## Importance
Bug in production.

## Description
Tooltips are broken in Safari: they sometimes simply wrap inner text:

![image](https://user-images.githubusercontent.com/6834224/68325880-3caf5380-00c2-11ea-8953-3852d014c365.png)

and sometimes allow content to escape outside the tooltip:

![image](https://user-images.githubusercontent.com/6834224/68325901-489b1580-00c2-11ea-99c5-0b2e9cd9dd75.png)

The reason seems to be that Safari does not respect the `width: max-content;` rule (or perhaps interprets it incorrectly) if `box-sizing` is `border-box` (example: https://jsfiddle.net/rt9vuadf/1/), but renders correctly if  `box-sizing` is `content-box` (example: https://jsfiddle.net/rt9vuadf/).

Safari is the new IE6! 😠 