### PR TITLE
Fix CI/CD pipeline - Don't trigger subsequent job if dependent job(s) fail 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,7 +80,8 @@ variables:
   - docker rmi ${CONTAINER_IMAGE}
   - docker logout "$CI_REGISTRY"
 
-  needs: ["Test_N_Build"]
+  needs:
+    - Test_N_Build
 
 # Template to deploy to WP k8s cluster
 .deploy-wp:
@@ -214,7 +215,8 @@ Nginx:Staging-WP:
     CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}-stage-ing
   only:
   - dev
-  needs: ["Test_N_Build"]
+  needs:
+    - Test_N_Build
 
 # Job to build nginx docker image for live environment
 # master branch -> Live
@@ -224,7 +226,8 @@ Nginx:Live-WP:
     CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}-prod-ing
   only:
   - master
-  needs: ["Test_N_Build"]
+  needs:
+    - Test_N_Build
 
 # Job to build nginx docker image for staging and internal environment
 # dev branch -> internal
@@ -235,7 +238,8 @@ Nginx:Internal-EHK:
     CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}-internal
   only:
   - dev
-  needs: ["Test_N_Build:internal"]
+  needs:
+    - Test_N_Build:internal
 
 # Job to build nginx docker image for staging and internal environment at WP
 # dev branch -> internal
@@ -246,7 +250,8 @@ Nginx:Internal-WP:
     CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}-internal-ing
   only:
   - dev
-  needs: ["Test_N_Build:internal"]
+  needs:
+    - Test_N_Build:internal
 
 Nginx:feature:
   extends: .build-nginx-ehk
@@ -269,7 +274,8 @@ Staging:EHK-HH:
     KUBE_CONTEXT: ens-stage-ctx
   only:
   - dev
-  needs: ["Nginx:Staging-EHK"]
+  needs:
+    - Nginx:Staging-EHK
 
 # Job to deploy to staging environment (WP-HX k8s cluster)
 Staging:WP-HX:
@@ -280,7 +286,9 @@ Staging:WP-HX:
     name : wp-hx-staging
   only:
   - dev
-  needs: ["Nginx:Staging-WP"]
+  needs:
+    - Test_N_Build
+    - Nginx:Staging-WP
 
 # Job to deploy to staging environment (WP-HH k8s cluster)
 Staging:WP-HH:
@@ -291,7 +299,9 @@ Staging:WP-HH:
     name : wp-hh-staging
   only:
   - dev
-  needs: ["Nginx:Staging-WP"]
+  needs:
+    - Test_N_Build
+    - Nginx:Staging-WP
 
 # Job to deploy to live environment (EHK k8s cluster)
 Live:EHK-HH:
@@ -302,7 +312,8 @@ Live:EHK-HH:
     KUBE_CONTEXT: ens-prod-ctx
   only:
   - master
-  needs: ["Nginx:Live-EHK"]
+  needs:
+    - Nginx:Live-EHK
 
 # Job to deploy to live environment (WP-HX k8s cluster)
 Live:WP-HX:
@@ -313,7 +324,9 @@ Live:WP-HX:
     name : wp-hx-live
   only:
   - master
-  needs: ["Nginx:Live-WP"]
+  needs:
+    - Test_N_Build
+    - Nginx:Live-WP
 
 # Job to deploy to live environment (WP-HH k8s cluster)
 Live:WP-HH:
@@ -324,7 +337,9 @@ Live:WP-HH:
     name : wp-hh-live
   only:
   - master
-  needs: ["Nginx:Live-WP"]
+  needs:
+    - Test_N_Build
+    - Nginx:Live-WP
 
 # Job to deploy to internal environment (EHK k8s cluster)
 Internal:EHK-HH:
@@ -335,7 +350,9 @@ Internal:EHK-HH:
     KUBE_CONTEXT: ens-dev-ctx
   only:
   - dev
-  needs: ["Nginx:Internal-EHK"]
+  needs:
+    - Test_N_Build:internal
+    - Nginx:Internal-EHK
 
 # Job to deploy to internal environment (WP-HX k8s cluster)
 Internal:WP-HX:
@@ -346,7 +363,9 @@ Internal:WP-HX:
     name : wp-hx-internal
   only:
   - dev
-  needs: ["Nginx:Internal-WP"]
+  needs:
+    - Test_N_Build:internal
+    - Nginx:Internal-WP
 
 # Job to deploy to internal environment (WP-HH k8s cluster)
 Internal:WP-HH:
@@ -357,7 +376,9 @@ Internal:WP-HH:
     name : wp-hh-internal
   only:
   - dev
