### PR TITLE
Protein sequence download

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.scss
@@ -7,7 +7,7 @@
   }
 }
 
-.proteinSummaryTopWrapper {
+.proteinSummaryTop {
   display: grid;
   grid-template-columns: 300px 395px;
 }

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.scss
@@ -1,15 +1,19 @@
-.bottomWrapper {
-  display: grid;
+.proteinSummary {
   margin-left: 178px;
   width: 695px;
 
   > div {
-    margin: 10px 0 10px 0;
+    padding: 10px 0 10px 0;
   }
 }
 
-.codingExonCount {
-  grid-column: 1/2;
+.proteinSummaryTopWrapper {
+  display: grid;
+  grid-template-columns: 300px 395px;
+}
+
+.downloadWrapper {
+  text-align: right;
 }
 
 .geneExternalReference {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.scss
@@ -8,12 +8,15 @@
 }
 
 .proteinSummaryTop {
+  align-items: center;
   display: grid;
-  grid-template-columns: 300px 395px;
+  grid-template-columns: [references] 300px [download] 395px;
 }
 
 .downloadWrapper {
-  text-align: right;
+  display: flex;
+  justify-content: flex-end;
+  grid-column: download;
 }
 
 .geneExternalReference {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
@@ -20,6 +20,7 @@ import ProteinDomainImage from 'src/content/app/entity-viewer/gene-view/componen
 import ProteinImage from 'src/content/app/entity-viewer/gene-view/components/protein-image/ProteinImage';
 import ProteinFeaturesCount from 'src/content/app/entity-viewer/gene-view/components/protein-features-count/ProteinFeaturesCount';
 import ExternalReference from 'src/shared/components/external-reference/ExternalReference';
+import InstantDownloadProtein from 'src/shared/components/instant-download/instant-download-protein/InstantDownloadProtein';
 
 import {
   ExternalSource,
@@ -77,35 +78,35 @@ const ProteinsListItemInfo = (props: Props) => {
             trackLength={trackLength}
             width={695}
           />
-        </>
-      )}
-      {proteinSummary && (
-        <div className={styles.bottomWrapper}>
-          <div>
-            <ProteinExternalReference
-              source={ExternalSource.INTERPRO}
-              externalId={proteinSummary.pdbeId}
-            />
-            <ProteinExternalReference
-              source={ExternalSource.UNIPROT}
-              externalId={proteinSummary.pdbeId}
-            />
-            Download component
-          </div>
-          <div>
-            <ProteinExternalReference
-              source={ExternalSource.PDBE}
-              externalId={proteinSummary.pdbeId}
-            />
-            {proteinSummary?.proteinStats && (
-              <div className={styles.proteinFeaturesCountWrapper}>
-                <ProteinFeaturesCount
-                  proteinStats={proteinSummary.proteinStats}
+          {proteinSummary && (
+            <div className={styles.bottomWrapper}>
+              <div>
+                <ProteinExternalReference
+                  source={ExternalSource.INTERPRO}
+                  externalId={proteinSummary.pdbeId}
                 />
+                <ProteinExternalReference
+                  source={ExternalSource.UNIPROT}
+                  externalId={proteinSummary.pdbeId}
+                />
+                <InstantDownloadProtein transcriptId={transcript.id} />
               </div>
-            )}
-          </div>
-        </div>
+              <div>
+                <ProteinExternalReference
+                  source={ExternalSource.PDBE}
+                  externalId={proteinSummary.pdbeId}
+                />
+                {proteinSummary?.proteinStats && (
+                  <div className={styles.proteinFeaturesCountWrapper}>
+                    <ProteinFeaturesCount
+                      proteinStats={proteinSummary.proteinStats}
+                    />
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
@@ -78,9 +78,9 @@ const ProteinsListItemInfo = (props: Props) => {
             trackLength={trackLength}
             width={695}
           />
-          {proteinSummary && (
-            <div className={styles.proteinSummary}>
-              <div className={styles.proteinSummaryTopWrapper}>
+          <div className={styles.proteinSummary}>
+            <div className={styles.proteinSummaryTop}>
+              {proteinSummary && (
                 <div className={styles.interproUniprotWrapper}>
                   <ProteinExternalReference
                     source={ExternalSource.INTERPRO}
@@ -91,10 +91,12 @@ const ProteinsListItemInfo = (props: Props) => {
                     externalId={proteinSummary.pdbeId}
                   />
                 </div>
-                <div className={styles.downloadWrapper}>
-                  <InstantDownloadProtein transcriptId={transcript.id} />
-                </div>
+              )}
+              <div className={styles.downloadWrapper}>
+                <InstantDownloadProtein transcriptId={transcript.id} />
               </div>
+            </div>
+            {proteinSummary && (
               <div>
                 <ProteinExternalReference
                   source={ExternalSource.PDBE}
@@ -108,8 +110,8 @@ const ProteinsListItemInfo = (props: Props) => {
                   </div>
                 )}
               </div>
-            </div>
-          )}
+            )}
+          </div>
         </>
       )}
     </div>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
@@ -79,17 +79,21 @@ const ProteinsListItemInfo = (props: Props) => {
             width={695}
           />
           {proteinSummary && (
-            <div className={styles.bottomWrapper}>
-              <div>
-                <ProteinExternalReference
-                  source={ExternalSource.INTERPRO}
-                  externalId={proteinSummary.pdbeId}
-                />
-                <ProteinExternalReference
-                  source={ExternalSource.UNIPROT}
-                  externalId={proteinSummary.pdbeId}
-                />
-                <InstantDownloadProtein transcriptId={transcript.id} />
+            <div className={styles.proteinSummary}>
+              <div className={styles.proteinSummaryTopWrapper}>
+                <div className={styles.interproUniprotWrapper}>
+                  <ProteinExternalReference
+                    source={ExternalSource.INTERPRO}
+                    externalId={proteinSummary.pdbeId}
+                  />
+                  <ProteinExternalReference
+                    source={ExternalSource.UNIPROT}
+                    externalId={proteinSummary.pdbeId}
+                  />
+                </div>
+                <div className={styles.downloadWrapper}>
+                  <InstantDownloadProtein transcriptId={transcript.id} />
+                </div>
               </div>
               <div>
                 <ProteinExternalReference

--- a/src/ensembl/src/shared/components/instant-download/instant-download-fetch/fetchForProtein.ts
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-fetch/fetchForProtein.ts
@@ -1,0 +1,63 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import downloadAsFile from 'src/shared/helpers/downloadAsFile';
+import {
+  ProteinOptions,
+  ProteinOption,
+  proteinOptionsOrder
+} from 'src/shared/components/instant-download/instant-download-protein/InstantDownloadProtein';
+
+type FetchPayload = {
+  proteinId: string;
+  options: ProteinOptions;
+};
+
+export const fetchForProtein = async (payload: FetchPayload) => {
+  const { proteinId, options } = payload;
+  const urls = buildUrlsForProtein(proteinId, options);
+
+  const sequencePromises = urls.map((url) =>
+    fetch(url).then((response) => response.text())
+  );
+
+  const sequences = await Promise.all(sequencePromises);
+  const combinedFasta = sequences.join(
+    '\n=====================================\n'
+  );
+
+  downloadAsFile(combinedFasta, `${proteinId}.fasta`, {
+    type: 'text/x-fasta'
+  });
+};
+
+const buildUrlsForProtein = (id: string, options: ProteinOptions) => {
+  return options
+    ? proteinOptionsOrder
+        .filter((option) => options[option])
+        .map((option) => buildFetchUrl(id, option))
+    : [];
+};
+
+const buildFetchUrl = (id: string, sequenceType: ProteinOption) => {
+  const sequenceTypeToTypeParam: Record<ProteinOption, string> = {
+    proteinSequence: 'protein',
+    cds: 'cds'
+  };
+  const typeParam = sequenceTypeToTypeParam[sequenceType];
+
+  return `https://rest.ensembl.org/sequence/id/${id}?content-type=text/x-fasta&type=${typeParam}`;
+};

--- a/src/ensembl/src/shared/components/instant-download/instant-download-fetch/fetchForProtein.ts
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-fetch/fetchForProtein.ts
@@ -22,24 +22,22 @@ import {
 } from 'src/shared/components/instant-download/instant-download-protein/InstantDownloadProtein';
 
 type FetchPayload = {
-  proteinId: string;
+  transcriptId: string;
   options: ProteinOptions;
 };
 
 export const fetchForProtein = async (payload: FetchPayload) => {
-  const { proteinId, options } = payload;
-  const urls = buildUrlsForProtein(proteinId, options);
+  const { transcriptId, options } = payload;
+  const urls = buildUrlsForProtein(transcriptId, options);
 
   const sequencePromises = urls.map((url) =>
     fetch(url).then((response) => response.text())
   );
 
   const sequences = await Promise.all(sequencePromises);
-  const combinedFasta = sequences.join(
-    '\n=====================================\n'
-  );
+  const combinedFasta = sequences.join('\n');
 
-  downloadAsFile(combinedFasta, `${proteinId}.fasta`, {
+  downloadAsFile(combinedFasta, `${transcriptId}.fasta`, {
     type: 'text/x-fasta'
   });
 };

--- a/src/ensembl/src/shared/components/instant-download/instant-download-protein/InstantDownloadProtein.scss
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-protein/InstantDownloadProtein.scss
@@ -1,0 +1,7 @@
+.checkboxLabel {
+  font-size: 13px;
+}
+
+.downloadButtonDisabled {
+  color: $dark-grey;
+}

--- a/src/ensembl/src/shared/components/instant-download/instant-download-protein/InstantDownloadProtein.scss
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-protein/InstantDownloadProtein.scss
@@ -1,7 +1,13 @@
 @import 'src/styles/common';
 
+.inputGroup {
+  display: inline-block;
+}
+
 .checkboxLabel {
   font-size: 13px;
+  margin-right: 20px;
+  max-width: inherit;
 }
 
 .downloadButtonDisabled {

--- a/src/ensembl/src/shared/components/instant-download/instant-download-protein/InstantDownloadProtein.scss
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-protein/InstantDownloadProtein.scss
@@ -1,3 +1,5 @@
+@import 'src/styles/common';
+
 .checkboxLabel {
   font-size: 13px;
 }

--- a/src/ensembl/src/shared/components/instant-download/instant-download-protein/InstantDownloadProtein.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-protein/InstantDownloadProtein.tsx
@@ -63,17 +63,19 @@ const InstantDownloadProtein = (props: InstantDownloadProteinProps) => {
   const isDownloadDisabled = () => !isProteinSeqSelected && !isCdsSeqSelected;
 
   return (
-    <div className={styles.container}>
+    <div>
       <div className={styles.inputGroup}>
         <Checkbox
           label={proteinOptionLabels.proteinSequence}
+          labelClassName={styles.checkboxLabel}
           checked={isProteinSeqSelected}
           onChange={onProteinCheckboxChange}
         />
       </div>
       <div className={styles.inputGroup}>
         <Checkbox
-          label="CDS"
+          label={proteinOptionLabels.cds}
+          labelClassName={styles.checkboxLabel}
           checked={isCdsSeqSelected}
           onChange={onCdsCheckboxChange}
         />

--- a/src/ensembl/src/shared/components/instant-download/instant-download-protein/InstantDownloadProtein.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-protein/InstantDownloadProtein.tsx
@@ -1,0 +1,96 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from 'react';
+
+import Checkbox from 'src/shared/components/checkbox/Checkbox';
+import InstantDownloadButton from 'src/shared/components/instant-download/instant-download-button/InstantDownloadButton';
+
+import { fetchForProtein } from '../instant-download-fetch/fetchForProtein';
+
+import { TranscriptOptions } from '../instant-download-transcript/InstantDownloadTranscript';
+
+import styles from './InstantDownloadProtein.scss';
+
+type InstantDownloadProteinProps = {
+  transcriptId: string;
+  proteinId: string;
+};
+
+export type ProteinOptions = Pick<TranscriptOptions, 'proteinSequence' | 'cds'>;
+
+export type ProteinOption = keyof Partial<ProteinOptions>;
+
+export const proteinOptionsOrder: ProteinOption[] = ['proteinSequence', 'cds'];
+
+const proteinOptionLabels: Record<keyof ProteinOptions, string> = {
+  proteinSequence: 'Protein sequence',
+  cds: 'CDS'
+};
+
+const InstantDownloadProtein = (props: InstantDownloadProteinProps) => {
+  const [isProteinSeqSelected, setProteinSeqSelected] = useState(false);
+  const [isCdsSeqSelected, setCdsSeqSelected] = useState(false);
+
+  const onProteinCheckboxChange = () =>
+    setProteinSeqSelected(!isProteinSeqSelected);
+  const onCdsCheckboxChange = () => setCdsSeqSelected(!isCdsSeqSelected);
+
+  const onSubmit = () => {
+    const payload = {
+      transcriptId: props.transcriptId,
+      proteinId: props.proteinId,
+      options: {
+        proteinSequence: isProteinSeqSelected,
+        cds: isCdsSeqSelected
+      }
+    };
+
+    fetchForProtein(payload);
+  };
+
+  const isDownloadDisabled = () => !isProteinSeqSelected && !isCdsSeqSelected;
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.inputGroup}>
+        <Checkbox
+          label={proteinOptionLabels.proteinSequence}
+          checked={isProteinSeqSelected}
+          onChange={onProteinCheckboxChange}
+        />
+      </div>
+      <div className={styles.inputGroup}>
+        <Checkbox
+          label="CDS"
+          checked={isCdsSeqSelected}
+          onChange={onCdsCheckboxChange}
+        />
+      </div>
+      <div className={styles.inputGroup}>
+        <InstantDownloadButton
+          className={
+            isDownloadDisabled() ? styles.downloadButtonDisabled : undefined
+          }
+          isDisabled={isDownloadDisabled()}
+          onClick={onSubmit}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default InstantDownloadProtein;

--- a/src/ensembl/src/shared/components/instant-download/instant-download-protein/InstantDownloadProtein.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-protein/InstantDownloadProtein.tsx
@@ -27,7 +27,6 @@ import styles from './InstantDownloadProtein.scss';
 
 type InstantDownloadProteinProps = {
   transcriptId: string;
-  proteinId: string;
 };
 
 export type ProteinOptions = Pick<TranscriptOptions, 'proteinSequence' | 'cds'>;
@@ -52,7 +51,6 @@ const InstantDownloadProtein = (props: InstantDownloadProteinProps) => {
   const onSubmit = () => {
     const payload = {
       transcriptId: props.transcriptId,
-      proteinId: props.proteinId,
       options: {
         proteinSequence: isProteinSeqSelected,
         cds: isCdsSeqSelected


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [x] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
[ENSWBSITES-650](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-650)

## Description
This PR adds the protein sequence download to the protein list item. It duplicates most of the code of the `InstantDownloadTranscript`.

## Views affected
Entity viewer -> gene view -> protein view
