### PR TITLE
Fix pseudogene stats

### DIFF
--- a/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
+++ b/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
@@ -111,27 +111,31 @@ const getExpandedContent = (statsSection: StatsSection) => {
     <div className={styles.expandedContent}>
       {groups.map((group, group_index) => {
         const { title, stats } = group;
-        return stats.map((groupStats, row_index) => {
-          const statsGroupClassName = classNames(styles.statsGroup, {
-            [styles.statsGroupWithExampleLink]:
-              !group_index && !row_index && exampleLinkText
-          });
-          return (
-            <div key={row_index} className={statsGroupClassName}>
-              {row_index === 0 && <span className={styles.title}>{title}</span>}
-              <div className={styles.stats}>
-                {groupStats.map((stat, stat_index) => {
-                  return <SpeciesStats key={stat_index} {...stat} />;
-                })}
-              </div>
-              {group_index === 0 && row_index === 0 && exampleLinks && (
-                <ExampleLinkWithPopup links={exampleLinks}>
-                  {exampleLinkText}
-                </ExampleLinkWithPopup>
-              )}
-            </div>
-          );
-        });
+        return stats
+          ? stats.map((groupStats, row_index) => {
+              const statsGroupClassName = classNames(styles.statsGroup, {
+                [styles.statsGroupWithExampleLink]:
+                  !group_index && !row_index && exampleLinkText
+              });
+              return (
+                <div key={row_index} className={statsGroupClassName}>
+                  {row_index === 0 && (
+                    <span className={styles.title}>{title}</span>
+                  )}
+                  <div className={styles.stats}>
+                    {groupStats.map((stat, stat_index) => {
+                      return <SpeciesStats key={stat_index} {...stat} />;
+                    })}
+                  </div>
+                  {group_index === 0 && row_index === 0 && exampleLinks && (
+                    <ExampleLinkWithPopup links={exampleLinks}>
+                      {exampleLinkText}
+                    </ExampleLinkWithPopup>
+                  )}
+                </div>
+              );
+            })
+          : null;
       })}
     </div>
   );

