### PR TITLE
Temporary fix for InstantDownloadTranscript in TranscriptListItemInfo

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -70,6 +70,7 @@ const QUERY = gql`
       transcripts {
         id
         symbol
+        so_term: biotype
         biotype
         slice {
           location {


### PR DESCRIPTION
## Type
- Bug fix

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-695

## Description
We are in a weird situation with all the uncertainty about so_terms and biotypes. Our [typescript type for transcript](https://github.com/Ensembl/ensembl-client/blob/dev/src/ensembl/src/content/app/entity-viewer/types/transcript.ts#L27-L28) currently assumes that the transcript will have both, but the GeneView component was only retrieving biotypes. InstantDownloadTranscript is currently expecting the transcript to have the `so_term` field. We know that this is incorrect and that in the future we should not rely on the so_term or biotype to decide whether a transcript has proteins; but for the time being this should suffice.

Currently, the transcripts requested from the graphql api in the GeneView component do not have the `so_term` field, which InstantDownloadTranscript is using to decide whether to show the protein checkboxes. In this PR, I am making sure that the transcripts will have this field.

## Deployment URL
<!--
If applicable, follow instructions here: https://www.ebi.ac.uk/seqdb/confluence/display/ENSWEB/Review+Apps+for+feature+branches on how to deploy.
-->

## Views affected
Entity viewer, gene view, default transcripts list.