### PR TITLE
Bring back the tooltip timeout

### DIFF
--- a/src/ensembl/src/shared/components/image-button/ImageButton.tsx
+++ b/src/ensembl/src/shared/components/image-button/ImageButton.tsx
@@ -57,11 +57,7 @@ export const ImageButton = (props: Props) => {
         )}
       </button>
       {shouldShowTooltip && (
-        <Tooltip
-          anchor={hoverRef.current}
-          autoAdjust={true}
-          delay={TOOLTIP_TIMEOUT}
-        >
+        <Tooltip anchor={hoverRef.current} autoAdjust={true}>
           {props.description}
         </Tooltip>
       )}

--- a/src/ensembl/src/shared/components/image-button/ImageButton.tsx
+++ b/src/ensembl/src/shared/components/image-button/ImageButton.tsx
@@ -4,9 +4,7 @@ import classNames from 'classnames';
 
 import useHover from 'src/shared/hooks/useHover';
 
-import Tooltip, {
-  TOOLTIP_TIMEOUT
-} from 'src/shared/components/tooltip/Tooltip';
+import Tooltip from 'src/shared/components/tooltip/Tooltip';
 
 import { Status } from 'src/shared/types/status';
 

--- a/src/ensembl/src/shared/components/image-button/ImageButton.tsx
+++ b/src/ensembl/src/shared/components/image-button/ImageButton.tsx
@@ -4,7 +4,9 @@ import classNames from 'classnames';
 
 import useHover from 'src/shared/hooks/useHover';
 
-import Tooltip from 'src/shared/components/tooltip/Tooltip';
+import Tooltip, {
+  TOOLTIP_TIMEOUT
+} from 'src/shared/components/tooltip/Tooltip';
 
 import { Status } from 'src/shared/types/status';
 
@@ -57,7 +59,11 @@ export const ImageButton = (props: Props) => {
         )}
       </button>
       {shouldShowTooltip && (
-        <Tooltip anchor={hoverRef.current} autoAdjust={true}>
+        <Tooltip
+          anchor={hoverRef.current}
+          autoAdjust={true}
+          delay={TOOLTIP_TIMEOUT}
+        >
           {props.description}
         </Tooltip>
       )}

--- a/src/ensembl/src/shared/components/tooltip/Tooltip.tsx
+++ b/src/ensembl/src/shared/components/tooltip/Tooltip.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useEffect, useState } from 'react';
 
-export { TOOLTIP_TIMEOUT } from './tooltip-constants';
+import { TOOLTIP_TIMEOUT } from './tooltip-constants';
 
 import PointerBox, {
   Position
@@ -60,8 +60,9 @@ const TooltipWithAnchor = (props: Props) => {
 };
 
 Tooltip.defaultProps = {
-  delay: 0,
+  delay: TOOLTIP_TIMEOUT,
   position: Position.BOTTOM_RIGHT
 };
 
+export { TOOLTIP_TIMEOUT };
 export default Tooltip;

--- a/src/ensembl/src/shared/components/tooltip/Tooltip.tsx
+++ b/src/ensembl/src/shared/components/tooltip/Tooltip.tsx
@@ -1,5 +1,7 @@
 import React, { ReactNode, useEffect, useState } from 'react';
 
+export { TOOLTIP_TIMEOUT } from './tooltip-constants';
+
 import PointerBox, {
   Position
 } from 'src/shared/components/pointer-box/PointerBox';

--- a/src/ensembl/src/shared/components/tooltip/tooltip-constants.ts
+++ b/src/ensembl/src/shared/components/tooltip/tooltip-constants.ts
@@ -1,5 +1,1 @@
-export const TIP_WIDTH = 18;
-export const TIP_HEIGHT = 13;
-export const TIP_HORIZONTAL_OFFSET = 20; // distance from the side of the tooltip to the beginning of the base of the tip
-
 export const TOOLTIP_TIMEOUT = 800;


### PR DESCRIPTION
## Type
- Bug fix

## Description
Before https://github.com/Ensembl/ensembl-client/pull/270, the default delay for the Tooltip used to be greater than 0 (specifically, 800ms)

![image](https://user-images.githubusercontent.com/6834224/78776918-890fff80-7990-11ea-9051-d57aa01781d0.png)

but in the course of refactoring, it was changed to 0, which makes the Tooltip appear uncomfortably quickly:

![image](https://user-images.githubusercontent.com/6834224/78777094-d68c6c80-7990-11ea-9be7-d023a19ffb3c.png)

This PR changes this back.

## Views affected
All