### PR TITLE
Remove default text from transcript left column

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -80,7 +80,7 @@ const DefaultTranscriptslist = (props: Props) => {
           return (
             <DefaultTranscriptsListItem
               key={index}
-              label={index === 0 ? 'Default' : ''}
+              label={index === 0 ? 'Selected' : ''}
               gene={gene}
               transcript={transcript}
               rulerTicks={props.rulerTicks}

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -80,6 +80,7 @@ const DefaultTranscriptslist = (props: Props) => {
           return (
             <DefaultTranscriptsListItem
               key={index}
+              label={index === 0 ? 'Default' : ''}
               gene={gene}
               transcript={transcript}
               rulerTicks={props.rulerTicks}

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -80,7 +80,7 @@ const DefaultTranscriptslist = (props: Props) => {
           return (
             <DefaultTranscriptsListItem
               key={index}
-              label={index === 0 ? 'Selected' : ''}
+              isDefault={index === 0}
               gene={gene}
               transcript={transcript}
               rulerTicks={props.rulerTicks}

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.scss
@@ -18,7 +18,3 @@
   justify-content: flex-end;
   align-items: baseline;
 }
-
-.helpText {
-  max-width: 300px;
-}

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.scss
@@ -12,3 +12,13 @@
   color: $blue;
   cursor: pointer;
 }
+
+.defaultTranscriptLabel {
+  display: flex;
+  justify-content: flex-end;
+  align-items: baseline;
+}
+
+.helpText {
+  max-width: 300px;
+}

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.test.tsx
@@ -87,6 +87,6 @@ describe('<DefaultTranscriptListItem />', () => {
 
   it('displays selected transcript', () => {
     wrapper = renderComponent({ isDefault: true });
-    expect(wrapper.find('.defaultTranscriptLabel')).toHaveLength(1);
+    expect(wrapper.find('.defaultTranscriptLabel').text()).toBe('Selected');
   });
 });

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.test.tsx
@@ -84,4 +84,9 @@ describe('<DefaultTranscriptListItem />', () => {
 
     expect(wrapper.exists(TranscriptsListItemInfo)).toBe(true);
   });
+
+  it('displays selected transcript', () => {
+    wrapper = renderComponent({ isDefault: true });
+    expect(wrapper.find('.defaultTranscriptLabel')).toHaveLength(1);
+  });
 });

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
@@ -68,25 +68,19 @@ export const DefaultTranscriptListItem = (
   };
 
   const defaultTranscriptLabelMap = {
-    select: {
+    selected: {
       label: 'Selected',
-      helpText:
-        'The selected transcript is a default single transcript per protein coding gene that is representative of biology, well-supported, expressed and highly conserved'
-    },
-    plus: {
-      label: 'MANE Plus',
       helpText:
         'The selected transcript is a default single transcript per protein coding gene that is representative of biology, well-supported, expressed and highly conserved'
     }
   };
 
-  const isCanonical = props.isDefault || false;
-  const canonicalType = 'select'; // TODO Change this to transcript.mane/plus etc when available
+  const canonicalType = 'selected'; // TODO Change this to transcript.mane/plus etc when available
 
   return (
     <div className={styles.defaultTranscriptListItem}>
       <div className={transcriptsListStyles.row}>
-        {isCanonical && (
+        {props.isDefault && (
           <div className={styles.defaultTranscriptLabel}>
             {defaultTranscriptLabelMap[canonicalType]?.label}
             <QuestionButton

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
@@ -27,13 +27,22 @@ import { toggleTranscriptInfo } from 'src/content/app/entity-viewer/state/gene-v
 import { Gene } from 'src/content/app/entity-viewer/types/gene';
 import { Transcript } from 'src/content/app/entity-viewer/types/transcript';
 import { TicksAndScale } from 'src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/BasePairsRuler';
+import QuestionButton, {
+  QuestionButtonOption
+} from 'src/shared/components/question-button/QuestionButton';
 
 import transcriptsListStyles from '../DefaultTranscriptsList.scss';
 import styles from './DefaultTranscriptListItem.scss';
 
+type defaultTranscriptLabelType = {
+  label: string;
+  helpText: string;
+};
+
 export type DefaultTranscriptListItemProps = {
   gene: Gene;
-  label: string;
+  isDefault?: boolean;
+  defaultTranscriptLabel?: defaultTranscriptLabelType;
   transcript: Transcript;
   rulerTicks: TicksAndScale;
   expandTranscript: boolean;
@@ -58,10 +67,34 @@ export const DefaultTranscriptListItem = (
     cursor: 'pointer'
   };
 
+  const defaultTranscriptLabelMap = {
+    select: {
+      label: 'Selected',
+      helpText:
+        'The selected transcript is a default single transcript per protein coding gene that is representative of biology, well-supported, expressed and highly conserved'
+    },
+    plus: {
+      label: 'MANE Plus',
+      helpText:
+        'The selected transcript is a default single transcript per protein coding gene that is representative of biology, well-supported, expressed and highly conserved'
+    }
+  };
+
+  const isCanonical = props.isDefault || false;
+  const canonicalType = 'select'; // TODO Change this to transcript.mane/plus etc when available
+
   return (
     <div className={styles.defaultTranscriptListItem}>
       <div className={transcriptsListStyles.row}>
-        <div className={transcriptsListStyles.left}>{props.label}</div>
+        {isCanonical && (
+          <div className={styles.defaultTranscriptLabel}>
+            {defaultTranscriptLabelMap[canonicalType]?.label}
+            <QuestionButton
+              helpText={defaultTranscriptLabelMap[canonicalType]?.helpText}
+              styleOption={QuestionButtonOption.INLINE}
+            />
+          </div>
+        )}
         <div
           className={transcriptsListStyles.middle}
           onClick={() => props.toggleTranscriptInfo(props.transcript.id)}

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
@@ -33,6 +33,7 @@ import styles from './DefaultTranscriptListItem.scss';
 
 export type DefaultTranscriptListItemProps = {
   gene: Gene;
+  label: string;
   transcript: Transcript;
   rulerTicks: TicksAndScale;
   expandTranscript: boolean;
@@ -60,7 +61,7 @@ export const DefaultTranscriptListItem = (
   return (
     <div className={styles.defaultTranscriptListItem}>
       <div className={transcriptsListStyles.row}>
-        <div className={transcriptsListStyles.left}>Left</div>
+        <div className={transcriptsListStyles.left}>{props.label}</div>
         <div
           className={transcriptsListStyles.middle}
           onClick={() => props.toggleTranscriptInfo(props.transcript.id)}

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -129,7 +129,7 @@ export const TranscriptsListItemInfo = (
   };
   return (
     <div className={mainStyles}>
-      <div className={transcriptsListStyles.left}>bottom left</div>
+      <div className={transcriptsListStyles.left}></div>
       <div className={midStyles}>
         <div className={styles.topLeft}>
           <div>

--- a/src/ensembl/src/shared/components/question-button/QuestionButton.tsx
+++ b/src/ensembl/src/shared/components/question-button/QuestionButton.tsx
@@ -63,7 +63,11 @@ const QuestionButton = (props: Props) => {
     >
       <QuestionIcon />
       {isHovering && (
-        <Tooltip anchor={elementRef.current} autoAdjust={true}>
+        <Tooltip
+          anchor={elementRef.current}
+          autoAdjust={true}
+          onClose={handleMouseLeave}
+        >
           {props.helpText}
         </Tooltip>
       )}

--- a/src/ensembl/src/shared/components/tooltip/Tooltip.scss
+++ b/src/ensembl/src/shared/components/tooltip/Tooltip.scss
@@ -10,6 +10,7 @@ $fill-color: $dark-grey;
   color: $white;
   border-radius: 4px;
   font-size: 14px;
+  max-width: 300px;
 }
 
 .tooltipTip {


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-693


## Description
Remove default text from the left column.
At the moment I am making the first one default. We may have to test/fix it once we have the sorting feature in place

http://remove-lhs-placeholder.review.ensembl.org/app/entity-viewer/homo_sapiens_GCA_000001405_28/gene:ENSG00000139618?view=transcripts

## Views affected
Transcript view


- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
N/A