### PR TITLE
Fix the view param

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -176,8 +176,8 @@ const useGeneViewRouting = () => {
   const { objectId: geneId } = parseFocusIdFromUrl(entityId);
   const { search } = useLocation();
   // TODO: discuss – is using URLSearchParams better than using the querystring package?
-  const view = new URLSearchParams(search).get('view') || 'transcripts';
-  const viewInRedux = useSelector(getGeneViewName);
+  const view = new URLSearchParams(search).get('view');
+  const viewInRedux = useSelector(getGeneViewName) || 'transcripts';
   const previousGenomeId = usePrevious(genomeId); // genomeId during previous render
   const selectedTabs = useSelector(getSelectedGeneViewTabs);
 


### PR DESCRIPTION
This PR is to fix a small bug that was introduced in the following PR:
https://github.com/Ensembl/ensembl-client/pull/315

The view was always getting set as transcripts as the default value was defined in the wrong place.

