### PR TITLE
Add licence header to typescript files

### DIFF
--- a/src/ensembl/src/analyticsHelper.ts
+++ b/src/ensembl/src/analyticsHelper.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export type AnalyticsOptions = {
   category: string;
   action: string;

--- a/src/ensembl/src/analyticsMiddleware.ts
+++ b/src/ensembl/src/analyticsMiddleware.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { LOCATION_CHANGE } from 'connected-react-router';
 
 import analyticsTracking from './services/analytics-service';

--- a/src/ensembl/src/content/Content.test.tsx
+++ b/src/ensembl/src/content/Content.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { render } from 'enzyme';
 

--- a/src/ensembl/src/content/Content.tsx
+++ b/src/ensembl/src/content/Content.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { FunctionComponent } from 'react';
 import { Route } from 'react-router-dom';
 import { connect } from 'react-redux';

--- a/src/ensembl/src/content/app/App.tsx
+++ b/src/ensembl/src/content/app/App.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useEffect, FunctionComponent, lazy, Suspense } from 'react';
 import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { connect } from 'react-redux';

--- a/src/ensembl/src/content/app/browser/Browser.test.tsx
+++ b/src/ensembl/src/content/app/browser/Browser.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { mount } from 'enzyme';

--- a/src/ensembl/src/content/app/browser/Browser.tsx
+++ b/src/ensembl/src/content/app/browser/Browser.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useEffect, useState, useCallback } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
 import { connect } from 'react-redux';

--- a/src/ensembl/src/content/app/browser/browser-app-bar/BrowserAppBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-app-bar/BrowserAppBar.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { memo, useMemo } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';

--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import { BrowserBar, BrowserBarProps } from './BrowserBar';

--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 

--- a/src/ensembl/src/content/app/browser/browser-cog/BrowserCog.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-cog/BrowserCog.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import faker from 'faker';
@@ -30,10 +46,7 @@ describe('<BrowserCog />', () => {
   describe('behaviour', () => {
     test('toggles cog on click', () => {
       const wrapper = mount(<BrowserCog {...defaultProps} />);
-      wrapper
-        .find('button')
-        .first()
-        .simulate('click');
+      wrapper.find('button').first().simulate('click');
       expect(wrapper.props().updateSelectedCog).toHaveBeenCalledTimes(1);
     });
   });

--- a/src/ensembl/src/content/app/browser/browser-cog/BrowserCog.tsx
+++ b/src/ensembl/src/content/app/browser/browser-cog/BrowserCog.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useCallback, useState, useEffect } from 'react';
 import { useTransition, animated } from 'react-spring';
 

--- a/src/ensembl/src/content/app/browser/browser-cog/BrowserCogList.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-cog/BrowserCogList.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import faker from 'faker';

--- a/src/ensembl/src/content/app/browser/browser-cog/BrowserCogList.tsx
+++ b/src/ensembl/src/content/app/browser/browser-cog/BrowserCogList.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 
@@ -136,7 +152,4 @@ const mapDispatchToProps = {
   updateSelectedCog
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(BrowserCogList);
+export default connect(mapStateToProps, mapDispatchToProps)(BrowserCogList);

--- a/src/ensembl/src/content/app/browser/browser-constants.ts
+++ b/src/ensembl/src/content/app/browser/browser-constants.ts
@@ -1,1 +1,17 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export const BROWSER_CONTAINER_ID = 'genome-browser';

--- a/src/ensembl/src/content/app/browser/browser-image/BrowserImage.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-image/BrowserImage.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 

--- a/src/ensembl/src/content/app/browser/browser-image/BrowserImage.tsx
+++ b/src/ensembl/src/content/app/browser/browser-image/BrowserImage.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useRef, useEffect, useCallback, memo } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
@@ -140,9 +156,7 @@ export const BrowserImage = (props: BrowserImageProps) => {
         />
         <BrowserCogList />
         <ZmenuController browserRef={browserRef} />
-        {props.isDisabled ? (
-          <Overlay />
-        ) : null}
+        {props.isDisabled ? <Overlay /> : null}
       </div>
     </>
   );

--- a/src/ensembl/src/content/app/browser/browser-location-indicator/BrowserLocationIndicator.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-location-indicator/BrowserLocationIndicator.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import faker from 'faker';
 import { render, mount } from 'enzyme';

--- a/src/ensembl/src/content/app/browser/browser-location-indicator/BrowserLocationIndicator.tsx
+++ b/src/ensembl/src/content/app/browser/browser-location-indicator/BrowserLocationIndicator.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';

--- a/src/ensembl/src/content/app/browser/browser-messaging-service.test.ts
+++ b/src/ensembl/src/content/app/browser/browser-messaging-service.test.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { BrowserMessagingService } from './browser-messaging-service';
 import faker from 'faker';
 

--- a/src/ensembl/src/content/app/browser/browser-messaging-service.ts
+++ b/src/ensembl/src/content/app/browser/browser-messaging-service.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import windowService, {
   WindowServiceInterface
 } from 'src/services/window-service';

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBar.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBar.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { render } from 'enzyme';
 

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBar.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarControls.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarControls.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import faker from 'faker';

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarControls.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarControls.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarRegionSwitcher.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarRegionSwitcher.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarRegionSwitcher.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarRegionSwitcher.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavIcon.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavIcon.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavIcon.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavIcon.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { FunctionComponent, memo } from 'react';
 
 import browserMessagingService from 'src/content/app/browser/browser-messaging-service';

--- a/src/ensembl/src/content/app/browser/browser-region-editor/BrowserRegionEditor.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-region-editor/BrowserRegionEditor.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import faker from 'faker';
@@ -149,10 +165,8 @@ describe('<BrowserRegionEditor />', () => {
         wrapper.find('form').simulate('submit');
 
         expect(
-          wrapper
-            .find('[role="startInputGroup"]')
-            .find(Tooltip)
-            .props().children
+          wrapper.find('[role="startInputGroup"]').find(Tooltip).props()
+            .children
         ).toBe(startError);
       });
 
@@ -192,10 +206,7 @@ describe('<BrowserRegionEditor />', () => {
         wrapper.find('form').simulate('submit');
 
         expect(
-          wrapper
-            .find('[role="endInputGroup"]')
-            .find(Tooltip)
-            .props().children
+          wrapper.find('[role="endInputGroup"]').find(Tooltip).props().children
         ).toBe(endError);
       });
     });

--- a/src/ensembl/src/content/app/browser/browser-region-editor/BrowserRegionEditor.tsx
+++ b/src/ensembl/src/content/app/browser/browser-region-editor/BrowserRegionEditor.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState, FormEvent, useRef, useEffect } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';

--- a/src/ensembl/src/content/app/browser/browser-region-field/BrowserRegionField.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-region-field/BrowserRegionField.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import faker from 'faker';

--- a/src/ensembl/src/content/app/browser/browser-region-field/BrowserRegionField.tsx
+++ b/src/ensembl/src/content/app/browser/browser-region-field/BrowserRegionField.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState, FormEvent, useRef, useEffect } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';

--- a/src/ensembl/src/content/app/browser/browser-reset/BrowserReset.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-reset/BrowserReset.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 

--- a/src/ensembl/src/content/app/browser/browser-reset/BrowserReset.tsx
+++ b/src/ensembl/src/content/app/browser/browser-reset/BrowserReset.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { FunctionComponent } from 'react';
 import { connect } from 'react-redux';
 

--- a/src/ensembl/src/content/app/browser/browser-storage-service.test.ts
+++ b/src/ensembl/src/content/app/browser/browser-storage-service.test.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { BrowserStorageService, StorageKeys } from './browser-storage-service';
 import { Status } from 'src/shared/types/status';
 import { TrackActivityStatus } from 'src/content/app/browser/track-panel/trackPanelConfig';

--- a/src/ensembl/src/content/app/browser/browser-storage-service.ts
+++ b/src/ensembl/src/content/app/browser/browser-storage-service.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import storageService, {
   StorageServiceInterface
 } from 'src/services/storage-service';

