### PR TITLE
Fix Safari external link icon bug

### DIFF
--- a/src/ensembl/src/shared/components/external-link/ExternalLink.scss
+++ b/src/ensembl/src/shared/components/external-link/ExternalLink.scss
@@ -11,6 +11,7 @@
   grid-column: icon;
   top: 1px;
   position: relative;
+  height: 12px;
 }
 
 .link {


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-825

## Description
- Fixed the external link icon size issue on safari

## Deployment URL
http://safari-external-link-icon.review.ensembl.org

## Views affected
External link component