### PR TITLE
Show all committed species in the app bar on species page

### DIFF
--- a/src/ensembl/src/content/app/species/components/species-app-bar/SpeciesAppBar.tsx
+++ b/src/ensembl/src/content/app/species/components/species-app-bar/SpeciesAppBar.tsx
@@ -20,7 +20,7 @@ import { connect } from 'react-redux';
 import { AppName } from 'src/global/globalConfig';
 
 import { getActiveGenomeId } from 'src/content/app/species/state/general/speciesGeneralSelectors';
-import { getEnabledCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
+import { getCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 
 import AppBar from 'src/shared/components/app-bar/AppBar';
 import { SelectedSpecies } from 'src/shared/components/selected-species';
@@ -60,7 +60,7 @@ const SpeciesAppBar = (props: SpeciesAppBarProps) => {
 };
 
 const mapStateToProps = (state: RootState) => ({
-  species: getEnabledCommittedSpecies(state),
+  species: getCommittedSpecies(state),
   activeGenomeId: getActiveGenomeId(state)
 });
 


### PR DESCRIPTION
## Type
- Bug fix

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEBREL-1095

## Description
This PR fixes the bug which is that species that are not in use are removed from the app bar of the species page. 

## Deployment URL
http://species-page-bar.review.ensembl.org

## Views affected
Species page 