### PR TITLE
Use a dedicated component for toggle switch in BrowserTrackConfig panel

### DIFF
--- a/src/ensembl/src/content/app/browser/browser-track-config/BrowserTrackConfig.scss
+++ b/src/ensembl/src/content/app/browser/browser-track-config/BrowserTrackConfig.scss
@@ -75,11 +75,11 @@
 
   /* button styling */
 
-  .trackConfigSlider {
-    height: 24px;
-    margin-left: 8px;
-    position: relative;
-    width: 30px;
+  .slideToggle {
+    height: 12px;
+    margin-left: 2px;
+    display: inline-block;
+    vertical-align: middle;
   }
 
   .trackHeightBtn {

--- a/src/ensembl/src/content/app/browser/browser-track-config/BrowserTrackConfig.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-track-config/BrowserTrackConfig.test.tsx
@@ -6,6 +6,7 @@ import {
   BrowserTrackConfigProps
 } from './BrowserTrackConfig';
 import Checkbox from 'src/shared/components/checkbox/Checkbox';
+import SlideToggle from 'src/shared/components/slide-toggle/SlideToggle';
 
 import {
   createTrackConfigLabel,
@@ -45,14 +46,34 @@ describe('<BrowserTrackConfig />', () => {
       expect(wrapper.props().updateApplyToAll).toHaveBeenCalledTimes(1);
     });
 
-    test('toggles track name when the toggle name slider is clicked', () => {
-      wrapper.find('.trackConfig-trackName').simulate('click');
-      expect(wrapper.props().updateTrackConfigNames).toHaveBeenCalledTimes(1);
+    test('passes updateTrackConfigNames to track name toggler', () => {
+      const toggle = wrapper
+        .find('label')
+        .filterWhere((wrapper: any) => wrapper.text() === 'Track name')
+        .parents()
+        .first() // <- enzyme's .parent method doesnt seem to be reliably working for mount
+        .find(SlideToggle);
+      toggle.prop('onChange')(true);
+      expect(defaultProps.updateTrackConfigNames).toHaveBeenCalledTimes(1);
+      expect(defaultProps.updateTrackConfigNames).toHaveBeenCalledWith(
+        defaultProps.selectedCog,
+        false
+      );
     });
 
     test('toggles track label when the toggle name slider is clicked', () => {
-      wrapper.find('.trackConfig-featureLabels').simulate('click');
-      expect(wrapper.props().updateTrackConfigLabel).toHaveBeenCalledTimes(1);
+      const toggle = wrapper
+        .find('label')
+        .filterWhere((wrapper: any) => wrapper.text() === 'Feature labels')
+        .parents()
+        .first() // <- enzyme's .parent method doesnt seem to be reliably working for mount
+        .find(SlideToggle);
+      toggle.prop('onChange')(true);
+      expect(defaultProps.updateTrackConfigLabel).toHaveBeenCalledTimes(1);
+      expect(defaultProps.updateTrackConfigLabel).toHaveBeenCalledWith(
+        defaultProps.selectedCog,
+        false
+      );
     });
   });
 });

--- a/src/ensembl/src/content/app/browser/browser-track-config/BrowserTrackConfig.tsx
+++ b/src/ensembl/src/content/app/browser/browser-track-config/BrowserTrackConfig.tsx
@@ -18,6 +18,8 @@ import analyticsTracking from 'src/services/analytics-service';
 
 import styles from './BrowserTrackConfig.scss';
 
+import SlideToggle from 'src/shared/components/slide-toggle/SlideToggle';
+
 import tracksSliderOnIcon from 'static/img/browser/icon_tracks_slider_on.svg';
 import tracksSliderOffIcon from 'static/img/browser/icon_tracks_slider_off.svg';
 import trackHeightBtn from 'static/img/browser/icon_tracks_height_grey.svg';
@@ -58,9 +60,6 @@ export const BrowserTrackConfig = (props: BrowserTrackConfigProps) => {
   const ref = useRef(null);
   useOutsideClick(ref, props.onClose);
 
-  const nameIcon = shouldShowTrackName
-    ? tracksSliderOnIcon
-    : tracksSliderOffIcon;
   const labelIcon =
     shouldShowTrackLabels !== false ? tracksSliderOnIcon : tracksSliderOffIcon;
 
@@ -137,12 +136,7 @@ export const BrowserTrackConfig = (props: BrowserTrackConfigProps) => {
       <dl>
         <dd>
           <label htmlFor="trackConfig-trackName">Track name</label>
-          <button
-            className={`${styles.trackConfigSlider} trackConfig-trackName`}
-            onClick={toggleName}
-          >
-            <img src={nameIcon} />
-          </button>
+          <SlideToggle isOn={shouldShowTrackName} onChange={toggleName} />
         </dd>
         <dd>
           <label htmlFor="trackConfig-featureLabels">Feature labels</label>
@@ -194,7 +188,4 @@ const mapDispatchToProps = {
   updateTrackConfigNames
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(BrowserTrackConfig);
+export default connect(mapStateToProps, mapDispatchToProps)(BrowserTrackConfig);

--- a/src/ensembl/src/content/app/browser/browser-track-config/BrowserTrackConfig.tsx
+++ b/src/ensembl/src/content/app/browser/browser-track-config/BrowserTrackConfig.tsx
@@ -20,8 +20,6 @@ import styles from './BrowserTrackConfig.scss';
 
 import SlideToggle from 'src/shared/components/slide-toggle/SlideToggle';
 
-import tracksSliderOnIcon from 'static/img/browser/icon_tracks_slider_on.svg';
-import tracksSliderOffIcon from 'static/img/browser/icon_tracks_slider_off.svg';
 import trackHeightBtn from 'static/img/browser/icon_tracks_height_grey.svg';
 import trackLockBtn from 'static/img/browser/icon_tracks_lock_open_grey.svg';
 import trackHighlightBtn from 'static/img/browser/icon_tracks_highlight_grey.svg';
@@ -59,9 +57,6 @@ export const BrowserTrackConfig = (props: BrowserTrackConfigProps) => {
 
   const ref = useRef(null);
   useOutsideClick(ref, props.onClose);
-
-  const labelIcon =
-    shouldShowTrackLabels !== false ? tracksSliderOnIcon : tracksSliderOffIcon;
 
   const toggleName = useCallback(() => {
     if (applyToAll) {
@@ -135,17 +130,20 @@ export const BrowserTrackConfig = (props: BrowserTrackConfigProps) => {
       </dl>
       <dl>
         <dd>
-          <label htmlFor="trackConfig-trackName">Track name</label>
-          <SlideToggle isOn={shouldShowTrackName} onChange={toggleName} />
+          <label>Track name</label>
+          <SlideToggle
+            isOn={shouldShowTrackName}
+            onChange={toggleName}
+            className={styles.slideToggle}
+          />
         </dd>
         <dd>
-          <label htmlFor="trackConfig-featureLabels">Feature labels</label>
-          <button
-            className={`${styles.trackConfigSlider} trackConfig-featureLabels`}
-            onClick={toggleLabel}
-          >
-            <img src={labelIcon} />
-          </button>
+          <label>Feature labels</label>
+          <SlideToggle
+            isOn={shouldShowTrackLabels}
+            onChange={toggleLabel}
+            className={styles.slideToggle}
+          />
         </dd>
         <dd className={styles.heightSwitcher}>
           <button className={styles.trackHeightBtn}>

--- a/src/ensembl/src/shared/components/slide-toggle/SlideToggle.scss
+++ b/src/ensembl/src/shared/components/slide-toggle/SlideToggle.scss
@@ -1,0 +1,5 @@
+.slideToggle {
+  cursor: pointer;
+  width: 40px;
+  user-select: none;
+}

--- a/src/ensembl/src/shared/components/slide-toggle/SlideToggle.scss
+++ b/src/ensembl/src/shared/components/slide-toggle/SlideToggle.scss
@@ -1,5 +1,41 @@
+$transitionTime: 0.15s;
+
 .slideToggle {
   cursor: pointer;
   width: 40px;
   user-select: none;
+
+  .slideToggleTrack {
+    transition: fill $transitionTime ease-in-out,
+      stroke $transitionTime ease-in-out;
+  }
+
+  .slideToggleThumb {
+    transition: transform $transitionTime ease-in-out,
+      fill $transitionTime ease-in-out;
+  }
+}
+
+.slideToggleOn {
+  .slideToggleTrack {
+    fill: #0099ff;
+    stroke: #0099ff;
+  }
+
+  .slideToggleThumb {
+    transform: translateX(9px);
+    fill: #ffffff;
+  }
+}
+
+.slideToggleOff {
+  .slideToggleTrack {
+    fill: #ffffff;
+    stroke: #b7c0c8;
+  }
+
+  .slideToggleThumb {
+    fill: #0099ff;
+    transform: translateX(0);
+  }
 }

--- a/src/ensembl/src/shared/components/slide-toggle/SlideToggle.test.tsx
+++ b/src/ensembl/src/shared/components/slide-toggle/SlideToggle.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { mount, render } from 'enzyme';
+import faker from 'faker';
+
+import SlideToggle from './SlideToggle';
+
+const defaultProps = {
+  isOn: false,
+  onChange: jest.fn()
+};
+
+describe('SlideToggle', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('has proper class when off', () => {
+      const renderedComponent = render(<SlideToggle {...defaultProps} />);
+      expect(renderedComponent.hasClass('slideToggleOff')).toBe(true);
+    });
+
+    it('has proper class when on', () => {
+      const props = {
+        ...defaultProps,
+        isOn: true
+      };
+      const renderedComponent = render(<SlideToggle {...props} />);
+      expect(renderedComponent.hasClass('slideToggleOn')).toBe(true);
+    });
+
+    it('adds class received from parent', () => {
+      const externalClassName = faker.random.word();
+      const props = {
+        ...defaultProps,
+        className: externalClassName
+      };
+      const renderedComponent = render(<SlideToggle {...props} />);
+      expect(renderedComponent.hasClass(externalClassName)).toBe(true);
+    });
+  });
+
+  describe('behaviour', () => {
+    test('correctly calls callback when switched on', () => {
+      const wrapper = mount(<SlideToggle {...defaultProps} />);
+      wrapper.simulate('click');
+
+      expect(defaultProps.onChange).toHaveBeenCalledTimes(1);
+      expect(defaultProps.onChange).toHaveBeenCalledWith(true);
+    });
+
+    test('correctly calls callback when switched off', () => {
+      const props = {
+        ...defaultProps,
+        isOn: true
+      };
+      const wrapper = mount(<SlideToggle {...props} />);
+      wrapper.simulate('click');
+
+      expect(defaultProps.onChange).toHaveBeenCalledTimes(1);
+      expect(defaultProps.onChange).toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/src/ensembl/src/shared/components/slide-toggle/SlideToggle.tsx
+++ b/src/ensembl/src/shared/components/slide-toggle/SlideToggle.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { useSpring, animated } from 'react-spring';
 import classNames from 'classnames';
 
 import styles from './SlideToggle.scss';
@@ -10,54 +9,20 @@ type Props = {
   onChange: (isOn: boolean) => void;
 };
 
-const springConfig = {
-  mass: 1,
-  tension: 320,
-  clamp: true,
-  friction: 10
-};
-
-const activeTrackStyles = {
-  config: springConfig,
-  fill: '#0099FF',
-  stroke: '#0099FF'
-};
-
-const inactiveTrackStyles = {
-  config: springConfig,
-  fill: '#FFFFFF',
-  stroke: '#B7C0C8'
-};
-
-const activeThumbStyles = {
-  config: springConfig,
-  fill: '#FFFFFF',
-  cx: 14
-};
-
-const inactiveThumbStyles = {
-  config: springConfig,
-  fill: '#0099FF',
-  cx: 5
-};
-
 const SlideToggle = (props: Props) => {
   const [isOn, setIsOn] = useState(props.isOn);
-  const [trackStyles, setTrackStyles] = useSpring(() =>
-    props.isOn ? activeTrackStyles : inactiveTrackStyles
-  );
-  const [thumbStyles, setThumbStyles] = useSpring(() =>
-    props.isOn ? activeThumbStyles : inactiveThumbStyles
-  );
 
   const onToggle = () => {
-    setTrackStyles(isOn ? inactiveTrackStyles : activeTrackStyles);
-    setThumbStyles(isOn ? inactiveThumbStyles : activeThumbStyles);
     props.onChange(!isOn);
     setIsOn(!isOn);
   };
 
-  const className = classNames(styles.slideToggle, props.className);
+  const className = classNames(
+    styles.slideToggle,
+    props.className,
+    { [styles.slideToggleOn]: isOn },
+    { [styles.slideToggleOff]: !isOn }
+  );
 
   return (
     <svg
@@ -66,12 +31,12 @@ const SlideToggle = (props: Props) => {
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 19 10"
     >
-      <animated.path
+      <path
+        className={styles.slideToggleTrack}
         d="M14.5,14.5h-9A4.48,4.48,0,0,1,1,10H1A4.48,4.48,0,0,1,5.5,5.5h9A4.48,4.48,0,0,1,19,10h0A4.48,4.48,0,0,1,14.5,14.5Z"
         transform="translate(-0.5 -5)"
-        style={trackStyles}
       />
-      <animated.circle style={thumbStyles} cy="5" r="4" />
+      <circle className={styles.slideToggleThumb} cx="5" cy="5" r="4" />
     </svg>
   );
 };

--- a/src/ensembl/src/shared/components/slide-toggle/SlideToggle.tsx
+++ b/src/ensembl/src/shared/components/slide-toggle/SlideToggle.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { useSpring, animated } from 'react-spring';
+import classNames from 'classnames';
+
+import styles from './SlideToggle.scss';
+
+type Props = {
+  isOn: boolean;
+  className?: string;
+  onChange: (isOn: boolean) => void;
+};
+
+const springConfig = {
+  mass: 1,
+  tension: 320,
+  clamp: true,
+  friction: 10
+};
+
+const activeTrackStyles = {
+  config: springConfig,
+  fill: '#0099FF',
+  stroke: '#0099FF'
+};
+
+const inactiveTrackStyles = {
+  config: springConfig,
+  fill: '#FFFFFF',
+  stroke: '#B7C0C8'
+};
+
+const activeThumbStyles = {
+  config: springConfig,
+  fill: '#FFFFFF',
+  cx: 14
+};
+
+const inactiveThumbStyles = {
+  config: springConfig,
+  fill: '#0099FF',
+  cx: 5
+};
+
+const SlideToggle = (props: Props) => {
+  const [isOn, setIsOn] = useState(props.isOn);
+  const [trackStyles, setTrackStyles] = useSpring(() =>
+    props.isOn ? activeTrackStyles : inactiveTrackStyles
+  );
+  const [thumbStyles, setThumbStyles] = useSpring(() =>
+    props.isOn ? activeThumbStyles : inactiveThumbStyles
+  );
+
+  const onToggle = () => {
+    setTrackStyles(isOn ? inactiveTrackStyles : activeTrackStyles);
+    setThumbStyles(isOn ? inactiveThumbStyles : activeThumbStyles);
+    props.onChange(!isOn);
+    setIsOn(!isOn);
+  };
+
+  const className = classNames(styles.slideToggle, props.className);
+
+  return (
+    <svg
+      className={className}
+      onClick={onToggle}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 19 10"
+    >
+      <animated.path
+        d="M14.5,14.5h-9A4.48,4.48,0,0,1,1,10H1A4.48,4.48,0,0,1,5.5,5.5h9A4.48,4.48,0,0,1,19,10h0A4.48,4.48,0,0,1,14.5,14.5Z"
+        transform="translate(-0.5 -5)"
+        style={trackStyles}
+      />
+      <animated.circle style={thumbStyles} cy="5" r="4" />
+    </svg>
+  );
+};
+
+export default SlideToggle;

--- a/src/ensembl/stories/shared-components/index.ts
+++ b/src/ensembl/stories/shared-components/index.ts
@@ -16,3 +16,4 @@ import './badged-button/BadgedButton.stories';
 import './species-tabs-wrapper/SpeciesTabsWrapper.stories';
 import './upload/Upload.stories';
 import './textarea/Textarea.stories';
+import './slide-toggle/SlideToggle.stories';

--- a/src/ensembl/stories/shared-components/slide-toggle/SlideToggle.stories.tsx
+++ b/src/ensembl/stories/shared-components/slide-toggle/SlideToggle.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import SlideToggle from 'src/shared/components/slide-toggle/SlideToggle';
+
+storiesOf('Components|Shared Components/SlideToggle', module).add(
+  'default',
+  () => {
+    return (
+      <div>
+        <SlideToggle isOn={false} onChange={() => console.log('change')} />
+      </div>
+    );
+  }
+);


### PR DESCRIPTION
## Type
- Refactoring
- Improvement to existing feature

## Description
This PR replaces the current element that toggles track names and labels with a dedicated component, which uses a single svg, and also animates the transition between the on and off states.

![image](https://user-images.githubusercontent.com/6834224/70457384-f75ab900-1aa7-11ea-9cc3-116338e5b56e.png)

It also relates to @jyothishnt 's branch `replace-svg-with-ImageButton`. Jyo had problems when he replaced the svg representing the toggle — specifically, after that change, clicking on the toggle also automatically closed the config panel (because that click was interpreted as a click outside the panel). This PR makes sure that click on the toggle will not close the config panel.


## Views affected
Genome browser