### PR TITLE
gene stable_id will have version, so dont concatenate

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-overview-image/GeneOverviewImage.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-overview-image/GeneOverviewImage.tsx
@@ -97,9 +97,7 @@ export const GeneImage = (props: GeneOverviewImageProps) => {
 };
 
 const GeneId = (props: GeneOverviewImageProps) => (
-  <div className={styles.geneId}>
-    {props.gene.id}.{props.gene.version}
-  </div>
+  <div className={styles.geneId}>{props.gene.id}</div>
 );
 
 const DirectionIndicator = () => {

--- a/src/ensembl/src/content/app/entity-viewer/types/gene.ts
+++ b/src/ensembl/src/content/app/entity-viewer/types/gene.ts
@@ -24,7 +24,6 @@ import { Metadata } from './metadata';
 export type Gene = {
   type: 'Gene';
   id: string;
-  version: number;
   symbol: string;
   source?: Source;
   so_term: string; // is there a better name for it?

--- a/src/ensembl/src/content/app/entity-viewer/types/gene.ts
+++ b/src/ensembl/src/content/app/entity-viewer/types/gene.ts
@@ -24,6 +24,7 @@ import { Metadata } from './metadata';
 export type Gene = {
   type: 'Gene';
   id: string;
+  version: number;
   symbol: string;
   source?: Source;
   so_term: string; // is there a better name for it?


### PR DESCRIPTION
## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-725

## Description
Stable IDs will have version added to it by default in Thoas. So remove previously concatenated version.

## Views affected
Entity viewer
