### PR TITLE
Fix cannot set property expandedTranscriptIds of undefined

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/proteins/geneViewProteinsSlice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/proteins/geneViewProteinsSlice.ts
@@ -107,7 +107,11 @@ const proteinsSlice = createSlice({
     ) {
       const { activeGenomeId, activeObjectId, expandedIds } = action.payload;
       if (!state[activeGenomeId]) {
-        state[activeGenomeId] = { [activeObjectId]: defaultStatePerGene };
+        state[activeGenomeId] = {
+          [activeObjectId]: { ...defaultStatePerGene }
+        };
+      } else if (!state[activeGenomeId][activeObjectId]) {
+        state[activeGenomeId][activeObjectId] = { ...defaultStatePerGene };
       }
       state[activeGenomeId][activeObjectId].expandedTranscriptIds = expandedIds;
     }


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-906

## Description
Steps to reproduce:
- go to entity viewer for brca2
- select gene function tab
- go back to genome browser
- open entity viewer for a different gene using the zmenu
- select gene function tab

## Deployment URL
http://cannot-set-property-expanded.review.ensembl.org

## Views affected
- Entity viewer -> Protein view

### Other effects
- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.
