### PR TITLE
Support graphql refactoring (Strand moves from Region up to Slice)

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
@@ -70,7 +70,12 @@ const client = new ApolloClient({
   cache: new InMemoryCache({
     typePolicies: {
       Gene: {
-        keyFields: ['stable_id']
+        keyFields: ['stable_id'],
+        fields: {
+          slice: {
+            merge: false
+          }
+        }
       }
     }
   })

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -79,6 +79,9 @@ const QUERY = gql`
             end
             length
           }
+          region {
+            name
+          }
           strand {
             code
           }

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -64,10 +64,8 @@ const QUERY = gql`
           start
           end
         }
-        region {
-          strand {
-            code
-          }
+        strand {
+          code
         }
       }
       transcripts {
@@ -81,11 +79,8 @@ const QUERY = gql`
             end
             length
           }
-          region {
-            name
-            strand {
-              code
-            }
+          strand {
+            code
           }
         }
         relative_location {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-overview-image/GeneOverviewImage.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-overview-image/GeneOverviewImage.tsx
@@ -114,9 +114,7 @@ const StrandIndicator = (props: GeneOverviewImageProps) => {
   const {
     gene: {
       slice: {
-        region: {
-          strand: { code: strandCode }
-        }
+        strand: { code: strandCode }
       }
     }
   } = props;

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-topbar/EntityViewerTopbar.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-topbar/EntityViewerTopbar.tsx
@@ -40,11 +40,11 @@ const QUERY = gql`
           start
           end
         }
+        strand {
+          code
+        }
         region {
           name
-          strand {
-            code
-          }
         }
       }
     }
@@ -82,7 +82,7 @@ const geneToEnsObjectFields = (gene: Gene) => {
     versioned_stable_id: gene.stable_id,
     label: gene.symbol,
     bio_type: gene.so_term,
-    strand: gene.slice.region.strand.code,
+    strand: gene.slice.strand.code,
     location: {
       chromosome: gene.slice.region.name,
       start: gene.slice.location.start,

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/entity-helpers.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/entity-helpers.ts
@@ -36,7 +36,7 @@ export const getRegionName = (feature: { slice: Slice }) =>
   feature.slice.region.name;
 
 export const getFeatureStrand = (feature: { slice: Slice }) =>
-  feature.slice.region.strand.code;
+  feature.slice.strand.code;
 
 export const getFeatureLength = (feature: { slice: Slice }) => {
   return feature.slice.location.length;

--- a/src/ensembl/src/content/app/entity-viewer/types/slice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/types/slice.ts
@@ -21,11 +21,11 @@ export type Slice = {
   location: LocationWithinRegion;
   region: {
     name: string;
-    strand: {
-      code: Strand;
-      value?: 1 | -1; // adding this field for documentation purposes; we shouldn't need to use it
-    };
     assembly: string;
+  };
+  strand: {
+    code: Strand;
+    value?: 1 | -1; // adding this field for documentation purposes; we shouldn't need to use it
   };
 };
 

--- a/src/ensembl/tests/fixtures/entity-viewer/slice.ts
+++ b/src/ensembl/tests/fixtures/entity-viewer/slice.ts
@@ -31,11 +31,11 @@ export const createSlice = (): Slice => {
       end,
       length
     },
+    strand: {
+      code: faker.random.boolean() ? Strand.FORWARD : Strand.REVERSE
+    },
     region: {
       name: faker.lorem.word(),
-      strand: {
-        code: faker.random.boolean() ? Strand.FORWARD : Strand.REVERSE
-      },
       assembly: faker.random.uuid()
     }
   };

--- a/src/ensembl/tests/fixtures/entity-viewer/transcript.ts
+++ b/src/ensembl/tests/fixtures/entity-viewer/transcript.ts
@@ -132,6 +132,7 @@ const createExons = (transcriptSlice: Slice): Exon[] => {
         end: index < numberOfExons - 1 ? exonEnd : transcriptEnd,
         length
       },
+      strand: transcriptSlice.strand,
       region: transcriptSlice.region
     };
 


### PR DESCRIPTION
## Type
- Improvement to existing feature

## Description
Graphql api is moving the Strand from the Region up to the Slice (see https://github.com/Ensembl/ensembl-thoas/pull/20). It is going to be **a breaking change**, and this PR is intended to support it. 

## Views affected
Entity Viewer