### PR TITLE
Fix track panel opened on desktop rather than big desktop

### DIFF
--- a/src/ensembl/src/content/app/browser/track-panel/TrackPanel.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/TrackPanel.test.tsx
@@ -33,7 +33,7 @@ describe('<TrackPanel />', () => {
   const defaultProps: TrackPanelProps = {
     activeGenomeId: null,
     browserActivated: false,
-    breakpointWidth: BreakpointWidth.DESKTOP,
+    breakpointWidth: BreakpointWidth.LAPTOP,
     isDrawerOpened: false,
     activeEnsObject: null,
     isTrackPanelModalOpened: false,
@@ -52,15 +52,15 @@ describe('<TrackPanel />', () => {
       expect(wrapper.html()).not.toBe(null);
     });
 
-    test('shows track panel only if screen is or bigger than big desktop', () => {
+    test('shows track panel only if the screen width is desktop or larger', () => {
       const wrapper = mountTrackPanel({
-        breakpointWidth: BreakpointWidth.BIG_DESKTOP
+        breakpointWidth: BreakpointWidth.DESKTOP
       });
       expect(wrapper.props().toggleTrackPanel).toHaveBeenCalledWith(true);
 
       jest.resetAllMocks();
 
-      wrapper.setProps({ breakpointWidth: BreakpointWidth.DESKTOP });
+      wrapper.setProps({ breakpointWidth: BreakpointWidth.LAPTOP });
       wrapper.update();
       expect(wrapper.props().toggleTrackPanel).toHaveBeenCalledWith(false);
     });

--- a/src/ensembl/src/content/app/browser/track-panel/TrackPanel.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/TrackPanel.test.tsx
@@ -41,19 +41,32 @@ describe('<TrackPanel />', () => {
     toggleTrackPanel: jest.fn()
   };
 
-  const mountBrowserImageComponent = (props?: Partial<TrackPanelProps>) =>
+  const mountTrackPanel = (props?: Partial<TrackPanelProps>) =>
     mount(<TrackPanel {...defaultProps} {...props} />);
 
   describe('rendering', () => {
     test('renders track panel when active genome is present', () => {
-      const wrapper = mountBrowserImageComponent({
+      const wrapper = mountTrackPanel({
         activeGenomeId: faker.lorem.words()
       });
       expect(wrapper.html()).not.toBe(null);
     });
 
+    test('shows track panel only if screen is or bigger than big desktop', () => {
+      const wrapper = mountTrackPanel({
+        breakpointWidth: BreakpointWidth.BIG_DESKTOP
+      });
+      expect(wrapper.props().toggleTrackPanel).toHaveBeenCalledWith(true);
+
+      jest.resetAllMocks();
+
+      wrapper.setProps({ breakpointWidth: BreakpointWidth.DESKTOP });
+      wrapper.update();
+      expect(wrapper.props().toggleTrackPanel).toHaveBeenCalledWith(false);
+    });
+
     test('renders track panel bar and track panel list when browser is activated and active feature is selected', () => {
-      const wrapper = mountBrowserImageComponent({
+      const wrapper = mountTrackPanel({
         activeGenomeId: faker.lorem.words(),
         browserActivated: true,
         activeEnsObject: createEnsObject()
@@ -63,7 +76,7 @@ describe('<TrackPanel />', () => {
     });
 
     test('renders track panel modal view when a track panel modal is selected', () => {
-      const wrapper = mountBrowserImageComponent({
+      const wrapper = mountTrackPanel({
         activeGenomeId: faker.lorem.words(),
         browserActivated: true,
         activeEnsObject: createEnsObject(),
@@ -73,7 +86,7 @@ describe('<TrackPanel />', () => {
     });
 
     test('renders drawer when it is set to open', () => {
-      const wrapper = mountBrowserImageComponent({
+      const wrapper = mountTrackPanel({
         activeGenomeId: faker.lorem.words(),
         browserActivated: true,
         activeEnsObject: createEnsObject(),

--- a/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
@@ -42,10 +42,10 @@ export const TrackPanel = (props: TrackPanelProps) => {
   const { isDrawerOpened } = props;
 
   useEffect(() => {
-    if (props.breakpointWidth <= BreakpointWidth.DESKTOP) {
-      props.toggleTrackPanel(false);
-    } else {
+    if (props.breakpointWidth >= BreakpointWidth.BIG_DESKTOP) {
       props.toggleTrackPanel(true);
+    } else {
+      props.toggleTrackPanel(false);
     }
   }, [props.breakpointWidth, props.toggleTrackPanel]);
 

--- a/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
@@ -42,7 +42,7 @@ export const TrackPanel = (props: TrackPanelProps) => {
   const { isDrawerOpened } = props;
 
   useEffect(() => {
-    if (props.breakpointWidth >= BreakpointWidth.BIG_DESKTOP) {
+    if (props.breakpointWidth >= BreakpointWidth.DESKTOP) {
       props.toggleTrackPanel(true);
     } else {
       props.toggleTrackPanel(false);

--- a/src/ensembl/src/global/globalConfig.ts
+++ b/src/ensembl/src/global/globalConfig.ts
@@ -5,7 +5,7 @@ export enum BreakpointWidth {
   PHONE = 0,
   TABLET = 600,
   LAPTOP = 900,
-  DESKTOP = 1400,
+  DESKTOP = 1200,
   BIG_DESKTOP = 1800
 }
 


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-454

## Description
The track panel is opened on screens smaller than big desktop. This is not correct according to the design. It needs to be opened only on a big desktop screen or bigger.

## Views affected
Browser and track panel

### Other effects

- [ ] I have checked any requirements for Google Analytics
- [x] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

**UPDATE**: As @azangru mentioned in a [comment below](https://github.com/Ensembl/ensembl-client/pull/223#discussion_r360349866), track panel needs to be closed only for screens smaller than desktop (rather than big desktop). So this PR won't be changing the way the track panel behaves. However, tests have been added to check this and also the incorrect `DESKTOP` breakpoint width value has been fixed.