### PR TITLE
Update scss loading rules in webpack config

### DIFF
--- a/src/ensembl/webpack/webpack.common.js
+++ b/src/ensembl/webpack/webpack.common.js
@@ -43,7 +43,7 @@ module.exports = (isDev, moduleRules, plugins) => ({
       // and extract the css for prod and minify it as external stylesheets
       {
         test: /.scss$/,
-        include: /src\/ensembl\/src(?!\/styles)/,
+        include: /src(?!\/styles)/,
         use: [
           isDev ? 'style-loader' : MiniCssExtractPlugin.loader,
           {
@@ -68,7 +68,7 @@ module.exports = (isDev, moduleRules, plugins) => ({
 
       {
         test: /.scss$/,
-        include: /src\/ensembl\/src\/styles/,
+        include: /src\/styles/,
         use: [
           isDev ? 'style-loader' : MiniCssExtractPlugin.loader,
           {

--- a/src/ensembl/webpack/webpack.common.js
+++ b/src/ensembl/webpack/webpack.common.js
@@ -43,7 +43,6 @@ module.exports = (isDev, moduleRules, plugins) => ({
       // and extract the css for prod and minify it as external stylesheets
       {
         test: /.scss$/,
-        include: /src(?!\/styles)/,
         use: [
           isDev ? 'style-loader' : MiniCssExtractPlugin.loader,
           {
@@ -53,29 +52,6 @@ module.exports = (isDev, moduleRules, plugins) => ({
               modules: {
                 localIdentName: '[local]__[name]__[hash:base64:5]'
               },
-            }
-          },
-          {
-            loader: 'postcss-loader',
-            options: {
-              ident: 'postcss',
-              plugins: () => [postcssPresetEnv()]
-            }
-          },
-          'sass-loader'
-        ]
-      },
-
-      {
-        test: /.scss$/,
-        include: /src\/styles/,
-        use: [
-          isDev ? 'style-loader' : MiniCssExtractPlugin.loader,
-          {
-            loader: 'css-loader',
-            options: {
-              importLoaders: 2,
-              sourceMap: true
             }
           },
           {


### PR DESCRIPTION
## Type
- Bug fix
- Housekeeping

## Description
We have recently updated packages, which [broke dev](https://gitlab.ebi.ac.uk/ensembl-web/ensembl-client/-/jobs/115807). While investigating what was wrong, I tried to reproduce scripts that we run in CI/CD environment in my local Docker container.

White https://github.com/Ensembl/ensembl-client/pull/199 fixes the primary problem (incorrect package versions in package-lock.json), there is a persisting problem that, to my great surprise, only manifests in my local Docker container. Running the build script in it produces these errors: 

![image](https://user-images.githubusercontent.com/6834224/68411682-cf172c00-0182-11ea-80bd-c33a2056701c.png)

The errors indicate that there is something wrong with processing of scss files. Which raises two questions regarding our current webpack config:

1) Why do our `include` rules for scss files include the `src/ensembl` part, although this is parent directory relative to the root of our project (from which we run npm commands)? From the above image with errors we can see that `src/ensembl` is not included in the path of scss files that are being transformed.

After I removed this part from the matching rule, I was able to get my local copy of Docker correctly build the project.

2) **More importantly:** Why don't we simply remove the second rule that targets `src/styles` folder and import the top-level global scss file in our top-level react component? MiniCssExtractPlugin splits CSS into chunks since webpack 4 anyway.

After I have removed the special loading rule for scss files in the `src/styles` folder, everything continues to work fine.

**Checks:**
- tested development build — ✅ 
- tested production build — ✅ 