### PR TITLE
Do not mutate redux state for Custom Download

### DIFF
--- a/src/ensembl/src/content/app/custom-download/components/content-builder/ContentBuilder.tsx
+++ b/src/ensembl/src/content/app/custom-download/components/content-builder/ContentBuilder.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import set from 'lodash/set';
+import set from 'lodash/fp/set';
 import get from 'lodash/get';
 import classNames from 'classnames';
 
@@ -69,21 +69,14 @@ const ContentBuilder = (props: ContentBuilderProps) => {
     path: (string | number)[],
     payload: PrimitiveOrArrayValue
   ) => {
-    const newSelectedData = { ...props.selectedData };
-
-    set(newSelectedData, path, payload);
-
-    props.onChange(newSelectedData);
+    props.onChange(set(path, payload, props.selectedData));
   };
 
   const onUiChangeHandler = (
     path: (string | number)[],
     payload: PrimitiveOrArrayValue
   ) => {
-    const updatedUi = { ...props.uiState };
-    set(updatedUi, path, payload);
-
-    props.onUiChange(updatedUi);
+    props.onUiChange(set(path, payload, props.uiState));
   };
 
   const buildCheckboxWithSelect = (
@@ -166,13 +159,17 @@ const ContentBuilder = (props: ContentBuilderProps) => {
       return null;
     }
 
-    const newSelectedData = { ...props.selectedData };
+    let newSelectedData = { ...props.selectedData };
     const gridOptions = [...entry.options] as CheckboxGridOption[];
     let shouldUpdateSelectedData = false;
 
     gridOptions.forEach((option) => {
       if (option.isChecked && selectedOptions[option.id] === undefined) {
-        set(newSelectedData, [...currentPath, option.id], true);
+        newSelectedData = set(
+          [...currentPath, option.id],
+          true,
+          newSelectedData
+        );
         shouldUpdateSelectedData = true;
       }
     });

--- a/src/ensembl/src/content/app/custom-download/components/content-builder/ContentBuilder.tsx
+++ b/src/ensembl/src/content/app/custom-download/components/content-builder/ContentBuilder.tsx
@@ -174,7 +174,10 @@ const ContentBuilder = (props: ContentBuilderProps) => {
       }
     });
     if (shouldUpdateSelectedData) {
-      props.onChange(newSelectedData);
+      // Rhe setTimeout below is a temporary hack.
+      // Running props.onChange(newSelectedData) synchronously causes the redux wrapper component
+      // to immediately try to re-render; which produces errors in the console in dev mode
+      setTimeout(() => props.onChange(newSelectedData), 0);
     }
 
     const gridClone = gridOptions.map((option) => {

--- a/src/ensembl/src/content/app/custom-download/components/content-builder/ContentBuilder.tsx
+++ b/src/ensembl/src/content/app/custom-download/components/content-builder/ContentBuilder.tsx
@@ -174,7 +174,7 @@ const ContentBuilder = (props: ContentBuilderProps) => {
       }
     });
     if (shouldUpdateSelectedData) {
-      // Rhe setTimeout below is a temporary hack.
+      // The setTimeout below is a temporary hack.
       // Running props.onChange(newSelectedData) synchronously causes the redux wrapper component
       // to immediately try to re-render; which produces errors in the console in dev mode
       setTimeout(() => props.onChange(newSelectedData), 0);

--- a/src/ensembl/src/content/app/custom-download/containers/content/attributes-accordion/sections/orthologues/Orthologues.tsx
+++ b/src/ensembl/src/content/app/custom-download/containers/content/attributes-accordion/sections/orthologues/Orthologues.tsx
@@ -16,7 +16,7 @@
 
 import React, { useCallback } from 'react';
 import { connect } from 'react-redux';
-import set from 'lodash/set';
+import set from 'lodash/fp/set';
 import findIndex from 'lodash/findIndex';
 
 import { RootState } from 'src/store';
@@ -81,8 +81,7 @@ const Orthologue = (props: Props) => {
 
     const path = ['orthologues', `${attributeId}(${species})`];
 
-    const updatedAttributes = { ...props.selectedAttributes };
-    set(updatedAttributes, path, status);
+    const updatedAttributes = set(path, status, props.selectedAttributes);
     props.updateSelectedAttributes(updatedAttributes);
 
     props.setOrthologueAttributes(

--- a/src/ensembl/src/content/app/custom-download/state/attributes/attributesActions.ts
+++ b/src/ensembl/src/content/app/custom-download/state/attributes/attributesActions.ts
@@ -18,7 +18,7 @@ import { createAsyncAction } from 'typesafe-actions';
 import { ThunkAction } from 'redux-thunk';
 import { ActionCreator, Action } from 'redux';
 import findIndex from 'lodash/findIndex';
-import set from 'lodash/set';
+import set from 'lodash/fp/set';
 
 import { orthologueSpecies as sampleOrthologueSpecies } from 'src/content/app/custom-download/sample-data/orthologue';
 import attributes from 'src/content/app/custom-download/sample-data/attributes';
@@ -64,13 +64,11 @@ export const fetchAttributes: ActionCreator<ThunkAction<
     dispatch(
       updateActiveConfigurationForGenome({
         activeGenomeId,
-        data: {
-          ...set(
-            getCustomDownloadActiveGenomeConfiguration(getState()),
-            'attributes.content',
-            attributes
-          )
-        }
+        data: set(
+          'attributes.content',
+          attributes,
+          getCustomDownloadActiveGenomeConfiguration(getState())
+        )
       })
     );
   } catch (error) {
@@ -96,13 +94,11 @@ export const updateSelectedAttributes: ActionCreator<ThunkAction<
   dispatch(
     updateActiveConfigurationForGenome({
       activeGenomeId,
-      data: {
-        ...set(
-          getCustomDownloadActiveGenomeConfiguration(getState()),
-          'attributes.selectedAttributes',
-          selectedAttributes
-        )
-      }
+      data: set(
+        'attributes.selectedAttributes',
+        selectedAttributes,
+        getCustomDownloadActiveGenomeConfiguration(getState())
+      )
     })
   );
 };
@@ -122,13 +118,11 @@ export const resetSelectedAttributes: ActionCreator<ThunkAction<
   dispatch(
     updateActiveConfigurationForGenome({
       activeGenomeId,
-      data: {
-        ...set(
-          getCustomDownloadActiveGenomeConfiguration(getState()),
-          'attributes.selectedAttributes',
-          {}
-        )
-      }
+      data: set(
+        'attributes.selectedAttributes',
+        {},
+        getCustomDownloadActiveGenomeConfiguration(getState())
+      )
     })
   );
 };
@@ -148,13 +142,11 @@ export const updateUi: ActionCreator<ThunkAction<
   dispatch(
     updateActiveConfigurationForGenome({
       activeGenomeId,
-      data: {
-        ...set(
-          getCustomDownloadActiveGenomeConfiguration(getState()),
-          'attributes.ui',
-          attributesUi
-        )
-      }
+      data: set(
+        'attributes.ui',
+        attributesUi,
+        getCustomDownloadActiveGenomeConfiguration(getState())
+      )
     })
   );
 };
