### PR TITLE
Update links to apps on home page to include entity viewer

### DIFF
--- a/src/ensembl/src/content/home/Home.scss
+++ b/src/ensembl/src/content/home/Home.scss
@@ -40,18 +40,3 @@
     text-transform: uppercase;
   }
 }
-
-.previouslyViewed {
-  line-height: 2;
-  padding: 15px 80px;
-}
-
-.previouslyViewedItem {
-  margin-left: 40px;
-}
-
-.previouslyViewedItemAssemblyName {
-  color: $medium-dark-grey;
-  font-size: 11px;
-  margin-left: 0.2em;
-}

--- a/src/ensembl/src/content/home/Home.scss
+++ b/src/ensembl/src/content/home/Home.scss
@@ -9,22 +9,6 @@
   position: relative;
 }
 
-.speciesBar {
-  display: flex;
-  align-items: center;
-  padding: 8px 20px;
-  min-height: 80px;
-}
-
-.emptySpeciesBar {
-  display: flex;
-  flex-direction: column;
-
-  .speciesSelectorBannerLink {
-    font-weight: 700;
-  }
-}
-
 .search {
   background: $light-grey;
   box-shadow: 0 3px 5px $medium-light-grey;
@@ -70,26 +54,4 @@
   color: $medium-dark-grey;
   font-size: 11px;
   margin-left: 0.2em;
-}
-
-.siteMessage {
-  margin-left: 120px;
-  padding-top: 2%;
-
-  h4 {
-    color: $grey;
-    font-size: 13px;
-    font-weight: $normal;
-    margin-bottom: 0.8em;
-  }
-
-  p {
-    font-size: 13px;
-    margin: 0;
-    line-height: 1.5;
-  }
-
-  .convoMessage {
-    margin-top: 1em;
-  }
 }

