### PR TITLE
Add storage service to species page to retain state

### DIFF
--- a/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
+++ b/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
@@ -26,11 +26,16 @@ import { isEnvironment, Environment } from 'src/shared/helpers/environment';
 
 import {
   getActiveGenomeId,
-  getActiveGenomeStats
+  getActiveGenomeStats,
+  getActiveGenomeUIState
 } from 'src/content/app/species/state/general/speciesGeneralSelectors';
 import { getGenomeExampleFocusObjects } from 'src/shared/state/genome/genomeSelectors';
 import { getCommittedSpeciesById } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
-import { fetchStatsForActiveGenome } from 'src/content/app/species/state/general/speciesGeneralSlice';
+import {
+  fetchStatsForActiveGenome,
+  setActiveGenomeExpandedSections,
+  GenomeUIState
+} from 'src/content/app/species/state/general/speciesGeneralSlice';
 
 import { RootState } from 'src/store';
 import { ExampleFocusObject } from 'src/shared/state/genome/genomeTypes';
@@ -39,7 +44,8 @@ import { urlObj } from 'src/shared/components/view-in-app/ViewInApp';
 import { CommittedItem } from 'src/content/app/species-selector/types/species-search';
 import {
   StatsSection,
-  sectionGroupsMap
+  sectionGroupsMap,
+  SpeciesStatsSection
 } from '../../state/general/speciesGeneralHelper';
 
 import styles from './SpeciesMainView.scss';
@@ -47,9 +53,11 @@ import styles from './SpeciesMainView.scss';
 type Props = {
   activeGenomeId: string | null;
   genomeStats: GenomeStats | undefined;
+  genomeUIState: GenomeUIState | undefined;
   exampleFocusObjects: ExampleFocusObject[];
   species: CommittedItem | null;
   fetchStatsForActiveGenome: () => void;
+  setExpandedSections: (expandedSections: string[]) => void;
 };
 
 type ExampleLinkPopupProps = {
@@ -163,6 +171,10 @@ const SpeciesMainViewStats = (props: Props) => {
     }
   }, [props.genomeStats, props.activeGenomeId, props.exampleFocusObjects]);
 
+  const expandedSections = props.genomeUIState
+    ? [...props.genomeUIState.expandedSections]
+    : [];
+
   if (
     !props.genomeStats ||
     !props.exampleFocusObjects?.length ||
@@ -170,6 +182,18 @@ const SpeciesMainViewStats = (props: Props) => {
   ) {
     return null;
   }
+
+  const onSectionToggle = (
+    section: SpeciesStatsSection,
+    isExpanded: boolean
+  ) => {
+    if (isExpanded) {
+      expandedSections.push(section);
+      props.setExpandedSections(expandedSections);
+    } else {
+      props.setExpandedSections(expandedSections.filter((s) => s != section));
+    }
+  };
 
   return (
     <div className={styles.statsWrapper}>
@@ -183,6 +207,10 @@ const SpeciesMainViewStats = (props: Props) => {
             key={key}
             collapsedContent={getCollapsedContent(contentProps)}
             expandedContent={getExpandedContent(contentProps)}
+            isExpanded={expandedSections.includes(statsSection.section)}
+            onToggle={(isEnabled) =>
+              onSectionToggle(statsSection.section, isEnabled)
+            }
           />
         );
       })}
