### PR TITLE
Update close button and add it to the top bar of species page

### DIFF
--- a/src/ensembl/src/content/app/species/SpeciesPage.scss
+++ b/src/ensembl/src/content/app/species/SpeciesPage.scss
@@ -1,0 +1,21 @@
+@import 'src/styles/common';
+
+.topbar {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  line-height: 1;
+}
+
+.topbarLeft {
+  display: flex;
+  align-items: center;
+}
+
+.pageTitle {
+  margin-right: 1rem;
+}
+
+.dataForSpecies {
+  color: $medium-dark-grey;
+}

--- a/src/ensembl/src/content/app/species/SpeciesPage.tsx
+++ b/src/ensembl/src/content/app/species/SpeciesPage.tsx
@@ -17,8 +17,10 @@
 import React, { useEffect } from 'react';
 import { useParams } from 'react-router';
 import { useSelector, useDispatch } from 'react-redux';
+import { push } from 'connected-react-router';
 
 import { BreakpointWidth } from 'src/global/globalConfig';
+import * as urlFor from 'src/shared/helpers/urlHelper';
 
 import { fetchGenomeData } from 'src/shared/state/genome/genomeActions';
 import { setActiveGenomeId } from 'src/content/app/species/state/general/speciesGeneralSlice';
@@ -30,6 +32,9 @@ import { toggleSidebar } from 'src/content/app/species/state/sidebar/speciesSide
 import SpeciesAppBar from './components/species-app-bar/SpeciesAppBar';
 import { StandardAppLayout } from 'src/shared/components/layout';
 import SpeciesMainView from 'src/content/app/species/components/species-main-view/SpeciesMainView';
+import CloseButton from 'src/shared/components/close-button/CloseButton';
+
+import styles from './SpeciesPage.scss';
 
 type SpeciesPageParams = {
   genomeId: string;
@@ -48,7 +53,6 @@ const SpeciesPage = () => {
 
   const sidebarContent = 'I am sidebar';
   const sidebarNavigationContent = 'I am sidebar navigation';
-  const topbarContent = 'I am topbar content';
 
   return (
     <>
@@ -57,7 +61,7 @@ const SpeciesPage = () => {
         mainContent={<SpeciesMainView />}
         sidebarContent={sidebarContent}
         sidebarNavigation={sidebarNavigationContent}
-        topbarContent={topbarContent}
+        topbarContent={<TopBar />}
         isSidebarOpen={sidebarStatus}
         onSidebarToggle={() => {
           dispatch(toggleSidebar());
@@ -65,6 +69,24 @@ const SpeciesPage = () => {
         viewportWidth={BreakpointWidth.DESKTOP}
       />
     </>
+  );
+};
+
+const TopBar = () => {
+  const dispatch = useDispatch();
+
+  const returnToSpeciesSelector = () => {
+    dispatch(push(urlFor.speciesSelector()));
+  };
+
+  return (
+    <div className={styles.topbar}>
+      <div className={styles.topbarLeft}>
+        <span className={styles.pageTitle}>Species Home page</span>
+        <CloseButton onClick={returnToSpeciesSelector} />
+      </div>
+      <div className={styles.dataForSpecies}>Data for this species</div>
+    </div>
   );
 };
 

--- a/src/ensembl/src/shared/components/close-button/CloseButton.scss
+++ b/src/ensembl/src/shared/components/close-button/CloseButton.scss
@@ -1,6 +1,19 @@
+@import 'src/styles/common';
+
+.closeButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 100%;
+  background: $blue;
+  cursor: pointer;
+}
+
 .icon {
   font-size: 0; // to make the height of the svg independent on font-size settings
-  height: 15px;
-  width: 15px;
-  cursor: pointer;
+  height: 10px;
+  width: 10px;
+  fill: white;
 }

--- a/src/ensembl/src/shared/components/close-button/CloseButton.tsx
+++ b/src/ensembl/src/shared/components/close-button/CloseButton.tsx
@@ -16,7 +16,9 @@
 
 import React from 'react';
 
-import { ReactComponent as CloseIcon } from 'static/img/shared/close.svg';
+// the shared close.svg file in static/img/shared folder has inline style with fill
+// TODO: consider moving the close.svg imported below back to shared folder when all our components use the CloseButton consistently
+import { ReactComponent as CloseIcon } from './close.svg';
 
 import styles from './CloseButton.scss';
 
@@ -25,7 +27,11 @@ type Props = {
 };
 
 const CloseButton = (props: Props) => {
-  return <CloseIcon className={styles.icon} onClick={props.onClick} />;
+  return (
+    <div className={styles.closeButton}>
+      <CloseIcon className={styles.icon} onClick={props.onClick} />
+    </div>
+  );
 };
 
 export default CloseButton;

--- a/src/ensembl/src/shared/components/close-button/close.svg
+++ b/src/ensembl/src/shared/components/close-button/close.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 20 20" style="enable-background:new 0 0 20 20;" xml:space="preserve">
+<polygon class="st0" points="17,4.4 13.7,4.4 10,8.4 6.3,4.4 3,4.4 8.4,10.2 3.3,15.6 6.6,15.6 10,11.9 13.4,15.6 16.7,15.6 
+	11.7,10.2 "/>
+</svg>


### PR DESCRIPTION
## Type
- New feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-792

## Description
- updated the CloseButton component to match updated Andrea's design
- added the close button to the top bar of species page, so that user can navigate back to SpeciesSelector

## Deployment URL
http://species-page-close.review.ensembl.org/species/homo_sapiens_GCA_000001405_28

## Views affected
Species page