--- a/src/ensembl/src/content/home/Home.scss
+++ b/src/ensembl/src/content/home/Home.scss
@@ -1,6 +1,8 @@
 @import 'src/styles/common';
 
 .home {
+  padding-bottom: 80px;
+
   h2 {
     color: $grey;
     font-size: 14px;

--- a/src/ensembl/src/content/home/Home.tsx
+++ b/src/ensembl/src/content/home/Home.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 
-import * as urlFor from 'src/shared/helpers/urlHelper';
 import { RootState } from 'src/store';
 
 import { fetchDataForLastVisitedObjects } from 'src/content/app/browser/browserActions';
@@ -13,9 +12,8 @@ import {
   PreviouslyViewedGenomeBrowserObjects
 } from 'src/content/home/homePageSelectors';
 
-import AppBar from 'src/shared/components/app-bar/AppBar';
-import SpeciesTabsWrapper from 'src/shared/components/species-tabs-wrapper/SpeciesTabsWrapper';
-import { SimpleSelectedSpecies } from 'src/shared/components/selected-species';
+import HomepageSpeciesBar from 'src/content/home/components/homepage-species-bar/HomepageSpeciesBar';
+import HomepageSiteInfo from 'src/content/home/components/homepage-site-info/HomepageSiteInfo';
 
 import { GenomeInfoData } from 'src/shared/state/genome/genomeTypes';
 import { CommittedItem } from '../app/species-selector/types/species-search';
@@ -41,7 +39,7 @@ const Home = (props: Props) => {
 
   return (
     <div className={styles.home}>
-      <SpeciesBar species={props.species} />
+      <HomepageSpeciesBar />
       <section className={styles.search}>
         <h2>Find</h2>
         <p>
@@ -54,35 +52,9 @@ const Home = (props: Props) => {
           props.previouslyViewedGenomeBrowserObjects
         }
       />
-      <UsingTheSite />
+      <HomepageSiteInfo />
     </div>
   );
-};
-
-const SpeciesBar = (props: { species: CommittedItem[] }) => {
-  let barContent;
-  if (!props.species.length) {
-    barContent = (
-      <div className={styles.emptySpeciesBar}>
-        <span className={styles.speciesSelectorBannerText}>
-          7 species now available
-        </span>
-        <Link
-          className={styles.speciesSelectorBannerLink}
-          to={urlFor.speciesSelector()}
-        >
-          Select a species to begin
-        </Link>
-      </div>
-    );
-  } else {
-    const speciesItems = props.species.map((species, index) => (
-      <SimpleSelectedSpecies key={index} species={species} />
-    ));
-    barContent = <SpeciesTabsWrapper speciesTabs={speciesItems} />;
-  }
-
-  return <AppBar mainContent={barContent} />;
 };
 
 const PreviouslyViewed = (props: PreviouslyViewedProps) => {
@@ -113,24 +85,6 @@ const PreviouslyViewed = (props: PreviouslyViewedProps) => {
   );
 };
 
-const UsingTheSite = () => (
-  <section className={styles.siteMessage}>
-    <h4>Using the site</h4>
-    <p>
-      A very limited data set has been made available for this first release.
-    </p>
-    <p>Blue icons and text are clickable and will usually 'do' something.</p>
-    <p>
-      Grey icons indicate apps &amp; functionality that is planned, but not
-      available yet.
-    </p>
-    <p className={styles.convoMessage}>
-      It's very early days, but why not join the conversation:
-    </p>
-    <p>helpdesk@ensembl.org</p>
-  </section>
-);
-
 const mapStateToProps = (state: RootState) => ({
   species: getEnabledCommittedSpecies(state),
   genomeInfo: getGenomeInfo(state),
@@ -143,7 +97,4 @@ const mapDispatchToProps = {
   fetchDataForLastVisitedObjects
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Home);
+export default connect(mapStateToProps, mapDispatchToProps)(Home);

--- a/src/ensembl/src/content/home/Home.tsx
+++ b/src/ensembl/src/content/home/Home.tsx
@@ -1,42 +1,12 @@
-import React, { useEffect } from 'react';
-import { Link } from 'react-router-dom';
-import { connect } from 'react-redux';
-
-import { RootState } from 'src/store';
-
-import { fetchDataForLastVisitedObjects } from 'src/content/app/browser/browserActions';
-import { getGenomeInfo } from 'src/shared/state/genome/genomeSelectors';
-import { getEnabledCommittedSpecies } from '../app/species-selector/state/speciesSelectorSelectors';
-import {
-  getPreviouslyViewedGenomeBrowserObjects,
-  PreviouslyViewedGenomeBrowserObjects
-} from 'src/content/home/homePageSelectors';
+import React from 'react';
 
 import HomepageSpeciesBar from 'src/content/home/components/homepage-species-bar/HomepageSpeciesBar';
 import HomepageSiteInfo from 'src/content/home/components/homepage-site-info/HomepageSiteInfo';
-
-import { GenomeInfoData } from 'src/shared/state/genome/genomeTypes';
-import { CommittedItem } from '../app/species-selector/types/species-search';
+import HomepageAppLinks from 'src/content/home/components/homepage-app-links/HomepageAppLinks';
 
 import styles from './Home.scss';
 
-type Props = {
-  species: CommittedItem[];
-  genomeInfo: GenomeInfoData;
-  previouslyViewedGenomeBrowserObjects: PreviouslyViewedGenomeBrowserObjects;
-  fetchDataForLastVisitedObjects: () => void;
-};
-
-type PreviouslyViewedProps = {
-  species: CommittedItem[];
-  previouslyViewedGenomeBrowserObjects: PreviouslyViewedGenomeBrowserObjects;
-};
-
-const Home = (props: Props) => {
-  useEffect(() => {
-    props.fetchDataForLastVisitedObjects();
-  }, []);
-
+const Home = () => {
   return (
     <div className={styles.home}>
       <HomepageSpeciesBar />
@@ -46,55 +16,10 @@ const Home = (props: Props) => {
           <input type="text" placeholder="Name, symbol or ID" disabled={true} />
         </p>
       </section>
-      <PreviouslyViewed
-        species={props.species}
-        previouslyViewedGenomeBrowserObjects={
-          props.previouslyViewedGenomeBrowserObjects
-        }
-      />
+      <HomepageAppLinks />
       <HomepageSiteInfo />
     </div>
   );
 };
 
-const PreviouslyViewed = (props: PreviouslyViewedProps) => {
-  if (
-    !props.species.length ||
-    props.previouslyViewedGenomeBrowserObjects.areLoading
-  ) {
-    return null;
-  }
-
-  const previouslyViewedLinks = props.previouslyViewedGenomeBrowserObjects.objects.map(
-    (object, index) => (
-      <div key={index} className={styles.previouslyViewedItem}>
-        <Link to={object.link}>{object.speciesName}</Link>
-        <span className={styles.previouslyViewedItemAssemblyName}>
-          {' '}
-          {object.assemblyName}
-        </span>
-      </div>
-    )
-  );
-
-  return (
-    <section className={styles.previouslyViewed}>
-      <h2>Previously viewed</h2>
-      {previouslyViewedLinks}
-    </section>
-  );
-};
-
-const mapStateToProps = (state: RootState) => ({
-  species: getEnabledCommittedSpecies(state),
-  genomeInfo: getGenomeInfo(state),
-  previouslyViewedGenomeBrowserObjects: getPreviouslyViewedGenomeBrowserObjects(
-    state
-  )
-});
-
-const mapDispatchToProps = {
-  fetchDataForLastVisitedObjects
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(Home);
+export default Home;

--- a/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.scss
+++ b/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.scss
@@ -8,14 +8,18 @@
   padding: 15px 80px;
 }
 
-.homepageAppLinksGroup {
+.homepageAppLinksRow {
   flex: 0 0 auto;
   display: inline-flex;
   justify-content: space-between;
   align-items: center;
-  background-color: $light-blue;
-  padding: 5px 20px;
+  height: 35px;
+  padding: 20px;
   min-width: 500px;
+
+  &Expanded {
+    background-color: $light-blue;
+  }
 }
 
 .homepageAppLink {
@@ -34,6 +38,11 @@
     fill: $white;
     background-color: $blue;
   }
+}
+
+.speciesName {
+  color: $blue;
+  cursor: pointer;
 }
 
 .assemblyName {

--- a/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.scss
+++ b/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.scss
@@ -4,29 +4,43 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  line-height: 1;
   padding: 15px 80px;
 }
 
 .homepageAppLinksRow {
   flex: 0 0 auto;
-  display: inline-flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 300px 60px auto;
   align-items: center;
-  height: 35px;
-  padding: 20px;
+  justify-items: start;
+  padding: 0 20px;
   min-width: 500px;
 
   &Expanded {
     background-color: $light-blue;
   }
+
+  .speciesNameColumn {
+    grid-column: 1/2;
+    line-height: 1.2;
+    padding: 13px 0;
+  }
 }
 
 .homepageAppLink {
-  margin-left: 1em;
+  margin-left: 1.1em;
+
+  &:first-of-type {
+    margin-left: 0.6em;
+  }
+}
+
+.speciesHomeButton {
+  width: 22px;
 }
 
 .homepageAppLinkButtons {
+  grid-column: 3/4;
   display: flex;
   align-items: center;
 }
@@ -43,6 +57,11 @@
 .speciesName {
   color: $blue;
   cursor: pointer;
+
+  .homepageAppLinksRowExpanded & {
+    color: $black;
+    cursor: default;
+  }
 }
 
 .assemblyName {

--- a/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.scss
+++ b/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.scss
@@ -1,0 +1,65 @@
+@import 'src/styles/common';
+
+.homepageAppLinks {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  line-height: 1;
+  padding: 15px 80px;
+}
+
+.homepageAppLinksGroup {
+  flex: 0 0 auto;
+  display: inline-flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: $light-blue;
+  padding: 5px 20px;
+  min-width: 500px;
+}
+
+.homepageAppLink {
+  margin-left: 1em;
+}
+
+.homepageAppLinkButtons {
+  display: flex;
+  align-items: center;
+}
+
+.homepageAppLinkButton {
+  svg {
+    width: 25px;
+    height: 25px;
+    fill: $white;
+    background-color: $blue;
+  }
+}
+
+.assemblyName {
+  margin-left: 0.8em;
+  font-size: 12px;
+  color: $grey;
+}
+
+.viewIn {
+  font-size: 10px;
+  color: $grey;
+}
+
+// TODO: remove the previouslyViewed styles after the PreviouslyViewedLinks fallback component
+// is deleted from HomepageAppLinks.tsx
+.previouslyViewed {
+  line-height: 2;
+  padding: 15px 80px;
+}
+
+.previouslyViewedItem {
+  margin-left: 40px;
+}
+
+.previouslyViewedItemAssemblyName {
+  color: $medium-dark-grey;
+  font-size: 11px;
+  margin-left: 0.2em;
+}

--- a/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.tsx
+++ b/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 
 import { isEnvironment, Environment } from 'src/shared/helpers/environment';
 import * as urlFor from 'src/shared/helpers/urlHelper';
+import useOutsideClick from 'src/shared/hooks/useOutsideClick';
 
 import { fetchDataForLastVisitedObjects } from 'src/content/app/browser/browserActions';
 
@@ -18,6 +19,7 @@ import ImageButton from 'src/shared/components/image-button/ImageButton';
 
 import { ReactComponent as BrowserIcon } from 'static/img/launchbar/browser.svg';
 import { ReactComponent as EntityViewerIcon } from 'static/img/launchbar/entity-viewer.svg';
+import { ReactComponent as HomeIcon } from 'static/img/header/home.svg';
 
 import styles from './HomepageAppLinks.scss';
 
@@ -70,9 +72,20 @@ const HomepageAppLinks = (props: Props) => {
 
 const HomepageAppLinksRow = (props: HomepageAppLinksRowProps) => {
   const { species, isExpanded, toggleExpand } = props;
+  const elementRef = useRef<HTMLDivElement>(null);
+
+  const onOutsideClick = () => {
+    toggleExpand();
+  };
+
+  useOutsideClick(elementRef, onOutsideClick);
+
+  const rowClasses = classNames(styles.homepageAppLinksRow, {
+    [styles.homepageAppLinksRowExpanded]: isExpanded
+  });
 
   const speciesName = (
-    <div>
+    <div className={styles.speciesNameColumn}>
       <span className={styles.speciesName} onClick={toggleExpand}>
         {species.common_name || species.scientific_name}
       </span>
@@ -80,13 +93,19 @@ const HomepageAppLinksRow = (props: HomepageAppLinksRowProps) => {
     </div>
   );
 
-  const rowClasses = classNames(styles.homepageAppLinksRow, {
-    [styles.homepageAppLinksRowExpanded]: isExpanded
-  });
-
   return isExpanded ? (
-    <div className={rowClasses}>
+    <div ref={elementRef} className={rowClasses}>
       {speciesName}
+      <div>
+        <ImageButton
+          classNames={{
+            [Status.DEFAULT]: styles.speciesHomeButton
+          }}
+          buttonStatus={Status.DEFAULT}
+          description="Species home page"
+          image={HomeIcon}
+        />
+      </div>
       <div className={styles.homepageAppLinkButtons}>
         <span className={styles.viewIn}>View in</span>
         <Link className={styles.homepageAppLink} to={urlFor.browser()}>
@@ -105,7 +124,7 @@ const HomepageAppLinksRow = (props: HomepageAppLinksRowProps) => {
               [Status.DEFAULT]: styles.homepageAppLinkButton
             }}
             buttonStatus={Status.DEFAULT}
-            description="Genome browser"
+            description="Entity viewer"
             image={EntityViewerIcon}
           />
         </Link>

--- a/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.tsx
+++ b/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.tsx
@@ -1,0 +1,125 @@
+import React, { useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { connect } from 'react-redux';
+
+import { isEnvironment, Environment } from 'src/shared/helpers/environment';
+import * as urlFor from 'src/shared/helpers/urlHelper';
+
+import { fetchDataForLastVisitedObjects } from 'src/content/app/browser/browserActions';
+
+import { getEnabledCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
+import {
+  getPreviouslyViewedGenomeBrowserObjects,
+  PreviouslyViewedGenomeBrowserObjects
+} from 'src/content/home/homePageSelectors';
+
+import ImageButton from 'src/shared/components/image-button/ImageButton';
+
+import { ReactComponent as BrowserIcon } from 'static/img/launchbar/browser.svg';
+import { ReactComponent as EntityViewerIcon } from 'static/img/launchbar/entity-viewer.svg';
+
+import styles from './HomepageAppLinks.scss';
+
+import { RootState } from 'src/store';
+import { Status } from 'src/shared/types/status';
+import { CommittedItem } from 'src/content/app/species-selector/types/species-search';
+
+type Props = {
+  species: CommittedItem[];
+  previouslyViewedGenomeBrowserObjects: PreviouslyViewedGenomeBrowserObjects;
+  fetchDataForLastVisitedObjects: () => void;
+};
+
+const HomepageAppLinks = (props: Props) => {
+  if (isEnvironment([Environment.DEVELOPMENT, Environment.INTERNAL])) {
+    const links = props.species.map((species) => (
+      <HomepageAppLinksGroup key={species.genome_id} species={species} />
+    ));
+    return (
+      <section className={styles.homepageAppLinks}>
+        <h2>Previously viewed</h2>
+        {links}
+      </section>
+    );
+  } else {
+    return <PreviouslyViewedLinks {...props} />;
+  }
+};
+
+const HomepageAppLinksGroup = ({ species }: { species: CommittedItem }) => (
+  <div className={styles.homepageAppLinksGroup}>
+    <div>
+      <span>{species.common_name || species.scientific_name}</span>
+      <span className={styles.assemblyName}>{species.assembly_name}</span>
+    </div>
+    <div className={styles.homepageAppLinkButtons}>
+      <span className={styles.viewIn}>View in</span>
+      <Link className={styles.homepageAppLink} to={urlFor.browser()}>
+        <ImageButton
+          classNames={{
+            [Status.DEFAULT]: styles.homepageAppLinkButton
+          }}
+          buttonStatus={Status.DEFAULT}
+          description="Genome browser"
+          image={BrowserIcon}
+        />
+      </Link>
+      <Link className={styles.homepageAppLink} to={urlFor.entityViewer()}>
+        <ImageButton
+          classNames={{
+            [Status.DEFAULT]: styles.homepageAppLinkButton
+          }}
+          buttonStatus={Status.DEFAULT}
+          description="Genome browser"
+          image={EntityViewerIcon}
+        />
+      </Link>
+    </div>
+  </div>
+);
+
+// Legacy component that stays there until we have a presentable EntityViewer
+const PreviouslyViewedLinks = (props: Props) => {
+  useEffect(() => {
+    props.fetchDataForLastVisitedObjects();
+  }, []);
+
+  if (
+    !props.species.length ||
+    props.previouslyViewedGenomeBrowserObjects.areLoading
+  ) {
+    return null;
+  }
+
+  const previouslyViewedLinks = props.previouslyViewedGenomeBrowserObjects.objects.map(
+    (object, index) => (
+      <div key={index} className={styles.previouslyViewedItem}>
+        <Link to={object.link}>{object.speciesName}</Link>
+        <span className={styles.previouslyViewedItemAssemblyName}>
+          {' '}
+          {object.assemblyName}
+        </span>
+      </div>
+    )
+  );
+
+  return (
+    <section className={styles.previouslyViewed}>
+      <h2>Previously viewed</h2>
+      {previouslyViewedLinks}
+    </section>
+  );
+};
+
+const mapStateToProps = (state: RootState) => ({
+  species: getEnabledCommittedSpecies(state),
+  previouslyViewedGenomeBrowserObjects: getPreviouslyViewedGenomeBrowserObjects(
+    state
+  )
+});
+
+const mapDispatchToProps = {
+  fetchDataForLastVisitedObjects
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(HomepageAppLinks);

--- a/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.tsx
+++ b/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.tsx
@@ -84,9 +84,11 @@ const HomepageAppLinksRow = (props: HomepageAppLinksRowProps) => {
     [styles.homepageAppLinksRowExpanded]: isExpanded
   });
 
+  const onNameClick = isExpanded ? null : { onClick: toggleExpand };
+
   const speciesName = (
     <div className={styles.speciesNameColumn}>
-      <span className={styles.speciesName} onClick={toggleExpand}>
+      <span className={styles.speciesName} {...onNameClick}>
         {species.common_name || species.scientific_name}
       </span>
       <span className={styles.assemblyName}>{species.assembly_name}</span>

--- a/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.tsx
+++ b/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.tsx
@@ -21,11 +21,11 @@ import { ReactComponent as BrowserIcon } from 'static/img/launchbar/browser.svg'
 import { ReactComponent as EntityViewerIcon } from 'static/img/launchbar/entity-viewer.svg';
 import { ReactComponent as HomeIcon } from 'static/img/header/home.svg';
 
-import styles from './HomepageAppLinks.scss';
-
 import { RootState } from 'src/store';
 import { Status } from 'src/shared/types/status';
 import { CommittedItem } from 'src/content/app/species-selector/types/species-search';
+
+import styles from './HomepageAppLinks.scss';
 
 type Props = {
   species: CommittedItem[];

--- a/src/ensembl/src/content/home/components/homepage-site-info/HomepageSiteInfo.scss
+++ b/src/ensembl/src/content/home/components/homepage-site-info/HomepageSiteInfo.scss
@@ -1,7 +1,7 @@
 @import 'src/styles/common';
 
 .siteMessage {
-  margin-left: 120px;
+  margin-left: 100px;
   padding-top: 2%;
 
   h4 {

--- a/src/ensembl/src/content/home/components/homepage-site-info/HomepageSiteInfo.scss
+++ b/src/ensembl/src/content/home/components/homepage-site-info/HomepageSiteInfo.scss
@@ -1,0 +1,23 @@
+@import 'src/styles/common';
+
+.siteMessage {
+  margin-left: 120px;
+  padding-top: 2%;
+
+  h4 {
+    color: $grey;
+    font-size: 13px;
+    font-weight: $normal;
+    margin-bottom: 0.8em;
+  }
+
+  p {
+    font-size: 13px;
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  .convoMessage {
+    margin-top: 1em;
+  }
+}

--- a/src/ensembl/src/content/home/components/homepage-site-info/HomepageSiteInfo.tsx
+++ b/src/ensembl/src/content/home/components/homepage-site-info/HomepageSiteInfo.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import styles from './HomepageSiteInfo.scss';
+
+const HomepageSiteInfo = () => (
+  <section className={styles.siteMessage}>
+    <h4>Using the site</h4>
+    <p>
+      A very limited data set has been made available for this first release.
+    </p>
+    <p>Blue icons and text are clickable and will usually 'do' something.</p>
+    <p>
+      Grey icons indicate apps &amp; functionality that is planned, but not
+      available yet.
+    </p>
+    <p className={styles.convoMessage}>
+      It's very early days, but why not join the conversation:
+    </p>
+    <p>
+      <a href="mailto:helpdesk@ensembl.org">helpdesk@ensembl.org</a>
+    </p>
+  </section>
+);
+
+export default HomepageSiteInfo;

--- a/src/ensembl/src/content/home/components/homepage-species-bar/HomepageSpeciesBar.scss
+++ b/src/ensembl/src/content/home/components/homepage-species-bar/HomepageSpeciesBar.scss
@@ -1,0 +1,8 @@
+.emptySpeciesBar {
+  display: flex;
+  flex-direction: column;
+
+  .speciesSelectorBannerLink {
+    font-weight: 700;
+  }
+}

--- a/src/ensembl/src/content/home/components/homepage-species-bar/HomepageSpeciesBar.tsx
+++ b/src/ensembl/src/content/home/components/homepage-species-bar/HomepageSpeciesBar.tsx
@@ -9,10 +9,10 @@ import AppBar from 'src/shared/components/app-bar/AppBar';
 import SpeciesTabsWrapper from 'src/shared/components/species-tabs-wrapper/SpeciesTabsWrapper';
 import { SimpleSelectedSpecies } from 'src/shared/components/selected-species';
 
-import styles from './HomepageSpeciesBar.scss';
-
 import { RootState } from 'src/store';
 import { CommittedItem } from 'src/content/app/species-selector/types/species-search';
+
+import styles from './HomepageSpeciesBar.scss';
 
 type Props = {
   species: CommittedItem[];

--- a/src/ensembl/src/content/home/components/homepage-species-bar/HomepageSpeciesBar.tsx
+++ b/src/ensembl/src/content/home/components/homepage-species-bar/HomepageSpeciesBar.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { connect } from 'react-redux';
+
+import * as urlFor from 'src/shared/helpers/urlHelper';
+import { getEnabledCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
+
+import AppBar from 'src/shared/components/app-bar/AppBar';
+import SpeciesTabsWrapper from 'src/shared/components/species-tabs-wrapper/SpeciesTabsWrapper';
+import { SimpleSelectedSpecies } from 'src/shared/components/selected-species';
+
+import styles from './HomepageSpeciesBar.scss';
+
+import { RootState } from 'src/store';
+import { CommittedItem } from 'src/content/app/species-selector/types/species-search';
+
+type Props = {
+  species: CommittedItem[];
+};
+
+const HomepageSpeciesBar = (props: Props) => {
+  let barContent;
+  if (!props.species.length) {
+    barContent = (
+      <div className={styles.emptySpeciesBar}>
+        <span className={styles.speciesSelectorBannerText}>
+          7 species now available
+        </span>
+        <Link
+          className={styles.speciesSelectorBannerLink}
+          to={urlFor.speciesSelector()}
+        >
+          Select a species to begin
+        </Link>
+      </div>
+    );
+  } else {
+    const speciesItems = props.species.map((species, index) => (
+      <SimpleSelectedSpecies key={index} species={species} />
+    ));
+    barContent = <SpeciesTabsWrapper speciesTabs={speciesItems} />;
+  }
+
+  return <AppBar mainContent={barContent} />;
+};
+
+const mapStateToProps = (state: RootState) => ({
+  species: getEnabledCommittedSpecies(state)
+});
+
+export default connect(mapStateToProps)(HomepageSpeciesBar);


### PR DESCRIPTION
## Type
- New feature

## Related JIRA Issue(s)
ENSWBSITES-459

## Description
Add to home page elements for viewing a species in different applications.
- these elements appear whenever the respective species has been selected (it's no longer a requirement to have viewed this species in any of the apps)
- in their initial state, these elements look like simple links
- when user clicks on such an element, it opens up a panel with buttons linking the user to appropriate applications)
- a click outside the open panel will close it

Also, refactored the code of the home page a bit, breaking it down into components.

## Views affected
Home page

**Deployed to:**
http://193.62.55.91:30280/