### PR TITLE
Add tracking for browser navigation inputs

### DIFF
--- a/src/ensembl/src/content/app/browser/browser-region-editor/BrowserRegionEditor.tsx
+++ b/src/ensembl/src/content/app/browser/browser-region-editor/BrowserRegionEditor.tsx
@@ -29,6 +29,8 @@ import {
 } from 'src/shared/helpers/numberFormatter';
 import { validateRegion, RegionValidationErrors } from '../browserHelper';
 
+import analyticsTracking from 'src/services/analytics-service';
+
 import applyIcon from 'static/img/shared/apply.svg';
 
 import styles from './BrowserRegionEditor.scss';
@@ -142,8 +144,20 @@ export const BrowserRegionEditor = (props: BrowserRegionEditorProps) => {
 
     if (stickInput === stick) {
       changeLocation(newChrLocation);
+
+      analyticsTracking.trackEvent({
+        category: 'browser_navigation',
+        label: 'region_editor_location',
+        action: 'change'
+      });
     } else {
       props.changeFocusObject(regionId);
+
+      analyticsTracking.trackEvent({
+        category: 'browser_navigation',
+        label: 'region_editor_focus',
+        action: 'change'
+      });
     }
   };
 

--- a/src/ensembl/src/content/app/browser/browser-region-editor/BrowserRegionEditor.tsx
+++ b/src/ensembl/src/content/app/browser/browser-region-editor/BrowserRegionEditor.tsx
@@ -144,21 +144,15 @@ export const BrowserRegionEditor = (props: BrowserRegionEditorProps) => {
 
     if (stickInput === stick) {
       changeLocation(newChrLocation);
-
-      analyticsTracking.trackEvent({
-        category: 'browser_navigation',
-        label: 'region_editor_location',
-        action: 'change'
-      });
     } else {
       props.changeFocusObject(regionId);
-
-      analyticsTracking.trackEvent({
-        category: 'browser_navigation',
-        label: 'region_editor_focus',
-        action: 'change'
-      });
     }
+
+    analyticsTracking.trackEvent({
+      category: 'browser_navigation',
+      label: 'region_editor',
+      action: 'change_region'
+    });
   };
 
   const closeForm = (event: Event) => {

--- a/src/ensembl/src/content/app/browser/browser-region-field/BrowserRegionField.tsx
+++ b/src/ensembl/src/content/app/browser/browser-region-field/BrowserRegionField.tsx
@@ -93,21 +93,15 @@ export const BrowserRegionField = (props: BrowserRegionFieldProps) => {
         ensObjectId: null,
         chrLocation: newChrLocation
       });
-
-      analyticsTracking.trackEvent({
-        category: 'browser_navigation',
-        label: 'region_field_location',
-        action: 'change'
-      });
     } else {
       props.changeFocusObject(regionId);
-
-      analyticsTracking.trackEvent({
-        category: 'browser_navigation',
-        label: 'region_field_focus',
-        action: 'change'
-      });
     }
+
+    analyticsTracking.trackEvent({
+      category: 'browser_navigation',
+      label: 'region_field',
+      action: 'change_region'
+    });
   };
 
   const closeForm = (event: Event) => {

--- a/src/ensembl/src/content/app/browser/browser-region-field/BrowserRegionField.tsx
+++ b/src/ensembl/src/content/app/browser/browser-region-field/BrowserRegionField.tsx
@@ -24,6 +24,8 @@ import {
   RegionValidationErrors
 } from '../browserHelper';
 
+import analyticsTracking from 'src/services/analytics-service';
+
 import applyIcon from 'static/img/shared/apply.svg';
 
 import styles from './BrowserRegionField.scss';
@@ -91,8 +93,20 @@ export const BrowserRegionField = (props: BrowserRegionFieldProps) => {
         ensObjectId: null,
         chrLocation: newChrLocation
       });
+
+      analyticsTracking.trackEvent({
+        category: 'browser_navigation',
+        label: 'region_field_location',
+        action: 'change'
+      });
     } else {
       props.changeFocusObject(regionId);
+
+      analyticsTracking.trackEvent({
+        category: 'browser_navigation',
+        label: 'region_field_focus',
+        action: 'change'
+      });
     }
   };
 

--- a/src/ensembl/src/content/app/browser/browserActions.ts
+++ b/src/ensembl/src/content/app/browser/browserActions.ts
@@ -20,7 +20,8 @@ import {
   getBrowserTrackStates,
   getChrLocation,
   getBrowserMessageCount,
-  getBrowserActiveEnsObjectIds
+  getBrowserActiveEnsObjectIds,
+  getBrowserNavOpened
 } from './browserSelectors';
 
 import { updatePreviouslyViewedObjectsAndSave } from 'src/content/app/browser/track-panel/trackPanelActions';
@@ -40,6 +41,7 @@ import {
 } from './browserState';
 import { TrackActivityStatus } from 'src/content/app/browser/track-panel/trackPanelConfig';
 import { Status } from 'src/shared/types/status';
+import analyticsTracking from 'src/services/analytics-service';
 
 export type UpdateTrackStatesPayload = {
   genomeId: string;
@@ -199,9 +201,37 @@ export const restoreBrowserTrackStates: ActionCreator<ThunkAction<
   });
 };
 
-export const toggleBrowserNav = createAction(
-  'browser/toggle-browser-navigation'
+export const openBrowserNav = createAction(
+  'browser/open-browser-navigation',
+  () => {
+    analyticsTracking.trackEvent({
+      category: 'browser_navigation',
+      label: 'open_browser_navigation',
+      action: 'clicked'
+    });
+  }
 )();
+
+export const closeBrowserNav = createAction(
+  'browser/close-browser-navigation'
+)();
+
+export const toggleBrowserNav: ActionCreator<ThunkAction<
+  any,
+  any,
+  null,
+  Action<string>
+>> = () => {
+  return (dispatch: Dispatch, getState: () => RootState) => {
+    const isBrowserNavOpened = getBrowserNavOpened(getState());
+
+    if (isBrowserNavOpened) {
+      dispatch(closeBrowserNav());
+    } else {
+      dispatch(openBrowserNav());
+    }
+  };
+};
 
 export const updateBrowserNavStates = createAction(
   'browser/update-browser-nav-states'

--- a/src/ensembl/src/content/app/browser/browserReducer.ts
+++ b/src/ensembl/src/content/app/browser/browserReducer.ts
@@ -66,8 +66,10 @@ export function browserNav(
   action: ActionType<typeof browserActions>
 ) {
   switch (action.type) {
-    case getType(browserActions.toggleBrowserNav):
-      return { ...state, browserNavOpened: !state.browserNavOpened };
+    case getType(browserActions.openBrowserNav):
+      return { ...state, browserNavOpened: true };
+    case getType(browserActions.closeBrowserNav):
+      return { ...state, browserNavOpened: false };
     case getType(browserActions.updateBrowserNavStates):
       return { ...state, browserNavStates: action.payload };
     default:


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
[ENSWBSITES-379](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-379)

## Description
Add google analytics tracking for browser navigation. There were three areas that were covered:

- Browser navigation opening
- Browser region editor usage
- Browser region field usage

The questions that need to be answered by the GA events are:
- How often do the users open the navigation bar?
- How often are the users using the region field and region editor?