@@ -177,13 +169,11 @@ export const setOrthologueAttributes: ActionCreator<ThunkAction<
   dispatch(
     updateActiveConfigurationForGenome({
       activeGenomeId,
-      data: {
-        ...set(
-          getCustomDownloadActiveGenomeConfiguration(getState()),
-          'attributes.content.orthologueAttributes.orthologues',
-          orthologues
-        )
-      }
+      data: set(
+        'attributes.content.orthologueAttributes.orthologues',
+        orthologues,
+        getCustomDownloadActiveGenomeConfiguration(getState())
+      )
     })
   );
 };
@@ -203,13 +193,11 @@ export const setOrthologueShowBestMatches: ActionCreator<ThunkAction<
   dispatch(
     updateActiveConfigurationForGenome({
       activeGenomeId,
-      data: {
-        ...set(
-          getCustomDownloadActiveGenomeConfiguration(getState()),
-          'attributes.content.orthologue.showBestMatches',
-          showBestMatches
-        )
-      }
+      data: set(
+        'attributes.content.orthologue.showBestMatches',
+        showBestMatches,
+        getCustomDownloadActiveGenomeConfiguration(getState())
+      )
     })
   );
 };
@@ -229,13 +217,11 @@ export const setOrthologueShowAll: ActionCreator<ThunkAction<
   dispatch(
     updateActiveConfigurationForGenome({
       activeGenomeId,
-      data: {
-        ...set(
-          getCustomDownloadActiveGenomeConfiguration(getState()),
-          'attributes.content.orthologue.showAll',
-          showAll
-        )
-      }
+      data: set(
+        'attributes.content.orthologue.showAll',
+        showAll,
+        getCustomDownloadActiveGenomeConfiguration(getState())
+      )
     })
   );
 };
@@ -255,13 +241,11 @@ export const setOrthologueApplyToAllSpecies: ActionCreator<ThunkAction<
   dispatch(
     updateActiveConfigurationForGenome({
       activeGenomeId,
-      data: {
-        ...set(
-          getCustomDownloadActiveGenomeConfiguration(getState()),
-          'attributes.content.orthologue.applyToAllSpecies',
-          applyToAllSpecies
-        )
-      }
+      data: set(
+        'attributes.content.orthologue.applyToAllSpecies',
+        applyToAllSpecies,
+        getCustomDownloadActiveGenomeConfiguration(getState())
+      )
     })
   );
 };
