### PR TITLE
Add label to the blue track representing the full protein in EntityViewer

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/protein-image/ProteinImage.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/protein-image/ProteinImage.scss
@@ -11,3 +11,8 @@
 .protein {
   fill: $blue;
 }
+
+.label {
+  font-size: 13px; // to override the 12px font-size coming from DefaultTranscriptList.row
+  color: $dark-grey;
+}

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/protein-image/ProteinImage.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/protein-image/ProteinImage.tsx
@@ -42,12 +42,12 @@ const ProteinImage = (props: ProteinImageProps) => {
     .range([0, props.width])
     .clamp(true);
 
-  const midStyles = transcriptsListStyles.middle;
-  const rightStyles = classNames(transcriptsListStyles.right, styles.label);
+  const trackContainerStyles = transcriptsListStyles.middle;
+  const labelStyles = classNames(transcriptsListStyles.right, styles.label);
 
   return (
     <div className={transcriptsListStyles.row}>
-      <div className={midStyles}>
+      <div className={trackContainerStyles}>
         <svg
           className={styles.containerSvg}
           width={props.width}
@@ -68,7 +68,7 @@ const ProteinImage = (props: ProteinImageProps) => {
           </g>
         </svg>
       </div>
-      <div className={rightStyles}>Amino acid length</div>
+      <div className={labelStyles}>Amino acid length</div>
     </div>
   );
 };

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/protein-image/ProteinImage.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/protein-image/ProteinImage.tsx
@@ -42,7 +42,8 @@ const ProteinImage = (props: ProteinImageProps) => {
     .range([0, props.width])
     .clamp(true);
 
-  const midStyles = classNames(transcriptsListStyles.middle, styles.middle);
+  const midStyles = transcriptsListStyles.middle;
+  const rightStyles = classNames(transcriptsListStyles.right, styles.label);
 
   return (
     <div className={transcriptsListStyles.row}>
@@ -67,6 +68,7 @@ const ProteinImage = (props: ProteinImageProps) => {
           </g>
         </svg>
       </div>
+      <div className={rightStyles}>Amino acid length</div>
     </div>
   );
 };


### PR DESCRIPTION
## Type
- Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-786

## Description
Adding a label to the previously unlabelled protein track in EntityViewer (protein view):

![image](https://user-images.githubusercontent.com/6834224/100399273-01bfeb00-304a-11eb-9baa-fcc719054aaf.png)

## Deployment URL
http://protein-track-label.review.ensembl.org/

## Views affected
EntityViewer (protein view)