### PR TITLE
Fix script linting during pre-commit hook

### DIFF
--- a/src/ensembl/package.json
+++ b/src/ensembl/package.json
@@ -33,7 +33,7 @@
   },
   "lint-staged": {
     "*.{ts,tsx}": [
-      "eslint"
+      "eslint --max-warnings=0"
     ],
     "*.{scss}": [
       "stylelint"


### PR DESCRIPTION
## Type
- Infrastructure

## Description
### Problem
Our pre-commit hook includes linting of staged typescript files, but this doesn't catch linter warnings.

**Example:**
- add an unused variable in a typescript file, and save the file
- verify that the linter catches this and warns about the unused variable (`npm run lint`)
- add and commit the modified file
- notice that the script ran by the pre-commit hook did not flag the unused variable, but instead allowed git to commit the changes

### Solution
As discussed in a github issue (`https://github.com/okonet/lint-staged/issues/661`), eslint exit code is 0 in case of warnings. Using the max-warnings eslint option, we can make lint-staged fail if eslint encounters a warning.

**Making sure this works**
- add an unused variable in a typescript file, and save the file
- add and commit the modified file
- see the linter error