@@ -281,13 +265,11 @@ export const setOrthologueSearchTerm: ActionCreator<ThunkAction<
   dispatch(
     updateActiveConfigurationForGenome({
       activeGenomeId,
-      data: {
-        ...set(
-          getCustomDownloadActiveGenomeConfiguration(getState()),
-          'attributes.content.orthologue.searchTerm',
-          searchTerm
-        )
-      }
+      data: set(
+        'attributes.content.orthologue.searchTerm',
+        searchTerm,
+        getCustomDownloadActiveGenomeConfiguration(getState())
+      )
     })
   );
 };
@@ -316,13 +298,11 @@ export const updateOrthologueSpecies: ActionCreator<ThunkAction<
   dispatch(
     updateActiveConfigurationForGenome({
       activeGenomeId,
-      data: {
-        ...set(
-          getCustomDownloadActiveGenomeConfiguration(getState()),
-          'attributes.content.orthologue.species',
-          orthologueSpecies
-        )
-      }
+      data: set(
+        'attributes.content.orthologue.species',
+        orthologueSpecies,
+        getCustomDownloadActiveGenomeConfiguration(getState())
+      )
     })
   );
 };
@@ -380,13 +360,11 @@ export const fetchOrthologueSpecies: ActionCreator<ThunkAction<
     dispatch(
       updateActiveConfigurationForGenome({
         activeGenomeId,
-        data: {
-          ...set(
-            getCustomDownloadActiveGenomeConfiguration(getState()),
-            'attributes.content.orthologue.species',
-            filteredSpecies
-          )
-        }
+        data: set(
+          'attributes.content.orthologue.species',
+          filteredSpecies,
+          getCustomDownloadActiveGenomeConfiguration(getState())
+        )
       })
     );
   } catch (error) {
@@ -409,13 +387,11 @@ export const setAttributesAccordionExpandedPanel: ActionCreator<ThunkAction<
   dispatch(
     updateActiveConfigurationForGenome({
       activeGenomeId,
-      data: {
-        ...set(
-          getCustomDownloadActiveGenomeConfiguration(getState()),
-          'attributes.expandedPanels',
-          expandedPanels
-        )
-      }
+      data: set(
+        'attributes.expandedPanels',
+        expandedPanels,
+        getCustomDownloadActiveGenomeConfiguration(getState())
+      )
     })
   );
 };

--- a/src/ensembl/src/content/app/custom-download/state/customDownloadActions.ts
+++ b/src/ensembl/src/content/app/custom-download/state/customDownloadActions.ts
@@ -15,7 +15,7 @@
  */
 
 import { createAction, createAsyncAction } from 'typesafe-actions';
-import set from 'lodash/set';
+import set from 'lodash/fp/set';
 import cloneDeep from 'lodash/cloneDeep';
 
 import * as allFilterAccordionActions from './filters/filtersActions';
@@ -90,9 +90,9 @@ export const updateSelectedPreFilter: ActionCreator<ThunkAction<
     updateActiveConfigurationForGenome({
       activeGenomeId,
       data: set(
-        getCustomDownloadActiveGenomeConfiguration(getState()),
         'preFilter.selectedPreFilter',
-        selectedPreFilter
+        selectedPreFilter,
+        getCustomDownloadActiveGenomeConfiguration(getState())
       )
     })
   );
@@ -117,9 +117,9 @@ export const togglePreFiltersPanel: ActionCreator<ThunkAction<
     updateActiveConfigurationForGenome({
       activeGenomeId,
       data: set(
-        getCustomDownloadActiveGenomeConfiguration(getState()),
         'preFilter.showPreFiltersPanel',
-        showPreFiltersPanel
+        showPreFiltersPanel,
+        getCustomDownloadActiveGenomeConfiguration(getState())
       )
     })
   );
@@ -173,9 +173,9 @@ export const setShowPreview: ActionCreator<ThunkAction<
     updateActiveConfigurationForGenome({
       activeGenomeId,
       data: set(
-        getCustomDownloadActiveGenomeConfiguration(getState()),
         'previewDownload.showSummary',
-        showSummary
+        showSummary,
+        getCustomDownloadActiveGenomeConfiguration(getState())
       )
     })
   );
