### PR TITLE
Fix Species Selector search field

### DIFF
--- a/src/ensembl/src/shared/components/input/Input.test.tsx
+++ b/src/ensembl/src/shared/components/input/Input.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -107,18 +107,35 @@ describe('<Input />', () => {
 
   describe('responding with events', () => {
     it('passes event to onChange', () => {
-      const inputValue = 'foo';
-      const { container } = getRenderedInputContainer({
-        ...commonInputProps,
-        value: inputValue,
-        callbackWithEvent: true
-      });
+      const initialInputValue = 'foo';
+
+      const StatefulWrapper = () => {
+        const [inputValue, setInputValue] = useState(initialInputValue);
+
+        const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+          const value = e.target.value;
+          commonInputProps.onChange(value);
+          setInputValue(value);
+        };
+
+        return (
+          <Input
+            {...commonInputProps}
+            onChange={onChange}
+            value={inputValue}
+            callbackWithEvent={true}
+          />
+        );
+      };
+
+      const { container } = render(<StatefulWrapper />);
 
       const inputNode = container.querySelector('input') as HTMLInputElement;
 
       userEvent.type(inputNode, '1');
+
       const lastCallArg = commonInputProps.onChange.mock.calls[0].pop();
-      expect(lastCallArg.target.value).toBe('foo1');
+      expect(lastCallArg).toBe('foo1');
     });
 
     it('passes event to onFocus', () => {

--- a/src/ensembl/src/shared/components/input/Input.test.tsx
+++ b/src/ensembl/src/shared/components/input/Input.test.tsx
@@ -17,6 +17,7 @@
 import React, { useState } from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import faker from 'faker';
 
 import Input, { Props as InputProps } from './Input';
 
@@ -60,6 +61,23 @@ describe('<Input />', () => {
       expect(inputElement.getAttribute('class')).toMatch(
         commonInputProps.className
       );
+    });
+
+    it('updates the input value when the props change', () => {
+      const inputValue = 'foo';
+      const { container, rerender } = getRenderedInputContainer({
+        ...props,
+        value: inputValue
+      });
+
+      const inputElement = container.querySelector('input') as HTMLInputElement;
+
+      expect(inputElement.value).toBe(inputValue);
+
+      const newValue = faker.lorem.words();
+      rerender(<Input {...props} value={newValue} />);
+
+      expect(inputElement.value).toBe(newValue);
     });
   });
 

--- a/src/ensembl/src/shared/components/input/Input.tsx
+++ b/src/ensembl/src/shared/components/input/Input.tsx
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import noop from 'lodash/noop';
 
 import styles from './Input.scss';
 
 type PropsForRespondingWithEvents = {
-  onChange: (e: React.SyntheticEvent<HTMLInputElement>) => void;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onFocus: (e: React.SyntheticEvent<HTMLInputElement>) => void;
   onBlur: (e: React.SyntheticEvent<HTMLInputElement>) => void;
   callbackWithEvent: true;
@@ -50,8 +50,6 @@ export type Props = {
 } & OnChangeProps;
 
 const Input = (props: Props) => {
-  const [inputValue, setInputValue] = useState(props.value);
-
   const eventHandler = (eventName: string) => (
     e: React.ChangeEvent<HTMLInputElement> | React.FocusEvent<HTMLInputElement>
   ) => {
@@ -60,7 +58,6 @@ const Input = (props: Props) => {
 
     if (eventName === 'change') {
       props.callbackWithEvent ? props.onChange(e) : props.onChange(value);
-      setInputValue(value);
     } else if (eventName === 'focus') {
       props.callbackWithEvent ? props.onFocus(e) : props.onFocus(value);
     } else if (eventName === 'blur') {
@@ -78,7 +75,7 @@ const Input = (props: Props) => {
       autoFocus={props.autoFocus}
       placeholder={props.placeholder}
       className={className}
-      value={inputValue}
+      value={props.value}
       onChange={eventHandler('change')}
       onFocus={eventHandler('focus')}
       onBlur={eventHandler('blur')}


### PR DESCRIPTION
## Type
- Bug fix

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-917

## Description

### Manifestation of the bug
_present on internal deployment_

1) Search for a species in species selector; click on a match from the dropdown. The text in the input does not get replaced with the name of the selected species

or

2) Click on a popular species button. The content of the search field does not get updated with the name of that species. 

### Cause of the bug
The bug was introduced in https://github.com/Ensembl/ensembl-client/pull/407, where the `Input` component was updated from being controlled entirely by props to storing the changes in its local state. The reason for the update was because the new tests were failing. Turns out, this breaks the Species Selector, where the Input needs to show whatever is coming with the props.

### Solution
In this PR, the Input is changed back into a controlled React component, and the tests are updated to work properly.

## Deployment URL
http://fix-species-selector.review.ensembl.org/species-selector

## Views affected
Species Selector