### PR TITLE
Reorder protein list when transcripts are ordered

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/ProteinsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/ProteinsList.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useLocation } from 'react-router';
 
@@ -24,12 +24,17 @@ import {
   getLongestProteinLength,
   isProteinCodingTranscript
 } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
-import { defaultSort } from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
+import {
+  transcriptSortingFunctions,
+  defaultSort
+} from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
 
 import { toggleExpandedProtein } from 'src/content/app/entity-viewer/state/gene-view/proteins/geneViewProteinsSlice';
 import { getExpandedTranscriptIds } from 'src/content/app/entity-viewer/state/gene-view/proteins/geneViewProteinsSelectors';
+import { getSortingRule } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors';
 
 import { Gene } from 'src/content/app/entity-viewer/types/gene';
+import { Transcript } from 'src/content/app/entity-viewer/types/transcript';
 
 import styles from './ProteinsList.scss';
 
@@ -42,8 +47,17 @@ const ProteinsList = (props: ProteinsListProps) => {
   const dispatch = useDispatch();
   const { search } = useLocation();
   const proteinIdToFocus = new URLSearchParams(search).get('protein_id');
+  const defaultTranscriptId = useMemo(() => {
+    const defaultTranscripts = defaultSort(props.gene.transcripts);
+    return defaultTranscripts[0].stable_id;
+  }, [props.gene.stable_id]);
 
-  const sortedTranscripts = defaultSort(props.gene.transcripts);
+  const sortingRule = useSelector(getSortingRule);
+
+  const sortingFunction = transcriptSortingFunctions[sortingRule];
+  const sortedTranscripts = sortingFunction(
+    props.gene.transcripts
+  ) as Transcript[];
   const proteinCodingTranscripts = sortedTranscripts.filter(
     isProteinCodingTranscript
   );
@@ -63,10 +77,10 @@ const ProteinsList = (props: ProteinsListProps) => {
 
   return (
     <div className={styles.proteinsList}>
-      {proteinCodingTranscripts.map((transcript, index) => (
+      {proteinCodingTranscripts.map((transcript) => (
         <ProteinsListItem
           key={transcript.stable_id}
-          isDefault={index == 0}
+          isDefault={transcript.stable_id === defaultTranscriptId}
           transcript={transcript}
           trackLength={longestProteinLength}
         />


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
[ENSWBSITES-747](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-747)

## Importance
n/a

## Description
Reordering the transcripts in the protein list Under Gene Function in EV when we apply a sorting on the transcripts in the transcripts image. The order should be reflected across. 
Also moving the selected label (same as we did in https://github.com/Ensembl/ensembl-client/pull/441)

## Deployment URL
http://protein-order.review.ensembl.org/

## Views affected
Protein view in Entity Viewer (Under Gene Functions Tab)

### Other effects
none

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
none