### PR TITLE
Improve sort and filter indicator for transcripts list

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -104,7 +104,7 @@ const DefaultTranscriptslist = (props: Props) => {
       <div className={styles.header}>
         {isFilterOpen && (
           <TranscriptsFilter
-            filterLabel={filterLabel}
+            label={filterLabel}
             toggleFilter={toggleFilter}
             transcripts={sortedTranscripts}
           />

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -93,6 +93,7 @@ const DefaultTranscriptslist = (props: Props) => {
       <div className={styles.header}>
         {isFilterOpen && (
           <TranscriptsFilter
+            shouldShowFilterIndicator={shouldShowFilterIndicator}
             toggleFilter={toggleFilter}
             transcripts={sortedTranscripts}
           />

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -16,6 +16,7 @@
 
 import React, { useState, useEffect, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import classNames from 'classnames';
 
 import { getFeatureCoordinates } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
 import {
@@ -84,6 +85,16 @@ const DefaultTranscriptslist = (props: Props) => {
   const shouldShowFilterIndicator =
     sortingRule !== SortingRule.DEFAULT || Object.values(filters).some(Boolean);
 
+  const filterLabel = (
+    <span
+      className={classNames({
+        [styles.labelWithActivityIndicator]: shouldShowFilterIndicator
+      })}
+    >
+      Filter & sort
+    </span>
+  );
+
   const toggleFilter = () => {
     setFilterOpen(!isFilterOpen);
   };
@@ -93,7 +104,7 @@ const DefaultTranscriptslist = (props: Props) => {
       <div className={styles.header}>
         {isFilterOpen && (
           <TranscriptsFilter
-            shouldShowFilterIndicator={shouldShowFilterIndicator}
+            filterLabel={filterLabel}
             toggleFilter={toggleFilter}
             transcripts={sortedTranscripts}
           />
@@ -101,15 +112,7 @@ const DefaultTranscriptslist = (props: Props) => {
         <div className={styles.row}>
           {gene.transcripts.length > 5 && !isFilterOpen && (
             <div className={styles.filterLabel} onClick={toggleFilter}>
-              <span
-                className={
-                  shouldShowFilterIndicator
-                    ? styles.labelWithActivityIndicator
-                    : undefined
-                }
-              >
-                Filter & sort
-              </span>
+              {filterLabel}
               <ChevronDown className={styles.chevron} />
             </div>
           )}

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.test.tsx
@@ -77,14 +77,16 @@ const defaultTranscripts = [
 ];
 
 const mockToggleFilter = jest.fn();
+let store: ReturnType<typeof mockStore>;
 
 const wrapInRedux = (
   state: typeof mockState = mockState,
   transcripts = defaultTranscripts
 ) => {
   const filterLabel = <span>Filter & sort</span>;
+  store = mockStore(state);
   return mount(
-    <Provider store={mockStore(state)}>
+    <Provider store={store}>
       <TranscriptsFilter
         filterLabel={filterLabel}
         transcripts={transcripts}
@@ -123,7 +125,6 @@ describe('<TranscriptsFilter />', () => {
   });
 
   it('correctly handles sorting order change', () => {
-    const store = mockStore(mockState);
     const wrapper = wrapInRedux();
     const radioGroup = wrapper.find(RadioGroup);
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.test.tsx
@@ -82,9 +82,11 @@ const wrapInRedux = (
   state: typeof mockState = mockState,
   transcripts = defaultTranscripts
 ) => {
+  const filterLabel = <span>Filter & sort</span>;
   return mount(
     <Provider store={mockStore(state)}>
       <TranscriptsFilter
+        filterLabel={filterLabel}
         transcripts={transcripts}
         toggleFilter={mockToggleFilter}
       />
@@ -122,14 +124,7 @@ describe('<TranscriptsFilter />', () => {
 
   it('correctly handles sorting order change', () => {
     const store = mockStore(mockState);
-    const wrapper = mount(
-      <Provider store={store}>
-        <TranscriptsFilter
-          transcripts={defaultTranscripts}
-          toggleFilter={mockToggleFilter}
-        />
-      </Provider>
-    );
+    const wrapper = wrapInRedux();
     const radioGroup = wrapper.find(RadioGroup);
 
     const onRadioChange = radioGroup.prop('onChange');

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
@@ -40,9 +40,11 @@ import { ReactComponent as ChevronUp } from 'static/img/shared/chevron-up.svg';
 
 import { Transcript } from 'src/content/app/entity-viewer/types/transcript';
 
+import transcriptListStyles from '../default-transcripts-list/DefaultTranscriptsList.scss';
 import styles from './TranscriptsFilter.scss';
 
 type Props = {
+  shouldShowFilterIndicator: boolean;
   transcripts: Transcript[];
   toggleFilter: () => void;
 };
@@ -124,7 +126,15 @@ const TranscriptsFilter = (props: Props) => {
   return (
     <div className={styles.container}>
       <div className={styles.filterLabel} onClick={props.toggleFilter}>
-        Filter & sort
+        <span
+          className={
+            props.shouldShowFilterIndicator
+              ? transcriptListStyles.labelWithActivityIndicator
+              : undefined
+          }
+        >
+          Filter & sort
+        </span>
         <ChevronUp className={styles.chevron} />
       </div>
       <div className={filterBoxClassnames}>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
@@ -43,7 +43,7 @@ import { Transcript } from 'src/content/app/entity-viewer/types/transcript';
 import styles from './TranscriptsFilter.scss';
 
 type Props = {
-  filterLabel: ReactNode;
+  label: ReactNode;
   transcripts: Transcript[];
   toggleFilter: () => void;
 };
@@ -125,7 +125,7 @@ const TranscriptsFilter = (props: Props) => {
   return (
     <div className={styles.container}>
       <div className={styles.filterLabel} onClick={props.toggleFilter}>
-        {props.filterLabel}
+        {props.label}
         <ChevronUp className={styles.chevron} />
       </div>
       <div className={filterBoxClassnames}>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect } from 'react';
+import React, { ReactNode, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import classNames from 'classnames';
 
@@ -40,11 +40,10 @@ import { ReactComponent as ChevronUp } from 'static/img/shared/chevron-up.svg';
 
 import { Transcript } from 'src/content/app/entity-viewer/types/transcript';
 
-import transcriptListStyles from '../default-transcripts-list/DefaultTranscriptsList.scss';
 import styles from './TranscriptsFilter.scss';
 
 type Props = {
-  shouldShowFilterIndicator: boolean;
+  filterLabel: ReactNode;
   transcripts: Transcript[];
   toggleFilter: () => void;
 };
@@ -126,15 +125,7 @@ const TranscriptsFilter = (props: Props) => {
   return (
     <div className={styles.container}>
       <div className={styles.filterLabel} onClick={props.toggleFilter}>
-        <span
-          className={
-            props.shouldShowFilterIndicator
-              ? transcriptListStyles.labelWithActivityIndicator
-              : undefined
-          }
-        >
-          Filter & sort
-        </span>
+        {props.filterLabel}
         <ChevronUp className={styles.chevron} />
       </div>
       <div className={filterBoxClassnames}>


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
[ENSWBSITES-944](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-944)

## Description
Sort and filter indicator for transcripts list in EV appears only after it is closed. This is not the ideal behaviour, so this PR makes it appear immediately when a change is made to the sort/filter.

## Deployment URL
http://transcript-filter-indicator.review.ensembl.org/

## Views affected
Entity viewer -> Transcripts list -> Sort and filter