### PR TITLE
Update gene symbol type and bookmarks example link text

### DIFF
--- a/src/ensembl/src/content/app/browser/Browser.tsx
+++ b/src/ensembl/src/content/app/browser/Browser.tsx
@@ -17,7 +17,6 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
-import upperFirst from 'lodash/upperFirst';
 
 import useBrowserRouting from './hooks/useBrowserRouting';
 
@@ -160,12 +159,7 @@ export const ExampleObjectLinks = (props: BrowserProps) => {
 
     return (
       <div key={exampleObject.object_id} className={styles.exampleLink}>
-        <Link to={path}>
-          <span className={styles.objectType}>
-            {upperFirst(exampleObject.type)}
-          </span>
-          <span className={styles.objectLabel}>{exampleObject.label}</span>
-        </Link>
+        <Link to={path}>{`Example ` + exampleObject.type}</Link>
       </div>
     );
   });

--- a/src/ensembl/src/content/app/browser/Browser.tsx
+++ b/src/ensembl/src/content/app/browser/Browser.tsx
@@ -159,7 +159,7 @@ export const ExampleObjectLinks = (props: BrowserProps) => {
 
     return (
       <div key={exampleObject.object_id} className={styles.exampleLink}>
-        <Link to={path}>{`Example ` + exampleObject.type}</Link>
+        <Link to={path}>Example {exampleObject.type}</Link>
       </div>
     );
   });

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/TrackPanelModal.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/TrackPanelModal.test.tsx
@@ -20,6 +20,7 @@ import { mount } from 'enzyme';
 import { TrackPanelModal, TrackPanelModalProps } from './TrackPanelModal';
 import TrackPanelSearch from './modal-views/TrackPanelSearch';
 import TrackPanelDownloads from './modal-views/TrackPanelDownloads';
