### PR TITLE
Proposal for url/redux sync

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.tsx
@@ -32,6 +32,7 @@ import ProteinsList from '../proteins-list/ProteinsList';
 import { RootState } from 'src/store';
 import { Gene } from 'src/content/app/entity-viewer/types/gene';
 import {
+  reduxViewToQueryParam,
   GeneViewTabMap,
   GeneViewTabName,
   GeneFunctionTabName
@@ -79,7 +80,7 @@ const GeneFunction = (props: Props) => {
     const url = urlFor.entityViewer({
       genomeId,
       entityId,
-      view
+      view: reduxViewToQueryParam(view)
     });
     props.push(url);
   };

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-relationships/GeneRelationships.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-relationships/GeneRelationships.tsx
@@ -29,6 +29,7 @@ import Panel from 'src/shared/components/panel/Panel';
 
 import { RootState } from 'src/store';
 import {
+  reduxViewToQueryParam,
   GeneViewTabMap,
   GeneViewTabName,
   GeneRelationshipsTabName
@@ -70,7 +71,7 @@ const GeneRelationships = (props: Props) => {
     const url = urlFor.entityViewer({
       genomeId,
       entityId,
-      view
+      view: reduxViewToQueryParam(view)
     });
     props.push(url);
   };

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-tabs/GeneViewTabs.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-tabs/GeneViewTabs.tsx
@@ -29,6 +29,7 @@ import Tabs, { Tab } from 'src/shared/components/tabs/Tabs';
 
 import { RootState } from 'src/store';
 import {
+  reduxViewToQueryParam,
   GeneViewTabName,
   View,
   SelectedTabViews
@@ -66,10 +67,11 @@ const GeneViewTabs = (props: Props) => {
     } else if (selectedTabName === GeneViewTabName.GENE_RELATIONSHIPS) {
       view = props.selectedTabViews.geneRelationshipsTab || View.ORTHOLOGUES;
     }
+
     const url = urlFor.entityViewer({
       genomeId,
       entityId,
-      view
+      view: reduxViewToQueryParam(view)
     });
     props.push(url);
   };

--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/entityViewerGeneViewState.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/entityViewerGeneViewState.ts
@@ -156,6 +156,12 @@ export const defaultEntityViewerGeneViewUIState: EntityViewerGeneViewUIState = {
   }
 };
 
+export const queryParamToReduxView = (viewFromUrl: string | null): string =>
+  viewFromUrl ? viewFromUrl : 'transcripts';
+
+export const reduxViewToQueryParam = (view: View): string | null =>
+  view === View.TRANSCRIPTS ? null : view;
+
 export const defaultEntityViewerGeneViewState: EntityViewerGeneViewState = {};
 
 // TODO: This will be loaded from storage services once it is setup

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralActions.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralActions.ts
@@ -75,12 +75,6 @@ export const setDataFromUrl: ActionCreator<ThunkAction<
     dispatch(setActiveGenomeId(genomeIdFromUrl));
     dispatch(fetchGenomeData(genomeIdFromUrl));
     // TODO: when backend is ready, entity info may also need fetching
-  } else if (activeGenomeId && entityIdForUrl) {
-    const newUrl = urlHelper.entityViewer({
-      genomeId: activeGenomeId,
-      entityId: entityIdForUrl
-    });
-    dispatch(replace(newUrl));
   } else if (activeGenomeId) {
     // TODO: when backend is ready, fetch entity info
     const genomeInfo = getGenomeInfoById(state, activeGenomeId);


### PR DESCRIPTION
Proposal for PR https://github.com/Ensembl/ensembl-client/pull/315 that should allow both not having the `view` query parameter in the url by default and keeping the view in the redux state.