### PR TITLE
Refactor breakpoint width

### DIFF
--- a/src/ensembl/src/content/app/browser/track-panel/TrackPanel.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/TrackPanel.test.tsx
@@ -10,9 +10,6 @@ import Drawer from '../drawer/Drawer';
 
 import { createEnsObject } from 'tests/fixtures/ens-object';
 import { BreakpointWidth } from 'src/global/globalConfig';
-import { TrackSet } from './trackPanelConfig';
-import { createGenomeCategories } from 'tests/fixtures/genomes';
-import { createTrackStates } from 'tests/fixtures/track-panel';
 
 jest.mock('./track-panel-bar/TrackPanelBar', () => () => (
   <div>Track Panel</div>

--- a/src/ensembl/src/content/app/browser/zmenu/Zmenu.test.tsx
+++ b/src/ensembl/src/content/app/browser/zmenu/Zmenu.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import faker from 'faker';
 
-import Zmenu, { ZmenuProps, Tip } from './Zmenu';
+import Zmenu, { ZmenuProps } from './Zmenu';
 import ZmenuContent from './ZmenuContent';
 
 import { createZmenuContent } from 'tests/fixtures/browser';

--- a/src/ensembl/src/global/globalActions.ts
+++ b/src/ensembl/src/global/globalActions.ts
@@ -4,7 +4,6 @@ import { ThunkAction } from 'redux-thunk';
 
 import { BreakpointWidth } from './globalConfig';
 import { getBreakpointWidth } from './globalSelectors';
-import { getBreakpoint } from './globalHelper';
 
 import { RootState } from 'src/store';
 
@@ -17,15 +16,14 @@ export const updateBreakpointWidth: ActionCreator<ThunkAction<
   any,
   null,
   Action<string>
->> = (width: keyof typeof BreakpointWidth) => async (
+>> = (viewportWidth: BreakpointWidth) => async (
   dispatch,
   getState: () => RootState
 ) => {
   const state = getState();
   const currentBreakpointWidth = getBreakpointWidth(state);
-  const newBreakpointWidth = getBreakpoint(width);
 
-  if (newBreakpointWidth !== currentBreakpointWidth) {
-    dispatch(setBreakpointWidth(newBreakpointWidth));
+  if (viewportWidth !== currentBreakpointWidth) {
+    dispatch(setBreakpointWidth(viewportWidth));
   }
 };

--- a/src/ensembl/src/global/globalHelper.ts
+++ b/src/ensembl/src/global/globalHelper.ts
@@ -1,21 +1,3 @@
-import { BreakpointWidth } from './globalConfig';
-
-export const getBreakpoint = (
-  key: keyof typeof BreakpointWidth
-): BreakpointWidth => {
-  if (BreakpointWidth[key] >= BreakpointWidth.BIG_DESKTOP) {
-    return BreakpointWidth.BIG_DESKTOP;
-  } else if (BreakpointWidth[key] >= BreakpointWidth.DESKTOP) {
-    return BreakpointWidth.DESKTOP;
-  } else if (BreakpointWidth[key] >= BreakpointWidth.LAPTOP) {
-    return BreakpointWidth.LAPTOP;
-  } else if (BreakpointWidth[key] >= BreakpointWidth.TABLET) {
-    return BreakpointWidth.TABLET;
-  } else {
-    return BreakpointWidth.PHONE;
-  }
-};
-
 export const getQueryParamsMap = (queryStr: string) => {
   const params = queryStr.replace('?', '').split('&'); // split all query param pairs
 

--- a/src/ensembl/src/root/Root.tsx
+++ b/src/ensembl/src/root/Root.tsx
@@ -15,9 +15,7 @@ import { GeneralErrorScreen } from 'src/shared/components/error-screen';
 import styles from './Root.scss';
 
 type Props = {
-  updateBreakpointWidth: (
-    breakpointWidth: keyof typeof BreakpointWidth
-  ) => void;
+  updateBreakpointWidth: (breakpointWidth: BreakpointWidth) => void;
 };
 
 export const Root = (props: Props) => {
@@ -25,7 +23,9 @@ export const Root = (props: Props) => {
 
   useEffect(() => {
     const subscription = observeMediaQueries(globalMediaQueries, (match) => {
-      props.updateBreakpointWidth(match as keyof typeof BreakpointWidth);
+      props.updateBreakpointWidth(
+        BreakpointWidth[match as keyof typeof BreakpointWidth]
+      );
     });
     return () => subscription.unsubscribe();
   }, []);

--- a/src/ensembl/src/shared/hooks/useResizeObserver.ts
+++ b/src/ensembl/src/shared/hooks/useResizeObserver.ts
@@ -1,6 +1,6 @@
 // modified from https://github.com/ZeeCoder/use-resize-observer/blob/master/src/index.js
 
-import { useEffect, useState, useRef, useMemo, RefObject } from 'react';
+import { useEffect, useState, useRef, RefObject } from 'react';
 import windowService from 'src/services/window-service';
 
 type Params<T> = {


### PR DESCRIPTION
## Type
Refactoring

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-453

## Description
The function `getBreakpoint` in `globalHelper.ts` is redundant as pointed out by @msmanoj in a PR comment here: https://github.com/Ensembl/ensembl-client/pull/205#pullrequestreview-333458453. So I have removed it in this PR.

Also, when I ran the linters it complained about a few unused imports. I have removed them too.

### Checks
- `npm t` — works fine
- `npm run check-types` — works fine
- development build — works fine
- production build — works fine
