### PR TITLE
Fix the track panel bar button status

### DIFF
--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBar.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBar.tsx
@@ -59,7 +59,7 @@ export const TrackPanelBar = (props: TrackPanelBarProps) => {
     <>
       <div className={styles.sidebarIcon} key="search">
         <ImageButton
-          status={getViewIconStatus('search')}
+          status={Status.DISABLED}
           description="Track search"
           onClick={() => toggleModalView('search')}
           image={searchIcon}
@@ -67,7 +67,7 @@ export const TrackPanelBar = (props: TrackPanelBarProps) => {
       </div>
       <div className={styles.sidebarIcon} key="tracks-manager">
         <ImageButton
-          status={getViewIconStatus('tracks-manager')}
+          status={Status.DISABLED}
           description="Tracks manager"
           onClick={() => toggleModalView('tracks-manager')}
           image={tracksManagerIcon}
@@ -83,7 +83,7 @@ export const TrackPanelBar = (props: TrackPanelBarProps) => {
       </div>
       <div className={styles.sidebarIcon} key="personal-data">
         <ImageButton
-          status={getViewIconStatus('personal-data')}
+          status={Status.DISABLED}
           description="Personal data"
           onClick={() => toggleModalView('personal-data')}
           image={personalDataIcon}
@@ -91,7 +91,7 @@ export const TrackPanelBar = (props: TrackPanelBarProps) => {
       </div>
       <div className={styles.sidebarIcon} key="share">
         <ImageButton
-          status={getViewIconStatus('share')}
+          status={Status.DISABLED}
           description="Share"
           onClick={() => toggleModalView('share')}
           image={shareIcon}
@@ -99,7 +99,7 @@ export const TrackPanelBar = (props: TrackPanelBarProps) => {
       </div>
       <div className={styles.sidebarIcon} key="downloads">
         <ImageButton
-          status={getViewIconStatus('downloads')}
+          status={Status.DISABLED}
           description="Downloads"
           onClick={() => toggleModalView('downloads')}
           image={downloadIcon}


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
[ENSWBSITES-478](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-478)

## Description
The status of track panel bar buttons, except for bookmarks, need to be disabled. The code changes was made for this in a previous PR (#238) but was then overwritten by a code merge, which I failed to spot. So have fixed it in this PR.

## Views affected
Track panel bar in genome browser
