### PR TITLE
Update styles for small screens

### DIFF
--- a/src/ensembl/src/shared/components/app-bar/AppBar.scss
+++ b/src/ensembl/src/shared/components/app-bar/AppBar.scss
@@ -3,6 +3,7 @@
 .appBar {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(250px, auto);
+  align-content: start;
   grid-template-areas:
     'top top'
     'main right';

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
@@ -7,6 +7,7 @@ $drawerWindowWidth: 45px;
 
 .standardAppLayout {
   height: 100%;
+  min-height: 550px; // based on the current interface of genome browser
   overflow: hidden;
 }
 

--- a/src/ensembl/src/styles/_scrollbars.scss
+++ b/src/ensembl/src/styles/_scrollbars.scss
@@ -1,0 +1,32 @@
+/*
+
+Trying to unify the appearance of scrollbars across browsers,
+but especially to fight the Mac behaviour, which by default forces browsers
+to show the scrollbar only when the element is being scrolled.
+
+Notice that this will work for webkit-based browsers, but will not work in Firefox.
+
+*/
+
+body,
+div,
+ul,
+p {
+  &::-webkit-scrollbar {
+    -webkit-appearance: none;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 8px;
+    border: 2px solid white; /* should match background, can't be transparent */
+    background-color: rgba(0, 0, 0, 0.5);
+  }
+
+  &::-webkit-scrollbar:vertical {
+    width: 11px;
+  }
+
+  &::-webkit-scrollbar:horizontal {
+    height: 11px;
+  }
+}

--- a/src/ensembl/src/styles/main.scss
+++ b/src/ensembl/src/styles/main.scss
@@ -1,6 +1,7 @@
 @import 'common';
 @import 'normalize';
 @import 'fonts';
+@import 'scrollbars';
 
 html,
 body,

--- a/src/ensembl/src/styles/main.scss
+++ b/src/ensembl/src/styles/main.scss
@@ -7,6 +7,7 @@ body,
 [class='ens-app'] {
   height: 100%;
   width: 100%;
+  min-width: 980px; // when mobile phones in portrait mode scale the page down to fill the screen, they usually go to 980px
 }
 
 a {


### PR DESCRIPTION
## Type
- Improvement to existing feature

## Description
- as introduced in https://github.com/Ensembl/ensembl-client/pull/225, mobile devices will show the desktop version of the site, but will scale it down to fill the screen (i.e. no responsive/adaptive mobile-first design)
- html body element has a minimum width of 980 pixels (this is the typical width that mobile devices in portrait mode will scale the site to)
- scrollbar is customised in such a way that should make it always visible on Macs, in the browsers that support such customisation (these are webkit- or blink-based browsers, such as Chrome or Safari)

## Views affected
All

**Deployed to:**
http://193.62.55.91:30603/