### PR TITLE
[ENSWBSITES-625] pass genmomeId to create the url

### DIFF
--- a/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.tsx
+++ b/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.tsx
@@ -126,8 +126,8 @@ const HomepageAppLinksRow = (props: HomepageAppLinksRowProps) => {
       <div className={styles.homepageAppLinkButtons}>
         <ViewInApp
           links={{
-            genomeBrowser: urlFor.browser(),
-            entityViewer: urlFor.entityViewer()
+            genomeBrowser: urlFor.browser({ genomeId: species.genome_id }),
+            entityViewer: urlFor.entityViewer({ genomeId: species.genome_id })
           }}
         />
       </div>


### PR DESCRIPTION

## Type

- [x ] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-625

## Importance
Fixes links from homepage

## Description
Links from homepage to other apps always been taken to humans. Now we pass the genome id and it is fixed.

## Views affected
Homepage


- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
NA