### PR TITLE
Add tracking and stop bumping links to top after revisiting

### DIFF
--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerBookmarks.tsx
@@ -9,6 +9,7 @@ import { PreviouslyViewedObject } from 'src/content/app/browser/track-panel/trac
 import { closeTrackPanelModal } from 'src/content/app/browser/track-panel/trackPanelActions';
 import { closeDrawer } from 'src/content/app/browser/drawer/drawerActions';
 import { getActiveGenomePreviouslyViewedObjects } from 'src/content/app/browser/track-panel/trackPanelSelectors';
+import analyticsTracking from 'src/services/analytics-service';
 
 import styles from './DrawerBookmarks.scss';
 
@@ -24,7 +25,14 @@ const DrawerBookmarks = (props: DrawerBookmarksProps) => {
     props.previouslyViewedObjects.length - 20
   );
 
-  const onClickHandler = () => {
+  const onClickHandler = (objectType: string, index: number) => {
+    analyticsTracking.trackEvent({
+      category: 'recent_bookmark_link',
+      label: objectType,
+      action: 'clicked',
+      value: index + 20
+    });
+
     props.closeTrackPanelModal();
     props.closeDrawer();
   };
@@ -44,7 +52,12 @@ const DrawerBookmarks = (props: DrawerBookmarksProps) => {
 
               return (
                 <span key={index} className={styles.linkHolder}>
-                  <Link to={path} onClick={onClickHandler}>
+                  <Link
+                    to={path}
+                    onClick={() =>
+                      onClickHandler(previouslyViewedObject.object_type, index)
+                    }
+                  >
                     {previouslyViewedObject.label}
                   </Link>
                   <span className={styles.previouslyViewedType}>

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerBookmarks.tsx
@@ -30,7 +30,7 @@ const DrawerBookmarks = (props: DrawerBookmarksProps) => {
       category: 'recent_bookmark_link',
       label: objectType,
       action: 'clicked',
-      value: index + 20
+      value: index + 21
     });
 
     props.closeTrackPanelModal();

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerBookmarks.tsx
@@ -30,7 +30,7 @@ const DrawerBookmarks = (props: DrawerBookmarksProps) => {
       category: 'recent_bookmark_link',
       label: objectType,
       action: 'clicked',
-      value: index + 21
+      value: index + 1
     });
 
     props.closeTrackPanelModal();

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
@@ -17,6 +17,7 @@ import ImageButton from 'src/shared/components/image-button/ImageButton';
 import { ReactComponent as EllipsisIcon } from 'static/img/track-panel/ellipsis.svg';
 import { changeDrawerViewAndOpen } from 'src/content/app/browser/drawer/drawerActions';
 import { PreviouslyViewedObject } from 'src/content/app/browser/track-panel/trackPanelState';
+import analyticsTracking from 'src/services/analytics-service';
 
 import { Status } from 'src/shared/types/status';
 
@@ -68,6 +69,17 @@ type PreviouslyViewedLinksProps = Pick<
 >;
 
 export const PreviouslyViewedLinks = (props: PreviouslyViewedLinksProps) => {
+  const onLinkClick = (objectType: string, index: number) => {
+    analyticsTracking.trackEvent({
+      category: 'recent_bookmark_link',
+      label: objectType,
+      action: 'clicked',
+      value: index
+    });
+
+    props.closeTrackPanelModal();
+  };
+
   return (
     <div>
       {[...props.previouslyViewedObjects]
@@ -80,7 +92,12 @@ export const PreviouslyViewedLinks = (props: PreviouslyViewedLinksProps) => {
 
           return (
             <div key={index} className={styles.linkHolder}>
-              <Link to={path} onClick={props.closeTrackPanelModal}>
+              <Link
+                to={path}
+                onClick={() =>
+                  onLinkClick(previouslyViewedObject.object_type, index)
+                }
+              >
                 {previouslyViewedObject.label}
               </Link>
               <span className={styles.previouslyViewedType}>
@@ -103,6 +120,17 @@ export const TrackPanelBookmarks = (props: TrackPanelBookmarksProps) => {
   } = props;
 
   const limitedPreviouslyViewedObjects = previouslyViewedObjects.slice(-20);
+
+  const onEllipsisClick = () => {
+    analyticsTracking.trackEvent({
+      category: 'recent_bookmark_link',
+      label: 'recent_bookmarks',
+      action: 'clicked',
+      value: previouslyViewedObjects.length
+    });
+
+    props.changeDrawerViewAndOpen('bookmarks');
+  };
 
   return (
     <section className="trackPanelBookmarks">
@@ -127,7 +155,7 @@ export const TrackPanelBookmarks = (props: TrackPanelBookmarksProps) => {
                   buttonStatus={Status.ACTIVE}
                   description={'View all'}
                   image={EllipsisIcon}
-                  onClick={() => props.changeDrawerViewAndOpen('bookmarks')}
+                  onClick={onEllipsisClick}
                 />
               </span>
             )}

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
@@ -123,7 +123,7 @@ export const TrackPanelBookmarks = (props: TrackPanelBookmarksProps) => {
 
   const onEllipsisClick = () => {
     analyticsTracking.trackEvent({
-      category: 'recent_bookmark_link',
+      category: 'drawer_open',
       label: 'recent_bookmarks',
       action: 'clicked',
       value: previouslyViewedObjects.length

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
@@ -74,7 +74,7 @@ export const PreviouslyViewedLinks = (props: PreviouslyViewedLinksProps) => {
       category: 'recent_bookmark_link',
       label: objectType,
       action: 'clicked',
-      value: index
+      value: index + 1
     });
 
     props.closeTrackPanelModal();

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
@@ -131,13 +131,6 @@ export const updatePreviouslyViewedObjectsAndSave: ActionCreator<
       object_type: activeEnsObject.object_type,
       label: activeEnsObject.label
     });
-  } else {
-    // If it is already present, bump it to the end
-    const [previouslyViewedObject] = previouslyViewedObjects.splice(
-      existingIndex,
-      1
-    );
-    previouslyViewedObjects.push({ ...previouslyViewedObject });
   }
 
   // Limit the total number of previously viewed objects to 250


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-405
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-380


## Description
- Remove the auto bumping of revisited previously viewed links to the top
- Added event tracking 

## Views affected
Browser -> TrackPanel -> Bookmarks

### Other effects

- [x] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

