### PR TITLE
Minor performance fixes

### DIFF
--- a/src/ensembl/src/content/app/browser/Browser.tsx
+++ b/src/ensembl/src/content/app/browser/Browser.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { replace, Replace } from 'connected-react-router';
@@ -141,7 +141,7 @@ export const Browser = (props: BrowserProps) => {
     props.setDataFromUrlAndSave(payload);
   };
 
-  const changeSelectedSpecies = (genomeId: string) => {
+  const changeSelectedSpecies = useCallback((genomeId: string) => {
     const { allChrLocations, allActiveEnsObjectIds } = props;
     const chrLocation = allChrLocations[genomeId];
     const activeEnsObjectId = allActiveEnsObjectIds[genomeId];
@@ -153,7 +153,7 @@ export const Browser = (props: BrowserProps) => {
     };
 
     props.replace(urlFor.browser(params));
-  };
+  }, []);
 
   // handle url changes
   useEffect(() => {

--- a/src/ensembl/src/content/app/browser/browser-app-bar/BrowserAppBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-app-bar/BrowserAppBar.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { memo, useMemo } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
+import isEqual from 'lodash/isEqual';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import { AppName } from 'src/global/globalConfig';
@@ -24,15 +25,20 @@ type BrowserAppBarProps = {
 };
 
 const BrowserAppBar = (props: BrowserAppBarProps) => {
-  const speciesTabs = props.species.map((species, index) => (
-    <FocusableSelectedSpecies
-      key={index}
-      species={species}
-      isActive={species.genome_id === props.activeGenomeId}
-      onClick={() => props.onSpeciesSelect(species.genome_id)}
-    />
-  ));
-  const speciesSelectorLink = <Link to={urlFor.speciesSelector()}>Change</Link>;
+  const speciesTabs = useMemo(() => {
+    return props.species.map((species, index) => (
+      <FocusableSelectedSpecies
+        key={index}
+        species={species}
+        isActive={species.genome_id === props.activeGenomeId}
+        onClick={() => props.onSpeciesSelect(species.genome_id)}
+      />
+    ));
+  }, [props.species]);
+  const speciesSelectorLink = useMemo(() => {
+    return <Link to={urlFor.speciesSelector()}>Change</Link>;
+  }, []);
+
   const wrappedSpecies = (
     <SpeciesTabsWrapper
       isWrappable={false}
@@ -55,4 +61,4 @@ const mapStateToProps = (state: RootState) => ({
   activeGenomeId: getBrowserActiveGenomeId(state)
 });
 
-export default connect(mapStateToProps)(BrowserAppBar);
+export default connect(mapStateToProps)(memo(BrowserAppBar, isEqual));

--- a/src/ensembl/src/content/app/browser/browser-image/BrowserImage.tsx
+++ b/src/ensembl/src/content/app/browser/browser-image/BrowserImage.tsx
@@ -87,9 +87,7 @@ export const BrowserImage = (props: BrowserImageProps) => {
     }
 
     if (actualLocation) {
-      console.timeStamp('before action');
       props.setActualChrLocation(parseLocation(actualLocation));
-      console.timeStamp('after action');
     }
 
     if (ensObjectId) {

--- a/src/ensembl/src/content/app/browser/browser-image/BrowserImage.tsx
+++ b/src/ensembl/src/content/app/browser/browser-image/BrowserImage.tsx
@@ -86,7 +86,9 @@ export const BrowserImage = (props: BrowserImageProps) => {
     }
 
     if (actualLocation) {
+      console.timeStamp('before action');
       props.setActualChrLocation(parseLocation(actualLocation));
+      console.timeStamp('after action');
     }
 
     if (ensObjectId) {

--- a/src/ensembl/src/content/app/browser/browser-image/BrowserImage.tsx
+++ b/src/ensembl/src/content/app/browser/browser-image/BrowserImage.tsx
@@ -1,6 +1,7 @@
-import React, { useRef, useEffect, useCallback } from 'react';
+import React, { useRef, useEffect, useCallback, memo } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
+import isEqual from 'lodash/isEqual';
 
 import BrowserCogList from '../browser-cog/BrowserCogList';
 import { ZmenuController } from 'src/content/app/browser/zmenu';
@@ -173,4 +174,4 @@ const mapDispatchToProps = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(BrowserImage);
+)(memo(BrowserImage, isEqual));

--- a/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, memo } from 'react';
 import { connect } from 'react-redux';
 import { useSpring, animated } from 'react-spring';
+import isEqual from 'lodash/isEqual';
 
 import TrackPanelBar from './track-panel-bar/TrackPanelBar';
 import TrackPanelList from './track-panel-list/TrackPanelList';
@@ -106,4 +107,4 @@ const mapDispatchToProps = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(TrackPanel);
+)(memo(TrackPanel, isEqual));

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent, ReactNode, useEffect } from 'react';
+import React, { MouseEvent, ReactNode, useEffect, useCallback } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 
@@ -115,7 +115,7 @@ export const TrackPanelListItem = (props: TrackPanelListItemProps) => {
     updateDrawerView(viewName);
   };
 
-  const drawerViewButtonHandler = () => {
+  const drawerViewButtonHandler = useCallback(() => {
     const viewName = track.track_id;
 
     if (drawerView !== viewName) {
@@ -127,7 +127,7 @@ export const TrackPanelListItem = (props: TrackPanelListItemProps) => {
     }
 
     updateDrawerView(viewName);
-  };
+  }, [track.track_id, drawerView]);
 
   const toggleExpand = () => {
     const { track_id: trackId } = props.track;
@@ -135,7 +135,7 @@ export const TrackPanelListItem = (props: TrackPanelListItemProps) => {
     props.updateCollapsedTrackIds({ trackId, isCollapsed: !isCollapsed });
   };
 
-  const toggleTrack = () => {
+  const toggleTrack = useCallback(() => {
     const newStatus =
       trackStatus === Status.ACTIVE ? Status.INACTIVE : Status.ACTIVE;
 
@@ -168,7 +168,7 @@ export const TrackPanelListItem = (props: TrackPanelListItemProps) => {
         }
       });
     }
-  };
+  }, [trackStatus, activeGenomeId, activeEnsObjectId, track.track_id]);
 
   const updateGenomeBrowser = (status: Status) => {
     const currentTrackStatus = status === Status.ACTIVE ? 'on' : 'off';

--- a/src/ensembl/src/header/Header.tsx
+++ b/src/ensembl/src/header/Header.tsx
@@ -1,4 +1,4 @@
-import React, { memo, FunctionComponent } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 
 import config from 'config';
@@ -35,7 +35,7 @@ export const Copyright = () => (
   </div>
 );
 
-export const Header: FunctionComponent<HeaderProps> = () => (
+export const Header = () => (
   <header>
     <div className={styles.topBar}>
       <div>
@@ -50,4 +50,4 @@ export const Header: FunctionComponent<HeaderProps> = () => (
   </header>
 );
 
-export default memo(Header);
+export default Header;

--- a/src/ensembl/src/header/launchbar/LaunchbarContainer.tsx
+++ b/src/ensembl/src/header/launchbar/LaunchbarContainer.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent, memo } from 'react';
 import { connect } from 'react-redux';
+import isEqual from 'lodash/isEqual';
 
 import { getEnabledCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 
@@ -20,7 +21,7 @@ type LaunchbarContainerProps = StateProps & OwnProps;
 
 export const LaunchbarContainer: FunctionComponent<
   LaunchbarContainerProps
-> = memo((props) => <Launchbar {...props} />);
+> = memo((props) => <Launchbar {...props} />, isEqual);
 
 const mapStateToProps = (state: RootState): StateProps => ({
   launchbarExpanded: getLaunchbarExpanded(state),

--- a/src/ensembl/src/shared/components/image-button/ImageButton.test.tsx
+++ b/src/ensembl/src/shared/components/image-button/ImageButton.test.tsx
@@ -3,7 +3,7 @@ import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import faker from 'faker';
 
-import ImageButton from './ImageButton';
+import { ImageButton } from './ImageButton';
 import ImageHolder from './ImageHolder';
 
 import Tooltip from 'src/shared/components/tooltip/Tooltip';

--- a/src/ensembl/src/shared/components/image-button/ImageButton.tsx
+++ b/src/ensembl/src/shared/components/image-button/ImageButton.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { memo } from 'react';
+import isEqual from 'lodash/isEqual';
 
 import useHover from 'src/shared/hooks/useHover';
 
@@ -63,4 +64,4 @@ ImageButton.defaultProps = {
   image: ''
 };
 
-export default ImageButton;
+export default memo(ImageButton, isEqual);

--- a/src/ensembl/src/shared/components/image-button/ImageButton.tsx
+++ b/src/ensembl/src/shared/components/image-button/ImageButton.tsx
@@ -26,7 +26,7 @@ type Props = {
   onClick?: () => void;
 };
 
-const ImageButton = (props: Props) => {
+export const ImageButton = (props: Props) => {
   const [hoverRef, isHovered] = useHover<HTMLDivElement>();
 
   const handleClick = () => {

--- a/src/ensembl/src/shared/components/image-button/ImageHolder.tsx
+++ b/src/ensembl/src/shared/components/image-button/ImageHolder.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { memo } from 'react';
 import classNames from 'classnames';
+import isEqual from 'lodash/isEqual';
 
 import { Status } from 'src/shared/types/status';
 
@@ -29,4 +30,4 @@ const ImageHolder = (props: Props) => {
   );
 };
 
-export default ImageHolder;
+export default memo(ImageHolder, isEqual);

--- a/src/ensembl/src/shared/components/species-tabs-wrapper/SingleLineSpeciesWrapper.tsx
+++ b/src/ensembl/src/shared/components/species-tabs-wrapper/SingleLineSpeciesWrapper.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useState, useEffect, useRef } from 'react';
+import React, { ReactElement, useState, useEffect, useRef, memo } from 'react';
+import isEqual from 'lodash/isEqual';
 
 import useResizeObserver from 'src/shared/hooks/useResizeObserver';
 import { getSpeciesItemWidths } from './speciesTabsWrapperHelpers';
@@ -143,4 +144,4 @@ const SingleLineWrapper = (props: Props) => {
   );
 };
 
-export default SingleLineWrapper;
+export default memo(SingleLineWrapper, isEqual);


### PR DESCRIPTION
## Type
- Performance

## Description
Trying to reduce React work when switching between focus objects (by clicking on zmenu). Example case: switch from BRCA2 to FRY.

Overall changes: before tweaking

![Screenshot 2019-11-18 at 09 44 18](https://user-images.githubusercontent.com/6834224/69042181-b0b5f980-09e8-11ea-972f-a05bd1389983.png)

after tweaking (notice how the flamecharts related to React updates got fewer and thinner) 

![Screenshot 2019-11-18 at 09 45 27](https://user-images.githubusercontent.com/6834224/69042199-b8759e00-09e8-11ea-9ea3-c03e2bbf3ca5.png)

In detail

1) React updates in response to actual location change

Before tweaking: 30 ms of render time in response to actual location change

![Screenshot 2019-11-15 at 09 27 59 (2)](https://user-images.githubusercontent.com/6834224/68933572-d8a92100-078c-11ea-9a93-3f456cc94a25.png)

After tweaking: 20 ms in response to actual location change

![Screenshot 2019-11-15 at 09 34 45 (2)](https://user-images.githubusercontent.com/6834224/68933636-fb3b3a00-078c-11ea-8291-51cef48f5742.png)

2) Remove useless re-renders

- Launchbar (shouldn't re-render when we change focus object)

Before tweaking:
![Screenshot 2019-11-15 at 09 57 38 (2)](https://user-images.githubusercontent.com/6834224/68934403-8cf77700-078e-11ea-8370-b1c2fb540023.png)

- ImageButton (shouldn't re-render when TrackPanelListItem is highlighted)

Before tweaking:
![Screenshot 2019-11-15 at 10 22 56 (2)](https://user-images.githubusercontent.com/6834224/68936286-1e1c1d00-0792-11ea-9bac-0376feec3e5d.png)


## Views affected
Genome browser