### PR TITLE
Fix checkbox styles

### DIFF
--- a/src/ensembl/src/shared/components/checkbox/Checkbox.scss
+++ b/src/ensembl/src/shared/components/checkbox/Checkbox.scss
@@ -2,7 +2,8 @@
 
 .checkboxHolder {
   display: grid;
-  grid-template-columns: 27px 100%;
+  width: 100%;
+  grid-template-columns: 27px 1fr;
 }
 
 .defaultCheckbox {


### PR DESCRIPTION
## Type
- Bug fix

## Description
Missed in a previous PR (https://github.com/Ensembl/ensembl-client/pull/303), where we updated Checkbox styles. The checkbox wrapper currently has two columns with the widths defined as follows:

```css
.checkboxHolder {
  display: grid;
  grid-template-columns: 27px 100%;
}
```

What this means is that the right column will have the same width as the whole container of the checkbox wrapper, as can be easily seen in the BrowserTrackConfig component:

![image](https://user-images.githubusercontent.com/6834224/94369379-4b8b6400-00e1-11eb-992f-c1fd16f803bd.png)

![image](https://user-images.githubusercontent.com/6834224/94369401-6067f780-00e1-11eb-93a1-1dc80a523ad5.png)

Notice how the right column of the wrapper's grid continues outside the content box of its parent component.

Here's the behaviour after the fix:

![image](https://user-images.githubusercontent.com/6834224/94369442-9b6a2b00-00e1-11eb-9d0c-8ce2c2e70213.png)

![image](https://user-images.githubusercontent.com/6834224/94369455-ac1aa100-00e1-11eb-99ab-a37a61309a38.png)

Notice how the grid stays within the content box of the parent element.

### Deployment URL
http://fix-checkbox.review.ensembl.org