### PR TITLE
Fix ImageButton height by setting its font-size to 0

### DIFF
--- a/src/ensembl/src/shared/components/image-button/ImageButton.scss
+++ b/src/ensembl/src/shared/components/image-button/ImageButton.scss
@@ -2,6 +2,7 @@
 
 .imageButton {
   position: relative;
+  font-size: 0;
 
   button {
     width: 100%;


### PR DESCRIPTION
## Type
- Improvement to existing feature

**Problem:** the wrappers around the svg in the ImageButton add some unwanted vertical spacing, which makes the height of the ImageButton element a bit unpredictable. I discovered that when testing #226. See the illustration below (click to enlarge):

![Untitled Diagram](https://user-images.githubusercontent.com/6834224/72005342-4893cf00-3245-11ea-852b-34ddceab713b.png)
