### PR TITLE
Fix for transcript order to match default order same as in transcript image

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.tsx
@@ -22,6 +22,7 @@ import sortBy from 'lodash/sortBy';
 
 import { getEntityViewerSidebarPayload } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors';
 import { parseEnsObjectIdFromUrl } from 'src/shared/state/ens-object/ensObjectHelpers';
+import { defaultSort } from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
 
 import {
   Accordion,
@@ -31,7 +32,6 @@ import {
   AccordionItemButton
 } from 'src/shared/components/accordion';
 import ExternalReference from 'src/shared/components/external-reference/ExternalReference';
-import { defaultSort } from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
 
 import { RootState } from 'src/store';
 import {
@@ -91,10 +91,10 @@ type Transcript = {
   stable_id: string;
   so_term: string;
   slice: SliceWithLocationOnly;
-  product_generating_contexts: Array<{
-    product_type: ProductGeneratingContext['product_type'];
-    product: ProductGeneratingContext['product'];
-  }>
+  product_generating_contexts: Pick<
+    ProductGeneratingContext,
+    'product_type' | 'product'
+  >[];
   external_references: ExternalReferenceType[];
 };
 
@@ -200,9 +200,7 @@ const GeneExternalReferences = () => {
   );
 };
 
-const RenderTranscriptXrefGroup = (props: {
-  transcript: Transcript;
-}) => {
+const RenderTranscriptXrefGroup = (props: { transcript: Transcript }) => {
   const { transcript } = props;
   const [isExpanded, setIsExpanded] = useState(false);
   const transcriptsXrefGroups = buildExternalReferencesGroups(


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-826

## Description
Matching the transcript order in the EV Sidebar in the external references to be the same as the default order in the transcript image. 

Note that the order doesnt change even if the transcript image order is changed by sorting. It will always be the default order

## Deployment URL
http://ev-xref-order-fix.review.ensembl.org

## Views affected
Entity viewer

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

