### PR TITLE
Refactor Help&Docs popup

### DIFF
--- a/src/ensembl/src/content/app/browser/browser-app-bar/BrowserAppBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-app-bar/BrowserAppBar.tsx
@@ -25,11 +25,10 @@ import { AppName } from 'src/global/globalConfig';
 import { getBrowserActiveGenomeId } from 'src/content/app/browser/browserSelectors';
 import { getEnabledCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 
-import AppBar, {
-  HelpAndDocumentation
-} from 'src/shared/components/app-bar/AppBar';
+import AppBar from 'src/shared/components/app-bar/AppBar';
 import { SelectedSpecies } from 'src/shared/components/selected-species';
 import SpeciesTabsWrapper from 'src/shared/components/species-tabs-wrapper/SpeciesTabsWrapper';
+import { HelpPopupButton } from 'src/shared/components/help-popup';
 
 import { RootState } from 'src/store';
 import { CommittedItem } from 'src/content/app/species-selector/types/species-search';
@@ -67,7 +66,7 @@ const BrowserAppBar = (props: BrowserAppBarProps) => {
     <AppBar
       appName={AppName.GENOME_BROWSER}
       mainContent={wrappedSpecies}
-      aside={<HelpAndDocumentation />}
+      aside={<HelpPopupButton slug="using-the-genome-browser" />}
     />
   );
 };

--- a/src/ensembl/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
@@ -56,7 +56,7 @@ export const SpeciesSelectorAppBar = (props: Props) => {
     <AppBar
       appName="Species Selector"
       mainContent={mainContent}
-      aside={<HelpPopupButton slug="selecting-a-species" />}
+      aside={<HelpPopupButton slug="species-selector" />}
     />
   );
 };

