### PR TITLE
Add generic species stats component

### DIFF
--- a/src/ensembl/src/content/app/species/components/species-stats/SpeciesStats.scss
+++ b/src/ensembl/src/content/app/species/components/species-stats/SpeciesStats.scss
@@ -8,7 +8,7 @@ $secondary-text-color: $dark-grey;
   vertical-align: top;
 }
 
-.title {
+.preLabel {
   color: $secondary-text-color;
   font-size: 11px;
 }
@@ -17,12 +17,6 @@ $secondary-text-color: $dark-grey;
   font-size: 12px;
   margin-top: -3px;
   font-weight: $bold;
-}
-
-.labelHint {
-  color: $secondary-text-color;
-  font-size: 11px;
-  padding-left: 3px;
 }
 
 .primaryValue {

--- a/src/ensembl/src/content/app/species/components/species-stats/SpeciesStats.scss
+++ b/src/ensembl/src/content/app/species/components/species-stats/SpeciesStats.scss
@@ -1,0 +1,51 @@
+@import 'src/styles/common';
+
+$secondary-text-color: $dark-grey;
+
+.wrapper {
+  width: 250px;
+  display: inline-block;
+  vertical-align: top;
+}
+
+.title {
+  color: $secondary-text-color;
+  font-size: 11px;
+}
+
+.label {
+  font-size: 12px;
+  margin-top: -3px;
+  font-weight: $bold;
+}
+
+.labelHint {
+  color: $secondary-text-color;
+  font-size: 11px;
+  padding-left: 3px;
+}
+
+.primaryValue {
+  font-size: 22px;
+  padding-left: 30px;
+}
+.primaryUnit {
+  color: $secondary-text-color;
+  font-size: 13px;
+  padding-left: 5px;
+}
+.secondaryValue {
+  font-size: 12px;
+  padding-left: 30px;
+}
+.secondaryUnit {
+  color: $secondary-text-color;
+  font-size: 11px;
+  padding-left: 3px;
+}
+.link {
+  text-align: center;
+  padding-left: 30px;
+  color: $secondary-text-color;
+  font-size: 11px;
+}

--- a/src/ensembl/src/content/app/species/components/species-stats/SpeciesStats.tsx
+++ b/src/ensembl/src/content/app/species/components/species-stats/SpeciesStats.tsx
@@ -19,20 +19,26 @@ import classNames from 'classnames';
 
 import defaultStyles from './SpeciesStats.scss';
 
-export type SpeciesStatsProps = {
-  title?: string;
-  label: string;
-  labelHint?: string;
+type PrimaryDataProps = {
   primaryValue: string;
   primaryUnit?: string;
-  secondaryValue?: string;
+};
+
+type PropsWithSecondaryData = {
+  secondaryValue: string;
   secondaryUnit?: string;
-  link?: React.ReactElement;
+};
+
+type PropsWithoutSecondaryData = {
+  secondaryValue?: never;
+  secondaryUnit?: never;
+};
+
+type ClassNamesProps = {
   classNames?: {
     wrapper?: string;
-    title?: string;
+    preLabel?: string;
     label?: string;
-    labelHint?: string;
     primaryValue?: string;
     primaryUnit?: string;
     secondaryValue?: string;
@@ -41,12 +47,19 @@ export type SpeciesStatsProps = {
   };
 };
 
+export type SpeciesStatsProps = PrimaryDataProps &
+  (PropsWithSecondaryData | PropsWithoutSecondaryData) &
+  ClassNamesProps & {
+    preLabel?: string;
+    label: string;
+    link?: React.ReactElement;
+  };
+
 const SpeciesStats = (props: SpeciesStatsProps) => {
   const styles = {
     wrapper: classNames(defaultStyles.wrapper, props.classNames?.wrapper),
-    title: classNames(defaultStyles.title, props.classNames?.title),
+    preLabel: classNames(defaultStyles.preLabel, props.classNames?.preLabel),
     label: classNames(defaultStyles.label, props.classNames?.label),
-    labelHint: classNames(defaultStyles.labelHint, props.classNames?.labelHint),
     primaryValue: classNames(
       defaultStyles.primaryValue,
       props.classNames?.primaryValue
@@ -68,14 +81,9 @@ const SpeciesStats = (props: SpeciesStatsProps) => {
 
   return (
     <div className={styles.wrapper}>
-      <span className={styles.title}>{props.title}</span>
+      <span className={styles.preLabel}>{props.preLabel}</span>
 
-      <div>
-        <span className={styles.label}>{props.label}</span>
-        {props.labelHint && (
-          <span className={styles.labelHint}>{props.labelHint}</span>
-        )}
-      </div>
+      <div className={styles.label}>{props.label}</div>
 
       <div>
         <span className={styles.primaryValue}>{props.primaryValue}</span>

--- a/src/ensembl/src/content/app/species/components/species-stats/SpeciesStats.tsx
+++ b/src/ensembl/src/content/app/species/components/species-stats/SpeciesStats.tsx
@@ -1,0 +1,102 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import classNames from 'classnames';
+
+import defaultStyles from './SpeciesStats.scss';
+
+export type SpeciesStatsProps = {
+  title?: string;
+  label: string;
+  labelHint?: string;
+  primaryValue: string;
+  primaryUnit?: string;
+  secondaryValue?: string;
+  secondaryUnit?: string;
+  link?: React.ReactElement;
+  classNames?: {
+    wrapper?: string;
+    title?: string;
+    label?: string;
+    labelHint?: string;
+    primaryValue?: string;
+    primaryUnit?: string;
+    secondaryValue?: string;
+    secondaryUnit?: string;
+    link?: string;
+  };
+};
+
+const SpeciesStats = (props: SpeciesStatsProps) => {
+  const styles = {
+    wrapper: classNames(defaultStyles.wrapper, props.classNames?.wrapper),
+    title: classNames(defaultStyles.title, props.classNames?.title),
+    label: classNames(defaultStyles.label, props.classNames?.label),
+    labelHint: classNames(defaultStyles.labelHint, props.classNames?.labelHint),
+    primaryValue: classNames(
+      defaultStyles.primaryValue,
+      props.classNames?.primaryValue
+    ),
+    primaryUnit: classNames(
+      defaultStyles.primaryUnit,
+      props.classNames?.primaryUnit
+    ),
+    secondaryValue: classNames(
+      defaultStyles.secondaryValue,
+      props.classNames?.secondaryValue
+    ),
+    secondaryUnit: classNames(
+      defaultStyles.secondaryUnit,
+      props.classNames?.secondaryUnit
+    ),
+    link: classNames(defaultStyles.link, props.classNames?.link)
+  };
+
+  return (
+    <div className={styles.wrapper}>
+      <span className={styles.title}>{props.title}</span>
+
+      <div>
+        <span className={styles.label}>{props.label}</span>
+        {props.labelHint && (
+          <span className={styles.labelHint}>{props.labelHint}</span>
+        )}
+      </div>
+
+      <div>
+        <span className={styles.primaryValue}>{props.primaryValue}</span>
+        {props.primaryUnit && (
+          <span className={styles.primaryUnit}>{props.primaryUnit}</span>
+        )}
+      </div>
+
+      {(props.secondaryValue || props.secondaryUnit) && (
+        <div>
+          <span className={styles.secondaryValue}>{props.secondaryValue}</span>
+
+          {props.secondaryUnit && (
+            <span className={styles.secondaryUnit}>{props.secondaryUnit}</span>
+          )}
+        </div>
+      )}
+
+      <span className={styles.link}>{props.link}</span>
+    </div>
+  );
+};
+
+export default SpeciesStats;

--- a/src/ensembl/src/content/app/species/components/species-stats/SpeciesStats.tsx
+++ b/src/ensembl/src/content/app/species/components/species-stats/SpeciesStats.tsx
@@ -92,7 +92,7 @@ const SpeciesStats = (props: SpeciesStatsProps) => {
         )}
       </div>
 
-      {(props.secondaryValue || props.secondaryUnit) && (
+      {props.secondaryValue && (
         <div>
           <span className={styles.secondaryValue}>{props.secondaryValue}</span>
 

--- a/src/ensembl/stories/species/index.ts
+++ b/src/ensembl/stories/species/index.ts
@@ -14,12 +14,4 @@
  * limitations under the License.
  */
 
-import 'src/styles/main.scss';
-
-import './design-primitives/index.ts';
-import './shared-components/index.ts';
-import './static-images/index.ts';
-import './genome-browser/index.ts';
-import './entity-viewer/index.ts';
-import './species/index.ts';
-import './hooks/index.ts';
+import './species-stats/SpeciesStats.stories';

--- a/src/ensembl/stories/species/species-stats/SpeciesStats.stories.scss
+++ b/src/ensembl/stories/species/species-stats/SpeciesStats.stories.scss
@@ -1,0 +1,3 @@
+.wrapper {
+  padding: 40px;
+}

--- a/src/ensembl/stories/species/species-stats/SpeciesStats.stories.tsx
+++ b/src/ensembl/stories/species/species-stats/SpeciesStats.stories.tsx
@@ -36,7 +36,16 @@ storiesOf('Components|Species/SpeciesStats', module).add('default', () => (
       secondaryUnit: 'readthrough'
     })}
     {renderSpeciesStats({
-      title: 'No. genes in',
+      preLabel: 'preLabel',
+      label: 'label',
+      primaryValue: 'primaryValue',
+      primaryUnit: 'primaryUnit',
+      secondaryValue: 'secondaryValue',
+      secondaryUnit: 'secondaryUnit',
+      link: <a href="/">Link</a>
+    })}
+    {renderSpeciesStats({
+      preLabel: 'No. genes in',
       label: 'Biological process',
       primaryValue: '7,343',
       primaryUnit: 'xyz',
@@ -50,7 +59,6 @@ storiesOf('Components|Species/SpeciesStats', module).add('default', () => (
     })}
     {renderSpeciesStats({
       label: 'SNVs',
-      labelHint: 'single nucleotide variants',
       primaryValue: '91%'
     })}
   </div>

--- a/src/ensembl/stories/species/species-stats/SpeciesStats.stories.tsx
+++ b/src/ensembl/stories/species/species-stats/SpeciesStats.stories.tsx
@@ -1,0 +1,57 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import SpeciesStats, {
+  SpeciesStatsProps
+} from 'src/content/app/species/components/species-stats/SpeciesStats';
+
+import styles from './SpeciesStats.stories.scss';
+
+const renderSpeciesStats = (props: SpeciesStatsProps) => {
+  return <SpeciesStats {...props} />;
+};
+
+storiesOf('Components|Species/SpeciesStats', module).add('default', () => (
+  <div className={styles.wrapper}>
+    {renderSpeciesStats({
+      label: 'Coding genes',
+      primaryValue: '20,438',
+      secondaryValue: '671',
+      secondaryUnit: 'readthrough'
+    })}
+    {renderSpeciesStats({
+      title: 'No. genes in',
+      label: 'Biological process',
+      primaryValue: '7,343',
+      primaryUnit: 'xyz',
+      secondaryValue: '1892',
+      secondaryUnit: 'terms'
+    })}
+    {renderSpeciesStats({
+      label: 'Transcriptomic data',
+      primaryValue: '90%',
+      link: <a href="/">View</a>
+    })}
+    {renderSpeciesStats({
+      label: 'SNVs',
+      labelHint: 'single nucleotide variants',
+      primaryValue: '91%'
+    })}
+  </div>
+));


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [x] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-745

## Description
This PR is to create a generic component to display the species stats in the species page.


XD:
https://xd.adobe.com/view/8d08bee6-405e-41d6-4a7f-0496e3f486f8-fb39/screen/92677847-0fa3-472c-a451-f462a7cb791e?fullscreen

## Deployment URL
Please checkout to this branch and run storybook locally to view it.

## Views affected
Storybook

