### PR TITLE
Fix regex in failing test for ChromosomeNavigator

### DIFF
--- a/src/ensembl/src/content/app/browser/chromosome-navigator/ChromosomeNavigator.test.tsx
+++ b/src/ensembl/src/content/app/browser/chromosome-navigator/ChromosomeNavigator.test.tsx
@@ -228,7 +228,7 @@ describe('Chromosome Navigator', () => {
         const transform = pointers
           .at(index)
           .prop('transform')
-          .match(/translate\((\d+)\)/)[1];
+          .match(/translate\((-?\d+)\)/)[1];
         const actualPosition = parseInt(transform, 10);
         expect(isApproximatelyEqual(position, actualPosition)).toBe(true);
       });


### PR DESCRIPTION
## Type
- Bug fix

## Description
**Problem:** A test for ChromosomeNavigator on dev/master branch occasionally fails with the following error:

![image](https://user-images.githubusercontent.com/6834224/72599879-6ed30200-390a-11ea-8419-8aff1a836f7e.png)

Further exploration showed that the error occurred because the regex (line 231 in the error screenshot) was returning `null`, and attempting to access `null[1]` threw an error.

**Cause:** The test checks for correct positioning of the markers showing the start and the end position of the focus region (orange triangles on screenshot below):

![image](https://user-images.githubusercontent.com/6834224/72599472-ab522e00-3909-11ea-88a1-310b54918524.png)

Once in a while, the randomly generated test data would position the start marker close to the beginning of the chromosome:

![image](https://user-images.githubusercontent.com/6834224/72599571-e18fad80-3909-11ea-8b84-2f37cbbd0dec.png)

In the SVG markup, this positioning of the markers is achieved through the transform attribute. When the start marker is pointing at the beginning of the chromosome, its transform attribute may become negative, which was what I saw in the test (notice the negative value of the `translate` directive):
```
    <g class="focusPointer" transform="translate(-2)"><line x1="5" y1="21" x2="5" y2="12"></line><polygon points="0,28 5,20 10,28"></polygon></g>
```

**Fix:** The regex used in the test was failing on negative values. After updating the regex to account for the possible minus, the test seems to have been fixed.