### PR TITLE
Integrate instant download into default transcripts list

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
@@ -60,7 +60,10 @@ const DefaultTranscriptListItem = (props: Props) => {
         </div>
       </div>
       {shouldShowInfo ? (
-        <TranscriptsListItemInfo transcript={props.transcript} />
+        <TranscriptsListItemInfo
+          gene={props.gene}
+          transcript={props.transcript}
+        />
       ) : null}
     </div>
   );

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
@@ -6,11 +6,13 @@
 }
 
 .middle {
+  display: grid;
+  grid-template-areas:
+    'left middle right .'
+    '. . . downloadLink'
+    'download download download download';
+  grid-column-gap: 10px;
   background: #374148;
-  display: flex;
-  justify-content: space-between;
-  grid-template-columns: 1.5fr 1fr 1.5fr 1fr;
-  grid-template-rows: auto;
   padding: 15px 20px;
 
   strong {
@@ -19,15 +21,42 @@
   }
 }
 
-.column:not(:last-child) {
-  margin-right: 20px;
-  padding-bottom: 30px;
+.topLeft {
+  grid-area: left;
+  width: 190px;
 }
 
-.column:last-child {
-  align-self: flex-end;
+.topMiddle {
+  grid-area: middle;
+  width: 150px;
+}
+
+.topRight {
+  grid-area: right;
+  width: 210px;
 }
 
 .downloadLink {
+  grid-area: downloadLink;
   color: $blue;
+  width: 66px;
+  height: 16px;
+  text-align: right;
+  line-height: 1;
+
+  span {
+    cursor: pointer;
+  }
+}
+
+.download {
+  grid-area: download;
+  padding-top: 15px;
+  margin-top: 15px;
+  border-top: 1px solid $dark-grey;
+}
+
+.closeIcon {
+  cursor: pointer;
+  height: 16px;
 }

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.test.tsx
@@ -3,21 +3,24 @@ import { mount } from 'enzyme';
 
 import TranscriptsListItemInfo from './TranscriptsListItemInfo';
 
+import { createGene } from 'tests/fixtures/entity-viewer/gene';
 import { createTranscript } from 'tests/fixtures/entity-viewer/transcript';
 
 describe('<TranscriptsListItemInfo /', () => {
   let wrapper: any;
+  const transcript = createTranscript();
+  const gene = createGene({ transcripts: [transcript] });
+  const props = {
+    gene,
+    transcript
+  };
 
   beforeEach(() => {
-    const props = {
-      transcript: createTranscript()
-    };
-
     wrapper = mount(<TranscriptsListItemInfo {...props} />);
   });
 
   it('displays amino acid length when transcript has CDS', () => {
-    expect(wrapper.find('#amino-acid-length')).toHaveLength(1);
+    expect(wrapper.find('.topMiddle strong')).toHaveLength(1);
   });
 
   it('contains the download link', () => {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.test.tsx
@@ -19,8 +19,19 @@ describe('<TranscriptsListItemInfo /', () => {
     wrapper = mount(<TranscriptsListItemInfo {...props} />);
   });
 
+  /*
+   * FIXME: the test below will have to change when api payload updates:
+   * 1) we will use protein length from api response instead of calculating it ourselves
+   * 2) we will check that protein product is present on a transcript instead of looking at CDS
+   */
   it('displays amino acid length when transcript has CDS', () => {
-    expect(wrapper.find('.topMiddle strong')).toHaveLength(1);
+    const totalExonsLength = props.transcript.exons.reduce((sum, exon) => {
+      return sum + exon.slice.location.end - exon.slice.location.start + 1;
+    }, 0);
+    const expectedProteinLength = Math.floor(totalExonsLength / 3);
+    expect(wrapper.find('.topMiddle strong').text()).toMatch(
+      `${expectedProteinLength}`
+    );
   });
 
   it('contains the download link', () => {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -58,12 +58,12 @@ const ItemInfo = (props: ItemInfoProps) => {
     if (cds) {
       firstCodingExonIndex = exons.findIndex((exon) => {
         const { start: exonStart, end: exonEnd } = getFeatureCoordinates(exon);
-        return exonStart <= cds.start && exonEnd >= cds.start ? true : false;
+        return exonStart <= cds.start && exonEnd >= cds.start;
       });
 
       lastCodingExonIndex = exons.findIndex((exon) => {
         const { start: exonStart, end: exonEnd } = getFeatureCoordinates(exon);
-        return exonStart <= cds.end && exonEnd >= cds.end ? true : false;
+        return exonStart <= cds.end && exonEnd >= cds.end;
       });
     }
 
@@ -82,6 +82,10 @@ const ItemInfo = (props: ItemInfoProps) => {
         firstCodingExonIndex,
         lastCodingExonIndex
       } = getFirstAndLastCodingExonIndexes();
+      if (firstCodingExonIndex === lastCodingExonIndex) {
+        return Math.floor((cds.end - cds.start + 1) / 3);
+      }
+
       let cdsLength = 0;
 
       // add coding length of the first coding exon

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import classNames from 'classnames';
 
 import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
@@ -8,17 +8,27 @@ import {
   getRegionName
 } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
 
+import { InstantDownloadTranscript } from 'src/shared/components/instant-download';
+
+import { ReactComponent as CloseIcon } from 'static/img/shared/close.svg';
+
+import { Gene } from 'src/content/app/entity-viewer/types/gene';
 import { Transcript } from 'src/content/app/entity-viewer/types/transcript';
 
 import transcriptsListStyles from '../DefaultTranscriptsList.scss';
 import styles from './TranscriptsListItemInfo.scss';
 
 type ItemInfoProps = {
+  gene: Gene;
   transcript: Transcript;
 };
 
 const ItemInfo = (props: ItemInfoProps) => {
+  const [isDownloadShown, setIsDownloadShown] = useState(false);
   const { transcript } = props;
+
+  const openDownload = () => setIsDownloadShown(true);
+  const closeDownload = () => setIsDownloadShown(false);
 
   const getTranscriptLocation = () => {
     const { start, end } = getFeatureCoordinates(transcript);
@@ -120,23 +130,23 @@ const ItemInfo = (props: ItemInfoProps) => {
     <div className={mainStyles}>
       <div className={transcriptsListStyles.left}>bottom left</div>
       <div className={midStyles}>
-        <div className={styles.column}>
+        <div className={styles.topLeft}>
           <div>
             <strong>{transcript.biotype}</strong>
           </div>
           <div>{getTranscriptLocation()}</div>
         </div>
-        <div className={styles.column}>
+        <div className={styles.topMiddle}>
           {transcript.cds && (
             <>
-              <div id="amino-acid-length">
+              <div>
                 <strong>{getAminoAcidLength()} aa</strong>
               </div>
               <div>ENSP1000000000</div>
             </>
           )}
         </div>
-        <div className={styles.column}>
+        <div className={styles.topRight}>
           <div>
             Spliced RNA length <strong>{getSplicedRNALength()} bp</strong>
           </div>
@@ -145,11 +155,24 @@ const ItemInfo = (props: ItemInfoProps) => {
             {transcript.exons.length}
           </div>
         </div>
-        <div className={styles.column}>
-          <div className={styles.downloadLink}>Download</div>
+        <div className={styles.downloadLink}>
+          {isDownloadShown ? (
+            <CloseIcon className={styles.closeIcon} onClick={closeDownload} />
+          ) : (
+            <span onClick={openDownload}>Download</span>
+          )}
         </div>
+        {isDownloadShown && renderInstantDownload(props)}
       </div>
       <div className={transcriptsListStyles.right}>{transcript.symbol}</div>
+    </div>
+  );
+};
+
+const renderInstantDownload = ({ gene, transcript }: ItemInfoProps) => {
+  return (
+    <div className={styles.download}>
+      <InstantDownloadTranscript transcript={transcript} gene={gene} />
     </div>
   );
 };

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.scss
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.scss
@@ -2,7 +2,12 @@
 
 $regularColor: $dark-grey;
 
-.outerExon {
+/* Duplicating class selectors below to increase sensitivity
+* and overwrite styles that can be added by the combination of
+* parentClass > rect
+*/
+
+.outerExon.outerExon {
   stroke: $regularColor;
   fill: none;
 
@@ -11,7 +16,7 @@ $regularColor: $dark-grey;
   }
 }
 
-.innerExon {
+.innerExon.innerExon {
   stroke: $regularColor;
   fill: $regularColor;
 
@@ -21,7 +26,7 @@ $regularColor: $dark-grey;
   }
 }
 
-.halfOuterExon {
+.halfOuterExon.halfOuterExon {
   stroke: $regularColor;
   fill: $regularColor;
 
@@ -31,7 +36,7 @@ $regularColor: $dark-grey;
   }
 }
 
-.intron {
+.intron.intron {
   stroke: $regularColor;
 
   &.highlighted {


### PR DESCRIPTION
## Type
- New feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-557

## Description
This PR integrates InstantDownloadTranscripts component into the DefaultTranscriptsList of the EntityViewer.

Steps to see the component:
- go to the gene view of EntityViewer
- click on one of the transcripts to open a transcript info block 
- click on the Download link to see the InstantDownload component

## Views affected
Entity viewer page

## Feature branch deployed to:
http://hx-rke-wp-webadmin-14-worker-1.caas.ebi.ac.uk:32015/