### PR TITLE
Add link to Europe PMC to Entity Viewer sidebar

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.test.tsx
@@ -30,6 +30,10 @@ jest.mock('@apollo/client', () => ({
   useQuery: jest.fn()
 }));
 
+jest.mock('../publications/GenePublications', () => () => (
+  <div className="genePublications" />
+));
+
 const genomeId = 'genome_id';
 const geneId = 'unversioned_gene_id';
 const geneName = 'gene_name';
@@ -107,12 +111,16 @@ describe('<GeneOverview />', () => {
       const geneNameElement = container.querySelector('.geneName');
       const synonymsElement = container.querySelector('.synonyms');
 
+      // child components
+      const genePublications = container.querySelector('.genePublications');
+
       expect(geneDetailsElement?.textContent).toMatch(geneSymbol);
       expect(geneDetailsElement?.textContent).toMatch(stableId);
       expect(geneNameElement?.textContent).toMatch(geneName);
       expect(synonymsElement?.textContent).toMatch(
         alternativeSymbols.join(', ')
       );
+      expect(genePublications).toBeTruthy();
     });
   });
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
@@ -20,6 +20,8 @@ import { useQuery, gql } from '@apollo/client';
 
 import { parseEnsObjectIdFromUrl } from 'src/shared/state/ens-object/ensObjectHelpers';
 
+import GenePublications from '../publications/GenePublications';
+
 import { EntityViewerParams } from 'src/content/app/entity-viewer/EntityViewer';
 import { Gene as GeneFromGraphql } from 'src/content/app/entity-viewer/types/gene';
 
@@ -85,6 +87,8 @@ const GeneOverview = () => {
           ? gene.alternative_symbols.join(', ')
           : 'No synonyms'}
       </div>
+
+      <GenePublications gene={gene} />
     </div>
   );
 };

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/publications/GenePublications.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/publications/GenePublications.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import set from 'lodash/fp/set';
+
+import GenePublications from './GenePublications';
+
+const defaultProps = {
+  gene: {
+    symbol: 'BRCA2'
+  }
+};
+
+const mockState = {
+  entityViewer: {
+    general: {
+      activeGenomeId: 'human-grch38'
+    }
+  },
+  speciesSelector: {
+    committedItems: [
+      {
+        genome_id: 'human-grch38',
+        common_name: 'human',
+        scientific_name: 'Homo sapiens'
+      }
+    ]
+  }
+};
+
+const mockStore = configureMockStore();
+
+const wrapInRedux = (
+  state: typeof mockState = mockState,
+  props: typeof defaultProps = defaultProps
+) => {
+  return render(
+    <Provider store={mockStore(state)}>
+      <GenePublications {...props} />
+    </Provider>
+  );
+};
+
+describe('GenePublications', () => {
+  it('does not render if gene does not have a symbol', () => {
+    const props = set('gene.symbol', null, defaultProps);
+    const { container } = wrapInRedux(undefined, props);
+
+    expect(container.firstChild).toBeFalsy();
+  });
+
+  describe('link to Europe PMC', () => {
+    it('contains both common name and scientific name in the query when both are present', () => {
+      const { container } = wrapInRedux();
+
+      const euroPMCLink = [...container.querySelectorAll('a')].find((element) =>
+        (element.textContent as string).match('Europe PMC')
+      ) as HTMLAnchorElement;
+
+      expect(euroPMCLink).toBeTruthy();
+
+      const expectedLink = `https://europepmc.org/search?query=${encodeURIComponent(
+        'BRCA2 ("human" OR "Homo sapiens")'
+      )}&sortBy=${encodeURIComponent('CITED+desc')}`;
+
+      expect(euroPMCLink.getAttribute('href')).toBe(expectedLink);
+    });
+
+    it('contains only scientific name in the query when species does not have a common name', () => {
+      const updatedState = set(
+        'speciesSelector.committedItems.0.common_name',
+        null,
+        mockState
+      );
+      const { container } = wrapInRedux(updatedState);
+
+      const euroPMCLink = [...container.querySelectorAll('a')].find((element) =>
+        (element.textContent as string).match('Europe PMC')
+      ) as HTMLAnchorElement;
+
+      expect(euroPMCLink).toBeTruthy();
+
+      const expectedLink = `https://europepmc.org/search?query=${encodeURIComponent(
+        'BRCA2 "Homo sapiens"'
+      )}&sortBy=${encodeURIComponent('CITED+desc')}`;
+
+      expect(euroPMCLink.getAttribute('href')).toBe(expectedLink);
+    });
+  });
+});

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/publications/GenePublications.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/publications/GenePublications.tsx
@@ -1,0 +1,71 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+import { getEntityViewerActiveGenomeId } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors';
+import { getCommittedSpeciesById } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
+
+import ExternalReference from 'src/shared/components/external-reference/ExternalReference';
+
+import { CommittedItem } from 'src/content/app/species-selector/types/species-search';
+import { RootState } from 'src/store';
+
+import geneOverviewStyles from '../overview/GeneOverview.scss';
+
+type Props = {
+  gene: {
+    symbol: string | null;
+  };
+};
+
+const GenePublications = (props: Props) => {
+  const {
+    gene: { symbol }
+  } = props;
+  const activeGenomeId = useSelector(getEntityViewerActiveGenomeId) || '';
+  const species = useSelector((state: RootState) =>
+    getCommittedSpeciesById(state, activeGenomeId)
+  );
+
+  if (!species || !symbol) {
+    return null;
+  }
+
+  const linkToEuroPMC = buildLinkToEuroPMC(symbol, species);
+
+  return (
+    <>
+      <div className={geneOverviewStyles.sectionHead}>Publications</div>
+
+      <ExternalReference to={linkToEuroPMC} linkText="Europe PMC" />
+    </>
+  );
+};
+
+const buildLinkToEuroPMC = (geneSymbol: string, species: CommittedItem) => {
+  const { common_name, scientific_name } = species;
+  const speciesSearchFragment = common_name
+    ? `("${common_name}" OR "${scientific_name}")`
+    : `"${scientific_name}"`;
+  const query = encodeURIComponent(`${geneSymbol} ${speciesSearchFragment}`);
+  const sortBy = encodeURIComponent('CITED+desc');
+
+  return `https://europepmc.org/search?query=${query}&sortBy=${sortBy}`;
+};
+
+export default GenePublications;


### PR DESCRIPTION
## Type
- New feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-863

## Description
Adding link to Europe PMC for genes.

### Note
The query generated for some organisms isn't ideal. For some organisms (such as wheat) this is because the sample data in the json file is incorrect ("TraesCS3D02G273600.1" is not gene symbol); but also, we are assuming the common_name and the scientific_name of a species are always different, which currently they aren't. Don't know whether we should check on the client if the scientific_name and the common_name values are identical or distinct, or whether we should just wait until our apis figure this out.

## Deployment URL
http://publications-link.review.ensembl.org/

## Views affected
Entity viewer -> Sidebar -> Overview