### PR TITLE
Revert "Save sidebar open or closed state in session"

### DIFF
--- a/src/ensembl/src/content/app/species/SpeciesPage.tsx
+++ b/src/ensembl/src/content/app/species/SpeciesPage.tsx
@@ -24,7 +24,7 @@ import * as urlFor from 'src/shared/helpers/urlHelper';
 
 import { fetchGenomeData } from 'src/shared/state/genome/genomeActions';
 import { isSidebarOpen } from 'src/content/app/species/state/sidebar/speciesSidebarSelectors';
-import { toggleSidebarAndSave } from 'src/content/app/species/state/sidebar/speciesSidebarSlice';
+import { toggleSidebar } from 'src/content/app/species/state/sidebar/speciesSidebarSlice';
 import { setActiveGenomeId } from 'src/content/app/species/state/general/speciesGeneralSlice';
 
 import SpeciesAppBar from './components/species-app-bar/SpeciesAppBar';
@@ -69,7 +69,7 @@ const SpeciesPage = () => {
         topbarContent={<TopBar />}
         isSidebarOpen={sidebarStatus}
         onSidebarToggle={() => {
-          dispatch(toggleSidebarAndSave());
+          dispatch(toggleSidebar());
         }}
         viewportWidth={BreakpointWidth.DESKTOP}
       />

--- a/src/ensembl/src/content/app/species/services/species-storage-service.ts
+++ b/src/ensembl/src/content/app/species/services/species-storage-service.ts
@@ -20,11 +20,9 @@ import storageService, {
 } from 'src/services/storage-service';
 
 import { UIState } from 'src/content/app/species/state/general/speciesGeneralSlice';
-import { SpeciesPageSidebarState } from 'src/content/app/species/state/sidebar/speciesSidebarSlice';
 
 export enum StorageKeys {
-  GENOME_UI_STATE = 'species.genomeUIState',
-  SIDEBAR_STATE = 'species.sidebar'
+  GENOME_UI_STATE = 'species.genomeUIState'
 }
 
 const options = {
@@ -44,18 +42,6 @@ export class SpeciesStorageService {
 
   public updateUIState(uiState: UIState) {
     this.storageService.update(StorageKeys.GENOME_UI_STATE, uiState, options);
-  }
-
-  public getSidebarState(): Partial<SpeciesPageSidebarState> {
-    return this.storageService.get(StorageKeys.SIDEBAR_STATE, options);
-  }
-
-  public updateSidebarState(sidebarState: Partial<SpeciesPageSidebarState>) {
-    this.storageService.update(
-      StorageKeys.SIDEBAR_STATE,
-      sidebarState,
-      options
-    );
   }
 }
 

--- a/src/ensembl/src/content/app/species/state/sidebar/speciesSidebarSlice.ts
+++ b/src/ensembl/src/content/app/species/state/sidebar/speciesSidebarSlice.ts
@@ -22,9 +22,6 @@ import {
 } from '@reduxjs/toolkit';
 
 import { getActiveGenomeId } from 'src/content/app/species/state/general/speciesGeneralSelectors';
-import { isSidebarOpen } from 'src/content/app/species/state/sidebar/speciesSidebarSelectors';
-import speciesStorageService from '../../services/species-storage-service';
-
 import { RootState } from 'src/store';
 
 import { sidebarData } from 'src/content/app/species/sample-data.ts';
@@ -61,7 +58,7 @@ export type SpeciesSidebarPayload = {
   strain: Strain | null;
 };
 
-export type SpeciesPageSidebarState = {
+type SpeciesPageSidebarState = {
   isOpen: boolean;
   species: {
     [genomeId: string]: {
@@ -71,7 +68,7 @@ export type SpeciesPageSidebarState = {
 };
 
 const initialState: SpeciesPageSidebarState = {
-  isOpen: speciesStorageService.getSidebarState()?.isOpen ?? true,
+  isOpen: true,
   species: {}
 };
 
@@ -95,24 +92,6 @@ export const fetchSidebarPayload = (): ThunkAction<
       sidebarPayload
     })
   );
-};
-
-export const toggleSidebarAndSave = (): ThunkAction<
-  void,
-  any,
-  null,
-  Action<string>
-> => (dispatch, getState: () => RootState) => {
-  const state = getState();
-  const activeGenomeId = getActiveGenomeId(state);
-  if (!activeGenomeId) {
-    return;
-  }
-  const isSidebarCurrentlyOpen = isSidebarOpen(state);
-
-  speciesStorageService.updateSidebarState({ isOpen: !isSidebarCurrentlyOpen });
-
-  dispatch(speciesPageSidebarSlice.actions.toggleSidebar());
 };
 
 const speciesPageSidebarSlice = createSlice({


### PR DESCRIPTION
Reverts Ensembl/ensembl-client#412

Reverting the changes made in the PR above as we decided not to store the sidebar open or closed state in session