### PR TITLE
Refactor tooltip to place it immediately inside the body element

### DIFF
--- a/src/ensembl/src/content/app/browser/browser-region-editor/BrowserRegionEditor.tsx
+++ b/src/ensembl/src/content/app/browser/browser-region-editor/BrowserRegionEditor.tsx
@@ -226,6 +226,7 @@ export const BrowserRegionEditor = (props: BrowserRegionEditorProps) => {
           ></Input>
           {locationStartErrorMessage ? (
             <Tooltip
+              anchor={locationStartRef.current}
               autoAdjust={true}
               container={locationStartRef.current}
               position={Position.BOTTOM_RIGHT}
@@ -249,6 +250,7 @@ export const BrowserRegionEditor = (props: BrowserRegionEditorProps) => {
           ></Input>
           {!locationStartErrorMessage && locationEndErrorMessage ? (
             <Tooltip
+              anchor={locationEndRef.current}
               autoAdjust={true}
               container={locationEndRef.current}
               position={Position.BOTTOM_LEFT}

--- a/src/ensembl/src/content/app/browser/browser-region-field/BrowserRegionField.tsx
+++ b/src/ensembl/src/content/app/browser/browser-region-field/BrowserRegionField.tsx
@@ -165,7 +165,9 @@ export const BrowserRegionField = (props: BrowserRegionFieldProps) => {
         </span>
       </form>
       {errorMessage ? (
-        <Tooltip autoAdjust={true}>{errorMessage}</Tooltip>
+        <Tooltip anchor={inputGroupRef.current} autoAdjust={true}>
+          {errorMessage}
+        </Tooltip>
       ) : null}
     </div>
   );

--- a/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.tsx
@@ -95,7 +95,9 @@ export const PopularSpeciesButton = (props: Props) => {
         <InlineSVG src={species.image} />
       </div>
       {isHovered && speciesDisplayName && (
-        <Tooltip autoAdjust={true}>{speciesDisplayName}</Tooltip>
+        <Tooltip anchor={hoverRef.current} autoAdjust={true}>
+          {speciesDisplayName}
+        </Tooltip>
       )}
     </div>
   );

--- a/src/ensembl/src/content/app/species-selector/components/strain-selector/StrainSelector.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/strain-selector/StrainSelector.tsx
@@ -46,7 +46,7 @@ const StrainSelector = (props: StrainSelectorProps) => {
     >
       {numberOfSelectedStrains} / {totalNumberOfStrains}
       {isTooltipVisible && (
-        <Tooltip onClose={hideTooltip}>
+        <Tooltip anchor={elementRef.current} onClose={hideTooltip}>
           <StrainsList {...props} />
         </Tooltip>
       )}

--- a/src/ensembl/src/shared/components/image-button/ImageButton.tsx
+++ b/src/ensembl/src/shared/components/image-button/ImageButton.tsx
@@ -52,7 +52,9 @@ export const ImageButton = (props: Props) => {
     >
       <ImageHolder {...rest} classNames={styles} />
       {shouldShowTooltip && (
-        <Tooltip autoAdjust={true}>{props.description}</Tooltip>
+        <Tooltip anchor={hoverRef.current} autoAdjust={true}>
+          {props.description}
+        </Tooltip>
       )}
     </div>
   );

--- a/src/ensembl/src/shared/components/question-button/QuestionButton.tsx
+++ b/src/ensembl/src/shared/components/question-button/QuestionButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import classNames from 'classnames';
 
 import Tooltip from 'src/shared/components/tooltip/Tooltip';
@@ -20,6 +20,7 @@ type Props = {
 
 const QuestionButton = (props: Props) => {
   const [isHovering, setIsHovering] = useState(false);
+  const elementRef = useRef<HTMLDivElement>(null);
 
   const handleMouseEnter = () => {
     setIsHovering(true);
@@ -39,12 +40,17 @@ const QuestionButton = (props: Props) => {
 
   return (
     <div
+      ref={elementRef}
       className={className}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
       <QuestionIcon />
-      {isHovering && <Tooltip autoAdjust={true}>{props.helpText}</Tooltip>}
+      {isHovering && (
+        <Tooltip anchor={elementRef.current} autoAdjust={true}>
+          {props.helpText}
+        </Tooltip>
+      )}
     </div>
   );
 };

--- a/src/ensembl/src/shared/components/tooltip/Tooltip.tsx
+++ b/src/ensembl/src/shared/components/tooltip/Tooltip.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode, useRef, useEffect, useState } from 'react';
+import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 import noop from 'lodash/noop';
 
@@ -17,11 +18,16 @@ import styles from './Tooltip.scss';
 
 type Props = {
   position: Position;
+  anchor: HTMLElement;
   container?: HTMLElement | null;
   autoAdjust: boolean; // try to adjust tooltip position so as not to extend beyond screen bounds
   delay: number;
   children: ReactNode;
   onClose: () => void;
+};
+
+type PropsWithNullableAnchor = Omit<Props, 'anchor'> & {
+  anchor: HTMLElement | null;
 };
 
 type TipProps = {
@@ -34,10 +40,13 @@ type InlineStylesState = {
   tipStyles: InlineStyles;
 };
 
-const Tooltip = (props: Props) => {
+const Tooltip = (props: PropsWithNullableAnchor) => {
+  return props.anchor ? <TooltipWithAnchor {...(props as Props)} /> : null;
+};
+
+const TooltipWithAnchor = (props: Props) => {
   const [isWaiting, setIsWaiting] = useState(true);
   const [isPositioning, setIsPositioning] = useState(props.autoAdjust);
-  const parentRef = useRef<HTMLElement | null>(null);
   const positionRef = useRef<Position | null>(null);
   const [inlineStyles, setInlineStyles] = useState<InlineStylesState>({
     bodyStyles: {},
@@ -51,8 +60,6 @@ const Tooltip = (props: Props) => {
   };
 
   const handleClickOutside = (e: Event) => {
-    if (!parentRef.current) return;
-
     let target;
     if (e.type === 'touchend' && (e as TouchEvent).touches) {
       target = (e as TouchEvent).touches[0];
@@ -60,7 +67,7 @@ const Tooltip = (props: Props) => {
       target = e.target;
     }
 
-    if (target instanceof HTMLElement && !parentRef.current.contains(target)) {
+    if (target instanceof HTMLElement && !props.anchor.contains(target)) {
       props.onClose();
     }
   };
@@ -88,17 +95,15 @@ const Tooltip = (props: Props) => {
     }
 
     const tooltipElement = tooltipElementRef.current;
-    const parentElement = tooltipElement && tooltipElement.parentElement;
 
-    if (!(tooltipElement && parentElement)) {
+    if (!tooltipElement) {
       return;
     }
 
-    parentRef.current = parentElement;
-    setInlineStyles(getInlineStyles({ ...props, parentElement }));
+    setInlineStyles(getInlineStyles(props));
 
     if (props.autoAdjust) {
-      adjustPosition(tooltipElement, parentElement);
+      adjustPosition(tooltipElement, props.anchor);
     }
   }, [isWaiting]);
 
@@ -125,8 +130,7 @@ const Tooltip = (props: Props) => {
     setInlineStyles(
       getInlineStyles({
         ...props,
-        position: optimalPosition,
-        parentElement
+        position: optimalPosition
       })
     );
     setIsPositioning(false);
@@ -135,43 +139,50 @@ const Tooltip = (props: Props) => {
   const className = classNames(
     styles.tooltip,
     positionRef.current || props.position,
-    { [styles.tooltipInvisible]: !parentRef.current || isPositioning }
+    { [styles.tooltipInvisible]: isPositioning }
   );
 
-  return isWaiting ? null : (
-    <div
-      className={className}
-      ref={tooltipElementRef}
-      style={inlineStyles.bodyStyles}
-      onClick={handleClickInside}
-    >
-      <TooltipTip style={inlineStyles.tipStyles} />
-      {props.children}
-    </div>
-  );
+  return isWaiting
+    ? null
+    : ReactDOM.createPortal(
+        <div
+          className={className}
+          ref={tooltipElementRef}
+          style={inlineStyles.bodyStyles}
+          onClick={handleClickInside}
+        >
+          <TooltipTip style={inlineStyles.tipStyles} />
+          {props.children}
+        </div>,
+        document.body
+      );
 };
 
-const getInlineStyles = (params: Props & { parentElement: HTMLElement }) => {
+type GetInlineStylesParams = Omit<Props, 'anchor'> & {
+  anchor: HTMLElement;
+};
+
+const getInlineStyles = (params: GetInlineStylesParams) => {
   // calculate styles of the tooltip
-  // considering that its tip points at the center of the parent
+  // considering that its tip points at the center of the anchor element
 
-  // NOTE: applying several consecutive translate functions in a transform
-  // instead of just using the CSS calc function
-  // is done to support IE11 (which doesn't allow calc inside of a transform)
-
-  const {
-    width: parentWidth,
-    height: parentHeight
-  } = params.parentElement.getBoundingClientRect();
+  const anchorBoundingRect = params.anchor.getBoundingClientRect();
+  const anchorWidth = anchorBoundingRect.width;
+  const halfAnchorWidth = anchorWidth / 2;
+  const anchorHeight = anchorBoundingRect.height;
+  const halfAnchorHeight = anchorHeight / 2;
+  const anchorLeft = Math.round(anchorBoundingRect.left);
+  const anchorTop = Math.round(anchorBoundingRect.top);
+  const halfTipWidth = TIP_WIDTH / 2;
 
   switch (params.position) {
     case Position.TOP_LEFT:
       return {
         bodyStyles: {
-          left: '50%',
+          left: `${anchorLeft + anchorWidth / 2}px`,
           transform: `translateX(calc(${TIP_HORIZONTAL_OFFSET}px + ${TIP_WIDTH /
             2}px - 100%))`,
-          bottom: `${parentHeight + TIP_HEIGHT}px`
+          bottom: `${window.innerHeight - anchorTop + TIP_HEIGHT}px`
         },
         tipStyles: {
           right: `${TIP_HORIZONTAL_OFFSET}px`,
@@ -182,8 +193,11 @@ const getInlineStyles = (params: Props & { parentElement: HTMLElement }) => {
     case Position.TOP_RIGHT:
       return {
         bodyStyles: {
-          left: `calc(50% - ${TIP_HORIZONTAL_OFFSET + TIP_WIDTH / 2}px)`,
-          bottom: `${parentHeight + TIP_HEIGHT}px`
+          left: `${anchorLeft +
+            halfAnchorWidth -
+            TIP_HORIZONTAL_OFFSET -
+            halfTipWidth}px`,
+          bottom: `${window.innerHeight - anchorTop + TIP_HEIGHT}px`
         },
         tipStyles: {
           bottom: `${-TIP_HEIGHT + 1}px`,
@@ -194,8 +208,8 @@ const getInlineStyles = (params: Props & { parentElement: HTMLElement }) => {
     case Position.BOTTOM_LEFT:
       return {
         bodyStyles: {
-          top: `${parentHeight + TIP_HEIGHT}px`,
-          left: '50%',
+          top: `${anchorTop + anchorHeight + TIP_HEIGHT}px`,
+          left: `${anchorLeft + anchorWidth / 2}px`,
           transform: `translateX(calc(-100% + ${TIP_HORIZONTAL_OFFSET}px + ${TIP_WIDTH /
             2}px)`
         },
@@ -208,8 +222,11 @@ const getInlineStyles = (params: Props & { parentElement: HTMLElement }) => {
     case Position.BOTTOM_RIGHT:
       return {
         bodyStyles: {
-          left: `${parentWidth / 2 - TIP_HORIZONTAL_OFFSET - TIP_WIDTH / 2}px`,
-          top: `${parentHeight + TIP_HEIGHT}px`
+          left: `${anchorLeft +
+            halfAnchorWidth -
+            TIP_HORIZONTAL_OFFSET -
+            halfTipWidth}px`,
+          top: `${anchorTop + anchorHeight + TIP_HEIGHT}px`
         },
         tipStyles: {
           top: `${-TIP_HEIGHT + 1}px`,
@@ -219,8 +236,8 @@ const getInlineStyles = (params: Props & { parentElement: HTMLElement }) => {
     case Position.LEFT_TOP:
       return {
         bodyStyles: {
-          left: `-${TIP_HEIGHT}px`,
-          top: `50%`,
+          left: `${anchorLeft - TIP_HEIGHT}px`,
+          top: `${anchorTop + halfAnchorHeight}px`,
           transform: `translateX(-100%) translateY(calc(-100% + ${TIP_HORIZONTAL_OFFSET}px))`
         },
         tipStyles: {
@@ -233,9 +250,9 @@ const getInlineStyles = (params: Props & { parentElement: HTMLElement }) => {
     case Position.LEFT_BOTTOM:
       return {
         bodyStyles: {
-          left: 0,
-          top: '50%',
-          transform: `translateX(calc(-100% - ${TIP_HEIGHT}px)) translateY(-${TIP_HORIZONTAL_OFFSET}px)`
+          left: `${anchorLeft - TIP_HEIGHT}px`,
+          top: `${anchorTop + halfAnchorHeight}px`,
+          transform: `translateX(-100%) translateY(-${TIP_HORIZONTAL_OFFSET}px)`
         },
         tipStyles: {
           left: 'calc(100% - 1px)',
@@ -248,8 +265,8 @@ const getInlineStyles = (params: Props & { parentElement: HTMLElement }) => {
     case Position.RIGHT_TOP:
       return {
         bodyStyles: {
-          left: `calc(100% + ${TIP_HEIGHT}px)`,
-          top: `calc(50% + ${TIP_HORIZONTAL_OFFSET}px)`,
+          left: `${anchorLeft + anchorWidth + TIP_HEIGHT}px`,
+          top: `${anchorTop + halfAnchorHeight + TIP_HORIZONTAL_OFFSET}px`,
           transform: `translateY(-100%)`
         },
         tipStyles: {
@@ -262,8 +279,8 @@ const getInlineStyles = (params: Props & { parentElement: HTMLElement }) => {
     case Position.RIGHT_BOTTOM:
       return {
         bodyStyles: {
-          left: `calc(100% + ${TIP_HEIGHT}px)`,
-          top: '50%',
+          left: `${anchorLeft + anchorWidth + TIP_HEIGHT}px`,
+          top: `${anchorTop + halfAnchorHeight}px`,
           transform: `translateY(-${TIP_HORIZONTAL_OFFSET}px)`
         },
         tipStyles: {

--- a/src/ensembl/src/shared/components/tooltip/Tooltip.tsx
+++ b/src/ensembl/src/shared/components/tooltip/Tooltip.tsx
@@ -138,11 +138,7 @@ const TooltipWithAnchor = (props: Props) => {
       );
 };
 
-type GetInlineStylesParams = Omit<Props, 'anchor'> & {
-  anchor: HTMLElement;
-};
-
-const getInlineStyles = (params: GetInlineStylesParams) => {
+const getInlineStyles = (params: Props) => {
   // calculate styles of the tooltip
   // considering that its tip points at the center of the anchor element
 

--- a/src/ensembl/src/shared/components/tooltip/Tooltip.tsx
+++ b/src/ensembl/src/shared/components/tooltip/Tooltip.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import noop from 'lodash/noop';
 
 import windowService from 'src/services/window-service';
+import useOutsideClick from 'src/shared/hooks/useOutsideClick';
 
 import { findOptimalPosition } from './tooltip-helper';
 import { Position } from './tooltip-types';
@@ -53,23 +54,11 @@ const TooltipWithAnchor = (props: Props) => {
     tipStyles: {}
   });
   const tooltipElementRef: React.RefObject<HTMLDivElement> = useRef(null);
+  useOutsideClick(tooltipElementRef, props.onClose);
   let timeoutId: NodeJS.Timeout;
 
   const handleClickInside = (e: React.MouseEvent | React.TouchEvent) => {
     e.stopPropagation();
-  };
-
-  const handleClickOutside = (e: Event) => {
-    let target;
-    if (e.type === 'touchend' && (e as TouchEvent).touches) {
-      target = (e as TouchEvent).touches[0];
-    } else {
-      target = e.target;
-    }
-
-    if (target instanceof HTMLElement && !props.anchor.contains(target)) {
-      props.onClose();
-    }
   };
 
   useEffect(() => {
@@ -78,15 +67,6 @@ const TooltipWithAnchor = (props: Props) => {
     }, props.delay);
 
     return () => clearTimeout(timeoutId);
-  }, []);
-
-  useEffect(() => {
-    document.addEventListener('click', handleClickOutside, true);
-    document.addEventListener('touchend', handleClickOutside, true);
-    return function cleanup() {
-      document.removeEventListener('click', handleClickOutside, true);
-      document.removeEventListener('touchend', handleClickOutside, true);
-    };
   }, []);
 
   useEffect(() => {

--- a/src/ensembl/stories/shared-components/tooltip/positioningStory.tsx
+++ b/src/ensembl/stories/shared-components/tooltip/positioningStory.tsx
@@ -21,15 +21,21 @@ type PositionsProps = {
 
 const Item = (props: ItemProps) => {
   const [showTooltip, setShowTooltip] = useState(false);
+  const anchorRef = useRef<HTMLDivElement>(null);
 
   const className = classNames(styles.positioningStoryItem, props.className);
 
   return (
-    <div className={className} onClick={() => setShowTooltip(!showTooltip)}>
+    <div
+      ref={anchorRef}
+      className={className}
+      onClick={() => setShowTooltip(!showTooltip)}
+    >
       Click me
       {showTooltip && (
         <Tooltip
           delay={0}
+          anchor={anchorRef.current}
           onClose={() => setShowTooltip(false)}
           position={props.position}
           container={props.container.current}

--- a/src/ensembl/stories/shared-components/tooltip/variantsStory.tsx
+++ b/src/ensembl/stories/shared-components/tooltip/variantsStory.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import classNames from 'classnames';
 
 import Tooltip, { Position } from 'src/shared/components/tooltip/Tooltip';
@@ -7,6 +7,14 @@ import styles from './Tooltip.stories.scss';
 
 const VariantsStory = () => {
   const [visibleId, setVisibleId] = useState<Position | null>(null);
+  const topLeftRef = useRef<HTMLDivElement>(null);
+  const topRightRef = useRef<HTMLDivElement>(null);
+  const rightTopRef = useRef<HTMLDivElement>(null);
+  const rightBottomRef = useRef<HTMLDivElement>(null);
+  const bottomLeftRef = useRef<HTMLDivElement>(null);
+  const bottomRightRef = useRef<HTMLDivElement>(null);
+  const leftTopRef = useRef<HTMLDivElement>(null);
+  const leftBottomRef = useRef<HTMLDivElement>(null);
 
   const handleClose = () => {
     setVisibleId(null);
@@ -17,6 +25,7 @@ const VariantsStory = () => {
       <h1>Click on the dots to see the tooltip</h1>
       <div className={styles.variantsStoryContainer}>
         <div
+          ref={topLeftRef}
           className={classNames(
             styles.variantsStoryAnchor,
             styles.variantsStoryTopLeft
@@ -25,6 +34,7 @@ const VariantsStory = () => {
         >
           {visibleId === Position.TOP_LEFT && (
             <Tooltip
+              anchor={topLeftRef.current}
               delay={0}
               onClose={handleClose}
               position={Position.TOP_LEFT}
@@ -34,6 +44,7 @@ const VariantsStory = () => {
           )}
         </div>
         <div
+          ref={topRightRef}
           className={classNames(
             styles.variantsStoryAnchor,
             styles.variantsStoryTopRight
@@ -42,6 +53,7 @@ const VariantsStory = () => {
         >
           {visibleId === Position.TOP_RIGHT && (
             <Tooltip
+              anchor={topRightRef.current}
               delay={0}
               onClose={handleClose}
               position={Position.TOP_RIGHT}
@@ -51,6 +63,7 @@ const VariantsStory = () => {
           )}
         </div>
         <div
+          ref={rightTopRef}
           className={classNames(
             styles.variantsStoryAnchor,
             styles.variantsStoryRightTop
@@ -59,6 +72,7 @@ const VariantsStory = () => {
         >
           {visibleId === Position.RIGHT_TOP && (
             <Tooltip
+              anchor={rightTopRef.current}
               delay={0}
               onClose={handleClose}
               position={Position.RIGHT_TOP}
@@ -68,6 +82,7 @@ const VariantsStory = () => {
           )}
         </div>
         <div
+          ref={rightBottomRef}
           className={classNames(
             styles.variantsStoryAnchor,
             styles.variantsStoryRightBottom
@@ -76,6 +91,7 @@ const VariantsStory = () => {
         >
           {visibleId === Position.RIGHT_BOTTOM && (
             <Tooltip
+              anchor={rightBottomRef.current}
               delay={0}
               onClose={handleClose}
               position={Position.RIGHT_BOTTOM}
@@ -85,6 +101,7 @@ const VariantsStory = () => {
           )}
         </div>
         <div
+          ref={bottomLeftRef}
           className={classNames(
             styles.variantsStoryAnchor,
             styles.variantsStoryBottomLeft
@@ -93,6 +110,7 @@ const VariantsStory = () => {
         >
           {visibleId === Position.BOTTOM_LEFT && (
             <Tooltip
+              anchor={bottomLeftRef.current}
               delay={0}
               onClose={handleClose}
               position={Position.BOTTOM_LEFT}
@@ -102,6 +120,7 @@ const VariantsStory = () => {
           )}
         </div>
         <div
+          ref={bottomRightRef}
           className={classNames(
             styles.variantsStoryAnchor,
             styles.variantsStoryBottomRight
@@ -110,6 +129,7 @@ const VariantsStory = () => {
         >
           {visibleId === Position.BOTTOM_RIGHT && (
             <Tooltip
+              anchor={bottomRightRef.current}
               delay={0}
               onClose={handleClose}
               position={Position.BOTTOM_RIGHT}
@@ -119,6 +139,7 @@ const VariantsStory = () => {
           )}
         </div>
         <div
+          ref={leftTopRef}
           className={classNames(
             styles.variantsStoryAnchor,
             styles.variantsStoryLeftTop
@@ -127,6 +148,7 @@ const VariantsStory = () => {
         >
           {visibleId === Position.LEFT_TOP && (
             <Tooltip
+              anchor={leftTopRef.current}
               delay={0}
               onClose={handleClose}
               position={Position.LEFT_TOP}
@@ -136,6 +158,7 @@ const VariantsStory = () => {
           )}
         </div>
         <div
+          ref={leftBottomRef}
           className={classNames(
             styles.variantsStoryAnchor,
             styles.variantsStoryLeftBottom
@@ -144,6 +167,7 @@ const VariantsStory = () => {
         >
           {visibleId === Position.LEFT_BOTTOM && (
             <Tooltip
+              anchor={leftBottomRef.current}
               delay={0}
               onClose={handleClose}
               position={Position.LEFT_BOTTOM}


### PR DESCRIPTION
## Type
- Bug fix
- Improvement to existing feature

## Related JIRA Issue(s)
ENSWBSITES-480

## Description
Our tooltip element previously rendered itself inside the element that it was to point at. What we did not realise was that by doing so we were preventing the tooltip from extending beyond the borders of the container of the parent:

![Untitled Diagram (2)](https://user-images.githubusercontent.com/6834224/72545367-d5134280-3880-11ea-8576-c014376c9ac4.png)

If the parent element is placed in a container with `overflow: hidden`, the tooltip would get cropped by the border of the container; and if the container has `overflow: auto`, the tooltip will increase the width or the height of the container causing scrollbars to appear.

One such problem is currently in production, where the tooltip gets cropped in the sidebar:

![image](https://user-images.githubusercontent.com/6834224/72545642-3a673380-3881-11ea-991e-d1dd0872ff5d.png)

This PR changes the placement of the tooltip from inside the anchor element to the top level of the `body` element using React portals. This will allow us to display the tooltip correctly over any element regardless of the style of its parents. Tooltip positioning algorithm has been updated accordingly to calculate tooltip's absolute position relative to the body rather than to the anchor.

## Views affected
All

**Deployed to:**
http://193.62.55.91:30589/