### PR TITLE
Create panel and tabs shared component

### DIFF
--- a/src/ensembl/src/shared/components/panel/Panel.scss
+++ b/src/ensembl/src/shared/components/panel/Panel.scss
@@ -1,0 +1,45 @@
+@import 'src/styles/common';
+
+.panelDefault {
+  position: relative;
+  min-height: 100px;
+  border-radius: 5px;
+  width: 600px;
+  max-width: 100%;
+  background: $white;
+  box-shadow: 1px 1px 4px $shadow-color;
+}
+
+.headerDefault {
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+  background-color: $light-grey;
+  box-shadow: 0px 1px 3px $medium-light-grey;
+  height: 34px;
+  padding: 4px 0 4px 10px;
+  width: 100%;
+  line-height: 24px;
+}
+
+.bodyDefault {
+  position: relative;
+  padding-right: 10px;
+  padding-bottom: 10px;
+  padding-left: 10px;
+  border-bottom-right-radius: 5px;
+  border-bottom-left-radius: 5px;
+  overflow: auto;
+  height: calc(100% - 54px);
+  margin-top: 10px;
+}
+
+.closeButton {
+  position: absolute;
+  right: 10px;
+  top: 40px;
+  cursor: pointer;
+  img {
+    height: 15px;
+    width: 15px;
+  }
+}

--- a/src/ensembl/src/shared/components/panel/Panel.scss
+++ b/src/ensembl/src/shared/components/panel/Panel.scss
@@ -1,6 +1,6 @@
 @import 'src/styles/common';
 
