### PR TITLE
Remove REST call to fetch UniProt ID

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -126,6 +126,7 @@ const QUERY = gql`
             length
             external_references {
               accession_id
+              name
               description
               source {
                 id

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/protein-list-constants.ts
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/protein-list-constants.ts
@@ -1,0 +1,17 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const SWISSPROT_SOURCE = 'Uniprot/SWISSPROT';

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
@@ -39,6 +39,8 @@ import { LoadingState } from 'src/shared/types/loading-state';
 import { Transcript } from 'src/content/app/entity-viewer/types/transcript';
 import { ProteinDomain } from 'src/content/app/entity-viewer/types/product';
 
+import { SWISSPROT_SOURCE } from '../protein-list-constants';
+
 import styles from './ProteinsListItemInfo.scss';
 import settings from 'src/content/app/entity-viewer/gene-view/styles/_constants.scss';
 
@@ -90,7 +92,7 @@ const ProteinsListItemInfo = (props: Props) => {
     transcriptWithProteinDomains?.product_generating_contexts[0] || {};
 
   const uniprotXref = product?.external_references.find(
-    (xref) => xref.source.id == 'Uniprot/SWISSPROT'
+    (xref) => xref.source.id == SWISSPROT_SOURCE
   );
 
   useEffect(() => {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
@@ -92,7 +92,7 @@ const ProteinsListItemInfo = (props: Props) => {
     transcriptWithProteinDomains?.product_generating_contexts[0] || {};
 
   const uniprotXref = product?.external_references.find(
-    (xref) => xref.source.id == SWISSPROT_SOURCE
+    (xref) => xref.source.id === SWISSPROT_SOURCE
   );
 
   useEffect(() => {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item/ProteinsListItem.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item/ProteinsListItem.tsx
@@ -31,10 +31,10 @@ import { TranscriptQualityLabel } from 'src/content/app/entity-viewer/shared/com
 import { Transcript } from 'src/content/app/entity-viewer/types/transcript';
 import { View } from 'src/content/app/entity-viewer/state/gene-view/view/geneViewViewSlice';
 
+import { SWISSPROT_SOURCE } from '../protein-list-constants';
+
 import transcriptsListStyles from 'src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.scss';
 import styles from './ProteinsListItem.scss';
-
-const SWISSPROT_SOURCE = 'Uniprot/SWISSPROT';
 
 type Props = {
   transcript: Transcript;

--- a/src/ensembl/src/content/app/entity-viewer/shared/rest/rest-data-fetchers/proteinData.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/rest/rest-data-fetchers/proteinData.ts
@@ -18,13 +18,6 @@ import apiService from 'src/services/api-service';
 
 import { restProteinSummaryAdaptor } from '../rest-adaptors/rest-protein-adaptor';
 
-export type Xref = {
-  primary_id: string;
-  display_id: string;
-};
-
-export type XrefsInResponse = Xref[];
-
 export type ProteinStatsInResponse = {
   pdbs: number;
   ligands: number;
@@ -49,25 +42,6 @@ export type ProteinStats = {
   ligandsCount: number;
   interactionsCount: number;
   annotationsCount: number;
-};
-
-export const fetchXrefId = async (
-  proteinId: string,
-  signal?: AbortSignal
-): Promise<Xref | undefined> => {
-  const xrefsUrl = `https://rest.ensembl.org/xrefs/id/${proteinId}?content-type=application/json;external_db=Uniprot/SWISSPROT`;
-  const xrefsData: XrefsInResponse | undefined = await apiService.fetch(
-    xrefsUrl,
-    {
-      signal
-    }
-  );
-
-  if (!xrefsData) {
-    return undefined;
-  }
-
-  return xrefsData[0];
 };
 
 export const fetchProteinSummaryStats = async (


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-908

http://remove-rest-for-pdblinks.review.ensembl.org/

## Description
No REST needed for fetching Uniprot/SWISSPROT id, use data that is retrieved from Thoas.

## Views affected
Entity Viewer - Gene function
