### PR TITLE
Bring back the entity viewer sidebar accordion

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.scss
@@ -2,7 +2,7 @@
 
 .overviewContainer {
   font-size: 13px;
-}
+
 .sectionHead {
   color: $dark-grey;
   font-size: 12px;
@@ -53,7 +53,7 @@
   border-radius: 5px;
 }
 
-.entityViewerAccordionButton {
+  .entityViewerAccordionButton {
   color: $blue;
   padding: 5px 0 5px 20px;
 
@@ -66,6 +66,7 @@
     color: $grey;
   }
 }
+
 
 .entityViewerAccordionItem:not(:first-child) {
   border-color: transparent;
@@ -155,4 +156,5 @@
 
 .tarkLabel {
   color: $dark-grey;
+}
 }

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.scss
@@ -22,24 +22,6 @@
   }
 }
 
-.otherAssembly {
-  display: grid;
-  grid-template-columns: [species] max-content 10px [assembly] auto 5px [stable-id] auto;
-
-  .speciesName {
-    grid-column: species;
-  }
-
-  .geneName {
-    grid-column: assembly;
-    color: $dark-grey;
-    font-weight: $light;
-  }
-
-  .stableId {
-    grid-column: stable-id;
-  }
-}
 
 .accordionContainer {
   width: 100%;
@@ -54,9 +36,10 @@
     border-radius: 5px;
   }
   
-    .entityViewerAccordionButton {
+  .entityViewerAccordionButton {
     color: $blue;
     padding: 5px 0 5px 20px;
+    border-radius: 5px;
   
     &:before,
     &:after {
@@ -68,7 +51,6 @@
     }
   }
   
-  
   .entityViewerAccordionItem:not(:first-child) {
     border-color: transparent;
   }
@@ -79,88 +61,4 @@
     padding: 20px;
   }
 
