### PR TITLE
Remove runtime cache for service worker

### DIFF
--- a/src/ensembl/webpack/environments/webpack.config.prod.js
+++ b/src/ensembl/webpack/environments/webpack.config.prod.js
@@ -112,11 +112,7 @@ module.exports = () => {
         swDest: '../service-worker.js', // save service worker in the root folder (/dist) instead of /dist/static
         clientsClaim: true,
         skipWaiting: true,
-        exclude: [/index.html$/, /\.gz$/, /\.br$/, /\.js\.map$/],
-        runtimeCaching: [{
-          urlPattern: ({ event }) => event.request.mode === 'navigate',
-          handler: 'NetworkFirst'
-        }]
+        exclude: [/index.html$/, /\.gz$/, /\.br$/, /\.js\.map$/]
       }),
 
       new RobotstxtPlugin({


### PR DESCRIPTION
## Type
- Bug fix (hopefully)

## Description
We are still getting error pages after deployment to production if the user has visited a page for which the javascript file has been modified. This is probably related to the service worker still caching our html pages. Here's the response that I see when I open the production site:

![response](https://user-images.githubusercontent.com/6834224/73202489-0fa79580-4133-11ea-833a-527e863d8efa.png)
 
This PR removes caching of html pages at all. Which means that our site will not load pages offline; but if our users do not have a network connection, the site is useless for them anyway.