--- a/src/ensembl/src/content/app/browser/browser-track-config/BrowserTrackConfig.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-track-config/BrowserTrackConfig.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 
@@ -39,10 +55,7 @@ describe('<BrowserTrackConfig />', () => {
 
   describe('behaviour', () => {
     test('sets all tracks to be updated when the all tracks checkbox is selected', () => {
-      wrapper
-        .find(Checkbox)
-        .props()
-        .onChange(true);
+      wrapper.find(Checkbox).props().onChange(true);
       expect(wrapper.props().updateApplyToAll).toHaveBeenCalledTimes(1);
     });
 

--- a/src/ensembl/src/content/app/browser/browser-track-config/BrowserTrackConfig.tsx
+++ b/src/ensembl/src/content/app/browser/browser-track-config/BrowserTrackConfig.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useCallback, useRef } from 'react';
 import { connect } from 'react-redux';
 

--- a/src/ensembl/src/content/app/browser/browserActions.ts
+++ b/src/ensembl/src/content/app/browser/browserActions.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { createAction } from 'typesafe-actions';
 import { Dispatch, ActionCreator, Action } from 'redux';
 import { replace } from 'connected-react-router';

--- a/src/ensembl/src/content/app/browser/browserConfig.ts
+++ b/src/ensembl/src/content/app/browser/browserConfig.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ReactComponent as zoomInIcon } from 'static/img/browser/zoom-in.svg';
 import { ReactComponent as zoomOutIcon } from 'static/img/browser/zoom-out.svg';
 import { ReactComponent as navigateUpIcon } from 'static/img/browser/navigate-up.svg';

--- a/src/ensembl/src/content/app/browser/browserHelper.test.ts
+++ b/src/ensembl/src/content/app/browser/browserHelper.test.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import faker from 'faker';
 
 import {

--- a/src/ensembl/src/content/app/browser/browserHelper.ts
+++ b/src/ensembl/src/content/app/browser/browserHelper.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import noop from 'lodash/noop';
 import apiService from 'src/services/api-service';
 

--- a/src/ensembl/src/content/app/browser/browserReducer.ts
+++ b/src/ensembl/src/content/app/browser/browserReducer.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { combineReducers } from 'redux';
 import { ActionType, getType } from 'typesafe-actions';
 import merge from 'lodash/merge';

--- a/src/ensembl/src/content/app/browser/browserSelectors.ts
+++ b/src/ensembl/src/content/app/browser/browserSelectors.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { RootState } from 'src/store';
 import { ChrLocation } from './browserState';
 

--- a/src/ensembl/src/content/app/browser/browserState.ts
+++ b/src/ensembl/src/content/app/browser/browserState.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import browserStorageService from './browser-storage-service';
 
 import { BrowserTrackStates } from './track-panel/trackPanelConfig';

--- a/src/ensembl/src/content/app/browser/chromosome-navigator/ChromosomeNavigator.test.tsx
+++ b/src/ensembl/src/content/app/browser/chromosome-navigator/ChromosomeNavigator.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import random from 'lodash/random';
@@ -100,10 +116,7 @@ describe('Chromosome Navigator', () => {
         the x-coordinate of the vertical bar of [
         which is the second tuple of coordinates in the points prop
       */
-      const bracketX = bracket
-        .prop('points')
-        .split(' ')[1]
-        .split(',')[0];
+      const bracketX = bracket.prop('points').split(' ')[1].split(',')[0];
       expect(parseInt(bracketX, 10)).toBe(position);
     };
 

--- a/src/ensembl/src/content/app/browser/chromosome-navigator/ChromosomeNavigator.tsx
+++ b/src/ensembl/src/content/app/browser/chromosome-navigator/ChromosomeNavigator.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useRef } from 'react';
 import { connect } from 'react-redux';
 

--- a/src/ensembl/src/content/app/browser/chromosome-navigator/chromosomeNavigatorConstants.ts
+++ b/src/ensembl/src/content/app/browser/chromosome-navigator/chromosomeNavigatorConstants.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export const TOTAL_HEIGHT = 20;
 
 export const STICK_HEIGHT = 4;

--- a/src/ensembl/src/content/app/browser/chromosome-navigator/chromosomeNavigatorHelper.ts
+++ b/src/ensembl/src/content/app/browser/chromosome-navigator/chromosomeNavigatorHelper.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
 import { measureText } from 'src/shared/helpers/textHelpers';
 
@@ -120,15 +136,17 @@ const getViewportStyles = (params: StyleCalculatorParams, scale: Scale) => {
     `${viewportStartX + VIEWPORT_BRACKET_BAR_WIDTH},${bracketY}`,
     `${viewportStartX},${bracketY}`,
     `${viewportStartX},${bracketY + VIEWPORT_BRACKET_HEIGHT}`,
-    `${viewportStartX + VIEWPORT_BRACKET_BAR_WIDTH},${bracketY +
-      VIEWPORT_BRACKET_HEIGHT}`
+    `${viewportStartX + VIEWPORT_BRACKET_BAR_WIDTH},${
+      bracketY + VIEWPORT_BRACKET_HEIGHT
+    }`
   ].join(' ');
   const closingBracketShape = [
     `${viewportEndX - VIEWPORT_BRACKET_BAR_WIDTH},${bracketY}`,
     `${viewportEndX},${bracketY}`,
     `${viewportEndX},${bracketY + VIEWPORT_BRACKET_HEIGHT}`,
-    `${viewportEndX - VIEWPORT_BRACKET_BAR_WIDTH},${bracketY +
-      VIEWPORT_BRACKET_HEIGHT}`
+    `${viewportEndX - VIEWPORT_BRACKET_BAR_WIDTH},${
+      bracketY + VIEWPORT_BRACKET_HEIGHT
+    }`
   ].join(' ');
 
   const areas = (viewportStartX < viewportEndX

--- a/src/ensembl/src/content/app/browser/drawer/Drawer.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/Drawer.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerBookmarks.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import upperFirst from 'lodash/upperFirst';
 import { Link } from 'react-router-dom';
@@ -81,7 +97,4 @@ const mapDispatchToProps = {
   closeDrawer
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(DrawerBookmarks);
+export default connect(mapStateToProps, mapDispatchToProps)(DrawerBookmarks);

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerContigs.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerContigs.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { FunctionComponent } from 'react';
 
 import styles from '../Drawer.scss';

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerGC.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerGC.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { FunctionComponent } from 'react';
 
 import styles from '../Drawer.scss';

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerGene.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerGene.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { FunctionComponent } from 'react';
 
 import { getDisplayStableId } from 'src/shared/state/ens-object/ensObjectHelpers';

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerTranscript.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerTranscript.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { FunctionComponent } from 'react';
 import get from 'lodash/get';
 import find from 'lodash/find';

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/OtherGenes.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/OtherGenes.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { FunctionComponent } from 'react';
 
 import styles from '../Drawer.scss';

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/ProteinCodingGenes.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/ProteinCodingGenes.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { FunctionComponent } from 'react';
 
 import styles from '../Drawer.scss';

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/SnpIndels.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/SnpIndels.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { FunctionComponent } from 'react';
 
 import styles from '../Drawer.scss';

--- a/src/ensembl/src/content/app/browser/drawer/drawerActions.ts
+++ b/src/ensembl/src/content/app/browser/drawer/drawerActions.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { createAction } from 'typesafe-actions';
 import { batch } from 'react-redux';
 import { ActionCreator, Action } from 'redux';
@@ -11,9 +27,12 @@ export const changeDrawerViewForGenome = createAction(
   (drawerViewForGenome: { [genomeId: string]: string }) => drawerViewForGenome
 )();
 
-export const changeDrawerView: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (drawerView: string) => (dispatch, getState: () => RootState) => {
+export const changeDrawerView: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (drawerView: string) => (dispatch, getState: () => RootState) => {
   const activeGenomeId = getBrowserActiveGenomeId(getState());
 
   if (!activeGenomeId) {
@@ -27,9 +46,12 @@ export const changeDrawerView: ActionCreator<
   );
 };
 
-export const changeDrawerViewAndOpen: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (drawerView: string) => (dispatch, getState: () => RootState) => {
+export const changeDrawerViewAndOpen: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (drawerView: string) => (dispatch, getState: () => RootState) => {
   const activeGenomeId = getBrowserActiveGenomeId(getState());
 
   if (!activeGenomeId) {
@@ -52,9 +74,12 @@ export const toggleDrawerForGenome = createAction(
     isDrawerOpenedForGenome
 )();
 
-export const toggleDrawer: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (isDrawerOpened: boolean) => (dispatch, getState: () => RootState) => {
+export const toggleDrawer: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (isDrawerOpened: boolean) => (dispatch, getState: () => RootState) => {
   const activeGenomeId = getBrowserActiveGenomeId(getState());
 
   if (!activeGenomeId) {
@@ -68,9 +93,12 @@ export const toggleDrawer: ActionCreator<
   );
 };
 
-export const closeDrawer: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = () => (dispatch, getState: () => RootState) => {
+export const closeDrawer: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = () => (dispatch, getState: () => RootState) => {
   const activeGenomeId = getBrowserActiveGenomeId(getState());
 
   if (!activeGenomeId) {

--- a/src/ensembl/src/content/app/browser/drawer/drawerReducer.ts
+++ b/src/ensembl/src/content/app/browser/drawer/drawerReducer.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ActionType, getType } from 'typesafe-actions';
 
 import { DrawerState, defaultDrawerState } from './drawerState';

--- a/src/ensembl/src/content/app/browser/drawer/drawerSelectors.ts
+++ b/src/ensembl/src/content/app/browser/drawer/drawerSelectors.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { RootState } from 'src/store';
 import { getBrowserActiveGenomeId } from '../browserSelectors';
 

--- a/src/ensembl/src/content/app/browser/drawer/drawerState.ts
+++ b/src/ensembl/src/content/app/browser/drawer/drawerState.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export type DrawerState = Readonly<{
   isDrawerOpened: { [genomeId: string]: boolean };
   drawerView: { [genomeId: string]: string };

--- a/src/ensembl/src/content/app/browser/track-panel/TrackPanel.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/TrackPanel.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import faker from 'faker';

--- a/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/TrackPanel.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { memo } from 'react';
 import { connect } from 'react-redux';
 import isEqual from 'lodash/isEqual';

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBar.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBar.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBar.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBar.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import faker from 'faker';

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 import get from 'lodash/get';

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import faker from 'faker';
@@ -78,19 +94,13 @@ describe('<TrackPanelListItem />', () => {
 
     test('opens/updates drawer view when clicked on the open track button', () => {
       const wrapper = mount(<TrackPanelListItem {...defaultProps} />);
-      wrapper
-        .find('.ellipsisHolder')
-        .find(ImageButton)
-        .simulate('click');
+      wrapper.find('.ellipsisHolder').find(ImageButton).simulate('click');
       expect(wrapper.props().changeDrawerView).toHaveBeenCalledTimes(1);
     });
 
     test('toggles the track when clicked on the toggle track button', () => {
       const wrapper = mount(<TrackPanelListItem {...defaultProps} />);
-      wrapper
-        .find('.eyeHolder')
-        .find(ImageButton)
-        .simulate('click');
+      wrapper.find('.eyeHolder').find(ImageButton).simulate('click');
       expect(wrapper.props().updateTrackStatesAndSave).toHaveBeenCalledTimes(1);
     });
   });

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { MouseEvent, ReactNode, useEffect, useCallback } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/TrackPanelModal.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/TrackPanelModal.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/TrackPanelModal.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/TrackPanelModal.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/PersonalData.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/PersonalData.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 const PersonalData = () => {

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import faker from 'faker';
@@ -74,10 +90,7 @@ describe('<TrackPanelBookmarks />', () => {
   it('calls closeTrackPanelModal when a previously viewed object link is clicked', () => {
     const previouslyViewedLinksWrapper = wrapper.find(PreviouslyViewedLinks);
 
-    previouslyViewedLinksWrapper
-      .find('.link')
-      .first()
-      .simulate('click');
+    previouslyViewedLinksWrapper.find('.link').first().simulate('click');
 
     expect(closeTrackPanelModal).toBeCalled();
   });
@@ -133,10 +146,7 @@ describe('<TrackPanelBookmarks />', () => {
 
   it('calls closeTrackPanelModal when an example object link is clicked', () => {
     const exampleLinksWrapper = wrapper.find(ExampleLinks);
-    exampleLinksWrapper
-      .find('.link')
-      .first()
-      .simulate('click');
+    exampleLinksWrapper.find('.link').first().simulate('click');
 
     expect(closeTrackPanelModal).toBeCalled();
   });

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelDownloads.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelDownloads.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 const TrackPanelDownloads = () => {

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelSearch.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelSearch.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 const TrackPanelSearch = () => {

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelShare.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelShare.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 const TrackPanelShare = () => {

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TracksManager.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TracksManager.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 const TracksManager = () => {

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-storage-service.test.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-storage-service.test.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {
   TrackPanelStorageService,
   StorageKeys

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-storage-service.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-storage-service.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import storageService, {
   StorageServiceInterface
 } from 'src/services/storage-service';

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-tabs/TrackPanelTabs.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-tabs/TrackPanelTabs.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 
@@ -50,10 +66,7 @@ describe('<TrackPanelTabs />', () => {
           />
         );
 
-        wrapper
-          .find('.trackPanelTab')
-          .first()
-          .simulate('click');
+        wrapper.find('.trackPanelTab').first().simulate('click');
       });
 
       test('selects track panel tab', () => {

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-tabs/TrackPanelTabs.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-tabs/TrackPanelTabs.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.test.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.test.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import faker from 'faker';

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { createAction } from 'typesafe-actions';
 import { ThunkAction } from 'redux-thunk';
 import { Action, ActionCreator } from 'redux';
@@ -35,9 +51,12 @@ export const updateTrackPanelForGenome = createAction(
   }
 )();
 
-export const toggleTrackPanel: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (isTrackPanelOpened: boolean) => (dispatch, getState: () => RootState) => {
+export const toggleTrackPanel: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (isTrackPanelOpened: boolean) => (dispatch, getState: () => RootState) => {
   const activeGenomeId = getBrowserActiveGenomeId(getState());
 
   if (!activeGenomeId) {
@@ -55,9 +74,12 @@ export const toggleTrackPanel: ActionCreator<
   );
 };
 
-export const selectTrackPanelTab: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (selectedTrackPanelTab: TrackSet) => (
+export const selectTrackPanelTab: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (selectedTrackPanelTab: TrackSet) => (
   dispatch,
   getState: () => RootState
 ) => {
@@ -86,9 +108,12 @@ export const selectTrackPanelTab: ActionCreator<
   );
 };
 
-export const changeTrackPanelModalViewForGenome: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (trackPanelModalView: string) => (dispatch, getState: () => RootState) => {
+export const changeTrackPanelModalViewForGenome: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (trackPanelModalView: string) => (dispatch, getState: () => RootState) => {
   const activeGenomeId = getBrowserActiveGenomeId(getState());
 
   if (!activeGenomeId) {
@@ -105,9 +130,12 @@ export const changeTrackPanelModalViewForGenome: ActionCreator<
   );
 };
 
-export const updatePreviouslyViewedObjectsAndSave: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = () => (dispatch, getState: () => RootState) => {
+export const updatePreviouslyViewedObjectsAndSave: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = () => (dispatch, getState: () => RootState) => {
   const state = getState();
   const activeGenomeId = getBrowserActiveGenomeId(state);
   const activeEnsObject = getBrowserActiveEnsObject(state);
@@ -151,9 +179,12 @@ export const updatePreviouslyViewedObjectsAndSave: ActionCreator<
   );
 };
 
-export const changeHighlightedTrackId: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (highlightedTrackId: string) => (dispatch, getState: () => RootState) => {
+export const changeHighlightedTrackId: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (highlightedTrackId: string) => (dispatch, getState: () => RootState) => {
   const state = getState();
   const activeGenomeId = getBrowserActiveGenomeId(state);
 
@@ -172,9 +203,12 @@ export const changeHighlightedTrackId: ActionCreator<
   );
 };
 
-export const openTrackPanelModal: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (trackPanelModalView: string) => (dispatch, getState: () => RootState) => {
+export const openTrackPanelModal: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (trackPanelModalView: string) => (dispatch, getState: () => RootState) => {
   const state = getState();
 
   const activeGenomeId = getBrowserActiveGenomeId(state);
@@ -195,9 +229,12 @@ export const openTrackPanelModal: ActionCreator<
   );
 };
 
-export const closeTrackPanelModal: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = () => (dispatch, getState: () => RootState) => {
+export const closeTrackPanelModal: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = () => (dispatch, getState: () => RootState) => {
   const state = getState();
   const activeGenomeId = getBrowserActiveGenomeId(state);
 
@@ -217,9 +254,12 @@ export const closeTrackPanelModal: ActionCreator<
   );
 };
 
-export const updateCollapsedTrackIds: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (payload: { trackId: string; isCollapsed: boolean }) => (
+export const updateCollapsedTrackIds: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (payload: { trackId: string; isCollapsed: boolean }) => (
   dispatch,
   getState: () => RootState
 ) => {

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelConfig.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelConfig.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Status } from 'src/shared/types/status';
 
 export enum TrackItemColour {

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelReducer.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelReducer.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ActionType, getType } from 'typesafe-actions';
 
 import {

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelSelectors.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelSelectors.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { RootState } from 'src/store';
 import { getBrowserActiveGenomeId } from '../browserSelectors';
 import { defaultTrackPanelStateForGenome } from './trackPanelState';

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { TrackSet } from './trackPanelConfig';
 import browserStorageService from '../browser-storage-service';
 import pick from 'lodash/pick';

--- a/src/ensembl/src/content/app/browser/zmenu/Zmenu.test.tsx
+++ b/src/ensembl/src/content/app/browser/zmenu/Zmenu.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import faker from 'faker';

--- a/src/ensembl/src/content/app/browser/zmenu/Zmenu.tsx
+++ b/src/ensembl/src/content/app/browser/zmenu/Zmenu.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 import browserMessagingService from 'src/content/app/browser/browser-messaging-service';

--- a/src/ensembl/src/content/app/browser/zmenu/ZmenuAppLinks.tsx
+++ b/src/ensembl/src/content/app/browser/zmenu/ZmenuAppLinks.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';

--- a/src/ensembl/src/content/app/browser/zmenu/ZmenuContent.test.tsx
+++ b/src/ensembl/src/content/app/browser/zmenu/ZmenuContent.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { Provider } from 'react-redux';
 import { mount } from 'enzyme';
@@ -48,12 +64,9 @@ describe('<ZmenuContent />', () => {
         .blocks.map((items: ZmenuContentItemType[]) => items[0].text);
 
       firstLineData.forEach((lineText: string) => {
-        expect(
-          wrapper
-            .find('.zmenuContentLine')
-            .first()
-            .text()
-        ).toContain(lineText);
+        expect(wrapper.find('.zmenuContentLine').first().text()).toContain(
+          lineText
+        );
       });
     });
   });

--- a/src/ensembl/src/content/app/browser/zmenu/ZmenuContent.tsx
+++ b/src/ensembl/src/content/app/browser/zmenu/ZmenuContent.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';

--- a/src/ensembl/src/content/app/browser/zmenu/ZmenuController.tsx
+++ b/src/ensembl/src/content/app/browser/zmenu/ZmenuController.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import pickBy from 'lodash/pickBy';
@@ -110,7 +126,4 @@ const mapDispatchToProps = {
   changeHighlightedTrackId
 };
 
-export default connect(
-  undefined,
-  mapDispatchToProps
-)(ZmenuController);
+export default connect(undefined, mapDispatchToProps)(ZmenuController);

--- a/src/ensembl/src/content/app/browser/zmenu/index.ts
+++ b/src/ensembl/src/content/app/browser/zmenu/index.ts
@@ -1,1 +1,17 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export { default as ZmenuController } from './ZmenuController';

--- a/src/ensembl/src/content/app/browser/zmenu/zmenu-types.ts
+++ b/src/ensembl/src/content/app/browser/zmenu/zmenu-types.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // relation of the point of interest to the central point of the canvas;
 // a gentle hint by genome browser about where there is the most available space
 // e.g. if the reported side of a point is 'left', zmenu will position itself

--- a/src/ensembl/src/content/app/custom-download/CustomDownload.tsx
+++ b/src/ensembl/src/content/app/custom-download/CustomDownload.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import PreFilterPanel from 'src/content/app/custom-download/containers/pre-filters-panel/PreFilterPanel';
@@ -59,7 +75,4 @@ const mapDispatchToProps: DispatchProps = {
   setActiveGenomeId
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(CustomDownload);
+export default connect(mapStateToProps, mapDispatchToProps)(CustomDownload);

--- a/src/ensembl/src/content/app/custom-download/components/checkbox-grid/CheckboxGrid.test.tsx
+++ b/src/ensembl/src/content/app/custom-download/components/checkbox-grid/CheckboxGrid.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 

--- a/src/ensembl/src/content/app/custom-download/components/checkbox-grid/CheckboxGrid.tsx
+++ b/src/ensembl/src/content/app/custom-download/components/checkbox-grid/CheckboxGrid.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState } from 'react';
 import classNames from 'classnames';
 

--- a/src/ensembl/src/content/app/custom-download/components/checkbox-with-radios/CheckboxWithRadios.test.tsx
+++ b/src/ensembl/src/content/app/custom-download/components/checkbox-with-radios/CheckboxWithRadios.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import CheckboxWithRadios from './CheckboxWithRadios';
@@ -47,10 +63,7 @@ describe('<CheckboxWithRadios />', () => {
   it('displays all the radios when the checkbox is checked', () => {
     wrapper = mount(<CheckboxWithRadios {...defaultProps} />);
 
-    wrapper
-      .find(Checkbox)
-      .find('.defaultCheckbox')
-      .simulate('click');
+    wrapper.find(Checkbox).find('.defaultCheckbox').simulate('click');
     expect(wrapper.find('input[type="radio"]').length).toBe(
       defaultProps.options.length
     );
@@ -59,15 +72,9 @@ describe('<CheckboxWithRadios />', () => {
   it('calls the onChange when the radio is changed with the selected option', () => {
     wrapper = mount(<CheckboxWithRadios {...defaultProps} />);
 
-    wrapper
-      .find(Checkbox)
-      .find('.defaultCheckbox')
-      .simulate('click');
+    wrapper.find(Checkbox).find('.defaultCheckbox').simulate('click');
 
-    wrapper
-      .find('input[type="radio"]')
-      .first()
-      .simulate('change');
+    wrapper.find('input[type="radio"]').first().simulate('change');
 
     expect(onChange).toHaveBeenCalledWith(defaultProps.options[0].value);
   });

--- a/src/ensembl/src/content/app/custom-download/components/checkbox-with-radios/CheckboxWithRadios.tsx
+++ b/src/ensembl/src/content/app/custom-download/components/checkbox-with-radios/CheckboxWithRadios.tsx
@@ -1,6 +1,24 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState } from 'react';
 import Checkbox from 'src/shared/components/checkbox/Checkbox';
-import RadioGroup, { RadioOptions } from 'src/shared/components/radio-group/RadioGroup';
+import RadioGroup, {
+  RadioOptions
+} from 'src/shared/components/radio-group/RadioGroup';
 
 import styles from './CheckboxWithRadios.scss';
 

--- a/src/ensembl/src/content/app/custom-download/components/checkbox-with-selects/CheckboxWithSelects.test.tsx
+++ b/src/ensembl/src/content/app/custom-download/components/checkbox-with-selects/CheckboxWithSelects.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import CheckboxWithSelects from './CheckboxWithSelects';
@@ -49,10 +65,7 @@ describe('<CheckboxWithSelects />', () => {
   it('displays one Select when the checkbox is checked', () => {
     wrapper = mount(<CheckboxWithSelects {...defaultProps} />);
 
-    wrapper
-      .find(Checkbox)
-      .find('.defaultCheckbox')
-      .simulate('click');
+    wrapper.find(Checkbox).find('.defaultCheckbox').simulate('click');
     expect(wrapper.find(Select).length).toBe(1);
   });
 
@@ -67,10 +80,7 @@ describe('<CheckboxWithSelects />', () => {
   it('does not display the remove button next to the Select if no option is selected ', () => {
     wrapper = mount(<CheckboxWithSelects {...defaultProps} />);
 
-    wrapper
-      .find(Checkbox)
-      .find('.defaultCheckbox')
-      .simulate('click');
+    wrapper.find(Checkbox).find('.defaultCheckbox').simulate('click');
     expect(wrapper.find(Select).length).toBe(1);
     expect(wrapper.find('.removeIconHolder').length).toBe(0);
   });
@@ -107,10 +117,7 @@ describe('<CheckboxWithSelects />', () => {
 
     expect(wrapper.find(Select)).toHaveLength(1);
 
-    wrapper
-      .find('.addIconHolder')
-      .find(ImageButton)
-      .simulate('click');
+    wrapper.find('.addIconHolder').find(ImageButton).simulate('click');
 
     expect(wrapper.find(Select)).toHaveLength(2);
   });
@@ -123,16 +130,8 @@ describe('<CheckboxWithSelects />', () => {
       />
     );
 
-    wrapper
-      .find('.addIconHolder')
-      .find(ImageButton)
-      .simulate('click');
-    expect(
-      wrapper
-        .find(Select)
-        .last()
-        .prop('options')
-    ).toHaveLength(4);
+    wrapper.find('.addIconHolder').find(ImageButton).simulate('click');
+    expect(wrapper.find(Select).last().prop('options')).toHaveLength(4);
   });
 
   it('does not display the Plus button when all the options are selected', () => {
@@ -156,23 +155,11 @@ describe('<CheckboxWithSelects />', () => {
       />
     );
 
-    wrapper
-      .find('.addIconHolder')
-      .find(ImageButton)
-      .simulate('click');
+    wrapper.find('.addIconHolder').find(ImageButton).simulate('click');
 
-    wrapper
-      .find(Select)
-      .last()
-      .find('.selectControl')
-      .simulate('click');
+    wrapper.find(Select).last().find('.selectControl').simulate('click');
     wrapper.update();
-    wrapper
-      .find('.optionsPanel')
-      .last()
-      .find('li')
-      .first()
-      .simulate('click');
+    wrapper.find('.optionsPanel').last().find('li').first().simulate('click');
 
     expect(onChange).toHaveBeenCalledWith([
       defaultProps.options[0].value,

--- a/src/ensembl/src/content/app/custom-download/components/checkbox-with-selects/CheckboxWithSelects.tsx
+++ b/src/ensembl/src/content/app/custom-download/components/checkbox-with-selects/CheckboxWithSelects.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState, useEffect } from 'react';
 import Checkbox from 'src/shared/components/checkbox/Checkbox';
 import Select, { Option } from 'src/shared/components/select/Select';

--- a/src/ensembl/src/content/app/custom-download/components/checkbox-with-textfields/CheckboxWithTextfields.test.tsx
+++ b/src/ensembl/src/content/app/custom-download/components/checkbox-with-textfields/CheckboxWithTextfields.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import faker from 'faker';
@@ -80,10 +96,7 @@ describe('<CheckboxWithTextfields />', () => {
     wrapper = mount(
       <CheckboxWithTextfields {...defaultProps} textValue={'foo'} />
     );
-    wrapper
-      .find(Checkbox)
-      .find('label')
-      .simulate('click');
+    wrapper.find(Checkbox).find('label').simulate('click');
     expect(onReset).toBeCalled();
   });
 

--- a/src/ensembl/src/content/app/custom-download/components/checkbox-with-textfields/CheckboxWithTextfields.tsx
+++ b/src/ensembl/src/content/app/custom-download/components/checkbox-with-textfields/CheckboxWithTextfields.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState, useEffect } from 'react';
 import Checkbox from 'src/shared/components/checkbox/Checkbox';
 

--- a/src/ensembl/src/content/app/custom-download/components/content-builder/ContentBuilder.tsx
+++ b/src/ensembl/src/content/app/custom-download/components/content-builder/ContentBuilder.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import set from 'lodash/set';
 import get from 'lodash/get';

--- a/src/ensembl/src/content/app/custom-download/components/info-card/CustomDownloadInfoCard.tsx
+++ b/src/ensembl/src/content/app/custom-download/components/info-card/CustomDownloadInfoCard.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import classNamesMerger from 'classnames';
 

--- a/src/ensembl/src/content/app/custom-download/containers/app-bar/CustomDownloadAppBar.tsx
+++ b/src/ensembl/src/content/app/custom-download/containers/app-bar/CustomDownloadAppBar.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';

--- a/src/ensembl/src/content/app/custom-download/containers/content/CustomDownloadContent.tsx
+++ b/src/ensembl/src/content/app/custom-download/containers/content/CustomDownloadContent.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 import { RootState } from 'src/store';

--- a/src/ensembl/src/content/app/custom-download/containers/content/attributes-accordion/AttributesAccordion.tsx
+++ b/src/ensembl/src/content/app/custom-download/containers/content/attributes-accordion/AttributesAccordion.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { RootState } from 'src/store';

--- a/src/ensembl/src/content/app/custom-download/containers/content/attributes-accordion/sections/AttributesAccordionSection.tsx
+++ b/src/ensembl/src/content/app/custom-download/containers/content/attributes-accordion/sections/AttributesAccordionSection.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 import { RootState } from 'src/store';

--- a/src/ensembl/src/content/app/custom-download/containers/content/attributes-accordion/sections/index.ts
+++ b/src/ensembl/src/content/app/custom-download/containers/content/attributes-accordion/sections/index.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import Orthologues from './orthologues/Orthologues';
 
 export { Orthologues };

--- a/src/ensembl/src/content/app/custom-download/containers/content/attributes-accordion/sections/orthologues/Orthologues.tsx
+++ b/src/ensembl/src/content/app/custom-download/containers/content/attributes-accordion/sections/orthologues/Orthologues.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useCallback } from 'react';
 import { connect } from 'react-redux';
 import set from 'lodash/set';
@@ -69,9 +85,11 @@ const Orthologue = (props: Props) => {
     set(updatedAttributes, path, status);
     props.updateSelectedAttributes(updatedAttributes);
 
-    props.setOrthologueAttributes(newOrthologueAttributes as {
-      [key: string]: AttributeWithOptions;
-    });
+    props.setOrthologueAttributes(
+      newOrthologueAttributes as {
+        [key: string]: AttributeWithOptions;
+      }
+    );
   };
 
   const speciesOnChangeHandler = (status: boolean, attributeId: string) => {
@@ -222,7 +240,4 @@ const mapStateToProps = (state: RootState): StateProps => ({
   selectedAttributes: getSelectedAttributes(state)
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Orthologue);
+export default connect(mapStateToProps, mapDispatchToProps)(Orthologue);

--- a/src/ensembl/src/content/app/custom-download/containers/content/customDownloadContentHelper.ts
+++ b/src/ensembl/src/content/app/custom-download/containers/content/customDownloadContentHelper.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import JSONValue from 'src/shared/types/JSON';
 
 export const flattenObject = (

--- a/src/ensembl/src/content/app/custom-download/containers/content/filter-accordion/FiltersAccordion.tsx
+++ b/src/ensembl/src/content/app/custom-download/containers/content/filter-accordion/FiltersAccordion.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 import { RootState } from 'src/store';

--- a/src/ensembl/src/content/app/custom-download/containers/content/filter-accordion/sections/FiltersAccordionSection.tsx
+++ b/src/ensembl/src/content/app/custom-download/containers/content/filter-accordion/sections/FiltersAccordionSection.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 import { RootState } from 'src/store';

--- a/src/ensembl/src/content/app/custom-download/containers/content/filter-accordion/sections/genes/Genes.tsx
+++ b/src/ensembl/src/content/app/custom-download/containers/content/filter-accordion/sections/genes/Genes.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 import { RootState } from 'src/store';
@@ -52,7 +68,4 @@ const mapStateToProps = (state: RootState): StateProps => ({
   uiState: getFiltersUi(state)
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Genes);
+export default connect(mapStateToProps, mapDispatchToProps)(Genes);

--- a/src/ensembl/src/content/app/custom-download/containers/content/filter-accordion/sections/index.ts
+++ b/src/ensembl/src/content/app/custom-download/containers/content/filter-accordion/sections/index.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import Genes from './genes/Genes';
 import Proteins from './proteins/Proteins';
 

--- a/src/ensembl/src/content/app/custom-download/containers/content/filter-accordion/sections/proteins/Proteins.tsx
+++ b/src/ensembl/src/content/app/custom-download/containers/content/filter-accordion/sections/proteins/Proteins.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 import { RootState } from 'src/store';
@@ -53,7 +69,4 @@ const mapStateToProps = (state: RootState): StateProps => ({
   uiState: getFiltersUi(state)
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Proteins);
+export default connect(mapStateToProps, mapDispatchToProps)(Proteins);

--- a/src/ensembl/src/content/app/custom-download/containers/content/preview-card/PreviewCard.tsx
+++ b/src/ensembl/src/content/app/custom-download/containers/content/preview-card/PreviewCard.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 import { RootState } from 'src/store';

--- a/src/ensembl/src/content/app/custom-download/containers/content/preview-card/previewCardHelper.ts
+++ b/src/ensembl/src/content/app/custom-download/containers/content/preview-card/previewCardHelper.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import JSONValue from 'src/shared/types/JSON';
 
 import {

--- a/src/ensembl/src/content/app/custom-download/containers/content/preview-download/PreviewDownload.tsx
+++ b/src/ensembl/src/content/app/custom-download/containers/content/preview-download/PreviewDownload.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import get from 'lodash/get';
 import { connect } from 'react-redux';

--- a/src/ensembl/src/content/app/custom-download/containers/header/CustomDownloadHeader.tsx
+++ b/src/ensembl/src/content/app/custom-download/containers/header/CustomDownloadHeader.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import {
@@ -218,7 +234,4 @@ const mapStateToProps = (state: RootState) => ({
   activeGenomeId: getCustomDownloadActiveGenomeId(state)
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Header);
+export default connect(mapStateToProps, mapDispatchToProps)(Header);

--- a/src/ensembl/src/content/app/custom-download/containers/header/customDownloadHeaderHelper.ts
+++ b/src/ensembl/src/content/app/custom-download/containers/header/customDownloadHeaderHelper.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import config from 'config';
 
 import mapKeys from 'lodash/mapKeys';
@@ -65,10 +81,7 @@ export const getEndpointUrl = (
   let endpoint = config.genesearchAPIEndpoint + `/genes/${method}?query=`;
 
   const genome = activeGenomeId
-    ? activeGenomeId
-        .split('_')
-        .slice(0, 2)
-        .join('_')
+    ? activeGenomeId.split('_').slice(0, 2).join('_')
     : 'homo_sapiens';
   const endpointFilters: JSONValue = {
     genome
@@ -91,10 +104,7 @@ export const getEndpointUrl = (
   const gene_source = get(processedFilters, 'genes.gene_source');
 
   if (gene_ids.filter(Boolean).length) {
-    endpointFilters.id = gene_ids
-      .filter(Boolean)
-      .join(',')
-      .split(',');
+    endpointFilters.id = gene_ids.filter(Boolean).join(',').split(',');
   }
 
   if (gene_biotypes) {

--- a/src/ensembl/src/content/app/custom-download/containers/pre-filters-panel/PreFilterPanel.tsx
+++ b/src/ensembl/src/content/app/custom-download/containers/pre-filters-panel/PreFilterPanel.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { FunctionComponent } from 'react';
 import { connect } from 'react-redux';
 import RoundButton, {
@@ -105,7 +121,4 @@ const mapStateToProps = (state: RootState): StateProps => ({
   selectedPreFilter: getSelectedPreFilter(state)
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(PreFilterPanel);
+export default connect(mapStateToProps, mapDispatchToProps)(PreFilterPanel);

--- a/src/ensembl/src/content/app/custom-download/sample-data/attributes.ts
+++ b/src/ensembl/src/content/app/custom-download/sample-data/attributes.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Attributes } from '../types/Attributes';
 
 const attributes: Attributes = {

--- a/src/ensembl/src/content/app/custom-download/sample-data/filters.ts
+++ b/src/ensembl/src/content/app/custom-download/sample-data/filters.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Attributes } from 'src/content/app/custom-download/types/Attributes';
 
 const filters: Attributes = {

--- a/src/ensembl/src/content/app/custom-download/sample-data/orthologue.tsx
+++ b/src/ensembl/src/content/app/custom-download/sample-data/orthologue.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export const orthologueAttributes = {
   id: 'orthologues',
   type: 'checkbox_grid',

--- a/src/ensembl/src/content/app/custom-download/services/custom-download-storage-service.tsx
+++ b/src/ensembl/src/content/app/custom-download/services/custom-download-storage-service.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import storageService, {
   StorageServiceInterface,
   StorageType

--- a/src/ensembl/src/content/app/custom-download/state/attributes/attributesActions.ts
+++ b/src/ensembl/src/content/app/custom-download/state/attributes/attributesActions.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { createAsyncAction } from 'typesafe-actions';
 import { ThunkAction } from 'redux-thunk';
 import { ActionCreator, Action } from 'redux';
@@ -25,9 +41,12 @@ export const setAttributes = createAsyncAction(
   'custom-download/set-attributes-failure'
 )<undefined, {}, Error>();
 
-export const fetchAttributes: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = () => (dispatch, getState: () => RootState) => {
+export const fetchAttributes: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = () => (dispatch, getState: () => RootState) => {
   const activeGenomeId = getCustomDownloadActiveGenomeId(getState());
 
   if (!activeGenomeId) {
@@ -56,9 +75,12 @@ export const fetchAttributes: ActionCreator<
   }
 };
 
-export const updateSelectedAttributes: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (selectedAttributes: JSONValue) => (
+export const updateSelectedAttributes: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (selectedAttributes: JSONValue) => (
   dispatch,
   getState: () => RootState
 ) => {
@@ -82,9 +104,12 @@ export const updateSelectedAttributes: ActionCreator<
   );
 };
 
-export const resetSelectedAttributes: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = () => (dispatch, getState: () => RootState) => {
+export const resetSelectedAttributes: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = () => (dispatch, getState: () => RootState) => {
   const activeGenomeId = getCustomDownloadActiveGenomeId(getState());
 
   if (!activeGenomeId) {
@@ -105,9 +130,12 @@ export const resetSelectedAttributes: ActionCreator<
   );
 };
 
-export const updateUi: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (attributesUi: JSONValue) => (dispatch, getState: () => RootState) => {
+export const updateUi: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (attributesUi: JSONValue) => (dispatch, getState: () => RootState) => {
   const activeGenomeId = getCustomDownloadActiveGenomeId(getState());
 
   if (!activeGenomeId) {
@@ -128,9 +156,12 @@ export const updateUi: ActionCreator<
   );
 };
 
-export const setOrthologueAttributes: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (orthologues: { [key: string]: AttributeWithOptions }) => (
+export const setOrthologueAttributes: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (orthologues: { [key: string]: AttributeWithOptions }) => (
   dispatch,
   getState: () => RootState
 ) => {
@@ -154,9 +185,12 @@ export const setOrthologueAttributes: ActionCreator<
   );
 };
 
-export const setOrthologueShowBestMatches: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (showBestMatches: boolean) => (dispatch, getState: () => RootState) => {
+export const setOrthologueShowBestMatches: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (showBestMatches: boolean) => (dispatch, getState: () => RootState) => {
   const activeGenomeId = getCustomDownloadActiveGenomeId(getState());
 
   if (!activeGenomeId) {
@@ -177,9 +211,12 @@ export const setOrthologueShowBestMatches: ActionCreator<
   );
 };
 
-export const setOrthologueShowAll: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (showAll: boolean) => (dispatch, getState: () => RootState) => {
+export const setOrthologueShowAll: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (showAll: boolean) => (dispatch, getState: () => RootState) => {
   const activeGenomeId = getCustomDownloadActiveGenomeId(getState());
 
   if (!activeGenomeId) {
@@ -200,9 +237,12 @@ export const setOrthologueShowAll: ActionCreator<
   );
 };
 
-export const setOrthologueApplyToAllSpecies: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (applyToAllSpecies: boolean) => (dispatch, getState: () => RootState) => {
+export const setOrthologueApplyToAllSpecies: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (applyToAllSpecies: boolean) => (dispatch, getState: () => RootState) => {
   const activeGenomeId = getCustomDownloadActiveGenomeId(getState());
 
   if (!activeGenomeId) {
@@ -223,9 +263,12 @@ export const setOrthologueApplyToAllSpecies: ActionCreator<
   );
 };
 
-export const setOrthologueSearchTerm: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (searchTerm: string) => (dispatch, getState: () => RootState) => {
+export const setOrthologueSearchTerm: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (searchTerm: string) => (dispatch, getState: () => RootState) => {
   const activeGenomeId = getCustomDownloadActiveGenomeId(getState());
 
   if (!activeGenomeId) {
@@ -252,9 +295,12 @@ export const setOrthologueSpecies = createAsyncAction(
   'custom-download/set-orthologue-species-failure'
 )<{ searchTerm: string }, void, Error>();
 
-export const updateOrthologueSpecies: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (orthologueSpecies: CheckboxGridOption[]) => (
+export const updateOrthologueSpecies: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (orthologueSpecies: CheckboxGridOption[]) => (
   dispatch,
   getState: () => RootState
 ) => {
@@ -278,9 +324,12 @@ export const updateOrthologueSpecies: ActionCreator<
   );
 };
 
-export const fetchOrthologueSpecies: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (searchTerm: string, orthologueSpecies: CheckboxGridOption[]) => (
+export const fetchOrthologueSpecies: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (searchTerm: string, orthologueSpecies: CheckboxGridOption[]) => (
   dispatch,
   getState: () => RootState
 ) => {
@@ -342,9 +391,12 @@ export const fetchOrthologueSpecies: ActionCreator<
   }
 };
 
-export const setAttributesAccordionExpandedPanel: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (expandedPanels: string[]) => (dispatch, getState: () => RootState) => {
+export const setAttributesAccordionExpandedPanel: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (expandedPanels: string[]) => (dispatch, getState: () => RootState) => {
   const activeGenomeId = getCustomDownloadActiveGenomeId(getState());
 
   if (!activeGenomeId) {

--- a/src/ensembl/src/content/app/custom-download/state/attributes/attributesSelector.ts
+++ b/src/ensembl/src/content/app/custom-download/state/attributes/attributesSelector.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { RootState } from 'src/store';
 
 import {

--- a/src/ensembl/src/content/app/custom-download/state/attributes/attributesState.ts
+++ b/src/ensembl/src/content/app/custom-download/state/attributes/attributesState.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { AttributeWithOptions } from 'src/content/app/custom-download/types/Attributes';
 import JSONValue from 'src/shared/types/JSON';
 import { CheckboxGridOption } from 'src/content/app/custom-download/components/checkbox-grid/CheckboxGrid';

--- a/src/ensembl/src/content/app/custom-download/state/customDownloadActions.ts
+++ b/src/ensembl/src/content/app/custom-download/state/customDownloadActions.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { createAction, createAsyncAction } from 'typesafe-actions';
 import set from 'lodash/set';
 import cloneDeep from 'lodash/cloneDeep';
@@ -28,9 +44,12 @@ export const updateActiveGenomeId = createAction(
   'custom-download/set-active-genome-id'
 )<string | null>();
 
-export const setActiveGenomeId: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (activeGenomeId: string) => (dispatch, getState: () => RootState) => {
+export const setActiveGenomeId: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (activeGenomeId: string) => (dispatch, getState: () => RootState) => {
   dispatch(updateActiveGenomeId(activeGenomeId));
 
   if (!getActiveConfigurations(getState())[activeGenomeId]) {
@@ -55,9 +74,12 @@ export const updateActiveConfigurationForGenome = createAction(
   }
 )();
 
-export const updateSelectedPreFilter: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (selectedPreFilter: boolean) => (dispatch, getState: () => RootState) => {
+export const updateSelectedPreFilter: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (selectedPreFilter: boolean) => (dispatch, getState: () => RootState) => {
   const activeGenomeId = getCustomDownloadActiveGenomeId(getState());
 
   if (!activeGenomeId) {
@@ -76,9 +98,15 @@ export const updateSelectedPreFilter: ActionCreator<
   );
 };
 
-export const togglePreFiltersPanel: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (showPreFiltersPanel: boolean) => (dispatch, getState: () => RootState) => {
+export const togglePreFiltersPanel: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (showPreFiltersPanel: boolean) => (
+  dispatch,
+  getState: () => RootState
+) => {
   const activeGenomeId = getCustomDownloadActiveGenomeId(getState());
 
   if (!activeGenomeId) {
@@ -103,9 +131,12 @@ export const setPreviewResult = createAsyncAction(
   'custom-download/preview-results-failure'
 )<{ endpointURL: string; headers: {} }, JSONValue, Error>();
 
-export const fetchPreviewResult: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (endpointURL: string) => (dispatch) => {
+export const fetchPreviewResult: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (endpointURL: string) => (dispatch) => {
   try {
     apiService
       .fetch(endpointURL, {
@@ -126,9 +157,12 @@ export const setIsLoadingResult = createAction(
   'custom-download/set-is-loading-result'
 )<boolean>();
 
-export const setShowPreview: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (showSummary: boolean) => (dispatch, getState: () => RootState) => {
+export const setShowPreview: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (showSummary: boolean) => (dispatch, getState: () => RootState) => {
   const activeGenomeId = getCustomDownloadActiveGenomeId(getState());
 
   if (!activeGenomeId) {
@@ -147,9 +181,12 @@ export const setShowPreview: ActionCreator<
   );
 };
 
-export const setShowExampleData: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (showExampleData: boolean) => (dispatch, getState: () => RootState) => {
+export const setShowExampleData: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (showExampleData: boolean) => (dispatch, getState: () => RootState) => {
   const activeGenomeId = getCustomDownloadActiveGenomeId(getState());
 
   if (!activeGenomeId) {
@@ -168,9 +205,12 @@ export const setShowExampleData: ActionCreator<
   );
 };
 
-export const setDownloadType: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (downloadType: string) => (dispatch, getState: () => RootState) => {
+export const setDownloadType: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (downloadType: string) => (dispatch, getState: () => RootState) => {
   const activeGenomeId = getCustomDownloadActiveGenomeId(getState());
 
   if (!activeGenomeId) {

--- a/src/ensembl/src/content/app/custom-download/state/customDownloadReducer.ts
+++ b/src/ensembl/src/content/app/custom-download/state/customDownloadReducer.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ActionType, getType } from 'typesafe-actions';
 
 import { RootAction } from 'src/objects';

--- a/src/ensembl/src/content/app/custom-download/state/customDownloadSelectors.ts
+++ b/src/ensembl/src/content/app/custom-download/state/customDownloadSelectors.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { RootState } from 'src/store';
 import { defaultCustomDownloadStateForGenome } from './customDownloadState';
 

--- a/src/ensembl/src/content/app/custom-download/state/customDownloadState.ts
+++ b/src/ensembl/src/content/app/custom-download/state/customDownloadState.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import JSONValue from 'src/shared/types/JSON';
 import { FiltersState, defaultFiltersState } from './filters/filtersState';
 import {

--- a/src/ensembl/src/content/app/custom-download/state/filters/filtersActions.ts
+++ b/src/ensembl/src/content/app/custom-download/state/filters/filtersActions.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ThunkAction } from 'redux-thunk';
 import { ActionCreator, Action } from 'redux';
 import set from 'lodash/set';
@@ -10,9 +26,12 @@ import {
   getCustomDownloadActiveGenomeConfiguration
 } from 'src/content/app/custom-download/state/customDownloadSelectors';
 
-export const setFiltersAccordionExpandedPanel: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (expandedPanels: string[]) => (dispatch, getState: () => RootState) => {
+export const setFiltersAccordionExpandedPanel: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (expandedPanels: string[]) => (dispatch, getState: () => RootState) => {
   const activeGenomeId = getCustomDownloadActiveGenomeId(getState());
 
   if (!activeGenomeId) {
@@ -33,9 +52,12 @@ export const setFiltersAccordionExpandedPanel: ActionCreator<
   );
 };
 
-export const updateSelectedFilters: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (selectedFilters: JSONValue) => (dispatch, getState: () => RootState) => {
+export const updateSelectedFilters: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (selectedFilters: JSONValue) => (dispatch, getState: () => RootState) => {
   const activeGenomeId = getCustomDownloadActiveGenomeId(getState());
 
   if (!activeGenomeId) {
@@ -56,9 +78,12 @@ export const updateSelectedFilters: ActionCreator<
   );
 };
 
-export const updateUi: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (filtersUi: JSONValue) => (dispatch, getState: () => RootState) => {
+export const updateUi: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (filtersUi: JSONValue) => (dispatch, getState: () => RootState) => {
   const activeGenomeId = getCustomDownloadActiveGenomeId(getState());
 
   if (!activeGenomeId) {
@@ -79,9 +104,12 @@ export const updateUi: ActionCreator<
   );
 };
 
-export const resetSelectedFilters: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = () => (dispatch, getState: () => RootState) => {
+export const resetSelectedFilters: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = () => (dispatch, getState: () => RootState) => {
   const activeGenomeId = getCustomDownloadActiveGenomeId(getState());
 
   if (!activeGenomeId) {

--- a/src/ensembl/src/content/app/custom-download/state/filters/filtersSelector.ts
+++ b/src/ensembl/src/content/app/custom-download/state/filters/filtersSelector.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { RootState } from 'src/store';
 import { getCustomDownloadActiveGenomeConfiguration } from '../customDownloadSelectors';
 

--- a/src/ensembl/src/content/app/custom-download/state/filters/filtersState.ts
+++ b/src/ensembl/src/content/app/custom-download/state/filters/filtersState.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Attributes } from 'src/content/app/custom-download/types/Attributes';
 import JSONValue from 'src/shared/types/JSON';
 

--- a/src/ensembl/src/content/app/custom-download/types/Attributes.ts
+++ b/src/ensembl/src/content/app/custom-download/types/Attributes.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { RadioOptions } from 'src/shared/components/radio-group/RadioGroup';
 import { Option } from 'src/shared/components/select/Select';
 import { CheckboxGridOption } from 'src/content/app/custom-download/components/checkbox-grid/CheckboxGrid';

--- a/src/ensembl/src/content/app/custom-download/types/Species.ts
+++ b/src/ensembl/src/content/app/custom-download/types/Species.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 type Species = {
   name: string;
   assembly: string;

--- a/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useEffect } from 'react';
 import ApolloClient from 'apollo-boost';
 import { connect } from 'react-redux';

--- a/src/ensembl/src/content/app/entity-viewer/components/transcript-filter/EntityViewerTranscriptFilter.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/components/transcript-filter/EntityViewerTranscriptFilter.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import times from 'lodash/times';

--- a/src/ensembl/src/content/app/entity-viewer/components/transcript-filter/EntityViewerTranscriptFilter.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/components/transcript-filter/EntityViewerTranscriptFilter.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import classNames from 'classnames';
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import { useQuery } from '@apollo/react-hooks';

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/BasePairsRuler.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/BasePairsRuler.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount, render } from 'enzyme';
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/BasePairsRuler.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/BasePairsRuler.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
 This component is a ruler for displaying alongside visualisation of a nucleic acid
 
@@ -41,9 +57,7 @@ type Props = {
 const FeatureLengthAxis = (props: Props) => {
   const domain = [1, props.length];
   const range = [0, props.width];
-  const scale = scaleLinear()
-    .domain(domain)
-    .range(range);
+  const scale = scaleLinear().domain(domain).range(range);
   const { ticks, labelledTicks } = getTicks(scale);
 
   useEffect(() => {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/basePairsRulerHelper.test.ts
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/basePairsRulerHelper.test.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { scaleLinear } from 'd3';
 
 import { getTicks } from './basePairsRulerHelper';
@@ -97,9 +113,7 @@ describe('featureLengthAxisHelper', () => {
     const width = 600;
 
     const generateScale = (length: number) =>
-      scaleLinear()
-        .domain([1, length])
-        .range([0, width]);
+      scaleLinear().domain([1, length]).range([0, width]);
 
     it('produces expected labelled ticks', () => {
       for (const example of examples) {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/basePairsRulerHelper.ts
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/basePairsRulerHelper.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ScaleLinear } from 'd3';
 
 export const getTicks = (scale: ScaleLinear<number, number>) => {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 import { getFeatureCoordinates } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState } from 'react';
 
 import { getFeatureCoordinates } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState } from 'react';
 import classNames from 'classnames';
 
@@ -124,8 +140,8 @@ const ItemInfo = (props: ItemInfoProps) => {
             Spliced RNA length <strong>{getSplicedRNALength()} bp</strong>
           </div>
           <div>
-            Coding exons <strong>{getNumberOfCodingExons(transcript)}</strong> of{' '}
-            {transcript.exons.length}
+            Coding exons <strong>{getNumberOfCodingExons(transcript)}</strong>{' '}
+            of {transcript.exons.length}
           </div>
         </div>
         <div className={styles.downloadLink}>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-overview-image/GeneOverviewImage.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-overview-image/GeneOverviewImage.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { scaleLinear } from 'd3';
 
@@ -47,9 +63,7 @@ export const GeneImage = (props: GeneOverviewImageProps) => {
 
   // FIXME: use the "length" property of the gene when it is added to payload;
   // (it will help with drawing genes of circular chromosomes)
-  const scale = scaleLinear()
-    .domain([geneStart, geneEnd])
-    .range([0, width]);
+  const scale = scaleLinear().domain([geneStart, geneEnd]).range([0, width]);
 
   const renderedTranscripts = props.gene.transcripts.map(
     (transcript, index) => {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-relationships/GeneRelationships.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-relationships/GeneRelationships.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar-tabs/GeneViewSidebarTabs.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar-tabs/GeneViewSidebarTabs.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/GeneViewSideBar.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/GeneViewSideBar.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/MainAccordion.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/MainAccordion.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import noop from 'lodash/noop';
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/PublicationsAccordion.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/PublicationsAccordion.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import classNames from 'classnames';
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-tabs/GeneViewTabs.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-tabs/GeneViewTabs.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState, useEffect } from 'react';
 import classNames from 'classnames';
 import { scaleLinear, ScaleLinear } from 'd3';

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/ProteinsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/ProteinsList.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useEffect, useState } from 'react';
 
 import ProteinsListItem from './proteins-list-item/ProteinsListItem';

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 import ProteinDomainImage from 'src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage';

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item/ProteinsListItem.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item/ProteinsListItem.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState } from 'react';
 import classNames from 'classnames';
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { render } from 'enzyme';
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import classNames from 'classnames';
 import { scaleLinear, ScaleLinear } from 'd3';

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-app-bar/EntityViewerAppBar.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-app-bar/EntityViewerAppBar.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { memo, useMemo } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar-toolstrip/EntityViewerSidebarToolstrip.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar-toolstrip/EntityViewerSidebarToolstrip.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import noop from 'lodash/noop';
 

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-topbar/EntityViewerTopbar.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-topbar/EntityViewerTopbar.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { useQuery } from '@apollo/react-hooks';
 import { gql } from 'apollo-boost';

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-topbar/scale-switcher/ScaleSwitcher.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-topbar/scale-switcher/ScaleSwitcher.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 import styles from './ScaleSwitcher.scss';

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/entity-helpers.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/entity-helpers.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
 
 import {
@@ -25,7 +41,6 @@ export const getFeatureLength = (feature: { slice: Slice }) => {
   const strandCode = getFeatureStrand(feature);
   return strandCode === 'forward' ? end - start + 1 : start - end + 1;
 };
-
 
 export const getFirstAndLastCodingExonIndexes = (transcript: Transcript) => {
   const { exons, cds } = transcript;

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/transcripts-sorter.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/transcripts-sorter.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import sortBy from 'lodash/sortBy';
 
 import { getFeatureLength } from './entity-helpers';

--- a/src/ensembl/src/content/app/entity-viewer/shared/rest/rest-adaptors/rest-gene-adaptor.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/rest/rest-adaptors/rest-gene-adaptor.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { restTranscriptAdaptor } from './rest-transcript-adaptor';
 
 import { GeneInResponse } from '../rest-data-fetchers/geneData';

--- a/src/ensembl/src/content/app/entity-viewer/shared/rest/rest-adaptors/rest-transcript-adaptor.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/rest/rest-adaptors/rest-transcript-adaptor.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Transcript } from 'src/content/app/entity-viewer/types/transcript';
 import { CDS } from 'src/content/app/entity-viewer/types/cds';
 import { Strand } from 'src/content/app/entity-viewer/types/strand';

--- a/src/ensembl/src/content/app/entity-viewer/shared/rest/rest-data-fetchers/geneData.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/rest/rest-data-fetchers/geneData.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { restGeneAdaptor } from '../rest-adaptors/rest-gene-adaptor';
 
 import { Gene } from '../../../types/gene';

--- a/src/ensembl/src/content/app/entity-viewer/shared/rest/rest-data-fetchers/transcriptData.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/rest/rest-data-fetchers/transcriptData.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { restTranscriptAdaptor } from 'src/content/app/entity-viewer/shared/rest/rest-adaptors/rest-transcript-adaptor';
 
 import { Transcript } from 'src/content/app/entity-viewer/types/transcript';

--- a/src/ensembl/src/content/app/entity-viewer/state/entityViewerReducer.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/entityViewerReducer.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { combineReducers } from 'redux';
 
 import entityViewerGeneralReducer from './general/entityViewerGeneralReducer';

--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/entityViewerGeneViewActions.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/entityViewerGeneViewActions.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { createAction } from 'typesafe-actions';
 import { ActionCreator, Action } from 'redux';
 import { ThunkAction } from 'redux-thunk';

--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/entityViewerGeneViewReducer.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/entityViewerGeneViewReducer.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ActionType, getType } from 'typesafe-actions';
 import merge from 'lodash/merge';
 import get from 'lodash/get';

--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/entityViewerGeneViewSelectors.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/entityViewerGeneViewSelectors.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { RootState } from 'src/store';
 import {
   getEntityViewerActiveGenomeId,

--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/entityViewerGeneViewState.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/entityViewerGeneViewState.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export type EntityViewerGeneFunctionState = {
   selectedTabName: GeneFunctionTabName;
 };

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralActions.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralActions.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { createAction } from 'typesafe-actions';
 import { ActionCreator, Action } from 'redux';
 import { batch } from 'react-redux';

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralReducer.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralReducer.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ActionType, getType } from 'typesafe-actions';
 
 import {

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { RootState } from 'src/store';
 import { getEnsObjectById } from 'src/shared/state/ens-object/ensObjectSelectors';
 

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralState.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralState.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export type EntityViewerGeneralState = Readonly<{
   activeGenomeId: string | null;
   activeEnsObjectIds: { [genomeId: string]: string };

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarActions.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarActions.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { createAction } from 'typesafe-actions';
 import { ActionCreator, Action } from 'redux';
 import { ThunkAction } from 'redux-thunk';

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarReducer.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarReducer.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ActionType, getType } from 'typesafe-actions';
 import merge from 'lodash/merge';
 import mergeWith from 'lodash/mergeWith';

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {
   getEntityViewerActiveGenomeId,
   getEntityViewerActiveEnsObjectId

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarState.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarState.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Status } from 'src/shared/types/status';
 import { Gene } from '../../types/gene';
 import { Transcript } from '../../types/transcript';

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/sampleData.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/sampleData.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { EntityViewerSidebarPayload } from './entityViewerSidebarState';
 import { DataSetType } from '../../types/dataSet';
 

--- a/src/ensembl/src/content/app/entity-viewer/types/assembly.ts
+++ b/src/ensembl/src/content/app/entity-viewer/types/assembly.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export type Assembly = {
   species_name: string;
   assembly_name: string;

--- a/src/ensembl/src/content/app/entity-viewer/types/cds.ts
+++ b/src/ensembl/src/content/app/entity-viewer/types/cds.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export type CDS = {
   start: number;
   end: number;

--- a/src/ensembl/src/content/app/entity-viewer/types/dataSet.ts
+++ b/src/ensembl/src/content/app/entity-viewer/types/dataSet.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export enum DataSetType {
   CURRENT_ASSEMBLY = 'Current assembly',
   GENE = 'Gene',

--- a/src/ensembl/src/content/app/entity-viewer/types/exon.ts
+++ b/src/ensembl/src/content/app/entity-viewer/types/exon.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export type Exon = {
   id: string;
   slice: {

--- a/src/ensembl/src/content/app/entity-viewer/types/externalLink.ts
+++ b/src/ensembl/src/content/app/entity-viewer/types/externalLink.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Source } from './source';
 
 export type ExternalLink = {

--- a/src/ensembl/src/content/app/entity-viewer/types/gene.ts
+++ b/src/ensembl/src/content/app/entity-viewer/types/gene.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import JSONValue from 'src/shared/types/JSON';
 import { Slice } from './slice';
 import { Transcript } from './transcript';

--- a/src/ensembl/src/content/app/entity-viewer/types/homeologue.ts
+++ b/src/ensembl/src/content/app/entity-viewer/types/homeologue.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export type Homeologue = {
   type: string;
   stable_id: string;

--- a/src/ensembl/src/content/app/entity-viewer/types/metadata.ts
+++ b/src/ensembl/src/content/app/entity-viewer/types/metadata.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Source } from './source';
 
 export type Metadata = {

--- a/src/ensembl/src/content/app/entity-viewer/types/product.ts
+++ b/src/ensembl/src/content/app/entity-viewer/types/product.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export type ProteinDomainsResources = {
   [name_of_resource: string]: {
     name: string;

--- a/src/ensembl/src/content/app/entity-viewer/types/publication.ts
+++ b/src/ensembl/src/content/app/entity-viewer/types/publication.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Source } from './source';
 
 export type Publication = {

--- a/src/ensembl/src/content/app/entity-viewer/types/slice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/types/slice.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Strand } from './strand';
 
 export type Slice = {

--- a/src/ensembl/src/content/app/entity-viewer/types/source.ts
+++ b/src/ensembl/src/content/app/entity-viewer/types/source.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export type Source = {
   name: string;
   value: string;

--- a/src/ensembl/src/content/app/entity-viewer/types/strand.ts
+++ b/src/ensembl/src/content/app/entity-viewer/types/strand.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export enum Strand {
   FORWARD = 'forward',
   REFVERSE = 'reverse'

--- a/src/ensembl/src/content/app/entity-viewer/types/transcript.ts
+++ b/src/ensembl/src/content/app/entity-viewer/types/transcript.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Slice } from './slice';
 import { Exon } from './exon';
 import { CDS } from './cds';

--- a/src/ensembl/src/content/app/global-search/GlobalSearch.tsx
+++ b/src/ensembl/src/content/app/global-search/GlobalSearch.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { Component } from 'react';
 
 class GlobalSearch extends Component {

--- a/src/ensembl/src/content/app/species-selector/SpeciesSelector.tsx
+++ b/src/ensembl/src/content/app/species-selector/SpeciesSelector.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { Component } from 'react';
 
 import SpeciesSearchPanel from 'src/content/app/species-selector/containers/species-search-panel/SpeciesSearchPanel';

--- a/src/ensembl/src/content/app/species-selector/components/assembly-selector/AssemblySelector.test.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/assembly-selector/AssemblySelector.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import faker from 'faker';

--- a/src/ensembl/src/content/app/species-selector/components/assembly-selector/AssemblySelector.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/assembly-selector/AssemblySelector.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 import find from 'lodash/find';
@@ -69,7 +85,4 @@ const mapDispatchToProps = {
   onSelect: changeAssembly
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(AssemblySelector);
+export default connect(mapStateToProps, mapDispatchToProps)(AssemblySelector);

--- a/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.test.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount, render } from 'enzyme';
 import set from 'lodash/fp/set';

--- a/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';

--- a/src/ensembl/src/content/app/species-selector/components/selected-species/SelectedSpecies.test.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/selected-species/SelectedSpecies.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { render, mount } from 'enzyme';
 import faker from 'faker';

--- a/src/ensembl/src/content/app/species-selector/components/selected-species/SelectedSpecies.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/selected-species/SelectedSpecies.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { FunctionComponent, useState } from 'react';
 import classNames from 'classnames';
 import noop from 'lodash/noop';

--- a/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.test.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 

--- a/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 

--- a/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.test.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import faker from 'faker';

--- a/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
 

--- a/src/ensembl/src/content/app/species-selector/components/species-search-match/SpeciesSearchMatch.test.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-search-match/SpeciesSearchMatch.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { render } from 'enzyme';
 

--- a/src/ensembl/src/content/app/species-selector/components/species-search-match/SpeciesSearchMatch.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-search-match/SpeciesSearchMatch.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import classNames from 'classnames';
 import zip from 'lodash/zip';

--- a/src/ensembl/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.test.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import times from 'lodash/times';

--- a/src/ensembl/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';

--- a/src/ensembl/src/content/app/species-selector/components/strain-selector/StrainSelector.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/strain-selector/StrainSelector.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState, useRef } from 'react';
 import classNames from 'classnames';
 

--- a/src/ensembl/src/content/app/species-selector/constants/speciesSelectorConstants.ts
+++ b/src/ensembl/src/content/app/species-selector/constants/speciesSelectorConstants.ts
@@ -1,1 +1,17 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export const MINIMUM_SEARCH_LENGTH = 3;

--- a/src/ensembl/src/content/app/species-selector/containers/popular-species-panel/PopularSpeciesPanel.tsx
+++ b/src/ensembl/src/content/app/species-selector/containers/popular-species-panel/PopularSpeciesPanel.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 

--- a/src/ensembl/src/content/app/species-selector/containers/species-search-panel/SpeciesSearchPanel.tsx
+++ b/src/ensembl/src/content/app/species-selector/containers/species-search-panel/SpeciesSearchPanel.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 import SpeciesSearchField from 'src/content/app/species-selector/components/species-search-field/SpeciesSearchField';

--- a/src/ensembl/src/content/app/species-selector/services/species-selector-storage-service.test.ts
+++ b/src/ensembl/src/content/app/species-selector/services/species-selector-storage-service.test.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {
   SpeciesSelectorStorageService,
   StorageKeys

--- a/src/ensembl/src/content/app/species-selector/services/species-selector-storage-service.ts
+++ b/src/ensembl/src/content/app/species-selector/services/species-selector-storage-service.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import storageService, {
   StorageServiceInterface
 } from 'src/services/storage-service';

--- a/src/ensembl/src/content/app/species-selector/speciesSelectorHelper.ts
+++ b/src/ensembl/src/content/app/species-selector/speciesSelectorHelper.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {
   CommittedItem,
   PopularSpecies

--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorActions.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorActions.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { createAsyncAction, createAction } from 'typesafe-actions';
 import { ActionCreator, Action } from 'redux';
 import { ThunkAction } from 'redux-thunk';
@@ -59,9 +75,12 @@ export const setSearchText = createAction('species_selector/set_search_text')<
   string
 >();
 
-export const updateSearch: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (text: string) => (dispatch, getState: () => RootState) => {
+export const updateSearch: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (text: string) => (dispatch, getState: () => RootState) => {
   const state = getState();
   const selectedItem = getSelectedItem(state);
   const previousText = getSearchText(state);
@@ -137,9 +156,12 @@ export const clearSelectedSearchResult = createAction(
 //   }
 // };
 
-export const ensureSpeciesIsCommitted: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (genomeId: string) => async (dispatch, getState: () => RootState) => {
+export const ensureSpeciesIsCommitted: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (genomeId: string) => async (dispatch, getState: () => RootState) => {
   const state = getState();
   const committedSpecies = getEnabledCommittedSpecies(state);
   const genomeInfo = getGenomeInfoById(state, genomeId);
@@ -161,9 +183,12 @@ export const ensureSpeciesIsCommitted: ActionCreator<
   speciesSelectorStorageService.saveSelectedSpecies(newCommittedSpecies);
 };
 
-export const fetchAssemblies: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (genomeId: string) => async (dispatch) => {
+export const fetchAssemblies: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (genomeId: string) => async (dispatch) => {
   try {
     dispatch(fetchAssembliesAsyncActions.request());
 
@@ -180,9 +205,12 @@ export const fetchAssemblies: ActionCreator<
   }
 };
 
-export const fetchPopularSpecies: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = () => async (dispatch) => {
+export const fetchPopularSpecies: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = () => async (dispatch) => {
   try {
     dispatch(fetchPopularSpeciesAsyncActions.request());
 
@@ -199,9 +227,12 @@ export const fetchPopularSpecies: ActionCreator<
   }
 };
 
-export const handleSelectedSpecies: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (item: SearchMatch | PopularSpecies) => (dispatch) => {
+export const handleSelectedSpecies: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (item: SearchMatch | PopularSpecies) => (dispatch) => {
   dispatch(setSelectedSpecies(item));
   const { genome_id } = item;
 
@@ -214,9 +245,12 @@ export const updateCommittedSpecies = createAction(
   'species_selector/toggle_species_use'
 )<CommittedItem[]>();
 
-export const commitSelectedSpeciesAndSave: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = () => (dispatch, getState) => {
+export const commitSelectedSpeciesAndSave: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = () => (dispatch, getState) => {
   const committedSpecies = getCommittedSpecies(getState());
   const selectedItem = getSelectedItem(getState());
 
@@ -245,9 +279,12 @@ export const commitSelectedSpeciesAndSave: ActionCreator<
   speciesSelectorStorageService.saveSelectedSpecies(newCommittedSpecies);
 };
 
-export const toggleSpeciesUseAndSave: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (genomeId: string) => (dispatch, getState) => {
+export const toggleSpeciesUseAndSave: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (genomeId: string) => (dispatch, getState) => {
   const state = getState();
   const committedSpecies = getCommittedSpecies(state);
   const currentSpecies = getCommittedSpeciesById(state, genomeId);
@@ -276,9 +313,12 @@ export const toggleSpeciesUseAndSave: ActionCreator<
   speciesSelectorStorageService.saveSelectedSpecies(updatedCommittedSpecies);
 };
 
-export const deleteSpeciesAndSave: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (genomeId: string) => (dispatch, getState) => {
+export const deleteSpeciesAndSave: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (genomeId: string) => (dispatch, getState) => {
   const committedSpecies = getCommittedSpecies(getState());
   const deletedSpecies = find(
     committedSpecies,

--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorEpics.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorEpics.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Epic } from 'redux-observable';
 import { map, switchMap, filter, distinctUntilChanged } from 'rxjs/operators';
 import { isActionOf, ActionType, PayloadAction } from 'typesafe-actions';

--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorReducer.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorReducer.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { getType, ActionType } from 'typesafe-actions';
 
 import * as speciesSelectorActions from './speciesSelectorActions';

--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorSelectors.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorSelectors.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import get from 'lodash/get';
 import find from 'lodash/find';
 

--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorState.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorState.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import speciesSelectorStorageService from 'src/content/app/species-selector/services/species-selector-storage-service';
 
 import { LoadingState } from 'src/shared/types/loading-state';

--- a/src/ensembl/src/content/app/species-selector/types/species-search.ts
+++ b/src/ensembl/src/content/app/species-selector/types/species-search.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // description of shape of data returned from the api
 
 export type SearchMatches = SearchMatch[];

--- a/src/ensembl/src/content/home/Home.tsx
+++ b/src/ensembl/src/content/home/Home.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 import HomepageSpeciesBar from 'src/content/home/components/homepage-species-bar/HomepageSpeciesBar';

--- a/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.tsx
+++ b/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';

--- a/src/ensembl/src/content/home/components/homepage-site-info/HomepageSiteInfo.tsx
+++ b/src/ensembl/src/content/home/components/homepage-site-info/HomepageSiteInfo.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 import styles from './HomepageSiteInfo.scss';

--- a/src/ensembl/src/content/home/components/homepage-species-bar/HomepageSpeciesBar.tsx
+++ b/src/ensembl/src/content/home/components/homepage-species-bar/HomepageSpeciesBar.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';

--- a/src/ensembl/src/content/home/homePageSelectors.ts
+++ b/src/ensembl/src/content/home/homePageSelectors.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import { getChrLocationStr } from 'src/content/app/browser/browserHelper';
 

--- a/src/ensembl/src/global/globalActions.ts
+++ b/src/ensembl/src/global/globalActions.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { createAction } from 'typesafe-actions';
 import { ActionCreator, Action } from 'redux';
 import { ThunkAction } from 'redux-thunk';

--- a/src/ensembl/src/global/globalConfig.ts
+++ b/src/ensembl/src/global/globalConfig.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export const assetsUrl = '/static';
 export const imgBaseUrl = `${assetsUrl}/img`;
 

--- a/src/ensembl/src/global/globalHelper.ts
+++ b/src/ensembl/src/global/globalHelper.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export const getQueryParamsMap = (queryStr: string) => {
   const params = queryStr.replace('?', '').split('&'); // split all query param pairs
 

--- a/src/ensembl/src/global/globalReducer.ts
+++ b/src/ensembl/src/global/globalReducer.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ActionType, getType } from 'typesafe-actions';
 
 import * as global from './globalActions';

--- a/src/ensembl/src/global/globalSelectors.ts
+++ b/src/ensembl/src/global/globalSelectors.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { RootState } from '../store';
 import { BreakpointWidth } from './globalConfig';
 

--- a/src/ensembl/src/global/globalState.ts
+++ b/src/ensembl/src/global/globalState.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { BreakpointWidth, globalMediaQueries } from './globalConfig';
 import { getCurrentMediaSize } from 'src/global/windowSizeHelpers';
 

--- a/src/ensembl/src/global/windowSizeHelpers.ts
+++ b/src/ensembl/src/global/windowSizeHelpers.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import reduce from 'lodash/reduce';
 
 import windowService from 'src/services/window-service';

--- a/src/ensembl/src/header/Header.test.tsx
+++ b/src/ensembl/src/header/Header.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { shallow } from 'enzyme';
 

--- a/src/ensembl/src/header/Header.tsx
+++ b/src/ensembl/src/header/Header.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { Link } from 'react-router-dom';
 

--- a/src/ensembl/src/header/account/Account.test.tsx
+++ b/src/ensembl/src/header/account/Account.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { shallow } from 'enzyme';
 

--- a/src/ensembl/src/header/account/Account.tsx
+++ b/src/ensembl/src/header/account/Account.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 

--- a/src/ensembl/src/header/header-buttons/HeaderButtons.test.tsx
+++ b/src/ensembl/src/header/header-buttons/HeaderButtons.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 

--- a/src/ensembl/src/header/header-buttons/HeaderButtons.tsx
+++ b/src/ensembl/src/header/header-buttons/HeaderButtons.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { FunctionComponent } from 'react';
 import { connect } from 'react-redux';
 

--- a/src/ensembl/src/header/headerActions.ts
+++ b/src/ensembl/src/header/headerActions.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { createAction } from 'typesafe-actions';
 import analyticsTracking from 'src/services/analytics-service';
 

--- a/src/ensembl/src/header/headerReducer.ts
+++ b/src/ensembl/src/header/headerReducer.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ActionType, getType } from 'typesafe-actions';
 
 import * as headerActions from './headerActions';

--- a/src/ensembl/src/header/headerSelectors.ts
+++ b/src/ensembl/src/header/headerSelectors.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { RootState } from '../store';
 
 export const getAccountExpanded = (state: RootState): boolean =>

--- a/src/ensembl/src/header/headerState.ts
+++ b/src/ensembl/src/header/headerState.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export type HeaderState = Readonly<{
   accountExpanded: boolean;
   currentApp: string;

--- a/src/ensembl/src/header/launchbar/Launchbar.test.tsx
+++ b/src/ensembl/src/header/launchbar/Launchbar.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 

--- a/src/ensembl/src/header/launchbar/Launchbar.tsx
+++ b/src/ensembl/src/header/launchbar/Launchbar.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 import ensemblIcon from 'static/img/launchbar/ensembl-logo.png'; // <-- note it's a png

--- a/src/ensembl/src/header/launchbar/LaunchbarButton.tsx
+++ b/src/ensembl/src/header/launchbar/LaunchbarButton.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { FunctionComponent } from 'react';
 import { NavLink } from 'react-router-dom';
 import { withRouter, RouteComponentProps } from 'react-router';

--- a/src/ensembl/src/header/launchbar/LaunchbarContainer.tsx
+++ b/src/ensembl/src/header/launchbar/LaunchbarContainer.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { memo } from 'react';
 import { connect } from 'react-redux';
 import isEqual from 'lodash/isEqual';

--- a/src/ensembl/src/index.tsx
+++ b/src/ensembl/src/index.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { StrictMode } from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';

--- a/src/ensembl/src/objects.ts
+++ b/src/ensembl/src/objects.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { RefObject, ReactEventHandler } from 'react';
 
 import * as headerActions from './header/headerActions';

--- a/src/ensembl/src/registerServiceWorker.ts
+++ b/src/ensembl/src/registerServiceWorker.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 declare global {
   interface Window {
     nodeEnv: string | undefined;

--- a/src/ensembl/src/root/Root.test.tsx
+++ b/src/ensembl/src/root/Root.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 

--- a/src/ensembl/src/root/Root.tsx
+++ b/src/ensembl/src/root/Root.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 

--- a/src/ensembl/src/root/rootEpic.ts
+++ b/src/ensembl/src/root/rootEpic.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { combineEpics } from 'redux-observable';
 import values from 'lodash/values';
 

--- a/src/ensembl/src/root/rootReducer.ts
+++ b/src/ensembl/src/root/rootReducer.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { combineReducers } from 'redux';
 import { connectRouter } from 'connected-react-router';
 

--- a/src/ensembl/src/services/analytics-service.ts
+++ b/src/ensembl/src/services/analytics-service.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import ReactGA from 'react-ga';
 import { AnalyticsOptions, CustomDimensions } from 'src/analyticsHelper';
 

--- a/src/ensembl/src/services/api-service.ts
+++ b/src/ensembl/src/services/api-service.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // this service temporarily uses the native browser fetch API;
 // we will modify it to use a library once we decide which one to choose
 

--- a/src/ensembl/src/services/error-service.ts
+++ b/src/ensembl/src/services/error-service.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import * as Sentry from '@sentry/browser';
 
 import config from 'config';

--- a/src/ensembl/src/services/observable-api-service.ts
+++ b/src/ensembl/src/services/observable-api-service.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { of } from 'rxjs';
 import { ajax } from 'rxjs/ajax';
 import { map, catchError } from 'rxjs/operators';

--- a/src/ensembl/src/services/storage-service.ts
+++ b/src/ensembl/src/services/storage-service.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import windowService, {
   WindowServiceInterface
 } from 'src/services/window-service';

--- a/src/ensembl/src/services/tests/api-service.test.ts
+++ b/src/ensembl/src/services/tests/api-service.test.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import faker from 'faker';
 
 import apiService, { HTTPMethod } from '../api-service';

--- a/src/ensembl/src/services/tests/storage-service.test.ts
+++ b/src/ensembl/src/services/tests/storage-service.test.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { StorageService, StorageType } from 'src/services/storage-service';
 import faker from 'faker';
 

--- a/src/ensembl/src/services/window-service.ts
+++ b/src/ensembl/src/services/window-service.ts
@@ -1,4 +1,20 @@
 /**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * This is a simple service whose purpose is to return objects from the window object.
  * This is helpful for mocking elements of the browser API during tests.
  */

--- a/src/ensembl/src/shared/components/accordion/components/Accordion.test.tsx
+++ b/src/ensembl/src/shared/components/accordion/components/Accordion.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 import { mount } from 'enzyme';
@@ -65,18 +81,12 @@ describe('Accordion', () => {
       wrapper.find(FooHeader).simulate('click');
       wrapper.find(BarHeader).simulate('click');
 
-      expect(
-        wrapper
-          .find(FooHeader)
-          .find('div')
-          .props()['aria-expanded']
-      ).toBe(true);
-      expect(
-        wrapper
-          .find(BarHeader)
-          .find('div')
-          .props()['aria-expanded']
-      ).toBe(true);
+      expect(wrapper.find(FooHeader).find('div').props()['aria-expanded']).toBe(
+        true
+      );
+      expect(wrapper.find(BarHeader).find('div').props()['aria-expanded']).toBe(
+        true
+      );
     });
 
     it('does not permit multiple items to be expanded when allowMultipleExpanded is false', () => {
@@ -103,18 +113,12 @@ describe('Accordion', () => {
       wrapper.find(FooHeader).simulate('click');
       wrapper.find(BarHeader).simulate('click');
 
-      expect(
-        wrapper
-          .find(FooHeader)
-          .find('div')
-          .props()['aria-expanded']
-      ).toBe(false);
-      expect(
-        wrapper
-          .find(BarHeader)
-          .find('div')
-          .props()['aria-expanded']
-      ).toBe(true);
+      expect(wrapper.find(FooHeader).find('div').props()['aria-expanded']).toBe(
+        false
+      );
+      expect(wrapper.find(BarHeader).find('div').props()['aria-expanded']).toBe(
+        true
+      );
     });
 
     describe('allowZeroExpanded prop', () => {
@@ -133,10 +137,7 @@ describe('Accordion', () => {
         wrapper.find(AccordionItemButton).simulate('click');
 
         expect(
-          wrapper
-            .find(AccordionItemButton)
-            .find('div')
-            .props()['aria-expanded']
+          wrapper.find(AccordionItemButton).find('div').props()['aria-expanded']
         ).toEqual(false);
       });
 
@@ -155,10 +156,7 @@ describe('Accordion', () => {
         wrapper.find(AccordionItemButton).simulate('click');
 
         expect(
-          wrapper
-            .find(AccordionItemButton)
-            .find('div')
-            .props()['aria-expanded']
+          wrapper.find(AccordionItemButton).find('div').props()['aria-expanded']
         ).toEqual(true);
       });
     });
@@ -176,10 +174,7 @@ describe('Accordion', () => {
         );
 
         expect(
-          wrapper
-            .find(AccordionItemButton)
-            .find('div')
-            .props()['aria-expanded']
+          wrapper.find(AccordionItemButton).find('div').props()['aria-expanded']
         ).toEqual(true);
       });
 
@@ -195,10 +190,7 @@ describe('Accordion', () => {
         );
 
         expect(
-          wrapper
-            .find(AccordionItemButton)
-            .find('div')
-            .props()['aria-expanded']
+          wrapper.find(AccordionItemButton).find('div').props()['aria-expanded']
         ).toEqual(false);
       });
     });

--- a/src/ensembl/src/shared/components/accordion/components/Accordion.tsx
+++ b/src/ensembl/src/shared/components/accordion/components/Accordion.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { DivAttributes } from '../helpers/types';
 import { Consumer, Provider } from './AccordionContext';

--- a/src/ensembl/src/shared/components/accordion/components/AccordionContext.test.tsx
+++ b/src/ensembl/src/shared/components/accordion/components/AccordionContext.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import { Consumer, Provider } from './AccordionContext';

--- a/src/ensembl/src/shared/components/accordion/components/AccordionContext.tsx
+++ b/src/ensembl/src/shared/components/accordion/components/AccordionContext.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState, useEffect } from 'react';
 import AccordionStore, {
   InjectedButtonAttributes,

--- a/src/ensembl/src/shared/components/accordion/components/AccordionItem.test.tsx
+++ b/src/ensembl/src/shared/components/accordion/components/AccordionItem.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import Accordion from './Accordion';
@@ -18,10 +34,7 @@ describe('AccordionItem', () => {
         </Accordion>
       );
       expect(
-        wrapper
-          .find(AccordionItem)
-          .find('div')
-          .hasClass('accordionItemDefault')
+        wrapper.find(AccordionItem).find('div').hasClass('accordionItemDefault')
       ).toBe(true);
     });
 
@@ -33,17 +46,11 @@ describe('AccordionItem', () => {
       );
 
       expect(
-        wrapper
-          .find(AccordionItem)
-          .find('div')
-          .hasClass('accordionItemDefault')
+        wrapper.find(AccordionItem).find('div').hasClass('accordionItemDefault')
       ).toBe(true);
-      expect(
-        wrapper
-          .find(AccordionItem)
-          .find('div')
-          .hasClass('foo')
-      ).toBe(true);
+      expect(wrapper.find(AccordionItem).find('div').hasClass('foo')).toBe(
+        true
+      );
     });
   });
 

--- a/src/ensembl/src/shared/components/accordion/components/AccordionItem.tsx
+++ b/src/ensembl/src/shared/components/accordion/components/AccordionItem.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { DivAttributes } from '../helpers/types';
 

--- a/src/ensembl/src/shared/components/accordion/components/AccordionItemButton.test.tsx
+++ b/src/ensembl/src/shared/components/accordion/components/AccordionItemButton.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import Accordion from './Accordion';
@@ -51,10 +67,7 @@ describe('AccordionItemButton', () => {
       ).toBe(true);
 
       expect(
-        wrapper
-          .find(AccordionItemButton)
-          .find('div')
-          .hasClass('foo')
+        wrapper.find(AccordionItemButton).find('div').hasClass('foo')
       ).toBe(true);
     });
   });

--- a/src/ensembl/src/shared/components/accordion/components/AccordionItemButton.tsx
+++ b/src/ensembl/src/shared/components/accordion/components/AccordionItemButton.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import noop from 'lodash/noop';
 import classNames from 'classnames';

--- a/src/ensembl/src/shared/components/accordion/components/AccordionItemHeading.test.tsx
+++ b/src/ensembl/src/shared/components/accordion/components/AccordionItemHeading.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import Accordion from './Accordion';

--- a/src/ensembl/src/shared/components/accordion/components/AccordionItemHeading.tsx
+++ b/src/ensembl/src/shared/components/accordion/components/AccordionItemHeading.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useEffect, useRef } from 'react';
 import { InjectedHeadingAttributes } from '../helpers/AccordionStore';
 import { DivAttributes } from '../helpers/types';

--- a/src/ensembl/src/shared/components/accordion/components/AccordionItemPanel.test.tsx
+++ b/src/ensembl/src/shared/components/accordion/components/AccordionItemPanel.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import Accordion from './Accordion';
@@ -49,12 +65,9 @@ describe('AccordionItemPanel', () => {
           .find('div')
           .hasClass('accordionPanelDefault')
       ).toBe(true);
-      expect(
-        wrapper
-          .find(AccordionItemPanel)
-          .find('div')
-          .hasClass('foo')
-      ).toBe(true);
+      expect(wrapper.find(AccordionItemPanel).find('div').hasClass('foo')).toBe(
+        true
+      );
     });
   });
 

--- a/src/ensembl/src/shared/components/accordion/components/AccordionItemPanel.tsx
+++ b/src/ensembl/src/shared/components/accordion/components/AccordionItemPanel.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { DivAttributes } from '../helpers/types';
 import { Consumer as ItemConsumer, ItemContext } from './ItemContext';

--- a/src/ensembl/src/shared/components/accordion/components/AccordionItemPermanentBlock.tsx
+++ b/src/ensembl/src/shared/components/accordion/components/AccordionItemPermanentBlock.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 // This block has to be placed either before or after AccordionItemPanel

--- a/src/ensembl/src/shared/components/accordion/components/AccordionItemState.tsx
+++ b/src/ensembl/src/shared/components/accordion/components/AccordionItemState.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { DivAttributes } from '../helpers/types';
 import { Consumer as ItemConsumer, ItemContext } from './ItemContext';

--- a/src/ensembl/src/shared/components/accordion/components/ItemContext.test.tsx
+++ b/src/ensembl/src/shared/components/accordion/components/ItemContext.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import Accordion from './Accordion';

--- a/src/ensembl/src/shared/components/accordion/components/ItemContext.tsx
+++ b/src/ensembl/src/shared/components/accordion/components/ItemContext.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import {
   InjectedButtonAttributes,

--- a/src/ensembl/src/shared/components/accordion/helpers/AccordionStore.test.ts
+++ b/src/ensembl/src/shared/components/accordion/helpers/AccordionStore.test.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import AccordionStore from './AccordionStore';
 
 enum UUIDS {

--- a/src/ensembl/src/shared/components/accordion/helpers/AccordionStore.ts
+++ b/src/ensembl/src/shared/components/accordion/helpers/AccordionStore.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { UUID } from '../components/ItemContext';
 
 export interface InjectedPanelAttributes {

--- a/src/ensembl/src/shared/components/accordion/helpers/types.ts
+++ b/src/ensembl/src/shared/components/accordion/helpers/types.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 export type DivAttributes = React.HTMLAttributes<HTMLDivElement>;

--- a/src/ensembl/src/shared/components/accordion/index.tsx
+++ b/src/ensembl/src/shared/components/accordion/index.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import Accordion from './components/Accordion';
 import AccordionItem from './components/AccordionItem';
 import AccordionItemButton from './components/AccordionItemButton';

--- a/src/ensembl/src/shared/components/app-bar/AppBar.tsx
+++ b/src/ensembl/src/shared/components/app-bar/AppBar.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 import chevronRightIcon from 'static/img/shared/chevron-right-grey.svg';

--- a/src/ensembl/src/shared/components/autosuggest-search-field/AutosuggestSearchField.test.tsx
+++ b/src/ensembl/src/shared/components/autosuggest-search-field/AutosuggestSearchField.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import faker from 'faker';
@@ -102,12 +118,9 @@ describe('<AutosuggestSearchField />', () => {
 
         const randomItemIndex = random(0, suggestedItems.length - 1);
         const randomItem = suggestedItems.at(randomItemIndex);
-        const itemsData = groupsOfMatches.reduce(
-          (result, group) => {
-            return [...result, ...group.matches.map(({ data }) => data)];
-          },
-          [] as any
-        );
+        const itemsData = groupsOfMatches.reduce((result, group) => {
+          return [...result, ...group.matches.map(({ data }) => data)];
+        }, [] as any);
 
         const expectedItemData = itemsData[randomItemIndex];
 

--- a/src/ensembl/src/shared/components/autosuggest-search-field/AutosuggestSearchField.tsx
+++ b/src/ensembl/src/shared/components/autosuggest-search-field/AutosuggestSearchField.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState, useEffect, useRef, ReactNode } from 'react';
 import classNames from 'classnames';
 import get from 'lodash/get';

--- a/src/ensembl/src/shared/components/autosuggest-search-field/AutosuggestionPanel.tsx
+++ b/src/ensembl/src/shared/components/autosuggest-search-field/AutosuggestionPanel.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { ReactNode } from 'react';
 import classNames from 'classnames';
 

--- a/src/ensembl/src/shared/components/badged-button/BadgedButton.test.tsx
+++ b/src/ensembl/src/shared/components/badged-button/BadgedButton.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import faker from 'faker';

--- a/src/ensembl/src/shared/components/badged-button/BadgedButton.tsx
+++ b/src/ensembl/src/shared/components/badged-button/BadgedButton.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import defaultStyles from './BadgedButton.scss';
 import classNames from 'classnames';

--- a/src/ensembl/src/shared/components/button/Button.test.tsx
+++ b/src/ensembl/src/shared/components/button/Button.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import faker from 'faker';

--- a/src/ensembl/src/shared/components/button/Button.tsx
+++ b/src/ensembl/src/shared/components/button/Button.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { ReactNode } from 'react';
 import classNames from 'classnames';
 

--- a/src/ensembl/src/shared/components/checkbox/Checkbox.test.tsx
+++ b/src/ensembl/src/shared/components/checkbox/Checkbox.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import Checkbox from './Checkbox';

--- a/src/ensembl/src/shared/components/checkbox/Checkbox.tsx
+++ b/src/ensembl/src/shared/components/checkbox/Checkbox.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import classNames from 'classnames';
 

--- a/src/ensembl/src/shared/components/clear-button/ClearButton.tsx
+++ b/src/ensembl/src/shared/components/clear-button/ClearButton.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import classNames from 'classnames';
 

--- a/src/ensembl/src/shared/components/error-boundary/ErrorBoundary.test.tsx
+++ b/src/ensembl/src/shared/components/error-boundary/ErrorBoundary.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 
@@ -38,10 +54,7 @@ describe('<ErrorBoundary />', () => {
     );
     const error = 'oops!';
 
-    wrapper
-      .find(Child)
-      .at(0)
-      .simulateError(error);
+    wrapper.find(Child).at(0).simulateError(error);
 
     expect(wrapper.find(Child).length).toBe(0);
     expect(wrapper.find(Fallback).length).toBe(1);
@@ -56,10 +69,7 @@ describe('<ErrorBoundary />', () => {
     );
     const error = 'oops!';
 
-    wrapper
-      .find(Child)
-      .at(0)
-      .simulateError(error);
+    wrapper.find(Child).at(0).simulateError(error);
 
     expect(errorService.report).toHaveBeenCalledWith(error);
   });

--- a/src/ensembl/src/shared/components/error-boundary/ErrorBoundary.tsx
+++ b/src/ensembl/src/shared/components/error-boundary/ErrorBoundary.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { PureComponent } from 'react';
 
 import errorService from 'src/services/error-service';

--- a/src/ensembl/src/shared/components/error-screen/GeneralErrorScreen.tsx
+++ b/src/ensembl/src/shared/components/error-screen/GeneralErrorScreen.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 import { HomeLink, ReleaseVersion, Copyright } from 'src/header/Header';

--- a/src/ensembl/src/shared/components/error-screen/NewTechError.tsx
+++ b/src/ensembl/src/shared/components/error-screen/NewTechError.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 import styles from './ErrorScreen.scss';

--- a/src/ensembl/src/shared/components/error-screen/index.ts
+++ b/src/ensembl/src/shared/components/error-screen/index.ts
@@ -1,2 +1,18 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export { default as NewTechError } from './NewTechError';
 export { default as GeneralErrorScreen } from './GeneralErrorScreen';

--- a/src/ensembl/src/shared/components/external-link/ExternalLink.test.tsx
+++ b/src/ensembl/src/shared/components/external-link/ExternalLink.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import faker from 'faker';

--- a/src/ensembl/src/shared/components/external-link/ExternalLink.tsx
+++ b/src/ensembl/src/shared/components/external-link/ExternalLink.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import classNames from 'classnames';
 

--- a/src/ensembl/src/shared/components/external-reference/ExternalReference.test.tsx
+++ b/src/ensembl/src/shared/components/external-reference/ExternalReference.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import faker from 'faker';

--- a/src/ensembl/src/shared/components/external-reference/ExternalReference.tsx
+++ b/src/ensembl/src/shared/components/external-reference/ExternalReference.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import classNames from 'classnames';
 

--- a/src/ensembl/src/shared/components/feature-summary-strip/FeatureSummaryStrip.test.tsx
+++ b/src/ensembl/src/shared/components/feature-summary-strip/FeatureSummaryStrip.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 

--- a/src/ensembl/src/shared/components/feature-summary-strip/FeatureSummaryStrip.tsx
+++ b/src/ensembl/src/shared/components/feature-summary-strip/FeatureSummaryStrip.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 import { GeneSummaryStrip, RegionSummaryStrip } from '../feature-summary-strip';

--- a/src/ensembl/src/shared/components/feature-summary-strip/GeneSummaryStrip.tsx
+++ b/src/ensembl/src/shared/components/feature-summary-strip/GeneSummaryStrip.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState, useEffect, useRef } from 'react';
 import classNames from 'classnames';
 

--- a/src/ensembl/src/shared/components/feature-summary-strip/RegionSummaryStrip.tsx
+++ b/src/ensembl/src/shared/components/feature-summary-strip/RegionSummaryStrip.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import classNames from 'classnames';
 

--- a/src/ensembl/src/shared/components/feature-summary-strip/index.ts
+++ b/src/ensembl/src/shared/components/feature-summary-strip/index.ts
@@ -1,2 +1,18 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export { default as GeneSummaryStrip } from './GeneSummaryStrip';
 export { default as RegionSummaryStrip } from './RegionSummaryStrip';

--- a/src/ensembl/src/shared/components/image-button/ImageButton.test.tsx
+++ b/src/ensembl/src/shared/components/image-button/ImageButton.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';

--- a/src/ensembl/src/shared/components/image-button/ImageButton.tsx
+++ b/src/ensembl/src/shared/components/image-button/ImageButton.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { memo } from 'react';
 import isEqual from 'lodash/isEqual';
 import classNames from 'classnames';

--- a/src/ensembl/src/shared/components/inline-svg/InlineSvg.test.tsx
+++ b/src/ensembl/src/shared/components/inline-svg/InlineSvg.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';

--- a/src/ensembl/src/shared/components/inline-svg/InlineSvg.tsx
+++ b/src/ensembl/src/shared/components/inline-svg/InlineSvg.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
 The purpose of this component is to get an svg image over the network,
 and then to inline it into the DOM (instead of assigning it as a src attribute

--- a/src/ensembl/src/shared/components/input/Input.test.tsx
+++ b/src/ensembl/src/shared/components/input/Input.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount, render } from 'enzyme';
 

--- a/src/ensembl/src/shared/components/input/Input.tsx
+++ b/src/ensembl/src/shared/components/input/Input.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import classNames from 'classnames';
 import noop from 'lodash/noop';

--- a/src/ensembl/src/shared/components/instant-download/index.ts
+++ b/src/ensembl/src/shared/components/instant-download/index.ts
@@ -1,1 +1,17 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export { default as InstantDownloadTranscript } from './instant-download-transcript/InstantDownloadTranscript';

--- a/src/ensembl/src/shared/components/instant-download/instant-download-button/InstantDownloadButton.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-button/InstantDownloadButton.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 import { PrimaryButton } from 'src/shared/components/button/Button';

--- a/src/ensembl/src/shared/components/instant-download/instant-download-fetch/fetchForTranscript.ts
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-fetch/fetchForTranscript.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import downloadAsFile from 'src/shared/helpers/downloadAsFile';
 import {
   TranscriptOptions,

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState, useEffect } from 'react';
 import classNames from 'classnames';
 import pick from 'lodash/pick';

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.test.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { render } from 'enzyme';
 

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import classNames from 'classnames';
 import times from 'lodash/times';
@@ -50,18 +66,18 @@ const InstantDownloadTranscriptVisualisation = (props: Props) => {
     return classNames({
       [styles.outerExon]: isOuterExon,
       [styles.innerExon]: isInnerExon,
-      [styles.highlighted]: isHighlighted,
+      [styles.highlighted]: isHighlighted
     });
   };
 
   const intronStyles = classNames(styles.intron, {
-    [styles.highlighted]: props.isGenomicSequenceEnabled,
+    [styles.highlighted]: props.isGenomicSequenceEnabled
   });
   const halfOuterExonStyles = classNames(styles.halfOuterExon, {
     [styles.highlighted]:
       props.isGenomicSequenceEnabled ||
       props.isCDNAEnabled ||
-      props.isCDSEnabled,
+      props.isCDSEnabled
   });
 
   const exons = times(exonsCount, (index) => {
@@ -145,7 +161,7 @@ InstantDownloadTranscriptVisualisation.defaultProps = {
   isCDNAEnabled: false,
   isCDSEnabled: false,
   isProteinSequenceEnabled: false,
-  width: 210,
+  width: 210
 } as Partial<Props>;
 
 export default InstantDownloadTranscriptVisualisation;

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.test.tsx
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount, render } from 'enzyme';
 import faker from 'faker';

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { ReactNode, useEffect } from 'react';
 import classNames from 'classnames';
 import noop from 'lodash/noop';

--- a/src/ensembl/src/shared/components/layout/index.ts
+++ b/src/ensembl/src/shared/components/layout/index.ts
@@ -1,1 +1,17 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export { default as StandardAppLayout } from './StandardAppLayout';

--- a/src/ensembl/src/shared/components/loader/Loader.tsx
+++ b/src/ensembl/src/shared/components/loader/Loader.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import classNames from 'classnames';
 

--- a/src/ensembl/src/shared/components/overlay/Overlay.tsx
+++ b/src/ensembl/src/shared/components/overlay/Overlay.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import classNames from 'classnames';
 import styles from './Overlay.scss';

--- a/src/ensembl/src/shared/components/panel/Panel.test.tsx
+++ b/src/ensembl/src/shared/components/panel/Panel.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import faker from 'faker';
@@ -38,10 +54,7 @@ describe('<Tabs />', () => {
     wrapper = mount(renderPanel());
 
     expect(
-      wrapper
-        .find('.header')
-        .children()
-        .contains(defaultProps.header)
+      wrapper.find('.header').children().contains(defaultProps.header)
     ).toBeTruthy();
   });
 
@@ -78,22 +91,13 @@ describe('<Tabs />', () => {
     wrapper = mount(renderPanel());
 
     expect(
-      wrapper
-        .find('.panel')
-        .first()
-        .hasClass(panelClassNames.panel)
+      wrapper.find('.panel').first().hasClass(panelClassNames.panel)
     ).toBeTruthy();
     expect(
-      wrapper
-        .find('.body')
-        .first()
-        .hasClass(panelClassNames.body)
+      wrapper.find('.body').first().hasClass(panelClassNames.body)
     ).toBeTruthy();
     expect(
-      wrapper
-        .find('.header')
-        .first()
-        .hasClass(panelClassNames.header)
+      wrapper.find('.header').first().hasClass(panelClassNames.header)
     ).toBeTruthy();
   });
 

--- a/src/ensembl/src/shared/components/panel/Panel.tsx
+++ b/src/ensembl/src/shared/components/panel/Panel.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import classNamesMerger from 'classnames';
 

--- a/src/ensembl/src/shared/components/pointer-box/PointerBox.test.tsx
+++ b/src/ensembl/src/shared/components/pointer-box/PointerBox.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import faker from 'faker';

--- a/src/ensembl/src/shared/components/pointer-box/PointerBox.tsx
+++ b/src/ensembl/src/shared/components/pointer-box/PointerBox.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { ReactNode, useRef, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';

--- a/src/ensembl/src/shared/components/pointer-box/pointer-box-constants.ts
+++ b/src/ensembl/src/shared/components/pointer-box/pointer-box-constants.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export const POINTER_WIDTH = 18;
 export const POINTER_HEIGHT = 13;
 export const POINTER_OFFSET = 20; // distance between the corner of the box and the beginning of the pointer base

--- a/src/ensembl/src/shared/components/pointer-box/pointer-box-helper.ts
+++ b/src/ensembl/src/shared/components/pointer-box/pointer-box-helper.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import bringToFront from 'src/shared/utils/bringToFront';
 
 import { Position } from './pointer-box-types';

--- a/src/ensembl/src/shared/components/pointer-box/pointer-box-inline-styles.ts
+++ b/src/ensembl/src/shared/components/pointer-box/pointer-box-inline-styles.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Position } from './pointer-box-types';
 import { PointerBoxProps, InlineStylesState } from './PointerBox';
 
@@ -83,8 +99,9 @@ const getCommonStyles = (params: Params): InlineStylesState => {
     case Position.LEFT_TOP:
       return {
         boxStyles: {
-          transform: `translateX(-100%) translateY(calc(-100% + ${pointerOffset +
-            halfPointerWidth}px))`
+          transform: `translateX(-100%) translateY(calc(-100% + ${
+            pointerOffset + halfPointerWidth
+          }px))`
         },
         pointerStyles: {
           left: 'calc(100% - 4px)',
@@ -96,8 +113,9 @@ const getCommonStyles = (params: Params): InlineStylesState => {
     case Position.LEFT_BOTTOM:
       return {
         boxStyles: {
-          transform: `translateX(-100%) translateY(-${pointerOffset +
-            halfPointerWidth}px)`
+          transform: `translateX(-100%) translateY(-${
+            pointerOffset + halfPointerWidth
+          }px)`
         },
         pointerStyles: {
           left: 'calc(100% - 4px)',
@@ -150,21 +168,18 @@ const getBoxStylesForRenderingIntoBody = (
     case Position.TOP_LEFT:
       return {
         left: `${anchorLeft + anchorWidth / 2}px`,
-        bottom: `${window.innerHeight -
-          window.scrollY -
-          anchorTop +
-          pointerHeight}px`
+        bottom: `${
+          window.innerHeight - window.scrollY - anchorTop + pointerHeight
+        }px`
       };
     case Position.TOP_RIGHT:
       return {
-        left: `${anchorLeft +
-          halfAnchorWidth -
-          pointerOffset -
-          halfPointerWidth}px`,
-        bottom: `${window.innerHeight -
-          window.scrollY -
-          anchorTop +
-          pointerHeight}px`
+        left: `${
+          anchorLeft + halfAnchorWidth - pointerOffset - halfPointerWidth
+        }px`,
+        bottom: `${
+          window.innerHeight - window.scrollY - anchorTop + pointerHeight
+        }px`
       };
     case Position.BOTTOM_LEFT:
       return {
@@ -173,10 +188,9 @@ const getBoxStylesForRenderingIntoBody = (
       };
     case Position.BOTTOM_RIGHT:
       return {
-        left: `${anchorLeft +
-          halfAnchorWidth -
-          pointerOffset -
-          halfPointerWidth}px`,
+        left: `${
+          anchorLeft + halfAnchorWidth - pointerOffset - halfPointerWidth
+        }px`,
         top: `${anchorTop + window.scrollY + anchorHeight + pointerHeight}px`
       };
     case Position.LEFT_TOP:
@@ -192,10 +206,9 @@ const getBoxStylesForRenderingIntoBody = (
     case Position.RIGHT_TOP:
       return {
         left: `${anchorLeft + anchorWidth + pointerHeight}px`,
-        top: `${anchorTop +
-          window.scrollY +
-          halfAnchorHeight +
-          pointerOffset}px`
+        top: `${
+          anchorTop + window.scrollY + halfAnchorHeight + pointerOffset
+        }px`
       };
     case Position.RIGHT_BOTTOM:
       return {

--- a/src/ensembl/src/shared/components/pointer-box/pointer-box-types.ts
+++ b/src/ensembl/src/shared/components/pointer-box/pointer-box-types.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
 The first part of position name signifies the direction in which PointerBox
 is positioned relative to the anchor.

--- a/src/ensembl/src/shared/components/privacy-banner/PrivacyBanner.tsx
+++ b/src/ensembl/src/shared/components/privacy-banner/PrivacyBanner.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { FunctionComponent } from 'react';
 import privacyConfig from './privacyConfig';
 import styles from './PrivacyBanner.scss';

--- a/src/ensembl/src/shared/components/privacy-banner/privacy-banner-service.test.ts
+++ b/src/ensembl/src/shared/components/privacy-banner/privacy-banner-service.test.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { PrivacyBannerService } from './privacy-banner-service';
 import privacyConfig from './privacyConfig';
 import faker from 'faker';

--- a/src/ensembl/src/shared/components/privacy-banner/privacy-banner-service.ts
+++ b/src/ensembl/src/shared/components/privacy-banner/privacy-banner-service.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import privacyConfig from './privacyConfig';
 import storageService, {
   StorageServiceInterface

--- a/src/ensembl/src/shared/components/privacy-banner/privacyConfig.ts
+++ b/src/ensembl/src/shared/components/privacy-banner/privacyConfig.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export default {
   name: 'ensembl_privacy_policy',
   version: '2.0.0',

--- a/src/ensembl/src/shared/components/question-button/QuestionButton.tsx
+++ b/src/ensembl/src/shared/components/question-button/QuestionButton.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState, useRef } from 'react';
 import classNames from 'classnames';
 

--- a/src/ensembl/src/shared/components/radio-group/RadioGroup.test.tsx
+++ b/src/ensembl/src/shared/components/radio-group/RadioGroup.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import RadioGroup from './RadioGroup';
@@ -37,10 +53,7 @@ describe('<RadioGroup />', () => {
       <RadioGroup {...defaultProps} selectedOption={selectedOption} />
     );
 
-    wrapper
-      .find('.radio')
-      .first()
-      .simulate('click');
+    wrapper.find('.radio').first().simulate('click');
 
     expect(onChange).not.toHaveBeenCalled();
   });
@@ -51,10 +64,7 @@ describe('<RadioGroup />', () => {
       <RadioGroup {...defaultProps} selectedOption={selectedOption} />
     );
 
-    wrapper
-      .find('.radio')
-      .first()
-      .simulate('click');
+    wrapper.find('.radio').first().simulate('click');
 
     expect(onChange).toHaveBeenCalledWith(defaultProps.options[0].value);
   });
@@ -62,10 +72,7 @@ describe('<RadioGroup />', () => {
   it('does not call onChange function if the status is disabled', () => {
     wrapper = mount(<RadioGroup {...defaultProps} disabled={true} />);
 
-    wrapper
-      .find('.radio')
-      .first()
-      .simulate('change');
+    wrapper.find('.radio').first().simulate('change');
 
     expect(onChange).not.toHaveBeenCalled();
   });

--- a/src/ensembl/src/shared/components/radio-group/RadioGroup.tsx
+++ b/src/ensembl/src/shared/components/radio-group/RadioGroup.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import classNames from 'classnames';
 

--- a/src/ensembl/src/shared/components/round-button/RoundButton.test.tsx
+++ b/src/ensembl/src/shared/components/round-button/RoundButton.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import faker from 'faker';

--- a/src/ensembl/src/shared/components/round-button/RoundButton.tsx
+++ b/src/ensembl/src/shared/components/round-button/RoundButton.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { ReactNode } from 'react';
 import classNames from 'classnames';
 

--- a/src/ensembl/src/shared/components/search-field/SearchField.test.tsx
+++ b/src/ensembl/src/shared/components/search-field/SearchField.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 

--- a/src/ensembl/src/shared/components/search-field/SearchField.tsx
+++ b/src/ensembl/src/shared/components/search-field/SearchField.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { ReactNode } from 'react';
 import classNames from 'classnames';
 

--- a/src/ensembl/src/shared/components/select/Select.test.tsx
+++ b/src/ensembl/src/shared/components/select/Select.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import faker from 'faker';
 import times from 'lodash/times';

--- a/src/ensembl/src/shared/components/select/Select.tsx
+++ b/src/ensembl/src/shared/components/select/Select.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState, useRef, useEffect } from 'react';
 import classNames from 'classnames';
 

--- a/src/ensembl/src/shared/components/select/SelectArrowhead.tsx
+++ b/src/ensembl/src/shared/components/select/SelectArrowhead.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 import styles from './Select.scss';

--- a/src/ensembl/src/shared/components/select/SelectOptionsPanel.tsx
+++ b/src/ensembl/src/shared/components/select/SelectOptionsPanel.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, {
   useState,
   useEffect,

--- a/src/ensembl/src/shared/components/select/helpers/select-helpers.spec.ts
+++ b/src/ensembl/src/shared/components/select/helpers/select-helpers.spec.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import faker from 'faker';
 import random from 'lodash/random';
 import times from 'lodash/times';

--- a/src/ensembl/src/shared/components/select/helpers/select-helpers.ts
+++ b/src/ensembl/src/shared/components/select/helpers/select-helpers.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import cloneDeep from 'lodash/cloneDeep';
 import isEqual from 'lodash/isEqual';
 

--- a/src/ensembl/src/shared/components/selected-species/FocusableSelectedSpecies.tsx
+++ b/src/ensembl/src/shared/components/selected-species/FocusableSelectedSpecies.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import classNames from 'classnames';
 

--- a/src/ensembl/src/shared/components/selected-species/SelectedSpeciesDisplayName.tsx
+++ b/src/ensembl/src/shared/components/selected-species/SelectedSpeciesDisplayName.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import classNames from 'classnames';
 

--- a/src/ensembl/src/shared/components/selected-species/SimpleSelectedSpecies.tsx
+++ b/src/ensembl/src/shared/components/selected-species/SimpleSelectedSpecies.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 import SelectedSpeciesDisplayName from './SelectedSpeciesDisplayName';

--- a/src/ensembl/src/shared/components/selected-species/index.ts
+++ b/src/ensembl/src/shared/components/selected-species/index.ts
@@ -1,4 +1,18 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export { default as SimpleSelectedSpecies } from './SimpleSelectedSpecies';
-export {
-  default as FocusableSelectedSpecies
-} from './FocusableSelectedSpecies';
+export { default as FocusableSelectedSpecies } from './FocusableSelectedSpecies';

--- a/src/ensembl/src/shared/components/selected-species/selectedSpeciesHelpers.ts
+++ b/src/ensembl/src/shared/components/selected-species/selectedSpeciesHelpers.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { CommittedItem } from 'src/content/app/species-selector/types/species-search';
 
 const SPECIES_NAME_SIZE = 14;

--- a/src/ensembl/src/shared/components/slide-toggle/SlideToggle.test.tsx
+++ b/src/ensembl/src/shared/components/slide-toggle/SlideToggle.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount, render } from 'enzyme';
 import faker from 'faker';

--- a/src/ensembl/src/shared/components/slide-toggle/SlideToggle.tsx
+++ b/src/ensembl/src/shared/components/slide-toggle/SlideToggle.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState } from 'react';
 import classNames from 'classnames';
 

--- a/src/ensembl/src/shared/components/species-tab/SpeciesTab.test.tsx
+++ b/src/ensembl/src/shared/components/species-tab/SpeciesTab.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { render, mount } from 'enzyme';
 import faker from 'faker';

--- a/src/ensembl/src/shared/components/species-tab/SpeciesTab.tsx
+++ b/src/ensembl/src/shared/components/species-tab/SpeciesTab.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState } from 'react';
 import classNames from 'classnames';
 

--- a/src/ensembl/src/shared/components/species-tabs-wrapper/MultiLineSpeciesWrapper.tsx
+++ b/src/ensembl/src/shared/components/species-tabs-wrapper/MultiLineSpeciesWrapper.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { ReactElement } from 'react';
 
 import { nonBreakingSpace } from 'src/shared/constants/strings';

--- a/src/ensembl/src/shared/components/species-tabs-wrapper/SingleLineSpeciesWrapper.tsx
+++ b/src/ensembl/src/shared/components/species-tabs-wrapper/SingleLineSpeciesWrapper.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { ReactElement, useState, useEffect, useRef, memo } from 'react';
 import isEqual from 'lodash/isEqual';
 

--- a/src/ensembl/src/shared/components/species-tabs-wrapper/SpeciesTabsWrapper.tsx
+++ b/src/ensembl/src/shared/components/species-tabs-wrapper/SpeciesTabsWrapper.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 import SingleLineSpeciesWrapper, {

--- a/src/ensembl/src/shared/components/species-tabs-wrapper/speciesTabsWrapperHelpers.ts
+++ b/src/ensembl/src/shared/components/species-tabs-wrapper/speciesTabsWrapperHelpers.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { getFullSpeciesItemWidth } from 'src/shared/components/selected-species/selectedSpeciesHelpers';
 
 import { Props as FocusableSelectedSpeciesProps } from 'src/shared/components/selected-species/FocusableSelectedSpecies';

--- a/src/ensembl/src/shared/components/tabs/Tabs.test.tsx
+++ b/src/ensembl/src/shared/components/tabs/Tabs.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import faker from 'faker';

--- a/src/ensembl/src/shared/components/tabs/Tabs.tsx
+++ b/src/ensembl/src/shared/components/tabs/Tabs.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import classNames from 'classnames';
 import noop from 'lodash/noop';

--- a/src/ensembl/src/shared/components/textarea/Textarea.test.tsx
+++ b/src/ensembl/src/shared/components/textarea/Textarea.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount, render } from 'enzyme';
 import faker from 'faker';

--- a/src/ensembl/src/shared/components/textarea/Textarea.tsx
+++ b/src/ensembl/src/shared/components/textarea/Textarea.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import classNames from 'classnames';
 import noop from 'lodash/noop';

--- a/src/ensembl/src/shared/components/toolbox/Toolbox.tsx
+++ b/src/ensembl/src/shared/components/toolbox/Toolbox.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { ReactNode } from 'react';
 
 import PointerBox, {

--- a/src/ensembl/src/shared/components/toolbox/index.ts
+++ b/src/ensembl/src/shared/components/toolbox/index.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export { default as Toolbox, ToolboxPosition } from './Toolbox';
 export { default as ToolboxExpandableContent } from './toolbox-expandable-content/ToolboxExpandableContent';
 export { ToggleButton } from './toolbox-expandable-content/ToolboxExpandableContent';

--- a/src/ensembl/src/shared/components/toolbox/toolbox-expandable-content/ToolboxExpandableContent.test.tsx
+++ b/src/ensembl/src/shared/components/toolbox/toolbox-expandable-content/ToolboxExpandableContent.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 

--- a/src/ensembl/src/shared/components/toolbox/toolbox-expandable-content/ToolboxExpandableContent.tsx
+++ b/src/ensembl/src/shared/components/toolbox/toolbox-expandable-content/ToolboxExpandableContent.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState, useContext, ReactNode } from 'react';
 import classNames from 'classnames';
 import noop from 'lodash/noop';

--- a/src/ensembl/src/shared/components/tooltip/Tooltip.tsx
+++ b/src/ensembl/src/shared/components/tooltip/Tooltip.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { ReactNode, useEffect, useState } from 'react';
 
 import { TOOLTIP_TIMEOUT } from './tooltip-constants';

--- a/src/ensembl/src/shared/components/tooltip/tooltip-constants.ts
+++ b/src/ensembl/src/shared/components/tooltip/tooltip-constants.ts
@@ -1,1 +1,17 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export const TOOLTIP_TIMEOUT = 800;

--- a/src/ensembl/src/shared/components/tooltip/tooltip-types.ts
+++ b/src/ensembl/src/shared/components/tooltip/tooltip-types.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Position } from 'src/shared/components/pointer-box/PointerBox';
 
 export type TooltipPosition =

--- a/src/ensembl/src/shared/components/upload/Upload.test.tsx
+++ b/src/ensembl/src/shared/components/upload/Upload.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import faker from 'faker';

--- a/src/ensembl/src/shared/components/upload/Upload.tsx
+++ b/src/ensembl/src/shared/components/upload/Upload.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState } from 'react';
 import get from 'lodash/get';
 import classNames from 'classnames';

--- a/src/ensembl/src/shared/components/view-in-app/ViewInApp.test.tsx
+++ b/src/ensembl/src/shared/components/view-in-app/ViewInApp.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import faker from 'faker';
 import { mount } from 'enzyme';

--- a/src/ensembl/src/shared/components/view-in-app/ViewInApp.tsx
+++ b/src/ensembl/src/shared/components/view-in-app/ViewInApp.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 import { push, Push } from 'connected-react-router';

--- a/src/ensembl/src/shared/components/visibility-icon/VisibilityIcon.test.tsx
+++ b/src/ensembl/src/shared/components/visibility-icon/VisibilityIcon.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 

--- a/src/ensembl/src/shared/components/visibility-icon/VisibilityIcon.tsx
+++ b/src/ensembl/src/shared/components/visibility-icon/VisibilityIcon.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 import ImageButton, {

--- a/src/ensembl/src/shared/constants/keyCodes.ts
+++ b/src/ensembl/src/shared/constants/keyCodes.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // Arrow keys
 export const UP = 38;
 export const DOWN = 40;

--- a/src/ensembl/src/shared/constants/strings.ts
+++ b/src/ensembl/src/shared/constants/strings.ts
@@ -1,1 +1,17 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export const nonBreakingSpace = String.fromCharCode(160);

--- a/src/ensembl/src/shared/data/centromeres.ts
+++ b/src/ensembl/src/shared/data/centromeres.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
 
 This file exists due to two reasons:

--- a/src/ensembl/src/shared/helpers/downloadAsFile.ts
+++ b/src/ensembl/src/shared/helpers/downloadAsFile.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const downloadAsFile = (
   content: string | string[],
   fileName: string,

--- a/src/ensembl/src/shared/helpers/environment.test.ts
+++ b/src/ensembl/src/shared/helpers/environment.test.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { isEnvironment, Environment } from './environment';
 import config from 'config';
 

--- a/src/ensembl/src/shared/helpers/environment.ts
+++ b/src/ensembl/src/shared/helpers/environment.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import config from 'config';
 
 export enum Environment {

--- a/src/ensembl/src/shared/helpers/fetchHelper.ts
+++ b/src/ensembl/src/shared/helpers/fetchHelper.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { LoadingState } from 'src/shared/types/loading-state';
 
 export const shouldFetch = (status: LoadingState) =>

--- a/src/ensembl/src/shared/helpers/formatters/numberFormater.test.ts
+++ b/src/ensembl/src/shared/helpers/formatters/numberFormater.test.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { getCommaSeparatedNumber } from './numberFormatter';
 
 import faker from 'faker';

--- a/src/ensembl/src/shared/helpers/formatters/numberFormatter.ts
+++ b/src/ensembl/src/shared/helpers/formatters/numberFormatter.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
     Formats the input number to comma separated representation
     eg: 10000 -> 10,000

--- a/src/ensembl/src/shared/helpers/formatters/pluralisationFormatter.test.ts
+++ b/src/ensembl/src/shared/helpers/formatters/pluralisationFormatter.test.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { pluralise } from './pluralisationFormatter';
 
 describe('pluralise', () => {

--- a/src/ensembl/src/shared/helpers/formatters/pluralisationFormatter.ts
+++ b/src/ensembl/src/shared/helpers/formatters/pluralisationFormatter.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 type PluralDictionary = {
   [key: string]: string;
 };

--- a/src/ensembl/src/shared/helpers/formatters/regionFormatter.ts
+++ b/src/ensembl/src/shared/helpers/formatters/regionFormatter.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
 
 import { EnsObjectLocation } from 'src/shared/state/ens-object/ensObjectTypes';

--- a/src/ensembl/src/shared/helpers/formatters/strandFormatter.test.ts
+++ b/src/ensembl/src/shared/helpers/formatters/strandFormatter.test.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { getStrandDisplayName } from './strandFormatter';
 import { Strand } from 'src/content/app/entity-viewer/types/strand';
 

--- a/src/ensembl/src/shared/helpers/formatters/strandFormatter.ts
+++ b/src/ensembl/src/shared/helpers/formatters/strandFormatter.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Strand } from 'src/content/app/entity-viewer/types/strand';
 
 export function getStrandDisplayName(strandCode: Strand) {

--- a/src/ensembl/src/shared/helpers/generateId.test.ts
+++ b/src/ensembl/src/shared/helpers/generateId.test.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { generateId, resetNextId } from './generateId';
 
 describe('generateId helper', () => {

--- a/src/ensembl/src/shared/helpers/generateId.ts
+++ b/src/ensembl/src/shared/helpers/generateId.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const DEFAULT = 0;
 
 let counter = DEFAULT;

--- a/src/ensembl/src/shared/helpers/textHelpers.ts
+++ b/src/ensembl/src/shared/helpers/textHelpers.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 type MeasureTextParams = {
   text: string;
   font: string; // e.g. "italic small-caps bold 12px arial";

--- a/src/ensembl/src/shared/helpers/urlHelper.ts
+++ b/src/ensembl/src/shared/helpers/urlHelper.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import queryString from 'query-string';
 
 export const speciesSelector = () => '/app/species-selector';

--- a/src/ensembl/src/shared/hooks/tests/useOutsideClick.test.tsx
+++ b/src/ensembl/src/shared/hooks/tests/useOutsideClick.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useRef } from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 

--- a/src/ensembl/src/shared/hooks/tests/useRefWithRerender.test.tsx
+++ b/src/ensembl/src/shared/hooks/tests/useRefWithRerender.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 

--- a/src/ensembl/src/shared/hooks/useHover.tsx
+++ b/src/ensembl/src/shared/hooks/useHover.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { useRef, useState, useEffect } from 'react';
 
 type UseHoverType<T extends HTMLElement> = [React.RefObject<T>, boolean];

--- a/src/ensembl/src/shared/hooks/useOutsideClick.tsx
+++ b/src/ensembl/src/shared/hooks/useOutsideClick.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { useEffect } from 'react';
 
 export default function useOutsideClick<T extends HTMLElement>(

--- a/src/ensembl/src/shared/hooks/usePrevious.ts
+++ b/src/ensembl/src/shared/hooks/usePrevious.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // From React docs, section Hook FAQ, How to get the previous props or state
 // (https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state)
 

--- a/src/ensembl/src/shared/hooks/useRefWithRerender.ts
+++ b/src/ensembl/src/shared/hooks/useRefWithRerender.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { useEffect, useState, useRef, MutableRefObject } from 'react';
 
 /*

--- a/src/ensembl/src/shared/hooks/useResizeObserver.ts
+++ b/src/ensembl/src/shared/hooks/useResizeObserver.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // modified from https://github.com/ZeeCoder/use-resize-observer/blob/master/src/index.js
 
 import { useEffect, useState, useRef, RefObject } from 'react';
@@ -7,7 +23,7 @@ type Params<T> = {
   ref?: RefObject<T> | null;
 };
 
-export default function<T extends HTMLElement>(params: Params<T> = {}) {
+export default function <T extends HTMLElement>(params: Params<T> = {}) {
   const defaultRef = useRef(null);
   const ref = params.ref || defaultRef;
   const [size, setSize] = useState({ width: 0, height: 0 });

--- a/src/ensembl/src/shared/state/ens-object/ensObjectActions.ts
+++ b/src/ensembl/src/shared/state/ens-object/ensObjectActions.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { createAsyncAction } from 'typesafe-actions';
 import { Action, ActionCreator } from 'redux';
 import { ThunkAction } from 'redux-thunk';

--- a/src/ensembl/src/shared/state/ens-object/ensObjectHelpers.ts
+++ b/src/ensembl/src/shared/state/ens-object/ensObjectHelpers.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { EnsObject } from 'src/shared/state/ens-object/ensObjectTypes';
 
 type StableIdField = 'versioned_stable_id' | 'stable_id';

--- a/src/ensembl/src/shared/state/ens-object/ensObjectReducer.ts
+++ b/src/ensembl/src/shared/state/ens-object/ensObjectReducer.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ActionType, getType } from 'typesafe-actions';
 
 import * as ensObjectActions from './ensObjectActions';

--- a/src/ensembl/src/shared/state/ens-object/ensObjectSelectors.ts
+++ b/src/ensembl/src/shared/state/ens-object/ensObjectSelectors.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import get from 'lodash/get';
 
 import { getGenomeInfoById } from 'src/shared/state/genome/genomeSelectors';

--- a/src/ensembl/src/shared/state/ens-object/ensObjectState.ts
+++ b/src/ensembl/src/shared/state/ens-object/ensObjectState.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { LoadingState } from 'src/shared/types/loading-state';
 import { EnsObject } from './ensObjectTypes';
 

--- a/src/ensembl/src/shared/state/ens-object/ensObjectTypes.ts
+++ b/src/ensembl/src/shared/state/ens-object/ensObjectTypes.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Strand } from 'src/content/app/entity-viewer/types/strand';
 
 export type EnsObjectLocation = {

--- a/src/ensembl/src/shared/state/genome/genomeActions.ts
+++ b/src/ensembl/src/shared/state/genome/genomeActions.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { createAsyncAction } from 'typesafe-actions';
 import { ThunkAction } from 'redux-thunk';
 import { Action, ActionCreator } from 'redux';
@@ -25,9 +41,12 @@ export const fetchGenomeInfoAsyncActions = createAsyncAction(
   'genome/fetch_genome_info_failure'
 )<undefined, GenomeInfoData, Error>();
 
-export const fetchGenomeData: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (genomeId: string) => async (dispatch) => {
+export const fetchGenomeData: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (genomeId: string) => async (dispatch) => {
   await Promise.all([
     dispatch(fetchGenomeInfo(genomeId)),
     dispatch(fetchGenomeTrackCategories(genomeId)),
@@ -39,9 +58,12 @@ export const fetchGenomeData: ActionCreator<
   dispatch(fetchExampleEnsObjects(genomeId));
 };
 
-export const fetchGenomeInfo: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (genomeId: string) => async (dispatch, getState: () => RootState) => {
+export const fetchGenomeInfo: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (genomeId: string) => async (dispatch, getState: () => RootState) => {
   const state = getState();
   const genomeInfo = getGenomeInfoById(state, genomeId);
   if (genomeInfo) {
@@ -68,9 +90,12 @@ export const fetchGenomeTrackCategoriesAsyncActions = createAsyncAction(
   'genome/fetch_genome_track_categories_failure'
 )<string, GenomeTrackCategories, Error>();
 
-export const fetchGenomeTrackCategories: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (genomeId: string) => async (dispatch, getState: () => RootState) => {
+export const fetchGenomeTrackCategories: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (genomeId: string) => async (dispatch, getState: () => RootState) => {
   try {
     const currentGenomeTrackCategories: GenomeTrackCategories = getGenomeTrackCategories(
       getState()
@@ -106,9 +131,12 @@ export const fetchGenomeKaryotypeAsyncActions = createAsyncAction(
   'genome/fetch_genome_karyotype_failure'
 )<string, any, Error>();
 
-export const fetchGenomeKaryotype: ActionCreator<
-  ThunkAction<void, any, null, Action<string>>
-> = (genomeId: string) => async (dispatch, getState: () => RootState) => {
+export const fetchGenomeKaryotype: ActionCreator<ThunkAction<
+  void,
+  any,
+  null,
+  Action<string>
+>> = (genomeId: string) => async (dispatch, getState: () => RootState) => {
   try {
     const currentGenomeKaryotype:
       | GenomeKaryotypeItem[]

--- a/src/ensembl/src/shared/state/genome/genomeReducer.ts
+++ b/src/ensembl/src/shared/state/genome/genomeReducer.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ActionType, getType } from 'typesafe-actions';
 import { combineReducers } from 'redux';
 

--- a/src/ensembl/src/shared/state/genome/genomeSelectors.ts
+++ b/src/ensembl/src/shared/state/genome/genomeSelectors.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { RootState } from 'src/store';
 import { GenomeInfo, GenomeInfoData } from './genomeTypes';
 import { getBrowserActiveGenomeId } from 'src/content/app/browser/browserSelectors';

--- a/src/ensembl/src/shared/state/genome/genomeState.ts
+++ b/src/ensembl/src/shared/state/genome/genomeState.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {
   GenomeInfoData,
   GenomeTrackCategories,

--- a/src/ensembl/src/shared/state/genome/genomeTypes.ts
+++ b/src/ensembl/src/shared/state/genome/genomeTypes.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { EnsObjectTrack } from 'src/shared/state/ens-object/ensObjectTypes';
 import { TrackSet } from 'src/content/app/browser/track-panel/trackPanelConfig';
 

--- a/src/ensembl/src/shared/types/JSON.ts
+++ b/src/ensembl/src/shared/types/JSON.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export type PrimitiveValue = string | number | boolean | null | undefined;
 export type ArrayValue = PrimitiveValue[] | JSONValue[];
 export type PrimitiveOrArrayValue = PrimitiveValue | ArrayValue;

--- a/src/ensembl/src/shared/types/loading-state.ts
+++ b/src/ensembl/src/shared/types/loading-state.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export enum LoadingState {
   NOT_REQUESTED = 'not requested',
   LOADING = 'loading',

--- a/src/ensembl/src/shared/types/status.ts
+++ b/src/ensembl/src/shared/types/status.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
   This file contains the Status enumerable type.
   The Status type does not correspond to any single thing,

--- a/src/ensembl/src/shared/types/utility-types/modify.ts
+++ b/src/ensembl/src/shared/types/utility-types/modify.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
 
 The Modify type makes it possible to overwrite specific fields of a given type

--- a/src/ensembl/src/shared/utils/bringToFront.ts
+++ b/src/ensembl/src/shared/utils/bringToFront.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /* 
   Given an array and a member of this array,
   return a copy of the received array, where the received member

--- a/src/ensembl/src/shared/utils/lruCache.ts
+++ b/src/ensembl/src/shared/utils/lruCache.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * This is a cache implementing the Least Recently Used algorithm
  * for preventing it from growing indefinitely. It also can invalidate

--- a/src/ensembl/src/shared/utils/tests/bringToFront.test.ts
+++ b/src/ensembl/src/shared/utils/tests/bringToFront.test.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import range from 'lodash/range';
 import random from 'lodash/random';
 import last from 'lodash/last';

--- a/src/ensembl/src/shared/utils/tests/lruCache.test.ts
+++ b/src/ensembl/src/shared/utils/tests/lruCache.test.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import faker from 'faker';
 import times from 'lodash/times';
 

--- a/src/ensembl/src/store.ts
+++ b/src/ensembl/src/store.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { applyMiddleware, createStore } from 'redux';
 import thunk from 'redux-thunk';
 import { composeWithDevTools } from 'redux-devtools-extension';

--- a/src/ensembl/stories/design-primitives/colours/ColourCard.tsx
+++ b/src/ensembl/stories/design-primitives/colours/ColourCard.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { FunctionComponent } from 'react';
 
 import styles from './ColourCard.scss';

--- a/src/ensembl/stories/design-primitives/colours/Colours.stories.tsx
+++ b/src/ensembl/stories/design-primitives/colours/Colours.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 

--- a/src/ensembl/stories/design-primitives/index.ts
+++ b/src/ensembl/stories/design-primitives/index.ts
@@ -1,2 +1,18 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import './colours/Colours.stories';
 import './typography/Typography.stories';

--- a/src/ensembl/stories/design-primitives/typography/Typography.stories.tsx
+++ b/src/ensembl/stories/design-primitives/typography/Typography.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 

--- a/src/ensembl/stories/entity-viewer/base-pairs-ruler/BasePairsRuler.stories.tsx
+++ b/src/ensembl/stories/entity-viewer/base-pairs-ruler/BasePairsRuler.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState, useRef } from 'react';
 import { storiesOf } from '@storybook/react';
 

--- a/src/ensembl/stories/entity-viewer/index.ts
+++ b/src/ensembl/stories/entity-viewer/index.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import './base-pairs-ruler/BasePairsRuler.stories';
 import './transcript-filter/TranscriptFilter.stories';
 import './transcripts/UnsplicedTranscripts.stories';

--- a/src/ensembl/stories/entity-viewer/protein/ProteinDomainImage.stories.tsx
+++ b/src/ensembl/stories/entity-viewer/protein/ProteinDomainImage.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState, useEffect, useRef } from 'react';
 import { storiesOf } from '@storybook/react';
 

--- a/src/ensembl/stories/entity-viewer/transcript-filter/TranscriptFilter.stories.tsx
+++ b/src/ensembl/stories/entity-viewer/transcript-filter/TranscriptFilter.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';

--- a/src/ensembl/stories/entity-viewer/transcripts/UnsplicedTranscripts.stories.tsx
+++ b/src/ensembl/stories/entity-viewer/transcripts/UnsplicedTranscripts.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState, useEffect, useRef } from 'react';
 import { scaleLinear } from 'd3';
 import classNames from 'classnames';

--- a/src/ensembl/stories/entity-viewer/transcripts/transcriptData.ts
+++ b/src/ensembl/stories/entity-viewer/transcripts/transcriptData.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { fetchGene } from 'src/content/app/entity-viewer/shared/rest/rest-data-fetchers/geneData';
 import { fetchTranscript } from 'src/content/app/entity-viewer/shared/rest/rest-data-fetchers/transcriptData';
 

--- a/src/ensembl/stories/genome-browser/chromosome-navigator/ChromosomeNavigator.stories.tsx
+++ b/src/ensembl/stories/genome-browser/chromosome-navigator/ChromosomeNavigator.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 
@@ -113,7 +129,7 @@ const Wrapper = () => {
   );
 };
 
-storiesOf('Components|Genome Browser/ChromosomeNavigator', module).add(
-  'default',
-  () => <Wrapper />
-);
+storiesOf(
+  'Components|Genome Browser/ChromosomeNavigator',
+  module
+).add('default', () => <Wrapper />);

--- a/src/ensembl/stories/genome-browser/index.ts
+++ b/src/ensembl/stories/genome-browser/index.ts
@@ -1,1 +1,17 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import './chromosome-navigator/ChromosomeNavigator.stories';

--- a/src/ensembl/stories/index.tsx
+++ b/src/ensembl/stories/index.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import 'src/styles/main.scss';
 
 import './design-primitives/index.ts';

--- a/src/ensembl/stories/shared-components/accordion/Accordion.stories.tsx
+++ b/src/ensembl/stories/shared-components/accordion/Accordion.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 

--- a/src/ensembl/stories/shared-components/autosuggest-search-field/AutosuggestSearchField.stories.tsx
+++ b/src/ensembl/stories/shared-components/autosuggest-search-field/AutosuggestSearchField.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState, useEffect } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';

--- a/src/ensembl/stories/shared-components/badged-button/BadgedButton.stories.tsx
+++ b/src/ensembl/stories/shared-components/badged-button/BadgedButton.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';

--- a/src/ensembl/stories/shared-components/button/Button.stories.tsx
+++ b/src/ensembl/stories/shared-components/button/Button.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';

--- a/src/ensembl/stories/shared-components/checkbox/Checkbox.stories.tsx
+++ b/src/ensembl/stories/shared-components/checkbox/Checkbox.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState } from 'react';
 
 import Checkbox, {

--- a/src/ensembl/stories/shared-components/clear-button/ClearButton.stories.tsx
+++ b/src/ensembl/stories/shared-components/clear-button/ClearButton.stories.tsx
@@ -1,8 +1,25 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import noop from 'lodash/noop';
 
 import ClearButton from 'src/shared/components/clear-button/ClearButton';
 
 storiesOf('Components|Shared Components/Clear button', module)
-  .add('default', () => <ClearButton onClick={() => {}} />)
-  .add('inverted', () => <ClearButton inverted onClick={() => {}} />);
+  .add('default', () => <ClearButton onClick={noop} />)
+  .add('inverted', () => <ClearButton inverted onClick={noop} />);

--- a/src/ensembl/stories/shared-components/external-link/ExternalLink.stories.tsx
+++ b/src/ensembl/stories/shared-components/external-link/ExternalLink.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 

--- a/src/ensembl/stories/shared-components/external-reference/ExternalReference.stories.tsx
+++ b/src/ensembl/stories/shared-components/external-reference/ExternalReference.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 

--- a/src/ensembl/stories/shared-components/image-button/ImageButton.stories.tsx
+++ b/src/ensembl/stories/shared-components/image-button/ImageButton.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import classNames from 'classnames';

--- a/src/ensembl/stories/shared-components/index.ts
+++ b/src/ensembl/stories/shared-components/index.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // Arrange alphabetically
 import './accordion/Accordion.stories';
 import './autosuggest-search-field/AutosuggestSearchField.stories';

--- a/src/ensembl/stories/shared-components/input/Input.stories.tsx
+++ b/src/ensembl/stories/shared-components/input/Input.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';

--- a/src/ensembl/stories/shared-components/instant-download/InstantDownload.stories.tsx
+++ b/src/ensembl/stories/shared-components/instant-download/InstantDownload.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 

--- a/src/ensembl/stories/shared-components/instant-download/InstantDownloadTranscript.stories.tsx
+++ b/src/ensembl/stories/shared-components/instant-download/InstantDownloadTranscript.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState } from 'react';
 
 import { createGene } from 'tests/fixtures/entity-viewer/gene';

--- a/src/ensembl/stories/shared-components/layout/Layout.stories.tsx
+++ b/src/ensembl/stories/shared-components/layout/Layout.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState, ReactNode } from 'react';
 import { storiesOf } from '@storybook/react';
 

--- a/src/ensembl/stories/shared-components/loader/Loader.stories.tsx
+++ b/src/ensembl/stories/shared-components/loader/Loader.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 

--- a/src/ensembl/stories/shared-components/panel/Panel.stories.tsx
+++ b/src/ensembl/stories/shared-components/panel/Panel.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';

--- a/src/ensembl/stories/shared-components/pointer-box/PointerBox.stories.tsx
+++ b/src/ensembl/stories/shared-components/pointer-box/PointerBox.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 

--- a/src/ensembl/stories/shared-components/pointer-box/positioningStory.tsx
+++ b/src/ensembl/stories/shared-components/pointer-box/positioningStory.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState, useRef } from 'react';
 import classNames from 'classnames';
 

--- a/src/ensembl/stories/shared-components/pointer-box/scrollingStory.tsx
+++ b/src/ensembl/stories/shared-components/pointer-box/scrollingStory.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState, useEffect, useRef } from 'react';
 import classNames from 'classnames';
 

--- a/src/ensembl/stories/shared-components/pointer-box/variantsStory.tsx
+++ b/src/ensembl/stories/shared-components/pointer-box/variantsStory.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState, useRef } from 'react';
 import classNames from 'classnames';
 import faker from 'faker';

--- a/src/ensembl/stories/shared-components/question-button/QuestionButton.stories.tsx
+++ b/src/ensembl/stories/shared-components/question-button/QuestionButton.stories.tsx
@@ -1,14 +1,31 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 
-import QuestionButton, {QuestionButtonOption} from 'src/shared/components/question-button/QuestionButton';
+import QuestionButton, {
+  QuestionButtonOption
+} from 'src/shared/components/question-button/QuestionButton';
 
 storiesOf('Components|Shared Components/Question button', module)
-  .add(
-    'default', () => (
-      <QuestionButton helpText="This is a hint" />
-    ))
-  .add(
-    'input', () => (
-      <QuestionButton helpText="This is a hint" styleOption={QuestionButtonOption.INPUT} />
-    ));
+  .add('default', () => <QuestionButton helpText="This is a hint" />)
+  .add('input', () => (
+    <QuestionButton
+      helpText="This is a hint"
+      styleOption={QuestionButtonOption.INPUT}
+    />
+  ));

--- a/src/ensembl/stories/shared-components/radio-group/RadioGroup.stories.tsx
+++ b/src/ensembl/stories/shared-components/radio-group/RadioGroup.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState } from 'react';
 
 import RadioGroup, {

--- a/src/ensembl/stories/shared-components/round-button/RoundButton.stories.tsx
+++ b/src/ensembl/stories/shared-components/round-button/RoundButton.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';

--- a/src/ensembl/stories/shared-components/search-field/SearchField.stories.tsx
+++ b/src/ensembl/stories/shared-components/search-field/SearchField.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 

--- a/src/ensembl/stories/shared-components/select/Select.stories.tsx
+++ b/src/ensembl/stories/shared-components/select/Select.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import times from 'lodash/times';

--- a/src/ensembl/stories/shared-components/slide-toggle/SlideToggle.stories.tsx
+++ b/src/ensembl/stories/shared-components/slide-toggle/SlideToggle.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import noop from 'lodash/noop';

--- a/src/ensembl/stories/shared-components/species-tabs-wrapper/SpeciesTabsWrapper.stories.tsx
+++ b/src/ensembl/stories/shared-components/species-tabs-wrapper/SpeciesTabsWrapper.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 

--- a/src/ensembl/stories/shared-components/species-tabs-wrapper/speciesData.ts
+++ b/src/ensembl/stories/shared-components/species-tabs-wrapper/speciesData.ts
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export default [
   {
     genome_id: 'homo_sapiens38',

--- a/src/ensembl/stories/shared-components/tabs/Tabs.stories.tsx
+++ b/src/ensembl/stories/shared-components/tabs/Tabs.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';

--- a/src/ensembl/stories/shared-components/textarea/Textarea.stories.tsx
+++ b/src/ensembl/stories/shared-components/textarea/Textarea.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';

--- a/src/ensembl/stories/shared-components/toolbox/Toolbox.stories.tsx
+++ b/src/ensembl/stories/shared-components/toolbox/Toolbox.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState, useRef } from 'react';
 import { storiesOf } from '@storybook/react';
 

--- a/src/ensembl/stories/shared-components/tooltip/Tooltip.stories.tsx
+++ b/src/ensembl/stories/shared-components/tooltip/Tooltip.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import classNames from 'classnames';

--- a/src/ensembl/stories/shared-components/upload/Upload.stories.tsx
+++ b/src/ensembl/stories/shared-components/upload/Upload.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';

--- a/src/ensembl/stories/static-images/ImageHolder.tsx
+++ b/src/ensembl/stories/static-images/ImageHolder.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 import styles from './ImageHolder.scss';

--- a/src/ensembl/stories/static-images/StaticImages.stories.tsx
+++ b/src/ensembl/stories/static-images/StaticImages.stories.tsx
@@ -1,3 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 
@@ -21,7 +37,7 @@ function importAllImages(fileType: string) {
 
   const images: any = [];
 
-  imagePaths.forEach(({  }: string, key: number) => {
+  imagePaths.forEach(({}: string, key: number) => {
     const filePath =
       'static/img' + imagePaths[key].substring(1, imagePaths[key].length);
     images.push([filePath, imageComponents[key]]);

--- a/src/ensembl/stories/static-images/index.ts
+++ b/src/ensembl/stories/static-images/index.ts
@@ -1,1 +1,17 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import './StaticImages.stories';


### PR DESCRIPTION
## Type
🤢 

## Related JIRA Issue(s)
ENSWBSITES-511

## Description
Add licence header to all typescript (.ts and .tsx) files:
- in the src directory
- in the stories directory

## Views affected
None