### PR TITLE
Add no-unneeded-ternary rule to ESLint

### DIFF
--- a/src/ensembl/.eslintrc.js
+++ b/src/ensembl/.eslintrc.js
@@ -29,7 +29,8 @@ module.exports = {
     'react/no-unescaped-entities': 0,
     'react-hooks/rules-of-hooks': 2,
     'prettier/prettier': 0,
-    'no-unused-vars': ['warn', { args: 'after-used' }]
+    'no-unused-vars': ['warn', { args: 'after-used' }],
+    'no-unneeded-ternary': 'error'
   },
   settings: {
     react: {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -128,9 +128,7 @@ const DefaultTranscriptslist = (props: Props) => {
           return (
             <DefaultTranscriptsListItem
               key={index}
-              isDefault={
-                transcript.stable_id === defaultTranscriptId ? true : false
-              }
+              isDefault={transcript.stable_id === defaultTranscriptId}
               gene={gene}
               transcript={transcript}
               rulerTicks={props.rulerTicks}


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Description
We should avoid using unnecessary ternary operators when the boolean result can be obtained via three equals (`===`) itself.  For example:
```
// an unnecessary ternary operator usage
transcript.stable_id === defaultTranscriptId ? true : false

// the above can be simply written as this to get the boolean value
transcript.stable_id === defaultTranscriptId
```

This PR adds the `no-unneeded-ternary` rule to `.eslint.js`, so that the linter complains when it sees it again.