-  needs: ["Nginx:Internal-WP"]
+  needs:
+    - Test_N_Build:internal
+    - Nginx:Internal-WP
 
 Feature:EHK-HH:
   extends: .deploy-ehk
@@ -369,7 +390,9 @@ Feature:EHK-HH:
   only:
   - /^feature\/.*$/
 
-  needs: ["Nginx:feature"]
+  needs:
+    - Test_N_Build:feature
+    - "Nginx:feature"
 
 Feature:WP-HX:
   extends: .deploy-wp-feature

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -184,8 +184,6 @@ Test_N_Build:feature:
     ENVIRONMENT: development
     API_HOST: ""
 
-  script:
-  - exit 1
   only:
   - /^feature\/.*$/
   - /^bugfix\/.*$/
@@ -258,8 +256,11 @@ Nginx:feature:
   only:
   - /^feature\/.*$/
   - /^bugfix\/.*$/
+  script:
+    - exit 1
 
-  needs: ["Test_N_Build:feature"]
+  needs:
+    - "Test_N_Build:feature"
 
 # Job to deploy to staging environment (EHK k8s cluster)
 Staging:EHK-HH:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -140,7 +140,6 @@ Test:
   - master
   - /^feature\/.*$/
   - /^migration\/.*$/
-  - /^bugfix\/.*$/
 
 # Job to build static asset for staging and live environment
 # dev branch -> Staging
@@ -187,7 +186,6 @@ Test_N_Build:feature:
 
   only:
   - /^feature\/.*$/
-  - /^bugfix\/.*$/
 
 # Job to build nginx docker image for staging environment (EHK k8s cluster)
 Nginx:Staging-EHK:
@@ -260,7 +258,6 @@ Nginx:feature:
     CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}-${CI_COMMIT_REF_SLUG}
   only:
   - /^feature\/.*$/
-  - /^bugfix\/.*$/
 
   needs:
     - "Test_N_Build:feature"
@@ -402,7 +399,6 @@ Feature:WP-HX:
     name : wp-hx-dev
   only:
   - /^feature\/.*$/
-  - /^bugfix\/.*$/
   needs:
     - Test_N_Build:feature
     - Nginx:feature

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -256,8 +256,6 @@ Nginx:feature:
   only:
   - /^feature\/.*$/
   - /^bugfix\/.*$/
-  script:
-    - exit 1
 
   needs:
     - "Test_N_Build:feature"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -378,4 +378,6 @@ Feature:WP-HX:
   only:
   - /^feature\/.*$/
   - /^bugfix\/.*$/
-  needs: ["Nginx:feature"]
+  needs:
+    - Test_N_Build:feature
+    - Nginx:feature

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -185,6 +185,7 @@ Test_N_Build:feature:
 
   only:
   - /^feature\/.*$/
+  - /^bugfix\/.*$/
 
 # Job to build nginx docker image for staging environment (EHK k8s cluster)
 Nginx:Staging-EHK:
@@ -253,6 +254,7 @@ Nginx:feature:
     CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}-${CI_COMMIT_REF_SLUG}
   only:
   - /^feature\/.*$/
+  - /^bugfix\/.*$/
 
   needs: ["Test_N_Build:feature"]
 
@@ -375,4 +377,5 @@ Feature:WP-HX:
     name : wp-hx-dev
   only:
   - /^feature\/.*$/
+  - /^bugfix\/.*$/
   needs: ["Nginx:feature"]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -184,6 +184,8 @@ Test_N_Build:feature:
     ENVIRONMENT: development
     API_HOST: ""
 
+  script:
+  - exit 1
   only:
   - /^feature\/.*$/
   - /^bugfix\/.*$/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -139,6 +139,7 @@ Test:
   - master
   - /^feature\/.*$/
   - /^migration\/.*$/
+  - /^bugfix\/.*$/
 
 # Job to build static asset for staging and live environment
 # dev branch -> Staging


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-619

## Importance
Jobs in CI/CD pipeline gets triggered even if the dependent job(s) have failed/not triggered. 

## Description
CI/CD pileline in Ensembl client has three stages
- test_build_static
- build_docker_images
- deploy

The job in deploy stage should not proceed if build_docker_images is not triggered or if it fails. 
This leads to trigger the deployment even if the docker images are not present.
See the attached image (or following links)
**Issue :** 
https://gitlab.ebi.ac.uk/ensembl-web/ensembl-client/pipelines/74988 
**Expected Behaviour**
https://gitlab.ebi.ac.uk/ensembl-web/ensembl-client/pipelines/75557
https://gitlab.ebi.ac.uk/ensembl-web/ensembl-client/pipelines/75561
## Views affected


### Other effects
- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
None