### PR TITLE
Update assembly dates to ISO YYYY-MM-DD format

### DIFF
--- a/src/ensembl/src/content/app/species/sample-data.ts
+++ b/src/ensembl/src/content/app/species/sample-data.ts
@@ -593,7 +593,7 @@ export const sidebarData: SpeciesSidebarData = {
     },
     assembly_level: 'complete genome',
     annotation_method: 'full genebuild',
-    assembly_date: 'June 2013',
+    assembly_date: '2013-06-01',
     notes: []
   },
   escherichia_coli_str_k_12_substr_mg1655_GCA_000005845_2: {
@@ -615,7 +615,7 @@ export const sidebarData: SpeciesSidebarData = {
     },
     assembly_level: 'complete genome',
     annotation_method: 'Generated from ENA annotation',
-    assembly_date: 'Sep 2013',
+    assembly_date: '2013-09-01',
     notes: []
   },
   caenorhabditis_elegans_GCA_000002985_3: {
@@ -640,7 +640,7 @@ export const sidebarData: SpeciesSidebarData = {
     },
     assembly_level: 'complete genome',
     annotation_method: 'Import',
-    assembly_date: 'Feb 2013',
+    assembly_date: '2013-02-01',
     notes: []
   },
   plasmodium_falciparum_GCA_000002765_2: {
@@ -662,7 +662,7 @@ export const sidebarData: SpeciesSidebarData = {
     },
     assembly_level: 'complete genome',
     annotation_method: 'Import',
-    assembly_date: 'Apr 2016',
+    assembly_date: '2016-04-01',
     notes: []
   },
   saccharomyces_cerevisiae_GCA_000146045_2: {
@@ -687,7 +687,7 @@ export const sidebarData: SpeciesSidebarData = {
     },
     assembly_level: 'complete genome',
     annotation_method: 'Import',
-    assembly_date: 'Dec 2014',
+    assembly_date: '2014-12-01',
     notes: []
   },
   triticum_aestivum_GCA_900519105_1: {
@@ -712,7 +712,7 @@ export const sidebarData: SpeciesSidebarData = {
     },
     assembly_level: 'complete genome',
     annotation_method: 'Import',
-    assembly_date: 'Aug 2018',
+    assembly_date: '2018-08-01',
     notes: []
   }
 };


### PR DESCRIPTION
## Type
- Bug fix

## Description
In species json files, almost all species have the assembly date in the format "Month year" (e.g. "Aug 2018"). Chrome, surprisingly, can create the Date object out of this string (see [this block of our code](https://github.com/Ensembl/ensembl-client/blob/dev/src/ensembl/src/content/app/species/components/species-sidebar/SpeciesSidebar.tsx#L57-L61)), but Firefox, predictably, cannot:

![image](https://user-images.githubusercontent.com/6834224/97861944-78442400-1cfc-11eb-8ff4-47121bdab23b.png)

I've standardized all dates to the `YYYY-MM-DD` format. I noticed that assembly dates in the database are stored in the `YYYY-MM` format, which should also be successfully recognised:

![image](https://user-images.githubusercontent.com/6834224/97861365-8d6c8300-1cfb-11eb-81ec-6c2b8b576b64.png)

## Views affected
Species page