### PR TITLE
Add sort filter indicator to EV transcripts list

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.scss
@@ -72,6 +72,18 @@
   cursor: pointer;
 }
 
+.filterActivityIndicator {
+  &::after {
+    border-radius: 100%;
+    background: $red;
+    display: inline-block;
+    height: 5px;
+    width: 5px;
+    position: relative;
+    bottom: 10px;
+  }
+}
+
 .chevron {
   margin-left: 10px;
   margin-bottom: -3px;
@@ -81,14 +93,4 @@
 
 .hidden {
   display: none;
-}
-
-.activeIndicator {
-  border-radius: 100%;
-  background: $red;
-  display: inline-block;
-  height: 5px;
-  width: 5px;
-  position: relative;
-  bottom: 10px;
 }

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.scss
@@ -82,3 +82,13 @@
 .hidden {
   display: none;
 }
+
+.filterSortIndicator {
+  border-radius: 100%;
+  background: $red;
+  display: inline-block;
+  height: 5px;
+  width: 5px;
+  position: relative;
+  bottom: 10px;
+}

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.scss
@@ -72,14 +72,19 @@
   cursor: pointer;
 }
 
-.filterActivityIndicator {
-  border-radius: 100%;
-  background: $red;
-  display: inline-block;
-  height: 5px;
-  width: 5px;
+.labelWithActivityIndicator {
   position: relative;
-  bottom: 10px;
+
+  &::after {
+    content: '';
+    position: absolute;
+    border-radius: 100%;
+    height: 5px;
+    width: 5px;
+    background: $red;
+    right: -6px;
+    top: -2px;
+  }
 }
 
 .chevron {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.scss
@@ -83,7 +83,7 @@
   display: none;
 }
 
-.filterSortIndicator {
+.activeIndicator {
   border-radius: 100%;
   background: $red;
   display: inline-block;

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.scss
@@ -73,15 +73,13 @@
 }
 
 .filterActivityIndicator {
-  &::after {
-    border-radius: 100%;
-    background: $red;
-    display: inline-block;
-    height: 5px;
-    width: 5px;
-    position: relative;
-    bottom: 10px;
-  }
+  border-radius: 100%;
+  background: $red;
+  display: inline-block;
+  height: 5px;
+  width: 5px;
+  position: relative;
+  bottom: 10px;
 }
 
 .chevron {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -16,7 +16,6 @@
 
 import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import classNames from 'classnames';
 
 import { getFeatureCoordinates } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
 import { transcriptSortingFunctions } from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
@@ -73,10 +72,8 @@ const DefaultTranscriptslist = (props: Props) => {
     }
   }, []);
 
-  const filterLabelClassNames = classNames(styles.filterLabel, {
-    [styles.filterActivityIndicator]:
-      sortingRule !== SortingRule.DEFAULT || Object.values(filters).some(Boolean)
-  });
+  const shouldShowFilterIndicator =
+    sortingRule !== SortingRule.DEFAULT || Object.values(filters).some(Boolean);
 
   const toggleFilter = () => {
     setFilterOpen(!isFilterOpen);
@@ -93,8 +90,11 @@ const DefaultTranscriptslist = (props: Props) => {
         )}
         <div className={styles.row}>
           {gene.transcripts.length > 5 && !isFilterOpen && (
-            <div className={filterLabelClassNames} onClick={toggleFilter}>
+            <div className={styles.filterLabel} onClick={toggleFilter}>
               Filter & sort
+              {shouldShowFilterIndicator && (
+                <span className={styles.filterActivityIndicator} />
+              )}
               <ChevronDown className={styles.chevron} />
             </div>
           )}

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -91,10 +91,15 @@ const DefaultTranscriptslist = (props: Props) => {
         <div className={styles.row}>
           {gene.transcripts.length > 5 && !isFilterOpen && (
             <div className={styles.filterLabel} onClick={toggleFilter}>
-              Filter & sort
-              {shouldShowFilterIndicator && (
-                <span className={styles.filterActivityIndicator} />
-              )}
+              <span
+                className={
+                  shouldShowFilterIndicator
+                    ? styles.labelWithActivityIndicator
+                    : undefined
+                }
+              >
+                Filter & sort
+              </span>
               <ChevronDown className={styles.chevron} />
             </div>
           )}

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -77,7 +77,7 @@ const DefaultTranscriptslist = (props: Props) => {
       return true;
     }
 
-    if (Object.values(filters).some((filterValue) => filterValue)) {
+    if (Object.values(filters).some(Boolean)) {
       return true;
     }
 
@@ -100,9 +100,9 @@ const DefaultTranscriptslist = (props: Props) => {
         <div className={styles.row}>
           {gene.transcripts.length > 5 && !isFilterOpen && (
             <div className={styles.filterLabel} onClick={toggleFilter}>
-              Filter & sort{' '}
+              Filter & sort
               {shouldShowIndicator() && (
-                <span className={styles.filterSortIndicator}></span>
+                <span className={styles.activeIndicator}></span>
               )}
               <ChevronDown className={styles.chevron} />
             </div>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -16,6 +16,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import classNames from 'classnames';
 
 import { getFeatureCoordinates } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
 import { transcriptSortingFunctions } from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
@@ -72,17 +73,10 @@ const DefaultTranscriptslist = (props: Props) => {
     }
   }, []);
 
-  const shouldShowIndicator = () => {
-    if (sortingRule !== SortingRule.DEFAULT) {
-      return true;
-    }
-
-    if (Object.values(filters).some(Boolean)) {
-      return true;
-    }
-
-    return false;
-  };
+  const filterLabelClassNames = classNames(styles.filterLabel, {
+    [styles.filterActivityIndicator]:
+      sortingRule !== SortingRule.DEFAULT || Object.values(filters).some(Boolean)
+  });
 
   const toggleFilter = () => {
     setFilterOpen(!isFilterOpen);
@@ -99,11 +93,8 @@ const DefaultTranscriptslist = (props: Props) => {
         )}
         <div className={styles.row}>
           {gene.transcripts.length > 5 && !isFilterOpen && (
-            <div className={styles.filterLabel} onClick={toggleFilter}>
+            <div className={filterLabelClassNames} onClick={toggleFilter}>
               Filter & sort
-              {shouldShowIndicator() && (
-                <span className={styles.activeIndicator}></span>
-              )}
               <ChevronDown className={styles.chevron} />
             </div>
           )}


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
[ENSWBSITES-913](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-913)

## Description
This PR adds a red dot indicator next to the `Filter & sort` text in the EV gene view. The indicator shows up when you have chosen a sort option that isn't `Default` and selected any option/s in the filter.

## Views affected
Entity viewer -> gene view -> filter and sort

### Other effects
<!--
_List any other functionality that may be affected or which requires additional changes, such as saved configurations. Please add an explanation if, for example, no test is needed._
-->

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.
