### PR TITLE
Integrate toygraphql - Update URLs

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
@@ -58,7 +58,7 @@ export type EntityViewerParams = {
 };
 
 const client = new ApolloClient({
-  uri: 'http://hx-rke-wp-webadmin-14-worker-1.caas.ebi.ac.uk:31770'
+  uri: '/toygraphql'
 });
 
 const EntityViewer = (props: Props) => {

--- a/src/ensembl/webpack/environments/webpack.config.dev.js
+++ b/src/ensembl/webpack/environments/webpack.config.dev.js
@@ -45,6 +45,11 @@ const devServerConfig = {
       target: 'https://staging-2020.ensembl.org',
       changeOrigin: true,
       secure: false
+    },
+    '/toygraphql': {
+      target: 'https://staging-2020.ensembl.org',
+      changeOrigin: true,
+      secure: false
     }
   },
 


### PR DESCRIPTION
## Requirements

EntityViewer does not work on internal-2020.ensembl.org if accessed through https

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature
- [x] BE service Integration

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-691

## Importance

## Description
Toy-GraphQL URL http://hx-rke-wp-webadmin-14-worker-1.caas.ebi.ac.uk:31770 is the internal URL of WP-k8s cluster this can be access over HTTP only. This causes problem with EntityViewer on  internal-2020.ensembl.org over https.
Toy GraphQL URLs
https://internal-2020.ensembl.org/toygraphql
https://staging-2020.ensembl.org/toygraphql

## Views affected
EntityViewer

### Other effects
None

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
None