### PR TITLE
Fix messaging to genome browser during first-time navigation to genome brower page

### DIFF
--- a/src/ensembl/src/content/app/browser/browserActions.ts
+++ b/src/ensembl/src/content/app/browser/browserActions.ts
@@ -118,6 +118,10 @@ export const setDataFromUrlAndSave: ActionCreator<ThunkAction<
   }
 };
 
+export const setActiveGenomeId = createAction('browser/set-active-genome-id')<
+  string
+>();
+
 export const fetchDataForLastVisitedObjects: ActionCreator<ThunkAction<
   void,
   any,

--- a/src/ensembl/src/content/app/browser/browserReducer.ts
+++ b/src/ensembl/src/content/app/browser/browserReducer.ts
@@ -52,6 +52,9 @@ export function browserEntity(
   action: ActionType<typeof browserActions>
 ): BrowserEntityState {
   switch (action.type) {
+    case getType(browserActions.setActiveGenomeId): {
+      return { ...state, activeGenomeId: action.payload };
+    }
     case getType(browserActions.setDataFromUrl): {
       const { activeGenomeId, activeEnsObjectId } = action.payload;
       const newState = {

--- a/src/ensembl/src/content/app/browser/hooks/useBrowserRouting.ts
+++ b/src/ensembl/src/content/app/browser/hooks/useBrowserRouting.ts
@@ -40,6 +40,7 @@ import {
 import {
   changeBrowserLocation,
   changeFocusObject,
+  setActiveGenomeId,
   setDataFromUrlAndSave
 } from '../browserActions';
 
@@ -101,11 +102,14 @@ const useBrowserRouting = () => {
       const newFocus = buildFocusIdForUrl(parseEnsObjectId(activeEnsObjectId));
       dispatch(replace(urlFor.browser({ genomeId, focus: newFocus })));
     } else if (focus && !chrLocation) {
+      if (!activeGenomeId) {
+        dispatch(setActiveGenomeId(genomeId));
+      }
       /*
        changeFocusObject needs to be called before setDataFromUrlAndSave
-       in order to prevent creating a previouslyViewedObject entry
-       for the focus object that is viewed first.
-       */
+       because it will also try to bookmark the Ensembl object that is stored in redux state
+       before it gets changed by setDataFromUrlAndSave
+      */
       dispatch(changeFocusObject(newFocusId as string));
     } else if (chrLocation) {
       const isSameLocationAsInRedux =

--- a/src/ensembl/src/content/app/browser/hooks/useBrowserRouting.ts
+++ b/src/ensembl/src/content/app/browser/hooks/useBrowserRouting.ts
@@ -98,13 +98,19 @@ const useBrowserRouting = () => {
       chrLocation
     };
 
+    if (!activeGenomeId) {
+      /*
+        Means that this is the first time user visits genome browser.
+        We need to make sure that active genome id is set properly in redux
+        for the actions below (e.g. changeFocusObject) to work
+      */
+      dispatch(setActiveGenomeId(genomeId));
+    }
+
     if (!focus && activeEnsObjectId) {
       const newFocus = buildFocusIdForUrl(parseEnsObjectId(activeEnsObjectId));
       dispatch(replace(urlFor.browser({ genomeId, focus: newFocus })));
     } else if (focus && !chrLocation) {
-      if (!activeGenomeId) {
-        dispatch(setActiveGenomeId(genomeId));
-      }
       /*
        changeFocusObject needs to be called before setDataFromUrlAndSave
        because it will also try to bookmark the Ensembl object that is stored in redux state


### PR DESCRIPTION
## Type
- Bug fix

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-895

## Reproduction steps:
### Via UI (longer)
- Clear Storage
- Select Human
- View Human (species page)
- Click on view example gene in browser

### Directly through browser url (quicker)
- clear storage
- navigate directly to https://internal-2020.ensembl.org/genome-browser/homo_sapiens_GCA_000001405_28?focus=gene:ENSG00000139618

Problem in both scenarios above: empty genome browser canvas.

## Cause of bug
Direct navigation to genome browser page when active genome id has not yet been set brings us to [this conditional clause](https://github.com/Ensembl/ensembl-client/blob/dev/src/ensembl/src/content/app/browser/hooks/useBrowserRouting.ts#L109) in useBrowserRouting:

```
 dispatch(changeFocusObject(newFocusId as string));
```

However, `changeFocusObject` [will do nothing](https://github.com/Ensembl/ensembl-client/blob/dev/src/ensembl/src/content/app/browser/browserActions.ts#L351-L356) if active genome id has not yet been set. Therefore, we need to set active genome id before calling `changeFocusObject`.

## Deployment URL
http://fix-browser-routing.review.ensembl.org/

## Views affected
Genome Browser

## Possible complications
There is a comment in the code with an explicit warning that `changeFocusObject` needs to be called before `setDataFromUrlAndSave`. I cannot remember why this was the case. Need to dig in the code to find out what it is we might have broken.