### PR TITLE
Fix protein list sorting

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/ProteinsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/ProteinsList.tsx
@@ -19,11 +19,12 @@ import React, { useEffect, useState } from 'react';
 import ProteinsListItem from './proteins-list-item/ProteinsListItem';
 
 import { fetchGene } from 'src/content/app/entity-viewer/shared/rest/rest-data-fetchers/geneData';
+import { getLongestProteinLength } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
+import { defaultSort } from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
 
 import { Gene } from 'src/content/app/entity-viewer/types/gene';
 
 import styles from './ProteinsList.scss';
-import { getLongestProteinLength } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
 
 type ProteinsListProps = {
   geneId: string;
@@ -54,7 +55,8 @@ const ProteinsList = (props: ProteinsListProps) => {
 };
 
 const ProteinsListWithData = (props: ProteinsListWithDataProps) => {
-  const proteinCodingTranscripts = props.gene.transcripts.filter(
+  const sortedTranscripts = defaultSort(props.gene.transcripts);
+  const proteinCodingTranscripts = sortedTranscripts.filter(
     (transcript) => !!transcript.cds
   );
 

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/entity-helpers.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/entity-helpers.ts
@@ -36,6 +36,9 @@ export const getRegionName = (feature: { slice: Slice }) =>
 export const getFeatureStrand = (feature: { slice: Slice }) =>
   feature.slice.region.strand.code;
 
+export const getBiotype = (feature: Gene | Transcript) =>
+  feature.so_term || feature.biotype;
+
 // FIXME: remove this when we can get the length from the API
 export const getFeatureLength = (feature: { slice: Slice }) => {
   const { start, end } = getFeatureCoordinates(feature);

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/transcripts-sorter.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/transcripts-sorter.ts
@@ -16,9 +16,9 @@
 
 import sortBy from 'lodash/sortBy';
 
-import { getFeatureLength } from './entity-helpers';
+import { getFeatureLength, getBiotype } from './entity-helpers';
 
-import { Transcript } from '../../types/transcript';
+import { Transcript } from 'src/content/app/entity-viewer/types/transcript';
 
 function compareTranscriptLengths(
   transcriptOne: Transcript,
@@ -40,11 +40,13 @@ function compareTranscriptLengths(
 
 export function defaultSort(transcripts: Transcript[]) {
   const proteinCodingTranscripts = transcripts
-    .filter((transcript) => transcript.biotype === 'protein_coding')
+    .filter((transcript) => getBiotype(transcript) === 'protein_coding')
     .sort(compareTranscriptLengths);
 
   const nonProteinCodingTranscripts = sortBy(
-    transcripts.filter((transcript) => transcript.biotype !== 'protein_coding'),
+    transcripts.filter(
+      (transcript) => getBiotype(transcript) !== 'protein_coding'
+    ),
     ['biotype']
   );
 

--- a/src/ensembl/src/content/app/entity-viewer/types/gene.ts
+++ b/src/ensembl/src/content/app/entity-viewer/types/gene.ts
@@ -27,6 +27,7 @@ export type Gene = {
   symbol: string;
   source?: Source;
   so_term: string; // is there a better name for it?
+  biotype?: string; // either this or so_term above need to be removed in the future
   slice: Slice;
   transcripts: Transcript[];
   synonyms?: string[];


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
[ENSWBSITES-692](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-692)

## Description
This PR fixes the protein list order in the protein view by reusing the `defaultSort` function written to sort the transcripts list.

## Deployment URL
<!--
If applicable, follow instructions here: https://www.ebi.ac.uk/seqdb/confluence/display/ENSWEB/Review+Apps+for+feature+branches on how to deploy.
-->

## Views affected
Entity viewer -> protein view
