### PR TITLE
Refactor image button classes

### DIFF
--- a/src/ensembl/src/content/app/browser/browser-reset/BrowserReset.tsx
+++ b/src/ensembl/src/content/app/browser/browser-reset/BrowserReset.tsx
@@ -40,15 +40,14 @@ export const BrowserReset: FunctionComponent<BrowserResetProps> = (
   };
 
   return (
-    <div className={styles.resetButton}>
-      <ImageButton
-        status={getResetIconStatus()}
-        description={'Reset browser image'}
-        image={resetIcon}
-        onClick={handleClick}
-        classNames={{ disabled: styles.imageButtonDisabled }}
-      />
-    </div>
+    <ImageButton
+      status={getResetIconStatus()}
+      description={'Reset browser image'}
+      image={resetIcon}
+      onClick={handleClick}
+      className={styles.resetButton}
+      statusClasses={{ disabled: styles.imageButtonDisabled }}
+    />
   );
 };
 

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar-toolstrip/EntityViewerSidebarToolstrip.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar-toolstrip/EntityViewerSidebarToolstrip.tsx
@@ -15,38 +15,38 @@ import styles from 'src/shared/components/layout/StandardAppLayout.scss';
 export const EntityViewerSidebarToolstrip = () => {
   return (
     <>
-      <div className={styles.sidebarIcon} key="search">
-        <ImageButton
-          status={Status.DISABLED}
-          description="Search"
-          onClick={noop}
-          image={searchIcon}
-        />
-      </div>
-      <div className={styles.sidebarIcon} key="bookmarks">
-        <ImageButton
-          status={Status.DISABLED}
-          description="Bookmarks"
-          onClick={noop}
-          image={bookmarkIcon}
-        />
-      </div>
-      <div className={styles.sidebarIcon} key="share">
-        <ImageButton
-          status={Status.DISABLED}
-          description="Share"
-          onClick={noop}
-          image={shareIcon}
-        />
-      </div>
-      <div className={styles.sidebarIcon} key="downloads">
-        <ImageButton
-          status={Status.DISABLED}
-          description="Downloads"
-          onClick={noop}
-          image={downloadIcon}
-        />
-      </div>
+      <ImageButton
+        status={Status.DISABLED}
+        description="Search"
+        className={styles.sidebarIcon}
+        key="search"
+        onClick={noop}
+        image={searchIcon}
+      />
+      <ImageButton
+        status={Status.DISABLED}
+        description="Bookmarks"
+        className={styles.sidebarIcon}
+        key="bookmarks"
+        onClick={noop}
+        image={bookmarkIcon}
+      />
+      <ImageButton
+        status={Status.DISABLED}
+        description="Share"
+        className={styles.sidebarIcon}
+        key="share"
+        onClick={noop}
+        image={shareIcon}
+      />
+      <ImageButton
+        status={Status.DISABLED}
+        description="Downloads"
+        className={styles.sidebarIcon}
+        key="downloads"
+        onClick={noop}
+        image={downloadIcon}
+      />
     </>
   );
 };

