### PR TITLE
Gene view  function / relationships tabs availability

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -162,7 +162,7 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
           )}
 
         {props.selectedGeneTabName === GeneViewTabName.GENE_FUNCTION && (
-          <GeneFunction geneId={props.gene.id} />
+          <GeneFunction geneId={props.gene.id} gene={props.gene} />
         )}
 
         {props.selectedGeneTabName === GeneViewTabName.GENE_RELATIONSHIPS && (

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -162,7 +162,7 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
           )}
 
         {props.selectedGeneTabName === GeneViewTabName.GENE_FUNCTION && (
-          <GeneFunction geneId={props.gene.id} gene={props.gene} />
+          <GeneFunction gene={props.gene} />
         )}
 
         {props.selectedGeneTabName === GeneViewTabName.GENE_RELATIONSHIPS && (

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.tsx
@@ -48,7 +48,6 @@ const tabClassNames = {
 };
 
 type Props = {
-  geneId: string;
   gene: Gene;
   isNarrow: boolean;
   selectedTabName: GeneFunctionTabName | null;
@@ -99,7 +98,7 @@ const GeneFunction = (props: Props) => {
   const getCurrentTabContent = () => {
     switch (selectedTabName) {
       case GeneFunctionTabName.PROTEINS:
-        return <ProteinsList geneId={props.geneId} />;
+        return <ProteinsList geneId={props.gene.id} />;
       default:
         return <>Data for these views will be available soon...</>;
     }

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.tsx
@@ -60,9 +60,14 @@ const GeneFunction = (props: Props) => {
   } = props;
   let { selectedTabName } = props;
 
+  // Check if we have at least one protein coding transcript
+  const proteinCodingTranscriptIndex = transcripts.findIndex(
+    (transcript) => transcript.biotype === 'protein_coding'
+  );
+
   // Disable the Proteins tab if there are no transcripts data
   // TODO: We need a better logic to disable tabs once we have the data available for other tabs
-  if (!transcripts || !transcripts.length) {
+  if (proteinCodingTranscriptIndex === -1) {
     const proteinTabIndex = tabsData.findIndex(
       (tab) => tab.title === GeneFunctionTabName.PROTEINS
     );
@@ -74,7 +79,8 @@ const GeneFunction = (props: Props) => {
   const selectedTabIndex = tabsData.findIndex(
     (tab) => tab.title === selectedTabName
   );
-  if (!selectedTabIndex || tabsData[selectedTabIndex].isDisabled) {
+
+  if (selectedTabIndex === -1 || tabsData[selectedTabIndex].isDisabled) {
     const nextAvailableTab = tabsData.find((tab) => !tab.isDisabled);
 
     selectedTabName = (nextAvailableTab?.title as GeneFunctionTabName) || null;

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.tsx
@@ -26,17 +26,20 @@ import Panel from 'src/shared/components/panel/Panel';
 import ProteinsList from '../proteins-list/ProteinsList';
 
 import { RootState } from 'src/store';
+import { Gene } from 'src/content/app/entity-viewer/types/gene';
 import { GeneFunctionTabName } from 'src/content/app/entity-viewer/state/gene-view/entityViewerGeneViewState.ts';
 
 import styles from './GeneFunction.scss';
 
+// TODO: the isDisabled flags are hardcoded here since we do not have any data available.
+// We need to update this logic once we have the data available
 const tabsData: Tab[] = [
-  { title: 'Proteins' },
-  { title: 'Variants' },
-  { title: 'Phenotypes' },
-  { title: 'Gene expression' },
-  { title: 'Gene ontology', isDisabled: true },
-  { title: 'Gene pathways' }
+  { title: GeneFunctionTabName.PROTEINS },
+  { title: GeneFunctionTabName.VARIANTS, isDisabled: true },
+  { title: GeneFunctionTabName.PHENOTYPES, isDisabled: true },
+  { title: GeneFunctionTabName.GENE_EXPRESSION, isDisabled: true },
+  { title: GeneFunctionTabName.GENE_ONTOLOGY, isDisabled: true },
+  { title: GeneFunctionTabName.GENE_PATHWAYS, isDisabled: true }
 ];
 
 const tabClassNames = {
@@ -46,12 +49,38 @@ const tabClassNames = {
 
 type Props = {
   geneId: string;
+  gene: Gene;
   isNarrow: boolean;
-  selectedTabName: GeneFunctionTabName;
+  selectedTabName: GeneFunctionTabName | null;
   setActiveGeneFunctionTab: (tab: string) => void;
 };
 
 const GeneFunction = (props: Props) => {
+  const {
+    gene: { transcripts }
+  } = props;
+  let { selectedTabName } = props;
+
+  // Disable the Proteins tab if there are no transcripts data
+  // TODO: We need a better logic to disable tabs once we have the data available for other tabs
+  if (!transcripts || !transcripts.length) {
+    const proteinTabIndex = tabsData.findIndex(
+      (tab) => tab.title === GeneFunctionTabName.PROTEINS
+    );
+
+    tabsData[proteinTabIndex].isDisabled = true;
+  }
+
+  // If the selectedTab is disabled or if there is no selectedtab, pick the first available tab
+  const selectedTabIndex = tabsData.findIndex(
+    (tab) => tab.title === selectedTabName
+  );
+  if (!selectedTabIndex || tabsData[selectedTabIndex].isDisabled) {
+    const nextAvailableTab = tabsData.find((tab) => !tab.isDisabled);
+
+    selectedTabName = (nextAvailableTab?.title as GeneFunctionTabName) || null;
+  }
+
   const TabWrapper = () => {
     const onTabChange = (tab: string) => {
       props.setActiveGeneFunctionTab(tab);
@@ -60,7 +89,7 @@ const GeneFunction = (props: Props) => {
     return (
       <Tabs
         tabs={tabsData}
-        selectedTab={props.selectedTabName}
+        selectedTab={selectedTabName}
         classNames={tabClassNames}
         onTabChange={onTabChange}
       />
@@ -68,11 +97,11 @@ const GeneFunction = (props: Props) => {
   };
 
   const getCurrentTabContent = () => {
-    switch (props.selectedTabName) {
+    switch (selectedTabName) {
       case GeneFunctionTabName.PROTEINS:
         return <ProteinsList geneId={props.geneId} />;
       default:
-        return <></>;
+        return <>Data for these views will be available soon...</>;
     }
   };
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-relationships/GeneRelationships.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-relationships/GeneRelationships.tsx
@@ -29,10 +29,16 @@ import { RootState } from 'src/store';
 
 import styles from './GeneRelationships.scss';
 
+// TODO: the isDisabled flags are hardcoded here since we do not have any data available.
+// We need to update this logic once we have the data available
 const tabsData: Tab[] = [
-  { title: 'Orthologues' },
-  { title: 'Gene families' },
-  { title: 'Gene panels' }
+  { title: GeneRelationshipsTabName.ORTHOLOGUES, isDisabled: true },
+  { title: GeneRelationshipsTabName.PARALOGUES, isDisabled: true },
+  { title: GeneRelationshipsTabName.GENE_FAMILIES, isDisabled: true },
+  { title: GeneRelationshipsTabName.GENE_CLUSTERS, isDisabled: true },
+  { title: GeneRelationshipsTabName.GENE_PANELS, isDisabled: true },
+  { title: GeneRelationshipsTabName.GENE_NEIGHBOUTHOOD, isDisabled: true },
+  { title: GeneRelationshipsTabName.GENE_SIMILARITY, isDisabled: true }
 ];
 
 const tabClassNames = {
@@ -41,11 +47,24 @@ const tabClassNames = {
 
 type Props = {
   isSidebarOpen: boolean;
-  selectedTabName: GeneRelationshipsTabName;
+  selectedTabName: GeneRelationshipsTabName | null;
   setActiveGeneRelationshipsTab: (tab: string) => void;
 };
 
 const GeneRelationships = (props: Props) => {
+  let { selectedTabName } = props;
+
+  // If the selectedTab is disabled or if there is no selectedtab, pick the first available tab
+  const selectedTabIndex = tabsData.findIndex(
+    (tab) => tab.title === selectedTabName
+  );
+  if (!selectedTabIndex || tabsData[selectedTabIndex].isDisabled) {
+    const nextAvailableTab = tabsData.find((tab) => !tab.isDisabled);
+
+    selectedTabName =
+      (nextAvailableTab?.title as GeneRelationshipsTabName) || null;
+  }
+
   const TabWrapper = () => {
     const onTabChange = (tab: string) => {
       props.setActiveGeneRelationshipsTab(tab);
@@ -54,11 +73,20 @@ const GeneRelationships = (props: Props) => {
     return (
       <Tabs
         tabs={tabsData}
-        selectedTab={props.selectedTabName}
+        selectedTab={selectedTabName}
         classNames={tabClassNames}
         onTabChange={onTabChange}
       />
     );
+  };
+
+  const getCurrentTabContent = () => {
+    switch (selectedTabName) {
+      case GeneRelationshipsTabName.GENE_FAMILIES:
+        return <>Gene families data</>;
+      default:
+        return <>Data for these views will be available soon...</>;
+    }
   };
 
   return (
@@ -69,7 +97,7 @@ const GeneRelationships = (props: Props) => {
         body: styles.panelBody
       }}
     >
-      <div>Panel content is coming...</div>
+      {getCurrentTabContent()}
     </Panel>
   );
 };

--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/entityViewerGeneViewState.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/entityViewerGeneViewState.ts
@@ -51,17 +51,21 @@ export enum GeneFunctionTabName {
 
 export enum GeneRelationshipsTabName {
   ORTHOLOGUES = 'Orthologues',
+  PARALOGUES = 'Paralogues',
   GENE_FAMILIES = 'Gene families',
-  GENE_PANELS = 'Gene panels'
+  GENE_CLUSTERS = 'Gene clusters',
+  GENE_PANELS = 'Gene panels',
+  GENE_NEIGHBOUTHOOD = 'Gene neighbouthood',
+  GENE_SIMILARITY = 'Gene similarity within-genome'
 }
 
 export const defaultEntityViewerGeneViewUIState = {
   selectedGeneTabName: GeneViewTabName.TRANSCRIPTS,
   geneFunction: {
-    selectedTabName: GeneFunctionTabName.PROTEINS
+    selectedTabName: null
   },
   geneRelationships: {
-    selectedTabName: GeneRelationshipsTabName.ORTHOLOGUES
+    selectedTabName: null
   }
 };
 


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-548


## Description
- the isDisabled flag is hardcoded to false for the tabs that does not have any data
- the first available tab is selected by default
- A standard message is displayed when no tabs are available to select


## Views affected
Entity viewer -> Gene view -> Gene function & Gene Relationships

### Other effects
I am not quire sure about what I can test here.

- [ ] I have created any required tests


## Possible complications
At the moment there is no easy way to identify which tabs needs to be disabled. I have created a ticket for us to look into a way of getting the availability data from Thoas:
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-636 