### PR TITLE
Deploy feature branches to WP-HX

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -165,25 +165,10 @@ Test_N_Build:internal:
   - dev
 
 Test_N_Build:feature:
-  image: node:12.13.0
-  stage: test_build_static
-
-  before_script:
-  - cd src/ensembl
-  - npm ci
-
-  script:
-  - npm run test
-  - export NODE_ENV=development
-  - export GOOGLE_ANALYTICS_KEY=${GA_KEY}
-  - export ENVIRONMENT=development
-  - export API_HOST=""
-  - npm run build
-
-  artifacts:
-    name: static_assets_feature
-    paths:
-    - src/ensembl/dist/
+  extends: .build-static
+  variables:
+    ENVIRONMENT: development
+    API_HOST: ""
 
   only:
   - /^feature\/.*$/
@@ -249,36 +234,15 @@ Nginx:Internal-WP:
   needs: ["Test_N_Build:internal"]
 
 Nginx:feature:
-  image: docker
-
-  services:
-    - docker:dind
-
-  stage: build_docker_images
-
-  before_script:
-  - case "${CI_COMMIT_REF_NAME}" in dev) DEPLOYENV="staging" ;; master) DEPLOYENV="prod" ;; cicd-test) DEPLOYENV="staging" ;; *) DEPLOYENV="dev" ;; esac
-
-  script:
-  - feature_branch=${CI_COMMIT_REF_NAME}
-  - feature_tag=${feature_branch#"feature/"}
-  - feature_tag=`echo "${feature_tag}" | tr '[A-Z]' '[a-z]'`
-  - apk update && apk add git
-  - git clone --depth 1 https://github.com/Ensembl/ensembl-2020-static-assests.git
-  - git clone https://gitlab.ebi.ac.uk/kamal/ensembl-client-nginx.git
-  - sed -i "s/<DEPLOYMENT_ENV>/internal/g" ensembl-client-nginx/config/conf.d/local.conf
-  - cat ensembl-client-nginx/config/conf.d/local.conf
-  - docker build -t ${CONTAINER_IMAGE}-$feature_tag -f ensembl-client-nginx/Dockerfile --no-cache .
-  - echo "$GITLAB_REGISTRY_TOKEN" | docker login -u "$GITLAB_REGISTRY_USER" --password-stdin https://"$GITLAB_REGISTRY_URL"
-  - docker push ${CONTAINER_IMAGE}-$feature_tag
-  - docker rmi ${CONTAINER_IMAGE}-$feature_tag
-  - docker logout "$GITLAB_REGISTRY_URL"
+  extends: .build-nginx-ehk
+  variables:
+    DEPLOYENV: internal
+    CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}-${CI_COMMIT_REF_SLUG}
 
   only:
   - /^feature\/.*$/
 
-  dependencies:
-  - Test_N_Build:feature
+  needs: ["Test_N_Build:feature"]
 
 # Job to deploy to staging environment (EHK k8s cluster)
 Staging:EHK-HH:
@@ -358,33 +322,13 @@ Internal:WP-HX:
   needs: ["Nginx:Internal-WP"]
 
 Feature:EHK-HH:
-  stage: deploy
-  image: alpine
-  before_script:
-  - export KUBECONFIG=/etc/deploy/config
-  - mkdir -p /etc/deploy
-  - echo ${EMBASSY_KUBECONFIG} | base64 -d > ${KUBECONFIG}
-
-  script:
-  - feature_branch=${CI_COMMIT_REF_NAME}
-  - feature_tag=${feature_branch#"feature/"}
-  - apk update && apk add --no-cache curl git
-  - curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
-  - chmod +x ./kubectl
-  - mv ./kubectl /usr/local/bin/kubectl
-  - git clone https://gitlab.ebi.ac.uk/kamal/ensembl-client-caas-deploy.git
-  - cd ensembl-client-caas-deploy
-  - git checkout refactor-manifest
-  - cd ..
-  - sed -i "s/<VERSION>/${CI_COMMIT_SHORT_SHA}-$feature_tag/g" ensembl-client-caas-deploy/ensembl_client_deployment.yaml
-  - sed -i "s/<DEPLOYMNET_ENV>/$feature_tag/g" ensembl-client-caas-deploy/ensembl_client_deployment.yaml
-  - cat ensembl-client-caas-deploy/ensembl_client_deployment.yaml
-  - kubectl config view
-  - kubectl config use-context ens-dev-ctx
-  - kubectl apply -f ensembl-client-caas-deploy/ensembl_client_deployment.yaml
+  extends: .deploy-ehk
+  variables:
+    DEPLOYENV: ${CI_COMMIT_REF_SLUG}
+    CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}-${CI_COMMIT_REF_SLUG}
+    KUBE_CONTEXT: ens-dev-ctx
 
   only:
   - /^feature\/.*$/
 
-  dependencies:
-  - Nginx:feature
+  needs: ["Nginx:feature"]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -236,7 +236,7 @@ Nginx:Internal-WP:
 Nginx:feature:
   extends: .build-nginx-ehk
   variables:
