### PR TITLE
Update popular species button behaviour

### DIFF
--- a/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.test.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.test.tsx
@@ -123,7 +123,7 @@ describe('<PopularSpeciesButton />', () => {
       );
     });
 
-    it('opens species homepage when it is clicked', () => {
+    it('opens species page when it is clicked', () => {
       const wrapper = mount(
         <PopularSpeciesButton {...commonProps} isCommitted={true} />
       ).find('.popularSpeciesButton');
@@ -131,7 +131,7 @@ describe('<PopularSpeciesButton />', () => {
       wrapper.simulate('click');
 
       expect(push).toHaveBeenCalledWith(
-        urlFor.speciesHomepage({
+        urlFor.speciesPage({
           genomeId: commonProps.species.genome_id
         })
       );

--- a/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.test.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.test.tsx
@@ -17,6 +17,9 @@
 import React from 'react';
 import { mount, render } from 'enzyme';
 import set from 'lodash/fp/set';
+import { push } from 'connected-react-router';
+
+import * as urlFor from 'src/shared/helpers/urlHelper';
 
 import { PopularSpeciesButton } from './PopularSpeciesButton';
 
@@ -25,10 +28,12 @@ import { createPopularSpecies } from 'tests/fixtures/popular-species';
 import styles from './PopularSpeciesButton.scss';
 
 jest.mock('src/shared/components/inline-svg/InlineSvg', () => () => <div />);
+jest.mock('connected-react-router', () => ({
+  push: jest.fn(() => ({ type: 'push' }))
+}));
 
 const handleSelectedSpecies = jest.fn();
 const clearSelectedSpecies = jest.fn();
-const deleteCommittedSpecies = jest.fn();
 
 const commonProps = {
   species: createPopularSpecies(),
@@ -36,7 +41,7 @@ const commonProps = {
   isCommitted: false,
   handleSelectedSpecies,
   clearSelectedSpecies,
-  deleteCommittedSpecies
+  push
 };
 
 describe('<PopularSpeciesButton />', () => {
@@ -104,7 +109,7 @@ describe('<PopularSpeciesButton />', () => {
 
       expect(clearSelectedSpecies).toHaveBeenCalled();
       expect(handleSelectedSpecies).not.toHaveBeenCalled();
-      expect(deleteCommittedSpecies).not.toHaveBeenCalled();
+      expect(push).not.toHaveBeenCalled();
     });
   });
 
@@ -118,13 +123,19 @@ describe('<PopularSpeciesButton />', () => {
       );
     });
 
-    it('deletes committed species when clicked', () => {
+    it('opens species homepage when it is clicked', () => {
       const wrapper = mount(
         <PopularSpeciesButton {...commonProps} isCommitted={true} />
       ).find('.popularSpeciesButton');
+
       wrapper.simulate('click');
 
-      expect(deleteCommittedSpecies).toHaveBeenCalled();
+      expect(push).toHaveBeenCalledWith(
+        urlFor.speciesHomepage({
+          genomeId: commonProps.species.genome_id
+        })
+      );
+
       expect(clearSelectedSpecies).not.toHaveBeenCalled();
       expect(handleSelectedSpecies).not.toHaveBeenCalled();
     });

--- a/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.tsx
@@ -18,33 +18,31 @@ import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import find from 'lodash/find';
+import { push } from 'connected-react-router';
 
+import Tooltip from 'src/shared/components/tooltip/Tooltip';
+import InlineSVG from 'src/shared/components/inline-svg/InlineSvg';
+import analyticsTracking from 'src/services/analytics-service';
 import useHover from 'src/shared/hooks/useHover';
+import * as urlFor from 'src/shared/helpers/urlHelper';
 
 import {
   handleSelectedSpecies,
-  clearSelectedSearchResult,
-  deleteSpeciesAndSave
+  clearSelectedSearchResult
 } from 'src/content/app/species-selector/state/speciesSelectorActions';
 import {
   getCurrentSpeciesGenomeId,
   getCommittedSpecies
 } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
+import { getSpeciesAnalyticsName } from 'src/content/app/species-selector/speciesSelectorHelper';
 
-import Tooltip from 'src/shared/components/tooltip/Tooltip';
-import InlineSVG from 'src/shared/components/inline-svg/InlineSvg';
-
+import { RootState } from 'src/store';
 import {
   CommittedItem,
   PopularSpecies
 } from 'src/content/app/species-selector/types/species-search';
 
-import analyticsTracking from 'src/services/analytics-service';
-import { getSpeciesAnalyticsName } from 'src/content/app/species-selector/speciesSelectorHelper';
-
 import styles from './PopularSpeciesButton.scss';
-
-import { RootState } from 'src/store';
 
 type OwnProps = {
   species: PopularSpecies;
@@ -56,7 +54,7 @@ type Props = {
   isCommitted: boolean;
   handleSelectedSpecies: (species: PopularSpecies) => void;
   clearSelectedSpecies: () => void;
-  deleteCommittedSpecies: (genome_id: string) => void;
+  push: (url: string) => void;
 };
 
 // named export is for testing purposes
@@ -83,7 +81,11 @@ export const PopularSpeciesButton = (props: Props) => {
         label: speciesName
       });
     } else if (isCommitted) {
-      props.deleteCommittedSpecies(genome_id);
+      props.push(
+        urlFor.speciesHomepage({
+          genomeId: species.genome_id
+        })
+      );
     } else {
       // the species is available, not selected and not committed;
       // go ahead and select it
@@ -133,7 +135,7 @@ const mapStateToProps = (state: RootState, ownProps: OwnProps) => ({
 const mapDispatchToProps = {
   handleSelectedSpecies,
   clearSelectedSpecies: clearSelectedSearchResult,
-  deleteCommittedSpecies: deleteSpeciesAndSave
+  push
 };
 
 export default connect(

--- a/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.tsx
@@ -20,8 +20,6 @@ import classNames from 'classnames';
 import find from 'lodash/find';
 import { push } from 'connected-react-router';
 
-import Tooltip from 'src/shared/components/tooltip/Tooltip';
-import InlineSVG from 'src/shared/components/inline-svg/InlineSvg';
 import analyticsTracking from 'src/services/analytics-service';
 import useHover from 'src/shared/hooks/useHover';
 import * as urlFor from 'src/shared/helpers/urlHelper';
@@ -35,6 +33,9 @@ import {
   getCommittedSpecies
 } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 import { getSpeciesAnalyticsName } from 'src/content/app/species-selector/speciesSelectorHelper';
+
+import Tooltip from 'src/shared/components/tooltip/Tooltip';
+import InlineSVG from 'src/shared/components/inline-svg/InlineSvg';
 
 import { RootState } from 'src/store';
 import {
@@ -82,7 +83,7 @@ export const PopularSpeciesButton = (props: Props) => {
       });
     } else if (isCommitted) {
       props.push(
-        urlFor.speciesHomepage({
+        urlFor.speciesPage({
           genomeId: species.genome_id
         })
       );

--- a/src/ensembl/src/content/app/species-selector/containers/popular-species-panel/PopularSpeciesPanel.tsx
+++ b/src/ensembl/src/content/app/species-selector/containers/popular-species-panel/PopularSpeciesPanel.tsx
@@ -17,16 +17,15 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 
-import { fetchPopularSpecies } from 'src/content/app/species-selector/state/speciesSelectorActions';
-
-import { getPopularSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
-
 import PopularSpeciesButton from 'src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton';
 
-import styles from './PopularSpeciesPanel.scss';
+import { fetchPopularSpecies } from 'src/content/app/species-selector/state/speciesSelectorActions';
+import { getPopularSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 
 import { RootState } from 'src/store';
 import { PopularSpecies } from 'src/content/app/species-selector/types/species-search';
+
+import styles from './PopularSpeciesPanel.scss';
 
 type Props = {
   fetchPopularSpecies: () => void;

--- a/src/ensembl/src/shared/helpers/urlHelper.ts
+++ b/src/ensembl/src/shared/helpers/urlHelper.ts
@@ -31,6 +31,16 @@ type EntityViewerUrlParams = {
   view?: string | null;
 };
 
+type SpeciesHomepage = {
+  genomeId: string;
+};
+
+export const speciesHomepage = (params: SpeciesHomepage) => {
+  const speciesHomepageRootPath = '/species';
+
+  return `${speciesHomepageRootPath}/${params.genomeId}`;
+};
+
 export const browser = (params?: BrowserUrlParams) => {
   const browserRootPath = '/genome-browser';
   if (params) {

--- a/src/ensembl/src/shared/helpers/urlHelper.ts
+++ b/src/ensembl/src/shared/helpers/urlHelper.ts
@@ -31,14 +31,14 @@ type EntityViewerUrlParams = {
   view?: string | null;
 };
 
-type SpeciesHomepage = {
+type SpeciesPageUrlParams = {
   genomeId: string;
 };
 
-export const speciesHomepage = (params: SpeciesHomepage) => {
-  const speciesHomepageRootPath = '/species';
+export const speciesPage = (params: SpeciesPageUrlParams) => {
+  const speciesPageRootPath = '/species';
 
-  return `${speciesHomepageRootPath}/${params.genomeId}`;
+  return `${speciesPageRootPath}/${params.genomeId}`;
 };
 
 export const browser = (params?: BrowserUrlParams) => {


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-790

## Description
Clicking on a popular species button for a committed species will open the species homepage instead of removing the species.

## Deployment URL
http://favourite-species.review.ensembl.org

## Views affected
Species selector -> Popular species

### Other effects
- [ ] I have checked any requirements for Google Analytics
- [x] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

