### PR TITLE
Restyle the protein graphic for the download panel

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.scss
@@ -1,12 +1,5 @@
 @import 'src/styles/settings';
 
-.defaultTranscriptListItem {
-  svg rect {
-    stroke: white;
-    fill: white;
-  }
-}
-
 .transcriptId {
   color: $blue;
   cursor: pointer;
@@ -20,5 +13,9 @@
 
 .transcriptWrapper {
   display: inline-block;
+  svg rect {
+    stroke: white;
+    fill: white;
+  }
 }
 

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.scss
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.scss
@@ -45,5 +45,5 @@ $regularColor: $dark-grey;
 }
 
 .protein {
-  fill: white;
+  fill: $green;
 }

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
@@ -51,12 +51,10 @@ const InstantDownloadTranscriptVisualisation = (props: Props) => {
   const proteinHeight = 4;
   const proteinBlockWidth = proteinHeight;
   const proteinBlockSpacing = 1;
-  const innerProteinExonBlocksCount = Math.round(
+  const innerProteinBlocksCount = Math.round(
     exonWidth / (proteinBlockWidth + proteinBlockSpacing)
   );
-  const outerProteinExonBlocksCount = Math.round(
-    innerProteinExonBlocksCount / 2
-  );
+  const outerProteinBlocksCount = Math.round(innerProteinBlocksCount / 2);
   const verticalGap = 5;
   const totalHeight = exonHeight + proteinHeight + verticalGap;
   const halfExonWidth = Math.floor(exonWidth / 2);
@@ -155,9 +153,7 @@ const InstantDownloadTranscriptVisualisation = (props: Props) => {
     const isOuterSegment =
       segmentIndex === 0 || segmentIndex === exonsCount - 1;
     return times(
-      isOuterSegment
-        ? outerProteinExonBlocksCount
-        : innerProteinExonBlocksCount,
+      isOuterSegment ? outerProteinBlocksCount : innerProteinBlocksCount,
       (blockIndex) => (
         <rect
           key={blockIndex}

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
@@ -50,9 +50,9 @@ const InstantDownloadTranscriptVisualisation = (props: Props) => {
   const exonWidth = Math.floor(props.width / 7);
   const proteinHeight = 4;
   const proteinBlockWidth = proteinHeight;
-  const proteinExonBlockSpacing = 1;
+  const proteinBlockSpacing = 1;
   const innerProteinExonBlocksCount = Math.round(
-    exonWidth / (proteinBlockWidth + proteinExonBlockSpacing)
+    exonWidth / (proteinBlockWidth + proteinBlockSpacing)
   );
   const outerProteinExonBlocksCount = Math.round(
     innerProteinExonBlocksCount / 2
@@ -142,13 +142,12 @@ const InstantDownloadTranscriptVisualisation = (props: Props) => {
   ) => {
     if (segmentIndex === 0) {
       return (
-        halfExonWidth +
-        blockIndex * (proteinBlockWidth + proteinExonBlockSpacing)
+        halfExonWidth + blockIndex * (proteinBlockWidth + proteinBlockSpacing)
       );
     }
     return (
       segmentIndex * (exonWidth + halfExonWidth) +
-      blockIndex * (proteinBlockWidth + proteinExonBlockSpacing)
+      blockIndex * (proteinBlockWidth + proteinBlockSpacing)
     );
   };
 

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
@@ -49,10 +49,10 @@ const InstantDownloadTranscriptVisualisation = (props: Props) => {
   const exonHeight = 5;
   const exonWidth = Math.floor(props.width / 7);
   const proteinHeight = 4;
-  const proteinExonBlockWidth = proteinHeight;
+  const proteinBlockWidth = proteinHeight;
   const proteinExonBlockSpacing = 1;
   const innerProteinExonBlocksCount = Math.round(
-    exonWidth / (proteinExonBlockWidth + proteinExonBlockSpacing)
+    exonWidth / (proteinBlockWidth + proteinExonBlockSpacing)
   );
   const outerProteinExonBlocksCount = Math.round(
     innerProteinExonBlocksCount / 2
@@ -136,33 +136,36 @@ const InstantDownloadTranscriptVisualisation = (props: Props) => {
     );
   });
 
-  const proteinSegments = times(exonsCount, (si) => {
-    const isOuterSegment = si === 0 || si === exonsCount - 1;
-
-    const calculateXPosition = (segmentIndex: number, blockIndex: number) => {
-      if (segmentIndex === 0) {
-        return (
-          halfExonWidth +
-          blockIndex * (proteinExonBlockWidth + proteinExonBlockSpacing)
-        );
-      }
+  const calculateProteinBlockXPosition = (
+    segmentIndex: number,
+    blockIndex: number
+  ) => {
+    if (segmentIndex === 0) {
       return (
-        segmentIndex * (exonWidth + halfExonWidth) +
-        blockIndex * (proteinExonBlockWidth + proteinExonBlockSpacing)
+        halfExonWidth +
+        blockIndex * (proteinBlockWidth + proteinExonBlockSpacing)
       );
-    };
+    }
+    return (
+      segmentIndex * (exonWidth + halfExonWidth) +
+      blockIndex * (proteinBlockWidth + proteinExonBlockSpacing)
+    );
+  };
 
+  const proteinSegments = times(exonsCount, (segmentIndex) => {
+    const isOuterSegment =
+      segmentIndex === 0 || segmentIndex === exonsCount - 1;
     return times(
       isOuterSegment
         ? outerProteinExonBlocksCount
         : innerProteinExonBlocksCount,
-      (bi) => (
+      (blockIndex) => (
         <rect
-          key={bi}
+          key={blockIndex}
           className={styles.protein}
-          x={calculateXPosition(si, bi)}
+          x={calculateProteinBlockXPosition(segmentIndex, blockIndex)}
           y={exonHeight + verticalGap}
-          width={proteinExonBlockWidth}
+          width={proteinBlockWidth}
           height={proteinHeight}
         />
       )

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
@@ -188,7 +188,7 @@ InstantDownloadTranscriptVisualisation.defaultProps = {
   isCDNAEnabled: false,
   isCDSEnabled: false,
   isProteinSequenceEnabled: false,
-  width: 240
+  width: 210
 } as Partial<Props>;
 
 export default InstantDownloadTranscriptVisualisation;

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
@@ -47,12 +47,16 @@ export type Props = {
 const InstantDownloadTranscriptVisualisation = (props: Props) => {
   const exonsCount = 5;
   const exonHeight = 5;
-  const proteinHeight = 3;
+  const proteinHeight = 4.3;
   const verticalGap = 5;
   const totalHeight = exonHeight + proteinHeight + verticalGap;
   const exonWidth = Math.floor(props.width / 7);
   const halfExonWidth = Math.floor(exonWidth / 2);
   const intronsCount = exonsCount - 1;
+  const proteinExonBlockWidth = 4.3;
+  const proteinExonBlockSpacing = 1;
+  const outerProteinExonBlocksCount = 3;
+  const innerProteinExonBlocksCount = outerProteinExonBlocksCount * 2;
 
   const getExonClasses = (exonIndex: number, exonsCount: number) => {
     const isOuterExon = exonIndex === 0 || exonIndex === exonsCount - 1;
@@ -128,17 +132,36 @@ const InstantDownloadTranscriptVisualisation = (props: Props) => {
     );
   });
 
-  const proteinSegments = times(exonsCount, (index) => {
-    const isOuterSegment = index === 0 || index === exonsCount - 1;
-    return (
-      <rect
-        key={index}
-        className={styles.protein}
-        x={index === 0 ? halfExonWidth : index * (exonWidth + halfExonWidth)}
-        y={exonHeight + verticalGap}
-        width={isOuterSegment ? halfExonWidth : exonWidth}
-        height={proteinHeight}
-      />
+  const proteinSegments = times(exonsCount, (si) => {
+    const isOuterSegment = si === 0 || si === exonsCount - 1;
+
+    const calculateXPosition = (segmentIndex: number, blockIndex: number) => {
+      if (segmentIndex === 0) {
+        return (
+          halfExonWidth +
+          blockIndex * (proteinExonBlockWidth + proteinExonBlockSpacing)
+        );
+      }
+      return (
+        segmentIndex * (exonWidth + halfExonWidth) +
+        blockIndex * (proteinExonBlockWidth + proteinExonBlockSpacing)
+      );
+    };
+
+    return times(
+      isOuterSegment
+        ? outerProteinExonBlocksCount
+        : innerProteinExonBlocksCount,
+      (bi) => (
+        <rect
+          key={bi}
+          className={styles.protein}
+          x={calculateXPosition(si, bi)}
+          y={exonHeight + verticalGap}
+          width={proteinExonBlockWidth}
+          height={proteinHeight}
+        />
+      )
     );
   });
 

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
@@ -51,17 +51,12 @@ const InstantDownloadTranscriptVisualisation = (props: Props) => {
   const proteinHeight = 4;
   const proteinExonBlockWidth = proteinHeight;
   const proteinExonBlockSpacing = 1;
-  let innerProteinExonBlocksCount =
-    exonWidth / (proteinExonBlockWidth + proteinExonBlockSpacing);
-  innerProteinExonBlocksCount =
-    innerProteinExonBlocksCount % 1 >= 0.5
-      ? Math.ceil(innerProteinExonBlocksCount)
-      : Math.floor(innerProteinExonBlocksCount);
-  let outerProteinExonBlocksCount = innerProteinExonBlocksCount / 2;
-  outerProteinExonBlocksCount =
-    outerProteinExonBlocksCount % 1 >= 0.5
-      ? Math.ceil(outerProteinExonBlocksCount)
-      : Math.floor(outerProteinExonBlocksCount);
+  const innerProteinExonBlocksCount = Math.round(
+    exonWidth / (proteinExonBlockWidth + proteinExonBlockSpacing)
+  );
+  const outerProteinExonBlocksCount = Math.round(
+    innerProteinExonBlocksCount / 2
+  );
   const verticalGap = 5;
   const totalHeight = exonHeight + proteinHeight + verticalGap;
   const halfExonWidth = Math.floor(exonWidth / 2);

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
@@ -48,12 +48,20 @@ const InstantDownloadTranscriptVisualisation = (props: Props) => {
   const exonsCount = 5;
   const exonHeight = 5;
   const exonWidth = Math.floor(props.width / 7);
-  const outerProteinExonBlocksCount = 3;
-  const innerProteinExonBlocksCount = outerProteinExonBlocksCount * 2;
-  const proteinExonBlockSpacing = 1;
-  const proteinHeight =
-    (exonWidth - proteinExonBlockSpacing * 5) / innerProteinExonBlocksCount;
+  const proteinHeight = 4;
   const proteinExonBlockWidth = proteinHeight;
+  const proteinExonBlockSpacing = 1;
+  let innerProteinExonBlocksCount =
+    exonWidth / (proteinExonBlockWidth + proteinExonBlockSpacing);
+  innerProteinExonBlocksCount =
+    innerProteinExonBlocksCount % 1 >= 0.5
+      ? Math.ceil(innerProteinExonBlocksCount)
+      : Math.floor(innerProteinExonBlocksCount);
+  let outerProteinExonBlocksCount = innerProteinExonBlocksCount / 2;
+  outerProteinExonBlocksCount =
+    outerProteinExonBlocksCount % 1 >= 0.5
+      ? Math.ceil(outerProteinExonBlocksCount)
+      : Math.floor(outerProteinExonBlocksCount);
   const verticalGap = 5;
   const totalHeight = exonHeight + proteinHeight + verticalGap;
   const halfExonWidth = Math.floor(exonWidth / 2);
@@ -185,7 +193,7 @@ InstantDownloadTranscriptVisualisation.defaultProps = {
   isCDNAEnabled: false,
   isCDSEnabled: false,
   isProteinSequenceEnabled: false,
-  width: 210
+  width: 240
 } as Partial<Props>;
 
 export default InstantDownloadTranscriptVisualisation;

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
@@ -47,16 +47,17 @@ export type Props = {
 const InstantDownloadTranscriptVisualisation = (props: Props) => {
   const exonsCount = 5;
   const exonHeight = 5;
-  const proteinHeight = 4.3;
-  const verticalGap = 5;
-  const totalHeight = exonHeight + proteinHeight + verticalGap;
   const exonWidth = Math.floor(props.width / 7);
-  const halfExonWidth = Math.floor(exonWidth / 2);
-  const intronsCount = exonsCount - 1;
-  const proteinExonBlockWidth = 4.3;
-  const proteinExonBlockSpacing = 1;
   const outerProteinExonBlocksCount = 3;
   const innerProteinExonBlocksCount = outerProteinExonBlocksCount * 2;
+  const proteinExonBlockSpacing = 1;
+  const proteinHeight =
+    (exonWidth - proteinExonBlockSpacing * 5) / innerProteinExonBlocksCount;
+  const proteinExonBlockWidth = proteinHeight;
+  const verticalGap = 5;
+  const totalHeight = exonHeight + proteinHeight + verticalGap;
+  const halfExonWidth = Math.floor(exonWidth / 2);
+  const intronsCount = exonsCount - 1;
 
   const getExonClasses = (exonIndex: number, exonsCount: number) => {
     const isOuterExon = exonIndex === 0 || exonIndex === exonsCount - 1;


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-860

## Description
- Restyled the protein segments 

From:
![Screenshot 2020-12-15 at 11 46 14](https://user-images.githubusercontent.com/3085815/102211186-2847a800-3ecb-11eb-96ed-cc0b54a517d1.png)

To:
![Screenshot 2020-12-15 at 11 46 44](https://user-images.githubusercontent.com/3085815/102211500-98562e00-3ecb-11eb-8f77-929efb306893.png)


-  Dynamically calculating the exon block height and width instead of fixed 3px to match with the transcript width

## Deployment URL
http://restyle-protein-graphic.review.ensembl.org

## Views affected
Entity viewer -> TranscriptInfo -> Download

### Other effects
- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