-    DEPLOYENV: internal
+    DEPLOYENV: dev
     CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}-${CI_COMMIT_REF_SLUG}
   only:
   - /^feature\/.*$/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -238,8 +238,6 @@ Nginx:feature:
   variables:
     DEPLOYENV: internal
     CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}-${CI_COMMIT_REF_SLUG}
-    DOCKER_HOST: tcp://docker:2376
-    DOCKER_TLS_CERTDIR: "/certs"
   only:
   - /^feature\/.*$/
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -238,7 +238,8 @@ Nginx:feature:
   variables:
     DEPLOYENV: internal
     CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}-${CI_COMMIT_REF_SLUG}
-
+    DOCKER_HOST: tcp://docker:2376
+    DOCKER_TLS_CERTDIR: "/certs"
   only:
   - /^feature\/.*$/
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,6 +92,17 @@ variables:
   - sed -i "s#<DOCKER_IMAGE>#${CONTAINER_IMAGE}#g" ensembl-client-caas-deploy/ensembl_client_deployment.yaml
   - kubectl apply -f ensembl-client-caas-deploy/ensembl_client_deployment.yaml
 
+# Template to deploy to WP k8s cluster
+.deploy-wp-feature:
+  stage: deploy
+  image: dockerhub.ebi.ac.uk/kamal/deploy-tools:0.1
+  script:
+  - git clone https://gitlab.ebi.ac.uk/kamal/ensembl-client-caas-deploy.git
+  - git -C ensembl-client-caas-deploy/ checkout deployfeature
+  - sed -i "s#<DEPLOYMNET_ENV>#${CI_COMMIT_REF_SLUG}#g" ensembl-client-caas-deploy/ensembl_client_deployment.yaml 
+  - sed -i "s#<DOCKER_IMAGE>#${CONTAINER_IMAGE}#g" ensembl-client-caas-deploy/ensembl_client_deployment.yaml
+  - kubectl apply -f ensembl-client-caas-deploy/ensembl_client_deployment.yaml
+
 # Template to deploy to EHK k8s cluster
 .deploy-ehk:
   stage: deploy
@@ -333,7 +344,7 @@ Feature:EHK-HH:
   needs: ["Nginx:feature"]
 
 Feature:WP-HX:
-  extends: .deploy-wp
+  extends: .deploy-wp-feature
   variables:
     CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}-${CI_COMMIT_REF_SLUG}
   environment:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -278,6 +278,17 @@ Staging:WP-HX:
   - dev
   needs: ["Nginx:Staging-WP"]
 
+# Job to deploy to staging environment (WP-HH k8s cluster)
+Staging:WP-HH:
+  extends: .deploy-wp
+  variables:
+    CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}-stage-ing
+  environment:
+    name : wp-hh-staging
+  only:
+  - dev
+  needs: ["Nginx:Staging-WP"]
+
 # Job to deploy to live environment (EHK k8s cluster)
 Live:EHK-HH:
   extends: .deploy-ehk
@@ -329,6 +340,17 @@ Internal:WP-HX:
     CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}-internal-ing
   environment:
     name : wp-hx-internal
+  only:
+  - dev
+  needs: ["Nginx:Internal-WP"]
+
+# Job to deploy to internal environment (WP-HH k8s cluster)
+Internal:WP-HH:
+  extends: .deploy-wp
+  variables:
+    CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}-internal-ing
+  environment:
+    name : wp-hh-internal
   only:
   - dev
   needs: ["Nginx:Internal-WP"]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -101,7 +101,9 @@ variables:
   - git -C ensembl-client-caas-deploy/ checkout deployfeature
   - sed -i "s#<DEPLOYMNET_ENV>#${CI_COMMIT_REF_SLUG}#g" ensembl-client-caas-deploy/ensembl_client_deployment.yaml 
   - sed -i "s#<DOCKER_IMAGE>#${CONTAINER_IMAGE}#g" ensembl-client-caas-deploy/ensembl_client_deployment.yaml
+  - sed -i "s#<DEPLOYMNET_ENV>#${CI_COMMIT_REF_SLUG}#g" ensembl-client-caas-deploy/ensembl_client_service_node.yaml
   - kubectl apply -f ensembl-client-caas-deploy/ensembl_client_deployment.yaml
+  - kubectl apply -f ensembl-client-caas-deploy/ensembl_client_service_node.yaml
 
 # Template to deploy to EHK k8s cluster
 .deploy-ehk:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -331,3 +331,13 @@ Feature:EHK-HH:
   - /^feature\/.*$/
 
   needs: ["Nginx:feature"]
+
+Feature:WP-HX:
+  extends: .deploy-wp
+  variables:
+    CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}-${CI_COMMIT_REF_SLUG}
+  environment:
+    name : wp-hx-dev
+  only:
+  - /^feature\/.*$/
+  needs: ["Nginx:feature"]


### PR DESCRIPTION
## Requirements
Deploying feature branches to WP-HX k8s cluster

## Type

- CI/CD pipeline

## Related JIRA Issue(s)

## Importance
During DC migration all the feature branches will be accessible from WP-HX k8s cluster
Deploy staging/internal to WP-HH k8s

## Note
Existing feature branches need to pull the changes in gitlab-ci file to deploy it to WP-HX k8s cluster

