### PR TITLE
Show only Swissprot description in gene function

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.tsx
@@ -15,11 +15,10 @@
  */
 
 import React from 'react';
-import { connect } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
-import { push, Push } from 'connected-react-router';
+import { push } from 'connected-react-router';
 
-import { isEntityViewerSidebarOpen } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors';
 import { getSelectedGeneViewTabs } from 'src/content/app/entity-viewer/state/gene-view/view/geneViewViewSelectors';
 import {
   GeneViewTabMap,
@@ -35,7 +34,6 @@ import Tabs, { Tab } from 'src/shared/components/tabs/Tabs';
 import Panel from 'src/shared/components/panel/Panel';
 import ProteinsList from '../proteins-list/ProteinsList';
 
-import { RootState } from 'src/store';
 import { Gene } from 'src/content/app/entity-viewer/types/gene';
 
 import styles from './GeneFunction.scss';
@@ -56,22 +54,23 @@ const tabClassNames = {
 
 type Props = {
   gene: Gene;
-  isNarrow: boolean;
-  selectedTabName: GeneFunctionTabName | null;
-  push: Push;
 };
 
 const GeneFunction = (props: Props) => {
+  const dispatch = useDispatch();
+  const selectedTabName = useSelector(getSelectedGeneViewTabs)
+    .secondaryTab as GeneFunctionTabName;
+
   const { genomeId, entityId } = useParams() as { [key: string]: string };
   const {
     gene: { transcripts }
   } = props;
-  const { selectedTabName } = props;
 
   const changeTab = (tab: string) => {
     const match = [...GeneViewTabMap.entries()].find(
       ([, { secondaryTab }]) => secondaryTab === tab
     );
+
     if (!match) {
       return;
     }
@@ -82,7 +81,8 @@ const GeneFunction = (props: Props) => {
       entityId,
       view
     });
-    props.push(url);
+
+    dispatch(push(url));
   };
 
   // Check if we have at least one protein coding transcript
@@ -134,14 +134,4 @@ const GeneFunction = (props: Props) => {
   );
 };
 
-const mapStateToProps = (state: RootState) => ({
-  isNarrow: isEntityViewerSidebarOpen(state),
-  selectedTabName: getSelectedGeneViewTabs(state)
-    .secondaryTab as GeneFunctionTabName
-});
-
-const mapDispatchToProps = {
-  push
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(GeneFunction);
+export default GeneFunction;

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/ProteinsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/ProteinsList.tsx
@@ -15,7 +15,7 @@
  */
 
 import React, { useEffect } from 'react';
-import { connect } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { useLocation } from 'react-router';
 
 import ProteinsListItem from './proteins-list-item/ProteinsListItem';
@@ -30,17 +30,16 @@ import { toggleExpandedProtein } from 'src/content/app/entity-viewer/state/gene-
 import { getExpandedTranscriptIds } from 'src/content/app/entity-viewer/state/gene-view/proteins/geneViewProteinsSelectors';
 
 import { Gene } from 'src/content/app/entity-viewer/types/gene';
-import { RootState } from 'src/store';
 
 import styles from './ProteinsList.scss';
 
 type ProteinsListProps = {
   gene: Gene;
-  expandedTranscriptIds: string[];
-  toggleExpandedProtein: (id: string) => void;
 };
 
 const ProteinsList = (props: ProteinsListProps) => {
+  const expandedTranscriptIds = useSelector(getExpandedTranscriptIds);
+  const dispatch = useDispatch();
   const { search } = useLocation();
   const proteinIdToFocus = new URLSearchParams(search).get('protein_id');
 
@@ -50,13 +49,13 @@ const ProteinsList = (props: ProteinsListProps) => {
   );
 
   useEffect(() => {
-    const hasExpandedTranscripts = !!props.expandedTranscriptIds.length;
+    const hasExpandedTranscripts = !!expandedTranscriptIds.length;
     const firstProteinId =
       proteinCodingTranscripts[0].product_generating_contexts[0].product
         .stable_id;
     // Expand the first transcript by default
     if (!hasExpandedTranscripts && !proteinIdToFocus) {
-      props.toggleExpandedProtein(firstProteinId);
+      dispatch(toggleExpandedProtein(firstProteinId));
     }
   }, []);
 
@@ -76,12 +75,4 @@ const ProteinsList = (props: ProteinsListProps) => {
   );
 };
 
-const mapStateToProps = (state: RootState) => ({
-  expandedTranscriptIds: getExpandedTranscriptIds(state)
-});
-
-const mapDispatchToProps = {
-  toggleExpandedProtein
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(ProteinsList);
+export default ProteinsList;

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item/ProteinsListItem.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item/ProteinsListItem.tsx
@@ -86,8 +86,8 @@ const ProteinsListItem = (props: Props) => {
   }, [proteinIdToFocus]);
 
   const getProteinDescription = () => {
-    const swissprotReference = product.external_references.find((reference) =>
-      reference.source.id.includes(SWISSPROT_SOURCE)
+    const swissprotReference = product.external_references.find(
+      (reference) => reference.source.id === SWISSPROT_SOURCE
     );
 
     return swissprotReference?.description;

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item/ProteinsListItem.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item/ProteinsListItem.tsx
@@ -34,7 +34,7 @@ import { View } from 'src/content/app/entity-viewer/state/gene-view/view/geneVie
 import transcriptsListStyles from 'src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.scss';
 import styles from './ProteinsListItem.scss';
 
-const SWISSPROT_SOURCE = 'SWISSPROT';
+const SWISSPROT_SOURCE = 'Uniprot/SWISSPROT';
 
 type Props = {
   transcript: Transcript;


### PR DESCRIPTION
<!--
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This will normally be the development branch, so please ask your reviewer if you think it needs to go somewhere else. 
-->

## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
[ENSWBSITES-909](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-909)

## Description
We need to show only protein descriptions from Swissprot as the other sources are not reliable. Also when there are more than one description for a protein list item, we need to show the first one. If there are no protein descriptions from Swissprot, then we show nothing for it.

## Deployment URL
<!--
If applicable, follow instructions here: https://www.ebi.ac.uk/seqdb/confluence/display/ENSWEB/Review+Apps+for+feature+branches on how to deploy.
-->

## Views affected
Entity viewer -> Gene function -> Protein list item
