### PR TITLE
Fix routes

### DIFF
--- a/src/ensembl/src/content/app/App.tsx
+++ b/src/ensembl/src/content/app/App.tsx
@@ -71,7 +71,7 @@ const AppInner = (props: AppProps) => {
           component={EntityViewer}
         />
         <ErrorBoundary fallbackComponent={NewTechError}>
-          <Route path={`/browser/:genomeId?`} component={Browser} />
+          <Route path={`/genome-browser/:genomeId?`} component={Browser} />
         </ErrorBoundary>
       </Switch>
     </Suspense>

--- a/src/ensembl/src/header/launchbar/Launchbar.test.tsx
+++ b/src/ensembl/src/header/launchbar/Launchbar.test.tsx
@@ -32,7 +32,7 @@ describe('<Launchbar />', () => {
   it('disables Genome Browser button when there are no committed species', () => {
     const wrapper = mount(<Launchbar {...defaultProps} />);
     const genomeBrowserButton = wrapper.findWhere(
-      (wrapper) => wrapper.prop('app') === 'browser'
+      (wrapper) => wrapper.prop('app') === 'genome-browser'
     );
 
     expect(genomeBrowserButton.prop('enabled')).toBe(false);
@@ -45,7 +45,7 @@ describe('<Launchbar />', () => {
     };
     const wrapper = mount(<Launchbar {...props} />);
     const genomeBrowserButton = wrapper.findWhere(
-      (wrapper) => wrapper.prop('app') === 'browser'
+      (wrapper) => wrapper.prop('app') === 'genome-browser'
     );
 
     expect(genomeBrowserButton.prop('enabled')).toBe(true);

--- a/src/ensembl/src/header/launchbar/Launchbar.tsx
+++ b/src/ensembl/src/header/launchbar/Launchbar.tsx
@@ -62,7 +62,7 @@ const Launchbar = (props: LaunchbarProps) => {
           </div>
           <div className={styles.category}>
             <LaunchbarButton
-              app="browser"
+              app="genome-browser"
               description="Genome browser"
               icon={BrowserIcon}
               enabled={props.committedSpecies.length > 0}

--- a/src/ensembl/src/shared/helpers/urlHelper.ts
+++ b/src/ensembl/src/shared/helpers/urlHelper.ts
@@ -16,8 +16,8 @@
 
 import queryString from 'query-string';
 
-export const speciesSelector = () => '/app/species-selector';
-export const customDownload = () => '/app/custom-download';
+export const speciesSelector = () => '/species-selector';
+export const customDownload = () => '/custom-download';
 
 type BrowserUrlParams = {
   genomeId?: string | null;
@@ -32,8 +32,9 @@ type EntityViewerUrlParams = {
 };
 
 export const browser = (params?: BrowserUrlParams) => {
+  const browserRootPath = '/genome-browser';
   if (params) {
-    const path = `/browser/${params.genomeId}`;
+    const path = `${browserRootPath}/${params.genomeId}`;
     // NOTE: if a parameter passed to queryString is null, it will still get into query;
     // so assign it to undefined in order to omit it from the query
     const query = queryString.stringify(
@@ -47,7 +48,7 @@ export const browser = (params?: BrowserUrlParams) => {
     );
     return query ? `${path}?${query}` : path;
   } else {
-    return `/browser/`;
+    return browserRootPath;
   }
 };
 


### PR DESCRIPTION
## Type
- Bug fix

## Description
- `/app` part was removed from the url in https://github.com/Ensembl/ensembl-client/pull/338
- changing `/browser` to `/genome-browser`, because: 1) currently, the `/browser` route is used by genome browser server, and 2) `/genome-browser` is more specific than `/browser` anyway
- removed forgotten `/app` segment from a couple of urls in `urlHelper`

## Deployment URL
http://fix-route-names.review.ensembl.org/