### PR TITLE
Update typing of the browser messaging service

### DIFF
--- a/src/ensembl/src/content/app/browser/browser-cog/BrowserCogList.tsx
+++ b/src/ensembl/src/content/app/browser/browser-cog/BrowserCogList.tsx
@@ -21,7 +21,8 @@ import browserMessagingService from 'src/content/app/browser/services/browser-me
 import { toggleTracksMessage } from 'src/content/app/browser/services/browser-messaging-service/browser-message-creator';
 import {
   BrowserToChromeMessagingAction,
-  BrowserScrollPayload
+  CogScrollPayload,
+  CogTrackScrollPayload
 } from 'src/content/app/browser/services/browser-messaging-service/browser-incoming-message-types';
 
 import BrowserCog from './BrowserCog';
@@ -57,29 +58,29 @@ type BrowserCogListProps = {
 
 export const BrowserCogList = (props: BrowserCogListProps) => {
   const { browserCogTrackList } = props;
-  const listenBpaneScroll = (payload: BrowserScrollPayload) => {
-    if (
-      payload.action === BrowserToChromeMessagingAction.UPDATE_SCROLL_POSITION
-    ) {
-      props.updateCogList(payload.delta_y);
-    }
-    if (
-      payload.action === BrowserToChromeMessagingAction.UPDATE_TRACK_POSITION
-    ) {
-      props.updateCogTrackList(payload.track_y);
-    }
+
+  const updateCogsPosition = (payload: CogScrollPayload) => {
+    props.updateCogList(payload.delta_y);
+  };
+
+  const updateCogTracksPosition = (payload: CogTrackScrollPayload) => {
+    props.updateCogTrackList(payload.track_y);
   };
 
   useEffect(() => {
-    const subscription = browserMessagingService.subscribe(
-      [
+    const subscriptions = [
+      browserMessagingService.subscribe(
         BrowserToChromeMessagingAction.UPDATE_SCROLL_POSITION,
-        BrowserToChromeMessagingAction.UPDATE_TRACK_POSITION
-      ],
-      listenBpaneScroll
-    );
+        updateCogsPosition
+      ),
+      browserMessagingService.subscribe(
+        BrowserToChromeMessagingAction.UPDATE_TRACK_POSITION,
+        updateCogTracksPosition
+      )
+    ];
 
-    return () => subscription.unsubscribe();
+    return () =>
+      subscriptions.forEach((subscription) => subscription.unsubscribe());
   }, []);
 
   useEffect(() => {

--- a/src/ensembl/src/content/app/browser/browser-image/BrowserImage.tsx
+++ b/src/ensembl/src/content/app/browser/browser-image/BrowserImage.tsx
@@ -79,7 +79,7 @@ const parseLocation = (location: ChrLocation) => {
 export const BrowserImage = (props: BrowserImageProps) => {
   const browserRef = useRef<HTMLDivElement>(null);
   const listenBpaneOut = useCallback(
-    ({ payload }: BrowserLocationUpdateMessage) => {
+    (payload: BrowserLocationUpdateMessage['payload']) => {
       const navIconStates = payload.bumper as BrowserNavStates;
       const intendedLocation = payload['intended-location'];
       const actualLocation = payload['actual-location'] || intendedLocation;

--- a/src/ensembl/src/content/app/browser/services/browser-messaging-service/browser-incoming-message-types.ts
+++ b/src/ensembl/src/content/app/browser/services/browser-messaging-service/browser-incoming-message-types.ts
@@ -34,15 +34,18 @@ export enum BrowserToChromeMessagingAction {
   GENOME_BROWSER_READY = 'genome_browser_ready'
 }
 
-export type BrowserScrollPayload =
-  | {
-      delta_y: number;
-      action: BrowserToChromeMessagingAction.UPDATE_SCROLL_POSITION;
-    }
-  | {
-      action: BrowserToChromeMessagingAction.UPDATE_TRACK_POSITION;
-      track_y: CogList;
-    };
+export type GenomeBrowserReadyMessage = {
+  action: BrowserToChromeMessagingAction.GENOME_BROWSER_READY;
+  payload: never;
+};
+
+export type CogScrollPayload = {
+  delta_y: number;
+};
+
+export type CogTrackScrollPayload = {
+  track_y: CogList;
+};
 
 export type BrowserLocationUpdateMessage = {
   action: BrowserToChromeMessagingAction.UPDATE_LOCATION;
@@ -52,6 +55,16 @@ export type BrowserLocationUpdateMessage = {
     'actual-location'?: ChrLocation;
     'is-focus-position'?: boolean;
   };
+};
+
+export type UpdateCogPositionMessage = {
+  action: BrowserToChromeMessagingAction.UPDATE_SCROLL_POSITION;
+  payload: CogScrollPayload;
+};
+
+export type UpdateCogTrackPositionMessage = {
+  action: BrowserToChromeMessagingAction.UPDATE_TRACK_POSITION;
+  payload: CogTrackScrollPayload;
 };
 
 export type ZmenuCreateMessage = {
@@ -64,8 +77,8 @@ export type ZmenuCreateMessage = {
 };
 
 export type ZmenuDestroyMessage = {
-  payload: { id: string };
   action: BrowserToChromeMessagingAction.ZMENU_DESTROY;
+  payload: { id: string };
 };
 
 export type ZmenuRepositionMessage = {
@@ -79,11 +92,20 @@ export type ZmenuRepositionMessage = {
   };
 };
 
-export type ZmenuIncomingMessage =
+export type IncomingMessage =
+  | GenomeBrowserReadyMessage
+  | BrowserLocationUpdateMessage
+  | UpdateCogPositionMessage
+  | UpdateCogTrackPositionMessage
   | ZmenuCreateMessage
   | ZmenuDestroyMessage
   | ZmenuRepositionMessage;
 
-export type BrowserIncomingMessage =
-  | BrowserLocationUpdateMessage
-  | ZmenuIncomingMessage;
+export type IncomingMessageAction = IncomingMessage['action'];
+
+export type ActionPayloadMap = {
+  [A in IncomingMessageAction]: Extract<
+    IncomingMessage,
+    { action: A }
+  >['payload'];
+};


### PR DESCRIPTION
## Type
- Proposal
- Bug fixes

## Description
This PR types the callback to the `subscribe` function properly, and makes sure that the callback will receive the payload associated with the appropriate action from the possible action/payload combinations.

The proper typing of the `subscribe` function helped find bugs in several subscribers (e.g. they were expecting the `action` to be a part of payload).

**Note:** we'll have to be less ambitious with the subscription function, which won't be able to subscribe a listener to an array of actions, but only to a single action at once. Given the way we are using the subscription, this should not be a problem for us.

## Demo
See [typescript playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBAYg9nACgQxAGzsgJlAvFAbygDMEAuKAIlLkqgF8BuAKFEigCFkAnFdTHPiIAjHhUqjudJs1bho8OAFkIAZ1XIA5tCFRkAY2ABLOADsKAchoXGUMKgzYKivo5wy20LtxXqtOwj1DE3MoC0kbOwcBCm9XAQYWTyhfDW08WARU-ygAH04ebO1ZZKKIABV5DLKAbUoDYzNKAF0kqvjsJWQwDIJmKAGoGoBBKCNTFLU0ivlmigBRAA9gbgaAHjKAGkCGkIpR+gA+Ovt+bBaWehKqgGFkNDRRfQBrNdGIZYhTLFVJv21Kux8GVARBDhkABSnNwUDpYLpgEbNACUeHBADc4EYsCxmPozKpgFBVABXYSqfTcIzCCDcVSwnjGe5rABKEHx3CwGym-lB2wAyhBgGs7g8ns9DpLejJmMQSaZgmZiWSKVSaW8oB9gF8fn9pqDDhDdmZ9tt9PdHgZnhRRZaXm9Dqi+oMoPjTITiUKMqTyZTqbTVDVjaZmlAAPxhqCmCAAdygguAEORLBdqiFADpsFgIeaxVa9L9kKYQMmoAB6MtQcoACyMvzreig1attmEJKJyCg6NpICgAFtxnBuHpvmNTKY4PovkSzBB+oMfar-XSg4qQ96hZdZG6PdrCYpIdCYpkkNFsKjcOCd3A0BB0xhNFCz1h0zRk3iCUS98BvIfn7EeDhC8rwJG87wfJ8zhfSR32YRc-RpCErAQCxtm-RR33gtUICQiI0LUH8eEwlUEJw5C4FQqBv28UsK1dZBgH0as1Co5jNW4bghwAQjgkjsNwnhKPQhBaMrc1GOY35gDY2lOO4HigA) demonstrating a minimal working example of the `subscribe` function that is aware of the association between an action and the payload that is passed to the listener function.