### PR TITLE
Watch ensembl-genome-browser node modules

### DIFF
--- a/src/ensembl/webpack/webpack.config.dev.js
+++ b/src/ensembl/webpack/webpack.config.dev.js
@@ -106,7 +106,7 @@ const devConfig = {
   // disable webpack from watching node modules
   // this would reduce memory consumption and also should improve build times
   watchOptions: {
-    ignored: /node_modules/
+    ignored: /node_modules([\\]+|\/)+(?!ensembl-genome-browser)/
   }
 };
 

--- a/src/ensembl/webpack/webpack.config.dev.js
+++ b/src/ensembl/webpack/webpack.config.dev.js
@@ -103,7 +103,7 @@ const devConfig = {
     }
   },
 
-  // disable webpack from watching node modules
+  // disable webpack from watching node modules (except for ensembl-genome-browser)
   // this would reduce memory consumption and also should improve build times
   watchOptions: {
     ignored: /node_modules([\\]+|\/)+(?!ensembl-genome-browser)/


### PR DESCRIPTION
## Type
- Infrastructure

## Description
### Problem
With our current config, webpack-dev-server is not watching changes in `node_modules` folder. However, after merging of https://github.com/Ensembl/ensembl-client/pull/181, every Rust rebuild changes the browser.js file in `node_modules/ensembl-genome-browser`; so without webpack watching files in this folder, Rust developer will need to re-build the whole ensembl-client project every time the wasm is recompiled. Which takes time and is annoying.

### Solution
Ignore all node_modules except for ensembl-genome-browser (regex [copied from Stack Overflow](https://stackoverflow.com/a/44166532/3925302)).