--- a/src/ensembl/src/shared/components/help-popup/HelpPopupBody.scss
+++ b/src/ensembl/src/shared/components/help-popup/HelpPopupBody.scss
@@ -47,9 +47,10 @@ $aside-left-padding: 1.6rem;
 }
 
 .videoWrapper {
-  // the wrapper needs to be able to change its width when its parent does
-  // (so that the wrapper's width can be observed with ResizeObserver, and the iframe dimensions set based on it)
-  // TODO: change to aspect-ratio rule when it gets better browser support
+  // the position of the wrapper is set to relative and the position of the iframe to absolute
+  // because the wrapper needs to change its dimensions when its parent does
+  // while iframe's dimensions are set via javascript by observing wrapper's dimensions through ResizeObserver
+  // TODO: change this to aspect-ratio CSS rule when it gets better browser support
   position: relative;
 
   iframe {

--- a/src/ensembl/src/shared/components/help-popup/HelpPopupBody.scss
+++ b/src/ensembl/src/shared/components/help-popup/HelpPopupBody.scss
@@ -15,20 +15,20 @@ $aside-left-padding: 1.6rem;
   grid-column-gap: 55px;
   height: 100%;
   padding-left: 52px;
-  overflow-y: auto;
 
   &_article {
-    grid-template-columns: [article] 440px [empty] 1fr [aside] minmax(200px, 450px);
+    grid-template-columns: [article] 440px [empty] 1fr [aside] minmax(200px, 350px);
   }
 
   &_video {
-    grid-template-columns: [video] 1fr [aside] minmax(200px, 450px);
+    grid-template-columns: [video] 1fr [aside] minmax(200px, 350px);
   }
 }
 
 .article {
   grid-column: article;
   padding-left: $heading-outdent;
+  overflow-y: auto;
 
   h1 {
     margin-left: -$heading-outdent;
@@ -43,17 +43,18 @@ $aside-left-padding: 1.6rem;
 
 .video {
   grid-column: video;
+  height: 90%;
 }
 
 .videoWrapper {
+  // the wrapper needs to be able to change its width when its parent does
+  // (so that the wrapper's width can be observed with ResizeObserver, and the iframe dimensions set based on it)
+  // TODO: change to aspect-ratio rule when it gets better browser support
   position: relative;
-  padding-top: 56.25%; // trick for enforcing the 16:9 aspect ratio in the container
 
   iframe {
     position: absolute;
     top: 0;
-    width: 100%;
-    height: 100%;
   }
 }
 

--- a/src/ensembl/src/shared/components/help-popup/HelpPopupBody.scss
+++ b/src/ensembl/src/shared/components/help-popup/HelpPopupBody.scss
@@ -84,6 +84,7 @@ $aside-left-padding: 1.6rem;
 }
 
 .relatedCurrent {
+  cursor: inherit;
   color: inherit;
 }
 

--- a/src/ensembl/src/shared/components/help-popup/HelpPopupBody.scss
+++ b/src/ensembl/src/shared/components/help-popup/HelpPopupBody.scss
@@ -12,16 +12,16 @@ $aside-left-padding: 1.6rem;
 
 .grid {
   display: grid;
-  grid-column-gap: 55px;
+  grid-column-gap: 15px;
   height: 100%;
-  padding-left: 52px;
 
   &_article {
-    grid-template-columns: [article] 440px [empty] 1fr [aside] minmax(200px, 350px);
+    grid-template-columns: [article] 440px [empty] 1fr [aside] minmax(200px, 300px);
   }
 
   &_video {
-    grid-template-columns: [video] 1fr [aside] minmax(200px, 350px);
+    grid-column-gap: 30px;
+    grid-template-columns: [video] minmax(450px, 1fr) [aside] minmax(200px, 300px);
   }
 }
 
@@ -80,6 +80,7 @@ $aside-left-padding: 1.6rem;
 .relatedVideo {
   color: $blue;
   cursor: pointer;
+  margin-bottom: 0.4rem;
 }
 
 .relatedVideo {

--- a/src/ensembl/src/shared/components/help-popup/HelpPopupBody.scss
+++ b/src/ensembl/src/shared/components/help-popup/HelpPopupBody.scss
@@ -83,6 +83,10 @@ $aside-left-padding: 1.6rem;
   margin-bottom: 0.4rem;
 }
 
+.relatedCurrent {
+  color: inherit;
+}
+
 .relatedVideo {
   position: relative;
 }

--- a/src/ensembl/src/shared/components/help-popup/HelpPopupBody.scss
+++ b/src/ensembl/src/shared/components/help-popup/HelpPopupBody.scss
@@ -12,15 +12,22 @@ $aside-left-padding: 1.6rem;
 
 .grid {
   display: grid;
-  grid-template-columns: [article-text] 2fr [article-video] 2fr [aside] 1fr;
-  grid-column-gap: 1rem;
+  grid-column-gap: 55px;
   height: 100%;
   padding-left: 52px;
   overflow-y: auto;
+
+  &_article {
+    grid-template-columns: [article] 440px [empty] 1fr [aside] minmax(200px, 450px);
+  }
+
+  &_video {
+    grid-template-columns: [video] 1fr [aside] minmax(200px, 450px);
+  }
 }
 
-.text {
-  grid-column: article-text;
+.article {
+  grid-column: article;
   padding-left: $heading-outdent;
 
   h1 {
@@ -35,7 +42,7 @@ $aside-left-padding: 1.6rem;
 }
 
 .video {
-  grid-column: article-video;
+  grid-column: video;
 }
 
 .videoWrapper {
@@ -51,6 +58,7 @@ $aside-left-padding: 1.6rem;
 }
 
 .aside {
+  grid-column: aside;
   padding-left: $aside-left-padding;
 
   h2 {

--- a/src/ensembl/src/shared/components/help-popup/HelpPopupBody.tsx
+++ b/src/ensembl/src/shared/components/help-popup/HelpPopupBody.tsx
@@ -105,14 +105,16 @@ type VideoProps = {
 };
 const Video = (props: VideoProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
-  const { width: containerWidth } = useResizeObserver({ ref: containerRef });
+  const { width: containerWidth, height: containerHeight } = useResizeObserver({
+    ref: containerRef
+  });
 
   // ensure that the video has a 16:9 aspect ratio
   // TODO: switch to pure CSS when the aspect-ratio rule gets better support (see https://caniuse.com/?search=aspect-ratio)
-  const videoWidth = containerWidth;
-  const videoHeight = containerWidth
-    ? Math.round((containerWidth / 16) * 9)
-    : 0;
+  const { width: videoWidth, height: videoHeight } = calculateVideoDimensions(
+    containerWidth,
+    containerHeight
+  );
 
   const videoStyle = {
     width: `${videoWidth}px`,
@@ -196,6 +198,32 @@ const createVideoReference = (youtubeId: string) => {
     type: 'video' as const,
     youtube_id: youtubeId
   };
+};
+
+const calculateVideoDimensions = (
+  containerWidth: number,
+  containerHeight: number
+) => {
+  if (!containerWidth || !containerHeight) {
+    return {
+      width: 0,
+      height: 0
+    };
+  }
+
+  const referenceSide =
+    containerWidth / containerHeight <= 16 / 9 ? 'width' : 'height';
+  if (referenceSide === 'width') {
+    return {
+      width: containerWidth,
+      height: Math.round((containerWidth * 9) / 16)
+    };
+  } else {
+    return {
+      width: Math.round((containerHeight * 16) / 9),
+      height: containerHeight
+    };
+  }
 };
 
 export default HelpPopupBody;

--- a/src/ensembl/src/shared/components/help-popup/HelpPopupBody.tsx
+++ b/src/ensembl/src/shared/components/help-popup/HelpPopupBody.tsx
@@ -14,7 +14,18 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useState, ReactNode } from 'react';
+import classNames from 'classnames';
+
+import useHelpArticle, {
+  emptyRelatedItems,
+  CurrentArticle,
+  CurrentVideo,
+  CurrentItem,
+  RelatedItems as RelatedItemsType,
+  ArticleReference,
+  VideoReference
+} from './useHelpArticle';
 
 import { CircleLoader } from 'src/shared/components/loader/Loader';
 
@@ -22,92 +33,117 @@ import { ReactComponent as VideoIcon } from 'static/img/shared/video.svg';
 
 import styles from './HelpPopupBody.scss';
 
-export type HelpVideo = {
-  title: string;
-  description: string;
-  youtube_id: string;
-};
+import {
+  RelatedArticle,
+  HelpVideo,
+  SlugReference,
+  PathReference
+} from './types';
 
-type ArticleSummary = {
-  title: string;
-  slug: string;
-  path: string;
-};
-
-export type HelpArticle = {
-  path: string;
-  slug: string;
-  body: string;
-  videos: HelpVideo[];
-  related_articles: ArticleSummary[];
-};
-
-type LoadingArticle =
-  | {
-      loading: true;
-      article: null;
-    }
-  | {
-      loading: false;
-      article: HelpArticle;
-    };
-
-type Props = LoadingArticle & {
-  onArticleChange: (slug: string) => void;
-  onVideoChange: (youtubeId: string) => void;
-};
+type Props = SlugReference | PathReference;
 
 const HelpPopupBody = (props: Props) => {
-  if (props.loading) {
-    // TODO: Ideally, we will want to avoid showing the spinner if the article is loaded
-    // nearly instantaneously. Perhaps revisit this when React gets Suspense.
+  const [currentReference, setCurrentReference] = useState<
+    ArticleReference | VideoReference
+  >(createArticleReference(props));
+  const { currentHelpItem, relatedItems } = useHelpArticle(currentReference);
+
+  const onRelatedItemClick = (reference: ArticleReference | VideoReference) => {
+    setCurrentReference(reference);
+  };
+
+  if (currentHelpItem?.type === 'article') {
     return (
-      <div className={styles.spinnerContainer}>
-        <CircleLoader />
-      </div>
+      <Grid type="article">
+        <Article article={currentHelpItem} />
+        <RelatedItems
+          items={relatedItems || emptyRelatedItems}
+          onItemClick={onRelatedItemClick}
+        />
+      </Grid>
     );
+  } else if (currentHelpItem?.type === 'video') {
+    return (
+      <Grid type="video">
+        <Video video={currentHelpItem} />
+        <RelatedItems
+          items={relatedItems || emptyRelatedItems}
+          onItemClick={onRelatedItemClick}
+        />
+      </Grid>
+    );
+  } else {
+    return <CircleLoader />;
   }
+};
 
-  // have to destructure article from props after checking for props.loading;
-  // because only then typescript will be sure that article exists
-  const { article } = props;
+type GridProps = {
+  type: CurrentItem['type'];
+  children: ReactNode;
+};
 
-  /**
-   * TODO: we do not know yet:
-   * - how the interface will behave if there are multiple videos associated with a single article
-   * - whether videos, in their turn, will also have related videos
-   * - what should happen in the popup when a related video link is clicked
-   * Therefore, the current implementation is provisional, and expected to be changed
-   */
+const Grid = (props: GridProps) => {
+  const gridClass = classNames(styles.grid, styles[`grid_${props.type}`]);
 
-  const firstVideo = article.videos[0];
-  const relatedVideos = article.videos.slice(1);
+  return <div className={gridClass}>{props.children}</div>;
+};
 
-  const renderedVideo = firstVideo ? (
-    <div className={styles.videoWrapper}>
-      <iframe
-        src={`https://www.youtube.com/embed/${firstVideo.youtube_id}`}
-        allowFullScreen
-        frameBorder="0"
-      />
+type ArticleProps = {
+  article: CurrentArticle;
+};
+const Article = (props: ArticleProps) => {
+  return (
+    <article className={styles.article}>
+      <div dangerouslySetInnerHTML={{ __html: props.article.body }} />
+    </article>
+  );
+};
+
+type VideoProps = {
+  video: CurrentVideo;
+};
+const Video = (props: VideoProps) => {
+  return (
+    <div>
+      <div className={styles.videoWrapper}>
+        <iframe
+          src={`https://www.youtube.com/embed/${props.video.youtube_id}`}
+          allowFullScreen
+          frameBorder="0"
+        />
+      </div>
     </div>
-  ) : null;
+  );
+};
 
-  const relatedArticles = article.related_articles.map((relatedArticle) => (
+type RelatedItemsProps = {
+  items: RelatedItemsType;
+  onItemClick: (reference: ArticleReference | VideoReference) => void;
+};
+const RelatedItems = (props: RelatedItemsProps) => {
+  const onArticleClick = (article: RelatedArticle) => {
+    props.onItemClick(createArticleReference({ path: article.path }));
+  };
+
+  const onVideoClick = (video: HelpVideo) => {
+    props.onItemClick(createVideoReference(video.youtube_id));
+  };
+
+  const relatedArticles = props.items.articles.map((relatedArticle) => (
     <span
       key={relatedArticle.slug}
       className={styles.relatedArticle}
-      onClick={() => props.onArticleChange(relatedArticle.slug)}
+      onClick={() => onArticleClick(relatedArticle)}
     >
       {relatedArticle.title}
     </span>
   ));
 
-  const relatedVideoElements = relatedVideos.map((video) => (
+  const relatedVideoElements = props.items.videos.map((video) => (
     <span
       key={video.youtube_id}
       className={styles.relatedVideo}
-      onClick={() => props.onVideoChange(video.youtube_id)}
+      onClick={() => onVideoClick(video)}
     >
       <span className={styles.relatedVideoIcon}>
         <VideoIcon />
@@ -117,24 +153,30 @@ const HelpPopupBody = (props: Props) => {
   ));
 
   return (
-    <div className={styles.grid}>
-      <div className={styles.text}>
-        <div dangerouslySetInnerHTML={{ __html: article.body }} />
-      </div>
-      <div className={styles.video}>{renderedVideo}</div>
-      <div className={styles.aside}>
-        {Boolean(relatedArticles.length) && (
-          <>
-            <h2>Related...</h2>
-            <div className={styles.relatedArticlesContainer}>
-              {relatedArticles}
-              {relatedVideoElements}
-            </div>
-          </>
-        )}
-      </div>
-    </div>
+    <aside className={styles.aside}>
+      <>
+        <h2>Related...</h2>
+        <div className={styles.relatedArticlesContainer}>
+          {relatedArticles}
+          {relatedVideoElements}
+        </div>
+      </>
+    </aside>
   );
+};
+
+const createArticleReference = (reference: SlugReference | PathReference) => {
+  return {
+    type: 'article' as const,
+    reference
+  };
+};
+
+const createVideoReference = (youtubeId: string) => {
+  return {
+    type: 'video' as const,
+    youtube_id: youtubeId
+  };
 };
 
 export default HelpPopupBody;

--- a/src/ensembl/src/shared/components/help-popup/HelpPopupBody.tsx
+++ b/src/ensembl/src/shared/components/help-popup/HelpPopupBody.tsx
@@ -47,7 +47,9 @@ const HelpPopupBody = (props: Props) => {
   const [currentReference, setCurrentReference] = useState<
     ArticleReference | VideoReference
   >(createArticleReference(props));
-  const { currentHelpItem, relatedItems } = useHelpArticle(currentReference);
+  const { currentHelpItem, relatedHelpItems } = useHelpArticle(
+    currentReference
+  );
 
   const onRelatedItemClick = (reference: ArticleReference | VideoReference) => {
     setCurrentReference(reference);
@@ -59,7 +61,7 @@ const HelpPopupBody = (props: Props) => {
         <Article article={currentHelpItem} />
         <RelatedItems
           currentItem={currentHelpItem}
-          items={relatedItems || emptyRelatedItems}
+          items={relatedHelpItems || emptyRelatedItems}
           onItemClick={onRelatedItemClick}
         />
       </Grid>
@@ -70,7 +72,7 @@ const HelpPopupBody = (props: Props) => {
         <Video video={currentHelpItem} />
         <RelatedItems
           currentItem={currentHelpItem}
-          items={relatedItems || emptyRelatedItems}
+          items={relatedHelpItems || emptyRelatedItems}
           onItemClick={onRelatedItemClick}
         />
       </Grid>

--- a/src/ensembl/src/shared/components/help-popup/HelpPopupBody.tsx
+++ b/src/ensembl/src/shared/components/help-popup/HelpPopupBody.tsx
@@ -32,14 +32,14 @@ import { CircleLoader } from 'src/shared/components/loader/Loader';
 
 import { ReactComponent as VideoIcon } from 'static/img/shared/video.svg';
 
-import styles from './HelpPopupBody.scss';
-
 import {
   RelatedArticle,
   HelpVideo,
   SlugReference,
   PathReference
 } from './types';
+
+import styles from './HelpPopupBody.scss';
 
 type Props = SlugReference | PathReference;
 

--- a/src/ensembl/src/shared/components/help-popup/HelpPopupBody.tsx
+++ b/src/ensembl/src/shared/components/help-popup/HelpPopupBody.tsx
@@ -176,7 +176,7 @@ const RelatedItems = (props: RelatedItemsProps) => {
   return (
     <aside className={styles.aside}>
       <>
-        <h2>Related...</h2>
+        <h2>Help with...</h2>
         <div className={styles.relatedArticlesContainer}>
           {relatedArticles}
           {relatedVideoElements}

--- a/src/ensembl/src/shared/components/help-popup/HelpPopupBody.tsx
+++ b/src/ensembl/src/shared/components/help-popup/HelpPopupBody.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState, ReactNode } from 'react';
+import React, { useState, useRef, ReactNode } from 'react';
 import classNames from 'classnames';
 
 import useHelpArticle, {
@@ -26,6 +26,7 @@ import useHelpArticle, {
   ArticleReference,
   VideoReference
 } from './useHelpArticle';
+import useResizeObserver from 'src/shared/hooks/useResizeObserver.ts';
 
 import { CircleLoader } from 'src/shared/components/loader/Loader';
 
@@ -103,15 +104,33 @@ type VideoProps = {
   video: CurrentVideo;
 };
 const Video = (props: VideoProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { width: containerWidth } = useResizeObserver({ ref: containerRef });
+
+  // ensure that the video has a 16:9 aspect ratio
+  // TODO: switch to pure CSS when the aspect-ratio rule gets better support (see https://caniuse.com/?search=aspect-ratio)
+  const videoWidth = containerWidth;
+  const videoHeight = containerWidth
+    ? Math.round((containerWidth / 16) * 9)
+    : 0;
+
+  const videoStyle = {
+    width: `${videoWidth}px`,
+    height: `${videoHeight}px`
+  };
+
   return (
-    <div>
-      <div className={styles.videoWrapper}>
-        <iframe
-          src={`https://www.youtube.com/embed/${props.video.youtube_id}`}
-          allowFullScreen
-          frameBorder="0"
-        />
-      </div>
+    <div ref={containerRef} className={styles.video}>
+      {videoWidth && videoHeight && (
+        <div className={styles.videoWrapper}>
+          <iframe
+            style={videoStyle}
+            src={`https://www.youtube.com/embed/${props.video.youtube_id}`}
+            allowFullScreen
+            frameBorder="0"
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/ensembl/src/shared/components/help-popup/HelpPopupBody.tsx
+++ b/src/ensembl/src/shared/components/help-popup/HelpPopupBody.tsx
@@ -58,6 +58,7 @@ const HelpPopupBody = (props: Props) => {
       <Grid type="article">
         <Article article={currentHelpItem} />
         <RelatedItems
+          currentItem={currentHelpItem}
           items={relatedItems || emptyRelatedItems}
           onItemClick={onRelatedItemClick}
         />
@@ -68,13 +69,18 @@ const HelpPopupBody = (props: Props) => {
       <Grid type="video">
         <Video video={currentHelpItem} />
         <RelatedItems
+          currentItem={currentHelpItem}
           items={relatedItems || emptyRelatedItems}
           onItemClick={onRelatedItemClick}
         />
       </Grid>
     );
   } else {
-    return <CircleLoader />;
+    return (
+      <div className={styles.spinnerContainer}>
+        <CircleLoader />
+      </div>
+    );
   }
 };
 
@@ -139,6 +145,7 @@ const Video = (props: VideoProps) => {
 
 type RelatedItemsProps = {
   items: RelatedItemsType;
+  currentItem: CurrentItem;
   onItemClick: (reference: ArticleReference | VideoReference) => void;
 };
 const RelatedItems = (props: RelatedItemsProps) => {
@@ -150,28 +157,43 @@ const RelatedItems = (props: RelatedItemsProps) => {
     props.onItemClick(createVideoReference(video.youtube_id));
   };
 
-  const relatedArticles = props.items.articles.map((relatedArticle) => (
-    <span
-      key={relatedArticle.slug}
-      className={styles.relatedArticle}
-      onClick={() => onArticleClick(relatedArticle)}
-    >
-      {relatedArticle.title}
-    </span>
-  ));
-
-  const relatedVideoElements = props.items.videos.map((video) => (
-    <span
-      key={video.youtube_id}
-      className={styles.relatedVideo}
-      onClick={() => onVideoClick(video)}
-    >
-      <span className={styles.relatedVideoIcon}>
-        <VideoIcon />
+  const relatedArticles = props.items.articles.map((relatedArticle) => {
+    const elementClasses = classNames(styles.relatedArticle, {
+      [styles.relatedCurrent]:
+        props.currentItem.type === 'article' &&
+        props.currentItem.path === relatedArticle.path
+    });
+    return (
+      <span
+        key={relatedArticle.slug}
+        className={elementClasses}
+        onClick={() => onArticleClick(relatedArticle)}
+      >
+        {relatedArticle.title}
       </span>
-      {video.title}
-    </span>
-  ));
+    );
+  });
+
+  const relatedVideoElements = props.items.videos.map((video) => {
+    const elementClasses = classNames(styles.relatedVideo, {
+      [styles.relatedCurrent]:
+        props.currentItem.type === 'video' &&
+        props.currentItem.youtube_id === video.youtube_id
+    });
+
+    return (
+      <span
+        key={video.youtube_id}
+        className={elementClasses}
+        onClick={() => onVideoClick(video)}
+      >
+        <span className={styles.relatedVideoIcon}>
+          <VideoIcon />
+        </span>
+        {video.title}
+      </span>
+    );
+  });
 
   return (
     <aside className={styles.aside}>

--- a/src/ensembl/src/shared/components/help-popup/HelpPopupButton.tsx
+++ b/src/ensembl/src/shared/components/help-popup/HelpPopupButton.tsx
@@ -14,16 +14,13 @@
  * limitations under the License.
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import classNames from 'classnames';
 
-import config from 'config';
-
-import useApiService from 'src/shared/hooks/useApiService';
 import { isEnvironment, Environment } from 'src/shared/helpers/environment';
 
 import Modal from 'src/shared/components/modal/Modal';
-import HelpPopupBody, { HelpArticle } from './HelpPopupBody';
+import HelpPopupBody from './HelpPopupBody';
 import { HelpAndDocumentation } from 'src/shared/components/app-bar/AppBar';
 
 import { ReactComponent as HelpIcon } from 'static/img/launchbar/help.svg';
@@ -43,46 +40,8 @@ type ArticleReference = SlugReference | PathReference;
 
 type Props = ArticleReference;
 
-const getQuery = (params: SlugReference | PathReference) => {
-  if ('slug' in params) {
-    return `slug=${params.slug}`;
-  } else {
-    return `path=${encodeURIComponent(params.path)}`;
-  }
-};
-
 const HelpPopupButton = (props: Props) => {
-  const [slug, setSlug] = useState<string | null>(null);
-  const [selectedVideoId, setSelectedVideoId] = useState<string | null>(null);
   const [shouldShowModal, setShouldShowModal] = useState(false);
-  const { helpApiHost } = config;
-
-  const query = slug ? getQuery({ slug }) : getQuery(props);
-
-  const url = `${helpApiHost}/api/article?${query}`;
-
-  // TODO: decide whether we want to show spinner while article content is loaded
-  // (it's gonna be fast, but we still might)
-  const { data: article } = useApiService<HelpArticle>({
-    endpoint: url,
-    skip: !shouldShowModal
-  });
-
-  useEffect(() => {
-    if (!shouldShowModal) {
-      setSlug(null);
-    }
-  }, [shouldShowModal]);
-
-  const handleArticleChange = (slug: string) => {
-    setSlug(slug);
-  };
-
-  // this is a provisional implementation and is likely to change
-  // as the design and the behaviour of the popup get more refined
-  const handleVideoChange = (youtubeId: string) => {
-    setSelectedVideoId(youtubeId);
-  };
 
   const openModal = () => {
     setShouldShowModal(true);
@@ -98,29 +57,6 @@ const HelpPopupButton = (props: Props) => {
     return <HelpAndDocumentation />;
   }
 
-  const sortedVideos = article?.videos.sort((a, b) => {
-    if (!selectedVideoId) {
-      return 0;
-    }
-    if (a.youtube_id === selectedVideoId) {
-      return -1;
-    } else if (b.youtube_id === selectedVideoId) {
-      return 1;
-    } else {
-      return 0;
-    }
-  });
-
-  const popupBodyProps = !article
-    ? {
-        loading: true as const,
-        article: null
-      }
-    : {
-        loading: false as const,
-        article: { ...article, videos: sortedVideos } as HelpArticle
-      };
-
   return (
     <>
       <div className={styles.wrapper} onClick={openModal}>
@@ -134,11 +70,7 @@ const HelpPopupButton = (props: Props) => {
       </div>
       {shouldShowModal && (
         <Modal onClose={closeModal}>
-          <HelpPopupBody
-            {...popupBodyProps}
-            onArticleChange={handleArticleChange}
-            onVideoChange={handleVideoChange}
-          />
+          <HelpPopupBody {...props} />
         </Modal>
       )}
     </>

--- a/src/ensembl/src/shared/components/help-popup/types.ts
+++ b/src/ensembl/src/shared/components/help-popup/types.ts
@@ -1,0 +1,44 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type HelpVideo = {
+  title: string;
+  description: string;
+  youtube_id: string;
+};
+
+export type RelatedArticle = {
+  title: string;
+  slug: string;
+  path: string;
+};
+
+export type HelpArticle = {
+  path: string;
+  slug: string;
+  title: string;
+  body: string;
+  videos: HelpVideo[];
+  related_articles: RelatedArticle[];
+};
+
+export type SlugReference = {
+  slug: string; // slug of the help article, e.g. "selecting-a-species"
+};
+
+export type PathReference = {
+  path: string; // path to the article in the help&docs repo starting from the docs root folder, e.g. "ensembl-help/getting-started/about-the-site"
+};

--- a/src/ensembl/src/shared/components/help-popup/useHelpArticle.ts
+++ b/src/ensembl/src/shared/components/help-popup/useHelpArticle.ts
@@ -1,0 +1,129 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, useEffect } from 'react';
+
+import config from 'config';
+
+import useApiService from 'src/shared/hooks/useApiService';
+
+import {
+  HelpArticle,
+  HelpVideo,
+  RelatedArticle,
+  SlugReference,
+  PathReference
+} from './types';
+
+const getQuery = (params: { reference: SlugReference | PathReference }) => {
+  if ('slug' in params.reference) {
+    return `slug=${params.reference.slug}`;
+  } else {
+    return `path=${encodeURIComponent(params.reference.path)}`;
+  }
+};
+
+type Reference = SlugReference | PathReference;
+
+export type ArticleReference = {
+  type: 'article';
+  reference: Reference;
+};
+
+export type VideoReference = {
+  type: 'video';
+  youtube_id: string;
+};
+
+export type RelatedItems = {
+  articles: RelatedArticle[];
+  videos: HelpVideo[];
+};
+
+export type CurrentArticle = HelpArticle & { type: 'article' };
+export type CurrentVideo = HelpVideo & { type: 'video' };
+export type CurrentItem = CurrentArticle | CurrentVideo;
+
+export const emptyRelatedItems: RelatedItems = {
+  articles: [],
+  videos: []
+};
+
+const useHelpArticle = (reference: ArticleReference | VideoReference) => {
+  const [currentHelpItem, setCurrentHelpItem] = useState<CurrentItem | null>(
+    null
+  );
+  const [relatedItems, setRelatedItems] = useState<RelatedItems | null>(null);
+
+  const query = reference.type === 'article' ? getQuery(reference) : null;
+  const { helpApiHost } = config;
+  const url = query ? `${helpApiHost}/api/article?${query}` : '';
+
+  const { data: article, loadingState } = useApiService<HelpArticle>({
+    endpoint: url,
+    skip: !url
+  });
+
+  useEffect(() => {
+    if (
+      article &&
+      reference.type === 'article' &&
+      (('slug' in reference.reference &&
+        reference.reference.slug === article.slug) ||
+        ('path' in reference.reference &&
+          reference.reference.path === article.path))
+    ) {
+      setCurrentHelpItem({
+        ...article,
+        type: 'article'
+      });
+    } else if (article && reference.type === 'video') {
+      const video = article.videos.find(
+        (video) => video.youtube_id === reference.youtube_id
+      ) as HelpVideo;
+      setCurrentHelpItem({ ...video, type: 'video' });
+    }
+  }, [article?.path, reference.type]);
+
+  useEffect(() => {
+    if (!article || relatedItems) {
+      return;
+    }
+    // keep track only for the article that was fetched initially
+    setRelatedItems(prepareRelatedItems(article));
+  });
+
+  return {
+    loadingState,
+    relatedItems,
+    currentHelpItem
+  };
+};
+
+const prepareRelatedItems = (article: HelpArticle): RelatedItems => {
+  const currentArticle = {
+    title: article.title,
+    slug: article.slug,
+    path: article.path
+  };
+  const relatedArticles = [currentArticle, ...article.related_articles];
+  return {
+    articles: relatedArticles,
+    videos: article.videos
+  };
+};
+
+export default useHelpArticle;

--- a/src/ensembl/src/shared/components/help-popup/useHelpArticle.ts
+++ b/src/ensembl/src/shared/components/help-popup/useHelpArticle.ts
@@ -66,7 +66,9 @@ const useHelpArticle = (reference: ArticleReference | VideoReference) => {
   const [currentHelpItem, setCurrentHelpItem] = useState<CurrentItem | null>(
     null
   );
-  const [relatedItems, setRelatedItems] = useState<RelatedItems | null>(null);
+  const [relatedHelpItems, setRelatedHelpItems] = useState<RelatedItems | null>(
+    null
+  );
 
   const query = reference.type === 'article' ? getQuery(reference) : null;
   const { helpApiHost } = config;
@@ -90,8 +92,8 @@ const useHelpArticle = (reference: ArticleReference | VideoReference) => {
         ...article,
         type: 'article'
       });
-    } else if (relatedItems && reference.type === 'video') {
-      const video = relatedItems.videos.find(
+    } else if (relatedHelpItems && reference.type === 'video') {
+      const video = relatedHelpItems.videos.find(
         (video) => video.youtube_id === reference.youtube_id
       ) as HelpVideo;
       setCurrentHelpItem({ ...video, type: 'video' });
@@ -99,16 +101,16 @@ const useHelpArticle = (reference: ArticleReference | VideoReference) => {
   }, [article?.path, reference.type]);
 
   useEffect(() => {
-    if (!article || relatedItems) {
+    if (!article || relatedHelpItems) {
       return;
     }
     // keep track only for the article that was fetched initially
-    setRelatedItems(prepareRelatedItems(article));
+    setRelatedHelpItems(prepareRelatedItems(article));
   });
 
   return {
     loadingState,
-    relatedItems,
+    relatedHelpItems,
     currentHelpItem
   };
 };

--- a/src/ensembl/src/shared/components/help-popup/useHelpArticle.ts
+++ b/src/ensembl/src/shared/components/help-popup/useHelpArticle.ts
@@ -90,8 +90,8 @@ const useHelpArticle = (reference: ArticleReference | VideoReference) => {
         ...article,
         type: 'article'
       });
-    } else if (article && reference.type === 'video') {
-      const video = article.videos.find(
+    } else if (relatedItems && reference.type === 'video') {
+      const video = relatedItems.videos.find(
         (video) => video.youtube_id === reference.youtube_id
       ) as HelpVideo;
       setCurrentHelpItem({ ...video, type: 'video' });

--- a/src/ensembl/src/shared/components/modal/Modal.scss
+++ b/src/ensembl/src/shared/components/modal/Modal.scss
@@ -16,11 +16,13 @@
   width: 80vw;
   height: 80vh;
   background: white;
-  padding-top: 45px;
+  padding: 30px 45px;
+  // this box-shadow is so dark because the modal body is set against a gray background
+  box-shadow: 0px 3px 6px #0000004D; // TODO: resolve box-shadow colour globally w/Andrea
 }
 
 .close {
   position: absolute;
-  right: 28px;
-  top: 26px;
+  right: 20px;
+  top: 17px;
 }

--- a/src/ensembl/src/shared/hooks/useApiService.ts
+++ b/src/ensembl/src/shared/hooks/useApiService.ts
@@ -81,7 +81,10 @@ const initialState: StateBeforeRequest = {
 const reducer = <T>(state: State<T>, action: Action<T>): State<T> => {
   switch (action.type) {
     case 'loading':
-      return initialState;
+      return {
+        ...initialState,
+        loadingState: LoadingState.LOADING
+      };
     case 'success':
       return {
         loadingState: LoadingState.SUCCESS,


### PR DESCRIPTION
## Type
- Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-784

(the CloseButton will be updated in a separate PR)

## Description
### Behaviour
- Change 3-column layout of the popup to a 2-column layout
- When a video is selected, it occupies all available space of the popup
- The list of related articles and videos remains fixed once the first article is loaded
### Code structure
- Moved logic for fetching help articles and keeping track of article updates into a dedicated hook (`useHelpArticles`)
- Fixed a bug in the `useApiService` hook
### Other
- Added contextual help button with link to relevant docs page to GenomeBrowser

## Deployment URL
http://update-contextual-help.review.ensembl.org (especially the genome browser page)

## Views affected
All views that are showing the contextual help