### PR TITLE
Fix CloseButton — move onClick from cross icon to the button

### DIFF
--- a/src/ensembl/src/shared/components/close-button/CloseButton.tsx
+++ b/src/ensembl/src/shared/components/close-button/CloseButton.tsx
@@ -28,8 +28,8 @@ type Props = {
 
 const CloseButton = (props: Props) => {
   return (
-    <div className={styles.closeButton}>
-      <CloseIcon className={styles.icon} onClick={props.onClick} />
+    <div className={styles.closeButton} onClick={props.onClick}>
+      <CloseIcon className={styles.icon} />
     </div>
   );
 };


### PR DESCRIPTION
## Type

- Bug fix

## Description
When CloseButton was refactored, the click handler was, by mistake, left on the cross icon; which means that now, for the button to function, user has to target the cross, otherwise the click doesn't get registered. This PR fixes this.