### PR TITLE
Fix test of ChromosomeNavigator

### DIFF
--- a/src/ensembl/src/content/app/browser/chromosome-navigator/ChromosomeNavigator.test.tsx
+++ b/src/ensembl/src/content/app/browser/chromosome-navigator/ChromosomeNavigator.test.tsx
@@ -128,7 +128,10 @@ describe('Chromosome Navigator', () => {
           expect(areas.at(index).prop('x')).toBe(x);
         }
         if (width !== undefined) {
-          expect(areas.at(index).prop('width')).toBe(width);
+          const widthDifference = Math.abs(
+            areas.at(index).prop('width') - width
+          );
+          expect(widthDifference).toBeLessThanOrEqual(1);
         }
       });
     };


### PR DESCRIPTION
## Type
- Bug fix

## Description
About once in a 1000 test runs, [this test](https://github.com/Ensembl/ensembl-client/blob/dev/src/ensembl/src/content/app/browser/chromosome-navigator/ChromosomeNavigator.test.tsx#L177-L203) of ChromosomeNavigator would fail because of a rounding error when comparing width of an svg element with the expected width.

[Example of a failed test](https://gitlab.ebi.ac.uk/ensembl-web/ensembl-client/-/jobs/212504) (expected a width of 94 pixels, got 93 pixels because of a different result of rounding:

![image](https://user-images.githubusercontent.com/6834224/84792317-9dedbc80-afeb-11ea-977d-7c28d8903ed4.png)

I've changed the check to account for possible differences within 1 pixel to account for possible different rounding results. 