### PR TITLE
Make BrowserInfo a shared component

### DIFF
--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.test.tsx
@@ -17,10 +17,10 @@ jest.mock(
   'src/content/app/browser/browser-location-indicator/BrowserLocationIndicator',
   () => () => <div>Browser Location Indicator</div>
 );
-jest.mock('src/shared/components/feature-summary-strip', () => ({
-  GeneSummaryStrip: () => <div>Gene Summary Strip</div>,
-  RegionSummaryStrip: () => <div>Region Summary Strip</div>
-}));
+jest.mock(
+  'src/shared/components/feature-summary-strip/FeatureSummaryStrip',
+  () => () => <div>Feature Summary Strip</div>
+);
 
 describe('<BrowserBar />', () => {
   const defaultProps = {
@@ -49,25 +49,20 @@ describe('<BrowserBar />', () => {
       expect(renderedBrowserBar.find(BrowserLocationIndicator).length).toBe(1);
     });
 
-    test('renders GeneSummaryStrip if focus object is gene', () => {
-      const renderedBrowserBar = mount(
-        renderBrowserBar({ ensObject: createEnsObject('gene') })
-      );
-      expect(renderedBrowserBar.find(FeatureSummaryStrip).length).toBe(1);
-    });
-
-    test('renders RegionSummaryStrip if focus object is region', () => {
-      const renderedBrowserBar = mount(
-        renderBrowserBar({ ensObject: createEnsObject('region') })
-      );
+    test('contains FeatureSummaryStrip', () => {
       expect(renderedBrowserBar.find(FeatureSummaryStrip).length).toBe(1);
     });
   });
 
   describe('behaviour', () => {
-    test('shows FeatureSummaryStrip panel by default', () => {
-      const renderedBrowserBar = mount(renderBrowserBar());
+    let renderedBrowserBar: any;
+
+    test('shows FeatureSummaryStrip when ensObject is not null', () => {
+      renderedBrowserBar = mount(renderBrowserBar());
       expect(renderedBrowserBar.find(FeatureSummaryStrip).length).toBe(1);
+
+      renderedBrowserBar = mount(renderBrowserBar({ ensObject: null }));
+      expect(renderedBrowserBar.find(FeatureSummaryStrip).length).toBe(0);
     });
   });
 });

--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.test.tsx
@@ -1,13 +1,10 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { BrowserBar, BrowserInfo, BrowserBarProps } from './BrowserBar';
+import { BrowserBar, BrowserBarProps } from './BrowserBar';
 
 import BrowserReset from 'src/content/app/browser/browser-reset/BrowserReset';
 import BrowserLocationIndicator from 'src/content/app/browser/browser-location-indicator/BrowserLocationIndicator';
-import {
-  GeneSummaryStrip,
-  RegionSummaryStrip
-} from 'src/shared/components/feature-summary-strip';
+import FeatureSummaryStrip from 'src/shared/components/feature-summary-strip/FeatureSummaryStrip';
 
 import { ChrLocation } from '../browserState';
 
@@ -56,21 +53,21 @@ describe('<BrowserBar />', () => {
       const renderedBrowserBar = mount(
         renderBrowserBar({ ensObject: createEnsObject('gene') })
       );
-      expect(renderedBrowserBar.find(GeneSummaryStrip).length).toBe(1);
+      expect(renderedBrowserBar.find(FeatureSummaryStrip).length).toBe(1);
     });
 
     test('renders RegionSummaryStrip if focus object is region', () => {
       const renderedBrowserBar = mount(
         renderBrowserBar({ ensObject: createEnsObject('region') })
       );
-      expect(renderedBrowserBar.find(RegionSummaryStrip).length).toBe(1);
+      expect(renderedBrowserBar.find(FeatureSummaryStrip).length).toBe(1);
     });
   });
 
   describe('behaviour', () => {
-    test('shows BrowserInfo panel by default', () => {
+    test('shows FeatureSummaryStrip panel by default', () => {
       const renderedBrowserBar = mount(renderBrowserBar());
-      expect(renderedBrowserBar.find(BrowserInfo).length).toBe(1);
+      expect(renderedBrowserBar.find(FeatureSummaryStrip).length).toBe(1);
     });
   });
 });

--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
@@ -9,10 +9,7 @@ import {
 import { getIsDrawerOpened } from '../drawer/drawerSelectors';
 
 import BrowserReset from '../browser-reset/BrowserReset';
-import {
-  GeneSummaryStrip,
-  RegionSummaryStrip
-} from 'src/shared/components/feature-summary-strip';
+import FeatureSummaryStrip from 'src/shared/components/feature-summary-strip/FeatureSummaryStrip';
 import BrowserLocationIndicator from '../browser-location-indicator/BrowserLocationIndicator';
 
 import { RootState } from 'src/store';
@@ -28,11 +25,6 @@ export type BrowserBarProps = {
   ensObject: EnsObject | null;
 };
 
-type BrowserInfoProps = {
-  ensObject: EnsObject;
-  isDrawerOpened: boolean;
-};
-
 export const BrowserBar = (props: BrowserBarProps) => {
   // return empty div instead of null, so that the dedicated slot in the CSS grid of StandardAppLayout
   // always contains a child DOM element
@@ -45,7 +37,7 @@ export const BrowserBar = (props: BrowserBarProps) => {
       <div className={styles.browserResetWrapper}>
         <BrowserReset />
       </div>
-      <BrowserInfo
+      <FeatureSummaryStrip
         ensObject={props.ensObject}
         isDrawerOpened={props.isDrawerOpened}
       />
@@ -54,21 +46,6 @@ export const BrowserBar = (props: BrowserBarProps) => {
       </div>
     </div>
   );
-};
-
-export const BrowserInfo = (props: BrowserInfoProps) => {
-  const { ensObject, isDrawerOpened } = props;
-  const childProps = {
-    isGhosted: isDrawerOpened
-  };
-  switch (ensObject.object_type) {
-    case 'gene':
-      return <GeneSummaryStrip gene={ensObject} {...childProps} />;
-    case 'region':
-      return <RegionSummaryStrip region={ensObject} {...childProps} />;
-    default:
-      return null;
-  }
 };
 
 const mapStateToProps = (state: RootState) => ({

--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
@@ -37,10 +37,12 @@ export const BrowserBar = (props: BrowserBarProps) => {
       <div className={styles.browserResetWrapper}>
         <BrowserReset />
       </div>
-      <FeatureSummaryStrip
-        ensObject={props.ensObject}
-        isDrawerOpened={props.isDrawerOpened}
-      />
+      {props.ensObject ? (
+        <FeatureSummaryStrip
+          ensObject={props.ensObject}
+          isGhosted={props.isDrawerOpened}
+        />
+      ) : null}
       <div className={styles.browserLocationIndicatorWrapper}>
         <BrowserLocationIndicator />
       </div>

--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
@@ -37,12 +37,12 @@ export const BrowserBar = (props: BrowserBarProps) => {
       <div className={styles.browserResetWrapper}>
         <BrowserReset />
       </div>
-      {props.ensObject ? (
+      {props.ensObject && (
         <FeatureSummaryStrip
           ensObject={props.ensObject}
           isGhosted={props.isDrawerOpened}
         />
-      ) : null}
+      )}
       <div className={styles.browserLocationIndicatorWrapper}>
         <BrowserLocationIndicator />
       </div>

--- a/src/ensembl/src/shared/components/feature-summary-strip/FeatureSummaryStrip.test.tsx
+++ b/src/ensembl/src/shared/components/feature-summary-strip/FeatureSummaryStrip.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import {
+  FeatureSummaryStrip,
+  FeatureSummaryStripProps
+} from './FeatureSummaryStrip';
+
+import { GeneSummaryStrip, RegionSummaryStrip } from '../feature-summary-strip';
+
+import { createEnsObject } from 'tests/fixtures/ens-object';
+
+jest.mock('../feature-summary-strip', () => ({
+  GeneSummaryStrip: () => <div>Gene Summary Strip</div>,
+  RegionSummaryStrip: () => <div>Region Summary Strip</div>
+}));
+
+describe('<FeatureSummaryStrip />', () => {
+  const defaultProps = {
+    ensObject: createEnsObject(),
+    isGhosted: false
+  };
+
+  const renderFeatureSummaryStrip = (
+    props?: Partial<FeatureSummaryStripProps>
+  ) => <FeatureSummaryStrip {...defaultProps} {...props} />;
+
+  describe('general', () => {
+    test('contains GeneSummaryStrip if focus object is gene', () => {
+      const renderedFeatureSummaryStrip = mount(
+        renderFeatureSummaryStrip({ ensObject: createEnsObject('gene') })
+      );
+      expect(renderedFeatureSummaryStrip.find(GeneSummaryStrip).length).toBe(1);
+    });
+
+    test('contains RegionSummaryStrip if focus object is region', () => {
+      const renderedFeatureSummaryStrip = mount(
+        renderFeatureSummaryStrip({ ensObject: createEnsObject('region') })
+      );
+      expect(renderedFeatureSummaryStrip.find(RegionSummaryStrip).length).toBe(
+        1
+      );
+    });
+
+    test('does not contain anything if focus object is not defined', () => {
+      const renderedFeatureSummaryStrip = mount(
+        renderFeatureSummaryStrip({ ensObject: createEnsObject('xyz') })
+      );
+      expect(renderedFeatureSummaryStrip.html()).toBe(null);
+    });
+  });
+});

--- a/src/ensembl/src/shared/components/feature-summary-strip/FeatureSummaryStrip.tsx
+++ b/src/ensembl/src/shared/components/feature-summary-strip/FeatureSummaryStrip.tsx
@@ -4,24 +4,19 @@ import { GeneSummaryStrip, RegionSummaryStrip } from '../feature-summary-strip';
 
 import { EnsObject } from 'src/shared/state/ens-object/ensObjectTypes';
 
-type FeatureSummaryStripProps = {
-  ensObject: EnsObject | null;
-  isDrawerOpened: boolean;
+export type FeatureSummaryStripProps = {
+  ensObject: EnsObject;
+  isGhosted: boolean;
 };
 
 export const FeatureSummaryStrip = (props: FeatureSummaryStripProps) => {
-  const { ensObject, isDrawerOpened } = props;
-  const childProps = {
-    isGhosted: isDrawerOpened
-  };
-  if (!ensObject) {
-    return null;
-  }
+  const { ensObject, isGhosted } = props;
+
   switch (ensObject.object_type) {
     case 'gene':
-      return <GeneSummaryStrip gene={ensObject} {...childProps} />;
+      return <GeneSummaryStrip gene={ensObject} isGhosted={isGhosted} />;
     case 'region':
-      return <RegionSummaryStrip region={ensObject} {...childProps} />;
+      return <RegionSummaryStrip region={ensObject} isGhosted={isGhosted} />;
     default:
       return null;
   }

--- a/src/ensembl/src/shared/components/feature-summary-strip/FeatureSummaryStrip.tsx
+++ b/src/ensembl/src/shared/components/feature-summary-strip/FeatureSummaryStrip.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { GeneSummaryStrip, RegionSummaryStrip } from '../feature-summary-strip';
+
+import { EnsObject } from 'src/shared/state/ens-object/ensObjectTypes';
+
+type FeatureSummaryStripProps = {
+  ensObject: EnsObject | null;
+  isDrawerOpened: boolean;
+};
+
+export const FeatureSummaryStrip = (props: FeatureSummaryStripProps) => {
+  const { ensObject, isDrawerOpened } = props;
+  const childProps = {
+    isGhosted: isDrawerOpened
+  };
+  if (!ensObject) {
+    return null;
+  }
+  switch (ensObject.object_type) {
+    case 'gene':
+      return <GeneSummaryStrip gene={ensObject} {...childProps} />;
+    case 'region':
+      return <RegionSummaryStrip region={ensObject} {...childProps} />;
+    default:
+      return null;
+  }
+};
+
+export default FeatureSummaryStrip;

--- a/src/ensembl/src/shared/components/feature-summary-strip/RegionSummaryStrip.tsx
+++ b/src/ensembl/src/shared/components/feature-summary-strip/RegionSummaryStrip.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 
 import { getFormattedLocation } from 'src/shared/helpers/regionFormatter';
 
@@ -8,11 +9,15 @@ import { EnsObject } from 'src/shared/state/ens-object/ensObjectTypes';
 
 type Props = {
   region: EnsObject;
+  isGhosted?: boolean;
 };
 
-const RegionSummaryStrip = ({ region }: Props) => {
+const RegionSummaryStrip = ({ region, isGhosted }: Props) => {
+  const stripClasses = classNames(styles.featureSummaryStrip, {
+    [styles.featureSummaryStripGhosted]: isGhosted
+  });
   return (
-    <div className={styles.featureSummaryStrip}>
+    <div className={stripClasses}>
       <span className={styles.featureSummaryStripLabel}>Region:</span>
       <span className={styles.featureDisplayName}>
         {getFormattedLocation(region.location)}


### PR DESCRIPTION
…or entity viewer top bar

## Type

- [ ] Bug fix
- [ ] New feature
- [X] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-463

## Importance

## Description
The browser bar component in genome browser uses the browser info component which contain the feature type information and which can be a shared component and reuse for entity viewer top bar.
The changes made are for making the browserinfo component a shared component.

## Views affected
GenomeBrowser and EntityViewer for later

### Other effects


- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications

