### PR TITLE
Instant download

### DIFF
--- a/src/ensembl/prettier.config.js
+++ b/src/ensembl/prettier.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   singleQuote: true,
-  arrowParens: 'always'
+  arrowParens: 'always',
+  trailingComma: "none"
 };

--- a/src/ensembl/src/content/app/entity-viewer/types/transcript.ts
+++ b/src/ensembl/src/content/app/entity-viewer/types/transcript.ts
@@ -8,7 +8,7 @@ export type Transcript = {
   type: 'Transcript';
   id: string;
   symbol: string;
-  so_term?: string; // is there a better name for it?
+  so_term: string; // is there a better name for it?
   biotype?: string; // either this or so_term above need to be removed in the future
   slice: Slice;
   exons: Exon[];

--- a/src/ensembl/src/shared/components/button/Button.scss
+++ b/src/ensembl/src/shared/components/button/Button.scss
@@ -1,6 +1,7 @@
 @import 'src/styles/common';
 
 .primaryButton {
+  border: 1px solid $green;
   background-color: $green;
   color: $white;
   padding: 8px 18px;
@@ -15,6 +16,7 @@
 }
 
 .secondaryButton {
+  border: 1px solid $blue;
   background-color: $blue;
   color: $white;
   font-weight: $bold;

--- a/src/ensembl/src/shared/components/checkbox/Checkbox.scss
+++ b/src/ensembl/src/shared/components/checkbox/Checkbox.scss
@@ -14,10 +14,13 @@
   transition: background-color 0.1s ease-in-out;
   float: left;
   margin-top: 2px;
+
+  & + label {
+    cursor: pointer;
+  }
 }
 
 .unchecked {
-  cursor: pointer;
   background-color: $white;
 }
 
@@ -28,6 +31,10 @@
 .disabled {
   background-color: $light-grey;
   cursor: default;
+
+  & + label {
+    cursor: default;
+  }
 }
 
 .defaultLabel {

--- a/src/ensembl/src/shared/components/checkbox/Checkbox.tsx
+++ b/src/ensembl/src/shared/components/checkbox/Checkbox.tsx
@@ -3,9 +3,16 @@ import classNames from 'classnames';
 
 import defaultStyles from './Checkbox.scss';
 
+type ClassNames = Partial<{
+  checkboxHolder: string;
+  checked: string;
+  unchecked: string;
+  disabled: string;
+}>;
+
 type WithoutLabelProps = {
   onChange: (status: boolean) => void;
-  classNames?: any;
+  classNames?: ClassNames;
   disabled?: boolean;
   checked: boolean;
 };
@@ -33,7 +40,7 @@ const Checkbox = (props: CheckboxProps) => {
   };
 
   const styles = props.classNames
-    ? { ...defaultStyles, ...props.classNames }
+    ? ({ ...defaultStyles, ...props.classNames } as { [key: string]: string })
     : defaultStyles;
   const className = classNames(
     styles.defaultCheckbox,

--- a/src/ensembl/src/shared/components/instant-download/index.ts
+++ b/src/ensembl/src/shared/components/instant-download/index.ts
@@ -1,0 +1,1 @@
+export { default as InstantDownloadTranscript } from './instant-download-transcript/InstantDownloadTranscript';

--- a/src/ensembl/src/shared/components/instant-download/instant-download-button/InstantDownloadButton.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-button/InstantDownloadButton.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { PrimaryButton } from 'src/shared/components/button/Button';
+
+type Props = {
+  isDisabled?: boolean;
+  className?: string;
+  onClick: () => void;
+};
+
+const InstantDownloadButton = (props: Props) => {
+  return <PrimaryButton {...props}>Download</PrimaryButton>;
+};
+
+export default InstantDownloadButton;

--- a/src/ensembl/src/shared/components/instant-download/instant-download-fetch/fetchForTranscript.ts
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-fetch/fetchForTranscript.ts
@@ -1,0 +1,63 @@
+import downloadAsFile from 'src/shared/helpers/downloadAsFile';
+import {
+  TranscriptOptions,
+  TranscriptOption,
+  transcriptOptionsOrder
+} from 'src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript';
+
+type Options = {
+  transcript: Partial<TranscriptOptions>;
+  gene: {
+    genomicSequence: boolean;
+  };
+};
+
+type FetchPayload = {
+  transcriptId: string;
+  geneId: string;
+  options: Options;
+};
+
+export const fetchForTranscript = async (payload: FetchPayload) => {
+  const {
+    geneId,
+    transcriptId,
+    options: { transcript: transcriptOptions, gene: geneOptions }
+  } = payload;
+  const urls = buildUrlsForTranscript(transcriptId, transcriptOptions);
+  if (geneOptions.genomicSequence) {
+    urls.push(buildFetchUrl(geneId, 'genomicSequence'));
+  }
+  const sequencePromises = urls.map((url) =>
+    fetch(url).then((response) => response.text())
+  );
+  const sequences = await Promise.all(sequencePromises);
+  const combinedFasta = sequences.join('\n');
+
+  downloadAsFile(combinedFasta, `${transcriptId}.fasta`, {
+    type: 'text/x-fasta'
+  });
+};
+
+const buildUrlsForTranscript = (
+  id: string,
+  options: Partial<TranscriptOptions>
+) => {
+  return options
+    ? transcriptOptionsOrder
+        .filter((option) => options[option])
+        .map((option) => buildFetchUrl(id, option))
+    : [];
+};
+
+const buildFetchUrl = (id: string, sequenceType: TranscriptOption) => {
+  const sequenceTypeToTypeParam: Record<TranscriptOption, string> = {
+    genomicSequence: 'genomic',
+    proteinSequence: 'protein',
+    cdna: 'cdna',
+    cds: 'cds'
+  };
+  const typeParam = sequenceTypeToTypeParam[sequenceType];
+
+  return `https://rest.ensembl.org/sequence/id/${id}?content-type=text/x-fasta&type=${typeParam}`;
+};

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.scss
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.scss
@@ -1,5 +1,45 @@
 @import 'src/styles/common';
 
+.checkboxGrid {
+  margin-top: 0.5em;
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  grid-template-rows: auto;
+  grid-row-gap: 0.2em;
+}
+
+.label {
+  color: white;
+  margin-bottom: 0.5em;
+  font-weight: $light;
+  word-break: break-all;
+
+  .featureId {
+    margin-left: 0.5em;
+    font-weight: $bold;
+  }
+}
+
+.transcriptVis {
+  margin-top: 18px;
+  margin-bottom: 9px;
+}
+
+.checkboxUnchecked {
+  background-color: transparent;
+  border-color: $dark-grey;
+}
+
+.checkboxLabel {
+  font-size: 13px;
+  color: white;
+}
+
+.downloadButtonDisabled {
+  border-color: $dark-grey;
+  color: $dark-grey;
+}
+
 .layout {
   display: grid;
   font-size: 13px;
@@ -70,44 +110,4 @@
       align-self: end;
     }
   }
-}
-
-.checkboxUnchecked {
-  background-color: transparent;
-  border-color: $dark-grey;
-}
-
-.checkboxLabel {
-  font-size: 13px;
-  color: white;
-}
-
-.checkboxGrid {
-  margin-top: 0.5em;
-  display: grid;
-  grid-template-columns: 1.5fr 1fr;
-  grid-template-rows: auto;
-  grid-row-gap: 0.2em;
-}
-
-.label {
-  color: white;
-  margin-bottom: 0.5em;
-  font-weight: $light;
-  word-break: break-all;
-
-  .featureId {
-    margin-left: 0.5em;
-    font-weight: $bold;
-  }
-}
-
-.transcriptVis {
-  margin-top: 18px;
-  margin-bottom: 9px;
-}
-
-.downloadButtonDisabled {
-  border-color: $dark-grey;
-  color: $dark-grey;
 }

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.scss
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.scss
@@ -1,0 +1,113 @@
+@import 'src/styles/common';
+
+.layout {
+  display: grid;
+  font-size: 13px;
+
+  &Horizontal {
+    grid-template-columns: 1fr 1fr;
+    grid-column-gap: 24px;
+    grid-template-areas:
+      'transcript gene'
+      'transcript download';
+
+    .transcriptSection {
+      grid-area: transcript;
+    }
+
+    .geneSection {
+      grid-area: gene;
+
+      .checkboxWrapper {
+        margin-top: 13px;
+        margin-left: 13px;
+      }
+    }
+
+    .transcriptVis,
+    .checkboxGrid {
+      margin-left: 18px;
+    }
+
+    button {
+      grid-area: download;
+      justify-self: end;
+      align-self: end;
+    }
+  }
+
+  &Vertical {
+    grid-row-gap: 0.5rem;
+
+    .transcriptSection,
+    .geneSection {
+      padding-left: 18px;
+    }
+
+    .geneSection {
+      margin-top: 18px;
+      margin-bottom: 18px;
+
+      .label {
+        margin-left: -18px;
+      }
+
+      .checkboxWrapper {
+        margin-top: 12px;
+      }
+    }
+
+    .transcriptSection .label {
+      margin-left: -18px;
+    }
+
+    .checkboxGrid {
+      grid-template-columns: 2fr 1fr;
+    }
+
+    button {
+      justify-self: end;
+      align-self: end;
+    }
+  }
+}
+
+.checkboxUnchecked {
+  background-color: transparent;
+  border-color: $dark-grey;
+}
+
+.checkboxLabel {
+  font-size: 13px;
+  color: white;
+}
+
+.checkboxGrid {
+  margin-top: 0.5em;
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  grid-template-rows: auto;
+  grid-row-gap: 0.2em;
+}
+
+.label {
+  color: white;
+  margin-bottom: 0.5em;
+  font-weight: $light;
+  word-break: break-all;
+
+  .featureId {
+    margin-left: 0.5em;
+    font-weight: $bold;
+  }
+}
+
+.transcriptVis {
+  margin-top: 18px;
+  margin-bottom: 9px;
+}
+
+.downloadButtonDisabled {
+  border-color: $dark-grey;
+  color: $dark-grey;
+}

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.tsx
@@ -1,0 +1,215 @@
+import React, { useState, useEffect } from 'react';
+import classNames from 'classnames';
+import pick from 'lodash/pick';
+
+import { fetchForTranscript } from '../instant-download-fetch/fetchForTranscript';
+
+import InstantDownloadTranscriptVisualisation from './InstantDownloadTranscriptVisualisation';
+import Checkbox from 'src/shared/components/checkbox/Checkbox';
+import InstantDownloadButton from '../instant-download-button/InstantDownloadButton';
+
+import styles from './InstantDownloadTranscript.scss';
+
+type Layout = 'horizontal' | 'vertical';
+
+type TranscriptFields = {
+  id: string;
+  so_term: string;
+};
+
+type GeneFields = {
+  id: string;
+};
+
+type Props = {
+  transcript: TranscriptFields;
+  gene: GeneFields;
+  layout: Layout;
+};
+
+type TranscriptSectionProps = {
+  transcript: TranscriptFields;
+  options: Partial<TranscriptOptions>;
+  onChange: (key: keyof TranscriptOptions) => void;
+};
+
+type GeneSectionProps = {
+  gene: GeneFields;
+  isGenomicSequenceSelected: boolean;
+  onChange: () => void;
+};
+
+export type TranscriptOptions = {
+  genomicSequence: boolean;
+  proteinSequence: boolean;
+  cdna: boolean;
+  cds: boolean;
+};
+
+export type TranscriptOption = keyof Partial<TranscriptOptions>;
+
+export const transcriptOptionsOrder: TranscriptOption[] = [
+  'genomicSequence',
+  'cdna',
+  'proteinSequence',
+  'cds'
+];
+
+const defaultTranscriptOptions: TranscriptOptions = {
+  genomicSequence: false,
+  cdna: false,
+  proteinSequence: false,
+  cds: false
+};
+
+const transcriptOptionLabels: Record<keyof TranscriptOptions, string> = {
+  genomicSequence: 'Genomic sequence',
+  proteinSequence: 'Protein sequence',
+  cdna: 'cDNA',
+  cds: 'CDS'
+};
+
+const filterTranscriptOptions = (
+  so_term: string
+): Partial<TranscriptOptions> => {
+  return so_term === 'protein_coding'
+    ? defaultTranscriptOptions
+    : pick(defaultTranscriptOptions, ['genomicSequence', 'cdna']);
+};
+
+const InstantDownloadTranscript = (props: Props) => {
+  const {
+    transcript: { so_term }
+  } = props;
+  const [transcriptOptions, setTranscriptOptions] = useState(
+    filterTranscriptOptions(so_term)
+  );
+  const [isGeneSequenceSelected, setIsGeneSequenceSelected] = useState(false);
+
+  useEffect(() => {
+    setTranscriptOptions(filterTranscriptOptions(so_term));
+  }, [so_term]);
+
+  const onTranscriptOptionChange = (key: keyof TranscriptOptions) => {
+    const updatedOptions = {
+      ...transcriptOptions,
+      [key]: !transcriptOptions[key]
+    };
+    setTranscriptOptions(updatedOptions);
+  };
+  const onGeneOptionChange = () => {
+    setIsGeneSequenceSelected(!isGeneSequenceSelected);
+  };
+  const onSubmit = () => {
+    const payload = {
+      transcriptId: props.transcript.id,
+      geneId: props.gene.id,
+      options: {
+        transcript: transcriptOptions,
+        gene: { genomicSequence: isGeneSequenceSelected }
+      }
+    };
+    fetchForTranscript(payload);
+  };
+
+  const layoutClass =
+    props.layout === 'horizontal'
+      ? classNames(styles.layout, styles.layoutHorizontal)
+      : classNames(styles.layout, styles.layoutVertical);
+
+  const isButtonDisabled = !hasSelectedOptions({
+    ...transcriptOptions,
+    geneSequence: isGeneSequenceSelected
+  });
+
+  return (
+    <div className={layoutClass}>
+      <TranscriptSection
+        transcript={props.transcript}
+        options={transcriptOptions}
+        onChange={onTranscriptOptionChange}
+      />
+      <GeneSection
+        gene={props.gene}
+        isGenomicSequenceSelected={isGeneSequenceSelected}
+        onChange={onGeneOptionChange}
+      />
+      <InstantDownloadButton
+        className={isButtonDisabled ? styles.downloadButtonDisabled : undefined}
+        isDisabled={isButtonDisabled}
+        onClick={onSubmit}
+      />
+    </div>
+  );
+};
+
+InstantDownloadTranscript.defaultProps = {
+  layout: 'horizontal'
+} as Props;
+
+const TranscriptSection = (props: TranscriptSectionProps) => {
+  const { transcript, options } = props;
+  const checkboxes = transcriptOptionsOrder.map((key) => (
+    <Checkbox
+      key={key}
+      classNames={{ unchecked: styles.checkboxUnchecked }}
+      labelClassName={styles.checkboxLabel}
+      label={transcriptOptionLabels[key as TranscriptOption]}
+      checked={options[key as TranscriptOption] as boolean}
+      onChange={() => props.onChange(key as TranscriptOption)}
+    />
+  ));
+
+  const transcriptVisualisation = (
+    <InstantDownloadTranscriptVisualisation
+      isGenomicSequenceEnabled={options.genomicSequence}
+      isProteinSequenceEnabled={options.proteinSequence}
+      isCDNAEnabled={options.cdna}
+      isCDSEnabled={options.cds}
+    />
+  );
+
+  return (
+    <div className={styles.transcriptSection}>
+      <div className={styles.label}>
+        Transcript
+        <span className={styles.featureId}>{transcript.id}</span>
+      </div>
+      <div className={styles.transcriptVis}>{transcriptVisualisation}</div>
+      <div className={styles.checkboxGrid}>{checkboxes}</div>
+    </div>
+  );
+};
+
+const GeneSection = (props: GeneSectionProps) => {
+  return (
+    <div className={styles.geneSection}>
+      <div className={styles.label}>
+        Gene
+        <span className={styles.featureId}>{props.gene.id}</span>
+      </div>
+      <div>
+        <Checkbox
+          classNames={{
+            checkboxHolder: styles.checkboxWrapper,
+            unchecked: styles.checkboxUnchecked
+          }}
+          labelClassName={styles.checkboxLabel}
+          label="Genomic sequence"
+          checked={props.isGenomicSequenceSelected}
+          onChange={props.onChange}
+        />
+      </div>
+    </div>
+  );
+};
+
+const hasSelectedOptions = (
+  options: Partial<TranscriptOptions> & { geneSequence: boolean }
+) => {
+  return Object.keys(options).some(
+    (key) => options[key as keyof TranscriptOptions]
+  );
+};
+
+export default InstantDownloadTranscript;

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.scss
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.scss
@@ -1,0 +1,44 @@
+@import 'src/styles/common';
+
+$regularColor: $dark-grey;
+
+.outerExon {
+  stroke: $regularColor;
+  fill: none;
+
+  &.highlighted {
+    stroke: white;
+  }
+}
+
+.innerExon {
+  stroke: $regularColor;
+  fill: $regularColor;
+
+  &.highlighted {
+    stroke: white;
+    fill: white;
+  }
+}
+
+.halfOuterExon {
+  stroke: $regularColor;
+  fill: $regularColor;
+
+  &.highlighted {
+    stroke: white;
+    fill: white;
+  }
+}
+
+.backbone {
+  stroke: $regularColor;
+
+  &.highlighted {
+    stroke: white;
+  }
+}
+
+.protein {
+  fill: white;
+}

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.scss
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.scss
@@ -31,7 +31,7 @@ $regularColor: $dark-grey;
   }
 }
 
-.backbone {
+.intron {
   stroke: $regularColor;
 
   &.highlighted {

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.test.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render } from 'enzyme';
+
+import InstantDownloadTranscriptVisualisation, {
+  Props
+} from './InstantDownloadTranscriptVisualisation';
+
+describe('InstantDownloadTranscriptVisualisation', () => {
+  const renderWrapper = (props: Partial<Props> = {}) => {
+    return render(<InstantDownloadTranscriptVisualisation {...props} />);
+  };
+
+  it('renders an svg element', () => {
+    const wrapper = renderWrapper();
+    expect(wrapper.is('svg')).toBe(true);
+  });
+
+  it('contains 5 exons', () => {
+    const wrapper = renderWrapper();
+    expect(wrapper.find('.outerExon, .innerExon').length).toBe(5);
+  });
+
+  it('highlights only exons within coding sequence if CDS is enabled', () => {
+    const wrapper = renderWrapper({ isCDSEnabled: true });
+    expect(wrapper.find('.highlighted.innerExon').length).toBeTruthy();
+    expect(wrapper.find('.highlighted.halfOuterExon').length).toBeTruthy();
+    expect(wrapper.find('.highlighted.outerExon').length).toBe(0);
+    expect(wrapper.find('.highlighted.backbone').length).toBe(0);
+  });
+
+  it('correctly highlights cDNA segments', () => {
+    const wrapper = renderWrapper({ isCDNAEnabled: true });
+    expect(wrapper.find('.highlighted.innerExon').length).toBeTruthy();
+    expect(wrapper.find('.highlighted.halfOuterExon').length).toBeTruthy();
+    expect(wrapper.find('.highlighted.outerExon').length).toBeTruthy();
+    expect(wrapper.find('.highlighted.backbone').length).toBe(0);
+  });
+
+  it('correctly highlights cDNA segments', () => {
+    const wrapper = renderWrapper({ isGenomicSequenceEnabled: true });
+    expect(wrapper.find('.highlighted.innerExon').length).toBeTruthy();
+    expect(wrapper.find('.highlighted.halfOuterExon').length).toBeTruthy();
+    expect(wrapper.find('.highlighted.outerExon').length).toBeTruthy();
+    expect(wrapper.find('.highlighted.backbone').length).toBeTruthy();
+  });
+
+  it('shows protein segments if protein sequence option is enabled', () => {
+    let wrapper = renderWrapper();
+    expect(wrapper.find('.protein').length).toBe(0);
+
+    wrapper = renderWrapper({ isProteinSequenceEnabled: true });
+    expect(wrapper.find('.protein').length).toBeTruthy();
+  });
+});

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.test.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from 'enzyme';
 
 import InstantDownloadTranscriptVisualisation, {
-  Props
+  Props,
 } from './InstantDownloadTranscriptVisualisation';
 
 describe('InstantDownloadTranscriptVisualisation', () => {
@@ -36,7 +36,7 @@ describe('InstantDownloadTranscriptVisualisation', () => {
     expect(wrapper.find('.highlighted.backbone').length).toBe(0);
   });
 
-  it('correctly highlights cDNA segments', () => {
+  it('correctly highlights complete genomic sequence', () => {
     const wrapper = renderWrapper({ isGenomicSequenceEnabled: true });
     expect(wrapper.find('.highlighted.innerExon').length).toBeTruthy();
     expect(wrapper.find('.highlighted.halfOuterExon').length).toBeTruthy();

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.test.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from 'enzyme';
 
 import InstantDownloadTranscriptVisualisation, {
-  Props,
+  Props
 } from './InstantDownloadTranscriptVisualisation';
 
 describe('InstantDownloadTranscriptVisualisation', () => {
@@ -41,7 +41,7 @@ describe('InstantDownloadTranscriptVisualisation', () => {
     expect(wrapper.find('.highlighted.innerExon').length).toBeTruthy();
     expect(wrapper.find('.highlighted.halfOuterExon').length).toBeTruthy();
     expect(wrapper.find('.highlighted.outerExon').length).toBeTruthy();
-    expect(wrapper.find('.highlighted.backbone').length).toBeTruthy();
+    expect(wrapper.find('.highlighted.intron').length).toBeTruthy();
   });
 
   it('shows protein segments if protein sequence option is enabled', () => {

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import classNames from 'classnames';
+
+import styles from './InstantDownloadTranscriptVisualisation.scss';
+
+/*
+
+Schematic representation of transcript:
+
+@@##--####--####--####--##@@
+
+if width of a single exon is x,
+and width of section between exons is x/2
+
+then
+
+5x + (4 * 0.5x) = totalWidth
+x = totalWidth / 7
+
+*/
+
+export type Props = {
+  isGenomicSequenceEnabled: boolean;
+  isCDNAEnabled: boolean;
+  isCDSEnabled: boolean;
+  isProteinSequenceEnabled: boolean;
+  width: number;
+};
+
+const InstantDownloadTranscriptVisualisation = (props: Props) => {
+  const exonsCount = 5;
+  const exonHeight = 5;
+  const proteinHeight = 3;
+  const verticalGap = 5;
+  const totalHeight = exonHeight + proteinHeight + verticalGap;
+  const exonWidth = Math.floor(props.width / 7);
+  const halfExonWidth = Math.floor(exonWidth / 2);
+  const backboneSegmentsCount = exonsCount - 1;
+
+  const getExonClasses = (exonIndex: number, exonsCount: number) => {
+    const isOuterExon = exonIndex === 0 || exonIndex === exonsCount - 1;
+    const isInnerExon = !isOuterExon;
+    const isHighlighted = isInnerExon
+      ? props.isGenomicSequenceEnabled ||
+        props.isCDNAEnabled ||
+        props.isCDSEnabled
+      : props.isGenomicSequenceEnabled || props.isCDNAEnabled;
+
+    return classNames({
+      [styles.outerExon]: isOuterExon,
+      [styles.innerExon]: isInnerExon,
+      [styles.highlighted]: isHighlighted
+    });
+  };
+  // FIXME: rename to introns?
+  const backboneStyles = classNames(styles.backbone, {
+    [styles.highlighted]: props.isGenomicSequenceEnabled
+  });
+  const halfOuterExonStyles = classNames(styles.halfOuterExon, {
+    [styles.highlighted]:
+      props.isGenomicSequenceEnabled ||
+      props.isCDNAEnabled ||
+      props.isCDSEnabled
+  });
+
+  const exons = [...Array(exonsCount)].map((_, index) => {
+    return (
+      <rect
+        key={index}
+        className={getExonClasses(index, exonsCount)}
+        x={index * (exonWidth + halfExonWidth)}
+        y={0}
+        width={exonWidth}
+        height={exonHeight}
+      />
+    );
+  });
+
+  const halfOuterExons = (
+    <>
+      <rect
+        className={halfOuterExonStyles}
+        x={halfExonWidth}
+        y={0}
+        width={halfExonWidth}
+        height={exonHeight}
+      />
+      <rect
+        className={halfOuterExonStyles}
+        x={4 * (exonWidth + halfExonWidth)}
+        y={0}
+        width={halfExonWidth}
+        height={exonHeight}
+      />
+    </>
+  );
+
+  const backboneSegments = [...Array(backboneSegmentsCount)].map((_, index) => {
+    const xStart = index * (exonWidth + halfExonWidth) + exonWidth;
+    const xEnd = xStart + halfExonWidth;
+    const y = Math.round(exonHeight / 2);
+    return (
+      <line
+        key={index}
+        className={backboneStyles}
+        x1={xStart}
+        x2={xEnd}
+        y1={y}
+        y2={y}
+      />
+    );
+  });
+
+  const proteinSegments = [...Array(exonsCount)].map((_, index) => {
+    const isOuterSegment = index === 0 || index === exonsCount - 1;
+    return (
+      <rect
+        key={index}
+        className={styles.protein}
+        x={index === 0 ? halfExonWidth : index * (exonWidth + halfExonWidth)}
+        y={exonHeight + verticalGap}
+        width={isOuterSegment ? halfExonWidth : exonWidth}
+        height={proteinHeight}
+      />
+    );
+  });
+
+  return (
+    <svg
+      style={{ overflow: 'visible' }}
+      width={props.width}
+      height={totalHeight}
+    >
+      {exons}
+      {halfOuterExons}
+      {backboneSegments}
+      {props.isProteinSequenceEnabled && proteinSegments}
+    </svg>
+  );
+};
+
+InstantDownloadTranscriptVisualisation.defaultProps = {
+  isGenomicSequenceEnabled: false,
+  isCDNAEnabled: false,
+  isCDSEnabled: false,
+  isProteinSequenceEnabled: false,
+  width: 210
+} as Partial<Props>;
+
+export default InstantDownloadTranscriptVisualisation;

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
@@ -35,7 +35,7 @@ const InstantDownloadTranscriptVisualisation = (props: Props) => {
   const totalHeight = exonHeight + proteinHeight + verticalGap;
   const exonWidth = Math.floor(props.width / 7);
   const halfExonWidth = Math.floor(exonWidth / 2);
-  const backboneSegmentsCount = exonsCount - 1;
+  const intronsCount = exonsCount - 1;
 
   const getExonClasses = (exonIndex: number, exonsCount: number) => {
     const isOuterExon = exonIndex === 0 || exonIndex === exonsCount - 1;
@@ -49,18 +49,18 @@ const InstantDownloadTranscriptVisualisation = (props: Props) => {
     return classNames({
       [styles.outerExon]: isOuterExon,
       [styles.innerExon]: isInnerExon,
-      [styles.highlighted]: isHighlighted
+      [styles.highlighted]: isHighlighted,
     });
   };
-  // FIXME: rename to introns?
-  const backboneStyles = classNames(styles.backbone, {
-    [styles.highlighted]: props.isGenomicSequenceEnabled
+
+  const intronStyles = classNames(styles.intron, {
+    [styles.highlighted]: props.isGenomicSequenceEnabled,
   });
   const halfOuterExonStyles = classNames(styles.halfOuterExon, {
     [styles.highlighted]:
       props.isGenomicSequenceEnabled ||
       props.isCDNAEnabled ||
-      props.isCDSEnabled
+      props.isCDSEnabled,
   });
 
   const exons = [...Array(exonsCount)].map((_, index) => {
@@ -95,14 +95,14 @@ const InstantDownloadTranscriptVisualisation = (props: Props) => {
     </>
   );
 
-  const backboneSegments = [...Array(backboneSegmentsCount)].map((_, index) => {
+  const introns = [...Array(intronsCount)].map((_, index) => {
     const xStart = index * (exonWidth + halfExonWidth) + exonWidth;
     const xEnd = xStart + halfExonWidth;
     const y = Math.round(exonHeight / 2);
     return (
       <line
         key={index}
-        className={backboneStyles}
+        className={intronStyles}
         x1={xStart}
         x2={xEnd}
         y1={y}
@@ -133,7 +133,7 @@ const InstantDownloadTranscriptVisualisation = (props: Props) => {
     >
       {exons}
       {halfOuterExons}
-      {backboneSegments}
+      {introns}
       {props.isProteinSequenceEnabled && proteinSegments}
     </svg>
   );
@@ -144,7 +144,7 @@ InstantDownloadTranscriptVisualisation.defaultProps = {
   isCDNAEnabled: false,
   isCDSEnabled: false,
   isProteinSequenceEnabled: false,
-  width: 210
+  width: 210,
 } as Partial<Props>;
 
 export default InstantDownloadTranscriptVisualisation;

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
+import times from 'lodash/times';
 
 import styles from './InstantDownloadTranscriptVisualisation.scss';
 
@@ -63,7 +64,7 @@ const InstantDownloadTranscriptVisualisation = (props: Props) => {
       props.isCDSEnabled,
   });
 
-  const exons = [...Array(exonsCount)].map((_, index) => {
+  const exons = times(exonsCount, (index) => {
     return (
       <rect
         key={index}
@@ -95,7 +96,7 @@ const InstantDownloadTranscriptVisualisation = (props: Props) => {
     </>
   );
 
-  const introns = [...Array(intronsCount)].map((_, index) => {
+  const introns = times(intronsCount, (index) => {
     const xStart = index * (exonWidth + halfExonWidth) + exonWidth;
     const xEnd = xStart + halfExonWidth;
     const y = Math.round(exonHeight / 2);
@@ -111,7 +112,7 @@ const InstantDownloadTranscriptVisualisation = (props: Props) => {
     );
   });
 
-  const proteinSegments = [...Array(exonsCount)].map((_, index) => {
+  const proteinSegments = times(exonsCount, (index) => {
     const isOuterSegment = index === 0 || index === exonsCount - 1;
     return (
       <rect

--- a/src/ensembl/src/shared/helpers/downloadAsFile.ts
+++ b/src/ensembl/src/shared/helpers/downloadAsFile.ts
@@ -1,0 +1,20 @@
+const downloadAsFile = (
+  content: string | string[],
+  fileName: string,
+  options: { type: string }
+) => {
+  if (typeof content === 'string') {
+    content = [content];
+  }
+  const blob = new Blob(content, options);
+  const blobUrl = URL.createObjectURL(blob);
+  const downloadLink = document.createElement('a');
+  downloadLink.href = blobUrl;
+  downloadLink.download = fileName;
+  downloadLink.click();
+  setTimeout(() => {
+    URL.revokeObjectURL(blobUrl);
+  }, 100);
+};
+
+export default downloadAsFile;

--- a/src/ensembl/src/styles/_settings.scss
+++ b/src/ensembl/src/styles/_settings.scss
@@ -3,7 +3,7 @@
 
 $global-font-size: 14px;
 $global-lineheight: 1.5;
-$black: #17354e;
+$black: #1b2c39;
 $white: #fff;
 $off-white: #fefefe;
 $body-background: $off-white;
@@ -18,6 +18,8 @@ $global-button-cursor: auto;
 
 // Colour Palette
 // ---------
+$soft-black: #374148;
+
 $shadow-color: rgba(0, 0, 0, 0.4);
 
 $light-blue: #e5f5ff; // text highlight

--- a/src/ensembl/stories/shared-components/checkbox/Checkbox.stories.scss
+++ b/src/ensembl/stories/shared-components/checkbox/Checkbox.stories.scss
@@ -2,8 +2,4 @@
 
 .wrapper {
   padding: 20px;
-  background-color: $light-grey;
-  width: 100%;
-  height: 100%;
-  position: absolute;
 }

--- a/src/ensembl/stories/shared-components/checkbox/Checkbox.stories.tsx
+++ b/src/ensembl/stories/shared-components/checkbox/Checkbox.stories.tsx
@@ -1,40 +1,50 @@
 import React, { useState } from 'react';
 
-import Checkbox from 'src/shared/components/checkbox/Checkbox';
+import Checkbox, {
+  CheckboxProps
+} from 'src/shared/components/checkbox/Checkbox';
 import { storiesOf } from '@storybook/react';
 import styles from './Checkbox.stories.scss';
 import { action } from '@storybook/addon-actions';
 
-const Wrapper = (props: any) => {
+const StatefulCheckbox = (props: Partial<CheckboxProps>) => {
   const [checked, setChecked] = useState(false);
 
-  const handleOnchange = (isChecked: boolean) => {
+  const handleChange = (isChecked: boolean) => {
     setChecked(isChecked);
     action('checkbox-toggled')(isChecked);
   };
 
   return (
-    <div className={styles.wrapper}>
-      <Checkbox {...props} checked={checked} onChange={handleOnchange} />
+    <div>
+      <Checkbox {...props} checked={checked} onChange={handleChange} />
     </div>
   );
 };
 
 storiesOf('Components|Shared Components/Checkbox', module)
   .add('default', () => {
-    return <Wrapper />;
+    return (
+      <div className={styles.wrapper}>
+        <StatefulCheckbox />
+      </div>
+    );
   })
   .add('disabled', () => {
     return (
       <div className={styles.wrapper}>
-        <Wrapper disabled={true} />
+        <StatefulCheckbox disabled={true} />
       </div>
     );
   })
   .add('with label', () => {
     return (
       <div className={styles.wrapper}>
-        <Wrapper label={'I am a label'} />
+        <StatefulCheckbox label={'I am label'} />
+        <StatefulCheckbox
+          disabled={true}
+          label={'I am label of disabled checkbox'}
+        />
       </div>
     );
   });

--- a/src/ensembl/stories/shared-components/index.ts
+++ b/src/ensembl/stories/shared-components/index.ts
@@ -23,3 +23,4 @@ import './panel/Panel.stories';
 import './tabs/Tabs.stories';
 import './external-reference/ExternalReference.stories';
 import './external-link/ExternalLink.stories';
+import './instant-download/InstantDownload.stories';

--- a/src/ensembl/stories/shared-components/instant-download/InstantDownload.stories.scss
+++ b/src/ensembl/stories/shared-components/instant-download/InstantDownload.stories.scss
@@ -1,0 +1,43 @@
+@import 'src/styles/common';
+
+.transcriptStoryContainer {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  padding-top: 10vh;
+  padding-bottom: 60px;
+  background: $black;
+
+  .optionsContainer {
+    margin-top: 1em;
+    border: 1px solid black;
+    background: rgba(white, 0.9);
+    padding: 1rem 2rem 1rem 1.5rem;
+
+    .optionsGroup {
+      &:not(:last-child) {
+        margin-bottom: 1em;
+      }
+    }
+
+    .optionsGroupHeading {
+      font-weight: bold;
+      margin-left: -0.5rem;
+    }
+
+    label {
+      display: block;
+    }
+
+    input {
+      margin-right: 0.5em;
+    }
+  }
+}
+
+.containerBlack {
+  padding: 1em;
+  background: $soft-black;
+}

--- a/src/ensembl/stories/shared-components/instant-download/InstantDownload.stories.tsx
+++ b/src/ensembl/stories/shared-components/instant-download/InstantDownload.stories.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import InstantDownloadTranscriptStory from './InstantDownloadTranscript.stories';
+
+storiesOf('Components|Shared Components/InstantDownload', module).add(
+  'transcript',
+  () => {
+    return <InstantDownloadTranscriptStory />;
+  }
+);

--- a/src/ensembl/stories/shared-components/instant-download/InstantDownloadTranscript.stories.tsx
+++ b/src/ensembl/stories/shared-components/instant-download/InstantDownloadTranscript.stories.tsx
@@ -1,0 +1,129 @@
+import React, { useState } from 'react';
+
+import { createGene } from 'tests/fixtures/entity-viewer/gene';
+import { createTranscript } from 'tests/fixtures/entity-viewer/transcript';
+
+import { InstantDownloadTranscript } from 'src/shared/components/instant-download';
+
+import styles from './InstantDownload.stories.scss';
+
+const buildProteinCodingGene = () => {
+  const transcript = createTranscript({
+    id: 'ENST00000496384',
+    so_term: 'protein_coding'
+  });
+  const gene = createGene({
+    id: 'ENSG00000157764',
+    so_term: 'protein_coding',
+    transcripts: [transcript]
+  });
+  return gene;
+};
+
+const buildNonProteinCodingGene = () => {
+  return createGene();
+};
+
+type Layout = 'horizontal' | 'vertical';
+type TranscriptType = 'coding' | 'non-coding';
+
+const InstantDownloadTranscriptStory = () => {
+  const [layout, setLayout] = useState<Layout>('horizontal');
+  const [transcriptType, setTranscriptType] = useState<TranscriptType>(
+    'coding'
+  );
+
+  const gene =
+    transcriptType === 'coding'
+      ? buildProteinCodingGene()
+      : buildNonProteinCodingGene();
+
+  const horizontalContainerProps = {
+    className: styles.containerBlack,
+    style: {
+      width: '695px'
+    }
+  };
+
+  const verticalContainerProps = {
+    className: styles.containerBlack,
+    style: {
+      width: '270px'
+    }
+  };
+
+  const containerProps =
+    layout === 'horizontal' ? horizontalContainerProps : verticalContainerProps;
+
+  return (
+    <div className={styles.transcriptStoryContainer}>
+      <div {...containerProps}>
+        <InstantDownloadTranscript
+          layout={layout}
+          gene={gene}
+          transcript={gene.transcripts[0]}
+        />
+      </div>
+      <StoryOptions
+        currentLayout={layout}
+        onLayoutChange={setLayout}
+        currentTranscriptType={transcriptType}
+        onTranscriptTypeChange={setTranscriptType}
+      />
+    </div>
+  );
+};
+
+type StoryOptionsProps = {
+  currentLayout: Layout;
+  onLayoutChange: (layout: Layout) => void;
+  currentTranscriptType: TranscriptType;
+  onTranscriptTypeChange: (type: TranscriptType) => void;
+};
+
+const StoryOptions = (props: StoryOptionsProps) => {
+  return (
+    <div className={styles.optionsContainer}>
+      <div className={styles.optionsGroup}>
+        <div className={styles.optionsGroupHeading}>Layout</div>
+        <label>
+          <input
+            type="radio"
+            checked={props.currentLayout === 'horizontal'}
+            onChange={() => props.onLayoutChange('horizontal')}
+          />
+          Horizontal
+        </label>
+        <label>
+          <input
+            type="radio"
+            checked={props.currentLayout === 'vertical'}
+            onChange={() => props.onLayoutChange('vertical')}
+          />
+          Vertical
+        </label>
+      </div>
+      <div className={styles.optionsGroup}>
+        <div className={styles.optionsGroupHeading}>Transcript type</div>
+        <label>
+          <input
+            type="radio"
+            checked={props.currentTranscriptType === 'coding'}
+            onChange={() => props.onTranscriptTypeChange('coding')}
+          />
+          Coding
+        </label>
+        <label>
+          <input
+            type="radio"
+            checked={props.currentTranscriptType === 'non-coding'}
+            onChange={() => props.onTranscriptTypeChange('non-coding')}
+          />
+          Non-coding
+        </label>
+      </div>
+    </div>
+  );
+};
+
+export default InstantDownloadTranscriptStory;

--- a/src/ensembl/tests/fixtures/entity-viewer/gene.ts
+++ b/src/ensembl/tests/fixtures/entity-viewer/gene.ts
@@ -8,7 +8,7 @@ import { createTranscript } from './transcript';
 import { Gene } from 'src/content/app/entity-viewer/types/gene';
 import { TicksAndScale } from 'src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/BasePairsRuler';
 
-export const createGene = (): Gene => {
+export const createGene = (fragment: Partial<Gene> = {}): Gene => {
   const geneSlice = createSlice();
   const transcript = createTranscript();
 
@@ -18,7 +18,8 @@ export const createGene = (): Gene => {
     symbol: faker.lorem.word(),
     so_term: faker.lorem.word(),
     slice: geneSlice,
-    transcripts: [transcript]
+    transcripts: [transcript],
+    ...fragment
   };
 };
 

--- a/src/ensembl/tests/fixtures/entity-viewer/transcript.ts
+++ b/src/ensembl/tests/fixtures/entity-viewer/transcript.ts
@@ -14,7 +14,7 @@ import {
   ProductType
 } from 'src/content/app/entity-viewer/types/product';
 
-export const createTranscript = (): Transcript => {
+export const createTranscript = (fragment: Partial<Transcript> = {}): Transcript => {
   const transcriptSlice = createSlice();
 
   return {
@@ -25,7 +25,8 @@ export const createTranscript = (): Transcript => {
     slice: transcriptSlice,
     exons: createExons(transcriptSlice),
     cds: createCDS(transcriptSlice),
-    product: createProduct()
+    product: createProduct(),
+    ...fragment
   };
 };
 

--- a/src/ensembl/tests/fixtures/entity-viewer/transcript.ts
+++ b/src/ensembl/tests/fixtures/entity-viewer/transcript.ts
@@ -11,7 +11,7 @@ import { CDS } from 'src/content/app/entity-viewer/types/cds';
 import {
   Product,
   ProteinDomainsResources,
-  ProductType,
+  ProductType
 } from 'src/content/app/entity-viewer/types/product';
 
 export const createTranscript = (
@@ -28,7 +28,7 @@ export const createTranscript = (
     exons: createExons(transcriptSlice),
     cds: createCDS(transcriptSlice),
     product: createProduct(),
-    ...fragment,
+    ...fragment
   };
 };
 
@@ -46,11 +46,11 @@ const createProduct = (): Product => {
       maxCoordinate - (maxCoordinate - minCoordinate) / 2;
     const start = faker.random.number({
       min: minCoordinate,
-      max: middleCoordinate,
+      max: middleCoordinate
     });
     const end = faker.random.number({
       min: middleCoordinate + 1,
-      max: maxCoordinate - 1,
+      max: maxCoordinate - 1
     });
     const resource_group_name = faker.random.words();
 
@@ -62,28 +62,28 @@ const createProduct = (): Product => {
           source_uri: '',
           source: {
             name: faker.random.words(),
-            uri: '',
+            uri: ''
           },
           location: {
             start: start,
-            end: end,
+            end: end
           },
-          score: faker.random.number(),
-        },
-      ],
+          score: faker.random.number()
+        }
+      ]
     };
   });
 
   return {
     protein_domains_resources: protein_domains_resources,
     type: ProductType.PROTEIN,
-    length: length,
+    length: length
   };
 };
 
 const createExons = (transcriptSlice: Slice): Exon[] => {
   const { start: transcriptStart, end: transcriptEnd } = getFeatureCoordinates({
-    slice: transcriptSlice,
+    slice: transcriptSlice
   });
   const length = transcriptEnd - transcriptStart + 1;
 
@@ -97,18 +97,18 @@ const createExons = (transcriptSlice: Slice): Exon[] => {
       maxCoordinate - (maxCoordinate - minCoordinate) / 2;
     const exonStart = faker.random.number({
       min: minCoordinate,
-      max: middleCoordinate,
+      max: middleCoordinate
     });
     const exonEnd = faker.random.number({
       min: middleCoordinate + 1,
-      max: maxCoordinate - 1,
+      max: maxCoordinate - 1
     });
     const slice = {
       location: {
         start: index > 0 ? exonStart : transcriptStart,
-        end: index < numberOfExons - 1 ? exonEnd : transcriptEnd,
+        end: index < numberOfExons - 1 ? exonEnd : transcriptEnd
       },
-      region: transcriptSlice.region,
+      region: transcriptSlice.region
     };
 
     return {
@@ -117,8 +117,8 @@ const createExons = (transcriptSlice: Slice): Exon[] => {
       relative_location: {
         // <-- we are still not sure about this relative location thing
         start: 0,
-        end: 0,
-      },
+        end: 0
+      }
     };
   });
 };
@@ -132,7 +132,7 @@ const createCDS = (transcriptSlice: Slice): CDS => {
     relative_location: {
       // <-- we are still not sure about this relative location thing
       start: 0,
-      end: 0,
-    },
+      end: 0
+    }
   };
 };

--- a/src/ensembl/tests/fixtures/entity-viewer/transcript.ts
+++ b/src/ensembl/tests/fixtures/entity-viewer/transcript.ts
@@ -11,10 +11,12 @@ import { CDS } from 'src/content/app/entity-viewer/types/cds';
 import {
   Product,
   ProteinDomainsResources,
-  ProductType
+  ProductType,
 } from 'src/content/app/entity-viewer/types/product';
 
-export const createTranscript = (fragment: Partial<Transcript> = {}): Transcript => {
+export const createTranscript = (
+  fragment: Partial<Transcript> = {}
+): Transcript => {
   const transcriptSlice = createSlice();
 
   return {
@@ -26,29 +28,29 @@ export const createTranscript = (fragment: Partial<Transcript> = {}): Transcript
     exons: createExons(transcriptSlice),
     cds: createCDS(transcriptSlice),
     product: createProduct(),
-    ...fragment
+    ...fragment,
   };
 };
 
 const createProduct = (): Product => {
   const length = faker.random.number({ min: 10, max: 100 });
-  const numberOfExons = faker.random.number({ min: 1, max: 10 });
-  const maxExonLength = Math.floor(length / numberOfExons);
+  const numberOfDomains = faker.random.number({ min: 1, max: 10 });
+  const maxDomainLength = Math.floor(length / numberOfDomains);
 
   const protein_domains_resources: ProteinDomainsResources = {};
 
-  times(numberOfExons, (index: number) => {
-    const minCoordinate = maxExonLength * index + 1;
-    const maxCoordinate = maxExonLength * index + 1;
+  times(numberOfDomains, (index: number) => {
+    const minCoordinate = maxDomainLength * index + 1;
+    const maxCoordinate = maxDomainLength * (index + 1);
     const middleCoordinate =
       maxCoordinate - (maxCoordinate - minCoordinate) / 2;
     const start = faker.random.number({
       min: minCoordinate,
-      max: middleCoordinate
+      max: middleCoordinate,
     });
     const end = faker.random.number({
       min: middleCoordinate + 1,
-      max: maxCoordinate - 1
+      max: maxCoordinate - 1,
     });
     const resource_group_name = faker.random.words();
 
@@ -60,30 +62,30 @@ const createProduct = (): Product => {
           source_uri: '',
           source: {
             name: faker.random.words(),
-            uri: ''
+            uri: '',
           },
           location: {
             start: start,
-            end: end
+            end: end,
           },
-          score: faker.random.number()
-        }
-      ]
+          score: faker.random.number(),
+        },
+      ],
     };
   });
 
   return {
     protein_domains_resources: protein_domains_resources,
     type: ProductType.PROTEIN,
-    length: length
+    length: length,
   };
 };
 
 const createExons = (transcriptSlice: Slice): Exon[] => {
   const { start: transcriptStart, end: transcriptEnd } = getFeatureCoordinates({
-    slice: transcriptSlice
+    slice: transcriptSlice,
   });
-  const length = (transcriptEnd - transcriptStart) + 1;
+  const length = transcriptEnd - transcriptStart + 1;
 
   const numberOfExons = faker.random.number({ min: 1, max: 10 });
   const maxExonLength = Math.floor(length / numberOfExons);
@@ -95,18 +97,18 @@ const createExons = (transcriptSlice: Slice): Exon[] => {
       maxCoordinate - (maxCoordinate - minCoordinate) / 2;
     const exonStart = faker.random.number({
       min: minCoordinate,
-      max: middleCoordinate
+      max: middleCoordinate,
     });
     const exonEnd = faker.random.number({
       min: middleCoordinate + 1,
-      max: maxCoordinate - 1
+      max: maxCoordinate - 1,
     });
     const slice = {
       location: {
         start: index > 0 ? exonStart : transcriptStart,
-        end: index < numberOfExons - 1 ? exonEnd : transcriptEnd
+        end: index < numberOfExons - 1 ? exonEnd : transcriptEnd,
       },
-      region: transcriptSlice.region
+      region: transcriptSlice.region,
     };
 
     return {
@@ -115,8 +117,8 @@ const createExons = (transcriptSlice: Slice): Exon[] => {
       relative_location: {
         // <-- we are still not sure about this relative location thing
         start: 0,
-        end: 0
-      }
+        end: 0,
+      },
     };
   });
 };
@@ -130,7 +132,7 @@ const createCDS = (transcriptSlice: Slice): CDS => {
     relative_location: {
       // <-- we are still not sure about this relative location thing
       start: 0,
-      end: 0
-    }
+      end: 0,
+    },
   };
 };


### PR DESCRIPTION
## Type
- New feature

## Related JIRA Issue(s)
ENSWBSITES-573

## Description
- Add `InstantDownloadTranscript` component for downloading sequences related to transcript or to its parent gene
- Add the general-purpose `downloadAsFile` helper for downloading data present in browser's memory to disk 

### Other changes
- Change the black colour across the site, and add soft-black colour.
- Update the `Checkbox` component to change cursor appearance to pointer when mousing over label, and to catalogue classNames props that can be passed to the Chackbox.
- Update the `Button` component so that the active state of the PrimaryButton and SecondaryButton have a 1px-wide border. This helps avoid changes in block height when toggling between disabled and enabled states of the button.

## Views affected
Storybook