### PR TITLE
Add 'view in genome browser' to transcript accordion

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.test.tsx
@@ -16,11 +16,17 @@
 
 import React from 'react';
 import { mount } from 'enzyme';
+import { MemoryRouter } from 'react-router';
 
 import TranscriptsListItemInfo from './TranscriptsListItemInfo';
+import ViewInApp from 'src/shared/components/view-in-app/ViewInApp';
 
 import { createGene } from 'tests/fixtures/entity-viewer/gene';
 import { createTranscript } from 'tests/fixtures/entity-viewer/transcript';
+
+jest.mock('src/shared/components/view-in-app/ViewInApp', () => () => (
+  <div>ViewInApp</div>
+));
 
 describe('<TranscriptsListItemInfo /', () => {
   let wrapper: any;
@@ -32,7 +38,11 @@ describe('<TranscriptsListItemInfo /', () => {
   };
 
   beforeEach(() => {
-    wrapper = mount(<TranscriptsListItemInfo {...props} />);
+    wrapper = mount(
+      <MemoryRouter>
+        <TranscriptsListItemInfo {...props} />
+      </MemoryRouter>
+    );
   });
 
   /*
@@ -52,5 +62,9 @@ describe('<TranscriptsListItemInfo /', () => {
 
   it('contains the download link', () => {
     expect(wrapper.find('.downloadLink')).toHaveLength(1);
+  });
+
+  it('renders ViewInApp component', () => {
+    expect(wrapper.find(ViewInApp)).toHaveLength(1);
   });
 });

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -26,8 +26,11 @@ import {
   getFirstAndLastCodingExonIndexes,
   getNumberOfCodingExons
 } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
+import * as urlFor from 'src/shared/helpers/urlHelper';
+import { buildFocusIdForUrl } from 'src/shared/state/ens-object/ensObjectHelpers';
 
 import { InstantDownloadTranscript } from 'src/shared/components/instant-download';
+import ViewInApp from 'src/shared/components/view-in-app/ViewInApp';
 
 import { ReactComponent as CloseIcon } from 'static/img/shared/close.svg';
 
@@ -36,9 +39,6 @@ import { Transcript } from 'src/content/app/entity-viewer/types/transcript';
 
 import transcriptsListStyles from '../DefaultTranscriptsList.scss';
 import styles from './TranscriptsListItemInfo.scss';
-import ViewInApp from 'src/shared/components/view-in-app/ViewInApp';
-import * as urlFor from 'src/shared/helpers/urlHelper';
-import { buildFocusIdForUrl } from 'src/shared/state/ens-object/ensObjectHelpers';
 
 type ItemInfoProps = {
   gene: Gene;

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -15,6 +15,7 @@
  */
 
 import React, { useState } from 'react';
+import { useParams } from 'react-router-dom';
 import classNames from 'classnames';
 
 import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
@@ -35,6 +36,9 @@ import { Transcript } from 'src/content/app/entity-viewer/types/transcript';
 
 import transcriptsListStyles from '../DefaultTranscriptsList.scss';
 import styles from './TranscriptsListItemInfo.scss';
+import ViewInApp from 'src/shared/components/view-in-app/ViewInApp';
+import * as urlFor from 'src/shared/helpers/urlHelper';
+import { buildFocusIdForUrl } from 'src/shared/state/ens-object/ensObjectHelpers';
 
 type ItemInfoProps = {
   gene: Gene;
@@ -44,6 +48,7 @@ type ItemInfoProps = {
 const ItemInfo = (props: ItemInfoProps) => {
   const [isDownloadShown, setIsDownloadShown] = useState(false);
   const { transcript } = props;
+  const params: { [key: string]: string } = useParams();
 
   const openDownload = () => setIsDownloadShown(true);
   const closeDownload = () => setIsDownloadShown(false);
@@ -115,6 +120,15 @@ const ItemInfo = (props: ItemInfoProps) => {
   const mainStyles = classNames(transcriptsListStyles.row, styles.listItemInfo);
   const midStyles = classNames(transcriptsListStyles.middle, styles.middle);
 
+  const focusIdForUrl = buildFocusIdForUrl({
+    type: 'gene',
+    objectId: props.gene.id
+  });
+
+  const getBrowserLink = () => {
+    const { genomeId } = params;
+    return urlFor.browser({ genomeId: genomeId, focus: focusIdForUrl });
+  };
   return (
     <div className={mainStyles}>
       <div className={transcriptsListStyles.left}>bottom left</div>
@@ -153,7 +167,12 @@ const ItemInfo = (props: ItemInfoProps) => {
         </div>
         {isDownloadShown && renderInstantDownload(props)}
       </div>
-      <div className={transcriptsListStyles.right}>{transcript.symbol}</div>
+      <div className={transcriptsListStyles.right}>
+        <div>{transcript.symbol}</div>
+        <div>
+          <ViewInApp links={{ genomeBrowser: getBrowserLink() }} />
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/ensembl/webpack/environments/webpack.config.dev.js
+++ b/src/ensembl/webpack/environments/webpack.config.dev.js
@@ -32,7 +32,7 @@ const devServerConfig = {
   // rules to proxy requests to the backend server in development
   proxy: {
     '/api': {
-      target: 'http://hx-rke-wp-webadmin-14-worker-1.caas.ebi.ac.uk:32014',
+      target: 'https://staging-2020.ensembl.org',
       changeOrigin: true,
       secure: false
     },


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [X] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
[ENSWBSITES-521](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-521)

## Description
Adds "View in genome browser" button to transcript accordion.

Clicking the view in genome browser button on any transcript currently takes you to the default transcript. When we have transcript view in genome browser it should select individual ones.

## Views affected
Entity viewer

### Other effects
N/A

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
NA