### PR TITLE
Update tests to use react-testing-library

### DIFF
--- a/src/ensembl/babel.config.js
+++ b/src/ensembl/babel.config.js
@@ -29,6 +29,11 @@ module.exports = {
           }
         ]
       ]
+    },
+    production: {
+      plugins: [
+        ['react-remove-properties', { 'properties': [ 'data-test-id' ] }]
+      ]
     }
   }
 };

--- a/src/ensembl/jest.config.js
+++ b/src/ensembl/jest.config.js
@@ -11,7 +11,10 @@ module.exports = {
   },
   roots: ['<rootDir>/src'],
   setupFiles: ['<rootDir>/tests/setup-jest.js'],
-  setupFilesAfterEnv: ['<rootDir>/tests/setup-enzyme.ts'],
+  setupFilesAfterEnv: [
+    '<rootDir>/tests/setup-enzyme.ts',
+    '<rootDir>/tests/setup-rtl.ts'
+  ],
   testEnvironment: 'jsdom',
   transform: {
     '.+\\.tsx?$': 'babel-jest',

--- a/src/ensembl/package-lock.json
+++ b/src/ensembl/package-lock.json
@@ -6053,6 +6053,12 @@
         "recast": "^0.14.7"
       }
     },
+    "babel-plugin-react-remove-properties": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-remove-properties/-/babel-plugin-react-remove-properties-0.3.0.tgz",
+      "integrity": "sha512-vbxegtXGyVcUkCvayLzftU95vuvpYFV85pRpeMpohMHeEY46Qe0VNWfkVVcCbaZ12CXHzDFOj0esumATcW83ng==",
+      "dev": true
+    },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",

--- a/src/ensembl/package.json
+++ b/src/ensembl/package.json
@@ -115,6 +115,7 @@
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "26.5.2",
     "babel-loader": "8.1.0",
