### PR TITLE
Save sidebar open or closed state in session

### DIFF
--- a/src/ensembl/src/content/app/species/SpeciesPage.tsx
+++ b/src/ensembl/src/content/app/species/SpeciesPage.tsx
@@ -24,7 +24,7 @@ import * as urlFor from 'src/shared/helpers/urlHelper';
 
 import { fetchGenomeData } from 'src/shared/state/genome/genomeActions';
 import { isSidebarOpen } from 'src/content/app/species/state/sidebar/speciesSidebarSelectors';
-import { toggleSidebar } from 'src/content/app/species/state/sidebar/speciesSidebarSlice';
+import { toggleSidebarAndSave } from 'src/content/app/species/state/sidebar/speciesSidebarSlice';
 import { setActiveGenomeId } from 'src/content/app/species/state/general/speciesGeneralSlice';
 
 import SpeciesAppBar from './components/species-app-bar/SpeciesAppBar';
@@ -69,7 +69,7 @@ const SpeciesPage = () => {
         topbarContent={<TopBar />}
         isSidebarOpen={sidebarStatus}
         onSidebarToggle={() => {
-          dispatch(toggleSidebar());
+          dispatch(toggleSidebarAndSave());
         }}
         viewportWidth={BreakpointWidth.DESKTOP}
       />

--- a/src/ensembl/src/content/app/species/services/species-storage-service.ts
+++ b/src/ensembl/src/content/app/species/services/species-storage-service.ts
@@ -46,11 +46,11 @@ export class SpeciesStorageService {
     this.storageService.update(StorageKeys.GENOME_UI_STATE, uiState, options);
   }
 
-  public getSidebarState(): SpeciesPageSidebarState {
+  public getSidebarState(): Partial<SpeciesPageSidebarState> {
     return this.storageService.get(StorageKeys.SIDEBAR_STATE, options);
   }
 
-  public updateSidebarState(sidebarState: SpeciesPageSidebarState) {
+  public updateSidebarState(sidebarState: Partial<SpeciesPageSidebarState>) {
     this.storageService.update(
       StorageKeys.SIDEBAR_STATE,
       sidebarState,

--- a/src/ensembl/src/content/app/species/services/species-storage-service.ts
+++ b/src/ensembl/src/content/app/species/services/species-storage-service.ts
@@ -20,9 +20,11 @@ import storageService, {
 } from 'src/services/storage-service';
 
 import { UIState } from 'src/content/app/species/state/general/speciesGeneralSlice';
+import { SpeciesPageSidebarState } from 'src/content/app/species/state/sidebar/speciesSidebarSlice';
 
 export enum StorageKeys {
-  GENOME_UI_STATE = 'species.genomeUIState'
+  GENOME_UI_STATE = 'species.genomeUIState',
+  SIDEBAR_STATE = 'species.sidebar'
 }
 
 const options = {
@@ -42,6 +44,18 @@ export class SpeciesStorageService {
 
   public updateUIState(uiState: UIState) {
     this.storageService.update(StorageKeys.GENOME_UI_STATE, uiState, options);
+  }
+
+  public getSidebarState(): SpeciesPageSidebarState {
+    return this.storageService.get(StorageKeys.SIDEBAR_STATE, options);
+  }
+
+  public updateSidebarState(sidebarState: SpeciesPageSidebarState) {
+    this.storageService.update(
+      StorageKeys.SIDEBAR_STATE,
+      sidebarState,
+      options
+    );
   }
 }
 

--- a/src/ensembl/src/content/app/species/state/sidebar/speciesSidebarSlice.ts
+++ b/src/ensembl/src/content/app/species/state/sidebar/speciesSidebarSlice.ts
@@ -72,8 +72,7 @@ export type SpeciesPageSidebarState = {
 };
 
 const initialState: SpeciesPageSidebarState = {
-  isOpen:
-    speciesStorageService.getSidebarState()?.isOpen === false ? false : true,
+  isOpen: speciesStorageService.getSidebarState()?.isOpen ?? true,
   species: {}
 };
 

--- a/src/ensembl/src/content/app/species/state/sidebar/speciesSidebarSlice.ts
+++ b/src/ensembl/src/content/app/species/state/sidebar/speciesSidebarSlice.ts
@@ -20,7 +20,6 @@ import {
   PayloadAction,
   ThunkAction
 } from '@reduxjs/toolkit';
-import set from 'lodash/fp/set';
 
 import { getActiveGenomeId } from 'src/content/app/species/state/general/speciesGeneralSelectors';
 import { isSidebarOpen } from 'src/content/app/species/state/sidebar/speciesSidebarSelectors';
@@ -111,9 +110,7 @@ export const toggleSidebarAndSave = (): ThunkAction<
   }
   const isSidebarCurrentlyOpen = isSidebarOpen(state);
 
-  speciesStorageService.updateSidebarState(
-    set(`isOpen`, !isSidebarCurrentlyOpen, state.speciesPage.sidebar)
-  );
+  speciesStorageService.updateSidebarState({ isOpen: !isSidebarCurrentlyOpen });
 
   dispatch(speciesPageSidebarSlice.actions.toggleSidebar());
 };


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-896

## Description
- Species sidebar open/close state is now retained in the session storage

## Deployment URL
http://species-sidebar-state.review.ensembl.org

## Views affected
SpeciesPage - > Sidebar

### Other effects
- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.