@@ -196,6 +224,7 @@ const mapStateToProps = (state: RootState) => {
   return {
     activeGenomeId,
     genomeStats: getActiveGenomeStats(state),
+    genomeUIState: getActiveGenomeUIState(state),
     exampleFocusObjects: activeGenomeId
       ? getGenomeExampleFocusObjects(state, activeGenomeId)
       : [],
@@ -206,7 +235,8 @@ const mapStateToProps = (state: RootState) => {
 };
 
 const mapDispatchToProps = {
-  fetchStatsForActiveGenome
+  fetchStatsForActiveGenome,
+  setExpandedSections: setActiveGenomeExpandedSections
 };
 
 export default connect(

--- a/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
+++ b/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
@@ -172,7 +172,7 @@ const SpeciesMainViewStats = (props: Props) => {
   }, [props.genomeStats, props.activeGenomeId, props.exampleFocusObjects]);
 
   const expandedSections = props.genomeUIState
-    ? [...props.genomeUIState.expandedSections]
+    ? props.genomeUIState.expandedSections
     : [];
 
   if (
@@ -188,8 +188,7 @@ const SpeciesMainViewStats = (props: Props) => {
     isExpanded: boolean
   ) => {
     if (isExpanded) {
-      expandedSections.push(section);
-      props.setExpandedSections(expandedSections);
+      props.setExpandedSections([...expandedSections, section]);
     } else {
       props.setExpandedSections(expandedSections.filter((s) => s != section));
     }

--- a/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
+++ b/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
@@ -57,7 +57,7 @@ type Props = {
   exampleFocusObjects: ExampleFocusObject[];
   species: CommittedItem | null;
   fetchStatsForActiveGenome: () => void;
-  setExpandedSections: (expandedSections: string[]) => void;
+  setExpandedSections: (expandedSections: SpeciesStatsSection[]) => void;
 };
 
 type ExampleLinkPopupProps = {

--- a/src/ensembl/src/content/app/species/services/species-storage-service.ts
+++ b/src/ensembl/src/content/app/species/services/species-storage-service.ts
@@ -22,8 +22,7 @@ import storageService, {
 import { UIState } from 'src/content/app/species/state/general/speciesGeneralSlice';
 
 export enum StorageKeys {
-  GENOME_UI_STATE = 'species.genomeUIState',
-  SIDEBAR_UI_STATE = 'species.sidebarUIState'
+  GENOME_UI_STATE = 'species.genomeUIState'
 }
 
 const options = {

--- a/src/ensembl/src/content/app/species/services/species-storage-service.ts
+++ b/src/ensembl/src/content/app/species/services/species-storage-service.ts
@@ -1,0 +1,51 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import storageService, {
+  StorageServiceInterface,
+  StorageType
+} from 'src/services/storage-service';
+
+import { UIState } from 'src/content/app/species/state/general/speciesGeneralSlice';
+
+export enum StorageKeys {
+  GENOME_UI_STATE = 'species.genomeUIState',
+  SIDEBAR_UI_STATE = 'species.sidebarUIState'
+}
+
+const options = {
+  storage: StorageType.SESSION_STORAGE
+};
+
+// named export is for testing purposes
+// for development, use default export
+export class SpeciesStorageService {
+  private storageService: StorageServiceInterface;
+
+  public constructor(storageService: StorageServiceInterface) {
+    this.storageService = storageService;
+  }
+
+  public getUIState(): UIState {
+    return this.storageService.get(StorageKeys.GENOME_UI_STATE, options);
+  }
+
+  public updateUIState(uiState: UIState) {
+    this.storageService.update(StorageKeys.GENOME_UI_STATE, uiState, options);
+  }
+}
+
+export default new SpeciesStorageService(storageService);

--- a/src/ensembl/src/content/app/species/services/species-storage-service.ts
+++ b/src/ensembl/src/content/app/species/services/species-storage-service.ts
@@ -30,8 +30,6 @@ const options = {
   storage: StorageType.SESSION_STORAGE
 };
 
-// named export is for testing purposes
-// for development, use default export
 export class SpeciesStorageService {
   private storageService: StorageServiceInterface;
 

--- a/src/ensembl/src/content/app/species/state/general/speciesGeneralSelectors.ts
+++ b/src/ensembl/src/content/app/species/state/general/speciesGeneralSelectors.ts
@@ -28,3 +28,13 @@ export const getActiveGenomeStats = (state: RootState) => {
 
   return state.speciesPage.general.stats[activeGenomeId];
 };
+
+export const getActiveGenomeUIState = (state: RootState) => {
+  const activeGenomeId = getActiveGenomeId(state);
+
+  if (!activeGenomeId) {
+    return;
+  }
+
+  return state.speciesPage.general.uiState[activeGenomeId];
+};

--- a/src/ensembl/src/content/app/species/state/general/speciesGeneralSlice.ts
+++ b/src/ensembl/src/content/app/species/state/general/speciesGeneralSlice.ts
@@ -36,7 +36,7 @@ import { RootState } from 'src/store';
 export type GenomeStats = StatsSection[];
 
 export type GenomeUIState = {
-  expandedSections: string[];
+  expandedSections: SpeciesStatsSection[];
 };
 
 export type UIState = {
@@ -93,7 +93,7 @@ export const fetchStatsForActiveGenome = (): ThunkAction<
 };
 
 export const setActiveGenomeExpandedSections = (
-  expandedSections: string[]
+  expandedSections: SpeciesStatsSection[]
 ): ThunkAction<void, any, null, Action<string>> => (
   dispatch,
   getState: () => RootState
@@ -137,7 +137,10 @@ const speciesGeneralSlice = createSlice({
 
     setExpandedSections(
       state,
-      action: PayloadAction<{ genomeId: string; expandedSections: string[] }>
+      action: PayloadAction<{
+        genomeId: string;
+        expandedSections: SpeciesStatsSection[];
+      }>
     ) {
       const stateToUpdate = state.uiState[action.payload.genomeId]
         ? state

--- a/src/ensembl/src/services/storage-service.ts
+++ b/src/ensembl/src/services/storage-service.ts
@@ -44,10 +44,11 @@ const defaultOptions: options = {
 };
 
 // We need to overwrite the arrays instead of merging them so that it is easier to remove entries
-const overwriteArray = (objValue: JSONValue, srcValue: JSONValue) => {
-  if (Array.isArray(objValue)) {
-    return srcValue;
+const overwriteArray = (currentValue: JSONValue, newValue: JSONValue) => {
+  if (Array.isArray(currentValue)) {
+    return newValue;
   }
+  return currentValue;
 };
 
 // named export is for testing;

--- a/src/ensembl/src/services/storage-service.ts
+++ b/src/ensembl/src/services/storage-service.ts
@@ -48,7 +48,6 @@ const overwriteArray = (currentValue: JSONValue, newValue: JSONValue) => {
   if (Array.isArray(currentValue)) {
     return newValue;
   }
-  return currentValue;
 };
 
 // named export is for testing;

--- a/src/ensembl/src/services/storage-service.ts
+++ b/src/ensembl/src/services/storage-service.ts
@@ -17,7 +17,7 @@
 import windowService, {
   WindowServiceInterface
 } from 'src/services/window-service';
-import merge from 'lodash/merge';
+import mergeWith from 'lodash/mergeWith';
 import JSONValue, { PrimitiveValue, ArrayValue } from 'src/shared/types/JSON';
 
 export enum StorageType {
@@ -41,6 +41,13 @@ export interface StorageServiceInterface {
 
 const defaultOptions: options = {
   storage: StorageType.LOCAL_STORAGE
+};
+
+// We need to overwrite the arrays instead of merging them so that it is easier to remove entries
+const overwriteArray = (objValue: JSONValue, srcValue: JSONValue) => {
+  if (Array.isArray(objValue)) {
+    return srcValue;
+  }
 };
 
 // named export is for testing;
@@ -75,7 +82,7 @@ export class StorageService implements StorageServiceInterface {
   public update(key: string, fragment: JSONValue, options = defaultOptions) {
     const storedData = this.get(key, options);
     if (storedData) {
-      this.save(key, merge(storedData, fragment), options);
+      this.save(key, mergeWith(storedData, fragment, overwriteArray), options);
     } else {
       this.save(key, fragment, options);
     }

--- a/src/ensembl/src/services/tests/storage-service.test.ts
+++ b/src/ensembl/src/services/tests/storage-service.test.ts
@@ -102,11 +102,27 @@ describe('storageService', () => {
         const key = faker.lorem.word();
         const key1 = faker.lorem.word();
         const key2 = faker.lorem.word();
+        const arrayKey1 = faker.lorem.word();
+        const arrayKey2 = faker.lorem.word();
+
         const value1 = faker.lorem.words();
         const value2 = faker.lorem.words();
         const value3 = faker.lorem.words();
-        const obj = { [key1]: value1 };
-        const updateObj = { [key1]: value3, [key2]: value2 };
+        const arrayValue1 = [faker.lorem.words()];
+        const arrayValue2 = [faker.lorem.words()];
+        const arrayValue3 = [faker.lorem.words()];
+
+        const obj = {
+          [key1]: value1,
+          [arrayKey1]: arrayValue1,
+          [arrayKey2]: arrayValue2
+        };
+        const updateObj = {
+          [key1]: value3,
+          [arrayKey1]: [],
+          [arrayKey2]: arrayValue3,
+          [key2]: value2
+        };
 
         jest
           .spyOn(mockLocalStorage, 'getItem')

--- a/src/ensembl/src/services/tests/storage-service.test.ts
+++ b/src/ensembl/src/services/tests/storage-service.test.ts
@@ -218,11 +218,27 @@ describe('storageService', () => {
         const key = faker.lorem.word();
         const key1 = faker.lorem.word();
         const key2 = faker.lorem.word();
+        const arrayKey1 = faker.lorem.word();
+        const arrayKey2 = faker.lorem.word();
+
         const value1 = faker.lorem.words();
         const value2 = faker.lorem.words();
         const value3 = faker.lorem.words();
-        const obj = { [key1]: value1 };
-        const updateObj = { [key1]: value3, [key2]: value2 };
+        const arrayValue1 = [faker.lorem.words()];
+        const arrayValue2 = [faker.lorem.words()];
+        const arrayValue3 = [faker.lorem.words()];
+
+        const obj = {
+          [key1]: value1,
+          [arrayKey1]: arrayValue1,
+          [arrayKey2]: arrayValue2
+        };
+        const updateObj = {
+          [key1]: value3,
+          [arrayKey1]: [],
+          [arrayKey2]: arrayValue3,
+          [key2]: value2
+        };
 
         jest
           .spyOn(mockSessionStorage, 'getItem')


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [x] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-838

## Description
- Added storage service to species page
- Species stats accordion expanded statuses are stored in the session storage for each genome
- Fixed an issue with the storage service update function where the array values such as `[x]` was not getting updated to `[]` when we use `merge` (https://github.com/lodash/lodash/issues/1313)

## Deployment URL
https://species-storage.review.ensembl.org

## Views affected
Species page -> Stats accordion

### Other effects

- [ ] I have checked any requirements for Google Analytics
- [x] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.
