### PR TITLE
Make sure that InlineSvg component can update properly

### DIFF
--- a/src/ensembl/src/shared/components/inline-svg/InlineSvg.tsx
+++ b/src/ensembl/src/shared/components/inline-svg/InlineSvg.tsx
@@ -38,8 +38,7 @@ type Props = {
 };
 
 const InlineSVG = (props: Props) => {
-  const [svg, setSvg] = useState<string | null>(null);
-  const [isSvgSet, setIsSvgSet] = useState(false);
+  const [svg, setSvg] = useState<string>('');
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -51,17 +50,15 @@ const InlineSVG = (props: Props) => {
         preserveEndpoint: true
       })
       .then((svg) => setSvg(svg));
-  }, []);
+  }, [props.src]);
 
-  useEffect(() => {
-    if (!isSvgSet && svg && containerRef.current) {
-      const container = containerRef.current;
-      container.insertAdjacentHTML('afterbegin', svg);
-      setIsSvgSet(true);
-    }
-  });
-
-  return <div className={styles.inlineSvgContainer} ref={containerRef} />;
+  return (
+    <div
+      className={styles.inlineSvgContainer}
+      ref={containerRef}
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  );
 };
 
 export default InlineSVG;


### PR DESCRIPTION
## Type
- Bug fix

## Description
@ens-st3 noticed that species icons don't update when you change species on the species page. This is caused by a couple of very strange choices made in the `InlineSvg` component (I can't imagine what I was thinking when I was writing it). This PR updates the component to allow for changing svg source passed in with the component's props. 

## Deployment URL
http://fix-inline-svg.review.ensembl.org/

## Views affected
Species selector page, Species page