-.panelDefault {
+.panel {
   position: relative;
   min-height: 100px;
   border-radius: 5px;
@@ -10,7 +10,7 @@
   box-shadow: 1px 1px 4px $shadow-color;
 }
 
-.headerDefault {
+.header {
   border-top-left-radius: 5px;
   border-top-right-radius: 5px;
   background-color: $light-grey;
@@ -21,7 +21,7 @@
   line-height: 24px;
 }
 
-.bodyDefault {
+.body {
   position: relative;
   padding-right: 10px;
   padding-bottom: 10px;

--- a/src/ensembl/src/shared/components/panel/Panel.scss
+++ b/src/ensembl/src/shared/components/panel/Panel.scss
@@ -16,16 +16,15 @@
   background-color: $light-grey;
   box-shadow: 0px 1px 3px $medium-light-grey;
   height: 34px;
-  padding: 4px 0 4px 10px;
+  padding: 4px 10px;
   width: 100%;
   line-height: 24px;
+  overflow: auto;
 }
 
 .body {
   position: relative;
-  padding-right: 10px;
-  padding-bottom: 10px;
-  padding-left: 10px;
+  padding: 0 20px 10px 10px;
   border-bottom-right-radius: 5px;
   border-bottom-left-radius: 5px;
   overflow: auto;

--- a/src/ensembl/src/shared/components/panel/Panel.scss
+++ b/src/ensembl/src/shared/components/panel/Panel.scss
@@ -19,7 +19,6 @@
   padding: 4px 10px;
   width: 100%;
   line-height: 24px;
-  overflow: auto;
 }
 
 .body {
@@ -29,13 +28,13 @@
   border-bottom-left-radius: 5px;
   overflow: auto;
   height: calc(100% - 54px);
-  margin-top: 10px;
+  margin-top: 15px;
 }
 
 .closeButton {
   position: absolute;
   right: 10px;
-  top: 40px;
+  top: 45px;
   cursor: pointer;
   img {
     height: 15px;

--- a/src/ensembl/src/shared/components/panel/Panel.test.tsx
+++ b/src/ensembl/src/shared/components/panel/Panel.test.tsx
@@ -23,8 +23,8 @@ const defaultProps: PanelProps = {
   classNames: panelClassNames
 };
 
-const renderPanel = (props: PanelProps = defaultProps) => {
-  return <Panel {...props} />;
+const renderPanel = (props?: any) => {
+  return <Panel {...defaultProps} {...props} />;
 };
 
 describe('<Tabs />', () => {
@@ -48,7 +48,7 @@ describe('<Tabs />', () => {
   it('displays the string header', () => {
     const stringHeader = faker.lorem.words();
 
-    wrapper = mount(renderPanel({ ...defaultProps, header: stringHeader }));
+    wrapper = mount(renderPanel({ header: stringHeader }));
     expect(wrapper.find('.header').text()).toBe(stringHeader);
   });
 
@@ -58,7 +58,7 @@ describe('<Tabs />', () => {
   });
 
   it('displays the close button only if onClose is set', () => {
-    wrapper = mount(renderPanel({ ...defaultProps, onClose }));
+    wrapper = mount(renderPanel({ onClose }));
     expect(wrapper.find('.closeButton')).toHaveLength(1);
   });
 
@@ -68,7 +68,7 @@ describe('<Tabs />', () => {
   });
 
   it('calls the onClose function when the close button is clicked', () => {
-    wrapper = mount(renderPanel({ ...defaultProps, onClose }));
+    wrapper = mount(renderPanel({ onClose }));
     wrapper.find('.closeButton').simulate('click');
 
     expect(onClose).toHaveBeenCalled();
@@ -98,7 +98,7 @@ describe('<Tabs />', () => {
   });
 
   it('applies the passed in closeButton className', () => {
-    wrapper = mount(renderPanel({ ...defaultProps, onClose }));
+    wrapper = mount(renderPanel({ onClose }));
     expect(wrapper.find('.closeButton').prop('className')).toContain(
       panelClassNames.closeButton
     );

--- a/src/ensembl/src/shared/components/panel/Panel.test.tsx
+++ b/src/ensembl/src/shared/components/panel/Panel.test.tsx
@@ -23,7 +23,7 @@ const defaultProps: PanelProps = {
   classNames: panelClassNames
 };
 
-const renderPanel = (props?: any) => {
+const renderPanel = (props?: Partial<PanelProps>) => {
   return <Panel {...defaultProps} {...props} />;
 };
 

--- a/src/ensembl/src/shared/components/panel/Panel.test.tsx
+++ b/src/ensembl/src/shared/components/panel/Panel.test.tsx
@@ -23,22 +23,20 @@ const defaultProps: PanelProps = {
   classNames: panelClassNames
 };
 
-const renderPanel = (props: PanelProps) => {
-  return <Panel {...props}></Panel>;
+const renderPanel = (props: PanelProps = defaultProps) => {
+  return <Panel {...props} />;
 };
 
 describe('<Tabs />', () => {
   let wrapper: any;
-
-  beforeEach(() => {
-    wrapper = mount(renderPanel({ ...defaultProps }));
-  });
 
   afterEach(() => {
     jest.resetAllMocks();
   });
 
   it('displays the HTML header', () => {
+    wrapper = mount(renderPanel());
+
     expect(
       wrapper
         .find('.header')
@@ -55,6 +53,7 @@ describe('<Tabs />', () => {
   });
 
   it('displays the body content', () => {
+    wrapper = mount(renderPanel());
     expect(wrapper.find('.body').contains(defaultProps.children)).toBeTruthy();
   });
 
@@ -64,6 +63,7 @@ describe('<Tabs />', () => {
   });
 
   it('does not display the close button if onClose is not set', () => {
+    wrapper = mount(renderPanel());
     expect(wrapper.find('.closeButton')).toHaveLength(0);
   });
 
@@ -74,22 +74,27 @@ describe('<Tabs />', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('applies the passed in panel className', () => {
-    expect(wrapper.find('.panel').prop('className')).toContain(
-      panelClassNames.panel
-    );
-  });
+  it('applies the passed in class', () => {
+    wrapper = mount(renderPanel());
 
-  it('applies the passed in header className', () => {
-    expect(wrapper.find('.header').prop('className')).toContain(
-      panelClassNames.header
-    );
-  });
-
-  it('applies the passed in body className', () => {
-    expect(wrapper.find('.body').prop('className')).toContain(
-      panelClassNames.body
-    );
+    expect(
+      wrapper
+        .find('.panel')
+        .first()
+        .hasClass(panelClassNames.panel)
+    ).toBeTruthy();
+    expect(
+      wrapper
+        .find('.body')
+        .first()
+        .hasClass(panelClassNames.body)
+    ).toBeTruthy();
+    expect(
+      wrapper
+        .find('.header')
+        .first()
+        .hasClass(panelClassNames.header)
+    ).toBeTruthy();
   });
 
   it('applies the passed in closeButton className', () => {

--- a/src/ensembl/src/shared/components/panel/Panel.test.tsx
+++ b/src/ensembl/src/shared/components/panel/Panel.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import faker from 'faker';
+
+import Panel, { PanelProps } from './Panel';
+
+const panelContent = <p>{faker.lorem.words()}</p>;
+
+const panelHeader = <p>{faker.lorem.words()}</p>;
+
+const onClose = jest.fn();
+
+const panelClassNames = {
+  panel: faker.lorem.word(),
+  header: faker.lorem.word(),
+  body: faker.lorem.word(),
+  closeButton: faker.lorem.word()
+};
+
+const defaultProps: PanelProps = {
+  header: panelHeader,
+  children: panelContent,
+  classNames: panelClassNames
+};
+
+const renderPanel = (props: PanelProps) => {
+  return <Panel {...props}></Panel>;
+};
+
+describe('<Tabs />', () => {
+  let wrapper: any;
+
+  beforeEach(() => {
+    wrapper = mount(renderPanel({ ...defaultProps }));
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('displays the HTML header', () => {
+    expect(
+      wrapper
+        .find('.header')
+        .children()
+        .contains(defaultProps.header)
+    ).toBeTruthy();
+  });
+
+  it('displays the string header', () => {
+    const stringHeader = faker.lorem.words();
+
+    wrapper = mount(renderPanel({ ...defaultProps, header: stringHeader }));
+    expect(wrapper.find('.header').text()).toBe(stringHeader);
+  });
+
+  it('displays the body content', () => {
+    expect(wrapper.find('.body').contains(defaultProps.children)).toBeTruthy();
+  });
+
+  it('displays the close button only if onClose is set', () => {
+    wrapper = mount(renderPanel({ ...defaultProps, onClose }));
+    expect(wrapper.find('.closeButton')).toHaveLength(1);
+  });
+
+  it('does not display the close button if onClose is not set', () => {
+    expect(wrapper.find('.closeButton')).toHaveLength(0);
+  });
+
+  it('calls the onClose function when the close button is clicked', () => {
+    wrapper = mount(renderPanel({ ...defaultProps, onClose }));
+    wrapper.find('.closeButton').simulate('click');
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('applies the passed in panel className', () => {
+    expect(wrapper.find('.panel').prop('className')).toContain(
+      panelClassNames.panel
+    );
+  });
+
+  it('applies the passed in header className', () => {
+    expect(wrapper.find('.header').prop('className')).toContain(
+      panelClassNames.header
+    );
+  });
+
+  it('applies the passed in body className', () => {
+    expect(wrapper.find('.body').prop('className')).toContain(
+      panelClassNames.body
+    );
+  });
+
+  it('applies the passed in closeButton className', () => {
+    wrapper = mount(renderPanel({ ...defaultProps, onClose }));
+    expect(wrapper.find('.closeButton').prop('className')).toContain(
+      panelClassNames.closeButton
+    );
+  });
+});

--- a/src/ensembl/src/shared/components/panel/Panel.test.tsx
+++ b/src/ensembl/src/shared/components/panel/Panel.test.tsx
@@ -74,7 +74,7 @@ describe('<Tabs />', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('applies the passed in class', () => {
+  it('applies the passed in classes', () => {
     wrapper = mount(renderPanel());
 
     expect(

--- a/src/ensembl/src/shared/components/panel/Panel.tsx
+++ b/src/ensembl/src/shared/components/panel/Panel.tsx
@@ -21,17 +21,17 @@ const Panel = (props: PanelProps) => {
   const { header, onClose, classNames } = props;
 
   const panelClassNames = classNames
-    ? classNamesMerger(classNames.panel, styles.panel)
+    ? classNamesMerger(styles.panel, classNames.panel)
     : styles.panel;
   const headerClassNames = classNames
-    ? classNamesMerger(classNames.header, styles.header)
+    ? classNamesMerger(styles.header, classNames.header)
     : styles.header;
   const bodyClassNames = classNames
-    ? classNamesMerger(classNames.body, styles.body)
+    ? classNamesMerger(styles.body, classNames.body)
     : styles.body;
 
   const closeButtonClassNames = classNames
-    ? classNamesMerger(classNames.closeButton, styles.closeButton)
+    ? classNamesMerger(styles.closeButton, classNames.closeButton)
     : styles.closeButton;
 
   return (

--- a/src/ensembl/src/shared/components/panel/Panel.tsx
+++ b/src/ensembl/src/shared/components/panel/Panel.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import classNamesMerger from 'classnames';
+
+import closeIcon from 'static/img/shared/close.svg';
+
+import styles from './Panel.scss';
+
+type Props = {
+  header: string | JSX.Element;
+  children: JSX.Element;
+  classNames?: {
+    panelClassName?: string;
+    headerClassName?: string;
+    bodyClassName?: string;
+  };
+  onClose?: () => void;
+};
+
+const Panel = (props: Props) => {
+  const { header, onClose, classNames } = props;
+
+  const panelClassNames = classNames
+    ? classNamesMerger(classNames.panelClassName, styles.panelDefault)
+    : styles.panelDefault;
+  const headerClassNames = classNames
+    ? classNamesMerger(classNames.headerClassName, styles.headerDefault)
+    : styles.headerDefault;
+  const bodyClassNames = classNames
+    ? classNamesMerger(classNames.bodyClassName, styles.bodyDefault)
+    : styles.bodyDefault;
+
+  return (
+    <div className={panelClassNames}>
+      {onClose && (
+        <span className={styles.closeButton} onClick={onClose}>
+          <img src={closeIcon}></img>
+        </span>
+      )}
+      <div className={headerClassNames}>{header}</div>
+      <div className={bodyClassNames}>
+        <div>{props.children}</div>
+      </div>
+    </div>
+  );
+};
+
+export default Panel;

--- a/src/ensembl/src/shared/components/panel/Panel.tsx
+++ b/src/ensembl/src/shared/components/panel/Panel.tsx
@@ -9,9 +9,10 @@ type Props = {
   header: string | JSX.Element;
   children: JSX.Element;
   classNames?: {
-    panelClassName?: string;
-    headerClassName?: string;
-    bodyClassName?: string;
+    panel?: string;
+    header?: string;
+    body?: string;
+    closeButton?: string;
   };
   onClose?: () => void;
 };
@@ -20,19 +21,23 @@ const Panel = (props: Props) => {
   const { header, onClose, classNames } = props;
 
   const panelClassNames = classNames
-    ? classNamesMerger(classNames.panelClassName, styles.panelDefault)
+    ? classNamesMerger(classNames.panel, styles.panelDefault)
     : styles.panelDefault;
   const headerClassNames = classNames
-    ? classNamesMerger(classNames.headerClassName, styles.headerDefault)
+    ? classNamesMerger(classNames.header, styles.headerDefault)
     : styles.headerDefault;
   const bodyClassNames = classNames
-    ? classNamesMerger(classNames.bodyClassName, styles.bodyDefault)
+    ? classNamesMerger(classNames.body, styles.bodyDefault)
     : styles.bodyDefault;
+
+  const closeButtonClassNames = classNames
+    ? classNamesMerger(classNames.closeButton, styles.closeButton)
+    : styles.closeButton;
 
   return (
     <div className={panelClassNames}>
       {onClose && (
-        <span className={styles.closeButton} onClick={onClose}>
+        <span className={closeButtonClassNames} onClick={onClose}>
           <img src={closeIcon}></img>
         </span>
       )}

--- a/src/ensembl/src/shared/components/panel/Panel.tsx
+++ b/src/ensembl/src/shared/components/panel/Panel.tsx
@@ -5,7 +5,7 @@ import closeIcon from 'static/img/shared/close.svg';
 
 import styles from './Panel.scss';
 
-type Props = {
+export type PanelProps = {
   header: string | JSX.Element;
   children: JSX.Element;
   classNames?: {
@@ -17,18 +17,18 @@ type Props = {
   onClose?: () => void;
 };
 
-const Panel = (props: Props) => {
+const Panel = (props: PanelProps) => {
   const { header, onClose, classNames } = props;
 
   const panelClassNames = classNames
-    ? classNamesMerger(classNames.panel, styles.panelDefault)
-    : styles.panelDefault;
+    ? classNamesMerger(classNames.panel, styles.panel)
+    : styles.panel;
   const headerClassNames = classNames
-    ? classNamesMerger(classNames.header, styles.headerDefault)
-    : styles.headerDefault;
+    ? classNamesMerger(classNames.header, styles.header)
+    : styles.header;
   const bodyClassNames = classNames
-    ? classNamesMerger(classNames.body, styles.bodyDefault)
-    : styles.bodyDefault;
+    ? classNamesMerger(classNames.body, styles.body)
+    : styles.body;
 
   const closeButtonClassNames = classNames
     ? classNamesMerger(classNames.closeButton, styles.closeButton)

--- a/src/ensembl/src/shared/components/tabs/Tabs.scss
+++ b/src/ensembl/src/shared/components/tabs/Tabs.scss
@@ -3,8 +3,10 @@
 .tabsContainer {
   display: flex;
   font-size: 14px;
-  overflow-x: auto;
-  height: 40px;
+  overflow-y: hidden;
+  height: 50px;
+  scrollbar-width: none;
+  padding-bottom: 50px;
 }
 
 .tab {

--- a/src/ensembl/src/shared/components/tabs/Tabs.scss
+++ b/src/ensembl/src/shared/components/tabs/Tabs.scss
@@ -1,0 +1,27 @@
+@import 'src/styles/common';
+
+.tabsContainer {
+  display: flex;
+  font-size: 14px;
+  overflow-x: auto;
+  height: 40px;
+}
+
+.tab {
+  padding: 3px 18px;
+  color: $dark-blue;
+  cursor: pointer;
+  margin-right: 3px;
+  white-space: nowrap;
+}
+
+.disabled {
+  color: $dark-grey;
+  cursor: default;
+}
+
+.selected {
+  color: $black;
+  position: relative;
+  cursor: default;
+}

--- a/src/ensembl/src/shared/components/tabs/Tabs.test.tsx
+++ b/src/ensembl/src/shared/components/tabs/Tabs.test.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import faker from 'faker';
+import times from 'lodash/times';
+
+import Tabs, { Tab, TabsProps } from './Tabs';
+
+const onTabSelect = jest.fn();
+
+const createTabGroup = (): Tab[] => {
+  const options = times(10, () => ({
+    title: faker.random.words(),
+    isDisabled: faker.random.boolean()
+  }));
+
+  // Make sure we have atleast one enabled and one disabled entry
+  options.push({
+    title: faker.random.words(),
+    isDisabled: true
+  });
+  options.push({
+    title: faker.random.words(),
+    isDisabled: false
+  });
+
+  return options;
+};
+
+const tabsData = createTabGroup();
+
+const tabClassNames = {
+  selected: faker.lorem.word(),
+  default: faker.lorem.word(),
+  disabled: faker.lorem.word(),
+  tabsContainer: faker.lorem.word()
+};
+
+const defaultProps = {
+  tabs: tabsData,
+  selectedTab: tabsData.find((tab) => !tab.isDisabled)?.title || '',
+  selectTab: onTabSelect,
+  classNames: tabClassNames
+};
+
+const renderTabs = (props: TabsProps) => <Tabs {...props}></Tabs>;
+
+describe('<Tabs />', () => {
+  let wrapper: any;
+
+  beforeEach(() => {
+    wrapper = mount(renderTabs({ ...defaultProps }));
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('displays all the tabs passed in', () => {
+    expect(wrapper.find('.tab')).toHaveLength(defaultProps.tabs.length);
+  });
+
+  it('adds respective class to the disabled tabs', () => {
+    const disabledTabIndex = tabsData.findIndex((tab) => tab.isDisabled);
+    expect(
+      wrapper
+        .find('.tab')
+        .at(disabledTabIndex)
+        .prop('className')
+    ).toContain('disabled');
+  });
+
+  it('adds respective class to the selected tab', () => {
+    const selectedTabIndex = tabsData.findIndex(
+      (tab) => tab.title === defaultProps.selectedTab
+    );
+    expect(
+      wrapper
+        .find('.tab')
+        .at(selectedTabIndex)
+        .prop('className')
+    ).toContain('selected');
+  });
+
+  it('calls the onTabSelect function when a tab is selected', () => {
+    const unselectedTabIndex = tabsData.findIndex(
+      (tab) => tab.title !== defaultProps.selectedTab && !tab.isDisabled
+    );
+    wrapper
+      .find('.tab')
+      .at(unselectedTabIndex)
+      .simulate('click');
+
+    expect(onTabSelect).toBeCalledWith(tabsData[unselectedTabIndex].title);
+  });
+
+  it(' does not call the onTabSelect if the tab is disabled', () => {
+    const unselectedDisabledTabIndex = tabsData.findIndex(
+      (tab) => tab.title !== defaultProps.selectedTab && tab.isDisabled
+    );
+    wrapper
+      .find('.tab')
+      .at(unselectedDisabledTabIndex)
+      .simulate('click');
+
+    expect(onTabSelect).not.toBeCalled();
+  });
+
+  it(' applies the passed in default className', () => {
+    expect(
+      wrapper
+        .find('.tab')
+        .first()
+        .prop('className')
+    ).toContain(tabClassNames.default);
+  });
+
+  it(' applies the passed in selected className', () => {
+    const selectedTabIndex = tabsData.findIndex(
+      (tab) => tab.title === defaultProps.selectedTab
+    );
+    expect(
+      wrapper
+        .find('.tab')
+        .at(selectedTabIndex)
+        .prop('className')
+    ).toContain(tabClassNames.selected);
+  });
+
+  it(' applies the passed in disabled className', () => {
+    const disabledTabIndex = tabsData.findIndex((tab) => tab.isDisabled);
+    expect(
+      wrapper
+        .find('.tab')
+        .at(disabledTabIndex)
+        .prop('className')
+    ).toContain(tabClassNames.disabled);
+  });
+
+  it(' applies the passed in tabsContainer className', () => {
+    expect(wrapper.find('.tabsContainer').prop('className')).toContain(
+      tabClassNames.tabsContainer
+    );
+  });
+});

--- a/src/ensembl/src/shared/components/tabs/Tabs.test.tsx
+++ b/src/ensembl/src/shared/components/tabs/Tabs.test.tsx
@@ -5,7 +5,7 @@ import times from 'lodash/times';
 
 import Tabs, { Tab, TabsProps } from './Tabs';
 
-const onTabSelect = jest.fn();
+const onTabChange = jest.fn();
 
 const createTabGroup = (): Tab[] => {
   const options = times(10, () => ({
@@ -38,7 +38,7 @@ const tabClassNames = {
 const defaultProps = {
   tabs: tabsData,
   selectedTab: tabsData.find((tab) => !tab.isDisabled)?.title || '',
-  selectTab: onTabSelect,
+  onTabChange,
   classNames: tabClassNames
 };
 
@@ -65,8 +65,8 @@ describe('<Tabs />', () => {
       wrapper
         .find('.tab')
         .at(disabledTabIndex)
-        .prop('className')
-    ).toContain('disabled');
+        .hasClass('disabled')
+    ).toBeTruthy();
   });
 
   it('adds respective class to the selected tab', () => {
@@ -77,11 +77,11 @@ describe('<Tabs />', () => {
       wrapper
         .find('.tab')
         .at(selectedTabIndex)
-        .prop('className')
-    ).toContain('selected');
+        .hasClass('selected')
+    ).toBeTruthy();
   });
 
-  it('calls the onTabSelect function when a tab is selected', () => {
+  it('calls the onTabChange function when a tab is selected', () => {
     const unselectedTabIndex = tabsData.findIndex(
       (tab) => tab.title !== defaultProps.selectedTab && !tab.isDisabled
     );
@@ -90,10 +90,10 @@ describe('<Tabs />', () => {
       .at(unselectedTabIndex)
       .simulate('click');
 
-    expect(onTabSelect).toBeCalledWith(tabsData[unselectedTabIndex].title);
+    expect(onTabChange).toBeCalledWith(tabsData[unselectedTabIndex].title);
   });
 
-  it(' does not call the onTabSelect if the tab is disabled', () => {
+  it(' does not call the onTabChange if the tab is disabled', () => {
     const unselectedDisabledTabIndex = tabsData.findIndex(
       (tab) => tab.title !== defaultProps.selectedTab && tab.isDisabled
     );
@@ -102,19 +102,19 @@ describe('<Tabs />', () => {
       .at(unselectedDisabledTabIndex)
       .simulate('click');
 
-    expect(onTabSelect).not.toBeCalled();
+    expect(onTabChange).not.toBeCalled();
   });
 
-  it(' applies the passed in default className', () => {
+  it(' applies the passed in default class', () => {
     expect(
       wrapper
         .find('.tab')
         .first()
-        .prop('className')
-    ).toContain(tabClassNames.default);
+        .hasClass(tabClassNames.default)
+    ).toBeTruthy();
   });
 
-  it(' applies the passed in selected className', () => {
+  it(' applies the passed in selected class', () => {
     const selectedTabIndex = tabsData.findIndex(
       (tab) => tab.title === defaultProps.selectedTab
     );
@@ -122,23 +122,23 @@ describe('<Tabs />', () => {
       wrapper
         .find('.tab')
         .at(selectedTabIndex)
-        .prop('className')
-    ).toContain(tabClassNames.selected);
+        .hasClass(tabClassNames.selected)
+    ).toBeTruthy();
   });
 
-  it(' applies the passed in disabled className', () => {
+  it(' applies the passed in disabled class', () => {
     const disabledTabIndex = tabsData.findIndex((tab) => tab.isDisabled);
     expect(
       wrapper
         .find('.tab')
         .at(disabledTabIndex)
-        .prop('className')
-    ).toContain(tabClassNames.disabled);
+        .hasClass(tabClassNames.disabled)
+    ).toBeTruthy();
   });
 
-  it(' applies the passed in tabsContainer className', () => {
-    expect(wrapper.find('.tabsContainer').prop('className')).toContain(
-      tabClassNames.tabsContainer
-    );
+  it(' applies the passed in tabsContainer class', () => {
+    expect(
+      wrapper.find('.tabsContainer').hasClass(tabClassNames.tabsContainer)
+    ).toBeTruthy();
   });
 });

--- a/src/ensembl/src/shared/components/tabs/Tabs.test.tsx
+++ b/src/ensembl/src/shared/components/tabs/Tabs.test.tsx
@@ -37,7 +37,7 @@ const tabClassNames = {
 
 const defaultProps = {
   tabs: tabsData,
-  selectedTab: tabsData.find((tab) => !tab.isDisabled)?.title || '',
+  selectedTab: (tabsData.find((tab) => !tab.isDisabled) as Tab).title,
   onTabChange,
   classNames: tabClassNames
 };

--- a/src/ensembl/src/shared/components/tabs/Tabs.tsx
+++ b/src/ensembl/src/shared/components/tabs/Tabs.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React from 'react';
 import classNames from 'classnames';
+import noop from 'lodash/noop';
 
 import styles from './Tabs.scss';
 
@@ -17,28 +18,26 @@ export type TabsProps = {
     tabsContainer?: string;
   };
   selectedTab: string;
-  selectTab: (selectedTab: string) => void;
+  onTabChange: (selectedTab: string) => void;
 };
 
 export const Tabs = (props: TabsProps) => {
-  const [selectedTab, setSelectedTab] = useState(props.selectedTab);
-
   const getTabClassNames = (tab: Tab) => {
     const defaultClassNames = classNames(props.classNames?.default, styles.tab);
 
     const disabledClassNames = classNames(
-      props.classNames?.disabled,
-      styles.disabled
+      styles.disabled,
+      props.classNames?.disabled
     );
 
     const selectedClassNames = classNames(
-      props.classNames?.selected,
-      styles.selected
+      styles.selected,
+      props.classNames?.selected
     );
 
     return classNames(defaultClassNames, {
       [disabledClassNames]: tab.isDisabled,
-      [selectedClassNames]: tab.title === selectedTab
+      [selectedClassNames]: tab.title === props.selectedTab
     });
   };
 
@@ -48,8 +47,7 @@ export const Tabs = (props: TabsProps) => {
   );
 
   const onTabSelect = (tabTitle: string) => {
-    setSelectedTab(tabTitle);
-    props.selectTab(tabTitle);
+    props.onTabChange(tabTitle);
   };
 
   return (
@@ -58,7 +56,7 @@ export const Tabs = (props: TabsProps) => {
         <span
           className={getTabClassNames(tab)}
           key={tab.title}
-          onClick={tab.isDisabled ? () => null : () => onTabSelect(tab.title)}
+          onClick={tab.isDisabled ? noop : () => onTabSelect(tab.title)}
         >
           {tab.title}
         </span>

--- a/src/ensembl/src/shared/components/tabs/Tabs.tsx
+++ b/src/ensembl/src/shared/components/tabs/Tabs.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import classNames from 'classnames';
+
+import defaultStyles from './Tabs.scss';
+
+export type Tab = {
+  title: string;
+  isDisabled?: boolean;
+};
+
+export type TabsProps = {
+  tabs: Tab[];
+  classNames?: {
+    default?: string;
+    disabled?: string;
+    selected?: string;
+    tabsContainer?: string;
+  };
+  selectedTab: string;
+  selectTab: (selectedTab: string) => void;
+};
+
+export const Tabs = (props: TabsProps) => {
+  const [selectedTab, setSelectedTab] = useState(props.selectedTab);
+
+  const getTabClassNames = (tab: Tab) => {
+    const defaultClassNames = classNames(
+      props.classNames?.default,
+      defaultStyles.tab
+    );
+
+    const disabledClassNames = classNames(
+      props.classNames?.disabled,
+      defaultStyles.disabled
+    );
+
+    const selectedClassNames = classNames(
+      props.classNames?.selected,
+      defaultStyles.selected
+    );
+
+    return classNames(defaultClassNames, {
+      [disabledClassNames]: tab.isDisabled,
+      [selectedClassNames]: tab.title === selectedTab
+    });
+  };
+
+  const tabsContainerClassName = classNames(
+    defaultStyles.tabsContainer,
+    props.classNames?.tabsContainer
+  );
+
+  const onTabSelect = (tabTitle: string) => {
+    setSelectedTab(tabTitle);
+    props.selectTab(tabTitle);
+  };
+
+  return (
+    <div className={tabsContainerClassName}>
+      {Object.values(props.tabs).map((tab: Tab) => (
+        <span
+          className={getTabClassNames(tab)}
+          key={tab.title}
+          onClick={tab.isDisabled ? () => null : () => onTabSelect(tab.title)}
+        >
+          {tab.title}
+        </span>
+      ))}
+    </div>
+  );
+};
+
+export default Tabs;

--- a/src/ensembl/src/shared/components/tabs/Tabs.tsx
+++ b/src/ensembl/src/shared/components/tabs/Tabs.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import classNames from 'classnames';
 
-import defaultStyles from './Tabs.scss';
+import styles from './Tabs.scss';
 
 export type Tab = {
   title: string;
@@ -24,19 +24,16 @@ export const Tabs = (props: TabsProps) => {
   const [selectedTab, setSelectedTab] = useState(props.selectedTab);
 
   const getTabClassNames = (tab: Tab) => {
-    const defaultClassNames = classNames(
-      props.classNames?.default,
-      defaultStyles.tab
-    );
+    const defaultClassNames = classNames(props.classNames?.default, styles.tab);
 
     const disabledClassNames = classNames(
       props.classNames?.disabled,
-      defaultStyles.disabled
+      styles.disabled
     );
 
     const selectedClassNames = classNames(
       props.classNames?.selected,
-      defaultStyles.selected
+      styles.selected
     );
 
     return classNames(defaultClassNames, {
@@ -46,7 +43,7 @@ export const Tabs = (props: TabsProps) => {
   };
 
   const tabsContainerClassName = classNames(
-    defaultStyles.tabsContainer,
+    styles.tabsContainer,
     props.classNames?.tabsContainer
   );
 

--- a/src/ensembl/src/shared/components/tabs/Tabs.tsx
+++ b/src/ensembl/src/shared/components/tabs/Tabs.tsx
@@ -23,7 +23,7 @@ export type TabsProps = {
 
 export const Tabs = (props: TabsProps) => {
   const getTabClassNames = (tab: Tab) => {
-    const defaultClassNames = classNames(props.classNames?.default, styles.tab);
+    const defaultClassNames = classNames(styles.tab, props.classNames?.default);
 
     const disabledClassNames = classNames(
       styles.disabled,

--- a/src/ensembl/stories/shared-components/index.ts
+++ b/src/ensembl/stories/shared-components/index.ts
@@ -17,3 +17,5 @@ import './species-tabs-wrapper/SpeciesTabsWrapper.stories';
 import './upload/Upload.stories';
 import './textarea/Textarea.stories';
 import './slide-toggle/SlideToggle.stories';
+import './panel/Panel.stories';
+import './tabs/Tabs.stories';

--- a/src/ensembl/stories/shared-components/panel/Panel.stories.scss
+++ b/src/ensembl/stories/shared-components/panel/Panel.stories.scss
@@ -1,0 +1,42 @@
+@import 'src/styles/common';
+
+.fullPageWrapper {
+  display: flex;
+  padding: 20px;
+  align-items: flex-start;
+  height: 100vh;
+}
+
+.fullPagePanel {
+  width: 100%;
+  height: 100%;
+}
+
+.defaultTab {
+  &:first-of-type {
+    margin-left: 30px;
+  }
+  &:last-of-type {
+    margin-right: 30px;
+  }
+}
+
+.selectedTab {
+  background-color: transparent;
+  color: $black;
+  &::after {
+    border: 6px solid $grey;
+    border-color: transparent transparent $light-grey $light-grey;
+    box-shadow: -2px 2px 2px 0 $medium-light-grey;
+
+    width: 0;
+    height: 0;
+    box-sizing: border-box;
+    content: '';
+    position: absolute;
+    left: calc(50% - 8px);
+    transform-origin: 0 0;
+    transform: rotate(-45deg);
+    top: 28px;
+  }
+}

--- a/src/ensembl/stories/shared-components/panel/Panel.stories.tsx
+++ b/src/ensembl/stories/shared-components/panel/Panel.stories.tsx
@@ -42,15 +42,6 @@ storiesOf('Components|Shared Components/Panel', module)
       </Panel>
     </div>
   ))
-  .add('default-with-tabs', () => {
-    return (
-      <div className={styles.fullPageWrapper}>
-        <Panel header={tabs} onClose={onClose}>
-          <div>Panel Content</div>
-        </Panel>
-      </div>
-    );
-  })
   .add('full-page', () => (
     <div className={styles.fullPageWrapper}>
       <Panel
@@ -64,7 +55,7 @@ storiesOf('Components|Shared Components/Panel', module)
       </Panel>
     </div>
   ))
-  .add('full-page-with-tabs', () => {
+  .add('with-tabs', () => {
     return (
       <div className={styles.fullPageWrapper}>
         <Panel

--- a/src/ensembl/stories/shared-components/panel/Panel.stories.tsx
+++ b/src/ensembl/stories/shared-components/panel/Panel.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import faker from 'faker';
@@ -25,14 +25,24 @@ const tabClassNames = {
   selected: styles.selectedTab,
   default: styles.defaultTab
 };
-const tabs = (
-  <Tabs
-    tabs={tabsData}
-    classNames={tabClassNames}
-    selectedTab={'Proteins'}
-    selectTab={(tab: string) => action('selected-tab')(tab)}
-  ></Tabs>
-);
+
+const TabWrapper = () => {
+  const [selectedTab, setselectedTab] = useState('Proteins');
+
+  const onTabChange = (tab: string) => {
+    setselectedTab(tab);
+    action('selected-tab')(tab);
+  };
+
+  return (
+    <Tabs
+      tabs={tabsData}
+      selectedTab={selectedTab}
+      classNames={tabClassNames}
+      onTabChange={onTabChange}
+    />
+  );
+};
 
 storiesOf('Components|Shared Components/Panel', module)
   .add('default', () => (
@@ -59,7 +69,7 @@ storiesOf('Components|Shared Components/Panel', module)
     return (
       <div className={styles.fullPageWrapper}>
         <Panel
-          header={tabs}
+          header={<TabWrapper />}
           onClose={onClose}
           classNames={{
             panel: styles.fullPagePanel
@@ -74,7 +84,7 @@ storiesOf('Components|Shared Components/Panel', module)
     return (
       <div className={styles.fullPageWrapper}>
         <Panel
-          header={tabs}
+          header={<TabWrapper />}
           onClose={onClose}
           classNames={{
             panel: styles.fullPagePanel

--- a/src/ensembl/stories/shared-components/panel/Panel.stories.tsx
+++ b/src/ensembl/stories/shared-components/panel/Panel.stories.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import faker from 'faker';
+
+import Panel from 'src/shared/components/panel/Panel';
+import Tabs, { Tab } from 'src/shared/components/tabs/Tabs';
+
+import styles from './Panel.stories.scss';
+
+const onClose = () => {
+  action('panel-closed')();
+};
+
+const tabsData: Tab[] = [
+  { title: 'Proteins' },
+  { title: 'Variants' },
+  { title: 'Phenotypes' },
+  { title: 'Gene expression' },
+  { title: 'Gene ontology', isDisabled: true },
+  { title: 'Gene pathways' }
+];
+
+const tabClassNames = {
+  selected: styles.selectedTab,
+  default: styles.defaultTab
+};
+const tabs = (
+  <Tabs
+    tabs={tabsData}
+    classNames={tabClassNames}
+    selectedTab={'Proteins'}
+    selectTab={(tab: string) => action('selected-tab')(tab)}
+  ></Tabs>
+);
+
+storiesOf('Components|Shared Components/Panel', module)
+  .add('default', () => (
+    <div className={styles.fullPageWrapper}>
+      <Panel header={'Default Panel'} onClose={onClose}>
+        <div>Panel Content</div>
+      </Panel>
+    </div>
+  ))
+  .add('default-with-tabs', () => {
+    return (
+      <div className={styles.fullPageWrapper}>
+        <Panel header={tabs} onClose={onClose}>
+          <div>Panel Content</div>
+        </Panel>
+      </div>
+    );
+  })
+  .add('full-page', () => (
+    <div className={styles.fullPageWrapper}>
+      <Panel
+        header={'Full Page Panel'}
+        onClose={onClose}
+        classNames={{
+          panelClassName: styles.fullPagePanel
+        }}
+      >
+        <div>Panel Content</div>
+      </Panel>
+    </div>
+  ))
+  .add('full-page-with-tabs', () => {
+    return (
+      <div className={styles.fullPageWrapper}>
+        <Panel
+          header={tabs}
+          onClose={onClose}
+          classNames={{
+            panelClassName: styles.fullPagePanel
+          }}
+        >
+          <div>Panel Content</div>
+        </Panel>
+      </div>
+    );
+  })
+  .add('long-content', () => {
+    return (
+      <div className={styles.fullPageWrapper}>
+        <Panel
+          header={tabs}
+          onClose={onClose}
+          classNames={{
+            panelClassName: styles.fullPagePanel
+          }}
+        >
+          <div>{faker.lorem.paragraphs(100)}</div>
+        </Panel>
+      </div>
+    );
+  });

--- a/src/ensembl/stories/shared-components/panel/Panel.stories.tsx
+++ b/src/ensembl/stories/shared-components/panel/Panel.stories.tsx
@@ -80,6 +80,15 @@ storiesOf('Components|Shared Components/Panel', module)
       </div>
     );
   })
+  .add('long-header', () => {
+    return (
+      <div className={styles.fullPageWrapper}>
+        <Panel header={<TabWrapper />} onClose={onClose}>
+          <div>{faker.lorem.paragraphs(100)}</div>
+        </Panel>
+      </div>
+    );
+  })
   .add('long-content', () => {
     return (
       <div className={styles.fullPageWrapper}>

--- a/src/ensembl/stories/shared-components/panel/Panel.stories.tsx
+++ b/src/ensembl/stories/shared-components/panel/Panel.stories.tsx
@@ -57,7 +57,7 @@ storiesOf('Components|Shared Components/Panel', module)
         header={'Full Page Panel'}
         onClose={onClose}
         classNames={{
-          panelClassName: styles.fullPagePanel
+          panel: styles.fullPagePanel
         }}
       >
         <div>Panel Content</div>
@@ -71,7 +71,7 @@ storiesOf('Components|Shared Components/Panel', module)
           header={tabs}
           onClose={onClose}
           classNames={{
-            panelClassName: styles.fullPagePanel
+            panel: styles.fullPagePanel
           }}
         >
           <div>Panel Content</div>
@@ -86,7 +86,7 @@ storiesOf('Components|Shared Components/Panel', module)
           header={tabs}
           onClose={onClose}
           classNames={{
-            panelClassName: styles.fullPagePanel
+            panel: styles.fullPagePanel
           }}
         >
           <div>{faker.lorem.paragraphs(100)}</div>

--- a/src/ensembl/stories/shared-components/tabs/Tabs.stories.scss
+++ b/src/ensembl/stories/shared-components/tabs/Tabs.stories.scss
@@ -1,0 +1,87 @@
+@import 'src/styles/common';
+
+.fullPageWrapper {
+  display: flex;
+  padding: 20px;
+  align-items: flex-start;
+  height: 100vh;
+
+  &Dark {
+    background-color: $black;
+  }
+}
+
+.defaultTabDark {
+  background-color: #33adff;
+  color: #fff;
+  font-weight: 700;
+  border-radius: 3px;
+  margin-right: 3px;
+  height: 30px;
+}
+
+.disabledTabDark {
+  background-color: $grey;
+}
+
+.selectedTabDark {
+  background-color: transparent;
+  border: 1px solid $blue;
+
+  &::after {
+    width: 12px;
+    height: 12px;
+    background-color: $black;
+    border: 1px solid $blue;
+    border-color: transparent transparent $blue $blue;
+    box-shadow: none;
+    box-sizing: border-box;
+    content: '';
+    position: absolute;
+    left: calc(50% - 8px);
+    transform-origin: 0 0;
+    transform: rotate(-45deg);
+    top: 28px;
+  }
+}
+
+.defaultTabPanel {
+  background-color: transparent;
+  color: $blue;
+  font-weight: 700;
+  border-radius: 3px;
+  margin-right: 3px;
+  height: 30px;
+  border: none;
+}
+
+.disabledTabPanel {
+  color: $grey;
+}
+
+.selectedTabPanel {
+  background-color: transparent;
+  color: $black;
+  &::after {
+    border: 6px solid $grey;
+    border-color: transparent transparent $light-grey $light-grey;
+    box-shadow: -2px 2px 2px 0 $medium-light-grey;
+
+    width: 0;
+    height: 0;
+    box-sizing: border-box;
+    content: '';
+    position: absolute;
+    left: calc(50% - 8px);
+    transform-origin: 0 0;
+    transform: rotate(-45deg);
+    top: 28px;
+  }
+}
+
+.panelTabsContainer {
+  height: auto;
+  overflow: unset;
+  background-color: $light-grey;
+  box-shadow: 0 2px 2px 0 $medium-light-grey;
+}

--- a/src/ensembl/stories/shared-components/tabs/Tabs.stories.tsx
+++ b/src/ensembl/stories/shared-components/tabs/Tabs.stories.tsx
@@ -31,7 +31,7 @@ storiesOf('Components|Shared Components/Tabs', module)
       <div className={styles.fullPageWrapper}>{renderTabs(defaultProps)}</div>
     );
   })
-  .add('panel-header', () => {
+  .add('panel-header-style', () => {
     const tabClassNames = {
       default: styles.defaultTabPanel,
       selected: styles.selectedTabPanel,
@@ -45,7 +45,7 @@ storiesOf('Components|Shared Components/Tabs', module)
       </div>
     );
   })
-  .add('entity-viewer', () => {
+  .add('entity-viewer-style', () => {
     const tabClassNames = {
       default: styles.defaultTabDark,
       selected: styles.selectedTabDark,

--- a/src/ensembl/stories/shared-components/tabs/Tabs.stories.tsx
+++ b/src/ensembl/stories/shared-components/tabs/Tabs.stories.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import classNames from 'classnames';
 
-import Tabs, { TabsProps, Tab } from 'src/shared/components/tabs/Tabs';
+import Tabs, { Tab } from 'src/shared/components/tabs/Tabs';
 
 import styles from './Tabs.stories.scss';
 
@@ -16,20 +16,27 @@ const tabsData: Tab[] = [
   { title: 'Gene pathways' }
 ];
 
-const defaultProps = {
-  tabs: tabsData,
-  selectedTab: 'Proteins',
-  selectTab: (tab: string) => action('selected-tab')(tab)
-};
-const renderTabs = (props: TabsProps) => {
-  return <Tabs {...props}></Tabs>;
+const Wrapper = (props: any) => {
+  const [selectedTab, setselectedTab] = useState('Proteins');
+
+  const onTabChange = (tab: string) => {
+    setselectedTab(tab);
+    action('selected-tab')(tab);
+  };
+
+  return (
+    <Tabs
+      {...props}
+      tabs={tabsData}
+      selectedTab={selectedTab}
+      onTabChange={onTabChange}
+    ></Tabs>
+  );
 };
 
 storiesOf('Components|Shared Components/Tabs', module)
   .add('default', () => {
-    return (
-      <div className={styles.fullPageWrapper}>{renderTabs(defaultProps)}</div>
-    );
+    return <div className={styles.fullPageWrapper}>{<Wrapper />}</div>;
   })
   .add('panel-header-style', () => {
     const tabClassNames = {
@@ -41,7 +48,7 @@ storiesOf('Components|Shared Components/Tabs', module)
 
     return (
       <div className={styles.fullPageWrapper}>
-        {renderTabs({ ...defaultProps, classNames: tabClassNames })}
+        {<Wrapper classNames={tabClassNames} />}
       </div>
     );
   })
@@ -58,7 +65,7 @@ storiesOf('Components|Shared Components/Tabs', module)
     );
     return (
       <div className={wrapperClassNames}>
-        {renderTabs({ ...defaultProps, classNames: tabClassNames })}
+        {<Wrapper classNames={tabClassNames} />}
       </div>
     );
   });

--- a/src/ensembl/stories/shared-components/tabs/Tabs.stories.tsx
+++ b/src/ensembl/stories/shared-components/tabs/Tabs.stories.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import classNames from 'classnames';
+
+import Tabs, { TabsProps, Tab } from 'src/shared/components/tabs/Tabs';
+
+import styles from './Tabs.stories.scss';
+
+const tabsData: Tab[] = [
+  { title: 'Proteins' },
+  { title: 'Variants' },
+  { title: 'Phenotypes' },
+  { title: 'Gene expression' },
+  { title: 'Gene ontology', isDisabled: true },
+  { title: 'Gene pathways' }
+];
+
+const defaultProps = {
+  tabs: tabsData,
+  selectedTab: 'Proteins',
+  selectTab: (tab: string) => action('selected-tab')(tab)
+};
+const renderTabs = (props: TabsProps) => {
+  return <Tabs {...props}></Tabs>;
+};
+
+storiesOf('Components|Shared Components/Tabs', module)
+  .add('default', () => {
+    return (
+      <div className={styles.fullPageWrapper}>{renderTabs(defaultProps)}</div>
+    );
+  })
+  .add('panel-header', () => {
+    const tabClassNames = {
+      default: styles.defaultTabPanel,
+      selected: styles.selectedTabPanel,
+      disabled: styles.disabledTabPanel,
+      tabsContainer: styles.panelTabsContainer
+    };
+
+    return (
+      <div className={styles.fullPageWrapper}>
+        {renderTabs({ ...defaultProps, classNames: tabClassNames })}
+      </div>
+    );
+  })
+  .add('entity-viewer', () => {
+    const tabClassNames = {
+      default: styles.defaultTabDark,
+      selected: styles.selectedTabDark,
+      disabled: styles.disabledTabDark
+    };
+
+    const wrapperClassNames = classNames(
+      styles.fullPageWrapper,
+      styles.fullPageWrapperDark
+    );
+    return (
+      <div className={wrapperClassNames}>
+        {renderTabs({ ...defaultProps, classNames: tabClassNames })}
+      </div>
+    );
+  });


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [x] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-470

## Importance
Required for Entity viewer

## Description
This PR is to create the two shared components called `Panel` and `Tabs` that are currently required for the Entity viewer.

- The `Panel` works and looks more of the way it is required by the Entity viewer.

- The `Tabs` component will look very basic by default and it will have to be customised by using CSS for specific needs. I have added two different styles to the storybook which we will be using for the panel-with-tabs and Entity viewer.

## Views affected
Storybook

### Other effects
- [ ] I have checked any requirements for Google Analytics
- [x] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