--- a/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.tsx
+++ b/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.tsx
@@ -100,7 +100,7 @@ const HomepageAppLinksRow = (props: HomepageAppLinksRowProps) => {
       {speciesName}
       <div>
         <ImageButton
-          classNames={{
+          statusClasses={{
             [Status.DEFAULT]: styles.speciesHomeButton
           }}
           status={Status.DEFAULT}
@@ -112,7 +112,7 @@ const HomepageAppLinksRow = (props: HomepageAppLinksRowProps) => {
         <span className={styles.viewIn}>View in</span>
         <Link className={styles.homepageAppLink} to={urlFor.browser()}>
           <ImageButton
-            classNames={{
+            statusClasses={{
               [Status.DEFAULT]: styles.homepageAppLinkButton
             }}
             status={Status.DEFAULT}
@@ -122,7 +122,7 @@ const HomepageAppLinksRow = (props: HomepageAppLinksRowProps) => {
         </Link>
         <Link className={styles.homepageAppLink} to={urlFor.entityViewer()}>
           <ImageButton
-            classNames={{
+            statusClasses={{
               [Status.DEFAULT]: styles.homepageAppLinkButton
             }}
             status={Status.DEFAULT}

--- a/src/ensembl/src/header/header-buttons/HeaderButtons.scss
+++ b/src/ensembl/src/header/header-buttons/HeaderButtons.scss
@@ -1,4 +1,4 @@
-.buttonWrapper {
+.button {
   display: inline-block;
   bottom: 1px;
   height: 17px;

--- a/src/ensembl/src/header/header-buttons/HeaderButtons.tsx
+++ b/src/ensembl/src/header/header-buttons/HeaderButtons.tsx
@@ -24,24 +24,22 @@ type OwnProps = {};
 type HeaderButtonsProps = StateProps & DispatchProps & OwnProps;
 
 export const HeaderButtons: FunctionComponent<HeaderButtonsProps> = (props) => (
-  <div className={styles.headerButtons}>
-    <div className={styles.buttonWrapper}>
-      <ImageButton
-        image={LaunchbarIcon}
-        description="Ensembl app launchbar"
-        onClick={props.toggleLaunchbar}
-      />
-    </div>
-    <div className={styles.buttonWrapper}>
-      <ImageButton
-        image={UserIcon}
-        description="Ensembl account"
-        status={Status.DISABLED}
-        classNames={{
-          [Status.DISABLED]: styles.headerButtonDisabled
-        }}
-      />
-    </div>
+  <div>
+    <ImageButton
+      image={LaunchbarIcon}
+      description="Ensembl app launchbar"
+      className={styles.button}
+      onClick={props.toggleLaunchbar}
+    />
+    <ImageButton
+      image={UserIcon}
+      description="Ensembl account"
+      status={Status.DISABLED}
+      className={styles.button}
+      statusClasses={{
+        [Status.DISABLED]: styles.headerButtonDisabled
+      }}
+    />
   </div>
 );
 

--- a/src/ensembl/src/header/launchbar/LaunchbarButton.tsx
+++ b/src/ensembl/src/header/launchbar/LaunchbarButton.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import { NavLink } from 'react-router-dom';
 import { withRouter, RouteComponentProps } from 'react-router';
+
 import ImageButton, {
   ImageButtonStatus
 } from 'src/shared/components/image-button/ImageButton';
@@ -28,7 +29,8 @@ const LaunchbarButton: FunctionComponent<LaunchbarButtonProps> = (
 
   const imageButton = (
     <ImageButton
-      classNames={{
+      className={props.enabled ? '' : styles.launchbarButton}
+      statusClasses={{
         [Status.UNSELECTED]: styles.launchbarButtonImage,
         [Status.SELECTED]: styles.launchbarButtonSelectedImage,
         [Status.DISABLED]: styles.launchbarButtonDisabledImage
@@ -48,11 +50,7 @@ const LaunchbarButton: FunctionComponent<LaunchbarButtonProps> = (
       {imageButton}
     </NavLink>
   ) : (
-    <div
-      className={`${styles.launchbarButton} ${styles.launchbarButtonDisabled}`}
-    >
-      {imageButton}
-    </div>
+    imageButton
   );
 };
 

--- a/src/ensembl/src/shared/components/image-button/ImageButton.tsx
+++ b/src/ensembl/src/shared/components/image-button/ImageButton.tsx
@@ -4,12 +4,11 @@ import classNames from 'classnames';
 
 import useHover from 'src/shared/hooks/useHover';
 
-import defaultStyles from './ImageButton.scss';
 import Tooltip from 'src/shared/components/tooltip/Tooltip';
 
-import imageButtonStyles from './ImageButton.scss';
-
 import { Status } from 'src/shared/types/status';
+
+import imageButtonStyles from './ImageButton.scss';
 
 export type ImageButtonStatus =
   | Status.DEFAULT
@@ -21,7 +20,8 @@ export type Props = {
   status: ImageButtonStatus;
   description: string;
   image: React.FunctionComponent<React.SVGProps<SVGSVGElement>> | string;
-  classNames?: { [key in ImageButtonStatus]?: string };
+  className?: string;
+  statusClasses?: { [key in ImageButtonStatus]?: string };
   onClick?: () => void;
 };
 
@@ -35,12 +35,13 @@ export const ImageButton = (props: Props) => {
   const buttonProps =
     props.status === Status.DISABLED ? {} : { onClick: handleClick };
 
-  const styles = props.classNames
-    ? { ...defaultStyles, ...props.classNames }
-    : defaultStyles;
+  const styles = props.statusClasses
+    ? { ...imageButtonStyles, ...props.statusClasses }
+    : imageButtonStyles;
 
   const imageButtonClasses = classNames(
     imageButtonStyles.imageButton,
+    props.className,
     styles[props.status]
   );
 

--- a/src/ensembl/src/shared/components/visibility-icon/VisibilityIcon.tsx
+++ b/src/ensembl/src/shared/components/visibility-icon/VisibilityIcon.tsx
@@ -41,7 +41,7 @@ export const VisibilityIcon = (props: VisibilityIconProps) => {
       status={imageButtonStatus}
       image={eyeIcon}
       description={props.description}
-      classNames={{
+      statusClasses={{
         [Status.DEFAULT]: className,
         [Status.SELECTED]: styles.selected,
         [Status.UNSELECTED]: styles.unselected


### PR DESCRIPTION
## Type
- Refactoring

## Related JIRA Issue(s)
[ENSWBSITES-527](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-527)

## Description
This PR adds an extra prop to `ImageButton` to receive a class to style the button itself. This will get rid of the need to use a wrapper `div` to style it.

## Views affected
Wherever `ImageButton` is used
