### PR TITLE
Add standard app layout

### DIFF
--- a/src/ensembl/babel.config.js
+++ b/src/ensembl/babel.config.js
@@ -15,7 +15,8 @@ module.exports = {
     '@babel/plugin-syntax-dynamic-import',
     '@babel/plugin-proposal-object-rest-spread',
     '@babel/plugin-proposal-class-properties',
-    '@babel/plugin-proposal-optional-chaining'
+    '@babel/plugin-proposal-optional-chaining',
+    '@babel/plugin-proposal-nullish-coalescing-operator'
   ],
   env: {
     test: {

--- a/src/ensembl/package.json
+++ b/src/ensembl/package.json
@@ -79,6 +79,7 @@
   "devDependencies": {
     "@babel/core": "7.7.5",
     "@babel/plugin-proposal-class-properties": "7.7.4",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "7.7.4",
     "@babel/plugin-proposal-object-rest-spread": "7.7.4",
     "@babel/plugin-proposal-optional-chaining": "7.7.5",
     "@babel/plugin-syntax-dynamic-import": "7.7.4",

--- a/src/ensembl/src/shared/components/image-button/ImageButton.scss
+++ b/src/ensembl/src/shared/components/image-button/ImageButton.scss
@@ -2,6 +2,11 @@
 
 .imageButton {
   position: relative;
+
+  button {
+    width: 100%;
+    height: 100%;
+  }
 }
 
 .default {

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
@@ -11,13 +11,15 @@ $drawerWindowWidth: 45px;
 }
 
 .topBar {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr $sideBarContentWidth;
+  grid-column-gap: $sideBarToolStripWidth;
   align-items: center;
   height: $topBarHeight;
   background: $light-grey;
   box-shadow: 0 2px 3px $grey;
   position: relative;
-  padding: 0 18px;
+  padding-left: 18px;
   z-index: 200;
 }
 
@@ -101,6 +103,38 @@ $drawerWindowWidth: 45px;
 
   &Open {
     transform: rotate(180deg);
+  }
+}
+
+.sidebarTabs {
+  display: flex;
+  justify-content: space-around;
+  padding: 0 15px;
+}
+
+.sidebarTab {
+  display: inline-block;
+  color: $blue;
+  cursor: pointer;
+
+  &Active {
+    position: relative;
+    color: $black;
+    cursor: default;
+
+    &:after {
+      content: '';
+      position: absolute;
+      border: 6px solid $grey;
+      border-color: transparent transparent $light-grey $light-grey;
+      box-shadow: -2px 2px 2px 0 $grey;
+      height: 0;
+      right: calc(60% - 6px);
+      transform-origin: 0 0;
+      transform: rotate(-45deg);
+      top: 30px;
+      width: 0;
+    }
   }
 }
 

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
@@ -3,6 +3,7 @@
 $sideBarContentWidth: 320px;
 $sideBarToolStripWidth: 46px;
 $topBarHeight: 40px;
+$drawerWindowWidth: 45px;
 
 .standardAppLayout {
   height: 100%;
@@ -59,7 +60,6 @@ $topBarHeight: 40px;
   width: 100%;
   height: 100%;
   display: flex;
-  background-color: rgba(255, 255, 255, 0.8);
   z-index: 1;
   transition: transform 0.3s ease-in-out;
 
@@ -70,8 +70,6 @@ $topBarHeight: 40px;
   }
 
   &DrawerOpen {
-    // DO THIS
-    // transform: translateX(45px);
     transform: translateX(0);
   }
 
@@ -86,6 +84,7 @@ $topBarHeight: 40px;
   width: $sideBarContentWidth;
   border-left: 1px solid $grey;
   padding: 15px;
+  background-color: white;
 }
 
 .sideBarToolstrip {
@@ -125,6 +124,12 @@ $topBarHeight: 40px;
   position: relative;
   padding: 15px 26px 15px 30px;
   border-left: solid $medium-light-grey 1px;
+  background-color: white;
+}
+
+.drawerWindow {
+  width: $drawerWindowWidth;
+  height: 100%;
 }
 
 .drawerClose {

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
@@ -10,6 +10,8 @@ $topBarHeight: 32px;
 }
 
 .topBar {
+  display: flex;
+  align-items: center;
   height: $topBarHeight;
   background: $light-grey;
   box-shadow: 0 2px 3px $grey;
@@ -25,7 +27,6 @@ $topBarHeight: 32px;
 .main {
   flex-grow: 1;
   flex-shrink: 0;
-  opacity: 0.2;
   height: 100%;
 }
 

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
@@ -1,0 +1,35 @@
+$sideBarContentWidth: 320px;
+$sideBarToolStripWidth: 36px;
+$topBarHeight: 32px;
+
+.standardAppLayout {
+  height: 100%;
+  overflow: hidden;
+  background: red;
+}
+
+.topBar {
+  height: $topBarHeight;
+}
+
+.mainWrapper {
+  display: flex;
+  height: calc(100% - #{$topBarHeight});
+}
+
+.main {
+  flex-grow: 1;
+  flex-shrink: 0;
+  background: blue;
+  height: 100%;
+  // flex-basis: fill;
+}
+
+.sideBar {
+  flex-grow: 0;
+  flex-shrink: 0;
+  flex-basis: auto;
+  width: calc(#{$sideBarContentWidth} + #{$sideBarToolStripWidth});
+  background: green;
+  height: 100%;
+}

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
@@ -16,6 +16,7 @@ $topBarHeight: 32px;
   background: $light-grey;
   box-shadow: 0 2px 3px $grey;
   position: relative;
+  padding: 0 18px;
   z-index: 200;
 }
 
@@ -82,6 +83,7 @@ $topBarHeight: 32px;
   height: 100%;
   width: $sideBarContentWidth;
   border-left: 1px solid $grey;
+  padding: 15px;
 }
 
 .sideBarToolstrip {
@@ -96,9 +98,15 @@ $topBarHeight: 32px;
   border-left: 1px solid $grey;
 }
 
+.sidebarToolstripContent {
+  width: 100%;
+  overflow-x: hidden;
+}
+
 .sidebarModeToggle {
   width: 22px;
   height: 22px;
+  margin-bottom: 30px;
 }
 
 .sidebarModeToggleChevron {
@@ -113,6 +121,7 @@ $topBarHeight: 32px;
   height: 100%;
   flex-grow: 1;
   position: relative;
+  padding: 40px 26px 15px 0;
 }
 
 .drawerClose {

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
@@ -22,41 +22,27 @@ $drawerWindowWidth: 45px;
 }
 
 .mainWrapper {
-  display: flex;
   height: calc(100% - #{$topBarHeight});
   position: relative;
-
-  &:after {
-    content: '';
-    height: 100%;
-    display: block;
-    flex-grow: 0;
-    flex-shrink: 0;
-    flex-basis: auto;
-    transition: width 0.3s ease-in-out;
-  }
-
-  &Default {
-    &:after {
-      width: calc(#{$sideBarContentWidth} + #{$sideBarToolStripWidth});
-    }
-  }
-
-  &FullWidth {
-    &:after {
-      width: $sideBarToolStripWidth;
-    }
-  }
 }
 
 .main {
-  flex-grow: 1;
-  flex-shrink: 0;
   height: 100%;
+  transition: margin 0.3s ease-in-out;
+
+  &Default {
+    margin-right: calc(#{$sideBarContentWidth} + #{$sideBarToolStripWidth});
+  }
+
+  &FullWidth {
+    margin-right: $sideBarToolStripWidth;
+  }
 }
 
 .sideBarWrapper {
   position: absolute;
+  top: 0;
+  left: 0;
   width: 100%;
   height: 100%;
   display: flex;

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
@@ -22,6 +22,29 @@ $topBarHeight: 32px;
 .mainWrapper {
   display: flex;
   height: calc(100% - #{$topBarHeight});
+  position: relative;
+
+  &:after {
+    content: '';
+    height: 100%;
+    display: block;
+    flex-grow: 0;
+    flex-shrink: 0;
+    flex-basis: auto;
+    transition: width 0.3s ease-in-out;
+  }
+
+  &Default {
+    &:after {
+      width: calc(#{$sideBarContentWidth} + #{$sideBarToolStripWidth});
+    }
+  }
+
+  &FullWidth {
+    &:after {
+      width: $sideBarToolStripWidth;
+    }
+  }
 }
 
 .main {
@@ -31,20 +54,26 @@ $topBarHeight: 32px;
 }
 
 .sideBarWrapper {
-  flex-grow: 0;
-  flex-shrink: 0;
-  flex-basis: auto;
-  display: flex;
+  position: absolute;
+  width: 100%;
   height: 100%;
-  overflow: hidden;
-  transition: width 0.2s ease-in-out;
+  display: flex;
+  background-color: rgba(255, 255, 255, 0.8);
+  z-index: 1;
+  transition: transform 0.3s ease-in-out;
 
   &Open {
-    width: calc(#{$sideBarContentWidth} + #{$sideBarToolStripWidth});
+    transform: translateX(
+      calc(100% - #{$sideBarContentWidth} - #{$sideBarToolStripWidth})
+    );
+  }
+
+  &DrawerOpen {
+    transform: translateX(0);
   }
 
   &Closed {
-    width: $sideBarToolStripWidth;
+    transform: translateX(calc(100% - #{$sideBarToolStripWidth}));
   }
 }
 
@@ -78,4 +107,19 @@ $topBarHeight: 32px;
   &Open {
     transform: rotate(180deg);
   }
+}
+
+.drawer {
+  height: 100%;
+  flex-grow: 1;
+  position: relative;
+}
+
+.drawerClose {
+  position: absolute;
+  right: 10px;
+  top: 10px;
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
 }

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
@@ -1,3 +1,5 @@
+@import 'src/styles/common';
+
 $sideBarContentWidth: 320px;
 $sideBarToolStripWidth: 36px;
 $topBarHeight: 32px;
@@ -5,11 +7,14 @@ $topBarHeight: 32px;
 .standardAppLayout {
   height: 100%;
   overflow: hidden;
-  background: red;
 }
 
 .topBar {
   height: $topBarHeight;
+  background: $light-grey;
+  box-shadow: 0 2px 3px $grey;
+  position: relative;
+  z-index: 200;
 }
 
 .mainWrapper {
@@ -20,16 +25,56 @@ $topBarHeight: 32px;
 .main {
   flex-grow: 1;
   flex-shrink: 0;
-  background: blue;
+  opacity: 0.2;
   height: 100%;
-  // flex-basis: fill;
 }
 
-.sideBar {
+.sideBarWrapper {
   flex-grow: 0;
   flex-shrink: 0;
   flex-basis: auto;
-  width: calc(#{$sideBarContentWidth} + #{$sideBarToolStripWidth});
-  background: green;
+  display: flex;
   height: 100%;
+  overflow: hidden;
+  transition: width 0.2s ease-in-out;
+
+  &Open {
+    width: calc(#{$sideBarContentWidth} + #{$sideBarToolStripWidth});
+  }
+
+  &Closed {
+    width: $sideBarToolStripWidth;
+  }
+}
+
+.sideBar {
+  flex: 0 0 auto;
+  height: 100%;
+  width: $sideBarContentWidth;
+  border-left: 1px solid $grey;
+}
+
+.sideBarToolstrip {
+  padding: 10px 0 30px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 0 0 auto;
+  width: $sideBarToolStripWidth;
+  height: 100%;
+  background: $light-grey;
+  border-left: 1px solid $grey;
+}
+
+.sidebarModeToggle {
+  width: 22px;
+  height: 22px;
+}
+
+.sidebarModeToggleChevron {
+  cursor: pointer;
+
+  &Open {
+    transform: rotate(180deg);
+  }
 }

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
@@ -1,8 +1,8 @@
 @import 'src/styles/common';
 
 $sideBarContentWidth: 320px;
-$sideBarToolStripWidth: 36px;
-$topBarHeight: 32px;
+$sideBarToolStripWidth: 46px;
+$topBarHeight: 40px;
 
 .standardAppLayout {
   height: 100%;
@@ -70,6 +70,8 @@ $topBarHeight: 32px;
   }
 
   &DrawerOpen {
+    // DO THIS
+    // transform: translateX(45px);
     transform: translateX(0);
   }
 
@@ -121,7 +123,8 @@ $topBarHeight: 32px;
   height: 100%;
   flex-grow: 1;
   position: relative;
-  padding: 40px 26px 15px 0;
+  padding: 15px 26px 15px 30px;
+  border-left: solid $medium-light-grey 1px;
 }
 
 .drawerClose {

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.test.tsx
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { mount, render } from 'enzyme';
+
+import StandardAppLayout from './StandardAppLayout';
+
+const MainContent = () => (
+  <div className="mainContent">This is main content</div>
+);
+const SidebarContent = () => (
+  <div className="sidebarContent">This is sidebar content</div>
+);
+const TopbarContent = () => (
+  <div className="topbarContent">This is topbar content</div>
+);
+
+const defaultProps = {
+  mainContent: <MainContent />,
+  sidebarContent: <SidebarContent />,
+  topbarContent: <TopbarContent />
+};
+
+describe('StandardAppLayout', () => {
+  describe('rendering', () => {
+    it('renders the main content in the main section', () => {
+      const wrapper = render(<StandardAppLayout {...defaultProps} />);
+      expect(wrapper.find('.main').find('.mainContent').length).toBe(1);
+    });
+
+    it('renders the top bar content in the top bar', () => {
+      const wrapper = render(<StandardAppLayout {...defaultProps} />);
+      expect(wrapper.find('.topBar').find('.topbarContent').length).toBe(1);
+    });
+
+    it('renders the sidebar content in the sidebar', () => {
+      const wrapper = render(<StandardAppLayout {...defaultProps} />);
+      expect(wrapper.find('.sideBar').find('.sidebarContent').length).toBe(1);
+    });
+  });
+});

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.test.tsx
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.test.tsx
@@ -13,27 +13,147 @@ const TopbarContent = () => (
   <div className="topbarContent">This is topbar content</div>
 );
 
-const defaultProps = {
+const SidebarToolstripContent = () => (
+  <div className="toolstripContent">This is topbar content</div>
+);
+
+const DrawerContent = () => (
+  <div className="drawerContent">This is drawer content</div>
+);
+
+const minimalProps = {
   mainContent: <MainContent />,
   sidebarContent: <SidebarContent />,
-  topbarContent: <TopbarContent />
+  sidebarToolstripContent: <SidebarToolstripContent />,
+  topbarContent: <TopbarContent />,
+  isSidebarOpen: true,
+  onSidebarToggle: jest.fn()
 };
 
 describe('StandardAppLayout', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   describe('rendering', () => {
     it('renders the main content in the main section', () => {
-      const wrapper = render(<StandardAppLayout {...defaultProps} />);
+      const wrapper = render(<StandardAppLayout {...minimalProps} />);
       expect(wrapper.find('.main').find('.mainContent').length).toBe(1);
     });
 
     it('renders the top bar content in the top bar', () => {
-      const wrapper = render(<StandardAppLayout {...defaultProps} />);
+      const wrapper = render(<StandardAppLayout {...minimalProps} />);
       expect(wrapper.find('.topBar').find('.topbarContent').length).toBe(1);
     });
 
     it('renders the sidebar content in the sidebar', () => {
-      const wrapper = render(<StandardAppLayout {...defaultProps} />);
+      const wrapper = render(<StandardAppLayout {...minimalProps} />);
       expect(wrapper.find('.sideBar').find('.sidebarContent').length).toBe(1);
+    });
+
+    it('renders sidebar toolstrip content in the sidebar toolstrip', () => {
+      const wrapper = render(<StandardAppLayout {...minimalProps} />);
+      expect(
+        wrapper.find('.sideBarToolstripContent').find('.toolstripContent')
+          .length
+      ).toBe(1);
+    });
+
+    describe('with drawer', () => {
+      const props = {
+        ...minimalProps,
+        isDrawerOpen: false,
+        drawerContent: <DrawerContent />,
+        onDrawerClose: jest.fn()
+      };
+
+      it('renders drawer content in the drawer', () => {
+        const wrapper = render(<StandardAppLayout {...props} />);
+        expect(wrapper.find('.drawer').find('.drawerContent').length).toBe(1);
+      });
+
+      it('applies correct classes to the sidebar/drawer wrapper', () => {
+        let wrapper, sidebarWrapper;
+        const closedSidebarProps = {
+          ...props,
+          isSidebarOpen: false
+        };
+        wrapper = render(<StandardAppLayout {...closedSidebarProps} />);
+        sidebarWrapper = wrapper.find('.sideBarWrapper');
+        expect(sidebarWrapper.hasClass('sideBarWrapperOpen')).toBe(false);
+        expect(sidebarWrapper.hasClass('sideBarWrapperClosed')).toBe(true);
+        expect(sidebarWrapper.hasClass('sideBarWrapperDrawerOpen')).toBe(false);
+
+        const openSidebarProps = props;
+        wrapper = render(<StandardAppLayout {...openSidebarProps} />);
+        sidebarWrapper = wrapper.find('.sideBarWrapper');
+        expect(sidebarWrapper.hasClass('sideBarWrapperOpen')).toBe(true);
+        expect(sidebarWrapper.hasClass('sideBarWrapperClosed')).toBe(false);
+        expect(sidebarWrapper.hasClass('sideBarWrapperDrawerOpen')).toBe(false);
+
+        const openDrawerProps = {
+          ...props,
+          isDrawerOpen: true
+        };
+        wrapper = render(<StandardAppLayout {...openDrawerProps} />);
+        sidebarWrapper = wrapper.find('.sideBarWrapper');
+        expect(sidebarWrapper.hasClass('sideBarWrapperOpen')).toBe(true);
+        expect(sidebarWrapper.hasClass('sideBarWrapperClosed')).toBe(false);
+        expect(sidebarWrapper.hasClass('sideBarWrapperDrawerOpen')).toBe(true);
+      });
+    });
+  });
+
+  describe('behaviour', () => {
+    const commonProps = {
+      ...minimalProps,
+      isDrawerOpen: false,
+      drawerContent: <DrawerContent />,
+      onDrawerClose: jest.fn()
+    };
+
+    describe('with closed drawer', () => {
+      const props = commonProps;
+
+      it('calls onSidebarToggle when sidebar toggle button is clicked', () => {
+        const wrapper = mount(<StandardAppLayout {...props} />);
+        wrapper.find('.sidebarModeToggleChevron').simulate('click');
+
+        expect(props.onSidebarToggle).toHaveBeenCalledTimes(1);
+
+        // do the same for closed sidebar
+        wrapper.setProps({ isSidebarOpen: false });
+        wrapper.find('.sidebarModeToggleChevron').simulate('click');
+
+        expect(props.onSidebarToggle).toHaveBeenCalledTimes(2);
+        expect(props.onDrawerClose).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('with open drawer', () => {
+      const props = { ...commonProps, isDrawerOpen: true };
+
+      it('closes drawer when sidebar toggle button is clicked', () => {
+        const wrapper = mount(<StandardAppLayout {...props} />);
+        wrapper.find('.sidebarModeToggleChevron').simulate('click');
+
+        expect(props.onDrawerClose).toHaveBeenCalledTimes(1);
+        expect(props.onSidebarToggle).not.toHaveBeenCalled();
+      });
+
+      it('closes drawer when drawer close button is clicked', () => {
+        const wrapper = mount(<StandardAppLayout {...props} />);
+        wrapper.find('.drawerClose').simulate('click');
+
+        expect(props.onDrawerClose).toHaveBeenCalledTimes(1);
+      });
+
+      it('closes drawer when drawer’s transparent window is clicked', () => {
+        const wrapper = mount(<StandardAppLayout {...props} />);
+        wrapper.find('.drawerWindow').simulate('click');
+
+        expect(props.onDrawerClose).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.test.tsx
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount, render } from 'enzyme';
+import faker from 'faker';
 
 import StandardAppLayout from './StandardAppLayout';
 
@@ -21,12 +22,25 @@ const DrawerContent = () => (
   <div className="drawerContent">This is drawer content</div>
 );
 
+const sidebarNavigationLinks = [...Array(3)].map(() => ({
+  label: faker.random.word(),
+  isActive: false
+}));
+const activeSidebarNavLinkIndex = Math.floor(
+  Math.random() * sidebarNavigationLinks.length
+);
+sidebarNavigationLinks[activeSidebarNavLinkIndex].isActive = true;
+
 const minimalProps = {
   mainContent: <MainContent />,
   sidebarContent: <SidebarContent />,
   sidebarToolstripContent: <SidebarToolstripContent />,
   topbarContent: <TopbarContent />,
   isSidebarOpen: true,
+  sidebarNavigation: {
+    links: sidebarNavigationLinks,
+    onChange: jest.fn()
+  },
   onSidebarToggle: jest.fn()
 };
 
@@ -100,6 +114,56 @@ describe('StandardAppLayout', () => {
         expect(sidebarWrapper.hasClass('sideBarWrapperOpen')).toBe(true);
         expect(sidebarWrapper.hasClass('sideBarWrapperClosed')).toBe(false);
         expect(sidebarWrapper.hasClass('sideBarWrapperDrawerOpen')).toBe(true);
+      });
+    });
+
+    describe('navigation tabs', () => {
+      it('renders navigation tabs', () => {
+        const wrapper = render(<StandardAppLayout {...minimalProps} />);
+        expect(wrapper.find('.sidebarTab').length).toBe(
+          minimalProps.sidebarNavigation.links.length
+        );
+      });
+
+      it('adds active class name to a tab if sidebar is open', () => {
+        const wrapper = render(<StandardAppLayout {...minimalProps} />);
+        wrapper
+          .find(`.sidebarTab`)
+          .toArray()
+          .forEach((element, index) => {
+            const shouldBeActive = index === activeSidebarNavLinkIndex;
+            expect(element.attribs.class.includes('sidebarTabActive')).toBe(
+              shouldBeActive
+            );
+          });
+      });
+
+      it('does not add active class name to tabs when sidebar is closed', () => {
+        const wrapper = render(
+          <StandardAppLayout {...{ ...minimalProps, isSidebarOpen: false }} />
+        );
+        wrapper
+          .find(`.sidebarTab`)
+          .toArray()
+          .forEach((element) => {
+            expect(element.attribs.class.includes('sidebarTabActive')).toBe(
+              false
+            );
+          });
+      });
+
+      it('does not add active class name to tabs when drawer is opened', () => {
+        const wrapper = render(
+          <StandardAppLayout {...{ ...minimalProps, isDrawerOpen: true }} />
+        );
+        wrapper
+          .find(`.sidebarTab`)
+          .toArray()
+          .forEach((element) => {
+            expect(element.attribs.class.includes('sidebarTabActive')).toBe(
+              false
+            );
+          });
       });
     });
   });

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
@@ -17,10 +17,19 @@ type SidebarModeToggleProps = {
   showAction: SidebarModeToggleAction;
 };
 
+type SidebarNavigationProps = {
+  links: Array<{
+    label: string;
+    isActive: boolean;
+  }>;
+  onChange: (index: number) => void;
+};
+
 type StandardAppLayoutProps = {
   mainContent: ReactNode;
   sidebarContent: ReactNode;
   sidebarToolstripContent?: ReactNode;
+  sidebarNavigation: SidebarNavigationProps;
   topbarContent: ReactNode;
   isSidebarOpen: boolean;
   onSidebarToggle: () => void;
@@ -48,7 +57,10 @@ const StandardAppLayout = (props: StandardAppLayoutProps) => {
 
   return (
     <div className={styles.standardAppLayout}>
-      <div className={styles.topBar}>{props.topbarContent}</div>
+      <div className={styles.topBar}>
+        {props.topbarContent}
+        <SidebarTabs {...props} />
+      </div>
       <div className={styles.mainWrapper}>
         <div className={mainClassnames}>{props.mainContent}</div>
         <div className={sidebarWrapperClassnames}>
@@ -99,6 +111,37 @@ const SidebarModeToggle = (props: SidebarModeToggleProps) => {
     </div>
   );
 };
+
+const SidebarTabs = (props: StandardAppLayoutProps) => {
+  const links = props.sidebarNavigation.links.map((link, index) => {
+    const isLinkActive = shouldLinkBeActive(
+      link,
+      props.isSidebarOpen,
+      props.isDrawerOpen
+    );
+    return (
+      <span
+        key={index}
+        className={classNames(styles.sidebarTab, {
+          [styles.sidebarTabActive]: isLinkActive
+        })}
+        {...(!isLinkActive
+          ? { onClick: () => props.sidebarNavigation.onChange(index) }
+          : null)}
+      >
+        {link.label}
+      </span>
+    );
+  });
+
+  return <div className={styles.sidebarTabs}>{links}</div>;
+};
+
+const shouldLinkBeActive = (
+  link: { isActive: boolean },
+  isSidebarOpen: boolean,
+  isDrawerOpen: boolean
+) => link.isActive && isSidebarOpen && !isDrawerOpen;
 
 // left-most transparent part of the drawer allowing the user to see what element is behind the drawer;
 // when clicked, will close the drawer

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
@@ -36,10 +36,10 @@ type StandardAppLayoutProps =
   | StandardAppLayoutWithDrawerProps;
 
 const StandardAppLayout = (props: StandardAppLayoutProps) => {
-  const mainContainerClassnames = classNames(
-    styles.mainWrapper,
-    { [styles.mainWrapperDefault]: props.isSidebarOpen },
-    { [styles.mainWrapperFullWidth]: !props.isSidebarOpen }
+  const mainClassnames = classNames(
+    styles.main,
+    { [styles.mainDefault]: props.isSidebarOpen },
+    { [styles.mainFullWidth]: !props.isSidebarOpen }
   );
 
   const sidebarWrapperClassnames = classNames(
@@ -52,8 +52,8 @@ const StandardAppLayout = (props: StandardAppLayoutProps) => {
   return (
     <div className={styles.standardAppLayout}>
       <div className={styles.topBar}>{props.topbarContent}</div>
-      <div className={mainContainerClassnames}>
-        <div className={styles.main}>{props.mainContent}</div>
+      <div className={styles.mainWrapper}>
+        <div className={mainClassnames}>{props.mainContent}</div>
         <div className={sidebarWrapperClassnames}>
           {props.isDrawerOpen && <DrawerWindow onClick={props.onDrawerClose} />}
           <div className={styles.sideBarToolstrip}>

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
@@ -55,9 +55,12 @@ const StandardAppLayout = (props: StandardAppLayoutProps) => {
       <div className={mainContainerClassnames}>
         <div className={styles.main}>{props.mainContent}</div>
         <div className={sidebarWrapperClassnames}>
+          {props.isDrawerOpen && <DrawerWindow onClick={props.onDrawerClose} />}
           <div className={styles.sideBarToolstrip}>
             <SidebarModeToggle
-              onClick={props.onSidebarToggle}
+              onClick={
+                props.isDrawerOpen ? props.onDrawerClose : props.onSidebarToggle
+              }
               showAction={
                 props.isSidebarOpen
                   ? SidebarModeToggleAction.CLOSE
@@ -93,6 +96,12 @@ const SidebarModeToggle = (props: SidebarModeToggleProps) => {
       <Chevron className={chevronClasses} onClick={props.onClick} />
     </div>
   );
+};
+
+// left-most transparent part of the drawer allowing the user to see what element is behind the drawer;
+// when clicked, will close the drawer
+const DrawerWindow = (props: { onClick: () => void }) => {
+  return <div className={styles.drawerWindow} onClick={props.onClick} />;
 };
 
 export default StandardAppLayout;

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
@@ -1,15 +1,65 @@
-import React from 'react';
+import React, { useState } from 'react';
+import classNames from 'classnames';
+
+import { ReactComponent as Chevron } from 'static/img/shared/chevron-right.svg';
 
 import styles from './StandardAppLayout.scss';
 
+enum SidebarModeToggleAction {
+  OPEN = 'open',
+  CLOSE = 'close'
+}
+
+type SidebarModeToggleProps = {
+  onClick: () => void;
+  showAction: SidebarModeToggleAction;
+};
+
 const StandardAppLayout = () => {
+  const [isOpen, setIsOpen] = useState(true);
+
+  const toggleSidebar = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const sidebarWrapperClassnames = classNames(
+    styles.sideBarWrapper,
+    { [styles.sideBarWrapperOpen]: isOpen },
+    { [styles.sideBarWrapperClosed]: !isOpen }
+  );
+
   return (
     <div className={styles.standardAppLayout}>
       <div className={styles.topBar}>I am top bar</div>
       <div className={styles.mainWrapper}>
         <div className={styles.main}>This is main</div>
-        <div className={styles.sideBar}>I am sidebar</div>
+        <div className={sidebarWrapperClassnames}>
+          <div className={styles.sideBarToolstrip}>
+            <SidebarModeToggle
+              onClick={toggleSidebar}
+              showAction={
+                isOpen
+                  ? SidebarModeToggleAction.CLOSE
+                  : SidebarModeToggleAction.OPEN
+              }
+            />
+          </div>
+          <div className={styles.sideBar}>I am sidebar</div>
+        </div>
       </div>
+    </div>
+  );
+};
+
+const SidebarModeToggle = (props: SidebarModeToggleProps) => {
+  const chevronClasses = classNames(styles.sidebarModeToggleChevron, {
+    [styles.sidebarModeToggleChevronOpen]:
+      props.showAction === SidebarModeToggleAction.OPEN
+  });
+
+  return (
+    <div className={styles.sidebarModeToggle}>
+      <Chevron className={chevronClasses} onClick={props.onClick} />
     </div>
   );
 };

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react';
 import classNames from 'classnames';
+import noop from 'lodash/noop';
 
 import { ReactComponent as Chevron } from 'static/img/shared/chevron-right.svg';
 import { ReactComponent as CloseIcon } from 'static/img/shared/close.svg';
@@ -16,24 +17,17 @@ type SidebarModeToggleProps = {
   showAction: SidebarModeToggleAction;
 };
 
-type StandardAppLayoutWithoutDrawerProps = {
+type StandardAppLayoutProps = {
   mainContent: ReactNode;
   sidebarContent: ReactNode;
   sidebarToolstripContent?: ReactNode;
   topbarContent: ReactNode;
   isSidebarOpen: boolean;
   onSidebarToggle: () => void;
-};
-
-type StandardAppLayoutWithDrawerProps = StandardAppLayoutWithoutDrawerProps & {
   isDrawerOpen: boolean;
-  drawerContent: ReactNode;
+  drawerContent?: ReactNode;
   onDrawerClose: () => void;
 };
-
-type StandardAppLayoutProps =
-  | StandardAppLayoutWithoutDrawerProps
-  | StandardAppLayoutWithDrawerProps;
 
 const StandardAppLayout = (props: StandardAppLayoutProps) => {
   const mainClassnames = classNames(
@@ -46,7 +40,10 @@ const StandardAppLayout = (props: StandardAppLayoutProps) => {
     styles.sideBarWrapper,
     { [styles.sideBarWrapperOpen]: props.isSidebarOpen },
     { [styles.sideBarWrapperClosed]: !props.isSidebarOpen },
-    { [styles.sideBarWrapperDrawerOpen]: props.isDrawerOpen || false }
+    {
+      [styles.sideBarWrapperDrawerOpen]:
+        'isDrawerOpen' in props ? props.isDrawerOpen : false
+    }
   );
 
   return (
@@ -83,6 +80,11 @@ const StandardAppLayout = (props: StandardAppLayoutProps) => {
       </div>
     </div>
   );
+};
+
+StandardAppLayout.defaultProps = {
+  isDrawerOpen: false,
+  onDrawerClose: noop
 };
 
 const SidebarModeToggle = (props: SidebarModeToggleProps) => {

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
@@ -50,8 +50,7 @@ const StandardAppLayout = (props: StandardAppLayoutProps) => {
     { [styles.sideBarWrapperOpen]: props.isSidebarOpen },
     { [styles.sideBarWrapperClosed]: !props.isSidebarOpen },
     {
-      [styles.sideBarWrapperDrawerOpen]:
-        'isDrawerOpen' in props ? props.isDrawerOpen : false
+      [styles.sideBarWrapperDrawerOpen]: props.isDrawerOpen ?? false
     }
   );
 

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, ReactNode } from 'react';
 import classNames from 'classnames';
 
 import { ReactComponent as Chevron } from 'static/img/shared/chevron-right.svg';
@@ -15,7 +15,13 @@ type SidebarModeToggleProps = {
   showAction: SidebarModeToggleAction;
 };
 
-const StandardAppLayout = () => {
+type StandardAppLayoutProps = {
+  mainContent: ReactNode;
+  sidebarContent: ReactNode;
+  topbarContent: ReactNode;
+};
+
+const StandardAppLayout = (props: StandardAppLayoutProps) => {
   const [isOpen, setIsOpen] = useState(true);
 
   const toggleSidebar = () => {
@@ -30,9 +36,9 @@ const StandardAppLayout = () => {
 
   return (
     <div className={styles.standardAppLayout}>
-      <div className={styles.topBar}>I am top bar</div>
+      <div className={styles.topBar}>{props.topbarContent}</div>
       <div className={styles.mainWrapper}>
-        <div className={styles.main}>This is main</div>
+        <div className={styles.main}>{props.mainContent}</div>
         <div className={sidebarWrapperClassnames}>
           <div className={styles.sideBarToolstrip}>
             <SidebarModeToggle
@@ -44,7 +50,7 @@ const StandardAppLayout = () => {
               }
             />
           </div>
-          <div className={styles.sideBar}>I am sidebar</div>
+          <div className={styles.sideBar}>{props.sidebarContent}</div>
         </div>
       </div>
     </div>

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import styles from './StandardAppLayout.scss';
+
+const StandardAppLayout = () => {
+  return (
+    <div className={styles.standardAppLayout}>
+      <div className={styles.topBar}>I am top bar</div>
+      <div className={styles.mainWrapper}>
+        <div className={styles.main}>This is main</div>
+        <div className={styles.sideBar}>I am sidebar</div>
+      </div>
+    </div>
+  );
+};
+
+export default StandardAppLayout;

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
@@ -1,7 +1,8 @@
-import React, { useState, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import classNames from 'classnames';
 
 import { ReactComponent as Chevron } from 'static/img/shared/chevron-right.svg';
+import { ReactComponent as CloseIcon } from 'static/img/shared/close.svg';
 
 import styles from './StandardAppLayout.scss';
 
@@ -15,42 +16,62 @@ type SidebarModeToggleProps = {
   showAction: SidebarModeToggleAction;
 };
 
-type StandardAppLayoutProps = {
+type StandardAppLayoutWithoutDrawerProps = {
   mainContent: ReactNode;
   sidebarContent: ReactNode;
   topbarContent: ReactNode;
+  isSidebarOpen: boolean;
+  onSidebarToggle: () => void;
 };
 
-const StandardAppLayout = (props: StandardAppLayoutProps) => {
-  const [isOpen, setIsOpen] = useState(true);
+type StandardAppLayoutWithDrawerProps = StandardAppLayoutWithoutDrawerProps & {
+  isDrawerOpen: boolean;
+  drawerContent: ReactNode;
+  onDrawerClose: () => void;
+};
 
-  const toggleSidebar = () => {
-    setIsOpen(!isOpen);
-  };
+type StandardAppLayoutProps =
+  | StandardAppLayoutWithoutDrawerProps
+  | StandardAppLayoutWithDrawerProps;
+
+const StandardAppLayout = (props: StandardAppLayoutProps) => {
+  const mainContainerClassnames = classNames(
+    styles.mainWrapper,
+    { [styles.mainWrapperDefault]: props.isSidebarOpen },
+    { [styles.mainWrapperFullWidth]: !props.isSidebarOpen }
+  );
 
   const sidebarWrapperClassnames = classNames(
     styles.sideBarWrapper,
-    { [styles.sideBarWrapperOpen]: isOpen },
-    { [styles.sideBarWrapperClosed]: !isOpen }
+    { [styles.sideBarWrapperOpen]: props.isSidebarOpen },
+    { [styles.sideBarWrapperClosed]: !props.isSidebarOpen },
+    { [styles.sideBarWrapperDrawerOpen]: props.isDrawerOpen || false }
   );
 
   return (
     <div className={styles.standardAppLayout}>
       <div className={styles.topBar}>{props.topbarContent}</div>
-      <div className={styles.mainWrapper}>
+      <div className={mainContainerClassnames}>
         <div className={styles.main}>{props.mainContent}</div>
         <div className={sidebarWrapperClassnames}>
           <div className={styles.sideBarToolstrip}>
             <SidebarModeToggle
-              onClick={toggleSidebar}
+              onClick={props.onSidebarToggle}
               showAction={
-                isOpen
+                props.isSidebarOpen
                   ? SidebarModeToggleAction.CLOSE
                   : SidebarModeToggleAction.OPEN
               }
             />
           </div>
           <div className={styles.sideBar}>{props.sidebarContent}</div>
+          <div className={styles.drawer}>
+            <CloseIcon
+              className={styles.drawerClose}
+              onClick={props.onDrawerClose}
+            />
+            {props.drawerContent || null}
+          </div>
         </div>
       </div>
     </div>

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
@@ -19,6 +19,7 @@ type SidebarModeToggleProps = {
 type StandardAppLayoutWithoutDrawerProps = {
   mainContent: ReactNode;
   sidebarContent: ReactNode;
+  sidebarToolstripContent?: ReactNode;
   topbarContent: ReactNode;
   isSidebarOpen: boolean;
   onSidebarToggle: () => void;
@@ -63,6 +64,9 @@ const StandardAppLayout = (props: StandardAppLayoutProps) => {
                   : SidebarModeToggleAction.OPEN
               }
             />
+            <div className={styles.sideBarToolstripContent}>
+              {props.sidebarToolstripContent}
+            </div>
           </div>
           <div className={styles.sideBar}>{props.sidebarContent}</div>
           <div className={styles.drawer}>

--- a/src/ensembl/src/shared/components/layout/index.ts
+++ b/src/ensembl/src/shared/components/layout/index.ts
@@ -1,0 +1,1 @@
+export { default as StandardAppLayout } from './StandardAppLayout';

--- a/src/ensembl/stories/shared-components/index.ts
+++ b/src/ensembl/stories/shared-components/index.ts
@@ -1,3 +1,4 @@
+import './layout/Layout.stories';
 import './button/Button.stories';
 import './clear-button/ClearButton.stories';
 import './question-button/QuestionButton.stories';

--- a/src/ensembl/stories/shared-components/layout/Layout.stories.scss
+++ b/src/ensembl/stories/shared-components/layout/Layout.stories.scss
@@ -2,3 +2,14 @@
   height: 100vh;
   padding: 50px 0 0;
 }
+
+.mainContent {
+  width: 100%;
+  height: 100%;
+  text-align: center;
+
+  img {
+    max-width: 100%;
+    max-height: 100%;
+  }
+}

--- a/src/ensembl/stories/shared-components/layout/Layout.stories.scss
+++ b/src/ensembl/stories/shared-components/layout/Layout.stories.scss
@@ -6,10 +6,16 @@
 .mainContent {
   width: 100%;
   height: 100%;
+  background: rgba(255, 255, 0, 0.25);
   text-align: center;
 
   img {
     max-width: 100%;
     max-height: 100%;
   }
+}
+
+.drawerContent {
+  background: rgba(255, 192, 203, 0.3);
+  height: 100%;
 }

--- a/src/ensembl/stories/shared-components/layout/Layout.stories.scss
+++ b/src/ensembl/stories/shared-components/layout/Layout.stories.scss
@@ -1,0 +1,4 @@
+.wrapper {
+  height: 100vh;
+  padding: 50px 0 0;
+}

--- a/src/ensembl/stories/shared-components/layout/Layout.stories.scss
+++ b/src/ensembl/stories/shared-components/layout/Layout.stories.scss
@@ -12,7 +12,17 @@
   img {
     max-width: 100%;
     max-height: 100%;
+    mix-blend-mode: multiply;
   }
+}
+
+.sidebarContent {
+  background: rgba(255, 144, 0, 0.25);
+  height: 100%;
+}
+
+.sidebarToolstripContent {
+  writing-mode: vertical-lr;
 }
 
 .drawerContent {

--- a/src/ensembl/stories/shared-components/layout/Layout.stories.tsx
+++ b/src/ensembl/stories/shared-components/layout/Layout.stories.tsx
@@ -56,12 +56,22 @@ const Wrapper = (props: {
   onSidebarToggle: () => void;
   onDrawerClose?: () => void;
 }) => {
+  const [activeLinkIndex, setActiveLinkIndex] = useState(0);
+  const sidebarNavigation = {
+    links: [...Array(2)].map((_, index) => ({
+      label: `Link ${index + 1}`,
+      isActive: index === activeLinkIndex
+    })),
+    onChange: (index: number) => setActiveLinkIndex(index)
+  };
+
   return (
     <div className={styles.wrapper}>
       <StandardAppLayout
         mainContent={<MainContent />}
         topbarContent={<TopBarContent />}
         sidebarContent={props.sidebarContent}
+        sidebarNavigation={sidebarNavigation}
         sidebarToolstripContent={<SidebarToolstripContent />}
         drawerContent={props.drawerContent || null}
         isSidebarOpen={props.isSidebarOpen}

--- a/src/ensembl/stories/shared-components/layout/Layout.stories.tsx
+++ b/src/ensembl/stories/shared-components/layout/Layout.stories.tsx
@@ -16,14 +16,16 @@ const MainContent = () => (
   </div>
 );
 
-const SidebarContentSimple = () => <div>This is sidebar content</div>;
+const SidebarContentSimple = () => (
+  <div className={styles.sidebarContent}>This is sidebar content</div>
+);
 
 const SidebarContentWithDrawerOpener = (props: {
   isDrawerOpen: boolean;
   openDrawer: () => void;
 }) => {
   return (
-    <div>
+    <div className={styles.sidebarContent}>
       This is sidebar with drawer opener
       <div>
         {props.isDrawerOpen ? (
@@ -37,6 +39,10 @@ const SidebarContentWithDrawerOpener = (props: {
     </div>
   );
 };
+
+const SidebarToolstripContent = () => (
+  <div className={styles.sidebarToolstripContent}>Here be icons</div>
+);
 
 const DrawerContent = () => (
   <div className={styles.drawerContent}>This is drawer content</div>
@@ -56,6 +62,7 @@ const Wrapper = (props: {
         mainContent={<MainContent />}
         topbarContent={<TopBarContent />}
         sidebarContent={props.sidebarContent}
+        sidebarToolstripContent={<SidebarToolstripContent />}
         drawerContent={props.drawerContent || null}
         isSidebarOpen={props.isSidebarOpen}
         isDrawerOpen={props.isDrawerOpen || false}

--- a/src/ensembl/stories/shared-components/layout/Layout.stories.tsx
+++ b/src/ensembl/stories/shared-components/layout/Layout.stories.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useState, ReactNode } from 'react';
 import { storiesOf } from '@storybook/react';
 
 import { StandardAppLayout } from 'src/shared/components/layout';
+import { SecondaryButton } from 'src/shared/components/button/Button';
 
 import styles from './Layout.stories.scss';
 
@@ -9,7 +10,6 @@ const TopBarContent = () => (
   <div className={styles.topBarContent}>This is top bar content</div>
 );
 
-// https://user-images.githubusercontent.com/6834224/70806519-6fc8bf00-1db3-11ea-8ecd-238b410230af.png
 const MainContent = () => (
   <div className={styles.mainContent}>
     <img src="https://user-images.githubusercontent.com/6834224/70806519-6fc8bf00-1db3-11ea-8ecd-238b410230af.png" />
@@ -18,17 +18,95 @@ const MainContent = () => (
 
 const SidebarContentSimple = () => <div>This is sidebar content</div>;
 
-storiesOf('Components|Shared Components/Layout/StandardAppLayout', module).add(
-  'default',
-  () => {
-    return (
-      <div className={styles.wrapper}>
-        <StandardAppLayout
-          mainContent={<MainContent />}
-          topbarContent={<TopBarContent />}
-          sidebarContent={<SidebarContentSimple />}
-        />
+const SidebarContentWithDrawerOpener = (props: {
+  isDrawerOpen: boolean;
+  openDrawer: () => void;
+}) => {
+  return (
+    <div>
+      This is sidebar with drawer opener
+      <div>
+        {props.isDrawerOpen ? (
+          'You have opened the drawer'
+        ) : (
+          <SecondaryButton onClick={props.openDrawer}>
+            Open drawer
+          </SecondaryButton>
+        )}
       </div>
-    );
-  }
+    </div>
+  );
+};
+
+const DrawerContent = () => (
+  <div className={styles.drawerContent}>This is drawer content</div>
 );
+
+const Wrapper = (props: {
+  isSidebarOpen: boolean;
+  isDrawerOpen?: boolean;
+  sidebarContent: ReactNode;
+  drawerContent?: ReactNode;
+  onSidebarToggle: () => void;
+  onDrawerClose?: () => void;
+}) => {
+  return (
+    <div className={styles.wrapper}>
+      <StandardAppLayout
+        mainContent={<MainContent />}
+        topbarContent={<TopBarContent />}
+        sidebarContent={props.sidebarContent}
+        drawerContent={props.drawerContent || null}
+        isSidebarOpen={props.isSidebarOpen}
+        isDrawerOpen={props.isDrawerOpen || false}
+        onSidebarToggle={props.onSidebarToggle}
+        onDrawerClose={props.onDrawerClose}
+      />
+    </div>
+  );
+};
+
+storiesOf('Components|Shared Components/Layout/StandardAppLayout', module)
+  .add('without drawer', () => {
+    const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+    const toggleSidebar = () => {
+      setIsSidebarOpen(!isSidebarOpen);
+    };
+
+    return (
+      <Wrapper
+        isSidebarOpen={isSidebarOpen}
+        sidebarContent={<SidebarContentSimple />}
+        onSidebarToggle={toggleSidebar}
+      />
+    );
+  })
+  .add('with drawer', () => {
+    const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+    const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+    const toggleSidebar = () => {
+      isDrawerOpen ? setIsDrawerOpen(false) : setIsSidebarOpen(!isSidebarOpen);
+    };
+    const openDrawer = () => {
+      setIsDrawerOpen(true);
+    };
+    const closeDrawer = () => {
+      setIsDrawerOpen(false);
+    };
+
+    return (
+      <Wrapper
+        isSidebarOpen={isSidebarOpen}
+        sidebarContent={
+          <SidebarContentWithDrawerOpener
+            isDrawerOpen={isDrawerOpen}
+            openDrawer={openDrawer}
+          />
+        }
+        onSidebarToggle={toggleSidebar}
+        isDrawerOpen={isDrawerOpen}
+        drawerContent={<DrawerContent />}
+        onDrawerClose={closeDrawer}
+      />
+    );
+  });

--- a/src/ensembl/stories/shared-components/layout/Layout.stories.tsx
+++ b/src/ensembl/stories/shared-components/layout/Layout.stories.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { StandardAppLayout } from 'src/shared/components/layout';
+
+import styles from './Layout.stories.scss';
+
+storiesOf('Components|Shared Components/Layout/StandardAppLayout', module).add(
+  'default',
+  () => {
+    return (
+      <div className={styles.wrapper}>
+        <StandardAppLayout />
+      </div>
+    );
+  }
+);

--- a/src/ensembl/stories/shared-components/layout/Layout.stories.tsx
+++ b/src/ensembl/stories/shared-components/layout/Layout.stories.tsx
@@ -5,12 +5,29 @@ import { StandardAppLayout } from 'src/shared/components/layout';
 
 import styles from './Layout.stories.scss';
 
+const TopBarContent = () => (
+  <div className={styles.topBarContent}>This is top bar content</div>
+);
+
+// https://user-images.githubusercontent.com/6834224/70806519-6fc8bf00-1db3-11ea-8ecd-238b410230af.png
+const MainContent = () => (
+  <div className={styles.mainContent}>
+    <img src="https://user-images.githubusercontent.com/6834224/70806519-6fc8bf00-1db3-11ea-8ecd-238b410230af.png" />
+  </div>
+);
+
+const SidebarContentSimple = () => <div>This is sidebar content</div>;
+
 storiesOf('Components|Shared Components/Layout/StandardAppLayout', module).add(
   'default',
   () => {
     return (
       <div className={styles.wrapper}>
-        <StandardAppLayout />
+        <StandardAppLayout
+          mainContent={<MainContent />}
+          topbarContent={<TopBarContent />}
+          sidebarContent={<SidebarContentSimple />}
+        />
       </div>
     );
   }


### PR DESCRIPTION
## Type
- Refactoring

## Description
This PR extracts a common layout pattern into a separate layout component. The component has:
- the main content area
- a top bar
- a side bar
- a toolstrip alongside the sidebar
- (optionally) a drawer

The sidebar opens and closes using CSS transition (which _might_ perform better than react-spring on genome browser page). The drawer also opens and closes using CSS transition (which will almost certainly perform better, because it's based on animating the transform property). When opened, the drawer still leaves a narrow space through which the user can see the main content area.

The layout currently exists only as a Storybook component. If approved, it will be a separate task to integrate it into the app.

The StandardAppLayout component can be viewed in Storybook — either locally, or at https://ensembl.github.io/ensembl-client/storybook/index.html?path=/story/components-shared-components-layout-standardapplayout--with-drawer

**Note:** the layout component, as it's implemented in this PR, is not responsible for showing the modal inside the sidebar. It is up to the parent component to decide whether it wants to put regular sidebar content or the modal content inside layout's sidebar.