### PR TITLE
Check if Uniprot ID exists on Interpro

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/shared/rest/rest-data-fetchers/proteinData.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/rest/rest-data-fetchers/proteinData.ts
@@ -87,3 +87,20 @@ export const fetchProteinSummaryStats = async (
 
   return restProteinSummaryAdaptor(proteinStatsData[xrefId]);
 };
+
+type InterproResponse = {
+  entries: unknown;
+};
+
+export const checkInterproUniprotId = async (
+  uniprotId: string,
+  signal?: AbortSignal
+): Promise<boolean> => {
+  const interproUrl = `https://www.ebi.ac.uk/interpro/api/entry/protein/uniprot/${uniprotId}`;
+
+  const interproData: InterproResponse = await apiService.fetch(interproUrl, {
+    signal
+  });
+
+  return !!interproData?.entries;
+};


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-891

## Description
- This PR is to adda check if the Uniprot ID is present on Interpro before displaying in the protein item info.

## Deployment URL
http://uniprot-validation.review.ensembl.org

## Views affected
Entity viewer -> Protein -> ProteinItemInfo

### Other effects
- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

