### PR TITLE
unlink pdb summary stats from xrefs

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
@@ -182,8 +182,8 @@ const ProteinsListItemInfo = (props: Props) => {
 
       <div className={styles.proteinSummary}>
         <>
-          {xref?.display_id && (
-            <div className={styles.proteinSummaryTop}>
+          <div className={styles.proteinSummaryTop}>
+            {xref?.display_id && (
               <div className={styles.interproUniprotWrapper}>
                 <ProteinExternalReference
                   source={ExternalSource.INTERPRO}
@@ -194,13 +194,13 @@ const ProteinsListItemInfo = (props: Props) => {
                   externalId={xref.display_id}
                 />
               </div>
-              <div className={styles.downloadWrapper}>
-                <InstantDownloadProtein
-                  transcriptId={transcript.unversioned_stable_id}
-                />
-              </div>
+            )}
+            <div className={styles.downloadWrapper}>
+              <InstantDownloadProtein
+                transcriptId={transcript.unversioned_stable_id}
+              />
             </div>
-          )}
+          </div>
           {proteinSummaryStats && (
             <div>
               <ProteinExternalReference

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
@@ -69,7 +69,7 @@ const ProteinsListItemInfo = (props: Props) => {
     setTranscriptWithProteinDomains
   ] = useState<Transcript | null>(null);
 
-  const [xref, setXref] = useState<Xref | null | undefined>();
+  const [xref, setXref] = useState<Xref | undefined>();
 
   const [proteinSummaryStats, setProteinSummaryStats] = useState<
     ProteinStats | null | undefined
@@ -123,7 +123,7 @@ const ProteinsListItemInfo = (props: Props) => {
       fetchXrefId(proteinId, abortController.signal)
         .then((response) => {
           if (!abortController.signal.aborted) {
-            response ? setXref(response) : setXref(null);
+            response ? setXref(response) : setXref(undefined);
             setXrefLoadingState(LoadingState.SUCCESS);
           }
         })
@@ -138,7 +138,7 @@ const ProteinsListItemInfo = (props: Props) => {
 
   useEffect(() => {
     const abortController = new AbortController();
-    if (xrefLoadingState === LoadingState.SUCCESS && xref === null) {
+    if (xrefLoadingState === LoadingState.SUCCESS && xref === undefined) {
       setSummaryStatsLoadingState(LoadingState.SUCCESS);
       return;
     }

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
@@ -138,7 +138,7 @@ const ProteinsListItemInfo = (props: Props) => {
 
   useEffect(() => {
     const abortController = new AbortController();
-    if (xrefLoadingState === LoadingState.SUCCESS && xref === undefined) {
+    if (xrefLoadingState === LoadingState.SUCCESS && !xref) {
       setSummaryStatsLoadingState(LoadingState.SUCCESS);
       return;
     }

--- a/src/ensembl/src/content/app/entity-viewer/shared/rest/rest-adaptors/rest-protein-adaptor.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/rest/rest-adaptors/rest-protein-adaptor.ts
@@ -16,18 +16,14 @@
 
 import {
   ProteinStatsInResponse,
-  ProteinSummary
+  ProteinStats
 } from '../rest-data-fetchers/proteinData';
 
 export const restProteinSummaryAdaptor = (
-  proteinStats: ProteinStatsInResponse,
-  pdbeId: string
-): ProteinSummary => ({
-  proteinStats: {
-    structuresCount: proteinStats.pdbs,
-    ligandsCount: proteinStats.ligands,
-    interactionsCount: proteinStats.interaction_partners,
-    annotationsCount: proteinStats.annotations
-  },
-  pdbeId
+  proteinStats: ProteinStatsInResponse
+): ProteinStats => ({
+  structuresCount: proteinStats.pdbs,
+  ligandsCount: proteinStats.ligands,
+  interactionsCount: proteinStats.interaction_partners,
+  annotationsCount: proteinStats.annotations
 });

--- a/src/ensembl/src/content/app/entity-viewer/shared/rest/rest-data-fetchers/proteinData.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/rest/rest-data-fetchers/proteinData.ts
@@ -53,7 +53,7 @@ export type ProteinStats = {
 export const fetchXrefId = async (
   proteinId: string,
   signal?: AbortSignal
-): Promise<Xref | null> => {
+): Promise<Xref | undefined> => {
   const xrefsUrl = `https://rest.ensembl.org/xrefs/id/${proteinId}?content-type=application/json;external_db=Uniprot/SWISSPROT`;
   const xrefsData: XrefsInResponse | undefined = await apiService.fetch(
     xrefsUrl,
@@ -63,7 +63,7 @@ export const fetchXrefId = async (
   );
 
   if (!xrefsData) {
-    return null;
+    return undefined;
   }
 
   return xrefsData[0];

--- a/src/ensembl/src/content/app/entity-viewer/shared/rest/rest-data-fetchers/proteinData.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/rest/rest-data-fetchers/proteinData.ts
@@ -50,15 +50,10 @@ export type ProteinStats = {
   annotationsCount: number;
 };
 
-export type ProteinSummary = {
-  proteinStats: ProteinStats;
-  pdbeId: string;
-};
-
-export const fetchProteinSummary = async (
+export const fetchXrefId = async (
   proteinId: string,
   signal?: AbortSignal
-): Promise<ProteinSummary | null> => {
+): Promise<Xref | null> => {
   const xrefsUrl = `https://rest.ensembl.org/xrefs/id/${proteinId}?content-type=application/json;external_db=Uniprot/SWISSPROT`;
   const xrefsData: XrefsInResponse | undefined = await apiService.fetch(
     xrefsUrl,
@@ -71,22 +66,23 @@ export const fetchProteinSummary = async (
     return null;
   }
 
-  if (xrefsData[0]) {
-    const pdbeId = xrefsData[0].display_id;
-    const proteinStatsUrl = `https://www.ebi.ac.uk/pdbe/graph-api/uniprot/summary_stats/${pdbeId}`;
+  return xrefsData[0];
+};
 
-    const proteinStatsData:
-      | UniProtSummaryStats
-      | undefined = await apiService.fetch(proteinStatsUrl, {
-      signal
-    });
+export const fetchProteinSummaryStats = async (
+  xrefId: string,
+  signal?: AbortSignal
+): Promise<ProteinStats | null> => {
+  const proteinStatsUrl = `https://www.ebi.ac.uk/pdbe/graph-api/uniprot/summary_stats/${xrefId}`;
 
-    if (!proteinStatsData) {
-      return null;
-    }
-
-    return restProteinSummaryAdaptor(proteinStatsData[pdbeId], pdbeId);
-  } else {
+  const proteinStatsData:
+    | UniProtSummaryStats
+    | undefined = await apiService.fetch(proteinStatsUrl, {
+    signal
+  });
+  if (!proteinStatsData) {
     return null;
   }
+
+  return restProteinSummaryAdaptor(proteinStatsData[xrefId]);
 };


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-816
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-815

## Description
1. Separating dependencies - requests for xref id and pdb stats

2. This PR also fixes the issue of instant download availability - by always showing instant download for a protein

## Deployment URL
http://unlink-stats.review.ensembl.org/entity-viewer/homo_sapiens_GCA_000001405_28/gene:ENSG00000159840?view=protein

## Views affected
Entity viewer protein list info

