### PR TITLE
ENSWBSITES-871: selected label rearrange when sorting apply

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
 import { getFeatureCoordinates } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
-import { transcriptSortingFunctions } from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
+import {
+  transcriptSortingFunctions,
+  defaultSort
+} from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
 
 import {
   getExpandedTranscriptIds,
@@ -57,6 +60,12 @@ const DefaultTranscriptslist = (props: Props) => {
   const dispatch = useDispatch();
 
   const { gene } = props;
+
+  //Using this to get the default order of transcripts in which the first one is selected, this might change later with the data coming directly from thoas
+  const defaultTranscriptId = useMemo(() => {
+    const sortedTranscripts = defaultSort(gene.transcripts);
+    return sortedTranscripts[0].stable_id;
+  }, [gene.stable_id]);
 
   const sortingFunction = transcriptSortingFunctions[sortingRule];
   const sortedTranscripts = sortingFunction(gene.transcripts) as Transcript[];
@@ -119,7 +128,9 @@ const DefaultTranscriptslist = (props: Props) => {
           return (
             <DefaultTranscriptsListItem
               key={index}
-              isDefault={index === 0}
+              isDefault={
+                transcript.stable_id === defaultTranscriptId ? true : false
+              }
               gene={gene}
               transcript={transcript}
               rulerTicks={props.rulerTicks}


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-871

## Importance
n/a

## Description
The selected label on the transcript image in Entity Viewer doesnt can reposition accordingly when you apply a sorting. It always stays at the top. The expected behavior is it should be next to the same transcript after sorting.

## Deployment URL
http://selected-label-fix.review.ensembl.org/

## Views affected
Entity viewer Transcript Image

### Other effects
None

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
None
