### PR TITLE
Clear search field in SpeciesSelector upon unmounting the component

### DIFF
--- a/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 
 import {
@@ -76,6 +76,10 @@ type RightCornerProps = {
 
 export const SpeciesSearchField = (props: Props) => {
   const [isFocused, setIsFocused] = useState(false);
+
+  useEffect(() => {
+    return () => clear();
+  }, []);
 
   const onMatchSelected = (match: SearchMatch) => {
     props.onMatchSelected(match);


### PR DESCRIPTION
## Type
- Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-837

## Description
This PR ensures that when user leaves Species Selector page, the species search field is cleared and the popular species button that was pressed, but left unconfirmed, is depressed. 

## Deployment URL
http://clear-species-search-on-unmount.review.ensembl.org/

## Views affected
Species Selector