### PR TITLE
Cleanup ensObjects in entity viewer

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
@@ -27,7 +27,7 @@ import { buildFocusIdForUrl } from 'src/shared/state/ens-object/ensObjectHelpers
 import { getBreakpointWidth } from 'src/global/globalSelectors';
 import {
   getEntityViewerActiveGenomeId,
-  getEntityViewerActiveEnsObjectId
+  getEntityViewerActiveEntityId
 } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors';
 import { isEntityViewerSidebarOpen } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors';
 
@@ -125,7 +125,7 @@ const EntityViewer = (props: Props) => {
 const mapStateToProps = (state: RootState) => {
   return {
     activeGenomeId: getEntityViewerActiveGenomeId(state),
-    activeEntityId: getEntityViewerActiveEnsObjectId(state),
+    activeEntityId: getEntityViewerActiveEntityId(state),
     isSidebarOpen: isEntityViewerSidebarOpen(state),
     viewportWidth: getBreakpointWidth(state)
   };

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.test.tsx
@@ -31,7 +31,7 @@ const mockState = {
   entityViewer: {
     general: {
       activeGenomeId: 'human',
-      activeEnsObjectIds: {
+      activeEntityIds: {
         human: 'gene:brca2'
       }
     },

--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/proteins/geneViewProteinsSelectors.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/proteins/geneViewProteinsSelectors.ts
@@ -16,7 +16,7 @@
 
 import {
   getEntityViewerActiveGenomeId,
-  getEntityViewerActiveEnsObjectId
+  getEntityViewerActiveEntityId
 } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors';
 
 import { RootState } from 'src/store';
@@ -26,7 +26,7 @@ const getSliceForGene = (
   state: RootState
 ): ProteinsStatePerGene | undefined => {
   const activeGenomeId = getEntityViewerActiveGenomeId(state);
-  const activeObjectId = getEntityViewerActiveEnsObjectId(state);
+  const activeObjectId = getEntityViewerActiveEntityId(state);
   if (!activeGenomeId || !activeObjectId) {
     return;
   }

--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/proteins/geneViewProteinsSelectors.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/proteins/geneViewProteinsSelectors.ts
@@ -26,11 +26,11 @@ const getSliceForGene = (
   state: RootState
 ): ProteinsStatePerGene | undefined => {
   const activeGenomeId = getEntityViewerActiveGenomeId(state);
-  const activeObjectId = getEntityViewerActiveEntityId(state);
-  if (!activeGenomeId || !activeObjectId) {
+  const activeEntityId = getEntityViewerActiveEntityId(state);
+  if (!activeGenomeId || !activeEntityId) {
     return;
   }
-  return state.entityViewer.geneView.proteins[activeGenomeId]?.[activeObjectId];
+  return state.entityViewer.geneView.proteins[activeGenomeId]?.[activeEntityId];
 };
 
 export const getExpandedTranscriptIds = (state: RootState): string[] => {

--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/proteins/geneViewProteinsSlice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/proteins/geneViewProteinsSlice.ts
@@ -20,7 +20,7 @@ import { ThunkAction } from 'redux-thunk';
 
 import {
   getEntityViewerActiveGenomeId,
-  getEntityViewerActiveEnsObjectId
+  getEntityViewerActiveEntityId
 } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors';
 import { getExpandedTranscriptIds } from './geneViewProteinsSelectors';
 
@@ -48,8 +48,8 @@ export const toggleExpandedProtein = (
 ) => {
   const state = getState();
   const activeGenomeId = getEntityViewerActiveGenomeId(state);
-  const activeObjectId = getEntityViewerActiveEnsObjectId(state);
-  if (!activeGenomeId || !activeObjectId) {
+  const activeEntityId = getEntityViewerActiveEntityId(state);
+  if (!activeGenomeId || !activeEntityId) {
     return;
   }
 
@@ -63,7 +63,7 @@ export const toggleExpandedProtein = (
   dispatch(
     proteinsSlice.actions.updateExpandedProteins({
       activeGenomeId,
-      activeObjectId,
+      activeEntityId,
       expandedIds: [...expandedIds.values()]
     })
   );
@@ -77,15 +77,15 @@ export const clearExpandedProteins = (): ThunkAction<
 > => (dispatch, getState: () => RootState) => {
   const state = getState();
   const activeGenomeId = getEntityViewerActiveGenomeId(state);
-  const activeObjectId = getEntityViewerActiveEnsObjectId(state);
-  if (!activeGenomeId || !activeObjectId) {
+  const activeEntityId = getEntityViewerActiveEntityId(state);
+  if (!activeGenomeId || !activeEntityId) {
     return;
   }
 
   dispatch(
     proteinsSlice.actions.updateExpandedProteins({
       activeGenomeId,
-      activeObjectId,
+      activeEntityId,
       expandedIds: []
     })
   );
@@ -93,7 +93,7 @@ export const clearExpandedProteins = (): ThunkAction<
 
 type ExpandedProteinsPayload = {
   activeGenomeId: string;
-  activeObjectId: string;
+  activeEntityId: string;
   expandedIds: string[];
 };
 
@@ -105,15 +105,15 @@ const proteinsSlice = createSlice({
       state,
       action: PayloadAction<ExpandedProteinsPayload>
     ) {
-      const { activeGenomeId, activeObjectId, expandedIds } = action.payload;
+      const { activeGenomeId, activeEntityId, expandedIds } = action.payload;
       if (!state[activeGenomeId]) {
         state[activeGenomeId] = {
-          [activeObjectId]: { ...defaultStatePerGene }
+          [activeEntityId]: { ...defaultStatePerGene }
         };
-      } else if (!state[activeGenomeId][activeObjectId]) {
-        state[activeGenomeId][activeObjectId] = { ...defaultStatePerGene };
+      } else if (!state[activeGenomeId][activeEntityId]) {
+        state[activeGenomeId][activeEntityId] = { ...defaultStatePerGene };
       }
-      state[activeGenomeId][activeObjectId].expandedTranscriptIds = expandedIds;
+      state[activeGenomeId][activeEntityId].expandedTranscriptIds = expandedIds;
     }
   }
 });

--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors.ts
@@ -16,7 +16,7 @@
 
 import {
   getEntityViewerActiveGenomeId,
-  getEntityViewerActiveEnsObjectId
+  getEntityViewerActiveEntityId
 } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors';
 
 import { RootState } from 'src/store';
@@ -30,12 +30,12 @@ const getSliceForGene = (
   state: RootState
 ): TranscriptsStatePerGene | undefined => {
   const activeGenomeId = getEntityViewerActiveGenomeId(state);
-  const activeObjectId = getEntityViewerActiveEnsObjectId(state);
-  if (!activeGenomeId || !activeObjectId) {
+  const activeEntityId = getEntityViewerActiveEntityId(state);
+  if (!activeGenomeId || !activeEntityId) {
     return;
   }
   return state.entityViewer.geneView.transcripts[activeGenomeId]?.[
-    activeObjectId
+    activeEntityId
   ];
 };
 

--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
@@ -21,7 +21,7 @@ import set from 'lodash/fp/set';
 
 import {
   getEntityViewerActiveGenomeId,
-  getEntityViewerActiveEnsObjectId
+  getEntityViewerActiveEntityId
 } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors';
 
 import {
@@ -69,14 +69,14 @@ export const setFilters = (
 ) => {
   const state = getState();
   const activeGenomeId = getEntityViewerActiveGenomeId(state);
-  const activeObjectId = getEntityViewerActiveEnsObjectId(state);
-  if (!activeGenomeId || !activeObjectId) {
+  const activeEntityId = getEntityViewerActiveEntityId(state);
+  if (!activeGenomeId || !activeEntityId) {
     return;
   }
   dispatch(
     transcriptsSlice.actions.updateFilters({
       activeGenomeId,
-      activeObjectId,
+      activeEntityId,
       filters
     })
   );
@@ -90,15 +90,15 @@ export const setSortingRule = (
 ) => {
   const state = getState();
   const activeGenomeId = getEntityViewerActiveGenomeId(state);
-  const activeObjectId = getEntityViewerActiveEnsObjectId(state);
-  if (!activeGenomeId || !activeObjectId) {
+  const activeEntityId = getEntityViewerActiveEntityId(state);
+  if (!activeGenomeId || !activeEntityId) {
     return;
   }
 
   dispatch(
     transcriptsSlice.actions.updateSortingRule({
       activeGenomeId,
-      activeObjectId,
+      activeEntityId,
       sortingRule
     })
   );
@@ -112,8 +112,8 @@ export const toggleTranscriptInfo = (
 ) => {
   const state = getState();
   const activeGenomeId = getEntityViewerActiveGenomeId(state);
-  const activeObjectId = getEntityViewerActiveEnsObjectId(state);
-  if (!activeGenomeId || !activeObjectId) {
+  const activeEntityId = getEntityViewerActiveEntityId(state);
+  if (!activeGenomeId || !activeEntityId) {
     return;
   }
 
@@ -127,7 +127,7 @@ export const toggleTranscriptInfo = (
   dispatch(
     transcriptsSlice.actions.updateExpandedTranscripts({
       activeGenomeId,
-      activeObjectId,
+      activeEntityId,
       expandedIds: [...expandedIds.values()]
     })
   );
@@ -141,8 +141,8 @@ export const toggleTranscriptDownload = (
 ) => {
   const state = getState();
   const activeGenomeId = getEntityViewerActiveGenomeId(state);
-  const activeObjectId = getEntityViewerActiveEnsObjectId(state);
-  if (!activeGenomeId || !activeObjectId) {
+  const activeEntityId = getEntityViewerActiveEntityId(state);
+  if (!activeGenomeId || !activeEntityId) {
     return;
   }
 
@@ -156,7 +156,7 @@ export const toggleTranscriptDownload = (
   dispatch(
     transcriptsSlice.actions.updateExpandedDownloads({
       activeGenomeId,
-      activeObjectId,
+      activeEntityId,
       expandedIds: [...expandedIds.values()]
     })
   );
@@ -164,18 +164,18 @@ export const toggleTranscriptDownload = (
 
 const ensureGenePresence = (
   state: GeneViewTranscriptsState,
-  ids: { activeGenomeId: string; activeObjectId: string }
+  ids: { activeGenomeId: string; activeEntityId: string }
 ) => {
-  const { activeGenomeId, activeObjectId } = ids;
+  const { activeGenomeId, activeEntityId } = ids;
   if (!state[activeGenomeId]) {
     return set(
       activeGenomeId,
-      { [activeObjectId]: defaultStatePerGene },
+      { [activeEntityId]: defaultStatePerGene },
       state
     );
-  } else if (!state[activeGenomeId][activeObjectId]) {
+  } else if (!state[activeGenomeId][activeEntityId]) {
     return set(
-      `${activeGenomeId}.${activeObjectId}`,
+      `${activeGenomeId}.${activeEntityId}`,
       defaultStatePerGene,
       state
     );
@@ -186,13 +186,13 @@ const ensureGenePresence = (
 
 type ExpandedIdsPayload = {
   activeGenomeId: string;
-  activeObjectId: string;
+  activeEntityId: string;
   expandedIds: string[];
 };
 
 type UpdateFiltersPayload = {
   activeGenomeId: string;
-  activeObjectId: string;
+  activeEntityId: string;
   filters: {
     [filter: string]: boolean;
   };
@@ -200,7 +200,7 @@ type UpdateFiltersPayload = {
 
 type UpdateSortingRulePayload = {
   activeGenomeId: string;
-  activeObjectId: string;
+  activeEntityId: string;
   sortingRule: SortingRule;
 };
 
@@ -212,37 +212,37 @@ const transcriptsSlice = createSlice({
       state,
       action: PayloadAction<ExpandedIdsPayload>
     ) {
-      const { activeGenomeId, activeObjectId, expandedIds } = action.payload;
+      const { activeGenomeId, activeEntityId, expandedIds } = action.payload;
       const updatedState = ensureGenePresence(state, action.payload);
       return set(
-        `${activeGenomeId}.${activeObjectId}.expandedIds`,
+        `${activeGenomeId}.${activeEntityId}.expandedIds`,
         expandedIds,
         updatedState
       );
     },
     updateExpandedDownloads(state, action: PayloadAction<ExpandedIdsPayload>) {
-      const { activeGenomeId, activeObjectId, expandedIds } = action.payload;
+      const { activeGenomeId, activeEntityId, expandedIds } = action.payload;
       const updatedState = ensureGenePresence(state, action.payload);
       return set(
-        `${activeGenomeId}.${activeObjectId}.expandedDownloadIds`,
+        `${activeGenomeId}.${activeEntityId}.expandedDownloadIds`,
         expandedIds,
         updatedState
       );
     },
     updateFilters(state, action: PayloadAction<UpdateFiltersPayload>) {
-      const { activeGenomeId, activeObjectId, filters } = action.payload;
+      const { activeGenomeId, activeEntityId, filters } = action.payload;
       const updatedState = ensureGenePresence(state, action.payload);
       return set(
-        `${activeGenomeId}.${activeObjectId}.filters`,
+        `${activeGenomeId}.${activeEntityId}.filters`,
         filters,
         updatedState
       );
     },
     updateSortingRule(state, action: PayloadAction<UpdateSortingRulePayload>) {
-      const { activeGenomeId, activeObjectId, sortingRule } = action.payload;
+      const { activeGenomeId, activeEntityId, sortingRule } = action.payload;
       const updatedState = ensureGenePresence(state, action.payload);
       return set(
-        `${activeGenomeId}.${activeObjectId}.sortingRule`,
+        `${activeGenomeId}.${activeEntityId}.sortingRule`,
         sortingRule,
         updatedState
       );

--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/view/geneViewViewSelectors.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/view/geneViewViewSelectors.ts
@@ -16,7 +16,7 @@
 
 import {
   getEntityViewerActiveGenomeId,
-  getEntityViewerActiveEnsObjectId
+  getEntityViewerActiveEntityId
 } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors';
 
 import { RootState } from 'src/store';
@@ -30,7 +30,7 @@ import {
 
 const getSliceForGene = (state: RootState): ViewStatePerGene | undefined => {
   const activeGenomeId = getEntityViewerActiveGenomeId(state);
-  const activeObjectId = getEntityViewerActiveEnsObjectId(state);
+  const activeObjectId = getEntityViewerActiveEntityId(state);
   if (!activeGenomeId || !activeObjectId) {
     return;
   }

--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/view/geneViewViewSlice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/view/geneViewViewSlice.ts
@@ -20,7 +20,7 @@ import { ThunkAction } from 'redux-thunk';
 
 import {
   getEntityViewerActiveGenomeId,
-  getEntityViewerActiveEnsObjectId
+  getEntityViewerActiveEntityId
 } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors';
 
 import { RootState } from 'src/store';
@@ -149,7 +149,7 @@ export const updateView = (
   getState: () => RootState
 ) => {
   const activeGenomeId = getEntityViewerActiveGenomeId(getState());
-  const activeObjectId = getEntityViewerActiveEnsObjectId(getState());
+  const activeObjectId = getEntityViewerActiveEntityId(getState());
   if (!activeGenomeId || !activeObjectId) {
     return;
   }

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralActions.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralActions.ts
@@ -96,7 +96,7 @@ export const setDataFromUrl: ActionCreator<ThunkAction<
 
   if (entityId && genomeIdFromUrl) {
     if (entityId !== activeEntityId) {
-      dispatch(updateEnsObject(entityId));
+      dispatch(updateEntityId(entityId));
     }
 
     entityViewerStorageService.updateGeneralState({
@@ -138,10 +138,10 @@ export const changeActiveGenomeId: ActionCreator<ThunkAction<
 };
 
 export const updateEntityViewerActiveEntityIds = createAction(
-  'entity-viewer/update-active-ens-object-ids'
+  'entity-viewer/update-active-entity-ids'
 )<{ [objectId: string]: string }>();
 
-export const updateEnsObject: ActionCreator<ThunkAction<
+export const updateEntityId: ActionCreator<ThunkAction<
   void,
   any,
   null,

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralActions.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralActions.ts
@@ -137,7 +137,7 @@ export const changeActiveGenomeId: ActionCreator<ThunkAction<
   });
 };
 
-export const updateEntityViewerActiveEntityIds = createAction(
+export const updateActiveEntityForGenome = createAction(
   'entity-viewer/update-active-entity-ids'
 )<{ [objectId: string]: string }>();
 
@@ -161,7 +161,7 @@ export const updateEntityId: ActionCreator<ThunkAction<
 
     const currentEntity = getEntityViewerActiveEntity(state);
 
-    dispatch(updateEntityViewerActiveEntityIds(updatedActiveEntityIds));
+    dispatch(updateActiveEntityForGenome(updatedActiveEntityIds));
     if (!currentEntity) {
       dispatch(fetchEnsObject(activeEntityId));
     }

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralActions.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralActions.ts
@@ -36,7 +36,6 @@ import {
 } from './entityViewerGeneralSelectors';
 import { getGenomeInfoById } from 'src/shared/state/genome/genomeSelectors';
 import { fetchEnsObject } from 'src/shared/state/ens-object/ensObjectActions';
-import { setSidebarInitialStateForGenome } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarActions';
 
 import { fetchGenomeData } from 'src/shared/state/genome/genomeActions';
 import { ensureSpeciesIsEnabled } from 'src/content/app/species-selector/state/speciesSelectorActions';
@@ -99,7 +98,6 @@ export const setDataFromUrl: ActionCreator<ThunkAction<
     if (entityId !== activeEntityId) {
       dispatch(updateEnsObject(entityId));
     }
-    dispatch(setSidebarInitialStateForGenome(genomeIdFromUrl));
 
     entityViewerStorageService.updateGeneralState({
       activeGenomeId: genomeIdFromUrl

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralActions.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralActions.ts
@@ -30,9 +30,9 @@ import entityViewerStorageService from 'src/content/app/entity-viewer/services/e
 import { getCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 import {
   getEntityViewerActiveGenomeId,
-  getEntityViewerActiveEnsObjectIds,
-  getEntityViewerActiveEnsObject,
-  getEntityViewerActiveEnsObjectId
+  getEntityViewerActiveEntityIds,
+  getEntityViewerActiveEntity,
+  getEntityViewerActiveEntityId
 } from './entityViewerGeneralSelectors';
 import { getGenomeInfoById } from 'src/shared/state/genome/genomeSelectors';
 import { fetchEnsObject } from 'src/shared/state/ens-object/ensObjectActions';
@@ -58,7 +58,7 @@ export const setDataFromUrl: ActionCreator<ThunkAction<
   const { genomeId: genomeIdFromUrl } = params;
 
   let activeGenomeId = getEntityViewerActiveGenomeId(state);
-  const activeEntityId = getEntityViewerActiveEnsObjectId(state) || undefined;
+  const activeEntityId = getEntityViewerActiveEntityId(state) || undefined;
 
   const entityIdForUrl = activeEntityId
     ? buildFocusIdForUrl(activeEntityId)
@@ -105,7 +105,7 @@ export const setDataFromUrl: ActionCreator<ThunkAction<
       activeGenomeId: genomeIdFromUrl
     });
     entityViewerStorageService.updateGeneralState({
-      activeEnsObjectIds: { [genomeIdFromUrl]: entityId }
+      activeEntityIds: { [genomeIdFromUrl]: entityId }
     });
   }
 };
@@ -139,7 +139,7 @@ export const changeActiveGenomeId: ActionCreator<ThunkAction<
   });
 };
 
-export const updateEntityViewerActiveEnsObjectIds = createAction(
+export const updateEntityViewerActiveEntityIds = createAction(
   'entity-viewer/update-active-ens-object-ids'
 )<{ [objectId: string]: string }>();
 
@@ -148,24 +148,24 @@ export const updateEnsObject: ActionCreator<ThunkAction<
   any,
   null,
   Action<string>
->> = (activeEnsObjectId: string) => {
+>> = (activeEntityId: string) => {
   return (dispatch, getState: () => RootState) => {
     const state = getState();
     const activeGenomeId = getEntityViewerActiveGenomeId(state);
     if (!activeGenomeId) {
       return;
     }
-    const currentActiveEnsObjectIds = getEntityViewerActiveEnsObjectIds(state);
-    const updatedActiveEnsObjectIds = {
-      ...currentActiveEnsObjectIds,
-      [activeGenomeId]: activeEnsObjectId
+    const currentActiveEntityIds = getEntityViewerActiveEntityIds(state);
+    const updatedActiveEntityIds = {
+      ...currentActiveEntityIds,
+      [activeGenomeId]: activeEntityId
     };
 
-    const currentEnsObject = getEntityViewerActiveEnsObject(state);
+    const currentEntity = getEntityViewerActiveEntity(state);
 
-    dispatch(updateEntityViewerActiveEnsObjectIds(updatedActiveEnsObjectIds));
-    if (!currentEnsObject) {
-      dispatch(fetchEnsObject(activeEnsObjectId));
+    dispatch(updateEntityViewerActiveEntityIds(updatedActiveEntityIds));
+    if (!currentEntity) {
+      dispatch(fetchEnsObject(activeEntityId));
     }
   };
 };

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralActions.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralActions.ts
@@ -31,11 +31,9 @@ import { getCommittedSpecies } from 'src/content/app/species-selector/state/spec
 import {
   getEntityViewerActiveGenomeId,
   getEntityViewerActiveEntityIds,
-  getEntityViewerActiveEntity,
   getEntityViewerActiveEntityId
 } from './entityViewerGeneralSelectors';
 import { getGenomeInfoById } from 'src/shared/state/genome/genomeSelectors';
-import { fetchEnsObject } from 'src/shared/state/ens-object/ensObjectActions';
 
 import { fetchGenomeData } from 'src/shared/state/genome/genomeActions';
 import { ensureSpeciesIsEnabled } from 'src/content/app/species-selector/state/speciesSelectorActions';
@@ -159,11 +157,6 @@ export const updateEntityId: ActionCreator<ThunkAction<
       [activeGenomeId]: activeEntityId
     };
 
-    const currentEntity = getEntityViewerActiveEntity(state);
-
     dispatch(updateActiveEntityForGenome(updatedActiveEntityIds));
-    if (!currentEntity) {
-      dispatch(fetchEnsObject(activeEntityId));
-    }
   };
 };

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralReducer.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralReducer.ts
@@ -33,8 +33,8 @@ export default function entityViewerReducer(
         activeGenomeId: action.payload
       };
     }
-    case getType(actions.updateEntityViewerActiveEnsObjectIds):
-      return { ...state, activeEnsObjectIds: action.payload };
+    case getType(actions.updateEntityViewerActiveEntityIds):
+      return { ...state, activeEntityIds: action.payload };
     default:
       return state;
   }

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralReducer.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralReducer.ts
@@ -33,7 +33,7 @@ export default function entityViewerReducer(
         activeGenomeId: action.payload
       };
     }
-    case getType(actions.updateEntityViewerActiveEntityIds):
+    case getType(actions.updateActiveEntityForGenome):
       return { ...state, activeEntityIds: action.payload };
     default:
       return state;

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors.ts
@@ -23,19 +23,19 @@ import { EnsObjectGene } from 'src/shared/state/ens-object/ensObjectTypes';
 export const getEntityViewerActiveGenomeId = (state: RootState) =>
   state.entityViewer.general.activeGenomeId;
 
-export const getEntityViewerActiveEnsObjectIds = (state: RootState) =>
-  state.entityViewer.general.activeEnsObjectIds;
+export const getEntityViewerActiveEntityIds = (state: RootState) =>
+  state.entityViewer.general.activeEntityIds;
 
-export const getEntityViewerActiveEnsObjectId = (state: RootState) => {
-  const activeEnsObjectIds = getEntityViewerActiveEnsObjectIds(state);
+export const getEntityViewerActiveEntityId = (state: RootState) => {
+  const activeEntityIds = getEntityViewerActiveEntityIds(state);
   const activeGenomeId = getEntityViewerActiveGenomeId(state);
-  return activeGenomeId ? activeEnsObjectIds[activeGenomeId] : null;
+  return activeGenomeId ? activeEntityIds[activeGenomeId] : null;
 };
 
-export const getEntityViewerActiveEnsObject = (
+export const getEntityViewerActiveEntity = (
   state: RootState
 ): EnsObjectGene | null => {
-  const activeObjectId = getEntityViewerActiveEnsObjectId(state);
+  const activeObjectId = getEntityViewerActiveEntityId(state);
   if (!activeObjectId) {
     return null;
   }

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors.ts
@@ -15,10 +15,8 @@
  */
 
 import { RootState } from 'src/store';
-import { getEnsObjectById } from 'src/shared/state/ens-object/ensObjectSelectors';
 
 import { getQueryParamsMap } from 'src/global/globalHelper';
-import { EnsObjectGene } from 'src/shared/state/ens-object/ensObjectTypes';
 
 export const getEntityViewerActiveGenomeId = (state: RootState) =>
   state.entityViewer.general.activeGenomeId;
@@ -30,16 +28,6 @@ export const getEntityViewerActiveEntityId = (state: RootState) => {
   const activeEntityIds = getEntityViewerActiveEntityIds(state);
   const activeGenomeId = getEntityViewerActiveGenomeId(state);
   return activeGenomeId ? activeEntityIds[activeGenomeId] : null;
-};
-
-export const getEntityViewerActiveEntity = (
-  state: RootState
-): EnsObjectGene | null => {
-  const activeObjectId = getEntityViewerActiveEntityId(state);
-  if (!activeObjectId) {
-    return null;
-  }
-  return getEnsObjectById(state, activeObjectId) as EnsObjectGene;
 };
 
 export const getEntityViewerQueryParams = (

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralState.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralState.ts
@@ -18,12 +18,12 @@ import entityViewerStorageService from 'src/content/app/entity-viewer/services/e
 
 export type EntityViewerGeneralState = Readonly<{
   activeGenomeId: string | null;
-  activeEnsObjectIds: { [genomeId: string]: string };
+  activeEntityIds: { [genomeId: string]: string };
 }>;
 
 export const initialState: EntityViewerGeneralState = {
   activeGenomeId: null, // FIXME add entity viewer storage service
-  activeEnsObjectIds: {}
+  activeEntityIds: {}
 };
 
 export const buildInitialState = () => {

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarActions.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarActions.ts
@@ -83,10 +83,6 @@ export const openSidebar = () => toggleSidebar(Status.OPEN);
 
 export const closeSidebar = () => toggleSidebar(Status.CLOSED);
 
-export const setSidebarInitialStateForGenome = createAction(
-  'entity-viewer-sidebar/set-initial-state-for-genome'
-)<string>();
-
 export const updateEntityUIState = createAction(
   'entity-viewer-sidebar/update-entity-ui-state'
 )<{

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarActions.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarActions.ts
@@ -20,7 +20,7 @@ import { ThunkAction } from 'redux-thunk';
 
 import {
   getEntityViewerActiveGenomeId,
-  getEntityViewerActiveEnsObjectId
+  getEntityViewerActiveEntityId
 } from '../general/entityViewerGeneralSelectors';
 import { isEntityViewerSidebarOpen } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors';
 
@@ -106,7 +106,7 @@ export const updateEntityUI: ActionCreator<ThunkAction<
 ) => {
   const state = getState();
   const genomeId = getEntityViewerActiveGenomeId(state);
-  const entityId = getEntityViewerActiveEnsObjectId(state);
+  const entityId = getEntityViewerActiveEntityId(state);
 
   if (!genomeId || !entityId) {
     return;

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarReducer.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarReducer.ts
@@ -22,7 +22,7 @@ import get from 'lodash/get';
 import * as actions from './entityViewerSidebarActions';
 
 import {
-  buildInitialStateForGenome,
+  buildInitialSidebarStateForGenome,
   EntityViewerSidebarState
 } from './entityViewerSidebarState';
 import JSONValue from 'src/shared/types/JSON';
@@ -37,7 +37,7 @@ export default function entityViewerSidebarReducer(
       const oldStateFragment = get(
         state,
         `${genomeId}`,
-        buildInitialStateForGenome()
+        buildInitialSidebarStateForGenome()
       );
       const updatedStateFragment = merge(
         {},

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarReducer.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarReducer.ts
@@ -20,7 +20,6 @@ import mergeWith from 'lodash/mergeWith';
 import get from 'lodash/get';
 
 import * as actions from './entityViewerSidebarActions';
-// import * as generalActions from '../general/entityViewerGeneralActions';
 
 import {
   buildInitialStateForGenome,

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarReducer.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarReducer.ts
@@ -20,7 +20,7 @@ import mergeWith from 'lodash/mergeWith';
 import get from 'lodash/get';
 
 import * as actions from './entityViewerSidebarActions';
-import * as generalActions from '../general/entityViewerGeneralActions';
+// import * as generalActions from '../general/entityViewerGeneralActions';
 
 import {
   buildInitialStateForGenome,
@@ -30,19 +30,16 @@ import JSONValue from 'src/shared/types/JSON';
 
 export default function entityViewerSidebarReducer(
   state: EntityViewerSidebarState = {},
-  action: ActionType<typeof actions | typeof generalActions>
+  action: ActionType<typeof actions>
 ) {
   switch (action.type) {
-    case getType(generalActions.setActiveGenomeId):
-      const genomeId = action.payload;
-      return state[genomeId]
-        ? state
-        : {
-            ...state,
-            ...buildInitialStateForGenome(action.payload)
-          };
     case getType(actions.updateGenomeState): {
-      const oldStateFragment = get(state, `${action.payload.genomeId}`);
+      const { genomeId } = action.payload;
+      const oldStateFragment = get(
+        state,
+        `${genomeId}`,
+        buildInitialStateForGenome()
+      );
       const updatedStateFragment = merge(
         {},
         oldStateFragment,

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarReducer.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarReducer.ts
@@ -20,6 +20,7 @@ import mergeWith from 'lodash/mergeWith';
 import get from 'lodash/get';
 
 import * as actions from './entityViewerSidebarActions';
+import * as generalActions from '../general/entityViewerGeneralActions';
 
 import {
   buildInitialStateForGenome,
@@ -29,11 +30,12 @@ import JSONValue from 'src/shared/types/JSON';
 
 export default function entityViewerSidebarReducer(
   state: EntityViewerSidebarState = {},
-  action: ActionType<typeof actions>
+  action: ActionType<typeof actions | typeof generalActions>
 ) {
   switch (action.type) {
-    case getType(actions.setSidebarInitialStateForGenome):
-      return state[action.payload]
+    case getType(generalActions.setActiveGenomeId):
+      const genomeId = action.payload;
+      return state[genomeId]
         ? state
         : {
             ...state,

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors.ts
@@ -16,7 +16,7 @@
 
 import {
   getEntityViewerActiveGenomeId,
-  getEntityViewerActiveEnsObjectId
+  getEntityViewerActiveEntityId
 } from '../general/entityViewerGeneralSelectors';
 
 import { Status } from 'src/shared/types/status';
@@ -33,7 +33,7 @@ export const getEntityViewerGenomeState = (state: RootState) => {
 };
 
 export const getEntityViewerSidebarUIState = (state: RootState) => {
-  const activeEntityId = getEntityViewerActiveEnsObjectId(state);
+  const activeEntityId = getEntityViewerActiveEntityId(state);
   return activeEntityId
     ? getEntityViewerGenomeState(state)?.entities[activeEntityId]?.uIState ||
         null
@@ -41,14 +41,14 @@ export const getEntityViewerSidebarUIState = (state: RootState) => {
 };
 
 export const getEntityViewerSidebarTabName = (state: RootState) => {
-  const activeEntityId = getEntityViewerActiveEnsObjectId(state);
+  const activeEntityId = getEntityViewerActiveEntityId(state);
   return activeEntityId
     ? getEntityViewerGenomeState(state)?.selectedTabName || null
     : null;
 };
 
 export const isEntityViewerSidebarOpen = (state: RootState): boolean => {
-  const activeEntityId = getEntityViewerActiveEnsObjectId(state);
+  const activeEntityId = getEntityViewerActiveEntityId(state);
   return activeEntityId
     ? getEntityViewerGenomeState(state)?.status === Status.OPEN
     : false;

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarState.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarState.ts
@@ -44,7 +44,7 @@ export type EntityViewerSidebarGenomeState = Readonly<{
   };
 }>;
 
-export const buildInitialStateForGenome = (): EntityViewerSidebarGenomeState => {
+export const buildInitialSidebarStateForGenome = (): EntityViewerSidebarGenomeState => {
   return {
     status: Status.OPEN,
     selectedTabName: SidebarTabName.OVERVIEW,

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarState.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarState.ts
@@ -44,14 +44,10 @@ export type EntityViewerSidebarGenomeState = Readonly<{
   };
 }>;
 
-export const buildInitialStateForGenome = (
-  genomeId: string
-): EntityViewerSidebarState => {
+export const buildInitialStateForGenome = (): EntityViewerSidebarGenomeState => {
   return {
-    [genomeId]: {
-      status: Status.OPEN,
-      selectedTabName: SidebarTabName.OVERVIEW,
-      entities: {}
-    }
+    status: Status.OPEN,
+    selectedTabName: SidebarTabName.OVERVIEW,
+    entities: {}
   };
 };


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-928


## Description
- Cleaned up entity viewer variables and function names to use `entityId` instead of `ensObject`.
- Removed the dedicated action to create the sidebar initial state
- Note that I have also changed the key value that was used to store the data in the localstorage which means that some unused data will remain permanently for users who have already used entity viewer (Unless they clear the cache).

NOTE: I haven't updated any tests in this PR but I'm happy to do that in a separate PR.

## Deployment URL
http://ev-ensobject-cleanup.review.ensembl.org

## Views affected
Entity viewer

### Other effects

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.
