### PR TITLE
Generalize parameter types in helper and sorter functions for transcripts

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -35,6 +35,7 @@ import TranscriptsFilter from 'src/content/app/entity-viewer/gene-view/component
 
 import { TicksAndScale } from 'src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/BasePairsRuler';
 import { Gene } from 'src/content/app/entity-viewer/types/gene';
+import { Transcript } from 'src/content/app/entity-viewer/types/transcript';
 import { RootState } from 'src/store';
 
 import { ReactComponent as ChevronDown } from 'static/img/shared/chevron-down.svg';
@@ -54,7 +55,7 @@ const DefaultTranscriptslist = (props: Props) => {
   const { gene, sortingRule } = props;
 
   const sortingFunction = transcriptSortingFunctions[sortingRule];
-  const sortedTranscripts = sortingFunction(gene.transcripts);
+  const sortedTranscripts = sortingFunction(gene.transcripts) as Transcript[];
 
   const [isFilterOpen, setFilterOpen] = useState(false);
 

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/entity-helpers.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/entity-helpers.ts
@@ -24,10 +24,39 @@ import {
   ProductType
 } from 'src/content/app/entity-viewer/types/product';
 
+export const getFeatureCoordinates = (feature: {
+  slice: SliceWithLocationOnly;
+}) => {
+  const { start, end } = feature.slice.location;
+  return { start, end };
+};
+
+export const getRegionName = (feature: { slice: Slice }) =>
+  feature.slice.region.name;
+
+export const getFeatureStrand = (feature: { slice: Slice }) =>
+  feature.slice.strand.code;
+
+export const getFeatureLength = (feature: { slice: SliceWithLocationOnly }) => {
+  return feature.slice.location.length;
+};
+
 export type IsProteinCodingTranscriptParam = {
   product_generating_contexts: Array<{
     product_type: ProductType;
   }>;
+};
+
+export const isProteinCodingTranscript = (
+  transcript: IsProteinCodingTranscriptParam
+) => {
+  const { product_generating_contexts } = transcript;
+  const firstProductGeneratingContext = product_generating_contexts[0];
+
+  return (
+    firstProductGeneratingContext &&
+    firstProductGeneratingContext.product_type === ProductType.PROTEIN
+  );
 };
 
 export type GetNumberOfCodingExonsParam = {
@@ -46,56 +75,6 @@ export type GetNumberOfCodingExonsParam = {
       stable_id: string;
     };
   }>;
-};
-
-export type GetProductAminoAcidLengthParam = {
-  product_generating_contexts: Array<{
-    product_type: ProductType.PROTEIN;
-    product: {
-      length: number;
-    };
-  }>;
-};
-
-export type GetSplicedRNALengthParam = {
-  spliced_exons: Array<{
-    exon: {
-      slice: SliceWithLocationOnly;
-    };
-  }>;
-};
-
-export type GetLongestProteinLengthParam = {
-  transcripts: GetProductAminoAcidLengthParam[];
-};
-
-export const getFeatureCoordinates = (feature: {
-  slice: SliceWithLocationOnly;
-}) => {
-  const { start, end } = feature.slice.location;
-  return { start, end };
-};
-
-export const getRegionName = (feature: { slice: Slice }) =>
-  feature.slice.region.name;
-
-export const getFeatureStrand = (feature: { slice: Slice }) =>
-  feature.slice.strand.code;
-
-export const getFeatureLength = (feature: { slice: SliceWithLocationOnly }) => {
-  return feature.slice.location.length;
-};
-
-export const isProteinCodingTranscript = (
-  transcript: IsProteinCodingTranscriptParam
-) => {
-  const { product_generating_contexts } = transcript;
-  const firstProductGeneratingContext = product_generating_contexts[0];
-
-  return (
-    firstProductGeneratingContext &&
-    firstProductGeneratingContext.product_type === ProductType.PROTEIN
-  );
 };
 
 export const getNumberOfCodingExons = (
@@ -123,6 +102,15 @@ export const getNumberOfCodingExons = (
     }).length;
 };
 
+export type GetProductAminoAcidLengthParam = {
+  product_generating_contexts: Array<{
+    product_type: ProductType.PROTEIN;
+    product: {
+      length: number;
+    };
+  }>;
+};
+
 export const getProductAminoAcidLength = (
   transcript: GetProductAminoAcidLengthParam
 ) => {
@@ -136,10 +124,22 @@ export const getProductAminoAcidLength = (
   return product.length;
 };
 
+export type GetSplicedRNALengthParam = {
+  spliced_exons: Array<{
+    exon: {
+      slice: SliceWithLocationOnly;
+    };
+  }>;
+};
+
 export const getSplicedRNALength = (transcript: GetSplicedRNALengthParam) =>
   transcript.spliced_exons.reduce((length, { exon }) => {
     return length + exon.slice.location.length;
   }, 0);
+
+export type GetLongestProteinLengthParam = {
+  transcripts: GetProductAminoAcidLengthParam[];
+};
 
 export const getLongestProteinLength = (gene: GetLongestProteinLengthParam) => {
   const proteinLengths = gene.transcripts.map(getProductAminoAcidLength);

--- a/src/ensembl/src/content/app/entity-viewer/types/slice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/types/slice.ts
@@ -33,5 +33,6 @@ export type SliceWithLocationOnly = {
   location: {
     start: number;
     end: number;
+    length: number;
   };
 };


### PR DESCRIPTION
## Related JIRA Issue(s)
Part of https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-879

## Description
We might have different components requesting different sets of fields for transcripts (compare the `GeneView` component and the `GeneExternalReferences` component, see https://github.com/Ensembl/ensembl-client/pull/406), but re-using the same helper functions or sorting functions. At the moment, helper functions and sorter functions expect their parameter to be of type `Transcript` as requested in the `GeneView` component, but that doesn't work for the `GeneExternalReferences` component. This PR is an attempt to describe more carefully the type requirements of these functions.