### PR TITLE
Ev transcripts sorting

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -81,7 +81,7 @@ const DefaultTranscriptslist = (props: Props) => {
           />
         )}
         <div className={styles.row}>
-          {gene.transcripts.length > 3 && !isFilterOpen && (
+          {gene.transcripts.length > 5 && !isFilterOpen && (
             <div className={styles.filterLabel} onClick={toggleFilter}>
               Filter & sort
               <ChevronDown className={styles.chevron} />

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -18,13 +18,17 @@ import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 
 import { getFeatureCoordinates } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
-import { defaultSort } from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
+import { transcriptSortingFunctions } from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
 
 import {
   getExpandedTranscriptIds,
-  getExpandedTranscriptDownloadIds
+  getExpandedTranscriptDownloadIds,
+  getSortingRule
 } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors';
-import { toggleTranscriptInfo } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
+import {
+  toggleTranscriptInfo,
+  SortingRule
+} from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 
 import DefaultTranscriptsListItem from './default-transcripts-list-item/DefaultTranscriptListItem';
 import TranscriptsFilter from 'src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter';
@@ -43,11 +47,14 @@ type Props = {
   expandedTranscriptIds: string[];
   expandedTranscriptDownloadIds: string[];
   toggleTranscriptInfo: (id: string) => void;
+  sortingRule: SortingRule;
 };
 
 const DefaultTranscriptslist = (props: Props) => {
-  const { gene } = props;
-  const sortedTranscripts = defaultSort(gene.transcripts);
+  const { gene, sortingRule } = props;
+
+  const sortingFunction = transcriptSortingFunctions[sortingRule];
+  const sortedTranscripts = sortingFunction(gene.transcripts);
 
   const [isFilterOpen, setFilterOpen] = useState(false);
 
@@ -127,7 +134,8 @@ const StripedBackground = (props: Props) => {
 
 const mapStateToProps = (state: RootState) => ({
   expandedTranscriptIds: getExpandedTranscriptIds(state),
-  expandedTranscriptDownloadIds: getExpandedTranscriptDownloadIds(state)
+  expandedTranscriptDownloadIds: getExpandedTranscriptDownloadIds(state),
+  sortingRule: getSortingRule(state)
 });
 
 const mapDispatchToProps = {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.test.tsx
@@ -120,14 +120,6 @@ describe('<TranscriptsFilter />', () => {
     expect(secondSortingRadioButton.prop('checked')).toBe(true);
   });
 
-  it.skip('shows sort by protein for protein-coding transcripts', () => {
-    //todo once we get confirmation
-  });
-
-  it.skip('does not show sort by protein for non-coding transcripts', () => {
-    //todo once we get confirmation
-  });
-
   it('correctly handles sorting order change', () => {
     const store = mockStore(mockState);
     const wrapper = mount(

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.test.tsx
@@ -112,7 +112,9 @@ describe('<TranscriptsFilter />', () => {
 
     const secondSortingLabel = wrapper
       .find('label')
-      .findWhere((el) => el.text() === 'Spliced length: longest – shortest');
+      .findWhere(
+        (el) => el.text() === 'Combined exon length: longest – shortest'
+      );
     const secondSortingRadioButton = secondSortingLabel.find('input');
 
     expect(secondSortingRadioButton.prop('checked')).toBe(true);

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.test.tsx
@@ -119,11 +119,11 @@ describe('<TranscriptsFilter />', () => {
   });
 
   it.skip('shows sort by protein for protein-coding transcripts', () => {
-    // not an empty function
+    //todo once we get confirmation
   });
 
   it.skip('does not show sort by protein for non-coding transcripts', () => {
-    // not an empty function
+    //todo once we get confirmation
   });
 
   it('correctly handles sorting order change', () => {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.test.tsx
@@ -105,7 +105,7 @@ describe('<TranscriptsFilter />', () => {
     // after we change sorting option
     const updatedState = set(
       'entityViewer.geneView.transcripts.human.gene:brca2.sortingRule',
-      'spliced_length_longest_to_shortest',
+      'spliced_length_desc',
       mockState
     );
     wrapper = wrapInRedux(updatedState);
@@ -133,7 +133,7 @@ describe('<TranscriptsFilter />', () => {
     const radioGroup = wrapper.find(RadioGroup);
 
     const onRadioChange = radioGroup.prop('onChange');
-    const newSortingRule = 'spliced_length_longest_to_shortest';
+    const newSortingRule = 'spliced_length_desc';
     onRadioChange(newSortingRule);
 
     const sortingActions = store

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import thunk from 'redux-thunk';
+import set from 'lodash/fp/set';
+
+import { Status } from 'src/shared/types/status';
+import { createTranscript } from 'tests/fixtures/entity-viewer/transcript';
+import TranscriptsFilter from './TranscriptsFilter';
+
+import RadioGroup from 'src/shared/components/radio-group/RadioGroup';
+
+const mockState = {
+  entityViewer: {
+    general: {
+      activeGenomeId: 'human',
+      activeEnsObjectIds: {
+        human: 'gene:brca2'
+      }
+    },
+    geneView: {
+      transcripts: {
+        human: {
+          'gene:brca2': {
+            expandedIds: [],
+            expandedDownloadIds: [],
+            filters: [],
+            sortingRule: 'default'
+          }
+        }
+      }
+    },
+    sidebar: {
+      human: {
+        status: Status.OPEN
+      }
+    }
+  }
+};
+
+const mockStore = configureMockStore([thunk]);
+
+const createProteinCodingTranscript = () => createTranscript();
+const createNonCodingTranscript = () => {
+  const transcript = createTranscript();
+  transcript.product_generating_contexts = [];
+  return transcript;
+};
+
+const proteinCodingTranscript1 = createProteinCodingTranscript();
+const proteinCodingTranscript2 = createProteinCodingTranscript();
+const nonCodingTranscript1 = createNonCodingTranscript();
+const nonCodingTranscript2 = createNonCodingTranscript();
+
+const defaultTranscripts = [
+  proteinCodingTranscript1,
+  proteinCodingTranscript2,
+  nonCodingTranscript1,
+  nonCodingTranscript2
+];
+
+const mockToggleFilter = jest.fn();
+
+const wrapInRedux = (
+  state: typeof mockState = mockState,
+  transcripts = defaultTranscripts
+) => {
+  return mount(
+    <Provider store={mockStore(state)}>
+      <TranscriptsFilter
+        transcripts={transcripts}
+        toggleFilter={mockToggleFilter}
+      />
+    </Provider>
+  );
+};
+
+describe('<TranscriptsFilter />', () => {
+  it('shows correct sorting option as selected', () => {
+    // default sorting option
+    let wrapper = wrapInRedux();
+    const defaultSortingLabel = wrapper
+      .find('label')
+      .findWhere((el) => el.text() === 'Default');
+    const defaultSortingRadioButton = defaultSortingLabel.find('input');
+    expect(defaultSortingRadioButton.prop('checked')).toBe(true);
+
+    // after we change sorting option
+    const updatedState = set(
+      'entityViewer.geneView.transcripts.human.gene:brca2.sortingRule',
+      'spliced_length_longest_to_shortest',
+      mockState
+    );
+    wrapper = wrapInRedux(updatedState);
+
+    const secondSortingLabel = wrapper
+      .find('label')
+      .findWhere((el) => el.text() === 'Spliced length: longest – shortest');
+    const secondSortingRadioButton = secondSortingLabel.find('input');
+
+    expect(secondSortingRadioButton.prop('checked')).toBe(true);
+  });
+
+  it.skip('shows sort by protein for protein-coding transcripts', () => {
+    // not an empty function
+  });
+
+  it.skip('does not show sort by protein for non-coding transcripts', () => {
+    // not an empty function
+  });
+
+  it('correctly handles sorting order change', () => {
+    const store = mockStore(mockState);
+    const wrapper = mount(
+      <Provider store={store}>
+        <TranscriptsFilter
+          transcripts={defaultTranscripts}
+          toggleFilter={mockToggleFilter}
+        />
+      </Provider>
+    );
+    const radioGroup = wrapper.find(RadioGroup);
+
+    const onRadioChange = radioGroup.prop('onChange');
+    const newSortingRule = 'spliced_length_longest_to_shortest';
+    onRadioChange(newSortingRule);
+
+    const sortingActions = store
+      .getActions()
+      .filter(
+        (action) =>
+          action.type ===
+          'entity-viewer-gene-view-transcripts/updateSortingRule'
+      );
+
+    expect(sortingActions.length).toBe(1);
+    expect(sortingActions[0].payload.sortingRule).toBe(newSortingRule);
+  });
+});

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
@@ -17,7 +17,6 @@
 import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import classNames from 'classnames';
-// import { connect } from 'react-redux';
 
 import { isEntityViewerSidebarOpen } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors';
 import {
@@ -59,7 +58,9 @@ const sortingOrderToLabel = [
   [
     SortingRule.SPLICED_LENGTH_SHORTEST_TO_LONGEST,
     'Spliced length: shortest – longest'
-  ]
+  ],
+  [SortingRule.EXON_COUNT_HIGH_TO_LOW, 'Exon count: high - low'],
+  [SortingRule.EXON_COUNT_LOW_TO_HIGH, 'Exon count: low - high']
 ];
 
 const radioData: RadioOptions = sortingOrderToLabel.map(([key, value]) => ({

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
@@ -51,16 +51,10 @@ type OptionValue = string | number | boolean;
 
 const sortingOrderToLabel = [
   [SortingRule.DEFAULT, 'Default'],
-  [
-    SortingRule.SPLICED_LENGTH_LONGEST_TO_SHORTEST,
-    'Combined exon length: longest – shortest'
-  ],
-  [
-    SortingRule.SPLICED_LENGTH_SHORTEST_TO_LONGEST,
-    'Combined exon length: shortest – longest'
-  ],
-  [SortingRule.EXON_COUNT_HIGH_TO_LOW, 'Exon count: high - low'],
-  [SortingRule.EXON_COUNT_LOW_TO_HIGH, 'Exon count: low - high']
+  [SortingRule.SPLICED_LENGTH_DESC, 'Combined exon length: longest – shortest'],
+  [SortingRule.SPLICED_LENGTH_ASC, 'Combined exon length: shortest – longest'],
+  [SortingRule.EXON_COUNT_DESC, 'Exon count: high - low'],
+  [SortingRule.EXON_COUNT_ASC, 'Exon count: low - high']
 ];
 
 const radioData: RadioOptions = sortingOrderToLabel.map(([key, value]) => ({

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
@@ -29,6 +29,7 @@ import {
   setSortingRule,
   SortingRule
 } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
+import { sortBySplicedLength } from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
 
 import RadioGroup, {
   RadioOptions
@@ -100,8 +101,14 @@ const TranscriptsFilter = (props: Props) => {
     [styles.filterBoxFullWidth]: !props.isSidebarOpen
   });
 
+  let sortedTranscripts: Transcript[];
   const onSortingRuleChange = (value: OptionValue) => {
     props.setSortingRule(value as SortingRule);
+    if(value === "spliced_length_longest_to_shortest") {
+      sortedTranscripts = sortBySplicedLength(props.transcripts, "longest");
+    } else if (value === "spliced_length_shortest_to_longest") {
+      sortedTranscripts = sortBySplicedLength(props.transcripts, "shortest");
+    }
   };
 
   const onFilterChange = (filterName: string, isChecked: boolean) => {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
@@ -53,11 +53,11 @@ const sortingOrderToLabel = [
   [SortingRule.DEFAULT, 'Default'],
   [
     SortingRule.SPLICED_LENGTH_LONGEST_TO_SHORTEST,
-    'Spliced length: longest – shortest'
+    'Combined exon length: longest – shortest'
   ],
   [
     SortingRule.SPLICED_LENGTH_SHORTEST_TO_LONGEST,
-    'Spliced length: shortest – longest'
+    'Combined exon length: shortest – longest'
   ],
   [SortingRule.EXON_COUNT_HIGH_TO_LOW, 'Exon count: high - low'],
   [SortingRule.EXON_COUNT_LOW_TO_HIGH, 'Exon count: low - high']

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/tests/transcripts-sorter.test.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/tests/transcripts-sorter.test.ts
@@ -1,0 +1,31 @@
+import { defaultSort } from '../transcripts-sorter';
+
+import { createTranscript } from 'tests/fixtures/entity-viewer/transcript';
+
+/*
+const longProteinCodingTranscript
+const shortProteinCodingTranscript
+const longNonCodingTranscript
+const shortNonCodingTranscript
+const transcriptWithManyExons
+const transcriptWithFewExons
+*/
+
+console.log(JSON.stringify(createTranscript(), null, 2));
+
+
+describe('default sort', () => {
+
+  it('puts protein-coding transcripts first', () => {
+
+  });
+
+  it('sorts protein-coding transcripts by length, putting the longest first', () => {
+
+  });
+
+  it('sorts non-coding transcripts by so_term alphabetically', () => {
+
+  });
+
+});

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/tests/transcripts-sorter.test.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/tests/transcripts-sorter.test.ts
@@ -16,10 +16,10 @@
 
 import {
   defaultSort,
-  sortBySplicedLengthLongestToShortest,
-  sortBySplicedLengthShortestToLongest,
-  sortByExonCountHightToLow,
-  sortByExonCountLowToHigh
+  sortBySplicedLengthDesc,
+  sortBySplicedLengthAsc,
+  sortByExonCountDesc,
+  sortByExonCountAsc
 } from '../transcripts-sorter';
 
 import { createTranscript } from 'tests/fixtures/entity-viewer/transcript';
@@ -144,7 +144,7 @@ describe('default sort', () => {
   });
 });
 
-describe('sortBySplicedLengthLongestToShortest', () => {
+describe('sortBySplicedLengthDesc', () => {
   it('sorts transcripts correctly', () => {
     const unsortedTranscripts = [
       transcriptWithMediumSplicedLength,
@@ -158,14 +158,14 @@ describe('sortBySplicedLengthLongestToShortest', () => {
     ];
 
     expect(
-      sortBySplicedLengthLongestToShortest(unsortedTranscripts).map(
+      sortBySplicedLengthDesc(unsortedTranscripts).map(
         ({ stable_id }) => stable_id
       )
     ).toEqual(expectedTranscriptIds);
   });
 });
 
-describe('sortBySplicedLengthShortestToLongest', () => {
+describe('sortBySplicedLengthAsc', () => {
   it('sorts transcripts correctly', () => {
     const unsortedTranscripts = [
       transcriptWithMediumSplicedLength,
@@ -179,14 +179,14 @@ describe('sortBySplicedLengthShortestToLongest', () => {
     ];
 
     expect(
-      sortBySplicedLengthShortestToLongest(unsortedTranscripts).map(
+      sortBySplicedLengthAsc(unsortedTranscripts).map(
         ({ stable_id }) => stable_id
       )
     ).toEqual(expectedTranscriptIds);
   });
 });
 
-describe('sortByExonCountHighToLow', () => {
+describe('sortByExonCountDesc', () => {
   it('sorts transcripts correctly(Exon count high to low)', () => {
     const unsortedTranscripts = [
       transcriptWithMediumExons,
@@ -200,14 +200,12 @@ describe('sortByExonCountHighToLow', () => {
     ];
 
     expect(
-      sortByExonCountHightToLow(unsortedTranscripts).map(
-        ({ stable_id }) => stable_id
-      )
+      sortByExonCountDesc(unsortedTranscripts).map(({ stable_id }) => stable_id)
     ).toEqual(expectedTranscriptIds);
   });
 });
 
-describe('sortByExonCountLowToHigh', () => {
+describe('sortByExonCountAsc', () => {
   it('sorts transcripts correctly(Exon count low to high)', () => {
     const unsortedTranscripts = [
       transcriptWithMediumExons,
@@ -221,9 +219,7 @@ describe('sortByExonCountLowToHigh', () => {
     ];
 
     expect(
-      sortByExonCountLowToHigh(unsortedTranscripts).map(
-        ({ stable_id }) => stable_id
-      )
+      sortByExonCountAsc(unsortedTranscripts).map(({ stable_id }) => stable_id)
     ).toEqual(expectedTranscriptIds);
   });
 });

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/tests/transcripts-sorter.test.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/tests/transcripts-sorter.test.ts
@@ -17,11 +17,14 @@
 import {
   defaultSort,
   sortBySplicedLengthLongestToShortest,
-  sortBySplicedLengthShortestToLongest
+  sortBySplicedLengthShortestToLongest,
+  sortByExonCountHightToLow,
+  sortByExonCountLowToHigh
 } from '../transcripts-sorter';
 
 import { createTranscript } from 'tests/fixtures/entity-viewer/transcript';
 
+/* Creating dummy transcritps with different protein coding and non coding length  to test default sort*/
 const createLongProteinCodingTranscript = () => {
   const transcript = createTranscript();
   transcript.slice.location.length = 100_000;
@@ -46,6 +49,8 @@ const createShortNonCodingTranscript = () => {
   transcript.product_generating_contexts = [];
   return transcript;
 };
+
+/* Creating dummy transcritps with different spliced length */
 const createTranscriptWithGreatestSplicedLength = () => {
   const transcript = createTranscript();
   const splicedExon = transcript.spliced_exons[0];
@@ -71,6 +76,35 @@ const createTranscriptWithSmallestSplicedLength = () => {
   return transcript;
 };
 
+/* Creating dummy transcritps with different numbers of Exons */
+const createTranscriptWithGreatestExons = () => {
+  const transcript = createTranscript();
+  const splicedExon = transcript.spliced_exons[0];
+  transcript.stable_id = 'transcript_with_greatest_exons';
+  transcript.spliced_exons = [
+    splicedExon,
+    splicedExon,
+    splicedExon,
+    splicedExon
+  ];
+  return transcript;
+};
+const createTranscriptWithMediumExons = () => {
+  const transcript = createTranscript();
+  transcript.stable_id = 'transcript_with_medium_exons';
+  const splicedExon = transcript.spliced_exons[0];
+  splicedExon.exon.slice.location.length = 10_000;
+  transcript.spliced_exons = [splicedExon, splicedExon, splicedExon];
+  return transcript;
+};
+const createTranscriptWithSmallestExons = () => {
+  const transcript = createTranscript();
+  transcript.stable_id = 'transcript_with_smallest_exons';
+  const splicedExon = transcript.spliced_exons[0];
+  transcript.spliced_exons = [splicedExon, splicedExon];
+  return transcript;
+};
+
 const longProteinCodingTranscript = createLongProteinCodingTranscript();
 const shortProteinCodingTranscript = createShortProteinCodingTranscript();
 const longNonCodingTranscript = createLongNonCodingTranscript();
@@ -78,6 +112,9 @@ const shortNonCodingTranscript = createShortNonCodingTranscript();
 const transcriptWithGreatestSplicedLength = createTranscriptWithGreatestSplicedLength();
 const transcriptWithMediumSplicedLength = createTranscriptWithMediumSplicedLength();
 const transcriptWithSmallestSplicedLength = createTranscriptWithSmallestSplicedLength();
+const transcriptWithGreatestExons = createTranscriptWithGreatestExons();
+const transcriptWithMediumExons = createTranscriptWithMediumExons();
+const transcriptWithSmallestExons = createTranscriptWithSmallestExons();
 
 describe('default sort', () => {
   it('sorts transcripts correctly', () => {
@@ -143,6 +180,48 @@ describe('sortBySplicedLengthShortestToLongest', () => {
 
     expect(
       sortBySplicedLengthShortestToLongest(unsortedTranscripts).map(
+        ({ stable_id }) => stable_id
+      )
+    ).toEqual(expectedTranscriptIds);
+  });
+});
+
+describe('sortByExonCountHighToLow', () => {
+  it('sorts transcripts correctly(Exon count high to low)', () => {
+    const unsortedTranscripts = [
+      transcriptWithMediumExons,
+      transcriptWithSmallestExons,
+      transcriptWithGreatestExons
+    ];
+    const expectedTranscriptIds = [
+      'transcript_with_greatest_exons',
+      'transcript_with_medium_exons',
+      'transcript_with_smallest_exons'
+    ];
+
+    expect(
+      sortByExonCountHightToLow(unsortedTranscripts).map(
+        ({ stable_id }) => stable_id
+      )
+    ).toEqual(expectedTranscriptIds);
+  });
+});
+
+describe('sortByExonCountLowToHigh', () => {
+  it('sorts transcripts correctly(Exon count low to high)', () => {
+    const unsortedTranscripts = [
+      transcriptWithMediumExons,
+      transcriptWithGreatestExons,
+      transcriptWithSmallestExons
+    ];
+    const expectedTranscriptIds = [
+      'transcript_with_smallest_exons',
+      'transcript_with_medium_exons',
+      'transcript_with_greatest_exons'
+    ];
+
+    expect(
+      sortByExonCountLowToHigh(unsortedTranscripts).map(
         ({ stable_id }) => stable_id
       )
     ).toEqual(expectedTranscriptIds);

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/tests/transcripts-sorter.test.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/tests/transcripts-sorter.test.ts
@@ -1,31 +1,150 @@
-import { defaultSort } from '../transcripts-sorter';
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  defaultSort,
+  sortBySplicedLengthLongestToShortest,
+  sortBySplicedLengthShortestToLongest
+} from '../transcripts-sorter';
 
 import { createTranscript } from 'tests/fixtures/entity-viewer/transcript';
 
-/*
-const longProteinCodingTranscript
-const shortProteinCodingTranscript
-const longNonCodingTranscript
-const shortNonCodingTranscript
-const transcriptWithManyExons
-const transcriptWithFewExons
-*/
+const createLongProteinCodingTranscript = () => {
+  const transcript = createTranscript();
+  transcript.slice.location.length = 100_000;
+  return transcript;
+};
+const createShortProteinCodingTranscript = () => {
+  const transcript = createTranscript();
+  transcript.slice.location.length = 10_000;
+  return transcript;
+};
+const createLongNonCodingTranscript = () => {
+  const transcript = createTranscript();
+  transcript.slice.location.length = 150_000;
+  transcript.so_term = 'xyz'; // <- to make sure that during default sorting we put this last
+  transcript.product_generating_contexts = [];
+  return transcript;
+};
+const createShortNonCodingTranscript = () => {
+  const transcript = createTranscript();
+  transcript.slice.location.length = 5_000;
+  transcript.so_term = 'abc'; // <- to make sure that during default sorting we put this first
+  transcript.product_generating_contexts = [];
+  return transcript;
+};
+const createTranscriptWithGreatestSplicedLength = () => {
+  const transcript = createTranscript();
+  const splicedExon = transcript.spliced_exons[0];
+  transcript.stable_id = 'transcript_with_greatest_spliced_length';
+  splicedExon.exon.slice.location.length = 15_000;
+  transcript.spliced_exons = [splicedExon, splicedExon, splicedExon];
+  return transcript;
+};
+const createTranscriptWithMediumSplicedLength = () => {
+  const transcript = createTranscript();
+  transcript.stable_id = 'transcript_with_medium_spliced_length';
+  const splicedExon = transcript.spliced_exons[0];
+  splicedExon.exon.slice.location.length = 10_000;
+  transcript.spliced_exons = [splicedExon, splicedExon, splicedExon];
+  return transcript;
+};
+const createTranscriptWithSmallestSplicedLength = () => {
+  const transcript = createTranscript();
+  transcript.stable_id = 'transcript_with_smallest_spliced_length';
+  const splicedExon = transcript.spliced_exons[0];
+  splicedExon.exon.slice.location.length = 5_000;
+  transcript.spliced_exons = [splicedExon, splicedExon, splicedExon];
+  return transcript;
+};
 
-console.log(JSON.stringify(createTranscript(), null, 2));
-
+const longProteinCodingTranscript = createLongProteinCodingTranscript();
+const shortProteinCodingTranscript = createShortProteinCodingTranscript();
+const longNonCodingTranscript = createLongNonCodingTranscript();
+const shortNonCodingTranscript = createShortNonCodingTranscript();
+const transcriptWithGreatestSplicedLength = createTranscriptWithGreatestSplicedLength();
+const transcriptWithMediumSplicedLength = createTranscriptWithMediumSplicedLength();
+const transcriptWithSmallestSplicedLength = createTranscriptWithSmallestSplicedLength();
 
 describe('default sort', () => {
+  it('sorts transcripts correctly', () => {
+    /*
+      - puts protein-coding transcripts first
+      - sorts protein-coding transcripts by length
+      - sorts non-coding transcripts by so_term term alphabetically
+    */
 
-  it('puts protein-coding transcripts first', () => {
+    const unsortedTranscripts = [
+      shortNonCodingTranscript,
+      shortProteinCodingTranscript,
+      longNonCodingTranscript, // this is the longest
+      longProteinCodingTranscript
+    ];
 
+    const expectedTranscripts = [
+      longProteinCodingTranscript,
+      shortProteinCodingTranscript,
+      shortNonCodingTranscript, // its so_term is "abc"
+      longNonCodingTranscript // its so_term is "xyz"
+    ];
+
+    const sortedTranscripts = defaultSort(unsortedTranscripts);
+
+    expect(sortedTranscripts).toEqual(expectedTranscripts);
   });
+});
 
-  it('sorts protein-coding transcripts by length, putting the longest first', () => {
+describe('sortBySplicedLengthLongestToShortest', () => {
+  it('sorts transcripts correctly', () => {
+    const unsortedTranscripts = [
+      transcriptWithMediumSplicedLength,
+      transcriptWithSmallestSplicedLength,
+      transcriptWithGreatestSplicedLength
+    ];
+    const expectedTranscriptIds = [
+      'transcript_with_greatest_spliced_length',
+      'transcript_with_medium_spliced_length',
+      'transcript_with_smallest_spliced_length'
+    ];
 
+    expect(
+      sortBySplicedLengthLongestToShortest(unsortedTranscripts).map(
+        ({ stable_id }) => stable_id
+      )
+    ).toEqual(expectedTranscriptIds);
   });
+});
 
-  it('sorts non-coding transcripts by so_term alphabetically', () => {
+describe('sortBySplicedLengthShortestToLongest', () => {
+  it('sorts transcripts correctly', () => {
+    const unsortedTranscripts = [
+      transcriptWithMediumSplicedLength,
+      transcriptWithSmallestSplicedLength,
+      transcriptWithGreatestSplicedLength
+    ];
+    const expectedTranscriptIds = [
+      'transcript_with_smallest_spliced_length',
+      'transcript_with_medium_spliced_length',
+      'transcript_with_greatest_spliced_length'
+    ];
 
+    expect(
+      sortBySplicedLengthShortestToLongest(unsortedTranscripts).map(
+        ({ stable_id }) => stable_id
+      )
+    ).toEqual(expectedTranscriptIds);
   });
-
 });

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/transcripts-sorter.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/transcripts-sorter.ts
@@ -53,3 +53,15 @@ export function defaultSort(transcripts: Transcript[]) {
 
   return [...proteinCodingTranscripts, ...sortedNonProteinCodingTranscripts];
 }
+
+export function sortBySplicedLength(transcripts: Transcript[], sortByValue: string) {
+  const sortedTranscripts = transcripts.sort(function(a, b){
+    if(sortByValue === "shortest") {
+      return a.slice.location.length - b.slice.location.length;
+    } else {
+      return b.slice.location.length - a.slice.location.length;
+    }
+  });
+
+  return sortedTranscripts;
+}

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/transcripts-sorter.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/transcripts-sorter.ts
@@ -60,42 +60,39 @@ export function defaultSort(transcripts: Transcript[]) {
   return [...proteinCodingTranscripts, ...sortedNonProteinCodingTranscripts];
 }
 
-export function sortBySplicedLengthLongestToShortest(
-  transcripts: Transcript[]
-) {
+export function sortBySplicedLengthDesc(transcripts: Transcript[]) {
   return [...transcripts].sort((transcriptA, transcriptB) => {
     return getSplicedRNALength(transcriptB) - getSplicedRNALength(transcriptA);
   });
 }
 
-export function sortBySplicedLengthShortestToLongest(
-  transcripts: Transcript[]
-) {
+export function sortBySplicedLengthAsc(transcripts: Transcript[]) {
   return [...transcripts].sort((transcriptA, transcriptB) => {
     return getSplicedRNALength(transcriptA) - getSplicedRNALength(transcriptB);
   });
 }
 
-export function sortByExonCountHightToLow(transcripts: Transcript[]) {
+export function sortByExonCountDesc(transcripts: Transcript[]) {
   return [...transcripts].sort((transcriptA, transcriptB) => {
     return transcriptB.spliced_exons.length - transcriptA.spliced_exons.length;
   });
 }
 
-export function sortByExonCountLowToHigh(transcripts: Transcript[]) {
+export function sortByExonCountAsc(transcripts: Transcript[]) {
   return [...transcripts].sort((transcriptA, transcriptB) => {
     return transcriptA.spliced_exons.length - transcriptB.spliced_exons.length;
   });
 }
 
 type SortingFunction = (transcripts: Transcript[]) => Transcript[];
+
 export const transcriptSortingFunctions: Record<
   SortingRule,
   SortingFunction
 > = {
   default: defaultSort,
-  spliced_length_longest_to_shortest: sortBySplicedLengthLongestToShortest,
-  spliced_length_shortest_to_longest: sortBySplicedLengthShortestToLongest,
-  exon_count_high_to_low: sortByExonCountHightToLow,
-  exon_count_low_to_high: sortByExonCountLowToHigh
+  spliced_length_desc: sortBySplicedLengthDesc,
+  spliced_length_asc: sortBySplicedLengthAsc,
+  exon_count_desc: sortByExonCountDesc,
+  exon_count_asc: sortByExonCountAsc
 };

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/transcripts-sorter.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/transcripts-sorter.ts
@@ -17,7 +17,11 @@
 import sortBy from 'lodash/sortBy';
 import partition from 'lodash/partition';
 
-import { getFeatureLength, isProteinCodingTranscript } from './entity-helpers';
+import {
+  getFeatureLength,
+  isProteinCodingTranscript,
+  getSplicedRNALength
+} from './entity-helpers';
 
 import { Transcript } from 'src/content/app/entity-viewer/types/transcript';
 
@@ -54,14 +58,24 @@ export function defaultSort(transcripts: Transcript[]) {
   return [...proteinCodingTranscripts, ...sortedNonProteinCodingTranscripts];
 }
 
-export function sortBySplicedLength(transcripts: Transcript[], sortByValue: string) {
-  const sortedTranscripts = transcripts.sort(function(a, b){
-    if(sortByValue === "shortest") {
-      return a.slice.location.length - b.slice.location.length;
-    } else {
-      return b.slice.location.length - a.slice.location.length;
-    }
+export function sortBySplicedLengthLongestToShortest(
+  transcripts: Transcript[]
+) {
+  return [...transcripts].sort((transcriptA, transcriptB) => {
+    return getSplicedRNALength(transcriptB) - getSplicedRNALength(transcriptA);
   });
-
-  return sortedTranscripts;
 }
+
+export function sortBySplicedLengthShortestToLongest(
+  transcripts: Transcript[]
+) {
+  return [...transcripts].sort((transcriptA, transcriptB) => {
+    return getSplicedRNALength(transcriptA) - getSplicedRNALength(transcriptB);
+  });
+}
+
+export const transcriptSortingFunctions = {
+  default: defaultSort,
+  spliced_length_longest_to_shortest: sortBySplicedLengthLongestToShortest,
+  spliced_length_shortest_to_longest: sortBySplicedLengthShortestToLongest
+};

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/transcripts-sorter.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/transcripts-sorter.ts
@@ -23,6 +23,8 @@ import {
   getSplicedRNALength
 } from './entity-helpers';
 
+import { SortingRule } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
+
 import { Transcript } from 'src/content/app/entity-viewer/types/transcript';
 
 function compareTranscriptLengths(
@@ -74,8 +76,26 @@ export function sortBySplicedLengthShortestToLongest(
   });
 }
 
-export const transcriptSortingFunctions = {
+export function sortByExonCountHightToLow(transcripts: Transcript[]) {
+  return [...transcripts].sort((transcriptA, transcriptB) => {
+    return transcriptB.spliced_exons.length - transcriptA.spliced_exons.length;
+  });
+}
+
+export function sortByExonCountLowToHigh(transcripts: Transcript[]) {
+  return [...transcripts].sort((transcriptA, transcriptB) => {
+    return transcriptA.spliced_exons.length - transcriptB.spliced_exons.length;
+  });
+}
+
+type SortingFunction = (transcripts: Transcript[]) => Transcript[];
+export const transcriptSortingFunctions: Record<
+  SortingRule,
+  SortingFunction
+> = {
   default: defaultSort,
   spliced_length_longest_to_shortest: sortBySplicedLengthLongestToShortest,
-  spliced_length_shortest_to_longest: sortBySplicedLengthShortestToLongest
+  spliced_length_shortest_to_longest: sortBySplicedLengthShortestToLongest,
+  exon_count_high_to_low: sortByExonCountHightToLow,
+  exon_count_low_to_high: sortByExonCountLowToHigh
 };

--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
@@ -34,7 +34,9 @@ import { RootState } from 'src/store';
 export enum SortingRule {
   DEFAULT = 'default',
   SPLICED_LENGTH_LONGEST_TO_SHORTEST = 'spliced_length_longest_to_shortest',
-  SPLICED_LENGTH_SHORTEST_TO_LONGEST = 'spliced_length_shortest_to_longest'
+  SPLICED_LENGTH_SHORTEST_TO_LONGEST = 'spliced_length_shortest_to_longest',
+  EXON_COUNT_HIGH_TO_LOW = 'exon_count_high_to_low',
+  EXON_COUNT_LOW_TO_HIGH = 'exon_count_low_to_high'
 }
 
 export type TranscriptsStatePerGene = {

--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
@@ -33,10 +33,10 @@ import { RootState } from 'src/store';
 
 export enum SortingRule {
   DEFAULT = 'default',
-  SPLICED_LENGTH_LONGEST_TO_SHORTEST = 'spliced_length_longest_to_shortest',
-  SPLICED_LENGTH_SHORTEST_TO_LONGEST = 'spliced_length_shortest_to_longest',
-  EXON_COUNT_HIGH_TO_LOW = 'exon_count_high_to_low',
-  EXON_COUNT_LOW_TO_HIGH = 'exon_count_low_to_high'
+  SPLICED_LENGTH_DESC = 'spliced_length_desc',
+  SPLICED_LENGTH_ASC = 'spliced_length_asc',
+  EXON_COUNT_DESC = 'exon_count_desc',
+  EXON_COUNT_ASC = 'exon_count_asc'
 }
 
 export type TranscriptsStatePerGene = {


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [X] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-538

## Description
Implementing sorting functionality.
Also increasing minimum number of transcripts to 6 for filter and sort by to be visible

## Deployment URL
http://ev-transcripts-sorting.review.ensembl.org/

## Views affected
Entity viewer transcripts

- [ ] I have checked any requirements for Google Analytics
- [x] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

