### PR TITLE
Fix expanded transcript ids on new genes

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
@@ -111,6 +111,8 @@ const ensureGenePresence = (
   const { activeGenomeId, activeObjectId } = ids;
   if (!state[activeGenomeId]) {
     state[activeGenomeId] = { [activeObjectId]: defaultStatePerGene };
+  } else if (!state[activeGenomeId][activeObjectId]) {
+    state[activeGenomeId][activeObjectId] = defaultStatePerGene;
   }
 };
 

--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
@@ -17,6 +17,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { Action } from 'redux';
 import { ThunkAction } from 'redux-thunk';
+import set from 'lodash/fp/set';
 
 import {
   getEntityViewerActiveGenomeId,
@@ -110,9 +111,19 @@ const ensureGenePresence = (
 ) => {
   const { activeGenomeId, activeObjectId } = ids;
   if (!state[activeGenomeId]) {
-    state[activeGenomeId] = { [activeObjectId]: defaultStatePerGene };
+    return set(
+      activeGenomeId,
+      { [activeObjectId]: defaultStatePerGene },
+      state
+    );
   } else if (!state[activeGenomeId][activeObjectId]) {
-    state[activeGenomeId][activeObjectId] = defaultStatePerGene;
+    return set(
+      `${activeGenomeId}.${activeObjectId}`,
+      defaultStatePerGene,
+      state
+    );
+  } else {
+    return state;
   }
 };
 
@@ -131,13 +142,21 @@ const transcriptsSlice = createSlice({
       action: PayloadAction<ExpandedIdsPayload>
     ) {
       const { activeGenomeId, activeObjectId, expandedIds } = action.payload;
-      ensureGenePresence(state, action.payload);
-      state[activeGenomeId][activeObjectId].expandedIds = expandedIds;
+      const updatedState = ensureGenePresence(state, action.payload);
+      return set(
+        `${activeGenomeId}.${activeObjectId}.expandedIds`,
+        expandedIds,
+        updatedState
+      );
     },
     updateExpandedDownloads(state, action: PayloadAction<ExpandedIdsPayload>) {
       const { activeGenomeId, activeObjectId, expandedIds } = action.payload;
-      ensureGenePresence(state, action.payload);
-      state[activeGenomeId][activeObjectId].expandedDownloadIds = expandedIds;
+      const updatedState = ensureGenePresence(state, action.payload);
+      return set(
+        `${activeGenomeId}.${activeObjectId}.expandedDownloadIds`,
+        expandedIds,
+        updatedState
+      );
     }
   }
 });


### PR DESCRIPTION
## Type
- Bug fix

## Description
### Steps to reproduce the bug
1) Open EntityViewer on BRCA2
2) Click on "View in genome browser" to navigate to genome browser
3) In genome browser, click on a different gene (e.g. PDS5B, which is the next large gene to the right of BRCA2)
4) In the zmenu that opens, click on the entity viewer button
5) **Bug:** you will see an error screen

### Cause of bug
There are several problems in the code.

The first, which is the immediate cause of the bug, is that we were not handling the case of setting new default state for a new gene from the same genome [here](https://github.com/Ensembl/ensembl-client/blob/dev/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts#L107-L115). 

The second — and this is super annoying — is that the `immer` library that redux-toolkit is using to simplify state updates, auto-freezes the parts of the state tree that have been updated, and therefore we cannot just do 

```
state[activeGenomeId][activeObjectId] = defaultStatePerGene;
```
followed by

```
state[activeGenomeId][activeObjectId].expandedIds = expandedIds;
```
because this would modify the updated `state[activeGenomeId][activeObjectId]` object that `immer` has auto-frozen. This is infuriating and can easily lead us to writing bugs.

## Deployment URL
http://fix-expanded-transcript-ids.review.ensembl.org

## Views affected
Entity Viewer