--- a/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
+++ b/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
@@ -107,7 +107,7 @@ const getExpandedContent = (statsSection: StatsSection) => {
   const { groups, exampleLinks, section } = statsSection;
   const { exampleLinkText } = sectionGroupsMap[section];
 
-  const expandedcontent = groups
+  const expandedContent = groups
     .map((group, group_index) => {
       const { title, stats } = group;
       return stats
@@ -138,8 +138,8 @@ const getExpandedContent = (statsSection: StatsSection) => {
     })
     .filter(Boolean);
 
-  return expandedcontent.length ? (
-    <div className={styles.expandedContent}>{expandedcontent}</div>
+  return expandedContent.length ? (
+    <div className={styles.expandedContent}>{expandedContent}</div>
   ) : null;
 };
 

--- a/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
+++ b/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
@@ -107,38 +107,40 @@ const getExpandedContent = (statsSection: StatsSection) => {
   const { groups, exampleLinks, section } = statsSection;
   const { exampleLinkText } = sectionGroupsMap[section];
 
-  return (
-    <div className={styles.expandedContent}>
-      {groups.map((group, group_index) => {
-        const { title, stats } = group;
-        return stats
-          ? stats.map((groupStats, row_index) => {
-              const statsGroupClassName = classNames(styles.statsGroup, {
-                [styles.statsGroupWithExampleLink]:
-                  !group_index && !row_index && exampleLinkText
-              });
-              return (
-                <div key={row_index} className={statsGroupClassName}>
-                  {row_index === 0 && (
-                    <span className={styles.title}>{title}</span>
-                  )}
-                  <div className={styles.stats}>
-                    {groupStats.map((stat, stat_index) => {
-                      return <SpeciesStats key={stat_index} {...stat} />;
-                    })}
-                  </div>
-                  {group_index === 0 && row_index === 0 && exampleLinks && (
-                    <ExampleLinkWithPopup links={exampleLinks}>
-                      {exampleLinkText}
-                    </ExampleLinkWithPopup>
-                  )}
+  const expandedcontent = groups
+    .map((group, group_index) => {
+      const { title, stats } = group;
+      return stats
+        ? stats.map((groupStats, row_index) => {
+            const statsGroupClassName = classNames(styles.statsGroup, {
+              [styles.statsGroupWithExampleLink]:
+                !group_index && !row_index && exampleLinkText
+            });
+            return (
+              <div key={row_index} className={statsGroupClassName}>
+                {row_index === 0 && (
+                  <span className={styles.title}>{title}</span>
+                )}
+                <div className={styles.stats}>
+                  {groupStats.map((stat, stat_index) => {
+                    return <SpeciesStats key={stat_index} {...stat} />;
+                  })}
                 </div>
-              );
-            })
-          : null;
-      })}
-    </div>
-  );
+                {group_index === 0 && row_index === 0 && exampleLinks && (
+                  <ExampleLinkWithPopup links={exampleLinks}>
+                    {exampleLinkText}
+                  </ExampleLinkWithPopup>
+                )}
+              </div>
+            );
+          })
+        : null;
+    })
+    .filter(Boolean);
+
+  return expandedcontent.length ? (
+    <div className={styles.expandedContent}>{expandedcontent}</div>
+  ) : null;
 };
 
 const SpeciesMainViewStats = (props: Props) => {

--- a/src/ensembl/src/content/app/species/state/general/speciesGeneralHelper.ts
+++ b/src/ensembl/src/content/app/species/state/general/speciesGeneralHelper.ts
@@ -626,23 +626,31 @@ export const getStatsForSection = (props: {
     exampleLinks,
     groups: groups.map((group) => {
       const groupStats = groupsStatsMap[group];
+
+      const processedStats = groupStats
+        .map((subGroupStats) => {
+          const processedSubGroupStats: IndividualStat[] = [];
+
+          subGroupStats.forEach((stat) => {
+            if (filteredData[stat] !== undefined) {
+              const individualStat = buildIndividualStat({
+                primaryKey: stat,
+                primaryValue: filteredData[stat],
+                section
+              });
+              individualStat && processedSubGroupStats.push(individualStat);
+            }
+          });
+
+          return processedSubGroupStats.length
+            ? processedSubGroupStats
+            : undefined;
+        })
+        .filter(Boolean);
+
       return {
         title: groupTitles[group],
-        stats: groupStats
-          .map((subGroupStats) => {
-            return subGroupStats
-              .map((stat) => {
-                return filteredData[stat]
-                  ? buildIndividualStat({
-                      primaryKey: stat,
-                      primaryValue: filteredData[stat],
-                      section
-                    })
-                  : undefined;
-              })
-              .filter(Boolean);
-          })
-          .filter(Boolean)
+        stats: processedStats.length ? processedStats : undefined
       };
     })
   } as StatsSection;

--- a/src/ensembl/src/content/app/species/state/general/speciesGeneralHelper.ts
+++ b/src/ensembl/src/content/app/species/state/general/speciesGeneralHelper.ts
@@ -632,7 +632,7 @@ export const getStatsForSection = (props: {
           const processedSubGroupStats: IndividualStat[] = [];
 
           subGroupStats.forEach((stat) => {
-            if (filteredData[stat] !== undefined) {
+            if (filteredData[stat]) {
               const individualStat = buildIndividualStat({
                 primaryKey: stat,
                 primaryValue: filteredData[stat],

--- a/src/ensembl/src/shared/components/expandable-section/ExpandableSection.tsx
+++ b/src/ensembl/src/shared/components/expandable-section/ExpandableSection.tsx
@@ -68,9 +68,11 @@ const ExpandableSection = (props: ExpandableSectionProps) => {
 
   return (
     <div className={wrapperClassNames}>
-      <div className={styles.toggle} onClick={toggleExpanded}>
-        <Chevron className={chevronClasses} />
-      </div>
+      {props.expandedContent && (
+        <div className={styles.toggle} onClick={toggleExpanded}>
+          <Chevron className={chevronClasses} />
+        </div>
+      )}
 
       {isExpanded ? (
         <div className={expandedContentClassNames}>{props.expandedContent}</div>


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-802

## Description
Fixed the issue with empty groups getting displayed in the Pseudogene stats section for Wheat.


## Deployment URL
http://fix-wheat-pseudogene-stats.review.ensembl.org

## Views affected
SpeciesPage - > Wheat
