### PR TITLE
Add use / don't use / remove functionality to species page

### DIFF
--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorActions.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorActions.ts
@@ -279,12 +279,9 @@ export const commitSelectedSpeciesAndSave: ActionCreator<ThunkAction<
   speciesSelectorStorageService.saveSelectedSpecies(newCommittedSpecies);
 };
 
-export const toggleSpeciesUseAndSave: ActionCreator<ThunkAction<
-  void,
-  any,
-  null,
-  Action<string>
->> = (genomeId: string) => (dispatch, getState) => {
+export const toggleSpeciesUseAndSave = (
+  genomeId: string
+): ThunkAction<void, any, null, Action<string>> => (dispatch, getState) => {
   const state = getState();
   const committedSpecies = getCommittedSpecies(state);
   const currentSpecies = getCommittedSpeciesById(state, genomeId);
@@ -313,12 +310,9 @@ export const toggleSpeciesUseAndSave: ActionCreator<ThunkAction<
   speciesSelectorStorageService.saveSelectedSpecies(updatedCommittedSpecies);
 };
 
-export const deleteSpeciesAndSave: ActionCreator<ThunkAction<
-  void,
-  any,
-  null,
-  Action<string>
->> = (genomeId: string) => (dispatch, getState) => {
+export const deleteSpeciesAndSave = (
+  genomeId: string
+): ThunkAction<void, any, null, Action<string>> => (dispatch, getState) => {
   const committedSpecies = getCommittedSpecies(getState());
   const deletedSpecies = find(
     committedSpecies,

--- a/src/ensembl/src/content/app/species/SpeciesPage.tsx
+++ b/src/ensembl/src/content/app/species/SpeciesPage.tsx
@@ -21,6 +21,8 @@ import { useSelector, useDispatch } from 'react-redux';
 import { BreakpointWidth } from 'src/global/globalConfig';
 
 import { fetchGenomeData } from 'src/shared/state/genome/genomeActions';
+import { setActiveGenomeId } from 'src/content/app/species/state/general/speciesGeneralSlice';
+
 import { getCommittedSpeciesById } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 import { isSidebarOpen } from 'src/content/app/species/state/sidebar/speciesSidebarSelectors';
 
@@ -31,6 +33,7 @@ import {
   StandardAppLayout,
   SidebarBehaviourType
 } from 'src/shared/components/layout';
+import SpeciesMainView from 'src/content/app/species/components/species-main-view/SpeciesMainView';
 
 import { RootState } from 'src/store';
 
@@ -47,12 +50,15 @@ const SpeciesPage = () => {
   const dispatch = useDispatch();
 
   useEffect(() => {
+    dispatch(setActiveGenomeId(genomeId));
+  }, [genomeId]);
+
+  useEffect(() => {
     if (!currentSpecies) {
       dispatch(fetchGenomeData(genomeId));
     }
   }, [genomeId, currentSpecies]);
 
-  const mainContent = 'I am main content';
   const sidebarContent = 'I am sidebar';
   const sidebarNavigationContent = 'I am sidebar navigation';
   const topbarContent = 'I am topbar content';
@@ -61,7 +67,7 @@ const SpeciesPage = () => {
     <>
       <SpeciesAppBar />
       <StandardAppLayout
-        mainContent={mainContent}
+        mainContent={<SpeciesMainView />}
         sidebarContent={sidebarContent}
         sidebarNavigation={sidebarNavigationContent}
         topbarContent={topbarContent}

--- a/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainView.scss
+++ b/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainView.scss
@@ -1,0 +1,10 @@
+.speciesMainViewTop {
+  display: grid;
+  grid-template-columns: max-content auto;
+  align-items: center;
+  padding-top: 20px;
+}
+
+.speciesLabelBlock {
+  padding: 0 75px 0 60px;
+}

--- a/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainView.tsx
+++ b/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainView.tsx
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-import { combineReducers } from 'redux';
+import React from 'react';
 
-import speciesPageSidebarReducer from './sidebar/speciesSidebarSlice';
-import speciesPageGeneralReducer from './general/speciesGeneralSlice';
+import SpeciesSelectionControls from 'src/content/app/species/components/species-selection-controls/SpeciesSelectionControls';
 
-export default combineReducers({
-  general: speciesPageGeneralReducer,
-  sidebar: speciesPageSidebarReducer
-});
+const SpeciesMainView = () => {
+  return (
+    <div style={{ paddingTop: '1em' }}>
+      <SpeciesSelectionControls />
+    </div>
+  );
+};
+
+export default SpeciesMainView;

--- a/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewTop.tsx
+++ b/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewTop.tsx
@@ -21,10 +21,24 @@ import SpeciesSelectionControls from 'src/content/app/species/components/species
 import styles from './SpeciesMainView.scss';
 
 const SpeciesMainViewTop = () => {
+  const mockSpeciesIcon = (
+    <div
+      style={{
+        height: '57px',
+        width: '57px',
+        background: '#d4d9de',
+        display: 'inline-block',
+        verticalAlign: 'middle',
+        marginRight: '18px'
+      }}
+    />
+  );
+
   return (
     <div className={styles.speciesMainViewTop}>
       <div className={styles.speciesLabelBlock}>
-        Place for species icon and name
+        {mockSpeciesIcon}
+        Species name
       </div>
       <SpeciesSelectionControls />
     </div>

--- a/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewTop.tsx
+++ b/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewTop.tsx
@@ -16,14 +16,19 @@
 
 import React from 'react';
 
-import SpeciesMainViewTop from './SpeciesMainViewTop';
+import SpeciesSelectionControls from 'src/content/app/species/components/species-selection-controls/SpeciesSelectionControls';
 
-const SpeciesMainView = () => {
+import styles from './SpeciesMainView.scss';
+
+const SpeciesMainViewTop = () => {
   return (
-    <div>
-      <SpeciesMainViewTop />
+    <div className={styles.speciesMainViewTop}>
+      <div className={styles.speciesLabelBlock}>
+        Place for species icon and name
+      </div>
+      <SpeciesSelectionControls />
     </div>
   );
 };
 
-export default SpeciesMainView;
+export default SpeciesMainViewTop;

--- a/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.scss
+++ b/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.scss
@@ -24,3 +24,8 @@
   color: $blue;
   cursor: pointer;
 }
+
+.questionButton {
+  height: 12px;
+  width: 12px;
+}

--- a/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.scss
+++ b/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.scss
@@ -17,7 +17,7 @@
 }
 
 .toggle {
-  height: 12px;
+  margin: 0 12px;
 }
 
 .removalContainer {

--- a/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.scss
+++ b/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.scss
@@ -20,11 +20,21 @@
   height: 12px;
 }
 
-.remove {
+.removalContainer {
   margin-left: 60px;
 }
 
 .clickable {
   color: $blue;
   cursor: pointer;
+}
+
+.speciesRemovalConfirmation {
+  button {
+    margin: 0 25px 0 35px;
+  }
+}
+
+.speciesRemovalWarning {
+  color: $red;
 }

--- a/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.scss
+++ b/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.scss
@@ -11,6 +11,10 @@
   display: flex;
   align-items: center;
 
+  span {
+    white-space: nowrap;
+  }
+
   span:last-of-type {
     margin-right: 15px;
   }

--- a/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.scss
+++ b/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.scss
@@ -10,6 +10,10 @@
 .speciesUseToggle {
   display: flex;
   align-items: center;
+
+  span:last-of-type {
+    margin-right: 15px;
+  }
 }
 
 .toggle {
@@ -23,9 +27,4 @@
 .clickable {
   color: $blue;
   cursor: pointer;
-}
-
-.questionButton {
-  height: 12px;
-  width: 12px;
 }

--- a/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.scss
+++ b/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.scss
@@ -1,0 +1,26 @@
+@import 'src/styles/common';
+
+.speciesSelectionControls {
+  display: flex;
+  align-items: center;
+  font-size: 12px;
+  line-height: 1;
+}
+
+.speciesUseToggle {
+  display: flex;
+  align-items: center;
+}
+
+.toggle {
+  height: 12px;
+}
+
+.remove {
+  margin-left: 60px;
+}
+
+.clickable {
+  color: $blue;
+  cursor: pointer;
+}

--- a/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.test.tsx
+++ b/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.test.tsx
@@ -167,7 +167,7 @@ describe('SpeciesSelectionControls', () => {
     );
   });
 
-  it('correctly togglew removal dialog', () => {
+  it('correctly toggles removal dialog', () => {
     const wrapper = wrapInRedux();
     const removeLabel = wrapper
       .find('span')

--- a/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.test.tsx
+++ b/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.test.tsx
@@ -30,7 +30,9 @@ import {
 
 import { createSelectedSpecies } from 'tests/fixtures/selected-species';
 
-import SpeciesSelectionControls from './SpeciesSelectionControls';
+import SpeciesSelectionControls, {
+  speciesRemovalConfirmationMessage
+} from './SpeciesSelectionControls';
 import SlideToggle from 'src/shared/components/slide-toggle/SlideToggle';
 
 jest.mock('connected-react-router', () => ({
@@ -165,13 +167,38 @@ describe('SpeciesSelectionControls', () => {
     );
   });
 
-  it('removes species and redirects to species selector after removal', () => {
+  it('correctly togglew removal dialog', () => {
     const wrapper = wrapInRedux();
-    const useLabel = wrapper
+    const removeLabel = wrapper
       .find('span')
       .filterWhere((wrapper) => wrapper.text() === 'Remove')
       .first();
-    useLabel.simulate('click');
+    removeLabel.simulate('click');
+
+    expect(wrapper.text()).toContain(speciesRemovalConfirmationMessage);
+
+    const doNotRemoveLabel = wrapper
+      .find('span')
+      .filterWhere((wrapper) => wrapper.text() === 'Do not remove')
+      .first();
+
+    doNotRemoveLabel.simulate('click');
+
+    expect(wrapper.text()).not.toContain(speciesRemovalConfirmationMessage);
+  });
+
+  it('removes species and redirects to species selector after removal', () => {
+    const wrapper = wrapInRedux();
+
+    // open removal confitmation dialog
+    const removeLabel = wrapper
+      .find('span')
+      .filterWhere((wrapper) => wrapper.text() === 'Remove')
+      .first();
+    removeLabel.simulate('click');
+
+    const removeButton = wrapper.find('button.primaryButton');
+    removeButton.simulate('click');
 
     expect(deleteSpeciesAndSave).toHaveBeenCalledWith(
       selectedSpecies.genome_id

--- a/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.test.tsx
+++ b/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import { push } from 'connected-react-router';
+import thunk from 'redux-thunk';
+import configureMockStore from 'redux-mock-store';
+
+import * as urlFor from 'src/shared/helpers/urlHelper';
+
+import {
+  toggleSpeciesUseAndSave,
+  deleteSpeciesAndSave
+} from 'src/content/app/species-selector/state/speciesSelectorActions';
+
+import { createSelectedSpecies } from 'tests/fixtures/selected-species';
+
+import SpeciesSelectionControls from './SpeciesSelectionControls';
+import SlideToggle from 'src/shared/components/slide-toggle/SlideToggle';
+
+jest.mock('connected-react-router', () => ({
+  push: jest.fn(() => ({ type: 'push' }))
+}));
+jest.mock(
+  'src/content/app/species-selector/state/speciesSelectorActions',
+  () => ({
+    deleteSpeciesAndSave: jest.fn(() => ({ type: 'deleteSpeciesAndSave' })),
+    toggleSpeciesUseAndSave: jest.fn(() => ({
+      type: 'toggleSpeciesUseAndSave'
+    }))
+  })
+);
+
+const selectedSpecies = createSelectedSpecies();
+const disabledSpecies = {
+  ...selectedSpecies,
+  isEnabled: false
+};
+
+const stateWithEnabledSpecies = {
+  speciesPage: {
+    general: {
+      activeGenomeId: selectedSpecies.genome_id
+    }
+  },
+  speciesSelector: {
+    committedItems: [selectedSpecies]
+  }
+};
+
+const stateWithDisabledSpecies = {
+  ...stateWithEnabledSpecies,
+  speciesSelector: {
+    committedItems: [disabledSpecies]
+  }
+};
+
+const mockStore = configureMockStore([thunk]);
+
+const wrapInRedux = (
+  state: typeof stateWithEnabledSpecies = stateWithEnabledSpecies
+) => {
+  return mount(
+    <Provider store={mockStore(state)}>
+      <SpeciesSelectionControls />
+    </Provider>
+  );
+};
+
+describe('SpeciesSelectionControls', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows correct controls for enabled species', () => {
+    const wrapper = wrapInRedux();
+    const slideToggle = wrapper.find(SlideToggle);
+    const useLabel = wrapper
+      .find('span')
+      .filterWhere((wrapper) => wrapper.text() === 'Use')
+      .first();
+    const doNotUseLabel = wrapper
+      .find('span')
+      .filterWhere((wrapper) => wrapper.text() === "Don't use")
+      .first();
+
+    expect(slideToggle.prop('isOn')).toBe(true);
+    expect(useLabel.hasClass('clickable')).toBe(false);
+    expect(doNotUseLabel.hasClass('clickable')).toBe(true);
+  });
+
+  it('shows correct controls for disabled species', () => {
+    const wrapper = wrapInRedux(stateWithDisabledSpecies);
+
+    const slideToggle = wrapper.find(SlideToggle);
+    const useLabel = wrapper
+      .find('span')
+      .filterWhere((wrapper) => wrapper.text() === 'Use')
+      .first();
+    const doNotUseLabel = wrapper
+      .find('span')
+      .filterWhere((wrapper) => wrapper.text() === "Don't use")
+      .first();
+
+    expect(slideToggle.prop('isOn')).toBe(false);
+    expect(useLabel.hasClass('clickable')).toBe(true);
+    expect(doNotUseLabel.hasClass('clickable')).toBe(false);
+  });
+
+  it('changes species status via the toggle', () => {
+    const wrapper = wrapInRedux(stateWithDisabledSpecies);
+    const slideToggle = wrapper.find(SlideToggle);
+    slideToggle.prop('onChange')(true);
+
+    expect(toggleSpeciesUseAndSave).toHaveBeenCalledWith(
+      disabledSpecies.genome_id
+    );
+
+    jest.clearAllMocks();
+
+    slideToggle.prop('onChange')(false);
+    expect(toggleSpeciesUseAndSave).toHaveBeenCalledWith(
+      disabledSpecies.genome_id
+    );
+  });
+
+  it('disables species by clicking on label', () => {
+    const wrapper = wrapInRedux();
+    const doNotUseLabel = wrapper
+      .find('span')
+      .filterWhere((wrapper) => wrapper.text() === "Don't use")
+      .first();
+    doNotUseLabel.simulate('click');
+
+    expect(toggleSpeciesUseAndSave).toHaveBeenCalledWith(
+      selectedSpecies.genome_id
+    );
+  });
+
+  it('enables species by clicking on label', () => {
+    const wrapper = wrapInRedux(stateWithDisabledSpecies);
+    const useLabel = wrapper
+      .find('span')
+      .filterWhere((wrapper) => wrapper.text() === 'Use')
+      .first();
+    useLabel.simulate('click');
+
+    expect(toggleSpeciesUseAndSave).toHaveBeenCalledWith(
+      selectedSpecies.genome_id
+    );
+  });
+
+  it('removes species and redirects to species selector after removal', () => {
+    const wrapper = wrapInRedux();
+    const useLabel = wrapper
+      .find('span')
+      .filterWhere((wrapper) => wrapper.text() === 'Remove')
+      .first();
+    useLabel.simulate('click');
+
+    expect(deleteSpeciesAndSave).toHaveBeenCalledWith(
+      selectedSpecies.genome_id
+    );
+    expect(push).toHaveBeenCalledWith(urlFor.speciesSelector());
+  });
+});

--- a/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.tsx
+++ b/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.tsx
@@ -99,10 +99,7 @@ const SpeciesUseToggle = (props: SpeciesUseToggle) => {
         onChange={props.onChange}
       />
       <span {...useLabelProps}>Use</span>
-      <QuestionButton
-        helpText={'help?'}
-        className={{ inline: styles.questionButton }}
-      />
+      <QuestionButton helpText={'help?'} />
     </div>
   );
 };

--- a/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.tsx
+++ b/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.tsx
@@ -30,6 +30,7 @@ import {
 } from 'src/content/app/species-selector/state/speciesSelectorActions';
 
 import SlideToggle from 'src/shared/components/slide-toggle/SlideToggle';
+import QuestionButton from 'src/shared/components/question-button/QuestionButton';
 
 import { RootState } from 'src/store';
 
@@ -98,6 +99,10 @@ const SpeciesUseToggle = (props: SpeciesUseToggle) => {
         onChange={props.onChange}
       />
       <span {...useLabelProps}>Use</span>
+      <QuestionButton
+        helpText={'help?'}
+        className={{ inline: styles.questionButton }}
+      />
     </div>
   );
 };

--- a/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.tsx
+++ b/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.tsx
@@ -43,7 +43,7 @@ type SpeciesUseToggle = {
 };
 
 type LabelProps = {
-  className: string;
+  className?: string;
   onClick?: () => void;
 };
 
@@ -102,8 +102,8 @@ const speciesUseToggleHelpMessage = `When 'Use' is selected, this species will a
 'Don't use' will disable this species in other apps, but will not remove it from your list in Species selector.`;
 
 const SpeciesUseToggle = (props: SpeciesUseToggle) => {
-  const doNotUseLabelProps: Partial<LabelProps> = {};
-  const useLabelProps: Partial<LabelProps> = {};
+  const doNotUseLabelProps: LabelProps = {};
+  const useLabelProps: LabelProps = {};
 
   if (props.isUsed) {
     doNotUseLabelProps.className = styles.clickable;

--- a/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.tsx
+++ b/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.tsx
@@ -1,0 +1,105 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { push } from 'connected-react-router';
+import classNames from 'classnames';
+
+import * as urlFor from 'src/shared/helpers/urlHelper';
+
+import { getActiveGenomeId } from 'src/content/app/species/state/general/speciesGeneralSelectors';
+import { getCommittedSpeciesById } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
+
+import {
+  toggleSpeciesUseAndSave,
+  deleteSpeciesAndSave
+} from 'src/content/app/species-selector/state/speciesSelectorActions';
+
+import SlideToggle from 'src/shared/components/slide-toggle/SlideToggle';
+
+import { RootState } from 'src/store';
+
+import styles from './SpeciesSelectionControls.scss';
+
+type SpeciesUseToggle = {
+  isUsed: boolean;
+  onChange: (isUsed: boolean) => void;
+};
+
+type LabelProps = {
+  className: string;
+  onClick?: () => void;
+};
+
+const SpeciesSelectionControls = () => {
+  const genomeId = useSelector(getActiveGenomeId);
+  const species = useSelector((state: RootState) =>
+    getCommittedSpeciesById(state, genomeId || '')
+  );
+  const dispatch = useDispatch();
+
+  if (!genomeId || !species) {
+    return null;
+  }
+
+  const onToggleUse = () => {
+    dispatch(toggleSpeciesUseAndSave(genomeId));
+  };
+
+  const onRemove = () => {
+    dispatch(push(urlFor.speciesSelector()));
+    dispatch(deleteSpeciesAndSave(genomeId));
+  };
+
+  const removeLabelStyles = classNames(styles.remove, styles.clickable);
+
+  return (
+    <div className={styles.speciesSelectionControls}>
+      <SpeciesUseToggle isUsed={species.isEnabled} onChange={onToggleUse} />
+      <span className={removeLabelStyles} onClick={onRemove}>
+        Remove
+      </span>
+    </div>
+  );
+};
+
+const SpeciesUseToggle = (props: SpeciesUseToggle) => {
+  const doNotUseLabelProps: Partial<LabelProps> = {};
+  const useLabelProps: Partial<LabelProps> = {};
+
+  if (props.isUsed) {
+    doNotUseLabelProps.className = styles.clickable;
+    doNotUseLabelProps.onClick = () => props.onChange(!props.isUsed);
+  } else {
+    useLabelProps.className = styles.clickable;
+    useLabelProps.onClick = () => props.onChange(!props.isUsed);
+  }
+
+  return (
+    <div className={styles.speciesUseToggle}>
+      <span {...doNotUseLabelProps}>Don't use</span>
+      <SlideToggle
+        className={styles.toggle}
+        isOn={props.isUsed}
+        onChange={props.onChange}
+      />
+      <span {...useLabelProps}>Use</span>
+    </div>
+  );
+};
+
+export default SpeciesSelectionControls;

--- a/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.tsx
+++ b/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { push } from 'connected-react-router';
 import classNames from 'classnames';
@@ -30,6 +30,7 @@ import {
 } from 'src/content/app/species-selector/state/speciesSelectorActions';
 
 import SlideToggle from 'src/shared/components/slide-toggle/SlideToggle';
+import { PrimaryButton } from 'src/shared/components/button/Button';
 import QuestionButton from 'src/shared/components/question-button/QuestionButton';
 
 import { RootState } from 'src/store';
@@ -46,7 +47,13 @@ type LabelProps = {
   onClick?: () => void;
 };
 
+type SpeciesRemovalConfirmationProps = {
+  onConfirm: () => void;
+  onReject: () => void;
+};
+
 const SpeciesSelectionControls = () => {
+  const [isRemoving, setIsRemoving] = useState(false);
   const genomeId = useSelector(getActiveGenomeId);
   const species = useSelector((state: RootState) =>
     getCommittedSpeciesById(state, genomeId || '')
@@ -61,6 +68,10 @@ const SpeciesSelectionControls = () => {
     dispatch(toggleSpeciesUseAndSave(genomeId));
   };
 
+  const toggleRemovalDialog = () => {
+    setIsRemoving(!isRemoving);
+  };
+
   const onRemove = () => {
     dispatch(push(urlFor.speciesSelector()));
     dispatch(deleteSpeciesAndSave(genomeId));
@@ -71,9 +82,18 @@ const SpeciesSelectionControls = () => {
   return (
     <div className={styles.speciesSelectionControls}>
       <SpeciesUseToggle isUsed={species.isEnabled} onChange={onToggleUse} />
-      <span className={removeLabelStyles} onClick={onRemove}>
-        Remove
-      </span>
+      <div className={styles.removalContainer}>
+        {isRemoving ? (
+          <SpeciesRemovalConfirmation
+            onConfirm={onRemove}
+            onReject={toggleRemovalDialog}
+          />
+        ) : (
+          <span className={removeLabelStyles} onClick={toggleRemovalDialog}>
+            Remove
+          </span>
+        )}
+      </div>
     </div>
   );
 };
@@ -100,6 +120,23 @@ const SpeciesUseToggle = (props: SpeciesUseToggle) => {
       />
       <span {...useLabelProps}>Use</span>
       <QuestionButton helpText={'help?'} />
+    </div>
+  );
+};
+
+export const speciesRemovalConfirmationMessage =
+  'If you remove this species, any views you have configured will be lost — do you wish to continue?';
+
+const SpeciesRemovalConfirmation = (props: SpeciesRemovalConfirmationProps) => {
+  return (
+    <div className={styles.speciesRemovalConfirmation}>
+      <span className={styles.speciesRemovalWarning}>
+        {speciesRemovalConfirmationMessage}
+      </span>
+      <PrimaryButton onClick={props.onConfirm}>Remove</PrimaryButton>
+      <span className={styles.clickable} onClick={props.onReject}>
+        Do not remove
+      </span>
     </div>
   );
 };

--- a/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.tsx
+++ b/src/ensembl/src/content/app/species/components/species-selection-controls/SpeciesSelectionControls.tsx
@@ -98,6 +98,9 @@ const SpeciesSelectionControls = () => {
   );
 };
 
+const speciesUseToggleHelpMessage = `When 'Use' is selected, this species will appear in the species list in all apps.
+'Don't use' will disable this species in other apps, but will not remove it from your list in Species selector.`;
+
 const SpeciesUseToggle = (props: SpeciesUseToggle) => {
   const doNotUseLabelProps: Partial<LabelProps> = {};
   const useLabelProps: Partial<LabelProps> = {};
@@ -119,7 +122,7 @@ const SpeciesUseToggle = (props: SpeciesUseToggle) => {
         onChange={props.onChange}
       />
       <span {...useLabelProps}>Use</span>
-      <QuestionButton helpText={'help?'} />
+      <QuestionButton helpText={speciesUseToggleHelpMessage} />
     </div>
   );
 };

--- a/src/ensembl/src/content/app/species/state/general/speciesGeneralSelectors.ts
+++ b/src/ensembl/src/content/app/species/state/general/speciesGeneralSelectors.ts
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-import { combineReducers } from 'redux';
+import { RootState } from 'src/store';
 
-import speciesPageSidebarReducer from './sidebar/speciesSidebarSlice';
-import speciesPageGeneralReducer from './general/speciesGeneralSlice';
-
-export default combineReducers({
-  general: speciesPageGeneralReducer,
-  sidebar: speciesPageSidebarReducer
-});
+export const getActiveGenomeId = (state: RootState) =>
+  state.speciesPage.general.activeGenomeId;

--- a/src/ensembl/src/content/app/species/state/general/speciesGeneralSlice.ts
+++ b/src/ensembl/src/content/app/species/state/general/speciesGeneralSlice.ts
@@ -14,12 +14,26 @@
  * limitations under the License.
  */
 
-import { combineReducers } from 'redux';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import speciesPageSidebarReducer from './sidebar/speciesSidebarSlice';
-import speciesPageGeneralReducer from './general/speciesGeneralSlice';
+type SpeciesGeneralState = {
+  activeGenomeId: string | null;
+};
 
-export default combineReducers({
-  general: speciesPageGeneralReducer,
-  sidebar: speciesPageSidebarReducer
+const initialState: SpeciesGeneralState = {
+  activeGenomeId: null
+};
+
+const speciesGeneralSlice = createSlice({
+  name: 'species-page-general',
+  initialState,
+  reducers: {
+    setActiveGenomeId(state, action: PayloadAction<string>) {
+      state.activeGenomeId = action.payload;
+    }
+  }
 });
+
+export const { setActiveGenomeId } = speciesGeneralSlice.actions;
+
+export default speciesGeneralSlice.reducer;

--- a/src/ensembl/src/shared/components/slide-toggle/SlideToggle.tsx
+++ b/src/ensembl/src/shared/components/slide-toggle/SlideToggle.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import classNames from 'classnames';
 
 import styles from './SlideToggle.scss';
@@ -27,6 +27,12 @@ type Props = {
 
 const SlideToggle = (props: Props) => {
   const [isOn, setIsOn] = useState(props.isOn);
+
+  useEffect(() => {
+    if (isOn !== props.isOn) {
+      setIsOn(props.isOn);
+    }
+  }, [props.isOn]);
 
   const onToggle = () => {
     props.onChange(!isOn);


### PR DESCRIPTION
## Type
- New feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-754

## Description
- Add to Species page elements to enable, disable, or remove the currently active species
- When the `Remove` element is clicked, the species is removed and the user is redirected to to Species Selector

## Deployment URL
http://use-dont-use-remove.review.ensembl.org/species/homo_sapiens_GCA_000001405_28

## Views affected
Species page