### PR TITLE
Update blue colours

### DIFF
--- a/src/ensembl/src/content/app/browser/browser-location-indicator/BrowserLocationIndicator.scss
+++ b/src/ensembl/src/content/app/browser/browser-location-indicator/BrowserLocationIndicator.scss
@@ -40,7 +40,7 @@
 }
 
 .chrCode {
-  background: $dark-blue;
+  background: $blue;
   color: $white;
   display: inline-block;
   font-weight: $bold;
@@ -54,6 +54,6 @@
 }
 
 .chrRegion {
-  color: $dark-blue;
+  color: $blue;
   display: inline-block;
 }

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.scss
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.scss
@@ -22,7 +22,7 @@
 
   &:hover,
   &.trackHighlighted {
-    background: $light-blue;
+    background: $ice-blue;
   }
 
   &.main {
@@ -65,8 +65,8 @@
     width: 11px;
 
     &.blue {
-      background: $dark-blue;
-      border-color: $dark-blue;
+      background: $blue;
+      border-color: $blue;
     }
 
     &.darkGrey {
@@ -98,7 +98,7 @@
 
 .selected {
   svg {
-    fill: $dark-blue;
+    fill: $blue;
   }
 }
 

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-tabs/TrackPanelTabs.scss
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-tabs/TrackPanelTabs.scss
@@ -7,7 +7,7 @@
 }
 
 .trackPanelTab {
-  color: $dark-blue;
+  color: $blue;
   cursor: pointer;
 }
 

--- a/src/ensembl/src/content/app/species-selector/components/species-search-match/SpeciesSearchMatch.scss
+++ b/src/ensembl/src/content/app/species-selector/components/species-search-match/SpeciesSearchMatch.scss
@@ -7,7 +7,7 @@
   cursor: pointer;
 
   &:hover {
-    background-color: $light-blue;
+    background-color: $ice-blue;
   }
 }
 

--- a/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.scss
+++ b/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.scss
@@ -17,7 +17,7 @@
   min-width: 500px;
 
   &Expanded {
-    background-color: $light-blue;
+    background-color: $ice-blue;
   }
 
   .speciesNameColumn {

--- a/src/ensembl/src/shared/components/autosuggest-search-field/AutosuggestSearchField.scss
+++ b/src/ensembl/src/shared/components/autosuggest-search-field/AutosuggestSearchField.scss
@@ -31,5 +31,5 @@
 }
 
 .autosuggestionPlateHighlightedItem {
-  background-color: $light-blue;
+  background-color: $ice-blue;
 }

--- a/src/ensembl/src/shared/components/image-button/ImageButton.scss
+++ b/src/ensembl/src/shared/components/image-button/ImageButton.scss
@@ -18,14 +18,14 @@
 
 .default {
   svg {
-    fill: $dark-blue;
+    fill: $blue;
   }
 }
 
 .selected {
   svg {
     fill: $white;
-    background: $dark-blue;
+    background: $blue;
   }
   &svg:hover {
     opacity: 0.8;
@@ -34,7 +34,7 @@
 
 .unselected {
   svg {
-    fill: $dark-blue;
+    fill: $blue;
   }
   &svg:hover {
     opacity: 0.8;

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
@@ -117,7 +117,7 @@ $drawerWindowWidth: 45px;
 
 .sidebarModeToggleChevron {
   cursor: pointer;
-  fill: $dark-blue;
+  fill: $blue;
 
   &Open {
     transform: rotate(180deg);

--- a/src/ensembl/src/shared/components/round-button/RoundButton.scss
+++ b/src/ensembl/src/shared/components/round-button/RoundButton.scss
@@ -6,7 +6,7 @@
   min-width: 170px;
   position: relative;
   border: 1px solid $blue;
-  color: $dark-blue;
+  color: $blue;
 
   &:active,
   &:focus {

--- a/src/ensembl/src/shared/components/select/Select.scss
+++ b/src/ensembl/src/shared/components/select/Select.scss
@@ -114,5 +114,5 @@ $optionsPanelLeftPadding: 14px;
 }
 
 .optionHighlighted {
-  background-color: $light-blue;
+  background-color: $ice-blue;
 }

--- a/src/ensembl/src/shared/components/tabs/Tabs.scss
+++ b/src/ensembl/src/shared/components/tabs/Tabs.scss
@@ -10,7 +10,7 @@
 
 .tab {
   padding: 3px 18px;
-  color: $dark-blue;
+  color: $blue;
   cursor: pointer;
   margin-right: 3px;
   white-space: nowrap;

--- a/src/ensembl/src/shared/components/visibility-icon/VisibilityIcon.scss
+++ b/src/ensembl/src/shared/components/visibility-icon/VisibilityIcon.scss
@@ -2,7 +2,7 @@
 
 .selected {
   svg {
-    fill: $dark-blue;
+    fill: $blue;
   }
   &svg:hover {
     opacity: 0.8;
@@ -20,7 +20,7 @@
 
 .partiallySelected {
   svg {
-    fill: $dark-blue;
+    fill: $blue;
     [class*='rightHalf'] {
       fill: $grey;
     }

--- a/src/ensembl/src/styles/_settings.scss
+++ b/src/ensembl/src/styles/_settings.scss
@@ -22,9 +22,9 @@ $soft-black: #374148;
 
 $shadow-color: rgba(0, 0, 0, 0.4);
 
-$light-blue: #e5f5ff; // text highlight
-$blue: #33adff; // blue on black
-$dark-blue: #0099ff; // blue on white
+$blue: #0099ff; // blue on white
+$light-blue: #33adff; // blue on black
+$ice-blue: #e5f5ff; // text highlight
 
 $light-grey: #f1f2f4;
 $medium-light-grey: #d4d9de;
@@ -45,7 +45,7 @@ $global-box-shadow: $medium-light-grey;
   soft-black: $soft-black;
   blue: $blue;
   light-blue: $light-blue;
-  dark-blue: $dark-blue;
+  ice-blue: $ice-blue;
   red: $red;
   orange: $orange;
   dark-grey: $dark-grey;

--- a/src/ensembl/src/styles/main.scss
+++ b/src/ensembl/src/styles/main.scss
@@ -12,7 +12,7 @@ body,
 }
 
 a {
-  color: $dark-blue;
+  color: $blue;
   text-decoration: none;
 
   &.inactive {

--- a/src/ensembl/stories/design-primitives/colours/Colours.stories.tsx
+++ b/src/ensembl/stories/design-primitives/colours/Colours.stories.tsx
@@ -36,14 +36,14 @@ const colours = [
     value: variables['blue']
   },
   {
-    name: 'Dark blue',
-    variableName: '$dark-blue',
-    value: variables['dark-blue']
-  },
-  {
     name: 'Light blue',
     variableName: '$light-blue',
     value: variables['light-blue']
+  },
+  {
+    name: 'Ice blue',
+    variableName: '$ice-blue',
+    value: variables['ice-blue']
   },
   {
     name: 'Red',


### PR DESCRIPTION
## Type
- Bug fix

## Description
Andrea noticed that we've been using `#33adff` as our main blue colour, while she wanted the default to be `#0099ff`. This PR updates blue colour variables using @ens-ap5's suggestion for the name of the lightest colour.

**Before:**

![image](https://user-images.githubusercontent.com/6834224/93531419-1fc8eb00-f937-11ea-957c-c8a7c622fe48.png)

**After:**

![image](https://user-images.githubusercontent.com/6834224/93531510-42f39a80-f937-11ea-80ad-2c6f540e1760.png)

## Views affected
All