### PR TITLE
Deploy dev-2020.ensembl.org (internal) from dev branch instead of master

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,7 +78,7 @@ Test_N_Build:internal:
     - src/ensembl/dist/
 
   only:
-  - master
+  - dev
 
 Test_N_Build:feature:
   image: node:12.13.0
@@ -163,7 +163,7 @@ Nginx:internal:
   - docker logout "$GITLAB_REGISTRY_URL"
 
   only:
-  - master
+  - dev
 
   dependencies:
   - Test_N_Build:internal
@@ -282,7 +282,7 @@ Deploy:internal:
   - kubectl apply -f ensembl-client-caas-deploy/ensembl_client_deployment.yaml
 
   only:
-  - master
+  - dev
 
   dependencies:
   - Nginx:internal


### PR DESCRIPTION
<!--
## Requirements

Dev site needed for internal visibility of Entity Viewer
-->

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature
- [x] CI/CD Pipeline improvement

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-479

## Importance
internal visibility of Entity Viewer

## Description
We already have internal deployment accessible at dev-2020.ensembl.org which is currently being deployed from the master branch. It was decided to deploy it from the dev branch.


## Possible complications
Might affect staging but we would not know until we merge this to dev