### PR TITLE
Change url for toy graphql server

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
@@ -51,7 +51,7 @@ export type EntityViewerParams = {
 };
 
 const client = new ApolloClient({
-  uri: 'http://193.62.55.158:30466'
+  uri: 'http://hx-rke-wp-webadmin-14-worker-1.caas.ebi.ac.uk:31770'
 });
 
 const EntityViewer = (props: Props) => {


### PR DESCRIPTION
## Description
Url for the toy graphql server has changed; we might as well merge it into dev.

Note: the url is accessible only on EBI network (which means, over the VPN).

## Views affected
Entity Viewer