+import CloseButton from 'src/shared/components/close-button/CloseButton';
 
 describe('<TrackPanelModal />', () => {
   afterEach(() => {
@@ -49,7 +50,7 @@ describe('<TrackPanelModal />', () => {
   describe('behaviour', () => {
     test('closes modal when close button is clicked', () => {
       const wrapper = mount(<TrackPanelModal {...defaultProps} />);
-      wrapper.find('button').simulate('click');
+      wrapper.find(CloseButton).simulate('click');
       expect(wrapper.props().closeTrackPanelModal).toHaveBeenCalledTimes(1);
     });
   });

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/TrackPanelModal.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/TrackPanelModal.tsx
@@ -17,21 +17,21 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
+import { getTrackPanelModalView } from '../trackPanelSelectors';
+import { closeTrackPanelModal } from '../trackPanelActions';
+import { closeDrawer } from '../../drawer/drawerActions';
+
 import TrackPanelSearch from './modal-views/TrackPanelSearch';
 import TracksManager from './modal-views/TracksManager';
 import TrackPanelBookmarks from './modal-views/TrackPanelBookmarks';
 import PersonalData from './modal-views/PersonalData';
 import TrackPanelShare from './modal-views/TrackPanelShare';
 import TrackPanelDownloads from './modal-views/TrackPanelDownloads';
+import CloseButton from 'src/shared/components/close-button/CloseButton';
 
-import { getTrackPanelModalView } from '../trackPanelSelectors';
-import { closeTrackPanelModal } from '../trackPanelActions';
 import { RootState } from 'src/store';
 
-import closeIcon from 'static/img/shared/close.svg';
-
 import styles from './TrackPanelModal.scss';
-import { closeDrawer } from '../../drawer/drawerActions';
 
 export type TrackPanelModalProps = {
   trackPanelModalView: string;
@@ -65,9 +65,9 @@ export const TrackPanelModal = (props: TrackPanelModalProps) => {
   };
   return (
     <section className={styles.trackPanelModal}>
-      <button onClick={onClickHandler} className={styles.closeButton}>
-        <img src={closeIcon} alt="Close track panel modal" />
-      </button>
+      <div className={styles.closeButton}>
+        <CloseButton onClick={onClickHandler} />
+      </div>
       <div className={styles.trackPanelModalView}>{getModalView()}</div>
     </section>
   );

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/TrackPanelModal.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/TrackPanelModal.tsx
@@ -59,14 +59,14 @@ export const TrackPanelModal = (props: TrackPanelModalProps) => {
     }
   };
 
-  const onClickHandler = () => {
+  const onClose = () => {
     props.closeDrawer();
     props.closeTrackPanelModal();
   };
   return (
     <section className={styles.trackPanelModal}>
       <div className={styles.closeButton}>
-        <CloseButton onClick={onClickHandler} />
+        <CloseButton onClick={onClose} />
       </div>
       <div className={styles.trackPanelModalView}>{getModalView()}</div>
     </section>

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.scss
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.scss
@@ -1,7 +1,7 @@
 @import 'src/styles/common';
 
 .linkHolder {
-  margin: 5px 0 0 15px;
+  margin: 5px 0 0 20px;
   text-overflow: ellipsis;
   overflow: hidden;
   a {
@@ -20,7 +20,13 @@
   font-weight: 300;
 }
 
-.title {
+.title{
+  font-size: 14px;
+  margin: 5px 0 10px 10px;
+  font-weight: $bold;
+}
+
+.sectionTitle {
   color: $dark-grey;
   font-size: 12px;
   border-bottom: 1px solid $grey;

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
@@ -19,15 +19,12 @@ import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import upperFirst from 'lodash/upperFirst';
 
-import { BrowserTrackStates } from 'src/content/app/browser/track-panel/trackPanelConfig';
+import analyticsTracking from 'src/services/analytics-service';
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import { buildFocusIdForUrl } from 'src/shared/state/ens-object/ensObjectHelpers';
-import analyticsTracking from 'src/services/analytics-service';
-
 import { getBrowserActiveGenomeId } from 'src/content/app/browser/browserSelectors';
 import { getActiveGenomePreviouslyViewedObjects } from 'src/content/app/browser/track-panel/trackPanelSelectors';
 import { getExampleEnsObjects } from 'src/shared/state/ens-object/ensObjectSelectors';
-
 import { closeTrackPanelModal } from '../../trackPanelActions';
 import { updateTrackStatesAndSave } from 'src/content/app/browser/browserActions';
 import { changeDrawerViewAndOpen } from 'src/content/app/browser/drawer/drawerActions';
@@ -36,9 +33,10 @@ import ImageButton from 'src/shared/components/image-button/ImageButton';
 import { ReactComponent as EllipsisIcon } from 'static/img/track-panel/ellipsis.svg';
 
 import { RootState } from 'src/store';
-import { PreviouslyViewedObject } from 'src/content/app/browser/track-panel/trackPanelState';
 import { EnsObject } from 'src/shared/state/ens-object/ensObjectTypes';
 import { Status } from 'src/shared/types/status';
+import { PreviouslyViewedObject } from 'src/content/app/browser/track-panel/trackPanelState';
+import { BrowserTrackStates } from 'src/content/app/browser/track-panel/trackPanelConfig';
 
 import styles from './TrackPanelBookmarks.scss';
 
@@ -67,11 +65,8 @@ export const ExampleLinks = (props: ExampleLinksProps) => {
         return (
           <div key={exampleObject.object_id} className={styles.linkHolder}>
             <Link to={path} onClick={props.closeTrackPanelModal}>
-              {exampleObject.label}
+              {`Example ` + exampleObject.type}
             </Link>
-            <span className={styles.previouslyViewedType}>
-              {upperFirst(exampleObject.type)}
-            </span>
           </div>
         );
       })}
@@ -158,7 +153,6 @@ export const TrackPanelBookmarks = (props: TrackPanelBookmarksProps) => {
       <h3>Bookmarks</h3>
       {exampleEnsObjects.length ? (
         <>
-          <div className={styles.title}>Example links</div>
           <ExampleLinks
             exampleEnsObjects={exampleEnsObjects}
             activeGenomeId={activeGenomeId}

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
@@ -56,6 +56,7 @@ type ExampleLinksProps = Pick<
 export const ExampleLinks = (props: ExampleLinksProps) => {
   return (
     <div>
+      <div className={styles.sectionTitle}>Example links</div>
       {props.exampleEnsObjects.map((exampleObject) => {
         const path = urlFor.browser({
           genomeId: props.activeGenomeId,
@@ -150,7 +151,7 @@ export const TrackPanelBookmarks = (props: TrackPanelBookmarksProps) => {
 
   return (
     <section className="trackPanelBookmarks">
-      <h3>Bookmarks</h3>
+      <div className={styles.title}>Bookmarks</div>
       {exampleEnsObjects.length ? (
         <>
           <ExampleLinks
@@ -162,7 +163,7 @@ export const TrackPanelBookmarks = (props: TrackPanelBookmarksProps) => {
       ) : null}
       {limitedPreviouslyViewedObjects.length ? (
         <>
-          <div className={styles.title}>
+          <div className={styles.sectionTitle}>
             Previously viewed
             {props.previouslyViewedObjects.length > 20 && (
               <span className={styles.ellipsis}>

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
@@ -66,7 +66,7 @@ export const ExampleLinks = (props: ExampleLinksProps) => {
         return (
           <div key={exampleObject.object_id} className={styles.linkHolder}>
             <Link to={path} onClick={props.closeTrackPanelModal}>
-              {`Example ` + exampleObject.type}
+              Example {exampleObject.type}
             </Link>
           </div>
         );

--- a/src/ensembl/src/content/app/entity-viewer/types/gene.ts
+++ b/src/ensembl/src/content/app/entity-viewer/types/gene.ts
@@ -31,7 +31,7 @@ export type Gene = {
   stable_id: string;
   unversioned_stable_id: string;
   version: number | null;
-  symbol: string;
+  symbol: string | null;
   name: string | null;
   source?: Source;
   so_term: string;


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-801

## Description
- Updated the type definition of gene symbol to `String | null`.
- Updated the example link text displayed in the genome browser bookmarks modal.
- Updated the example link text displayed in the genome browser interstitial page

## Deployment URL
http://handle-empty-symbol.review.ensembl.org

## Views affected
Genome browser - > Track Panel -> Bookmarks