### PR TITLE
Update tests to use react-testing-library

### DIFF
--- a/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-bar/BrowserBar.test.tsx
@@ -15,27 +15,25 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import { BrowserBar, BrowserBarProps } from './BrowserBar';
-
-import BrowserReset from 'src/content/app/browser/browser-reset/BrowserReset';
-import BrowserLocationIndicator from 'src/content/app/browser/browser-location-indicator/BrowserLocationIndicator';
-import FeatureSummaryStrip from 'src/shared/components/feature-summary-strip/FeatureSummaryStrip';
 
 import { ChrLocation } from '../browserState';
 
 import { createEnsObject } from 'tests/fixtures/ens-object';
 
 jest.mock('src/content/app/browser/browser-reset/BrowserReset', () => () => (
-  <div>BrowserReset</div>
+  <div id="browserReset">BrowserReset</div>
 ));
 jest.mock(
   'src/content/app/browser/browser-location-indicator/BrowserLocationIndicator',
-  () => () => <div>Browser Location Indicator</div>
+  () => () => (
+    <div id="browserLocationIndicator">Browser Location Indicator</div>
+  )
 );
 jest.mock(
   'src/shared/components/feature-summary-strip/FeatureSummaryStrip',
-  () => () => <div>Feature Summary Strip</div>
+  () => () => <div id="featureSummaryStrip">Feature Summary Strip</div>
 );
 
 describe('<BrowserBar />', () => {
@@ -46,39 +44,28 @@ describe('<BrowserBar />', () => {
     isDrawerOpened: false
   };
 
-  const renderBrowserBar = (props?: Partial<BrowserBarProps>) => (
-    <BrowserBar {...defaultProps} {...props} />
-  );
+  const renderBrowserBar = (props?: Partial<BrowserBarProps>) =>
+    render(<BrowserBar {...defaultProps} {...props} />);
 
-  describe('general', () => {
-    let renderedBrowserBar: any;
-
-    beforeEach(() => {
-      renderedBrowserBar = mount(renderBrowserBar());
+  describe('rendering', () => {
+    it('contains BrowserReset button', () => {
+      const { container } = renderBrowserBar();
+      expect(container.querySelector('#browserReset')).toBeTruthy();
     });
 
-    test('contains BrowserReset button', () => {
-      expect(renderedBrowserBar.find(BrowserReset).length).toBe(1);
+    it('contains BrowserLocationIndicator', () => {
+      const { container } = renderBrowserBar();
+      expect(container.querySelector('#browserLocationIndicator')).toBeTruthy();
     });
 
-    test('contains BrowserLocationIndicator', () => {
-      expect(renderedBrowserBar.find(BrowserLocationIndicator).length).toBe(1);
+    it('contains FeatureSummaryStrip when ensObject is not null', () => {
+      const { container } = renderBrowserBar();
+      expect(container.querySelector('#featureSummaryStrip')).toBeTruthy();
     });
 
-    test('contains FeatureSummaryStrip', () => {
-      expect(renderedBrowserBar.find(FeatureSummaryStrip).length).toBe(1);
-    });
-  });
-
-  describe('behaviour', () => {
-    let renderedBrowserBar: any;
-
-    test('shows FeatureSummaryStrip when ensObject is not null', () => {
-      renderedBrowserBar = mount(renderBrowserBar());
-      expect(renderedBrowserBar.find(FeatureSummaryStrip).length).toBe(1);
-
-      renderedBrowserBar = mount(renderBrowserBar({ ensObject: null }));
-      expect(renderedBrowserBar.find(FeatureSummaryStrip).length).toBe(0);
+    it('does not contain FeatureSummaryStrip when ensObject is null', () => {
+      const { container } = renderBrowserBar({ ensObject: null });
+      expect(container.querySelector('#featureSummaryStrip')).toBeFalsy();
     });
   });
 });

--- a/src/ensembl/src/content/app/browser/browser-cog/BrowserCog.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-cog/BrowserCog.test.tsx
@@ -15,14 +15,14 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import faker from 'faker';
 
 import BrowserCog, { BrowserCogProps } from './BrowserCog';
-import BrowserTrackConfig from '../browser-track-config/BrowserTrackConfig';
 
 jest.mock('../browser-track-config/BrowserTrackConfig', () => () => (
-  <div>BrowserTrackConfig</div>
+  <div id="browserTrackConfig">BrowserTrackConfig</div>
 ));
 
 describe('<BrowserCog />', () => {
@@ -38,16 +38,17 @@ describe('<BrowserCog />', () => {
 
   describe('rendering', () => {
     test('renders browser track config', () => {
-      const wrapper = mount(<BrowserCog {...defaultProps} />);
-      expect(wrapper.find(BrowserTrackConfig).length).toBeGreaterThan(0);
+      const { container } = render(<BrowserCog {...defaultProps} />);
+      expect(container.querySelector('#browserTrackConfig')).toBeTruthy();
     });
   });
 
   describe('behaviour', () => {
     test('toggles cog on click', () => {
-      const wrapper = mount(<BrowserCog {...defaultProps} />);
-      wrapper.find('button').first().simulate('click');
-      expect(wrapper.props().updateSelectedCog).toHaveBeenCalledTimes(1);
+      const { container } = render(<BrowserCog {...defaultProps} />);
+      const cogButton = container.querySelector('button');
+      userEvent.click(cogButton as HTMLButtonElement);
+      expect(defaultProps.updateSelectedCog).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/ensembl/src/content/app/browser/browser-image/BrowserImage.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-image/BrowserImage.test.tsx
@@ -15,28 +15,24 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 
 import { BrowserImage, BrowserImageProps } from './BrowserImage';
-import BrowserCogList from '../browser-cog/BrowserCogList';
-import { ZmenuController } from 'src/content/app/browser/zmenu';
-import { CircleLoader } from 'src/shared/components/loader/Loader';
-import Overlay from 'src/shared/components/overlay/Overlay';
 
 jest.mock('../browser-cog/BrowserCogList', () => () => (
-  <div>BrowserCogList</div>
+  <div id="browserCogList" />
 ));
 
 jest.mock('src/content/app/browser/zmenu', () => ({
-  ZmenuController: () => <div>ZmenuController</div>
+  ZmenuController: () => <div id="zmenuController" />
 }));
 
 jest.mock('src/shared/components/loader/Loader', () => ({
-  CircleLoader: () => <div>CircleLoader</div>
+  CircleLoader: () => <div id="circleLoader" />
 }));
 
 jest.mock('src/shared/components/overlay/Overlay', () => () => (
-  <div>Overlay</div>
+  <div id="overlay" />
 ));
 
 describe('<BrowserImage />', () => {
@@ -59,35 +55,35 @@ describe('<BrowserImage />', () => {
     changeHighlightedTrackId: jest.fn()
   };
 
-  const mountBrowserImageComponent = (props?: Partial<BrowserImageProps>) =>
-    mount(<BrowserImage {...defaultProps} {...props} />);
+  const renderBrowserImage = (props?: Partial<BrowserImageProps>) =>
+    render(<BrowserImage {...defaultProps} {...props} />);
 
   describe('rendering', () => {
-    test('renders loader if browser is not activated', () => {
-      const wrapper = mountBrowserImageComponent();
-      expect(wrapper.find(CircleLoader)).toHaveLength(1);
+    it('renders loader if browser is not activated', () => {
+      const { container } = renderBrowserImage();
+      expect(container.querySelector('#circleLoader')).toBeTruthy();
     });
 
-    test('renders browser cog list', () => {
-      const wrapper = mountBrowserImageComponent();
-      expect(wrapper.find(BrowserCogList).length).toBe(1);
+    it('renders browser cog list', () => {
+      const { container } = renderBrowserImage();
+      expect(container.querySelector('#browserCogList')).toBeTruthy();
     });
 
-    test('renders zmenu controller', () => {
-      const wrapper = mountBrowserImageComponent();
-      expect(wrapper.find(ZmenuController).length).toBe(1);
+    it('renders zmenu controller', () => {
+      const { container } = renderBrowserImage();
+      expect(container.querySelector('#zmenuController')).toBeTruthy();
     });
 
-    test('has an overlay on top when disabled', () => {
-      const wrapper = mountBrowserImageComponent({ isDisabled: true });
-      expect(wrapper.find(Overlay).length).toBe(1);
+    it('has an overlay on top when disabled', () => {
+      const { container } = renderBrowserImage({ isDisabled: true });
+      expect(container.querySelector('#overlay')).toBeTruthy();
     });
   });
 
   describe('behaviour', () => {
-    test('activates browser on mount', () => {
-      const wrapper = mountBrowserImageComponent();
-      expect(wrapper.props().activateBrowser).toHaveBeenCalled();
+    it('activates browser on mount', () => {
+      renderBrowserImage();
+      expect(defaultProps.activateBrowser).toHaveBeenCalled();
     });
   });
 });

--- a/src/ensembl/src/content/app/browser/browser-location-indicator/BrowserLocationIndicator.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-location-indicator/BrowserLocationIndicator.test.tsx
@@ -16,7 +16,8 @@
 
 import React from 'react';
 import faker from 'faker';
-import { render, mount } from 'enzyme';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
 
@@ -42,15 +43,15 @@ describe('BrowserLocationIndicator', () => {
 
   describe('rendering', () => {
     it('displays chromosome name', () => {
-      const wrapper = render(<BrowserLocationIndicator {...props} />);
-      const renderedName = wrapper.find('.chrCode');
-      expect(renderedName.text()).toBe(chrName);
+      const { container } = render(<BrowserLocationIndicator {...props} />);
+      const renderedName = container.querySelector('.chrCode');
+      expect(renderedName?.textContent).toBe(chrName);
     });
 
     it('displays location', () => {
-      const wrapper = render(<BrowserLocationIndicator {...props} />);
-      const renderedLocation = wrapper.find('.chrRegion');
-      expect(renderedLocation.text()).toBe(
+      const { container } = render(<BrowserLocationIndicator {...props} />);
+      const renderedLocation = container.querySelector('.chrRegion');
+      expect(renderedLocation?.textContent).toBe(
         `${getCommaSeparatedNumber(startPosition)}-${getCommaSeparatedNumber(
           endPosition
         )}`
@@ -58,29 +59,37 @@ describe('BrowserLocationIndicator', () => {
     });
 
     it('adds disabled class when component is disabled', () => {
-      const wrapper = mount(<BrowserLocationIndicator {...props} />);
+      const { container, rerender } = render(
+        <BrowserLocationIndicator {...props} />
+      );
+      const element = container.firstChild as HTMLDivElement;
       expect(
-        wrapper.childAt(0).hasClass('browserLocationIndicatorDisabled')
-      ).not.toBe(true);
+        element.classList.contains('browserLocationIndicatorDisabled')
+      ).toBe(false);
 
-      wrapper.setProps({ disabled: true });
+      rerender(<BrowserLocationIndicator {...props} disabled={true} />);
       expect(
-        wrapper.childAt(0).hasClass('browserLocationIndicatorDisabled')
+        element.classList.contains('browserLocationIndicatorDisabled')
       ).toBe(true);
     });
   });
 
   describe('behaviour', () => {
     it('calls the onClick prop when clicked', () => {
-      const wrapper = mount(<BrowserLocationIndicator {...props} />);
-      wrapper.find('.chrLocationView').simulate('click');
+      const { container } = render(<BrowserLocationIndicator {...props} />);
+      const indicator = container.querySelector('.chrLocationView');
+
+      userEvent.click(indicator as HTMLDivElement);
       expect(props.onClick).toHaveBeenCalled();
     });
 
     it('does not call the onClick prop if disabled', () => {
-      const wrapper = mount(<BrowserLocationIndicator {...props} />);
-      wrapper.setProps({ disabled: true });
-      wrapper.find('.chrLocationView').simulate('click');
+      const { container } = render(
+        <BrowserLocationIndicator {...props} disabled={true} />
+      );
+      const indicator = container.querySelector('.chrLocationView');
+
+      userEvent.click(indicator as HTMLDivElement);
       expect(props.onClick).not.toHaveBeenCalled();
     });
   });

--- a/src/ensembl/src/global/windowSizeHelpers.ts
+++ b/src/ensembl/src/global/windowSizeHelpers.ts
@@ -51,13 +51,13 @@ export const observeMediaQueries = (
         callback(key);
       }
     };
-    mediaQueryList.addListener(onChange);
+    mediaQueryList.addEventListener('change', onChange);
     return { mediaQueryList, onChange };
   });
 
   const unsubscribe = () => {
     observableQueries.forEach(({ mediaQueryList, onChange }) => {
-      mediaQueryList.removeListener(onChange);
+      mediaQueryList.removeEventListener('change', onChange);
     });
   };
   return { unsubscribe };

--- a/src/ensembl/src/root/Root.tsx
+++ b/src/ensembl/src/root/Root.tsx
@@ -33,7 +33,7 @@ import {
 
 import styles from './Root.scss';
 
-type Props = {
+export type Props = {
   updateBreakpointWidth: (breakpointWidth: BreakpointWidth) => void;
 };
 

--- a/src/ensembl/tests/mocks/mockWindowService.ts
+++ b/src/ensembl/tests/mocks/mockWindowService.ts
@@ -1,18 +1,32 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { WindowServiceInterface } from 'src/services/window-service';
 
 export const mockMatchMedia = () => () => ({
   matches: true,
-  addListener: () => null
+  addEventListener: () => null,
+  removeEventListener: () => null
 });
 
 const mockWindowService: WindowServiceInterface = {
   getLocalStorage: jest.fn(),
   getSessionStorage: jest.fn(),
   getResizeObserver: jest.fn(),
-  getMatchMedia: jest.fn().mockImplementation(() => () => ({
-    matches: true,
-    addListener: () => null
-  })),
+  getMatchMedia: jest.fn().mockImplementation(mockMatchMedia),
   getWindow: jest.fn(),
   getFileReader: jest.fn(),
   getLocation: jest.fn()


### PR DESCRIPTION
## Type
- Refactoring

## Description
Migrated tests for several components from enzyme to react-testing-library

- `Root`
- `BrowserBar`
- `BrowserCog`
- `BrowserCogList`
- `BrowserImage`
- `BrowserLocationIndicator`

### Other noteworthy changes
Changing `addListener` and `removeListener` on MediaQueryList to `addEventListener` and `removeEventListener`. `addListener` and `removeListener` are deprecated. The most problematic browser in this respect is Safari; but it added `addEventListener` and `removeEventListener` in version 14.