-
-.sequenceAccordion {
-  & .geneDetails {
-    margin-bottom: 10px;
-    & .geneTitle {
-      color: $dark-grey;
-      margin-right: 10px;
-      font-size: 12px;
-      font-weight: $light;
-    }
-
-    & .stableId {
-      font-weight: $bold;
-    }
-  }
-}
-
-.accordionContentTitle {
-  color: $dark-grey;
-  margin-bottom: 15px;
-  margin-top: 20px;
-}
-
-}
-
-
-
-.geneFunction {
-  margin-bottom: 15px;
-}
-
-.geneFunctionLabel {
-  font-size: 12px;
-  color: $grey;
-}
-
-.providedBy {
-  color: $dark-grey;
-  font-size: 12px;
-  font-weight: $light;
-}
-
-
-.sequenceDownload {
-  text-align: right;
-  margin: 30px 0;
-}
-
-.customDownload {
-  display: grid;
-  grid-template-columns: [label] max-content 20px [icon] 30px;
-  & .label {
-    grid-column: label;
-  }
-
-  & .icon {
-    grid-column: icon;
-  }
-}
-
-.standardLabelValue {
-  display: grid;
-  grid-template-columns: [label] max-content 10px [value] auto;
-
-  .label {
-    grid-column: label;
-    color: $dark-grey;
-  }
-
-  .value {
-    grid-column: value;
-    font-weight: $bold;
-  }
-}
-
-.tark {
-  & .description {
-    margin: 20px 0 10px;
-    font-weight: $bold;
-  }
-}
-
-.tarkLabel {
-  color: $dark-grey;
 }

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.scss
@@ -2,6 +2,8 @@
 
 .overviewContainer {
   font-size: 13px;
+}
+
 
 .sectionHead {
   color: $dark-grey;
@@ -41,57 +43,42 @@
 
 .accordionContainer {
   width: 100%;
-}
 
-.entityViewerAccordion {
-  border: none;
-  margin-top: 30px;
-}
-
-.entityViewerAccordionHeader {
-  background-color: $light-grey;
-  border-radius: 5px;
-}
-
-  .entityViewerAccordionButton {
-  color: $blue;
-  padding: 5px 0 5px 20px;
-
-  &:before,
-  &:after {
-    margin-top: -3px;
+  .entityViewerAccordion {
+    border: none;
+    margin-top: 30px;
+  }
+  
+  .entityViewerAccordionHeader {
+    background-color: $light-grey;
+    border-radius: 5px;
+  }
+  
+    .entityViewerAccordionButton {
+    color: $blue;
+    padding: 5px 0 5px 20px;
+  
+    &:before,
+    &:after {
+      margin-top: -3px;
+    }
+  
+    &Disabled {
+      color: $grey;
+    }
+  }
+  
+  
+  .entityViewerAccordionItem:not(:first-child) {
+    border-color: transparent;
+  }
+  
+  .entityViewerAccordionItemContent {
+    background-color: transparent;
+    border: none;
+    padding: 20px;
   }
 
-  &Disabled {
-    color: $grey;
-  }
-}
-
-
-.entityViewerAccordionItem:not(:first-child) {
-  border-color: transparent;
-}
-
-.entityViewerAccordionItemContent {
-  background-color: transparent;
-  border: none;
-  padding: 20px;
-}
-
-.geneFunction {
-  margin-bottom: 15px;
-}
-
-.geneFunctionLabel {
-  font-size: 12px;
-  color: $grey;
-}
-
-.providedBy {
-  color: $dark-grey;
-  font-size: 12px;
-  font-weight: $light;
-}
 
 .sequenceAccordion {
   & .geneDetails {
@@ -114,6 +101,26 @@
   margin-bottom: 15px;
   margin-top: 20px;
 }
+
+}
+
+
+
+.geneFunction {
+  margin-bottom: 15px;
+}
+
+.geneFunctionLabel {
+  font-size: 12px;
+  color: $grey;
+}
+
+.providedBy {
+  color: $dark-grey;
+  font-size: 12px;
+  font-weight: $light;
+}
+
 
 .sequenceDownload {
   text-align: right;
@@ -156,5 +163,4 @@
 
 .tarkLabel {
   color: $dark-grey;
-}
 }

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
@@ -17,7 +17,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import { useQuery, gql } from '@apollo/client';
-
 import { parseEnsObjectIdFromUrl } from 'src/shared/state/ens-object/ensObjectHelpers';
 
 import GenePublications from '../publications/GenePublications';
@@ -28,7 +27,11 @@ import { Gene as GeneFromGraphql } from 'src/content/app/entity-viewer/types/gen
 
 import styles from './GeneOverview.scss';
 
-// TODO: Refer PR #422 when more data becomes available.
+/*  
+  TODO: When more data becomes available
+  Please refer to the PR https://github.com/Ensembl/ensembl-client/pull/422
+  and check if some of the deleted code segments can be reused to display the new data.
+*/
 export const GENE_OVERVIEW_QUERY = gql`
   query Gene($genomeId: String!, $geneId: String!) {
     gene(byId: { genome_id: $genomeId, stable_id: $geneId }) {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
@@ -85,7 +85,6 @@ const GeneOverview = () => {
           <div className={styles.geneName}>{gene.name}</div>
         </>
       )}
-      <MainAccordion />
 
       <div className={styles.sectionHead}>Synonyms</div>
       <div className={styles.synonyms}>
@@ -93,6 +92,8 @@ const GeneOverview = () => {
           ? gene.alternative_symbols.join(', ')
           : 'No synonyms'}
       </div>
+
+      <MainAccordion />
 
       <GenePublications gene={gene} />
     </div>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
@@ -21,12 +21,14 @@ import { useQuery, gql } from '@apollo/client';
 import { parseEnsObjectIdFromUrl } from 'src/shared/state/ens-object/ensObjectHelpers';
 
 import GenePublications from '../publications/GenePublications';
+import MainAccordion from './MainAccordion';
 
 import { EntityViewerParams } from 'src/content/app/entity-viewer/EntityViewer';
 import { Gene as GeneFromGraphql } from 'src/content/app/entity-viewer/types/gene';
 
 import styles from './GeneOverview.scss';
 
+// TODO: Refer PR #422 when more data becomes available.
 export const GENE_OVERVIEW_QUERY = gql`
   query Gene($genomeId: String!, $geneId: String!) {
     gene(byId: { genome_id: $genomeId, stable_id: $geneId }) {
@@ -80,6 +82,7 @@ const GeneOverview = () => {
           <div className={styles.geneName}>{gene.name}</div>
         </>
       )}
+      <MainAccordion />
 
       <div className={styles.sectionHead}>Synonyms</div>
       <div className={styles.synonyms}>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/MainAccordion.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/MainAccordion.tsx
@@ -84,7 +84,7 @@ const MainAccordion = () => {
           <AccordionItemPanel
             className={styles.entityViewerAccordionItemContent}
           >
-            <div className={styles.sequenceAccordion}>No data available</div>
+            <div>No data available</div>
           </AccordionItemPanel>
         </AccordionItem>
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/MainAccordion.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/MainAccordion.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import noop from 'lodash/noop';
+// import noop from 'lodash/noop';
 import classNames from 'classnames';
 
 import {
@@ -25,53 +25,18 @@ import {
   AccordionItemPanel,
   AccordionItemButton
 } from 'src/shared/components/accordion';
-import ExternalReference from 'src/shared/components/external-reference/ExternalReference';
-import { PrimaryButton } from 'src/shared/components/button/Button';
-import ImageButton from 'src/shared/components/image-button/ImageButton';
-import { ReactComponent as DownloadButton } from 'static/img/launchbar/custom-download.svg';
-import Checkbox from 'src/shared/components/checkbox/Checkbox';
-
-import { Status } from 'src/shared/types/status';
-
-import { EntityViewerSidebarUIState } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarState';
 
 import styles from './GeneOverview.scss';
 
 // FIXME:
 // We started using real data from Thoas, and are not yet getting anything that can be rendered
 // in this accordion. When we get back to using this accordion, the type of its props will need updating
-type Props = {
-  sidebarPayload: any | null; // FIXME: update the type with appropriate shape of data
-  sidebarUIState: EntityViewerSidebarUIState | null;
-  updateEntityUI: (uIstate: Partial<EntityViewerSidebarUIState>) => void;
-};
-
 export type AccordionSectionID = 'function' | 'sequence' | 'other_data_sets';
 
-// TODO: Remove me once instant download component is available
-const mockOnClick = noop;
+const MainAccordion = () => {
+  const hasFunctionDescription = false;
 
-const MainAccordion = (props: Props) => {
-  const { sidebarPayload, sidebarUIState } = props;
-
-  if (!sidebarPayload) {
-    return null;
-  }
-
-  const { gene } = sidebarPayload;
-  const hasFunctionDescription = Boolean(gene.function?.description);
-
-  const expandedPanels =
-    sidebarUIState?.mainAccordion?.expandedPanels ||
-    (hasFunctionDescription ? ['function'] : []);
-
-  const onChange = (newExpandedPanels: (string | number)[] = []) => {
-    props.updateEntityUI({
-      mainAccordion: {
-        expandedPanels: newExpandedPanels as AccordionSectionID[]
-      }
-    });
-  };
+  const sidebarPayload = {} as any;
 
   const functionAccordionButtonClass = classNames(
     styles.entityViewerAccordionButton,
@@ -84,8 +49,6 @@ const MainAccordion = (props: Props) => {
     <div className={styles.accordionContainer}>
       <Accordion
         className={styles.entityViewerAccordion}
-        onChange={onChange}
-        preExpanded={expandedPanels}
         allowMultipleExpanded={true}
       >
         <AccordionItem
@@ -103,23 +66,7 @@ const MainAccordion = (props: Props) => {
           <AccordionItemPanel
             className={styles.entityViewerAccordionItemContent}
           >
-            {gene.function?.description && (
-              <div>
-                <div className={styles.geneFunction}>
-                  {gene.function.description}
-                </div>
-                {gene.function.source?.id && (
-                  <ExternalReference
-                    label={gene.function.source.name}
-                    linkText={gene.function.source.id}
-                    to={gene.function.source.url}
-                    classNames={{
-                      label: styles.providedBy
-                    }}
-                  />
-                )}
-              </div>
-            )}
+            No data available
           </AccordionItemPanel>
         </AccordionItem>
 
@@ -135,62 +82,7 @@ const MainAccordion = (props: Props) => {
           <AccordionItemPanel
             className={styles.entityViewerAccordionItemContent}
           >
-            <div className={styles.sequenceAccordion}>
-              <div className={styles.geneDetails}>
-                <span className={styles.geneTitle}>Gene</span>
-                <span className={styles.stableId}>{gene.id}</span>
-              </div>
-              <div className={styles.geneCheckboxList}>
-                {renderCheckbox({ label: 'Genomic sequence', checked: false })}
-              </div>
-
-              <div className={styles.accordionContentTitle}>
-                All transcripts
-              </div>
-              <div className={styles.transcriptsCheckboxList}>
-                {(gene.filters?.transcript?.sequence as {
-                  label: string;
-                }[]).map((filter, key) =>
-                  renderCheckbox({
-                    label: filter.label,
-                    checked: false,
-                    key: key
-                  })
-                )}
-              </div>
-
-              <div className={styles.sequenceDownload}>
-                <PrimaryButton onClick={mockOnClick} isDisabled={true}>
-                  Download
-                </PrimaryButton>
-              </div>
-
-              <div className={styles.customDownload}>
-                <div className={styles.label}>Get a custom download</div>
-                <div className={styles.icon}>
-                  <ImageButton
-                    image={DownloadButton}
-                    onClick={mockOnClick}
-                    status={Status.SELECTED}
-                  ></ImageButton>
-                </div>
-              </div>
-
-              {gene.filters?.transcript.tark_url && (
-                <div className={styles.tark}>
-                  <div className={styles.description}>
-                    Archive of transcript sequences, including historical gene
-                    sets
-                  </div>
-                  <ExternalReference
-                    label={'Ensembl Transcript Archive'}
-                    linkText={'TARK'}
-                    to={gene.filters.transcript.tark_url as string}
-                    classNames={{ label: styles.tarkLabel }}
-                  />
-                </div>
-              )}
-            </div>
+            <div className={styles.sequenceAccordion}>No data available</div>
           </AccordionItemPanel>
         </AccordionItem>
 
@@ -201,7 +93,7 @@ const MainAccordion = (props: Props) => {
           <AccordionItemHeading className={styles.entityViewerAccordionHeader}>
             <AccordionItemButton
               className={styles.entityViewerAccordionButton}
-              disabled={sidebarPayload.other_data_sets ? false : true}
+              disabled={sidebarPayload?.other_data_sets ? false : true}
             >
               Other data sets
             </AccordionItemButton>
@@ -209,49 +101,10 @@ const MainAccordion = (props: Props) => {
           <AccordionItemPanel
             className={styles.entityViewerAccordionItemContent}
           >
-            <div>
-              {sidebarPayload.other_data_sets?.map((
-                entry: any /* FIXME! */,
-                key: number
-              ) =>
-                renderStandardLabelValue({
-                  label: entry.type,
-                  value: entry.value,
-                  key
-                })
-              )}
-            </div>
+            <div>No data available</div>
           </AccordionItemPanel>
         </AccordionItem>
       </Accordion>
-    </div>
-  );
-};
-
-const renderCheckbox = (props: {
-  label: string;
-  checked: boolean;
-  key?: number;
-}) => {
-  // TODO: Remove me once instant download component is available
-  const onChangeMock = noop;
-
-  return (
-    <div key={props.key}>
-      <Checkbox onChange={onChangeMock} {...props} />
-    </div>
-  );
-};
-
-const renderStandardLabelValue = (props: {
-  label: string;
-  key?: number;
-  value: string | JSX.Element;
-}) => {
-  return (
-    <div className={styles.standardLabelValue} key={props.key}>
-      <div className={styles.label}>{props.label}</div>
-      <div className={styles.value}>{props.value}</div>
     </div>
   );
 };

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/MainAccordion.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/MainAccordion.tsx
@@ -15,7 +15,6 @@
  */
 
 import React from 'react';
-// import noop from 'lodash/noop';
 import classNames from 'classnames';
 
 import {
@@ -28,20 +27,20 @@ import {
 
 import styles from './GeneOverview.scss';
 
-// FIXME:
-// We started using real data from Thoas, and are not yet getting anything that can be rendered
-// in this accordion. When we get back to using this accordion, the type of its props will need updating
+/*  
+  FIXME: 
+  We started using real data from Thoas, and are not yet getting anything that can be rendered in this accordion. 
+  When more data becomes available, please refer to the PR https://github.com/Ensembl/ensembl-client/pull/433
+  and check if some of the deleted code segments can be reused to display the new data.
+*/
+
 export type AccordionSectionID = 'function' | 'sequence' | 'other_data_sets';
 
 const MainAccordion = () => {
-  const hasFunctionDescription = false;
-
-  const sidebarPayload = {} as any;
-
-  const functionAccordionButtonClass = classNames(
+  const disabledAccordionButtonClass = classNames(
     styles.entityViewerAccordionButton,
     {
-      [styles.entityViewerAccordionButtonDisabled]: !hasFunctionDescription
+      [styles.entityViewerAccordionButtonDisabled]: true
     }
   );
 
@@ -57,8 +56,8 @@ const MainAccordion = () => {
         >
           <AccordionItemHeading className={styles.entityViewerAccordionHeader}>
             <AccordionItemButton
-              className={functionAccordionButtonClass}
-              disabled={!hasFunctionDescription}
+              className={disabledAccordionButtonClass}
+              disabled={true}
             >
               Function
             </AccordionItemButton>
@@ -75,7 +74,10 @@ const MainAccordion = () => {
           uuid={'sequence'}
         >
           <AccordionItemHeading className={styles.entityViewerAccordionHeader}>
-            <AccordionItemButton className={styles.entityViewerAccordionButton}>
+            <AccordionItemButton
+              className={disabledAccordionButtonClass}
+              disabled={true}
+            >
               Sequence
             </AccordionItemButton>
           </AccordionItemHeading>
@@ -92,8 +94,8 @@ const MainAccordion = () => {
         >
           <AccordionItemHeading className={styles.entityViewerAccordionHeader}>
             <AccordionItemButton
-              className={styles.entityViewerAccordionButton}
-              disabled={sidebarPayload?.other_data_sets ? false : true}
+              className={disabledAccordionButtonClass}
+              disabled={true}
             >
               Other data sets
             </AccordionItemButton>


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-905

## Description
- This PR brings back the sidebar accordion that got hidden in the PR https://github.com/Ensembl/ensembl-client/pull/422
- We came across the issue where the accordion override styles were not getting applied properly which was fixed by increasing the specificity.
<img width="393" alt="Screenshot 2021-01-12 at 15 12 32" src="https://user-images.githubusercontent.com/3085815/104472768-336a2280-55b4-11eb-884f-71834e48f346.png">



## Deployment URL
http://fix-ev-function-accordion.review.ensembl.org

## Views affected
Entity viewer sidebar

### Other effects

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.
