### PR TITLE
Change the retry user message in protein list item

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
@@ -266,7 +266,9 @@ const StatusContent = (props: StatusContentProps) => {
   return props.domainsLoadingState === LoadingState.ERROR ||
     props.summaryLoadingState === LoadingState.ERROR ? (
     <div className={styles.statusContainer}>
-      <span className={styles.errorMessage}>Failed to get data</span>
+      <span className={styles.errorMessage}>
+        Failed to get data from PDBe Knowledge Base.
+      </span>
       <PrimaryButton onClick={retryHandler}>Try again</PrimaryButton>
     </div>
   ) : null;


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
[ENSWBSITES-874](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-874)

## Description
Change the message shown to the user when data retrieval from PDBe endpoint fails in protein info.

## Views affected
Entity viewer -> gene function -> protein list item
