### PR TITLE
Default sorting for transcripts list in EV gene view

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -1,16 +1,12 @@
 import React from 'react';
-import sortBy from 'lodash/sortBy';
 
-import {
-  getFeatureCoordinates,
-  getFeatureLength
-} from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
+import { getFeatureCoordinates } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
+import { defaultSort } from '../../../shared/helpers/transcripts-sorter';
 
 import DefaultTranscriptsListItem from './default-transcripts-list-item/DefaultTranscriptListItem';
 
 import { TicksAndScale } from 'src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/BasePairsRuler';
 import { Gene } from 'src/content/app/entity-viewer/types/gene';
-import { Transcript } from 'src/content/app/entity-viewer/types/transcript';
 
 import styles from './DefaultTranscriptsList.scss';
 
@@ -19,54 +15,9 @@ type Props = {
   rulerTicks: TicksAndScale;
 };
 
-const compareTranscriptLength = (
-  transcriptOne: Transcript,
-  transcriptTwo: Transcript
-) => {
-  const transcriptOneLength = getFeatureLength(transcriptOne);
-  const transcriptTwoLength = getFeatureLength(transcriptTwo);
-
-  if (transcriptOneLength < transcriptTwoLength) {
-    return -1;
-  }
-
-  if (transcriptOneLength > transcriptTwoLength) {
-    return 1;
-  }
-
-  return 0;
-};
-
-const sortTranscripts = (transcripts: Transcript[]) => {
-  const transcriptsWithCds = transcripts
-    .filter((transcript) => transcript.cds)
-    .sort(compareTranscriptLength);
-
-  const transcriptsWithoutCds = transcripts.filter(
-    (transcript) => !transcript.cds
-  );
-
-  const proteinCodingTranscripts = transcriptsWithoutCds
-    .filter((transcript) => transcript.biotype === 'protein_coding')
-    .sort(compareTranscriptLength);
-
-  const nonProteinCodingTranscripts = sortBy(
-    transcriptsWithoutCds.filter(
-      (transcript) => transcript.biotype !== 'protein_coding'
-    ),
-    ['biotype']
-  );
-
-  return [
-    ...transcriptsWithCds,
-    ...proteinCodingTranscripts,
-    ...nonProteinCodingTranscripts
-  ];
-};
-
 const DefaultTranscriptslist = (props: Props) => {
   const { gene } = props;
-  const sortedTranscripts = sortTranscripts(gene.transcripts);
+  const sortedTranscripts = defaultSort(gene.transcripts);
 
   return (
     <div>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { getFeatureCoordinates } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
-import { defaultSort } from '../../../shared/helpers/transcripts-sorter';
+import { defaultSort } from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
 
 import DefaultTranscriptsListItem from './default-transcripts-list-item/DefaultTranscriptListItem';
 

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/entity-helpers.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/entity-helpers.ts
@@ -1,8 +1,20 @@
-import { SliceWithLocationOnly } from 'src/content/app/entity-viewer/types/slice';
+import {
+  Slice,
+  SliceWithLocationOnly
+} from 'src/content/app/entity-viewer/types/slice';
 
 export const getFeatureCoordinates = (feature: {
   slice: SliceWithLocationOnly;
 }) => {
   const { start, end } = feature.slice.location;
   return { start, end };
+};
+
+export const getFeatureStrand = (feature: { slice: Slice }) =>
+  feature.slice.region.strand;
+
+export const getFeatureLength = (feature: { slice: Slice }) => {
+  const { start, end } = getFeatureCoordinates(feature);
+  const { code: strandCode } = getFeatureStrand(feature);
+  return strandCode === 'forward' ? end - start + 1 : start - end + 1;
 };

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/entity-helpers.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/entity-helpers.ts
@@ -11,10 +11,11 @@ export const getFeatureCoordinates = (feature: {
 };
 
 export const getFeatureStrand = (feature: { slice: Slice }) =>
-  feature.slice.region.strand;
+  feature.slice.region.strand.code;
 
+// FIXME: remove this when we can get the length from the API
 export const getFeatureLength = (feature: { slice: Slice }) => {
   const { start, end } = getFeatureCoordinates(feature);
-  const { code: strandCode } = getFeatureStrand(feature);
+  const strandCode = getFeatureStrand(feature);
   return strandCode === 'forward' ? end - start + 1 : start - end + 1;
 };

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/transcripts-sorter.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/transcripts-sorter.ts
@@ -1,0 +1,50 @@
+import sortBy from 'lodash/sortby';
+
+import { getFeatureLength } from './entity-helpers';
+
+import { Transcript } from '../../types/transcript';
+
+function compareTranscriptLengths(
+  transcriptOne: Transcript,
+  transcriptTwo: Transcript
+) {
+  const transcriptOneLength = getFeatureLength(transcriptOne);
+  const transcriptTwoLength = getFeatureLength(transcriptTwo);
+
+  if (transcriptOneLength < transcriptTwoLength) {
+    return -1;
+  }
+
+  if (transcriptOneLength > transcriptTwoLength) {
+    return 1;
+  }
+
+  return 0;
+}
+
+export function defaultSort(transcripts: Transcript[]) {
+  const transcriptsWithCds = transcripts
+    .filter((transcript) => transcript.cds)
+    .sort(compareTranscriptLengths);
+
+  const transcriptsWithoutCds = transcripts.filter(
+    (transcript) => !transcript.cds
+  );
+
+  const proteinCodingTranscripts = transcriptsWithoutCds
+    .filter((transcript) => transcript.biotype === 'protein_coding')
+    .sort(compareTranscriptLengths);
+
+  const nonProteinCodingTranscripts = sortBy(
+    transcriptsWithoutCds.filter(
+      (transcript) => transcript.biotype !== 'protein_coding'
+    ),
+    ['biotype']
+  );
+
+  return [
+    ...transcriptsWithCds,
+    ...proteinCodingTranscripts,
+    ...nonProteinCodingTranscripts
+  ];
+}

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/transcripts-sorter.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/transcripts-sorter.ts
@@ -23,28 +23,14 @@ function compareTranscriptLengths(
 }
 
 export function defaultSort(transcripts: Transcript[]) {
-  const transcriptsWithCds = transcripts
-    .filter((transcript) => transcript.cds)
-    .sort(compareTranscriptLengths);
-
-  const transcriptsWithoutCds = transcripts.filter(
-    (transcript) => !transcript.cds
-  );
-
-  const proteinCodingTranscripts = transcriptsWithoutCds
+  const proteinCodingTranscripts = transcripts
     .filter((transcript) => transcript.biotype === 'protein_coding')
     .sort(compareTranscriptLengths);
 
   const nonProteinCodingTranscripts = sortBy(
-    transcriptsWithoutCds.filter(
-      (transcript) => transcript.biotype !== 'protein_coding'
-    ),
+    transcripts.filter((transcript) => transcript.biotype !== 'protein_coding'),
     ['biotype']
   );
 
-  return [
-    ...transcriptsWithCds,
-    ...proteinCodingTranscripts,
-    ...nonProteinCodingTranscripts
-  ];
+  return [...proteinCodingTranscripts, ...nonProteinCodingTranscripts];
 }

--- a/src/ensembl/src/content/app/entity-viewer/types/transcript.ts
+++ b/src/ensembl/src/content/app/entity-viewer/types/transcript.ts
@@ -6,7 +6,8 @@ export type Transcript = {
   type: 'Transcript';
   id: string;
   symbol: string;
-  so_term: string; // is there a better name for it?
+  so_term?: string; // is there a better name for it?
+  biotype?: string;
   slice: Slice;
   exons: Exon[];
   cds: CDS | null;


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [x] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
[ENSWBSITES-537](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-537)

## Description
This default transcript list needs to be sorted according to the following criteria:

1. Transcripts with CCDS come before the rest, and are sorted by length.
2. Within the non-CCDS group, the transcripts are sorted by biotype (see point 3, below) and then by length.
3. The biotype sort is "Protein coding comes first, then everything else is sorted alphabetically".

This is going to change in the future and we are not certain how it will. So for the time being, the above criteria is what we will consider for sorting.

## Views affected
Gene view in entity viewer
