### PR TITLE
Use window.matchMedia instead of ResizeObserver for window size changes

### DIFF
--- a/src/ensembl/src/global/globalActions.ts
+++ b/src/ensembl/src/global/globalActions.ts
@@ -17,7 +17,10 @@ export const updateBreakpointWidth: ActionCreator<ThunkAction<
   any,
   null,
   Action<string>
->> = (width: number) => async (dispatch, getState: () => RootState) => {
+>> = (width: keyof typeof BreakpointWidth) => async (
+  dispatch,
+  getState: () => RootState
+) => {
   const state = getState();
   const currentBreakpointWidth = getBreakpointWidth(state);
   const newBreakpointWidth = getBreakpoint(width);

--- a/src/ensembl/src/global/globalConfig.ts
+++ b/src/ensembl/src/global/globalConfig.ts
@@ -14,3 +14,14 @@ export enum AppName {
   SPECIES_SELECTOR = 'Species selector',
   CUSTOM_DOWNLOADS = 'Custom downloads'
 }
+
+export const globalMediaQueries: Record<
+  keyof typeof BreakpointWidth,
+  string
+> = {
+  PHONE: 'screen and (min-width: 599px)',
+  TABLET: 'screen and (min-width: 600px) and (max-width: 899px)',
+  LAPTOP: 'screen and (min-width: 900px) and (max-width: 1199px)',
+  DESKTOP: 'screen and (min-width: 1200px) and (max-width: 1799px)',
+  BIG_DESKTOP: 'screen and (min-width: 1800px)'
+};

--- a/src/ensembl/src/global/globalHelper.ts
+++ b/src/ensembl/src/global/globalHelper.ts
@@ -1,9 +1,11 @@
 import { BreakpointWidth } from './globalConfig';
 
-export const getBreakpoint = (width: number): BreakpointWidth => {
-  if (width > BreakpointWidth.DESKTOP) {
+export const getBreakpoint = (
+  key: keyof typeof BreakpointWidth
+): BreakpointWidth => {
+  if (BreakpointWidth[key] >= BreakpointWidth.DESKTOP) {
     return BreakpointWidth.DESKTOP;
-  } else if (width > BreakpointWidth.LAPTOP) {
+  } else if (BreakpointWidth[key] >= BreakpointWidth.LAPTOP) {
     return BreakpointWidth.LAPTOP;
   } else {
     return BreakpointWidth.TABLET;

--- a/src/ensembl/src/global/windowSizeHelpers.ts
+++ b/src/ensembl/src/global/windowSizeHelpers.ts
@@ -1,0 +1,46 @@
+import reduce from 'lodash/reduce';
+
+export const getCurrentMediaSize = (queries: { [key: string]: string }) => {
+  return reduce(
+    queries,
+    (result: string | null, mediaQuery, mediaSize) => {
+      const match = window.matchMedia(mediaQuery);
+      if (match.matches) {
+        return mediaSize;
+      } else {
+        return result;
+      }
+    },
+    null
+  );
+};
+
+export const observeMediaQueries = (
+  queries: { [key: string]: string },
+  callback: (key: string) => void
+) => {
+  // First, get instant media query match
+  const currentMediaSize = getCurrentMediaSize(queries);
+  if (currentMediaSize) {
+    callback(currentMediaSize);
+  }
+
+  // Second, subscribe to subsequent media query changes
+  const observableQueries = Object.entries(queries).map(([key, query]) => {
+    const mediaQueryList = window.matchMedia(query);
+    const onChange = (event: MediaQueryListEvent) => {
+      if (event.matches) {
+        callback(key);
+      }
+    };
+    mediaQueryList.addListener(onChange);
+    return { mediaQueryList, onChange };
+  });
+
+  const unsubscribe = () => {
+    observableQueries.forEach(({ mediaQueryList, onChange }) => {
+      mediaQueryList.removeListener(onChange);
+    });
+  };
+  return { unsubscribe };
+};

--- a/src/ensembl/src/global/windowSizeHelpers.ts
+++ b/src/ensembl/src/global/windowSizeHelpers.ts
@@ -1,11 +1,13 @@
 import reduce from 'lodash/reduce';
 
+import windowService from 'src/services/window-service';
+
 export const getCurrentMediaSize = (queries: { [key: string]: string }) => {
   return reduce(
     queries,
     (result: string | null, mediaQuery, mediaSize) => {
-      const match = window.matchMedia(mediaQuery);
-      if (match.matches) {
+      const mediaQueryList = getMediaQueryList(mediaQuery);
+      if (mediaQueryList.matches) {
         return mediaSize;
       } else {
         return result;
@@ -27,7 +29,7 @@ export const observeMediaQueries = (
 
   // Second, subscribe to subsequent media query changes
   const observableQueries = Object.entries(queries).map(([key, query]) => {
-    const mediaQueryList = window.matchMedia(query);
+    const mediaQueryList = getMediaQueryList(query);
     const onChange = (event: MediaQueryListEvent) => {
       if (event.matches) {
         callback(key);
@@ -43,4 +45,9 @@ export const observeMediaQueries = (
     });
   };
   return { unsubscribe };
+};
+
+const getMediaQueryList = (query: string) => {
+  const matchMedia = windowService.getMatchMedia();
+  return matchMedia(query);
 };

--- a/src/ensembl/src/root/Root.test.tsx
+++ b/src/ensembl/src/root/Root.test.tsx
@@ -7,7 +7,7 @@ import Content from '../content/Content';
 import privacyBannerService from '../shared/components/privacy-banner/privacy-banner-service';
 import windowService from 'src/services/window-service';
 
-import MockResizeObserver from 'tests/mocks/mockResizeObserver';
+import { mockMatchMedia } from 'tests/mocks/mockWindowService';
 
 jest.mock('../header/Header', () => () => 'Header');
 jest.mock('../content/Content', () => () => 'Content');
@@ -28,8 +28,8 @@ describe('<Root />', () => {
 
   beforeEach(() => {
     jest
-      .spyOn(windowService, 'getResizeObserver')
-      .mockImplementation((): any => MockResizeObserver);
+      .spyOn(windowService, 'getMatchMedia')
+      .mockImplementation(mockMatchMedia as any);
     wrapper = mount(getRenderedRoot(defaultProps));
   });
 

--- a/src/ensembl/src/root/Root.tsx
+++ b/src/ensembl/src/root/Root.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 
-import { BreakpointWidth } from '../global/globalConfig';
+import { globalMediaQueries, BreakpointWidth } from '../global/globalConfig';
 import { updateBreakpointWidth } from '../global/globalActions';
 import { observeMediaQueries } from 'src/global/windowSizeHelpers';
 
@@ -20,19 +20,11 @@ type Props = {
   ) => void;
 };
 
-const defaultMediaQueries: Record<keyof typeof BreakpointWidth, string> = {
-  PHONE: 'screen and (min-width: 599px)',
-  TABLET: 'screen and (min-width: 600px) and (max-width: 899px)',
-  LAPTOP: 'screen and (min-width: 900px) and (max-width: 1199px)',
-  DESKTOP: 'screen and (min-width: 1200px) and (max-width: 1799px)',
-  BIG_DESKTOP: 'screen and (min-width: 1800px)'
-};
-
 export const Root = (props: Props) => {
   const [showPrivacyBanner, setShowPrivacyBanner] = useState(false);
 
   useEffect(() => {
-    const subscription = observeMediaQueries(defaultMediaQueries, (match) => {
+    const subscription = observeMediaQueries(globalMediaQueries, (match) => {
       props.updateBreakpointWidth(match as keyof typeof BreakpointWidth);
     });
     return () => subscription.unsubscribe();

--- a/src/ensembl/src/services/tests/storage-service.test.ts
+++ b/src/ensembl/src/services/tests/storage-service.test.ts
@@ -1,6 +1,7 @@
 import { StorageService, StorageType } from 'src/services/storage-service';
-import { WindowServiceInterface } from 'src/services/window-service';
 import faker from 'faker';
+
+import mockWindowService from 'tests/mocks/mockWindowService';
 
 const mockLocalStorage: any = {
   getItem: jest.fn(),
@@ -16,16 +17,16 @@ const mockSessionStorage: any = {
   clear: jest.fn()
 };
 
-const mockWindowService: WindowServiceInterface = {
-  getLocalStorage: () => mockLocalStorage,
-  getSessionStorage: () => mockSessionStorage,
-  getResizeObserver: jest.fn(),
-  getWindow: jest.fn(),
-  getFileReader: jest.fn(),
-  getLocation: jest.fn()
-};
-
 describe('storageService', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(mockWindowService, 'getLocalStorage')
+      .mockImplementation(() => mockLocalStorage);
+    jest
+      .spyOn(mockWindowService, 'getSessionStorage')
+      .mockImplementation(() => mockSessionStorage);
+  });
+
   afterEach(() => {
     jest.resetAllMocks();
   });

--- a/src/ensembl/src/services/window-service.ts
+++ b/src/ensembl/src/services/window-service.ts
@@ -10,6 +10,7 @@ export interface WindowServiceInterface {
   getLocation: () => Location;
   getFileReader: () => FileReader;
   getResizeObserver: () => typeof ResizeObserver;
+  getMatchMedia: () => (query: string) => MediaQueryList;
 }
 
 class WindowService implements WindowServiceInterface {
@@ -35,6 +36,10 @@ class WindowService implements WindowServiceInterface {
 
   public getResizeObserver() {
     return ResizeObserver;
+  }
+
+  public getMatchMedia() {
+    return window.matchMedia;
   }
 
   // return viewport dimensions in the ClientRect format

--- a/src/ensembl/tests/mocks/mockWindowService.ts
+++ b/src/ensembl/tests/mocks/mockWindowService.ts
@@ -1,0 +1,21 @@
+import { WindowServiceInterface } from 'src/services/window-service';
+
+export const mockMatchMedia = () => () => ({
+  matches: true,
+  addListener: () => null
+});
+
+const mockWindowService: WindowServiceInterface = {
+  getLocalStorage: jest.fn(),
+  getSessionStorage: jest.fn(),
+  getResizeObserver: jest.fn(),
+  getMatchMedia: jest.fn().mockImplementation(() => () => ({
+    matches: true,
+    addListener: () => null
+  })),
+  getWindow: jest.fn(),
+  getFileReader: jest.fn(),
+  getLocation: jest.fn()
+};
+
+export default mockWindowService;


### PR DESCRIPTION
## Type
- Refactoring

## Description
This is a suggestion. Not sure whether good or bad.

Currently, we use ResizeObserver to observe changes in size of the top-level React container. While there is technically nothing wrong with this, there exists a dedicated API `window.matchMedia` that does precisely that.

I am still uncertain whether ResizeObserver completely removes the need for `window.matchMedia` or not, but here's a quick assessment of using this API:

### Pros
- it is more economical — it will fire only when a specific breakpoint is crossed, in contrast to ResizeObserver that fires upon every change in dimensions of an element
- it is probably more idiomatic for answering the question "I wonder which breakpoint does my screen match"; we could thus share breakpoints between js and scss
- it allows detection of switching between landscape and portrait modes

### Cons
- it is somewhat more cumbersome than the ResizeObserver API, which simply returns width and height of the observed element.