### PR TITLE
Add sample regulation stats for human and mouse

### DIFF
--- a/src/ensembl/src/content/app/species/sample-data.ts
+++ b/src/ensembl/src/content/app/species/sample-data.ts
@@ -20,7 +20,7 @@ import { SpeciesStatsSection } from 'src/content/app/species/state/general/speci
 
 type RawSpeciesStats = {
   [genomeId: string]: {
-    [key in SpeciesStatsSection]: {
+    [key in SpeciesStatsSection]?: {
       [key: string]: string | number | null;
     };
   };
@@ -89,6 +89,10 @@ export const sampleData: RawSpeciesStats = {
       average_exons_per_transcript: 2.36,
       total_introns: 25165,
       average_intron_length: 4336.85
+    },
+    regulation_stats: {
+      enhancers: 132592,
+      promoters: 35191
     }
   },
   homo_sapiens_GCA_000001405_14: {
@@ -153,6 +157,10 @@ export const sampleData: RawSpeciesStats = {
       average_exons_per_transcript: 2.31,
       total_introns: 22805,
       average_intron_length: 3049.46
+    },
+    regulation_stats: {
+      enhancers: 92264,
+      promoters: 21822
     }
   },
   escherichia_coli_str_k_12_substr_mg1655_GCA_000005845_2: {

--- a/src/ensembl/src/content/app/species/state/general/speciesGeneralHelper.ts
+++ b/src/ensembl/src/content/app/species/state/general/speciesGeneralHelper.ts
@@ -165,7 +165,7 @@ export const sectionGroupsMap: SpeciesStatsSectionGroups = {
   [SpeciesStatsSection.REGULATION]: {
     title: 'Regulation',
     groups: [Groups.REGULATION],
-    summaryStatsKeys: [Stats.REGULATION]
+    summaryStatsKeys: [Stats.REGULATION_ENHANCERS, Stats.REGULATION_PROMOTERS]
   }
 };
 
@@ -463,9 +463,11 @@ const statsFormattingOptions: StatsFormattingOptions = {
       label: 'Regulation'
     },
     [Stats.REGULATION_ENHANCERS]: {
+      headerUnit: 'enhancers',
       label: 'Enhancers'
     },
     [Stats.REGULATION_PROMOTERS]: {
+      headerUnit: 'promoters',
       label: 'Promoters'
     }
   }

--- a/src/ensembl/src/content/app/species/state/general/speciesGeneralHelper.ts
+++ b/src/ensembl/src/content/app/species/state/general/speciesGeneralHelper.ts
@@ -28,7 +28,8 @@ export enum SpeciesStatsSection {
   CODING_STATS = 'coding_stats',
   NON_CODING_STATS = 'non_coding_stats',
   PSEUDOGENES = 'pseudogene_stats',
-  ASSEMBLY = 'assembly_stats'
+  ASSEMBLY = 'assembly_stats',
+  REGULATION = 'regulation_stats'
 }
 
 // SpeciesStatsSection -> Groups
@@ -41,7 +42,8 @@ enum Groups {
   PSEUDOGENES_ANALYSIS = 'pseudogenes_analysis',
   ASSEMBLY = 'assembly',
   ASSEMBLY_ANALYSIS = 'assembly_analysis',
-  TRANSCRIPTS = 'transcripts'
+  TRANSCRIPTS = 'transcripts',
+  REGULATION = 'regulation'
 }
 
 const groupTitles = {
@@ -53,7 +55,8 @@ const groupTitles = {
   [Groups.PSEUDOGENES_ANALYSIS]: 'Analysis',
   [Groups.ASSEMBLY]: 'Assembly',
   [Groups.ASSEMBLY_ANALYSIS]: 'Analysis',
-  [Groups.TRANSCRIPTS]: 'Transcripts'
+  [Groups.TRANSCRIPTS]: 'Transcripts',
+  [Groups.REGULATION]: 'Regulation'
 };
 
 // SpeciesStatsSection -> Groups -> Stats
@@ -118,7 +121,12 @@ enum Stats {
   PSEUDOGENES_AVERAGE_EXON_LENGTH = 'average_exon_length',
   PSEUDOGENES_AVERAGE_EXONS_PER_TRANSCRIPT = 'average_exons_per_transcript',
   PSEUDOGENES_TOTAL_INTRONS = 'total_introns',
-  PSEUDOGENES_AVERAGE_INTRON_LENGTH = 'average_intron_length'
+  PSEUDOGENES_AVERAGE_INTRON_LENGTH = 'average_intron_length',
+
+  // Regulation stats
+  REGULATION = 'regulation',
+  REGULATION_ENHANCERS = 'enhancers',
+  REGULATION_PROMOTERS = 'promoters'
 }
 
 type SpeciesStatsSectionGroups = {
@@ -153,6 +161,11 @@ export const sectionGroupsMap: SpeciesStatsSectionGroups = {
     title: 'Non-coding genes',
     groups: [Groups.NON_CODING_GENES, Groups.NON_CODING_ANALYSIS],
     summaryStatsKeys: [Stats.NON_CODING_GENES]
+  },
+  [SpeciesStatsSection.REGULATION]: {
+    title: 'Regulation',
+    groups: [Groups.REGULATION],
+    summaryStatsKeys: [Stats.REGULATION]
   }
 };
 
@@ -248,7 +261,10 @@ const groupsStatsMap = {
     [Stats.TOPLEVEL_SEQUENCES, Stats.TOTAL_GAP_LENGTH, Stats.SPANNED_GAP],
     [Stats.COMPONENT_SEQUENCES, Stats.CONTIG_N50]
   ],
-  [Groups.ASSEMBLY_ANALYSIS]: [[Stats.AVERAGE_GC_CONTENT]]
+  [Groups.ASSEMBLY_ANALYSIS]: [[Stats.AVERAGE_GC_CONTENT]],
+  [Groups.REGULATION]: [
+    [Stats.REGULATION_ENHANCERS, Stats.REGULATION_PROMOTERS]
+  ]
 };
 
 // Individual stat formatting options.
@@ -441,6 +457,17 @@ const statsFormattingOptions: StatsFormattingOptions = {
       primaryValuePostfix: '%',
       label: 'Average GC content'
     }
+  },
+  [SpeciesStatsSection.REGULATION]: {
+    [Stats.REGULATION]: {
+      label: 'Regulation'
+    },
+    [Stats.REGULATION_ENHANCERS]: {
+      label: 'Enhancers'
+    },
+    [Stats.REGULATION_PROMOTERS]: {
+      label: 'Promoters'
+    }
   }
 };
 
@@ -581,6 +608,8 @@ export const getStatsForSection = (props: {
   const { section, genome_id, exampleFocusObjects } = props;
 
   const data = sampleData[genome_id][section];
+
+  if (!data) return;
 
   const filteredData: {
     [key: string]: string | number;


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-887

## Description
Adds new Regulation section to species stats

## Deployment URL
http://reg-stats.review.ensembl.org/species/homo_sapiens_GCA_000001405_28

## Views affected
Species page

