### PR TITLE
Use primary_id field from Ensembl REST response for protein xrefs for further querying

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
@@ -183,15 +183,17 @@ const ProteinsListItemInfo = (props: Props) => {
       <div className={styles.proteinSummary}>
         <>
           <div className={styles.proteinSummaryTop}>
-            {xref?.display_id && (
+            {xref && (
               <div className={styles.interproUniprotWrapper}>
                 <ProteinExternalReference
                   source={ExternalSource.INTERPRO}
-                  externalId={xref.display_id}
+                  unversionedId={xref.primary_id}
+                  versionedId={xref.display_id}
                 />
                 <ProteinExternalReference
                   source={ExternalSource.UNIPROT}
-                  externalId={xref.display_id}
+                  unversionedId={xref.primary_id}
+                  versionedId={xref.display_id}
                 />
               </div>
             )}
@@ -201,11 +203,12 @@ const ProteinsListItemInfo = (props: Props) => {
               />
             </div>
           </div>
-          {proteinSummaryStats && (
+          {proteinSummaryStats && xref && (
             <div>
               <ProteinExternalReference
                 source={ExternalSource.PDBE}
-                externalId={xref?.display_id}
+                unversionedId={xref.primary_id}
+                versionedId={xref.display_id}
               />
               {proteinSummaryStats && (
                 <div className={styles.proteinFeaturesCountWrapper}>
@@ -271,21 +274,22 @@ const StatusContent = (props: StatusContentProps) => {
 
 type ProteinExternalReferenceProps = {
   source: ExternalSource;
-  externalId: string | undefined;
+  unversionedId: string;
+  versionedId: string;
 };
 
 const ProteinExternalReference = (props: ProteinExternalReferenceProps) => {
-  const url = `${externalSourceLinks[props.source]}${props.externalId}`;
+  const url = `${externalSourceLinks[props.source]}${props.unversionedId}`;
 
-  return props.externalId ? (
+  return (
     <div className={styles.proteinExternalReference}>
       <ExternalReference
         label={props.source}
         to={url}
-        linkText={props.externalId}
+        linkText={props.versionedId}
       />
     </div>
-  ) : null;
+  );
 };
 
 export default ProteinsListItemInfo;

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
@@ -144,7 +144,7 @@ const ProteinsListItemInfo = (props: Props) => {
     }
 
     if (summaryStatsLoadingState === LoadingState.LOADING && xref) {
-      fetchProteinSummaryStats(xref?.display_id, abortController.signal)
+      fetchProteinSummaryStats(xref.primary_id, abortController.signal)
         .then((response) => {
           if (!abortController.signal.aborted) {
             response

--- a/src/ensembl/src/content/app/entity-viewer/shared/rest/rest-data-fetchers/proteinData.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/rest/rest-data-fetchers/proteinData.ts
@@ -19,6 +19,7 @@ import apiService from 'src/services/api-service';
 import { restProteinSummaryAdaptor } from '../rest-adaptors/rest-protein-adaptor';
 
 export type Xref = {
+  primary_id: string;
   display_id: string;
 };
 


### PR DESCRIPTION
## Type
- Bug fix

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-899

## Description
Protein xref display ids returned by Ensembl REST api since e102 are versioned; whereas for links and XHR requests we need to use unversioned ids.

## Deployment URL
http://protein-xref-primary-id.review.ensembl.org/

## Views affected
Entity viewer -> protein view