### PR TITLE
Fix styles of selected species tab

### DIFF
--- a/src/ensembl/src/shared/components/selected-species/SelectedSpecies.scss
+++ b/src/ensembl/src/shared/components/selected-species/SelectedSpecies.scss
@@ -9,10 +9,10 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: $white;
+  margin-bottom: 12px;
 
   &:not(:last-child) {
     margin-right: 15px;
-    margin-bottom: 12px;
   }
 }
 


### PR DESCRIPTION
## Type
- Bug fix

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-835

## Description
We missed a bug in https://github.com/Ensembl/ensembl-client/pull/366

In species selector, before fix:

![image](https://user-images.githubusercontent.com/6834224/98876554-76a1fb00-2476-11eb-9fd3-806a00664f18.png)

After fix:

One row of species:
![image](https://user-images.githubusercontent.com/6834224/98876649-a51fd600-2476-11eb-9ed1-91cd1a975c86.png)

Multiple rows of species:
![image](https://user-images.githubusercontent.com/6834224/98876595-8b7e8e80-2476-11eb-945e-bf85e1af5ffa.png)