+    "babel-plugin-react-remove-properties": "0.3.0",
     "brotli-webpack-plugin": "1.1.0",
     "compression-webpack-plugin": "5.0.2",
     "connect-history-api-fallback": "1.6.0",

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBar.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBar.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { render } from '@testing-library/react';
 
 jest.mock('./BrowserNavBarControls', () => () => (
   <div>BrowserNavBarControls</div>
@@ -27,11 +27,18 @@ import { BrowserNavBar } from './BrowserNavBar';
 describe('<BrowserNavBar />', () => {
   describe('rendering', () => {
     it('correctly interprets the "expanded" prop', () => {
-      const contractedBar = render(<BrowserNavBar expanded={false} />);
-      expect(contractedBar.hasClass('browserNavBarExpanded')).toBe(false);
+      const { container, rerender } = render(
+        <BrowserNavBar expanded={false} />
+      );
+      const browserNavBar = container.firstChild as HTMLDivElement;
+      expect(browserNavBar.classList.contains('browserNavBarExpanded')).toBe(
+        false
+      );
 
-      const expandedBar = render(<BrowserNavBar expanded={true} />);
-      expect(expandedBar.hasClass('browserNavBarExpanded')).toBe(true);
+      rerender(<BrowserNavBar expanded={true} />);
+      expect(browserNavBar.classList.contains('browserNavBarExpanded')).toBe(
+        true
+      );
     });
   });
 });

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarControls.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarControls.test.tsx
@@ -15,47 +15,49 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import faker from 'faker';
 import times from 'lodash/times';
 
-import BrowserNavIcon from './BrowserNavIcon';
-
 import { BrowserNavBarControls } from './BrowserNavBarControls';
 import { BrowserNavStates } from '../browserState';
-import Overlay from 'src/shared/components/overlay/Overlay';
 
-jest.mock('./BrowserNavIcon', () => () => <div>BrowserNavIcon</div>);
+jest.mock('./BrowserNavIcon', () => (props: { enabled: boolean }) => {
+  const className = props.enabled ? 'browserNavIcon enabled' : 'browserNavIcon';
+  return <div className={className} />;
+});
+jest.mock('src/shared/components/overlay/Overlay', () => () => (
+  <div className="overlay" />
+));
 
 const browserNavStates = times(6, faker.random.boolean) as BrowserNavStates;
 
 describe('BrowserNavBarControls', () => {
-  let wrapper: any;
-
-  beforeEach(() => {
-    wrapper = mount(
+  it('has an overlay on top when browser nav bar controls are disabled', () => {
+    const { container } = render(
       <BrowserNavBarControls
         browserNavStates={browserNavStates}
-        isDisabled={faker.random.boolean()}
+        isDisabled={true}
       />
     );
-  });
-
-  it('has an overlay on top when browser nav bar controls are disabled', () => {
-    wrapper.setProps({ isDisabled: true });
-    expect(wrapper.find(Overlay).length).toBe(1);
+    expect(container.querySelector('.overlay')).toBeTruthy();
   });
 
   it('disables buttons if corresponding actions are not possible', () => {
     // browserNavStates are an array of booleans that indicate whether the button
     // has already caused maximum corresponding effect, and will have no further effect if pressed
-    wrapper.setProps({ isDisabled: false });
+    const { container } = render(
+      <BrowserNavBarControls
+        browserNavStates={browserNavStates}
+        isDisabled={false}
+      />
+    );
 
-    const controlButtons = wrapper.find(BrowserNavIcon);
+    const controlButtons = container.querySelectorAll('.browserNavIcon');
 
-    controlButtons.forEach((button: any, index: number) => {
-      const hasCausedMaximumEffect = browserNavStates[index];
-      expect(button.prop('enabled')).toBe(!hasCausedMaximumEffect);
+    controlButtons.forEach((button, index) => {
+      const isDisabled = browserNavStates[index];
+      expect(button.classList.contains('enabled')).toBe(!isDisabled);
     });
   });
 });

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarMain.test.tsx
@@ -15,20 +15,19 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { BrowserNavBarMain, BrowserNavBarMainProps } from './BrowserNavBarMain';
 
-import ChromosomeNavigator from 'src/content/app/browser/chromosome-navigator/ChromosomeNavigator';
-import BrowserNavBarRegionSwitcher from './BrowserNavBarRegionSwitcher';
 import { BreakpointWidth } from 'src/global/globalConfig';
 
 jest.mock(
   'src/content/app/browser/chromosome-navigator/ChromosomeNavigator',
-  () => () => <div>ChromosomeNavigator</div>
+  () => () => <div className="chromosomeNavigator" />
 );
 jest.mock('./BrowserNavBarRegionSwitcher', () => () => (
-  <div>BrowserNavBarRegionSwitcher</div>
+  <div className="browserNavBarRegionSwitcher" />
 ));
 
 const props: BrowserNavBarMainProps = {
@@ -36,46 +35,56 @@ const props: BrowserNavBarMainProps = {
 };
 
 describe('BrowserNavBarMain', () => {
-  let wrapper: any;
-
-  beforeEach(() => {
-    wrapper = mount(<BrowserNavBarMain {...props} />);
-  });
-
   afterEach(() => {
     jest.resetAllMocks();
   });
 
   it('does not render chromosome visualization by default for screens smaller than laptops', () => {
-    expect(wrapper.find(ChromosomeNavigator).length).toBe(0);
+    const { container } = render(<BrowserNavBarMain {...props} />);
+    expect(container.querySelector('.chromosomeNavigator')).toBeFalsy();
   });
 
   it('renders chromosome visualization by default for laptops or bigger screens', () => {
-    wrapper.setProps({ viewportWidth: BreakpointWidth.LAPTOP });
+    const { container } = render(
+      <BrowserNavBarMain {...props} viewportWidth={BreakpointWidth.LAPTOP} />
+    );
 
-    expect(wrapper.find(ChromosomeNavigator).length).toBe(1);
-    expect(wrapper.find(BrowserNavBarRegionSwitcher).length).toBe(0);
+    expect(container.querySelector('.chromosomeNavigator')).toBeTruthy();
+    expect(container.querySelector('.browserNavBarRegionSwitcher')).toBeFalsy();
   });
 
   it('renders RegionSwitcher when user clicks on Change', () => {
-    wrapper.setProps({ viewportWidth: BreakpointWidth.LAPTOP });
+    const { container } = render(
+      <BrowserNavBarMain {...props} viewportWidth={BreakpointWidth.LAPTOP} />
+    );
 
-    const changeButton = wrapper.find('.contentSwitcher');
-    changeButton.simulate('click');
-    expect(wrapper.find(ChromosomeNavigator).length).toBe(0);
-    expect(wrapper.find(BrowserNavBarRegionSwitcher).length).toBe(1);
+    const changeButton = container.querySelector(
+      '.contentSwitcher'
+    ) as HTMLSpanElement;
+    userEvent.click(changeButton);
+
+    expect(container.querySelector('.chromosomeNavigator')).toBeFalsy();
+    expect(
+      container.querySelector('.browserNavBarRegionSwitcher')
+    ).toBeTruthy();
   });
 
   it('renders chromosome visualization when user closes RegionSwitcher', () => {
-    wrapper.setProps({ viewportWidth: BreakpointWidth.LAPTOP });
+    const { container } = render(
+      <BrowserNavBarMain {...props} viewportWidth={BreakpointWidth.LAPTOP} />
+    );
 
-    const changeButton = wrapper.find('.contentSwitcher');
-    changeButton.simulate('click');
+    const changeButton = container.querySelector(
+      '.contentSwitcher'
+    ) as HTMLSpanElement;
+    userEvent.click(changeButton);
 
-    const closeButton = wrapper.find('.contentSwitcherClose');
-    closeButton.simulate('click');
+    const closeButton = container.querySelector(
+      '.contentSwitcherClose'
+    ) as HTMLSpanElement;
+    userEvent.click(closeButton);
 
-    expect(wrapper.find(ChromosomeNavigator).length).toBe(1);
-    expect(wrapper.find(BrowserNavBarRegionSwitcher).length).toBe(0);
+    expect(container.querySelector('.chromosomeNavigator')).toBeTruthy();
+    expect(container.querySelector('.browserNavBarRegionSwitcher')).toBeFalsy();
   });
 });

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarRegionSwitcher.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavBarRegionSwitcher.test.tsx
@@ -15,21 +15,19 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 
 import { BrowserNavBarRegionSwitcher } from './BrowserNavBarRegionSwitcher';
-import BrowserRegionEditor from '../browser-region-editor/BrowserRegionEditor';
-import BrowserRegionField from '../browser-region-field/BrowserRegionField';
 
 import { BreakpointWidth } from 'src/global/globalConfig';
 
 jest.mock(
   'src/content/app/browser/browser-region-editor/BrowserRegionEditor',
-  () => () => <div>BrowserRegionEditor</div>
+  () => () => <div className="browserRegionEditor" />
 );
 jest.mock(
   'src/content/app/browser/browser-region-field/BrowserRegionField',
-  () => () => <div>BrowserRegionField</div>
+  () => () => <div className="browserRegionField" />
 );
 
 const props = {
@@ -39,37 +37,38 @@ const props = {
 };
 
 describe('BrowserNavBarRegionSwitcher', () => {
-  let wrapper: any;
-
   beforeEach(() => {
-    wrapper = mount(<BrowserNavBarRegionSwitcher {...props} />);
-  });
-
-  afterEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
   });
 
   describe('rendering', () => {
-    it('renders region field and not region editor on smaller screens', () => {
-      expect(wrapper.find(BrowserRegionField)).toHaveLength(1);
-      expect(wrapper.find(BrowserRegionEditor)).toHaveLength(0);
+    it('renders only region field on smaller screens', () => {
+      const { container } = render(<BrowserNavBarRegionSwitcher {...props} />);
+
+      expect(container.querySelector('.browserRegionField')).toBeTruthy();
+      expect(container.querySelector('.browserRegionEditor')).toBeFalsy();
     });
 
     it('renders both region field and region editor on big desktop screens', () => {
-      wrapper.setProps({ viewportWidth: BreakpointWidth.BIG_DESKTOP });
+      const { container } = render(
+        <BrowserNavBarRegionSwitcher
+          {...props}
+          viewportWidth={BreakpointWidth.BIG_DESKTOP}
+        />
+      );
 
-      expect(wrapper.find(BrowserRegionEditor)).toHaveLength(1);
-      expect(wrapper.find(BrowserRegionField)).toHaveLength(1);
+      expect(container.querySelector('.browserRegionField')).toBeTruthy();
+      expect(container.querySelector('.browserRegionEditor')).toBeTruthy();
     });
   });
 
   it('calls cleanup functions on unmount', () => {
-    const wrapper = mount(<BrowserNavBarRegionSwitcher {...props} />);
+    const { unmount } = render(<BrowserNavBarRegionSwitcher {...props} />);
 
     expect(props.toggleRegionEditorActive).not.toHaveBeenCalled();
     expect(props.toggleRegionFieldActive).not.toHaveBeenCalled();
 
-    wrapper.unmount();
+    unmount();
 
     expect(props.toggleRegionEditorActive).toHaveBeenCalledWith(false);
     expect(props.toggleRegionFieldActive).toHaveBeenCalledWith(false);

--- a/src/ensembl/src/content/app/browser/browser-nav/BrowserNavIcon.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-nav/BrowserNavIcon.test.tsx
@@ -15,7 +15,8 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { BrowserNavIcon } from './BrowserNavIcon';
 import browserMessagingService from 'src/content/app/browser/browser-messaging-service';
@@ -27,12 +28,17 @@ describe('<BrowserNavIcon />', () => {
   test('sends navigation message when clicked', () => {
     jest.spyOn(browserMessagingService, 'send');
 
-    const renderedNavIcon = mount(
+    const { container } = render(
       <BrowserNavIcon browserNavItem={browserNavItem} enabled={true} />
     );
+    const button = container.querySelector('button') as HTMLButtonElement;
 
-    renderedNavIcon.find('button').simulate('click');
+    userEvent.click(button);
     expect(browserMessagingService.send).toHaveBeenCalledTimes(1);
+    expect(browserMessagingService.send).toHaveBeenCalledWith(
+      'bpane',
+      browserNavItem.detail
+    );
 
     (browserMessagingService.send as any).mockRestore();
   });

--- a/src/ensembl/src/content/app/browser/browser-region-editor/BrowserRegionEditor.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-region-editor/BrowserRegionEditor.test.tsx
@@ -67,7 +67,7 @@ describe('<BrowserRegionEditor />', () => {
       expect(container.querySelector('.select')).toBeTruthy();
     });
 
-    it('contains two Input elements', () => {
+    it('contains two input elements', () => {
       const { container } = render(<BrowserRegionEditor {...defaultProps} />);
       expect(container.querySelectorAll('input').length).toBe(2);
     });

--- a/src/ensembl/src/content/app/browser/browser-region-editor/BrowserRegionEditor.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-region-editor/BrowserRegionEditor.test.tsx
@@ -15,31 +15,36 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
+import { screen, render, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import faker from 'faker';
 
 import {
   BrowserRegionEditor,
   BrowserRegionEditorProps
 } from './BrowserRegionEditor';
-import Input from 'src/shared/components/input/Input';
-import Select from 'src/shared/components/select/Select';
-import Tooltip from 'src/shared/components/tooltip/Tooltip';
-import Overlay from 'src/shared/components/overlay/Overlay';
 
 import { createGenomeKaryotype } from 'tests/fixtures/genomes';
-import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
+import {
+  getCommaSeparatedNumber,
+  getNumberWithoutCommas
+} from 'src/shared/helpers/formatters/numberFormatter';
 import {
   createChrLocationValues,
   createRegionValidationMessages
 } from 'tests/fixtures/browser';
 import * as browserHelper from '../browserHelper';
 
-describe('<BrowserRegionEditor />', () => {
-  afterEach(() => {
-    jest.resetAllMocks();
-  });
+jest.mock('src/shared/components/select/Select', () => () => (
+  <div className="select" />
+));
+jest.mock('src/shared/components/overlay/Overlay', () => () => (
+  <div className="overlay" />
+));
 
+jest.mock('../browserHelper');
+
+describe('<BrowserRegionEditor />', () => {
   const initialChrLocation = createChrLocationValues().tupleValue;
   const defaultProps: BrowserRegionEditorProps = {
     activeGenomeId: faker.lorem.words(),
@@ -52,64 +57,66 @@ describe('<BrowserRegionEditor />', () => {
     toggleRegionEditorActive: jest.fn()
   };
 
-  let wrapper: any;
-
   beforeEach(() => {
-    wrapper = mount(<BrowserRegionEditor {...defaultProps} />);
+    jest.resetAllMocks();
   });
 
   describe('rendering', () => {
-    test('contains Select', () => {
-      expect(wrapper.find(Select).length).toBe(1);
+    it('contains Select', () => {
+      const { container } = render(<BrowserRegionEditor {...defaultProps} />);
+      expect(container.querySelector('.select')).toBeTruthy();
     });
 
-    test('contains two Input elements', () => {
-      expect(wrapper.find(Input).length).toBe(2);
+    it('contains two Input elements', () => {
+      const { container } = render(<BrowserRegionEditor {...defaultProps} />);
+      expect(container.querySelectorAll('input').length).toBe(2);
     });
 
-    test('contains submit and close buttons', () => {
-      expect(wrapper.find('button[type="submit"]')).toHaveLength(1);
+    it('contains submit and close buttons', () => {
+      const { container } = render(<BrowserRegionEditor {...defaultProps} />);
+      expect(container.querySelector('button[type="submit"]')).toBeTruthy();
     });
 
-    test('has an overlay on top when disabled', () => {
-      wrapper.setProps({ isDisabled: true });
-      expect(wrapper.find(Overlay).length).toBe(1);
+    it('has an overlay on top when disabled', () => {
+      const { container } = render(
+        <BrowserRegionEditor {...defaultProps} isDisabled={true} />
+      );
+      expect(container.querySelector('.overlay')).toBeTruthy();
     });
   });
 
   describe('behaviour', () => {
-    test('shows form buttons when focussed', () => {
-      wrapper.find('form').simulate('focus');
-      expect(wrapper.props().toggleRegionEditorActive).toHaveBeenCalledTimes(1);
+    it('shows form buttons when focussed', () => {
+      const { container } = render(<BrowserRegionEditor {...defaultProps} />);
+      const form = container.querySelector('form') as HTMLFormElement;
+
+      fireEvent.focus(form);
+
+      expect(defaultProps.toggleRegionEditorActive).toHaveBeenCalledTimes(1);
     });
 
-    test('validates region input on submit', () => {
+    it('validates region input on submit', () => {
       const [stick] = initialChrLocation;
       const locationStartInput = getCommaSeparatedNumber(faker.random.number());
       const locationEndInput = getCommaSeparatedNumber(faker.random.number());
-      const validateRegion = jest.fn();
 
-      jest
-        .spyOn(browserHelper, 'validateRegion')
-        .mockImplementation(validateRegion);
+      const { container } = render(<BrowserRegionEditor {...defaultProps} />);
+      const [firstInput, secondInput] = container.querySelectorAll('input');
+      const submitButton = container.querySelector(
+        'button[type="submit"]'
+      ) as HTMLButtonElement;
 
-      wrapper
-        .find(Input)
-        .first()
-        .simulate('change', {
-          target: { value: locationStartInput }
-        });
+      userEvent.clear(firstInput);
+      userEvent.type(firstInput, locationStartInput);
 
-      wrapper
-        .find(Input)
-        .last()
-        .simulate('change', { target: { value: locationEndInput } });
+      userEvent.clear(secondInput);
+      userEvent.type(secondInput, locationEndInput);
 
-      wrapper.find('form').simulate('submit');
+      userEvent.click(submitButton);
 
-      expect(validateRegion).toHaveBeenCalledWith({
+      expect(browserHelper.validateRegion).toHaveBeenCalledWith({
         regionInput: `${stick}:${locationStartInput}-${locationEndInput}`,
-        genomeId: wrapper.props().activeGenomeId,
+        genomeId: defaultProps.activeGenomeId,
         onSuccess: expect.any(Function),
         onError: expect.any(Function)
       });
@@ -124,11 +131,11 @@ describe('<BrowserRegionEditor />', () => {
 
       const locationStartInput = getCommaSeparatedNumber(faker.random.number());
       const locationEndInput = getCommaSeparatedNumber(faker.random.number());
-      const startError = faker.lorem.words();
-      const endError = faker.lorem.words();
+      const startError = 'start error message';
+      const endError = 'end error message';
       const mockValidationMessages = createRegionValidationMessages();
 
-      test('displays the start error message', () => {
+      it('displays the start error message', async () => {
         const mockErrorMessages = {
           ...mockValidationMessages.errorMessages,
           startError,
@@ -138,39 +145,33 @@ describe('<BrowserRegionEditor />', () => {
         jest
           .spyOn(browserHelper, 'validateRegion')
           .mockImplementation(
-            async (params: {
-              regionInput: string;
-              genomeId: string | null;
-              onSuccess: (regionId: string) => void;
-              onError: (
-                errorMessages: browserHelper.RegionValidationErrors
-              ) => void;
-            }) => {
-              params.onError(mockErrorMessages);
-            }
+            async ({
+              onError
+            }: {
+              onError: (arg: typeof mockErrorMessages) => void;
+            }): Promise<void> => onError(mockErrorMessages)
           );
 
-        wrapper
-          .find(Input)
-          .first()
-          .simulate('change', { target: { value: locationStartInput } });
+        const { container } = render(<BrowserRegionEditor {...defaultProps} />);
+        const [firstInput, secondInput] = container.querySelectorAll('input');
+        const submitButton = container.querySelector(
+          'button[type="submit"]'
+        ) as HTMLButtonElement;
 
-        wrapper
-          .find(Input)
-          .last()
-          .simulate('change', {
-            target: { value: locationEndInput }
-          });
+        userEvent.clear(firstInput);
+        userEvent.type(firstInput, locationStartInput);
 
-        wrapper.find('form').simulate('submit');
+        userEvent.clear(secondInput);
+        userEvent.type(secondInput, locationEndInput);
 
-        expect(
-          wrapper.find('[role="startInputGroup"]').find(Tooltip).props()
-            .children
-        ).toBe(startError);
+        userEvent.click(submitButton);
+
+        const errorMessageElement = await screen.findByText(startError);
+        expect(errorMessageElement).toBeTruthy();
+        expect(errorMessageElement.classList.contains('tooltip')).toBe(true);
       });
 
-      test('displays the end error message', () => {
+      it('displays the end error message', async () => {
         const mockErrorMessages = {
           ...mockValidationMessages.errorMessages,
           endError
@@ -179,35 +180,30 @@ describe('<BrowserRegionEditor />', () => {
         jest
           .spyOn(browserHelper, 'validateRegion')
           .mockImplementation(
-            async (params: {
-              regionInput: string;
-              genomeId: string | null;
-              onSuccess: (regionId: string) => void;
-              onError: (
-                errorMessages: browserHelper.RegionValidationErrors
-              ) => void;
-            }) => {
-              params.onError(mockErrorMessages);
-            }
+            async ({
+              onError
+            }: {
+              onError: (arg: typeof mockErrorMessages) => void;
+            }): Promise<void> => onError(mockErrorMessages)
           );
 
-        wrapper
-          .find(Input)
-          .first()
-          .simulate('change', { target: { value: locationStartInput } });
+        const { container } = render(<BrowserRegionEditor {...defaultProps} />);
+        const [firstInput, secondInput] = container.querySelectorAll('input');
+        const submitButton = container.querySelector(
+          'button[type="submit"]'
+        ) as HTMLButtonElement;
 
-        wrapper
-          .find(Input)
-          .last()
-          .simulate('change', {
-            target: { value: locationEndInput }
-          });
+        userEvent.clear(firstInput);
+        userEvent.type(firstInput, locationStartInput);
 
-        wrapper.find('form').simulate('submit');
+        userEvent.clear(secondInput);
+        userEvent.type(secondInput, locationEndInput);
 
-        expect(
-          wrapper.find('[role="endInputGroup"]').find(Tooltip).props().children
-        ).toBe(endError);
+        userEvent.click(submitButton);
+
+        const errorMessageElement = await screen.findByText(endError);
+        expect(errorMessageElement).toBeTruthy();
+        expect(errorMessageElement.classList.contains('tooltip')).toBe(true);
       });
     });
 
@@ -217,41 +213,46 @@ describe('<BrowserRegionEditor />', () => {
       const regionId = faker.lorem.words();
 
       beforeEach(() => {
+        jest.resetAllMocks();
         jest
           .spyOn(browserHelper, 'validateRegion')
           .mockImplementation(
-            async (params: {
-              regionInput: string;
-              genomeId: string | null;
-              onSuccess: (regionId: string) => void;
-              onError: (
-                errorMessages: browserHelper.RegionValidationErrors
-              ) => void;
-            }) => {
-              params.onSuccess(regionId);
-            }
+            async ({
+              onSuccess
+            }: {
+              onSuccess: (arg: string) => void;
+            }): Promise<void> => onSuccess(regionId)
           );
-      });
-
-      afterEach(() => {
-        jest.restoreAllMocks();
       });
 
       // TODO:
       // Test focus object change on submission. This can be done if <Select /> value can be changed.
 
-      test('changes the browser location in same region if stick is the same', () => {
-        wrapper
-          .find(Input)
-          .first()
-          .simulate('change', { target: { value: locationStartInput } });
-        wrapper
-          .find(Input)
-          .last()
-          .simulate('change', { target: { value: locationEndInput } });
-        wrapper.find('form').simulate('submit');
+      it('changes the browser location in same region if stick is the same', () => {
+        const { container } = render(<BrowserRegionEditor {...defaultProps} />);
+        const [firstInput, secondInput] = container.querySelectorAll('input');
+        const submitButton = container.querySelector(
+          'button[type="submit"]'
+        ) as HTMLButtonElement;
 
-        expect(wrapper.props().changeBrowserLocation).toHaveBeenCalled();
+        userEvent.clear(firstInput);
+        userEvent.type(firstInput, locationStartInput);
+
+        userEvent.clear(secondInput);
+        userEvent.type(secondInput, locationEndInput);
+
+        userEvent.click(submitButton);
+
+        expect(defaultProps.changeBrowserLocation).toHaveBeenCalled();
+
+        const {
+          ensObjectId,
+          chrLocation
+        } = (defaultProps.changeBrowserLocation as any).mock.calls[0][0];
+        const [, start, end] = chrLocation;
+        expect(ensObjectId).toBe(null);
+        expect(start).toBe(getNumberWithoutCommas(locationStartInput));
+        expect(end).toBe(getNumberWithoutCommas(locationEndInput));
       });
     });
   });

--- a/src/ensembl/src/content/app/browser/browser-region-field/BrowserRegionField.tsx
+++ b/src/ensembl/src/content/app/browser/browser-region-field/BrowserRegionField.tsx
@@ -99,7 +99,7 @@ export const BrowserRegionField = (props: BrowserRegionFieldProps) => {
       ? regionFieldInput.split(':')[0]
       : stick;
 
-    if (stickInput === stick) {
+    if (stickInput === `${stick}`) {
       const newChrLocation = getChrLocationFromStr(
         getRegionInputWithStick(regionFieldInput)
       );

--- a/src/ensembl/src/content/app/browser/browser-reset/BrowserReset.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-reset/BrowserReset.test.tsx
@@ -15,14 +15,14 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import faker from 'faker';
 
 import { BrowserReset, BrowserResetProps } from './BrowserReset';
-import ImageButton from 'src/shared/components/image-button/ImageButton';
 
 describe('<BrowserReset />', () => {
-  afterEach(() => {
+  beforeEach(() => {
     jest.resetAllMocks();
   });
 
@@ -33,24 +33,29 @@ describe('<BrowserReset />', () => {
   };
 
   describe('rendering', () => {
-    test('renders image button when focus feature exists', () => {
-      const wrapper = mount(<BrowserReset {...defaultProps} />);
-      expect(wrapper.find(ImageButton)).toHaveLength(1);
+    it('renders image button when focus feature exists', () => {
+      const { container } = render(<BrowserReset {...defaultProps} />);
+      expect(container.querySelector('button')).toBeTruthy();
     });
 
-    test('renders nothing when focus feature does not exist', () => {
-      const wrapper = mount(
+    it('renders nothing when focus feature does not exist', () => {
+      const { container } = render(
         <BrowserReset {...defaultProps} focusObjectId={null} />
       );
-      expect(wrapper.html()).toBe(null);
+      expect(container.firstChild).toBeFalsy();
     });
   });
 
   describe('behaviour', () => {
-    test('changes focus object when clicked', () => {
-      const wrapper = mount(<BrowserReset {...defaultProps} />);
-      wrapper.find(ImageButton).simulate('click');
-      expect(wrapper.props().changeFocusObject).toHaveBeenCalledTimes(1);
+    it('changes focus object when clicked', () => {
+      const { container } = render(<BrowserReset {...defaultProps} />);
+      const button = container.querySelector('button') as HTMLButtonElement;
+
+      userEvent.click(button);
+
+      expect(defaultProps.changeFocusObject).toHaveBeenCalledWith(
+        defaultProps.focusObjectId
+      );
     });
   });
 });

--- a/src/ensembl/src/content/app/browser/browser-track-config/BrowserTrackConfig.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-track-config/BrowserTrackConfig.test.tsx
@@ -15,14 +15,13 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import {
   BrowserTrackConfig,
   BrowserTrackConfigProps
 } from './BrowserTrackConfig';
-import Checkbox from 'src/shared/components/checkbox/Checkbox';
-import SlideToggle from 'src/shared/components/slide-toggle/SlideToggle';
 
 import {
   createTrackConfigLabel,
@@ -31,7 +30,7 @@ import {
 } from 'tests/fixtures/browser';
 
 describe('<BrowserTrackConfig />', () => {
-  afterEach(() => {
+  beforeEach(() => {
     jest.resetAllMocks();
   });
 
@@ -47,26 +46,26 @@ describe('<BrowserTrackConfig />', () => {
     onClose: jest.fn()
   };
 
-  let wrapper: any;
-
-  beforeEach(() => {
-    wrapper = mount(<BrowserTrackConfig {...defaultProps} />);
-  });
-
   describe('behaviour', () => {
-    test('sets all tracks to be updated when the all tracks checkbox is selected', () => {
-      wrapper.find(Checkbox).props().onChange(true);
-      expect(wrapper.props().updateApplyToAll).toHaveBeenCalledTimes(1);
+    it('sets all tracks to be updated when the all tracks checkbox is selected', () => {
+      const { container } = render(<BrowserTrackConfig {...defaultProps} />);
+      const checkbox = container.querySelector(
+        'input[type="checkbox"]'
+      ) as HTMLInputElement;
+
+      userEvent.click(checkbox);
+
+      expect(defaultProps.updateApplyToAll).toHaveBeenCalledTimes(1);
     });
 
-    test('passes updateTrackConfigNames to track name toggler', () => {
-      const toggle = wrapper
-        .find('label')
-        .filterWhere((wrapper: any) => wrapper.text() === 'Track name')
-        .parents()
-        .first() // <- enzyme's .parent method doesnt seem to be reliably working for mount
-        .find(SlideToggle);
-      toggle.prop('onChange')(true);
+    it('toggles track name', () => {
+      const { container } = render(<BrowserTrackConfig {...defaultProps} />);
+      const toggle = [...container.querySelectorAll('label')]
+        .find((element) => element.textContent === 'Track name')
+        ?.parentElement?.querySelector('svg') as SVGElement;
+
+      userEvent.click(toggle);
+
       expect(defaultProps.updateTrackConfigNames).toHaveBeenCalledTimes(1);
       expect(defaultProps.updateTrackConfigNames).toHaveBeenCalledWith(
         defaultProps.selectedCog,
@@ -74,14 +73,14 @@ describe('<BrowserTrackConfig />', () => {
       );
     });
 
-    test('toggles track label when the toggle name slider is clicked', () => {
-      const toggle = wrapper
-        .find('label')
-        .filterWhere((wrapper: any) => wrapper.text() === 'Feature labels')
-        .parents()
-        .first() // <- enzyme's .parent method doesnt seem to be reliably working for mount
-        .find(SlideToggle);
-      toggle.prop('onChange')(true);
+    it('toggles feature labels on the track', () => {
+      const { container } = render(<BrowserTrackConfig {...defaultProps} />);
+      const toggle = [...container.querySelectorAll('label')]
+        .find((element) => element.textContent === 'Feature labels')
+        ?.parentElement?.querySelector('svg') as SVGElement;
+
+      userEvent.click(toggle);
+
       expect(defaultProps.updateTrackConfigLabel).toHaveBeenCalledTimes(1);
       expect(defaultProps.updateTrackConfigLabel).toHaveBeenCalledWith(
         defaultProps.selectedCog,

--- a/src/ensembl/src/content/app/browser/track-panel/TrackPanel.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/TrackPanel.test.tsx
@@ -15,25 +15,23 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import faker from 'faker';
 
 import { TrackPanel, TrackPanelProps } from './TrackPanel';
-import TrackPanelList from './track-panel-list/TrackPanelList';
-import TrackPanelModal from './track-panel-modal/TrackPanelModal';
 
 import { createEnsObject } from 'tests/fixtures/ens-object';
 
 jest.mock('./track-panel-bar/TrackPanelBar', () => () => (
-  <div>Track Panel</div>
+  <div className="trackPanel" />
 ));
 jest.mock('./track-panel-list/TrackPanelList', () => () => (
-  <div>Track Panel List</div>
+  <div className="trackPanelList" />
 ));
 jest.mock('./track-panel-modal/TrackPanelModal', () => () => (
-  <div>Track Panel Modal</div>
+  <div className="trackPanelModal" />
 ));
-jest.mock('../drawer/Drawer', () => () => <div>Drawer</div>);
+jest.mock('../drawer/Drawer', () => () => <div className="drawer" />);
 
 describe('<TrackPanel />', () => {
   afterEach(() => {
@@ -48,34 +46,34 @@ describe('<TrackPanel />', () => {
     restoreBrowserTrackStates: jest.fn()
   };
 
-  const mountTrackPanel = (props?: Partial<TrackPanelProps>) =>
-    mount(<TrackPanel {...defaultProps} {...props} />);
+  const renderTrackPanel = (props?: Partial<TrackPanelProps>) =>
+    render(<TrackPanel {...defaultProps} {...props} />);
 
   describe('rendering', () => {
-    test('does not render anything when not all rendering requirements are satisfied', () => {
+    it('does not render anything when not all rendering requirements are satisfied', () => {
       // defaultProps are insufficient for rendering anything useful
       // TODO: in the future, it might be a good idea to at least render a spinner here
-      const wrapper = mountTrackPanel();
-      expect(wrapper.html()).toBe(null);
+      const { container } = renderTrackPanel();
+      expect(container.firstChild).toBeFalsy();
     });
 
-    test('renders TrackPanelList when necessary requirements are satisfied', () => {
-      const wrapper = mountTrackPanel({
+    it('renders TrackPanelList when necessary requirements are satisfied', () => {
+      const { container } = renderTrackPanel({
         browserActivated: true,
         activeEnsObject: createEnsObject(),
         activeGenomeId: faker.lorem.words()
       });
-      expect(wrapper.find(TrackPanelList).length).toBe(1);
+      expect(container.querySelector('.trackPanelList')).toBeTruthy();
     });
 
-    test('renders track panel modal when necessary requirements are satisfied', () => {
-      const wrapper = mountTrackPanel({
+    it('renders track panel modal when necessary requirements are satisfied', () => {
+      const { container } = renderTrackPanel({
         activeGenomeId: faker.lorem.words(),
         browserActivated: true,
         activeEnsObject: createEnsObject(),
         isTrackPanelModalOpened: true
       });
-      expect(wrapper.find(TrackPanelModal)).toHaveLength(1);
+      expect(container.querySelector('.trackPanelModal')).toBeTruthy();
     });
   });
 });

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.test.tsx
@@ -15,21 +15,22 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import faker from 'faker';
 
 import { TrackPanelList, TrackPanelListProps } from './TrackPanelList';
-import TrackPanelListItem from './TrackPanelListItem';
 
 import { createEnsObject } from 'tests/fixtures/ens-object';
 import { TrackSet } from '../trackPanelConfig';
 import { createGenomeCategories } from 'tests/fixtures/genomes';
 import { createTrackStates } from 'tests/fixtures/track-panel';
 
-jest.mock('./TrackPanelListItem', () => () => <div>TrackPanelListItem</div>);
+jest.mock('./TrackPanelListItem', () => () => (
+  <div className="trackPanelListItem" />
+));
 
 describe('<TrackPanelList />', () => {
-  afterEach(() => {
+  beforeEach(() => {
     jest.resetAllMocks();
   });
 
@@ -46,19 +47,21 @@ describe('<TrackPanelList />', () => {
   };
 
   const mountTrackPanelList = (props?: Partial<TrackPanelListProps>) =>
-    mount(<TrackPanelList {...defaultProps} {...props} />);
+    render(<TrackPanelList {...defaultProps} {...props} />);
 
   describe('rendering', () => {
-    test('renders track panel items', () => {
-      const wrapper = mountTrackPanelList();
-      expect(wrapper.find(TrackPanelListItem).length).toBeGreaterThan(0);
+    it('renders track panel items', () => {
+      const { container } = mountTrackPanelList();
+      expect(
+        container.querySelectorAll('.trackPanelListItem').length
+      ).toBeGreaterThan(0);
     });
 
-    test('does not render main track if the focus feature is a region', () => {
-      const wrapper = mountTrackPanelList({
+    it('does not render main track if the focus feature is a region', () => {
+      const { container } = mountTrackPanelList({
         activeEnsObject: createEnsObject('region')
       });
-      expect(wrapper.find('.mainTrackItem')).toHaveLength(0);
+      expect(container.querySelector('.mainTrackItem')).toBeFalsy();
     });
   });
 });

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/TrackPanelModal.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/TrackPanelModal.test.tsx
@@ -15,15 +15,28 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { TrackPanelModal, TrackPanelModalProps } from './TrackPanelModal';
-import TrackPanelSearch from './modal-views/TrackPanelSearch';
-import TrackPanelDownloads from './modal-views/TrackPanelDownloads';
-import CloseButton from 'src/shared/components/close-button/CloseButton';
+
+jest.mock('./modal-views/TrackPanelSearch', () => () => (
+  <div className="trackPanelSearch" />
+));
+
+jest.mock('./modal-views/TrackPanelDownloads', () => () => (
+  <div className="trackPanelDownloads" />
+));
+
+jest.mock(
+  'src/shared/components/close-button/CloseButton',
+  () => (props: { onClick: () => void }) => (
+    <button className="closeButton" onClick={props.onClick}></button>
+  )
+);
 
 describe('<TrackPanelModal />', () => {
-  afterEach(() => {
+  beforeEach(() => {
     jest.resetAllMocks();
   });
 
@@ -34,24 +47,26 @@ describe('<TrackPanelModal />', () => {
   };
 
   describe('rendering', () => {
-    test('displays track pane modal view for search', () => {
-      const wrapper = mount(<TrackPanelModal {...defaultProps} />);
-      expect(wrapper.find(TrackPanelSearch)).toHaveLength(1);
+    it('displays track pane modal view for search', () => {
+      const { container } = render(<TrackPanelModal {...defaultProps} />);
+      expect(container.querySelector('.trackPanelSearch')).toBeTruthy();
     });
 
-    test('displays track pane modal view for downloads', () => {
-      const wrapper = mount(
+    it('displays track pane modal view for downloads', () => {
+      const { container } = render(
         <TrackPanelModal {...defaultProps} trackPanelModalView="downloads" />
       );
-      expect(wrapper.find(TrackPanelDownloads)).toHaveLength(1);
+      expect(container.querySelector('.trackPanelDownloads')).toBeTruthy();
     });
   });
 
   describe('behaviour', () => {
-    test('closes modal when close button is clicked', () => {
-      const wrapper = mount(<TrackPanelModal {...defaultProps} />);
-      wrapper.find(CloseButton).simulate('click');
-      expect(wrapper.props().closeTrackPanelModal).toHaveBeenCalledTimes(1);
+    it('closes modal when close button is clicked', () => {
+      const { container } = render(<TrackPanelModal {...defaultProps} />);
+      const closeButton = container.querySelector('button.closeButton');
+
+      userEvent.click(closeButton as HTMLElement);
+      expect(defaultProps.closeTrackPanelModal).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.test.tsx
@@ -84,8 +84,9 @@ describe('<TrackPanelBookmarks />', () => {
 
   it('closes the bookmarks modal when a bookmark link is clicked', () => {
     render(<TrackPanelBookmarks {...props} />);
-    const previouslyViewedLinksContainer = screen.getByText('Previously viewed')
-      .nextSibling;
+    const previouslyViewedLinksContainer = screen.getByTestId(
+      'previously viewed links'
+    );
     const firstLink = (previouslyViewedLinksContainer as HTMLElement).querySelector(
       '.link'
     );
@@ -142,7 +143,7 @@ describe('<TrackPanelBookmarks />', () => {
 
   it('renders correct number of links to example objects', () => {
     render(<TrackPanelBookmarks {...props} />);
-    const exampleLinksWrapper = screen.getByText('Example links').parentElement;
+    const exampleLinksWrapper = screen.getByTestId('example links');
 
     expect(exampleLinksWrapper?.querySelectorAll('.link').length).toBe(
       numberOfExampleObjects
@@ -151,7 +152,7 @@ describe('<TrackPanelBookmarks />', () => {
 
   it('calls closeTrackPanelModal when an example object link is clicked', () => {
     render(<TrackPanelBookmarks {...props} />);
-    const exampleLinksWrapper = screen.getByText('Example links').parentElement;
+    const exampleLinksWrapper = screen.getByTestId('example links');
     const exampleLink = exampleLinksWrapper?.querySelector('.link');
 
     userEvent.click(exampleLink as HTMLElement);

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
@@ -55,7 +55,7 @@ type ExampleLinksProps = Pick<
 >;
 export const ExampleLinks = (props: ExampleLinksProps) => {
   return (
-    <div>
+    <div data-test-id="example links">
       <div className={styles.sectionTitle}>Example links</div>
       {props.exampleEnsObjects.map((exampleObject) => {
         const path = urlFor.browser({
@@ -95,7 +95,7 @@ export const PreviouslyViewedLinks = (props: PreviouslyViewedLinksProps) => {
   };
 
   return (
-    <div>
+    <div data-test-id="previously viewed links">
       {[...props.previouslyViewedObjects]
         .reverse()
         .map((previouslyViewedObject, index) => {

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-tabs/TrackPanelTabs.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-tabs/TrackPanelTabs.test.tsx
@@ -15,7 +15,8 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { TrackPanelTabs, TrackPanelTabsProps } from './TrackPanelTabs';
 
@@ -39,46 +40,59 @@ describe('<TrackPanelTabs />', () => {
   };
 
   describe('rendering', () => {
-    test('contains all track panel tabs', () => {
-      const wrapper = mount(<TrackPanelTabs {...defaultProps} />);
-      const tabValues = Object.values(TrackSet).reduce(
-        (acc, currValue) => `${acc} ${currValue}`,
-        ''
-      );
-      const tabs = wrapper.getDOMNode().querySelectorAll('dd');
+    it('contains all track panel tabs', () => {
+      const { container } = render(<TrackPanelTabs {...defaultProps} />);
+      const tabValues = Object.values(TrackSet);
+      const tabs = [...container.querySelectorAll('.trackPanelTab')];
 
-      tabs.forEach((tabNode: HTMLElement) => {
-        expect(tabValues).toContain(tabNode.textContent);
+      tabValues.forEach((text) => {
+        expect(tabs.some((tab) => tab.innerHTML === text));
       });
     });
   });
 
   describe('behaviour', () => {
     describe('on track panel tab click', () => {
-      let wrapper: any;
+      // wrapper.find('.trackPanelTab').first().simulate('click');
 
-      beforeEach(() => {
-        wrapper = mount(
-          <TrackPanelTabs
-            {...defaultProps}
-            isTrackPanelOpened={false}
-            isDrawerOpened={true}
-          />
+      it('selects track panel tab', () => {
+        const { container } = render(<TrackPanelTabs {...defaultProps} />);
+        const tab = container.querySelector('.trackPanelTab') as HTMLElement;
+
+        userEvent.click(tab);
+        expect(defaultProps.selectTrackPanelTab).toHaveBeenCalledWith(
+          Object.values(TrackSet)[0]
         );
-
-        wrapper.find('.trackPanelTab').first().simulate('click');
       });
 
-      test('selects track panel tab', () => {
-        expect(wrapper.props().selectTrackPanelTab).toHaveBeenCalledTimes(1);
+      it('opens track panel if it is closed', () => {
+        const { container, rerender } = render(
+          <TrackPanelTabs {...defaultProps} isTrackPanelOpened={true} />
+        );
+        const tab = container.querySelector('.trackPanelTab') as HTMLElement;
+
+        userEvent.click(tab);
+        expect(defaultProps.toggleTrackPanel).not.toHaveBeenCalled();
+
+        rerender(
+          <TrackPanelTabs {...defaultProps} isTrackPanelOpened={false} />
+        );
+        userEvent.click(tab);
+        expect(defaultProps.toggleTrackPanel).toHaveBeenCalledWith(true);
       });
 
-      test('opens track panel if it is already closed', () => {
-        expect(wrapper.props().toggleTrackPanel).toHaveBeenCalledTimes(1);
-      });
+      it('closes drawer if it is opened', () => {
+        const { container, rerender } = render(
+          <TrackPanelTabs {...defaultProps} isDrawerOpened={false} />
+        );
+        const tab = container.querySelector('.trackPanelTab') as HTMLElement;
 
-      test('closes drawer if it is already opened', () => {
-        expect(wrapper.props().closeDrawer).toHaveBeenCalledTimes(1);
+        userEvent.click(tab);
+        expect(defaultProps.closeDrawer).not.toHaveBeenCalled();
+
+        rerender(<TrackPanelTabs {...defaultProps} isDrawerOpened={true} />);
+        userEvent.click(tab);
+        expect(defaultProps.closeDrawer).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-tabs/TrackPanelTabs.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-tabs/TrackPanelTabs.test.tsx
@@ -53,8 +53,6 @@ describe('<TrackPanelTabs />', () => {
 
   describe('behaviour', () => {
     describe('on track panel tab click', () => {
-      // wrapper.find('.trackPanelTab').first().simulate('click');
-
       it('selects track panel tab', () => {
         const { container } = render(<TrackPanelTabs {...defaultProps} />);
         const tab = container.querySelector('.trackPanelTab') as HTMLElement;

--- a/src/ensembl/tests/setup-rtl.ts
+++ b/src/ensembl/tests/setup-rtl.ts
@@ -1,0 +1,21 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { configure } from '@testing-library/dom';
+
+configure({
+  testIdAttribute: 'data-test-id'
+});


### PR DESCRIPTION
## Type
- Refactoring
 
## Description
Migrate genome browser-related tests from enzyme to react-testing-library

## Notes
- this behaviour of BrowserRegionField [described in an existing test](https://github.com/Ensembl/ensembl-client/blob/dev/src/ensembl/src/content/app/browser/browser-region-field/BrowserRegionField.test.tsx#L178-L180) looks strange; not sure if it's correct. I've replicated it in the updated tests; but we probably want to confirm/fix the behaviour in later PRs.