### PR TITLE
Transcript reactome xref groups

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.tsx
@@ -150,36 +150,7 @@ const GeneExternalReferences = () => {
       </div>
 
       <div className={styles.sectionHead}>Gene</div>
-      {data.gene.external_references &&
-        Object.values(externalReferencesGroups).map(
-          (externalReferencesGroup, key) => {
-            if (externalReferencesGroup.references.length === 1) {
-              return (
-                <div key={key}>
-                  <ExternalReference
-                    label={externalReferencesGroup.source.name}
-                    to={externalReferencesGroup.references[0].url}
-                    linkText={
-                      externalReferencesGroup.references[0].accession_id
-                    }
-                    classNames={{
-                      container: styles.externalReferenceContainer
-                    }}
-                  />
-                </div>
-              );
-            } else {
-              return externalReferencesGroup.references[0].name ===
-                externalReferencesGroup.source.name
-                ? renderXrefGroupWithSameLabels(externalReferencesGroup, key)
-                : renderXrefGroupWithDifferentLabels(
-                    externalReferencesGroup,
-                    key
-                  );
-            }
-          }
-        )}
-
+      {data.gene.external_references && renderXrefs(externalReferencesGroups)}
       {transcripts && (
         <div>
           <div className={styles.sectionHead}>Transcripts</div>
@@ -200,7 +171,9 @@ const GeneExternalReferences = () => {
 const RenderTranscriptXrefGroup = (props: { transcript: Transcript }) => {
   const { transcript } = props;
   const [isExpanded, setIsExpanded] = useState(false);
-
+  const transcriptsXrefGroups = buildExternalReferencesGroups(
+    transcript.external_references
+  );
   return (
     <div className={styles.transcriptWrapper}>
       <div
@@ -211,21 +184,37 @@ const RenderTranscriptXrefGroup = (props: { transcript: Transcript }) => {
       </div>
       {transcript.external_references && isExpanded && (
         <div className={styles.transcriptXrefs}>
-          {transcript.external_references.map((xref, key) => (
-            <ExternalReference
-              label={xref.source.name}
-              to={xref.url}
-              linkText={xref.accession_id}
-              key={key}
-              classNames={{
-                container: styles.externalReferenceContainer
-              }}
-            />
-          ))}
+          {renderXrefs(transcriptsXrefGroups)}
         </div>
       )}
     </div>
   );
+};
+
+const renderXrefs = (xrefGroups: {
+  [key: string]: ExternalReferencesGroup;
+}) => {
+  return Object.values(xrefGroups).map((externalReferencesGroup, key) => {
+    if (externalReferencesGroup.references.length === 1) {
+      return (
+        <div key={key}>
+          <ExternalReference
+            label={externalReferencesGroup.source.name}
+            to={externalReferencesGroup.references[0].url}
+            linkText={externalReferencesGroup.references[0].accession_id}
+            classNames={{
+              container: styles.externalReferenceContainer
+            }}
+          />
+        </div>
+      );
+    } else {
+      return externalReferencesGroup.references[0].name ===
+        externalReferencesGroup.source.name
+        ? renderXrefGroupWithSameLabels(externalReferencesGroup, key)
+        : renderXrefGroupWithDifferentLabels(externalReferencesGroup, key);
+    }
+  });
 };
 
 const renderXrefGroupWithSameLabels = (


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-830

## Description
- Descriptions are now displayed under the transcript level Reactome xrefs

## Deployment URL
https://transcript-reactome.review.ensembl.org


## Views affected
Entity Viewer -> Sidebar -> External References -> Transcripts -> Reactome

### Other effects
- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.
