### PR TITLE
Add padding to the right of contextual help article to show the scrollbar

### DIFF
--- a/src/ensembl/src/shared/components/help-popup/HelpPopupBody.scss
+++ b/src/ensembl/src/shared/components/help-popup/HelpPopupBody.scss
@@ -2,6 +2,7 @@
 
 $heading-outdent: 16px;
 $aside-left-padding: 1.6rem;
+$article-right-padding: 1.5rem; // area over which Macs (which hide their scrollbars by default) will display the scrollbar
 
 .spinnerContainer {
   height: 100%;
@@ -16,7 +17,7 @@ $aside-left-padding: 1.6rem;
   height: 100%;
 
   &_article {
-    grid-template-columns: [article] 440px [empty] 1fr [aside] minmax(200px, 300px);
+    grid-template-columns: [article] calc(440px + #{$article-right-padding}) [empty] 1fr [aside] minmax(200px, 300px);
   }
 
   &_video {
@@ -28,6 +29,7 @@ $aside-left-padding: 1.6rem;
 .article {
   grid-column: article;
   padding-left: $heading-outdent;
+  padding-right: $article-right-padding;
   overflow-y: auto;
 
   h1 {


### PR DESCRIPTION
## Type
- Bug fix

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-893

## Description
On Macs, the default scrollbar behaviour is to hide the scrollbar and then to show it only when the container gets scrolled, overlaying the scrollbar over the appropriate edge (right or bottom) of the scrollable container.

Therefore, on Macs with this setting enabled, the scrollbar when scrolling the article in the contextual help popup will appear on top of the article's text, like so:

![image](https://user-images.githubusercontent.com/6834224/105365970-b9125180-5bf6-11eb-86aa-b10a0471c912.png)

This PR adds a right padding to the article container, while also expanding the width of this container by the same distance, so that the width of the text doesn't change:

![image](https://user-images.githubusercontent.com/6834224/105366256-08588200-5bf7-11eb-9971-a615cc145598.png)