### PR TITLE
Add tabs for EntityViewer sidebar

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { Link, useParams } from 'react-router-dom';
 
@@ -8,9 +8,11 @@ import * as urlHelper from 'src/shared/helpers/urlHelper';
 import { getBreakpointWidth } from 'src/global/globalSelectors';
 import { getExampleGenes } from 'src/shared/state/ens-object/ensObjectSelectors';
 import { getEntityViewerActiveGenomeId } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors';
+import { isEntityViewerSidebarOpen } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors';
 
 import { fetchGenomeData } from 'src/shared/state/genome/genomeActions';
 import { setDataFromUrl } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralActions';
+import { toggleSidebar } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarActions';
 
 import { StandardAppLayout } from 'src/shared/components/layout';
 import EntityViewerSidebarTabs from 'src/content/app/entity-viewer/components/entity-viewer-sidebar-tabs/EntityViewerSidebarTabs';
@@ -23,10 +25,12 @@ import { EnsObject } from 'src/shared/state/ens-object/ensObjectTypes';
 
 type Props = {
   activeGenomeId: string | null;
+  isSidebarOpen: boolean;
   exampleGenes: EnsObject[];
   viewportWidth: BreakpointWidth;
   setDataFromUrl: (params: EntityViewerParams) => void;
   fetchGenomeData: (genomeId: string) => void;
+  toggleSidebar: (isOpen?: boolean) => void;
 };
 
 export type EntityViewerParams = {
@@ -36,8 +40,6 @@ export type EntityViewerParams = {
 
 const EntityViewer = (props: Props) => {
   const params: EntityViewerParams = useParams(); // NOTE: will likely cause a problem when server-side rendering
-
-  const [isSidebarOpen, setIsSidebarOpen] = useState(true); // TODO: push this bit ot state to redux soon
 
   useEffect(() => {
     props.setDataFromUrl(params);
@@ -52,8 +54,8 @@ const EntityViewer = (props: Props) => {
           sidebarContent={<div>Sidebar content is coming...</div>}
           sidebarNavigation={<EntityViewerSidebarTabs />}
           topbarContent={<div>Entity info summary goes here</div>}
-          isSidebarOpen={isSidebarOpen}
-          onSidebarToggle={() => setIsSidebarOpen(!isSidebarOpen)}
+          isSidebarOpen={props.isSidebarOpen}
+          onSidebarToggle={props.toggleSidebar}
           isDrawerOpen={false}
           viewportWidth={props.viewportWidth}
         />
@@ -96,13 +98,15 @@ const mapStateToProps = (state: RootState) => {
   return {
     activeGenomeId,
     exampleGenes,
+    isSidebarOpen: isEntityViewerSidebarOpen(state),
     viewportWidth: getBreakpointWidth(state)
   };
 };
 
 const mapDispatchToProps = {
   setDataFromUrl,
-  fetchGenomeData
+  fetchGenomeData,
+  toggleSidebar
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(EntityViewer);

--- a/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
@@ -18,10 +18,11 @@ import { StandardAppLayout } from 'src/shared/components/layout';
 import EntityViewerSidebarTabs from 'src/content/app/entity-viewer/components/entity-viewer-sidebar-tabs/EntityViewerSidebarTabs';
 import EntityViewerAppBar from 'src/content/app/entity-viewer/components/entity-viewer-app-bar/EntityViewerAppBar';
 
-import styles from './EntityViewer.scss';
-
 import { RootState } from 'src/store';
 import { EnsObject } from 'src/shared/state/ens-object/ensObjectTypes';
+import { SidebarStatus } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarState';
+
+import styles from './EntityViewer.scss';
 
 type Props = {
   activeGenomeId: string | null;
@@ -30,7 +31,7 @@ type Props = {
   viewportWidth: BreakpointWidth;
   setDataFromUrl: (params: EntityViewerParams) => void;
   fetchGenomeData: (genomeId: string) => void;
-  toggleSidebar: (isOpen?: boolean) => void;
+  toggleSidebar: (status?: SidebarStatus) => void;
 };
 
 export type EntityViewerParams = {

--- a/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
@@ -13,6 +13,7 @@ import { fetchGenomeData } from 'src/shared/state/genome/genomeActions';
 import { setDataFromUrl } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralActions';
 
 import { StandardAppLayout } from 'src/shared/components/layout';
+import EntityViewerSidebarTabs from 'src/content/app/entity-viewer/components/entity-viewer-sidebar-tabs/EntityViewerSidebarTabs';
 import EntityViewerAppBar from 'src/content/app/entity-viewer/components/entity-viewer-app-bar/EntityViewerAppBar';
 
 import styles from './EntityViewer.scss';
@@ -49,7 +50,7 @@ const EntityViewer = (props: Props) => {
         <StandardAppLayout
           mainContent={<div>Main content is coming...</div>}
           sidebarContent={<div>Sidebar content is coming...</div>}
-          sidebarNavigation={<div>Sidebar navigation goes here</div>}
+          sidebarNavigation={<EntityViewerSidebarTabs />}
           topbarContent={<div>Entity info summary goes here</div>}
           isSidebarOpen={isSidebarOpen}
           onSidebarToggle={() => setIsSidebarOpen(!isSidebarOpen)}

--- a/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
@@ -7,10 +7,10 @@ import * as urlHelper from 'src/shared/helpers/urlHelper';
 
 import { getBreakpointWidth } from 'src/global/globalSelectors';
 import { getExampleGenes } from 'src/shared/state/ens-object/ensObjectSelectors';
-import { getEntityViewerActiveGenomeId } from 'src/content/app/entity-viewer/state/entityViewerSelectors';
+import { getEntityViewerActiveGenomeId } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors';
 
 import { fetchGenomeData } from 'src/shared/state/genome/genomeActions';
-import { setDataFromUrl } from 'src/content/app/entity-viewer/state/entityViewerActions';
+import { setDataFromUrl } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralActions';
 
 import { StandardAppLayout } from 'src/shared/components/layout';
 import EntityViewerAppBar from 'src/content/app/entity-viewer/components/entity-viewer-app-bar/EntityViewerAppBar';

--- a/src/ensembl/src/content/app/entity-viewer/components/entity-viewer-app-bar/EntityViewerAppBar.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/components/entity-viewer-app-bar/EntityViewerAppBar.tsx
@@ -6,10 +6,10 @@ import isEqual from 'lodash/isEqual';
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import { AppName } from 'src/global/globalConfig';
 
-import { getEntityViewerActiveGenomeId } from 'src/content/app/entity-viewer/state/entityViewerSelectors';
+import { getEntityViewerActiveGenomeId } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors';
 import { getEnabledCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 
-import { changeActiveGenomeId } from 'src/content/app/entity-viewer/state/entityViewerActions';
+import { changeActiveGenomeId } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralActions';
 
 import AppBar, {
   HelpAndDocumentation

--- a/src/ensembl/src/content/app/entity-viewer/components/entity-viewer-sidebar-tabs/EntityViewerSidebarTabs.scss
+++ b/src/ensembl/src/content/app/entity-viewer/components/entity-viewer-sidebar-tabs/EntityViewerSidebarTabs.scss
@@ -1,0 +1,16 @@
+@import 'src/styles/common';
+
+.tabs {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  // display: flex;
+  // justify-content: space-around;
+}
+
+.tab {
+  cursor: default;
+  &Unselected {
+    cursor: pointer;
+    color: $blue;
+  }
+}

--- a/src/ensembl/src/content/app/entity-viewer/components/entity-viewer-sidebar-tabs/EntityViewerSidebarTabs.scss
+++ b/src/ensembl/src/content/app/entity-viewer/components/entity-viewer-sidebar-tabs/EntityViewerSidebarTabs.scss
@@ -3,8 +3,6 @@
 .tabs {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  // display: flex;
-  // justify-content: space-around;
 }
 
 .tab {

--- a/src/ensembl/src/content/app/entity-viewer/components/entity-viewer-sidebar-tabs/EntityViewerSidebarTabs.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/components/entity-viewer-sidebar-tabs/EntityViewerSidebarTabs.tsx
@@ -2,9 +2,15 @@ import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 
-import { setSidebarTabName } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarActions';
+import {
+  toggleSidebar,
+  setSidebarTabName
+} from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarActions';
 
-import { getEntityViewerSidebarTabName } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors';
+import {
+  isEntityViewerSidebarOpen,
+  getEntityViewerSidebarTabName
+} from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors';
 
 import styles from './EntityViewerSidebarTabs.scss';
 
@@ -13,7 +19,9 @@ import { RootState } from 'src/store';
 
 type Props = {
   activeTabName: SidebarTabName | null;
+  isSidebarOpen: boolean;
   setSidebarTabName: (name: SidebarTabName) => void;
+  toggleSidebar: (isOpen?: boolean) => void;
 };
 
 const EntityViewerSidebarTabs = (props: Props) => {
@@ -22,14 +30,18 @@ const EntityViewerSidebarTabs = (props: Props) => {
   }
 
   const handleTabChange = (name: SidebarTabName) => {
+    if (!props.isSidebarOpen) {
+      props.toggleSidebar(true);
+    }
     props.setSidebarTabName(name);
   };
 
   const getTabProps = (name: SidebarTabName) => {
-    const isActiveTab = name === props.activeTabName;
+    const isActiveTab = props.isSidebarOpen && name === props.activeTabName;
     const classes = classNames(styles.tab, {
       [styles.tabUnselected]: !isActiveTab
     });
+
     const onClick = isActiveTab
       ? null
       : { onClick: () => handleTabChange(name) };
@@ -49,11 +61,13 @@ const EntityViewerSidebarTabs = (props: Props) => {
 };
 
 const mapStateToProps = (state: RootState) => ({
-  activeTabName: getEntityViewerSidebarTabName(state)
+  activeTabName: getEntityViewerSidebarTabName(state),
+  isSidebarOpen: isEntityViewerSidebarOpen(state)
 });
 
 const mapDispatchToProps = {
-  setSidebarTabName
+  setSidebarTabName,
+  toggleSidebar
 };
 
 export default connect(

--- a/src/ensembl/src/content/app/entity-viewer/components/entity-viewer-sidebar-tabs/EntityViewerSidebarTabs.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/components/entity-viewer-sidebar-tabs/EntityViewerSidebarTabs.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import classNames from 'classnames';
+
+import { setSidebarTabName } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarActions';
+
+import { getEntityViewerSidebarTabName } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors';
+
+import styles from './EntityViewerSidebarTabs.scss';
+
+import { SidebarTabName } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarState';
+import { RootState } from 'src/store';
+
+type Props = {
+  activeTabName: SidebarTabName;
+  setSidebarTabName: (name: SidebarTabName) => void;
+};
+
+const EntityViewerSidebarTabs = (props: Props) => {
+  const handleTabChange = (name: SidebarTabName) => {
+    props.setSidebarTabName(name);
+  };
+
+  const getTabProps = (name: SidebarTabName) => {
+    const isActiveTab = name === props.activeTabName;
+    const classes = classNames(styles.tab, {
+      [styles.tabUnselected]: !isActiveTab
+    });
+    const onClick = isActiveTab
+      ? null
+      : { onClick: () => handleTabChange(name) };
+
+    return {
+      className: classes,
+      ...onClick
+    };
+  };
+
+  return (
+    <div className={styles.tabs}>
+      <span {...getTabProps(SidebarTabName.OVERVIEW)}>Overview</span>
+      <span {...getTabProps(SidebarTabName.PUBLICATIONS)}>Publications</span>
+    </div>
+  );
+};
+
+const mapStateToProps = (state: RootState) => ({
+  activeTabName: getEntityViewerSidebarTabName(state)
+});
+
+const mapDispatchToProps = {
+  setSidebarTabName
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(EntityViewerSidebarTabs);

--- a/src/ensembl/src/content/app/entity-viewer/components/entity-viewer-sidebar-tabs/EntityViewerSidebarTabs.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/components/entity-viewer-sidebar-tabs/EntityViewerSidebarTabs.tsx
@@ -12,11 +12,15 @@ import { SidebarTabName } from 'src/content/app/entity-viewer/state/sidebar/enti
 import { RootState } from 'src/store';
 
 type Props = {
-  activeTabName: SidebarTabName;
+  activeTabName: SidebarTabName | null;
   setSidebarTabName: (name: SidebarTabName) => void;
 };
 
 const EntityViewerSidebarTabs = (props: Props) => {
+  if (!props.activeTabName) {
+    return null;
+  }
+
   const handleTabChange = (name: SidebarTabName) => {
     props.setSidebarTabName(name);
   };

--- a/src/ensembl/src/content/app/entity-viewer/components/entity-viewer-sidebar-tabs/EntityViewerSidebarTabs.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/components/entity-viewer-sidebar-tabs/EntityViewerSidebarTabs.tsx
@@ -12,10 +12,10 @@ import {
   getEntityViewerSidebarTabName
 } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors';
 
-import styles from './EntityViewerSidebarTabs.scss';
-
 import { SidebarTabName } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarState';
 import { RootState } from 'src/store';
+
+import styles from './EntityViewerSidebarTabs.scss';
 
 type Props = {
   activeTabName: SidebarTabName | null;

--- a/src/ensembl/src/content/app/entity-viewer/components/entity-viewer-sidebar-tabs/EntityViewerSidebarTabs.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/components/entity-viewer-sidebar-tabs/EntityViewerSidebarTabs.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 
 import {
-  toggleSidebar,
+  openSidebar,
   setSidebarTabName
 } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarActions';
 
@@ -21,7 +21,7 @@ type Props = {
   activeTabName: SidebarTabName | null;
   isSidebarOpen: boolean;
   setSidebarTabName: (name: SidebarTabName) => void;
-  toggleSidebar: (isOpen?: boolean) => void;
+  openSidebar: () => void;
 };
 
 const EntityViewerSidebarTabs = (props: Props) => {
@@ -31,7 +31,7 @@ const EntityViewerSidebarTabs = (props: Props) => {
 
   const handleTabChange = (name: SidebarTabName) => {
     if (!props.isSidebarOpen) {
-      props.toggleSidebar(true);
+      props.openSidebar();
     }
     props.setSidebarTabName(name);
   };
@@ -67,7 +67,7 @@ const mapStateToProps = (state: RootState) => ({
 
 const mapDispatchToProps = {
   setSidebarTabName,
-  toggleSidebar
+  openSidebar
 };
 
 export default connect(

--- a/src/ensembl/src/content/app/entity-viewer/state/entityViewerReducer.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/entityViewerReducer.ts
@@ -1,20 +1,9 @@
-import { ActionType, getType } from 'typesafe-actions';
+import { combineReducers } from 'redux';
 
-import { initialState, EntityViewerState } from './entityViewerState';
-import * as entityViewerActions from './entityViewerActions';
+import entityViewerGeneralReducer from './general/entityViewerGeneralReducer';
+import entityViewerSidebarReducer from './sidebar/entityViewerSidebarReducer';
 
-export default function entityViewerReducer(
-  state: EntityViewerState = initialState,
-  action: ActionType<typeof entityViewerActions>
-) {
-  switch (action.type) {
-    case getType(entityViewerActions.setActiveGenomeId): {
-      return {
-        ...state,
-        activeGenomeId: action.payload
-      };
-    }
-    default:
-      return state;
-  }
-}
+export default combineReducers({
+  general: entityViewerGeneralReducer,
+  sidebar: entityViewerSidebarReducer
+});

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralActions.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralActions.ts
@@ -7,7 +7,7 @@ import { ThunkAction } from 'redux-thunk';
 import * as urlHelper from 'src/shared/helpers/urlHelper';
 
 import { getCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
-import { getEntityViewerActiveGenomeId } from 'src/content/app/entity-viewer/state/entityViewerSelectors';
+import { getEntityViewerActiveGenomeId } from './entityViewerGeneralSelectors';
 import { getGenomeInfoById } from 'src/shared/state/genome/genomeSelectors';
 
 import { fetchGenomeData } from 'src/shared/state/genome/genomeActions';

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralReducer.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralReducer.ts
@@ -1,0 +1,23 @@
+import { ActionType, getType } from 'typesafe-actions';
+
+import {
+  initialState,
+  EntityViewerGeneralState
+} from './entityViewerGeneralState';
+import * as actions from './entityViewerGeneralActions';
+
+export default function entityViewerReducer(
+  state: EntityViewerGeneralState = initialState,
+  action: ActionType<typeof actions>
+) {
+  switch (action.type) {
+    case getType(actions.setActiveGenomeId): {
+      return {
+        ...state,
+        activeGenomeId: action.payload
+      };
+    }
+    default:
+      return state;
+  }
+}

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors.ts
@@ -1,4 +1,4 @@
 import { RootState } from 'src/store';
 
 export const getEntityViewerActiveGenomeId = (state: RootState) =>
-  state.entityViewer.activeGenomeId;
+  state.entityViewer.general.activeGenomeId;

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralState.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralState.ts
@@ -1,7 +1,7 @@
-export type EntityViewerState = Readonly<{
+export type EntityViewerGeneralState = Readonly<{
   activeGenomeId: string | null;
 }>;
 
-export const initialState: EntityViewerState = {
+export const initialState: EntityViewerGeneralState = {
   activeGenomeId: null // FIXME add entity viewer storage service
 };

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarActions.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarActions.ts
@@ -1,0 +1,7 @@
+import { createAction } from 'typesafe-actions';
+
+import { SidebarTabName } from './entityViewerSidebarState';
+
+export const setSidebarTabName = createAction(
+  'entity-viewer-sidebar/set-sidebar-tab-name'
+)<SidebarTabName>();

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarActions.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarActions.ts
@@ -7,8 +7,10 @@ import { isEntityViewerSidebarOpen } from 'src/content/app/entity-viewer/state/s
 
 import {
   EntityViewerSidebarStateForGenome,
-  SidebarTabName
+  SidebarTabName,
+  SidebarStatus
 } from './entityViewerSidebarState';
+import { Status } from 'src/shared/types/status';
 import { RootState } from 'src/store';
 
 export const updateSidebar = createAction(
@@ -38,15 +40,19 @@ export const toggleSidebar: ActionCreator<ThunkAction<
   any,
   null,
   Action<string>
->> = (isOpen?: boolean) => (dispatch, getState: () => RootState) => {
+>> = (status?: SidebarStatus) => (dispatch, getState: () => RootState) => {
   const state = getState();
   const genomeId = getEntityViewerActiveGenomeId(state);
   if (!genomeId) {
     return;
   }
-  if (isOpen === undefined) {
+  if (status === undefined) {
     const isCurrentlyOpen = isEntityViewerSidebarOpen(state);
-    isOpen = !isCurrentlyOpen;
+    status = isCurrentlyOpen ? Status.CLOSED : Status.OPEN;
   }
-  dispatch(updateSidebar({ genomeId, fragment: { isOpen } }));
+  dispatch(updateSidebar({ genomeId, fragment: { status } }));
 };
+
+export const openSidebar = () => toggleSidebar(Status.OPEN);
+
+export const closeSidebar = () => toggleSidebar(Status.CLOSED);

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarActions.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarActions.ts
@@ -3,6 +3,7 @@ import { ActionCreator, Action } from 'redux';
 import { ThunkAction } from 'redux-thunk';
 
 import { getEntityViewerActiveGenomeId } from '../general/entityViewerGeneralSelectors';
+import { isEntityViewerSidebarOpen } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors';
 
 import {
   EntityViewerSidebarStateForGenome,
@@ -12,7 +13,7 @@ import { RootState } from 'src/store';
 
 export const updateSidebar = createAction(
   'entity-viewer-sidebar/update-sidebar'
-)<{ genomeId: string; data: Partial<EntityViewerSidebarStateForGenome> }>();
+)<{ genomeId: string; fragment: Partial<EntityViewerSidebarStateForGenome> }>();
 
 export const setSidebarTabName: ActionCreator<ThunkAction<
   void,
@@ -27,7 +28,25 @@ export const setSidebarTabName: ActionCreator<ThunkAction<
   dispatch(
     updateSidebar({
       genomeId: activeGenomeId,
-      data: { activeTabName: tabName }
+      fragment: { activeTabName: tabName }
     })
   );
+};
+
+export const toggleSidebar: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (isOpen?: boolean) => (dispatch, getState: () => RootState) => {
+  const state = getState();
+  const genomeId = getEntityViewerActiveGenomeId(state);
+  if (!genomeId) {
+    return;
+  }
+  if (isOpen === undefined) {
+    const isCurrentlyOpen = isEntityViewerSidebarOpen(state);
+    isOpen = !isCurrentlyOpen;
+  }
+  dispatch(updateSidebar({ genomeId, fragment: { isOpen } }));
 };

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarActions.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarActions.ts
@@ -1,7 +1,33 @@
 import { createAction } from 'typesafe-actions';
+import { ActionCreator, Action } from 'redux';
+import { ThunkAction } from 'redux-thunk';
 
-import { SidebarTabName } from './entityViewerSidebarState';
+import { getEntityViewerActiveGenomeId } from '../general/entityViewerGeneralSelectors';
 
-export const setSidebarTabName = createAction(
-  'entity-viewer-sidebar/set-sidebar-tab-name'
-)<SidebarTabName>();
+import {
+  EntityViewerSidebarStateForGenome,
+  SidebarTabName
+} from './entityViewerSidebarState';
+import { RootState } from 'src/store';
+
+export const updateSidebar = createAction(
+  'entity-viewer-sidebar/update-sidebar'
+)<{ genomeId: string; data: Partial<EntityViewerSidebarStateForGenome> }>();
+
+export const setSidebarTabName: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (tabName: SidebarTabName) => (dispatch, getState: () => RootState) => {
+  const activeGenomeId = getEntityViewerActiveGenomeId(getState());
+  if (!activeGenomeId) {
+    return;
+  }
+  dispatch(
+    updateSidebar({
+      genomeId: activeGenomeId,
+      data: { activeTabName: tabName }
+    })
+  );
+};

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarReducer.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarReducer.ts
@@ -29,7 +29,10 @@ export default function entityViewerSidebarReducer(
           };
     case getType(actions.updateSidebar): {
       const oldStateFragment = state[action.payload.genomeId];
-      const newStateFragment = { ...oldStateFragment, ...action.payload.data };
+      const newStateFragment = {
+        ...oldStateFragment,
+        ...action.payload.fragment
+      };
       return {
         ...state,
         [action.payload.genomeId]: newStateFragment

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarReducer.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarReducer.ts
@@ -9,9 +9,15 @@ import {
   EntityViewerSidebarState
 } from './entityViewerSidebarState';
 
+// type EntityViewerSidebarReducer = (
+//   state: EntityViewerSidebarState,
+//   action: ActionType<typeof actions | typeof generalActions>
+// ) => EntityViewerSidebarState;
+// const entityViewerSidebarReducer: EntityViewerSidebarReducer = (
+
 export default function entityViewerSidebarReducer(
   state: EntityViewerSidebarState = initialState,
-  action: ActionType<typeof actions | typeof generalActions.setActiveGenomeId>
+  action: ActionType<typeof actions | typeof generalActions>
 ) {
   switch (action.type) {
     case getType(generalActions.setActiveGenomeId):
@@ -21,10 +27,12 @@ export default function entityViewerSidebarReducer(
             ...state,
             ...buildInitialStateForGenome(action.payload)
           };
-    case getType(actions.setSidebarTabName): {
+    case getType(actions.updateSidebar): {
+      const oldStateFragment = state[action.payload.genomeId];
+      const newStateFragment = { ...oldStateFragment, ...action.payload.data };
       return {
         ...state,
-        activeTabName: action.payload
+        [action.payload.genomeId]: newStateFragment
       };
     }
     default:

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarReducer.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarReducer.ts
@@ -1,0 +1,24 @@
+import { ActionType, getType } from 'typesafe-actions';
+
+import * as actions from './entityViewerSidebarActions';
+
+import {
+  initialState,
+  EntityViewerSidebarState
+} from './entityViewerSidebarState';
+
+export default function entityViewerSidebarReducer(
+  state: EntityViewerSidebarState = initialState,
+  action: ActionType<typeof actions>
+) {
+  switch (action.type) {
+    case getType(actions.setSidebarTabName): {
+      return {
+        ...state,
+        activeTabName: action.payload
+      };
+    }
+    default:
+      return state;
+  }
+}

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarReducer.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarReducer.ts
@@ -9,12 +9,6 @@ import {
   EntityViewerSidebarState
 } from './entityViewerSidebarState';
 
-// type EntityViewerSidebarReducer = (
-//   state: EntityViewerSidebarState,
-//   action: ActionType<typeof actions | typeof generalActions>
-// ) => EntityViewerSidebarState;
-// const entityViewerSidebarReducer: EntityViewerSidebarReducer = (
-
 export default function entityViewerSidebarReducer(
   state: EntityViewerSidebarState = initialState,
   action: ActionType<typeof actions | typeof generalActions>

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarReducer.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarReducer.ts
@@ -1,17 +1,26 @@
 import { ActionType, getType } from 'typesafe-actions';
 
+import * as generalActions from '../general/entityViewerGeneralActions';
 import * as actions from './entityViewerSidebarActions';
 
 import {
   initialState,
+  buildInitialStateForGenome,
   EntityViewerSidebarState
 } from './entityViewerSidebarState';
 
 export default function entityViewerSidebarReducer(
   state: EntityViewerSidebarState = initialState,
-  action: ActionType<typeof actions>
+  action: ActionType<typeof actions | typeof generalActions.setActiveGenomeId>
 ) {
   switch (action.type) {
+    case getType(generalActions.setActiveGenomeId):
+      return state[action.payload]
+        ? state
+        : {
+            ...state,
+            ...buildInitialStateForGenome(action.payload)
+          };
     case getType(actions.setSidebarTabName): {
       return {
         ...state,

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors.ts
@@ -1,5 +1,6 @@
 import { getEntityViewerActiveGenomeId } from '../general/entityViewerGeneralSelectors';
 
+import { Status } from 'src/shared/types/status';
 import { RootState } from 'src/store';
 
 export const getEntityViewerSidebarTabName = (state: RootState) => {
@@ -12,6 +13,6 @@ export const getEntityViewerSidebarTabName = (state: RootState) => {
 export const isEntityViewerSidebarOpen = (state: RootState): boolean => {
   const activeGenomeId = getEntityViewerActiveGenomeId(state);
   return activeGenomeId
-    ? state.entityViewer.sidebar[activeGenomeId].isOpen
+    ? state.entityViewer.sidebar[activeGenomeId].status === Status.OPEN
     : false;
 };

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors.ts
@@ -1,4 +1,10 @@
+import { getEntityViewerActiveGenomeId } from '../general/entityViewerGeneralSelectors';
+
 import { RootState } from 'src/store';
 
-export const getEntityViewerSidebarTabName = (state: RootState) =>
-  state.entityViewer.sidebar.activeTabName;
+export const getEntityViewerSidebarTabName = (state: RootState) => {
+  const activeGenomeId = getEntityViewerActiveGenomeId(state);
+  return activeGenomeId
+    ? state.entityViewer.sidebar[activeGenomeId].activeTabName
+    : null;
+};

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors.ts
@@ -8,3 +8,10 @@ export const getEntityViewerSidebarTabName = (state: RootState) => {
     ? state.entityViewer.sidebar[activeGenomeId].activeTabName
     : null;
 };
+
+export const isEntityViewerSidebarOpen = (state: RootState): boolean => {
+  const activeGenomeId = getEntityViewerActiveGenomeId(state);
+  return activeGenomeId
+    ? state.entityViewer.sidebar[activeGenomeId].isOpen
+    : false;
+};

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors.ts
@@ -1,0 +1,4 @@
+import { RootState } from 'src/store';
+
+export const getEntityViewerSidebarTabName = (state: RootState) =>
+  state.entityViewer.sidebar.activeTabName;

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarState.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarState.ts
@@ -3,10 +3,22 @@ export enum SidebarTabName {
   PUBLICATIONS = 'publications'
 }
 
-export type EntityViewerSidebarState = Readonly<{
+export type EntityViewerSidebarState = {
+  [genomeId: string]: EntityViewerSidebarStateForGenome;
+};
+
+export type EntityViewerSidebarStateForGenome = Readonly<{
+  isOpen: boolean;
   activeTabName: SidebarTabName;
 }>;
 
-export const initialState: EntityViewerSidebarState = {
-  activeTabName: SidebarTabName.OVERVIEW
-};
+export const buildInitialStateForGenome = (
+  genomeId: string
+): EntityViewerSidebarState => ({
+  [genomeId]: {
+    isOpen: true,
+    activeTabName: SidebarTabName.OVERVIEW
+  }
+});
+
+export const initialState: EntityViewerSidebarState = {};

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarState.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarState.ts
@@ -3,9 +3,9 @@ export enum SidebarTabName {
   PUBLICATIONS = 'publications'
 }
 
-export type EntityViewerSidebarState = {
+export type EntityViewerSidebarState = Readonly<{
   [genomeId: string]: EntityViewerSidebarStateForGenome;
-};
+}>;
 
 export type EntityViewerSidebarStateForGenome = Readonly<{
   isOpen: boolean;

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarState.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarState.ts
@@ -1,14 +1,18 @@
+import { Status } from 'src/shared/types/status';
+
 export enum SidebarTabName {
   OVERVIEW = 'overview',
   PUBLICATIONS = 'publications'
 }
+
+export type SidebarStatus = Status.OPEN | Status.CLOSED;
 
 export type EntityViewerSidebarState = Readonly<{
   [genomeId: string]: EntityViewerSidebarStateForGenome;
 }>;
 
 export type EntityViewerSidebarStateForGenome = Readonly<{
-  isOpen: boolean;
+  status: SidebarStatus;
   activeTabName: SidebarTabName;
 }>;
 
@@ -16,7 +20,7 @@ export const buildInitialStateForGenome = (
   genomeId: string
 ): EntityViewerSidebarState => ({
   [genomeId]: {
-    isOpen: true,
+    status: Status.OPEN,
     activeTabName: SidebarTabName.OVERVIEW
   }
 });

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarState.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarState.ts
@@ -1,0 +1,12 @@
+export enum SidebarTabName {
+  OVERVIEW = 'overview',
+  PUBLICATIONS = 'publications'
+}
+
+export type EntityViewerSidebarState = Readonly<{
+  activeTabName: SidebarTabName;
+}>;
+
+export const initialState: EntityViewerSidebarState = {
+  activeTabName: SidebarTabName.OVERVIEW
+};

--- a/src/ensembl/src/header/launchbar/LaunchbarButton.tsx
+++ b/src/ensembl/src/header/launchbar/LaunchbarButton.tsx
@@ -1,7 +1,9 @@
 import React, { FunctionComponent } from 'react';
 import { NavLink } from 'react-router-dom';
 import { withRouter, RouteComponentProps } from 'react-router';
-import ImageButton from 'src/shared/components/image-button/ImageButton';
+import ImageButton, {
+  ImageButtonStatus
+} from 'src/shared/components/image-button/ImageButton';
 
 import { Status } from 'src/shared/types/status';
 
@@ -60,7 +62,7 @@ const getImageButtonStatus = ({
 }: {
   isDisabled: boolean;
   isActive: boolean;
-}): Status => {
+}): ImageButtonStatus => {
   if (isDisabled) {
     return Status.DISABLED;
   } else if (isActive) {

--- a/src/ensembl/src/shared/components/image-button/ImageButton.tsx
+++ b/src/ensembl/src/shared/components/image-button/ImageButton.tsx
@@ -11,7 +11,7 @@ import imageButtonStyles from './ImageButton.scss';
 
 import { Status } from 'src/shared/types/status';
 
-type ImageButtonStatus =
+export type ImageButtonStatus =
   | Status.ACTIVE
   | Status.INACTIVE
   | Status.DISABLED

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
@@ -73,7 +73,9 @@ const StandardAppLayout = (props: StandardAppLayoutProps) => {
           <div className={styles.sideBarToolstrip}>
             <SidebarModeToggle
               onClick={
-                props.isDrawerOpen ? props.onDrawerClose : props.onSidebarToggle
+                props.isDrawerOpen
+                  ? () => props.onDrawerClose()
+                  : () => props.onSidebarToggle()
               }
               showAction={
                 props.isSidebarOpen

--- a/src/ensembl/src/shared/types/status.ts
+++ b/src/ensembl/src/shared/types/status.ts
@@ -12,5 +12,7 @@ export enum Status {
   DISABLED = 'disabled',
   DEFAULT = 'default',
   HIGHLIGHTED = 'highlighted',
-  INACTIVE = 'inactive'
+  INACTIVE = 'inactive',
+  OPEN = 'open',
+  CLOSED = 'closed'
 }

--- a/src/ensembl/stories/shared-components/image-button/ImageButtonParent.stories.tsx
+++ b/src/ensembl/stories/shared-components/image-button/ImageButtonParent.stories.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
-import ImageButton from 'src/shared/components/image-button/ImageButton';
+import ImageButton, {
+  ImageButtonStatus
+} from 'src/shared/components/image-button/ImageButton';
 
 import { Status } from 'src/shared/types/status';
 
@@ -14,7 +16,9 @@ type Props = {
 import styles from './ImageButton.stories.scss';
 
 const ImageButtonParent = (props: Props) => {
-  const [buttonStatus, setVisible] = useState(Status.DEFAULT);
+  const [buttonStatus, setVisible] = useState<ImageButtonStatus>(
+    Status.DEFAULT
+  );
 
   const toggleImage = () => {
     switch (buttonStatus) {


### PR DESCRIPTION
## Type
New feature

## Related Jira issue
ENSWBSITES-466

## Description
- Added EntityViewerSidebarTabs component
- Split entity viewer redux state into smaller parts, one of which is `sidebar`
- Added the `sidebar` part of entity viewer redux state, modelled as an object keyed by genome id.

## Behaviour
- Entity viewer shows two tabs ("Overview" and "Publications") above the sidebar, as in the design mockup
- The "Overview" tab is active by default
- User can change the active tab by clicking on it. Other than visual appearance of the tabs, nothing changes externally (but internally, in the app, this is all wired up so the app knows that the sidebar tab has changed)
- If sidebar is closed, then clicking on any sidebar tab will open the sidebar

**Deployed to**
http://193.62.55.91:30704/