### PR TITLE
Remove counter from genome browser messages

### DIFF
--- a/src/ensembl/src/content/app/browser/browser-image/BrowserImage.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-image/BrowserImage.test.tsx
@@ -55,7 +55,6 @@ describe('<BrowserImage />', () => {
     updateBrowserActiveEnsObject: jest.fn(),
     setChrLocation: jest.fn(),
     setActualChrLocation: jest.fn(),
-    updateMessageCounter: jest.fn(),
     updateDefaultPositionFlag: jest.fn(),
     changeHighlightedTrackId: jest.fn()
   };

--- a/src/ensembl/src/content/app/browser/browser-image/BrowserImage.tsx
+++ b/src/ensembl/src/content/app/browser/browser-image/BrowserImage.tsx
@@ -40,7 +40,6 @@ import {
   updateBrowserNavStates,
   setChrLocation,
   setActualChrLocation,
-  updateMessageCounter,
   updateBrowserActiveEnsObjectIdsAndSave,
   updateDefaultPositionFlag
 } from '../browserActions';
@@ -64,7 +63,6 @@ export type BrowserImageProps = {
   updateBrowserActiveEnsObject: (objectId: string) => void;
   setChrLocation: (chrLocation: ChrLocation) => void;
   setActualChrLocation: (chrLocation: ChrLocation) => void;
-  updateMessageCounter: (count: number) => void;
   updateDefaultPositionFlag: (isDefaultPosition: boolean) => void;
   changeHighlightedTrackId: (trackId: string) => void;
 };
@@ -92,7 +90,6 @@ export const BrowserImage = (props: BrowserImageProps) => {
     const navIconStates = payload.bumper as BrowserNavStates;
     const intendedLocation = payload['intended-location'];
     const actualLocation = payload['actual-location'] || intendedLocation;
-    const messageCount = payload['message-counter'];
     const isFocusObjectInDefaultPosition = payload['is-focus-position'];
 
     if (navIconStates) {
@@ -110,10 +107,6 @@ export const BrowserImage = (props: BrowserImageProps) => {
     if (ensObjectId) {
       const parsedId = parseFeatureId(ensObjectId);
       props.updateBrowserActiveEnsObject(buildEnsObjectId(parsedId));
-    }
-
-    if (messageCount) {
-      props.updateMessageCounter(messageCount);
     }
 
     if (typeof isFocusObjectInDefaultPosition === 'boolean') {
@@ -179,7 +172,6 @@ const mapDispatchToProps = {
   updateBrowserActiveEnsObject: updateBrowserActiveEnsObjectIdsAndSave,
   setChrLocation,
   setActualChrLocation,
-  updateMessageCounter,
   updateDefaultPositionFlag,
   changeHighlightedTrackId
 };

--- a/src/ensembl/src/content/app/browser/browserActions.ts
+++ b/src/ensembl/src/content/app/browser/browserActions.ts
@@ -36,7 +36,6 @@ import {
   getBrowserActiveEnsObjectId,
   getBrowserTrackStates,
   getChrLocation,
-  getBrowserMessageCount,
   getBrowserActiveEnsObjectIds,
   getBrowserNavOpened
 } from './browserSelectors';
@@ -312,10 +311,6 @@ export const setChrLocation: ActionCreator<ThunkAction<
   };
 };
 
-export const updateMessageCounter = createAction(
-  'browser/update-message-counter'
-)<number>();
-
 export const changeBrowserLocation: ActionCreator<ThunkAction<
   any,
   any,
@@ -333,7 +328,6 @@ export const changeBrowserLocation: ActionCreator<ThunkAction<
     const activeEnsObjectId =
       locationData.ensObjectId || getBrowserActiveEnsObjectId(state);
 
-    const messageCount = getBrowserMessageCount(state);
     const focusInstruction: { focus?: string } = {};
     if (activeEnsObjectId) {
       focusInstruction.focus = activeEnsObjectId;
@@ -342,7 +336,6 @@ export const changeBrowserLocation: ActionCreator<ThunkAction<
     browserMessagingService.send('bpane', {
       stick: `${locationData.genomeId}:${chrCode}`,
       goto: `${startBp}-${endBp}`,
-      'message-counter': messageCount,
       ...focusInstruction
     });
   };
@@ -355,7 +348,6 @@ export const changeFocusObject = (
   getState: () => RootState
 ) => {
   const state = getState();
-  const messageCount = getBrowserMessageCount(state);
   const activeGenomeId = getBrowserActiveGenomeId(state);
 
   if (!activeGenomeId) {
@@ -365,8 +357,7 @@ export const changeFocusObject = (
   dispatch(updatePreviouslyViewedObjectsAndSave());
 
   browserMessagingService.send('bpane', {
-    focus: objectId,
-    'message-counter': messageCount
+    focus: objectId
   });
 };
 

--- a/src/ensembl/src/content/app/browser/browserReducer.ts
+++ b/src/ensembl/src/content/app/browser/browserReducer.ts
@@ -73,8 +73,6 @@ export function browserEntity(
         ...state,
         trackStates: merge({}, state.trackStates, action.payload)
       };
-    case getType(browserActions.updateMessageCounter):
-      return { ...state, messageCounter: action.payload };
     default:
       return state;
   }

--- a/src/ensembl/src/content/app/browser/browserSelectors.ts
+++ b/src/ensembl/src/content/app/browser/browserSelectors.ts
@@ -104,9 +104,6 @@ export const getRegionEditorActive = (state: RootState) =>
 export const getRegionFieldActive = (state: RootState) =>
   state.browser.browserLocation.regionFieldActive;
 
-export const getBrowserMessageCount = (state: RootState) =>
-  state.browser.browserEntity.messageCounter;
-
 export const getBrowserCogList = (state: RootState) =>
   state.browser.trackConfig.browserCogList;
 

--- a/src/ensembl/src/content/app/browser/browserState.ts
+++ b/src/ensembl/src/content/app/browser/browserState.ts
@@ -53,14 +53,12 @@ export type BrowserEntityState = Readonly<{
   activeGenomeId: string | null;
   activeEnsObjectIds: { [genomeId: string]: string };
   trackStates: BrowserTrackStates;
-  messageCounter: number;
 }>;
 
 export const defaultBrowserEntityState: BrowserEntityState = {
   activeGenomeId,
   activeEnsObjectIds,
-  trackStates,
-  messageCounter: -1
+  trackStates
 };
 
 export type BrowserNavState = Readonly<{

--- a/src/ensembl/src/content/app/browser/hooks/useBrowserRouting.ts
+++ b/src/ensembl/src/content/app/browser/hooks/useBrowserRouting.ts
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import { useEffect, useCallback } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
 import { replace } from 'connected-react-router';
 import { useSelector, useDispatch } from 'react-redux';
+import isEqual from 'lodash/isEqual';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import { getQueryParamsMap } from 'src/global/globalHelper';
@@ -57,6 +58,7 @@ import {
  */
 
 const useBrowserRouting = () => {
+  const firstRenderRef = useRef(true);
   const params: { [key: string]: string } = useParams();
   const { search } = useLocation(); // from document.location provided by the router
   const dispatch = useDispatch();
@@ -105,22 +107,21 @@ const useBrowserRouting = () => {
        for the focus object that is viewed first.
        */
       dispatch(changeFocusObject(newFocusId as string));
-    } else if (focus && chrLocation) {
-      dispatch(
-        changeBrowserLocation({
-          genomeId,
-          ensObjectId: newFocusId,
-          chrLocation
-        })
-      );
     } else if (chrLocation) {
-      dispatch(
-        changeBrowserLocation({
-          genomeId,
-          ensObjectId: newFocusId,
-          chrLocation
-        })
-      );
+      const isSameLocationAsInRedux =
+        activeGenomeId && isEqual(chrLocation, allChrLocations[activeGenomeId]);
+      const isFirstRender = firstRenderRef.current;
+
+      if (!isSameLocationAsInRedux || isFirstRender) {
+        dispatch(
+          changeBrowserLocation({
+            genomeId,
+            ensObjectId: newFocusId,
+            chrLocation
+          })
+        );
+      }
+      firstRenderRef.current = false;
     }
 
     dispatch(setDataFromUrlAndSave(payload));


### PR DESCRIPTION
## Type
- refactoring

## Description

### 1. Removing message counter

A while back, we added a counter to the messages that React chrome was exchanging with the genome browser (see https://github.com/Ensembl/ensembl-client/pull/108).

The purpose of the message counter was to solve a nasty bug that originated from both genome browser reporting to React its current location, and React reporting back to genome browser the location it read from the url. These streams of messages going in the opposite directions tended to get out of sync during vigorous dragging/zooming of the canvas area, and the app would end up in an infinite loop, when genome browser sends a message about its current location while it's still travelling to a different one, and React send this same location back to genome browser while it has already moved to another location.

It seems that separating the browser location payload into `intendedLocation` and `actualLocation`, when only the `intendedLocation` is used by React to update the url has already taken care of this problem; so we are taking this opportunity to remove messageCounter from React, because of the complexity it is introducing into the React-based code. 

### 2. Avoid unnecessary messages to genome browser

Even with just removal of the message counter in part 1 above, genome browser does not get into an infinite loop; but we can also avoid sending messages to change browser location if the location is already current. By doing so, we will also prevent the accidental genome browser behaviour when changing the location causes it to reset the vertical scroll (see https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-730).

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-710

## Deployment URL
http://remove-message-counter.review.ensembl.org/

## Views affected
Genome browser