@@ -197,9 +197,9 @@ export const setShowExampleData: ActionCreator<ThunkAction<
     updateActiveConfigurationForGenome({
       activeGenomeId,
       data: set(
-        getCustomDownloadActiveGenomeConfiguration(getState()),
         'previewDownload.showExampleData',
-        showExampleData
+        showExampleData,
+        getCustomDownloadActiveGenomeConfiguration(getState())
       )
     })
   );
@@ -221,9 +221,9 @@ export const setDownloadType: ActionCreator<ThunkAction<
     updateActiveConfigurationForGenome({
       activeGenomeId,
       data: set(
-        getCustomDownloadActiveGenomeConfiguration(getState()),
         'previewDownload.downloadType',
-        downloadType
+        downloadType,
+        getCustomDownloadActiveGenomeConfiguration(getState())
       )
     })
   );

--- a/src/ensembl/src/content/app/custom-download/state/filters/filtersActions.ts
+++ b/src/ensembl/src/content/app/custom-download/state/filters/filtersActions.ts
@@ -16,7 +16,7 @@
 
 import { ThunkAction } from 'redux-thunk';
 import { ActionCreator, Action } from 'redux';
-import set from 'lodash/set';
+import set from 'lodash/fp/set';
 
 import { RootState } from 'src/store';
 import JSONValue from 'src/shared/types/JSON';
@@ -41,13 +41,11 @@ export const setFiltersAccordionExpandedPanel: ActionCreator<ThunkAction<
   dispatch(
     updateActiveConfigurationForGenome({
       activeGenomeId,
-      data: {
-        ...set(
-          getCustomDownloadActiveGenomeConfiguration(getState()),
-          'filters.expandedPanels',
-          expandedPanels
-        )
-      }
+      data: set(
+        'filters.expandedPanels',
+        expandedPanels,
+        getCustomDownloadActiveGenomeConfiguration(getState())
+      )
     })
   );
 };
@@ -67,13 +65,11 @@ export const updateSelectedFilters: ActionCreator<ThunkAction<
   dispatch(
     updateActiveConfigurationForGenome({
       activeGenomeId,
-      data: {
-        ...set(
-          getCustomDownloadActiveGenomeConfiguration(getState()),
-          'filters.selectedFilters',
-          selectedFilters
-        )
-      }
+      data: set(
+        'filters.selectedFilters',
+        selectedFilters,
+        getCustomDownloadActiveGenomeConfiguration(getState())
+      )
     })
   );
 };
@@ -93,13 +89,11 @@ export const updateUi: ActionCreator<ThunkAction<
   dispatch(
     updateActiveConfigurationForGenome({
       activeGenomeId,
-      data: {
-        ...set(
-          getCustomDownloadActiveGenomeConfiguration(getState()),
-          'filters.ui',
-          filtersUi
-        )
-      }
+      data: set(
+        'filters.ui',
+        filtersUi,
+        getCustomDownloadActiveGenomeConfiguration(getState())
+      )
     })
   );
 };
@@ -119,13 +113,11 @@ export const resetSelectedFilters: ActionCreator<ThunkAction<
   dispatch(
     updateActiveConfigurationForGenome({
       activeGenomeId,
-      data: {
-        ...set(
-          getCustomDownloadActiveGenomeConfiguration(getState()),
-          'filters.selectedFilters',
-          {}
-        )
-      }
+      data: set(
+        'filters.selectedFilters',
+        {},
+        getCustomDownloadActiveGenomeConfiguration(getState())
+      )
     })
   );
 };


### PR DESCRIPTION
## Type
- Bug fix

## Description

### 1. Redux state mutations
If you run Ensembl client in development mode, and switch to Custom Download, you will see an error screen and multiple errors in the console:

![image](https://user-images.githubusercontent.com/6834224/94378496-02a7cf80-0122-11eb-9b6b-9aa385adfa75.png)

The cause of the error is that the code uses the lodash's `set` function, which mutates the source object, both in CustomDownload-related redux actions, and in the ContentBuilder component.

This PR is a quick fix to these errors. It changes the regular lodash's `set` to the `set` function from `lodash/fp`, which creates a copy of the source object instead of mutating it. We shall revisit this later when we return to CustomDownload.

### 2. Redux wrapper re-rendering during the render of the `ContentBuilder`:

If you navigate to the initial CustomDownload screen and press the Gene/Transcripts button:

![image](https://user-images.githubusercontent.com/6834224/94424195-bc825880-0181-11eb-91f0-2144296a568d.png)

you will see an error/warning in the console about how `react-redux`'s component (`ConnectFunction`) tried to re-render while the `ContentBuilder` component was rendering:

![image](https://user-images.githubusercontent.com/6834224/94424135-a4aad480-0181-11eb-8441-bda3b7a64de4.png)

This PR wraps the update function in a setTimeout to move it to the end of the event loop queue.