### PR TITLE
Sticky header tabs - gene function

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.scss
@@ -9,6 +9,12 @@
   color: $black;
 }
 
+.header {
+  position: sticky;
+  top: -5px;
+  z-index: 1;
+}
+
 .defaultTabName {
   padding: 3px 30px;
 }

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.tsx
@@ -125,6 +125,7 @@ const GeneFunction = (props: Props) => {
       header={<TabWrapper />}
       classNames={{
         panel: styles.panel,
+        header: styles.header,
         body: styles.panelBody
       }}
     >


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [x ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-757


## Description
Relationship between tabs and header panel to be maintained - only the transcript list and protein panels should scroll behind


## Deployment URL
http://sticky-tabs.review.ensembl.org/entity-viewer/homo_sapiens_GCA_000001405_28/gene:ENSG00000139618?view=protein

## Views affected
Entity viewer


## Possible complications
Nothing at the moment :-) 