### PR TITLE
Make sidebar slide over EV content view when open

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
@@ -71,6 +71,7 @@ const EntityViewer = (props: Props) => {
             sidebarNavigation={<GeneViewSidebarTabs />}
             sidebarToolstripContent={<EntityViewerSidebarToolstrip />}
             topbarContent={<EntityViewerTopbar />}
+            isSidebarFloating={true}
             isSidebarOpen={props.isSidebarOpen}
             onSidebarToggle={props.toggleSidebar}
             isDrawerOpen={false}

--- a/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
@@ -30,6 +30,7 @@ import GeneViewSidebarTabs from './gene-view/components/gene-view-sidebar-tabs/G
 import { RootState } from 'src/store';
 import { EnsObject } from 'src/shared/state/ens-object/ensObjectTypes';
 import { SidebarStatus } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarState';
+import { SidebarBehaviourType } from 'src/shared/components/layout/StandardAppLayout';
 
 import styles from './EntityViewer.scss';
 
@@ -67,11 +68,11 @@ const EntityViewer = (props: Props) => {
         {params.entityId ? (
           <StandardAppLayout
             mainContent={<GeneView />}
+            topbarContent={<EntityViewerTopbar />}
             sidebarContent={<GeneViewSideBar />}
             sidebarNavigation={<GeneViewSidebarTabs />}
             sidebarToolstripContent={<EntityViewerSidebarToolstrip />}
-            topbarContent={<EntityViewerTopbar />}
-            isSidebarFloating={true}
+            sidebarBehaviour={SidebarBehaviourType.SLIDEOVER}
             isSidebarOpen={props.isSidebarOpen}
             onSidebarToggle={props.toggleSidebar}
             isDrawerOpen={false}

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
@@ -70,10 +70,6 @@ $drawerWindowWidth: 45px;
     );
   }
 
-  &Floating {
-    z-index: 4;
-  }
-
   &DrawerOpen {
     transform: translateX(#{$drawerWindowWidth});
   }

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
@@ -68,6 +68,7 @@ $drawerWindowWidth: 45px;
     transform: translateX(
       calc(100% - #{$sidebarContentWidth} - #{$sidebarToolstripWidth})
     );
+    z-index: 4;
   }
 
   &DrawerOpen {

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
@@ -68,6 +68,9 @@ $drawerWindowWidth: 45px;
     transform: translateX(
       calc(100% - #{$sidebarContentWidth} - #{$sidebarToolstripWidth})
     );
+  }
+
+  &Floating {
     z-index: 4;
   }
 

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.test.tsx
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.test.tsx
@@ -82,11 +82,10 @@ describe('StandardAppLayout', () => {
       ).toBe(1);
     });
 
-    it.only('main content remains full width when sidebar behaviour is slideover', () => {
+    it('does not change main area styles when sidebar slides over it', () => {
       const props = {
         ...minimalProps,
-        sidebarBehaviour: SidebarBehaviourType.SLIDEOVER,
-        isSidebarOpen: true
+        sidebarBehaviour: SidebarBehaviourType.SLIDEOVER
       };
       const wrapper = render(<StandardAppLayout {...props} />);
       const mainContent = wrapper.find('.main');

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.test.tsx
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.test.tsx
@@ -82,6 +82,17 @@ describe('StandardAppLayout', () => {
       ).toBe(1);
     });
 
+    it('floats the sidebar over the main content when isSidebarFloating set to true', () => {
+      const props = {
+        ...minimalProps,
+        isSidebarFloating: true,
+        isSidebarOpen: true
+      };
+      const wrapper = render(<StandardAppLayout {...props} />);
+      const sidebarWrapper = wrapper.find('.sidebarWrapper');
+      expect(sidebarWrapper.hasClass('sidebarWrapperFloating')).toBe(true);
+    });
+
     describe('with drawer', () => {
       const props = {
         ...minimalProps,

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.test.tsx
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.test.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { mount, render } from 'enzyme';
 import faker from 'faker';
 
-import { BreakpointWidth } from 'src/global/globalConfig';
+import StandardAppLayout, { SidebarBehaviourType } from './StandardAppLayout';
 
-import StandardAppLayout from './StandardAppLayout';
+import { BreakpointWidth } from 'src/global/globalConfig';
 
 const MainContent = () => (
   <div className="mainContent">This is main content</div>
@@ -82,15 +82,15 @@ describe('StandardAppLayout', () => {
       ).toBe(1);
     });
 
-    it('floats the sidebar over the main content when isSidebarFloating set to true', () => {
+    it.only('main content remains full width when sidebar behaviour is slideover', () => {
       const props = {
         ...minimalProps,
-        isSidebarFloating: true,
+        sidebarBehaviour: SidebarBehaviourType.SLIDEOVER,
         isSidebarOpen: true
       };
       const wrapper = render(<StandardAppLayout {...props} />);
-      const sidebarWrapper = wrapper.find('.sidebarWrapper');
-      expect(sidebarWrapper.hasClass('sidebarWrapperFloating')).toBe(true);
+      const mainContent = wrapper.find('.main');
+      expect(mainContent.hasClass('mainFullWidth')).toBe(true);
     });
 
     describe('with drawer', () => {

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
@@ -26,6 +26,7 @@ type StandardAppLayoutProps = {
   sidebarToolstripContent?: ReactNode;
   sidebarNavigation: ReactNode;
   topbarContent: ReactNode;
+  isSidebarFloating?: boolean;
   isSidebarOpen: boolean;
   onSidebarToggle: () => void;
   isDrawerOpen: boolean;
@@ -45,8 +46,8 @@ const StandardAppLayout = (props: StandardAppLayoutProps) => {
 
   const mainClassNames = classNames(
     styles.main,
-    { [styles.mainDefault]: props.isSidebarOpen },
-    { [styles.mainFullWidth]: !props.isSidebarOpen }
+    { [styles.mainDefault]: props.isSidebarOpen && !props.isSidebarFloating },
+    { [styles.mainFullWidth]: !props.isSidebarOpen || props.isSidebarFloating }
   );
 
   const shouldShowSidebarNavigation =
@@ -103,6 +104,7 @@ const StandardAppLayout = (props: StandardAppLayoutProps) => {
 
 StandardAppLayout.defaultProps = {
   isDrawerOpen: false,
+  isSidebarFloating: false,
   onDrawerClose: noop
 };
 

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
@@ -139,6 +139,10 @@ const useSidebarWrapperClassNames = (props: StandardAppLayoutProps) => {
     { [styles.sidebarWrapperOpen]: props.isSidebarOpen },
     { [styles.sidebarWrapperClosed]: !props.isSidebarOpen },
     {
+      [styles.sidebarWrapperFloating]:
+        props.isSidebarOpen && props.isSidebarFloating
+    },
+    {
       [styles.sidebarWrapperDrawerOpen]: props.isDrawerOpen ?? false
     },
     { [styles.instantaneous]: isInstantaneous }

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
@@ -15,6 +15,11 @@ enum SidebarModeToggleAction {
   CLOSE = 'close'
 }
 
+export enum SidebarBehaviourType {
+  PUSH = 'push',
+  SLIDEOVER = 'slideover'
+}
+
 type SidebarModeToggleProps = {
   onClick: () => void;
   showAction: SidebarModeToggleAction;
@@ -26,7 +31,7 @@ type StandardAppLayoutProps = {
   sidebarToolstripContent?: ReactNode;
   sidebarNavigation: ReactNode;
   topbarContent: ReactNode;
-  isSidebarFloating?: boolean;
+  sidebarBehaviour: SidebarBehaviourType;
   isSidebarOpen: boolean;
   onSidebarToggle: () => void;
   isDrawerOpen: boolean;
@@ -46,8 +51,16 @@ const StandardAppLayout = (props: StandardAppLayoutProps) => {
 
   const mainClassNames = classNames(
     styles.main,
-    { [styles.mainDefault]: props.isSidebarOpen && !props.isSidebarFloating },
-    { [styles.mainFullWidth]: !props.isSidebarOpen || props.isSidebarFloating }
+    {
+      [styles.mainDefault]:
+        props.isSidebarOpen &&
+        props.sidebarBehaviour === SidebarBehaviourType.PUSH
+    },
+    {
+      [styles.mainFullWidth]:
+        !props.isSidebarOpen ||
+        props.sidebarBehaviour === SidebarBehaviourType.SLIDEOVER
+    }
   );
 
   const shouldShowSidebarNavigation =
@@ -104,7 +117,7 @@ const StandardAppLayout = (props: StandardAppLayoutProps) => {
 
 StandardAppLayout.defaultProps = {
   isDrawerOpen: false,
-  isSidebarFloating: false,
+  sidebarBehaviour: SidebarBehaviourType.PUSH,
   onDrawerClose: noop
 };
 
@@ -138,10 +151,6 @@ const useSidebarWrapperClassNames = (props: StandardAppLayoutProps) => {
     styles.sidebarWrapper,
     { [styles.sidebarWrapperOpen]: props.isSidebarOpen },
     { [styles.sidebarWrapperClosed]: !props.isSidebarOpen },
-    {
-      [styles.sidebarWrapperFloating]:
-        props.isSidebarOpen && props.isSidebarFloating
-    },
     {
       [styles.sidebarWrapperDrawerOpen]: props.isDrawerOpen ?? false
     },

--- a/src/ensembl/stories/shared-components/layout/Layout.stories.tsx
+++ b/src/ensembl/stories/shared-components/layout/Layout.stories.tsx
@@ -87,11 +87,15 @@ const Wrapper = (props: {
         sidebarNavigation={<SidebarNavigation />}
         sidebarToolstripContent={<SidebarToolstripContent />}
         drawerContent={props.drawerContent || null}
-        sidebarBehaviour={props.sidebarBehaviour || SidebarBehaviourType.PUSH}
+        {...(props.sidebarBehaviour
+          ? { sidebarBehaviour: props.sidebarBehaviour }
+          : null)}
         isSidebarOpen={props.isSidebarOpen}
-        isDrawerOpen={props.isDrawerOpen || false}
+        {...(props.isDrawerOpen ? { isDrawerOpen: props.isDrawerOpen } : null)}
         onSidebarToggle={props.onSidebarToggle}
-        onDrawerClose={props.onDrawerClose}
+        {...(props.onDrawerClose
+          ? { onDrawerClose: props.onDrawerClose }
+          : null)}
         viewportWidth={BreakpointWidth.BIG_DESKTOP}
       />
     </div>

--- a/src/ensembl/stories/shared-components/layout/Layout.stories.tsx
+++ b/src/ensembl/stories/shared-components/layout/Layout.stories.tsx
@@ -83,20 +83,10 @@ const Wrapper = (props: {
       <StandardAppLayout
         mainContent={<MainContent />}
         topbarContent={<TopbarContent />}
-        sidebarContent={props.sidebarContent}
         sidebarNavigation={<SidebarNavigation />}
         sidebarToolstripContent={<SidebarToolstripContent />}
-        drawerContent={props.drawerContent || null}
-        {...(props.sidebarBehaviour
-          ? { sidebarBehaviour: props.sidebarBehaviour }
-          : null)}
-        isSidebarOpen={props.isSidebarOpen}
-        {...(props.isDrawerOpen ? { isDrawerOpen: props.isDrawerOpen } : null)}
-        onSidebarToggle={props.onSidebarToggle}
-        {...(props.onDrawerClose
-          ? { onDrawerClose: props.onDrawerClose }
-          : null)}
         viewportWidth={BreakpointWidth.BIG_DESKTOP}
+        {...props}
       />
     </div>
   );

--- a/src/ensembl/stories/shared-components/layout/Layout.stories.tsx
+++ b/src/ensembl/stories/shared-components/layout/Layout.stories.tsx
@@ -7,6 +7,7 @@ import { StandardAppLayout } from 'src/shared/components/layout';
 import { SecondaryButton } from 'src/shared/components/button/Button';
 
 import styles from './Layout.stories.scss';
+import { SidebarBehaviourType } from 'src/shared/components/layout/StandardAppLayout';
 
 const TopbarContent = () => (
   <div className={styles.topbarContent}>This is top bar content</div>
@@ -72,6 +73,7 @@ const Wrapper = (props: {
   isSidebarOpen: boolean;
   isDrawerOpen?: boolean;
   sidebarContent: ReactNode;
+  sidebarBehaviour?: SidebarBehaviourType;
   drawerContent?: ReactNode;
   onSidebarToggle: () => void;
   onDrawerClose?: () => void;
@@ -85,6 +87,7 @@ const Wrapper = (props: {
         sidebarNavigation={<SidebarNavigation />}
         sidebarToolstripContent={<SidebarToolstripContent />}
         drawerContent={props.drawerContent || null}
+        sidebarBehaviour={props.sidebarBehaviour || SidebarBehaviourType.PUSH}
         isSidebarOpen={props.isSidebarOpen}
         isDrawerOpen={props.isDrawerOpen || false}
         onSidebarToggle={props.onSidebarToggle}
@@ -136,6 +139,21 @@ storiesOf('Components|Shared Components/Layout/StandardAppLayout', module)
         isDrawerOpen={isDrawerOpen}
         drawerContent={<DrawerContent />}
         onDrawerClose={closeDrawer}
+      />
+    );
+  })
+  .add('with slideover sidebar', () => {
+    const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+    const toggleSidebar = () => {
+      setIsSidebarOpen(!isSidebarOpen);
+    };
+
+    return (
+      <Wrapper
+        isSidebarOpen={isSidebarOpen}
+        sidebarContent={<SidebarContentSimple />}
+        sidebarBehaviour={SidebarBehaviourType.SLIDEOVER}
+        onSidebarToggle={toggleSidebar}
       />
     );
   });


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
[ENSWBSITES-517](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-517)

## Description
This PR adds the capability of the standard app layout sidebar to slide over the main content. This is necessary for EV, whereas the GB behaviour will remain the same (sidebar does not slide over).

## Views affected
Entity Viewer