### PR TITLE
Hide species page example links popup on production

### DIFF
--- a/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
+++ b/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
@@ -17,6 +17,7 @@
 import React, { useEffect, ReactNode } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
+import { Link } from 'react-router-dom';
 
 import ViewInAppPopup from 'src/shared/components/view-in-app-popup/ViewInAppPopup';
 import SpeciesStats from 'src/content/app/species/components/species-stats/SpeciesStats';
@@ -40,7 +41,6 @@ import {
 } from '../../state/general/speciesGeneralHelper';
 
 import styles from './SpeciesMainView.scss';
-import { Link } from 'react-router-dom';
 
 type Props = {
   activeGenomeId: string | null;

--- a/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
+++ b/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
@@ -21,6 +21,7 @@ import classNames from 'classnames';
 import ViewInAppPopup from 'src/shared/components/view-in-app-popup/ViewInAppPopup';
 import SpeciesStats from 'src/content/app/species/components/species-stats/SpeciesStats';
 import ExpandableSection from 'src/shared/components/expandable-section/ExpandableSection';
+import { isEnvironment, Environment } from 'src/shared/helpers/environment';
 
 import {
   getActiveGenomeId,
@@ -39,6 +40,7 @@ import {
 } from '../../state/general/speciesGeneralHelper';
 
 import styles from './SpeciesMainView.scss';
+import { Link } from 'react-router-dom';
 
 type Props = {
   activeGenomeId: string | null;
@@ -53,6 +55,18 @@ type ExampleLinkPopupProps = {
 };
 
 const ExampleLinkWithPopup = (props: ExampleLinkPopupProps) => {
+  const isProduction = isEnvironment([Environment.PRODUCTION]);
+
+  if (isProduction) {
+    const linkToGenomeBrowser = props.links?.genomeBrowser;
+
+    return linkToGenomeBrowser ? (
+      <div className={styles.exampleLink}>
+        <Link to={linkToGenomeBrowser}>{props.children}</Link>
+      </div>
+    ) : null;
+  }
+
   return (
     <div className={styles.exampleLink}>
       <ViewInAppPopup links={props.links}>


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-793

## Description
This PR is to hide the example links popup and display a link to genome browser when the environment is production.

## Views affected
Species homepage
