### PR TITLE
Add cache to api-service

### DIFF
--- a/src/ensembl/src/services/api-service.ts
+++ b/src/ensembl/src/services/api-service.ts
@@ -22,7 +22,7 @@ type FetchOptions = {
   headers?: { [key: string]: string };
   body?: string; // stringified json
   preserveEndpoint?: boolean;
-  skipCache?: boolean;
+  noCache?: boolean;
 };
 
 const defaultMethod = HTTPMethod.GET;
@@ -68,7 +68,7 @@ class ApiService {
     const fetch = this.getFetch();
     const url = options.preserveEndpoint ? endpoint : `${host}${endpoint}`;
 
-    if (!options.skipCache) {
+    if (!options.noCache) {
       const cachedItem = this.cache.get(url);
       if (cachedItem) {
         return cachedItem;
@@ -86,7 +86,7 @@ class ApiService {
         response,
         fetchOptions
       );
-      if (!options.skipCache) {
+      if (!options.noCache) {
         this.cache.set(url, processedResponse);
       }
       return processedResponse;

--- a/src/ensembl/src/services/api-service.ts
+++ b/src/ensembl/src/services/api-service.ts
@@ -2,6 +2,7 @@
 // we will modify it to use a library once we decide which one to choose
 
 import config from 'config';
+import LRUCache from 'src/shared/utils/lruCache';
 
 export enum HTTPMethod {
   GET = 'GET',
@@ -21,6 +22,7 @@ type FetchOptions = {
   headers?: { [key: string]: string };
   body?: string; // stringified json
   preserveEndpoint?: boolean;
+  skipCache?: boolean;
 };
 
 const defaultMethod = HTTPMethod.GET;
@@ -28,9 +30,11 @@ const defaultHeaders = { Accept: 'application/json' };
 
 class ApiService {
   private host: string;
+  private cache: LRUCache;
 
   public constructor(config: ApiServiceConfig) {
     this.host = config.host || '';
+    this.cache = new LRUCache({ maxAge: 60 * 60 * 1000 });
   }
 
   // temporary method, for easy testing, until we choose a library
@@ -63,6 +67,14 @@ class ApiService {
     const host = options.host || this.host;
     const fetch = this.getFetch();
     const url = options.preserveEndpoint ? endpoint : `${host}${endpoint}`;
+
+    if (!options.skipCache) {
+      const cachedItem = this.cache.get(url);
+      if (cachedItem) {
+        return cachedItem;
+      }
+    }
+
     const fetchOptions = this.buildFetchOptions(options);
 
     try {
@@ -70,7 +82,14 @@ class ApiService {
       if (!response.ok) {
         throw await this.handleError(response);
       }
-      return await this.handleResponse(response, fetchOptions);
+      const processedResponse = await this.handleResponse(
+        response,
+        fetchOptions
+      );
+      if (!options.skipCache) {
+        this.cache.set(url, processedResponse);
+      }
+      return processedResponse;
     } catch (error) {
       throw error;
     }

--- a/src/ensembl/src/services/tests/api-service.test.ts
+++ b/src/ensembl/src/services/tests/api-service.test.ts
@@ -142,9 +142,11 @@ describe('api service', () => {
     });
 
     it('respects the option not to cache the response', async () => {
-      await apiService.fetch(endpoint, { skipCache: true });
+      const response = await apiService.fetch(endpoint, { noCache: true });
       expect(LRUCache.prototype.get).not.toHaveBeenCalled();
       expect(LRUCache.prototype.set).not.toHaveBeenCalled();
+
+      expect(response).toEqual(mockResponse);
     });
 
     describe('when request fails', () => {

--- a/src/ensembl/src/services/tests/api-service.test.ts
+++ b/src/ensembl/src/services/tests/api-service.test.ts
@@ -2,6 +2,7 @@ import faker from 'faker';
 
 import apiService, { HTTPMethod } from '../api-service';
 import config from 'config';
+import LRUCache from 'src/shared/utils/lruCache';
 
 jest.mock('config', () => ({
   apiHost: 'http://foo.bar'
@@ -33,6 +34,8 @@ describe('api service', () => {
   beforeEach(() => {
     const mockSuccessResponse = generateMockSuccessResponse();
     mockFetch = generateMockFetch(mockSuccessResponse);
+    LRUCache.prototype.get = jest.fn();
+    LRUCache.prototype.set = jest.fn();
     jest
       .spyOn(apiService, 'getFetch')
       .mockImplementation(() => mockFetch as any);
@@ -45,7 +48,7 @@ describe('api service', () => {
   describe('.fetch', () => {
     const endpoint = `/${faker.lorem.word()}/${faker.lorem.word()}`;
 
-    test('calls fetch passing it the endpoint', async () => {
+    it('calls fetch passing it the endpoint', async () => {
       await apiService.fetch(endpoint);
 
       expect(mockFetch).toHaveBeenCalled();
@@ -56,7 +59,7 @@ describe('api service', () => {
       expect(url).toEqual(`${config.apiHost}${endpoint}`);
     });
 
-    test('respects an option for not modifying the endpoint', async () => {
+    it('respects an option for not modifying the endpoint', async () => {
       await apiService.fetch(endpoint, { preserveEndpoint: true });
 
       expect(mockFetch).toHaveBeenCalled();
@@ -67,7 +70,7 @@ describe('api service', () => {
       expect(url).toEqual(endpoint);
     });
 
-    test('respects the host passed in options', async () => {
+    it('respects the host passed in options', async () => {
       const host = faker.internet.url();
       await apiService.fetch(endpoint, { host });
 
@@ -79,7 +82,7 @@ describe('api service', () => {
       expect(url).toEqual(`${host}${endpoint}`);
     });
 
-    test('passes options to fetch', async () => {
+    it('passes options to fetch', async () => {
       const options = {
         method: HTTPMethod.POST,
         body: JSON.stringify({ foo: 'bar' })
@@ -96,7 +99,7 @@ describe('api service', () => {
       });
     });
 
-    test('uses GET by default', async () => {
+    it('uses GET by default', async () => {
       await apiService.fetch(endpoint);
 
       const mockFetchCall: any[] = mockFetch.mock.calls[0];
@@ -105,10 +108,43 @@ describe('api service', () => {
       expect(options.method).toEqual(`GET`);
     });
 
-    test('returns response from the api endpoint', async () => {
+    it('returns response from the api endpoint', async () => {
       const response = await apiService.fetch(endpoint);
 
       expect(response).toEqual(mockResponse);
+    });
+
+    it('caches the response', async () => {
+      let response = await apiService.fetch(endpoint, {
+        preserveEndpoint: true
+      });
+      // first, api service will try to access the cache
+      expect(LRUCache.prototype.get).toHaveBeenCalledTimes(1);
+      expect(LRUCache.prototype.get).toHaveBeenCalledWith(endpoint);
+      // since the cache is empty, api service will fetch the data
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      // and it will store response in the cache
+      expect(LRUCache.prototype.set).toHaveBeenCalledTimes(1);
+      expect(LRUCache.prototype.set).toHaveBeenCalledWith(endpoint, response);
+
+      jest.resetAllMocks();
+
+      const mockCachedResponse = { foo: 'this comes from cache' };
+      jest
+        .spyOn(LRUCache.prototype, 'get')
+        .mockImplementation(() => mockCachedResponse);
+
+      response = await apiService.fetch(endpoint, { preserveEndpoint: true });
+      expect(LRUCache.prototype.get).toHaveBeenCalledTimes(1); // checks cache and gets item from cache
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(LRUCache.prototype.set).not.toHaveBeenCalled();
+      expect(response).toEqual(mockCachedResponse);
+    });
+
+    it('respects the option not to cache the response', async () => {
+      await apiService.fetch(endpoint, { skipCache: true });
+      expect(LRUCache.prototype.get).not.toHaveBeenCalled();
+      expect(LRUCache.prototype.set).not.toHaveBeenCalled();
     });
 
     describe('when request fails', () => {
@@ -122,7 +158,7 @@ describe('api service', () => {
         jest.spyOn(apiService, 'getFetch').mockImplementation(() => mockFetch);
       });
 
-      test('throws an error', async () => {
+      it('throws an error', async () => {
         const expectedError = {
           ...mockError,
           status: mockErrorResponse.status

--- a/src/ensembl/src/shared/components/tabs/Tabs.test.tsx
+++ b/src/ensembl/src/shared/components/tabs/Tabs.test.tsx
@@ -9,7 +9,7 @@ const onTabChange = jest.fn();
 
 const createTabGroup = (): Tab[] => {
   const options = times(10, () => ({
-    title: faker.random.words(),
+    title: faker.random.uuid(),
     isDisabled: faker.random.boolean()
   }));
 
@@ -62,10 +62,7 @@ describe('<Tabs />', () => {
   it('adds respective class to the disabled tabs', () => {
     const disabledTabIndex = tabsData.findIndex((tab) => tab.isDisabled);
     expect(
-      wrapper
-        .find('.tab')
-        .at(disabledTabIndex)
-        .hasClass('disabled')
+      wrapper.find('.tab').at(disabledTabIndex).hasClass('disabled')
     ).toBeTruthy();
   });
 
@@ -74,10 +71,7 @@ describe('<Tabs />', () => {
       (tab) => tab.title === defaultProps.selectedTab
     );
     expect(
-      wrapper
-        .find('.tab')
-        .at(selectedTabIndex)
-        .hasClass('selected')
+      wrapper.find('.tab').at(selectedTabIndex).hasClass('selected')
     ).toBeTruthy();
   });
 
@@ -85,10 +79,7 @@ describe('<Tabs />', () => {
     const unselectedTabIndex = tabsData.findIndex(
       (tab) => tab.title !== defaultProps.selectedTab && !tab.isDisabled
     );
-    wrapper
-      .find('.tab')
-      .at(unselectedTabIndex)
-      .simulate('click');
+    wrapper.find('.tab').at(unselectedTabIndex).simulate('click');
 
     expect(onTabChange).toBeCalledWith(tabsData[unselectedTabIndex].title);
   });
@@ -97,20 +88,14 @@ describe('<Tabs />', () => {
     const unselectedDisabledTabIndex = tabsData.findIndex(
       (tab) => tab.title !== defaultProps.selectedTab && tab.isDisabled
     );
-    wrapper
-      .find('.tab')
-      .at(unselectedDisabledTabIndex)
-      .simulate('click');
+    wrapper.find('.tab').at(unselectedDisabledTabIndex).simulate('click');
 
     expect(onTabChange).not.toBeCalled();
   });
 
   it(' applies the passed in default class', () => {
     expect(
-      wrapper
-        .find('.tab')
-        .first()
-        .hasClass(tabClassNames.default)
+      wrapper.find('.tab').first().hasClass(tabClassNames.default)
     ).toBeTruthy();
   });
 
@@ -119,20 +104,14 @@ describe('<Tabs />', () => {
       (tab) => tab.title === defaultProps.selectedTab
     );
     expect(
-      wrapper
-        .find('.tab')
-        .at(selectedTabIndex)
-        .hasClass(tabClassNames.selected)
+      wrapper.find('.tab').at(selectedTabIndex).hasClass(tabClassNames.selected)
     ).toBeTruthy();
   });
 
   it(' applies the passed in disabled class', () => {
     const disabledTabIndex = tabsData.findIndex((tab) => tab.isDisabled);
     expect(
-      wrapper
-        .find('.tab')
-        .at(disabledTabIndex)
-        .hasClass(tabClassNames.disabled)
+      wrapper.find('.tab').at(disabledTabIndex).hasClass(tabClassNames.disabled)
     ).toBeTruthy();
   });
 

--- a/src/ensembl/src/shared/utils/lruCache.ts
+++ b/src/ensembl/src/shared/utils/lruCache.ts
@@ -100,10 +100,11 @@ export default class LRUCache implements LRUCacheInterface {
     if (nextNode) {
       nextNode.previous = previousNode;
     }
-    const formerHeadNode = this.head;
+    const formerHeadNode = this.head as LinkedListNode;
     this.head = node;
     node.next = formerHeadNode;
     node.previous = null;
+    formerHeadNode.previous = node;
     node.timestamp = Date.now(); // refresh timestamp
   }
 

--- a/src/ensembl/src/shared/utils/lruCache.ts
+++ b/src/ensembl/src/shared/utils/lruCache.ts
@@ -1,0 +1,157 @@
+/*
+ * This is a cache implementing the Least Recently Used algorithm
+ * for preventing it from growing indefinitely. It also can invalidate
+ * individual items based on the max time during which an item is allowed
+ * to be retrieved from the cache.
+ *
+ * The Least Recently Used algorithm requires coordinated use of a doubly linked list
+ * for storing cached values, and a map for quick access to the nodes of the list
+ */
+
+interface LRUCacheInterface {
+  get(key: string): any;
+  set(key: string, value: any): void;
+  reset(): void;
+}
+
+interface LinkedListNodeInterface {
+  value: any;
+  next: LinkedListNode | null;
+  previous: LinkedListNode | null;
+  timestamp: number;
+}
+
+type LRUCacheOptions = {
+  size?: number; // max number of items that can be stored in cache; defaults to 1000
+  maxAge?: number; // time period, in milliseconds, during which a cache item is retrievable
+};
+
+type LinkedListNodeOptions = {
+  key: string;
+  value: any;
+  timestamp: number;
+};
+
+const DEFAULT_SIZE = 1000;
+
+export default class LRUCache implements LRUCacheInterface {
+  private size: number;
+  private maxAge?: number;
+  private currentSize = 0;
+  private head: LinkedListNode | null;
+  private tail: LinkedListNode | null;
+  private listNodesMap: Map<string, LinkedListNode>;
+
+  constructor(options: LRUCacheOptions = {}) {
+    if (options.size && options.size <= 0) {
+      throw new Error('Cache size must be a positive integer');
+    }
+    this.size = options.size || DEFAULT_SIZE;
+    this.maxAge = options.maxAge;
+
+    this.head = null;
+    this.tail = null;
+    this.listNodesMap = new Map();
+  }
+
+  public get(key: string) {
+    const cachedNode = this.listNodesMap.get(key);
+    if (cachedNode) {
+      if (this.isExpiredNode(cachedNode)) {
+        this.removeNode(cachedNode);
+        return;
+      }
+      this.moveNodeToHead(cachedNode);
+      cachedNode.timestamp = Date.now();
+      return cachedNode.value;
+    }
+  }
+
+  public set(key: string, value: any) {
+    const savedNode = this.listNodesMap.get(key);
+    if (savedNode) {
+      this.moveNodeToHead(savedNode);
+      savedNode.value = value;
+    } else {
+      this.addNode(key, value);
+    }
+  }
+
+  public reset() {
+    this.head = null;
+    this.tail = null;
+    this.currentSize = 0;
+    this.listNodesMap.clear();
+  }
+
+  private isExpiredNode(node: LinkedListNode) {
+    if (!this.maxAge) {
+      return false;
+    }
+    return Date.now() - node.timestamp > this.maxAge;
+  }
+
+  private moveNodeToHead(node: LinkedListNode) {
+    const previousNode = node.previous;
+    const nextNode = node.next;
+    if (previousNode) {
+      previousNode.next = nextNode;
+    }
+    if (nextNode) {
+      nextNode.previous = previousNode;
+    }
+    const formerHeadNode = this.head;
+    this.head = node;
+    node.next = formerHeadNode;
+    node.previous = null;
+    node.timestamp = Date.now(); // refresh timestamp
+  }
+
+  private addNode(key: string, value: any) {
+    const newNode = new LinkedListNode({
+      key,
+      value,
+      timestamp: Date.now()
+    });
+    if (this.currentSize === 0) {
+      this.head = newNode;
+      this.tail = newNode;
+    } else if (this.currentSize === this.size) {
+      const newTail = (this.tail as LinkedListNode).previous as LinkedListNode;
+      this.removeNode(this.tail as LinkedListNode);
+      this.tail = newTail;
+
+      this.moveNodeToHead(newNode);
+    } else {
+      this.moveNodeToHead(newNode);
+    }
+    this.listNodesMap.set(key, newNode);
+    this.currentSize++;
+  }
+
+  private removeNode(node: LinkedListNode) {
+    const { previous, next, key } = node;
+    node.previous = null;
+    node.next = null;
+    node.value = null;
+    previous && (previous.next = next);
+    next && (next.previous = previous);
+    this.listNodesMap.delete(key);
+
+    this.currentSize--;
+  }
+}
+
+class LinkedListNode implements LinkedListNodeInterface {
+  public timestamp: number;
+  public next: LinkedListNode | null = null;
+  public previous: LinkedListNode | null = null;
+  public key: string;
+  public value: any;
+
+  constructor(options: LinkedListNodeOptions) {
+    this.key = options.key;
+    this.value = options.value;
+    this.timestamp = options.timestamp;
+  }
+}

--- a/src/ensembl/src/shared/utils/lruCache.ts
+++ b/src/ensembl/src/shared/utils/lruCache.ts
@@ -100,6 +100,9 @@ export default class LRUCache implements LRUCacheInterface {
     if (nextNode) {
       nextNode.previous = previousNode;
     }
+    if (this.tail === node) {
+      this.tail = previousNode;
+    }
     const formerHeadNode = this.head as LinkedListNode;
     this.head = node;
     node.next = formerHeadNode;

--- a/src/ensembl/src/shared/utils/tests/lruCache.test.ts
+++ b/src/ensembl/src/shared/utils/tests/lruCache.test.ts
@@ -6,8 +6,8 @@ import LRUCache from '../lruCache';
 describe('LRUCache', () => {
   it('can store items', () => {
     const cache = new LRUCache();
-    const items = times(10, () => ({
-      key: faker.random.uuid(),
+    const items = times(10, (index) => ({
+      key: `${index}`,
       value: faker.lorem.words()
     }));
     items.forEach(({ key, value }) => {
@@ -20,19 +20,45 @@ describe('LRUCache', () => {
   });
 
   it('removes the least recently used item from cache', () => {
+    // the test also demonstrates that the cache can handle multiple cycles
+    // of replacement of its items
     const cache = new LRUCache({ size: 10 });
-    const items = times(11, () => ({
-      key: faker.random.uuid(),
+    const items = times(100, (index) => ({
+      key: `${index}`,
       value: faker.lorem.words()
     }));
     items.forEach(({ key, value }) => {
       cache.set(key, value);
     });
 
-    expect(cache.get(items[0].key)).toBeUndefined();
-    items.slice(1).forEach(({ key, value }) => {
+    const itemsExpectedToBeDropped = items.slice(0, 90);
+    const itemsExpectedToRemain = items.slice(90);
+    itemsExpectedToBeDropped.forEach(({ key }) => {
+      expect(cache.get(key)).toBeUndefined();
+    });
+    itemsExpectedToRemain.forEach(({ key, value }) => {
       expect(cache.get(key)).toBe(value);
     });
+  });
+
+  it('can successfully go through multiple cycles of replacing all stored items', () => {
+    const cache = new LRUCache({ size: 10 });
+    const items = times(11, (index) => ({
+      key: `${index}`,
+      value: faker.lorem.words()
+    }));
+    const extraItem = items.pop() as { key: string; value: string };
+    items.forEach(({ key, value }) => {
+      cache.set(key, value);
+    });
+    const lastItem = items[items.length - 1];
+    const penultimateItem = items[items.length - 2];
+
+    cache.get(lastItem.key); // now last item has been used most recently
+    cache.set(extraItem.key, extraItem.value); // now penultimate item should have been dropped from cache
+
+    expect(cache.get(lastItem.key)).toBe(lastItem.value);
+    expect(cache.get(penultimateItem.key)).toBeUndefined();
   });
 
   it('invalidates cached item if it’s gone stale', () => {

--- a/src/ensembl/src/shared/utils/tests/lruCache.test.ts
+++ b/src/ensembl/src/shared/utils/tests/lruCache.test.ts
@@ -41,7 +41,7 @@ describe('LRUCache', () => {
     });
   });
 
-  it('can successfully go through multiple cycles of replacing all stored items', () => {
+  it('keeps items that have been recently accessed', () => {
     const cache = new LRUCache({ size: 10 });
     const items = times(11, (index) => ({
       key: `${index}`,
@@ -51,14 +51,14 @@ describe('LRUCache', () => {
     items.forEach(({ key, value }) => {
       cache.set(key, value);
     });
-    const lastItem = items[items.length - 1];
-    const penultimateItem = items[items.length - 2];
+    const oldestItem = items[0];
+    const secondOldestItem = items[1];
 
-    cache.get(lastItem.key); // now last item has been used most recently
-    cache.set(extraItem.key, extraItem.value); // now penultimate item should have been dropped from cache
+    cache.get(oldestItem.key); // accessing the item that would have otherwise been dropped by the cache
+    cache.set(extraItem.key, extraItem.value); // now second oldest item should have been dropped from cache
 
-    expect(cache.get(lastItem.key)).toBe(lastItem.value);
-    expect(cache.get(penultimateItem.key)).toBeUndefined();
+    expect(cache.get(oldestItem.key)).toBe(oldestItem.value);
+    expect(cache.get(secondOldestItem.key)).toBeUndefined();
   });
 
   it('invalidates cached item if it’s gone stale', () => {

--- a/src/ensembl/src/shared/utils/tests/lruCache.test.ts
+++ b/src/ensembl/src/shared/utils/tests/lruCache.test.ts
@@ -1,0 +1,56 @@
+import faker from 'faker';
+import times from 'lodash/times';
+
+import LRUCache from '../lruCache';
+
+describe('LRUCache', () => {
+  it('can store items', () => {
+    const cache = new LRUCache();
+    const items = times(10, () => ({
+      key: faker.random.uuid(),
+      value: faker.lorem.words()
+    }));
+    items.forEach(({ key, value }) => {
+      cache.set(key, value);
+    });
+
+    items.forEach(({ key, value }) => {
+      expect(cache.get(key)).toBe(value);
+    });
+  });
+
+  it('removes the least recently used item from cache', () => {
+    const cache = new LRUCache({ size: 10 });
+    const items = times(11, () => ({
+      key: faker.random.uuid(),
+      value: faker.lorem.words()
+    }));
+    items.forEach(({ key, value }) => {
+      cache.set(key, value);
+    });
+
+    expect(cache.get(items[0].key)).toBeUndefined();
+    items.slice(1).forEach(({ key, value }) => {
+      expect(cache.get(key)).toBe(value);
+    });
+  });
+
+  it('invalidates cached item if it’s gone stale', () => {
+    const cache = new LRUCache({ maxAge: 1000 });
+    const item = { key: faker.random.uuid(), value: faker.lorem.words() };
+    const timestamp = Date.now();
+    cache.set(item.key, item.value);
+
+    jest.spyOn(global.Date, 'now').mockImplementation(() => timestamp + 1);
+
+    // value can be retrieved before cache has gone stale
+    // (btw, notice that accessing a value from cache will reset its timestamp)
+    expect(cache.get(item.key)).toBe(item.value);
+
+    jest
+      .spyOn(global.Date, 'now')
+      .mockImplementation(() => timestamp + 1000 + 2);
+
+    expect(cache.get(item.key)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Type
- New feature

## Related JIRA Issue(s)
ENSWBSITES-608

## Description
**Purpose:** Some user interactions resulting in http requests can occur repeatedly (e.g. user opening and closing an element that retrieves its content from the network). We would prefer that if the data has been received by the client it were used in subsequent requests. 

This PR:
- Adds a cache class implementing the Least Recently Used mechanism for ensuring maximum size
- Adds the cache to the api service
- Adds tests

Also:
- update the way we are getting random values in Tabs.test to avoid duplicate keys in lists, such as happened here:

<img width="1440" alt="Screenshot 2020-05-11 at 23 05 28" src="https://user-images.githubusercontent.com/6834224/81623597-da763900-93eb-11ea-998d-a9167095e110.png">

## Possible alternatives
There is a library that's gaining traction in the React community called [react-query](https://github.com/tannerlinsley/react-query), which does caching and other cool things such as request cancellation, request deduplications, or retries. It can't be used from within redux though, as opposed to our api-service; so if we decide to use it, we might want to reconsider how we fetch stuff.