### PR TITLE
Fix checkbox styles in BrowserTrackConfig

### DIFF
--- a/src/ensembl/src/content/app/browser/browser-track-config/BrowserTrackConfig.scss
+++ b/src/ensembl/src/content/app/browser/browser-track-config/BrowserTrackConfig.scss
@@ -70,3 +70,7 @@
     width: 14px;
   }
 }
+
+.checkboxHolder {
+  width: 100%;
+}

--- a/src/ensembl/src/content/app/browser/browser-track-config/BrowserTrackConfig.tsx
+++ b/src/ensembl/src/content/app/browser/browser-track-config/BrowserTrackConfig.tsx
@@ -137,6 +137,7 @@ export const BrowserTrackConfig = (props: BrowserTrackConfigProps) => {
           label="All tracks"
           checked={applyToAll}
           onChange={applyToAllToggle}
+          classNames={{ checkboxHolder: styles.checkboxHolder }}
         />
       </div>
       <div className={styles.section}>


### PR DESCRIPTION
## Type

- Bug fix

## Description
I'm afraid when I updated Checkbox styles, and then updated them again to fix the instant download in https://github.com/Ensembl/ensembl-client/pull/367, I broke the checkbox in BrowserTrackConfig. As a result, it fell apart and now looks like this:

![image](https://user-images.githubusercontent.com/6834224/97464339-b2967580-1938-11eb-89cf-a68e4b43929e.png)

This PR fixes it:

![image](https://user-images.githubusercontent.com/6834224/97464403-c641dc00-1938-11eb-90b7-5848bee559c2.png)


## Deployment URL
http://fix-browser-track-config-bar.review.ensembl.org/

## Views affected
Genome Browser page