### PR TITLE
Use the common 'api/' namespace for different api endpoints

### DIFF
--- a/src/ensembl/src/content/app/browser/browserActions.ts
+++ b/src/ensembl/src/content/app/browser/browserActions.ts
@@ -84,7 +84,7 @@ export const activateBrowser = () => {
     const host = config.apiHost || currentHost;
 
     const payload = {
-      'config-url': `${protocol}${host}/browser/config`,
+      'config-url': `${protocol}${host}/api/browser/config`,
       key: 'main', // TODO: remove this field after we confirmed that it is redundant
       selector: `#${BROWSER_CONTAINER_ID}`
     };

--- a/src/ensembl/src/content/app/browser/browserHelper.ts
+++ b/src/ensembl/src/content/app/browser/browserHelper.ts
@@ -176,7 +176,7 @@ export const validateRegion = async (params: {
 
   if (genomeId) {
     try {
-      const url = `/api/genome/region/validate?genome_id=${genomeId}&region=${regionInput}`;
+      const url = `/api/genomesearch/genome/region/validate?genome_id=${genomeId}&region=${regionInput}`;
       const response: RegionValidationResponse = await apiService.fetch(url);
       const regionId = buildEnsObjectId({
         genomeId,

--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorActions.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorActions.ts
@@ -208,7 +208,7 @@ export const fetchAssemblies: ActionCreator<ThunkAction<
   try {
     dispatch(fetchAssembliesAsyncActions.request());
 
-    const url = `/api/alternative_assemblies?genome_id=${genomeId}`;
+    const url = `/api/genomesearch/alternative_assemblies?genome_id=${genomeId}`;
     const response = await apiService.fetch(url, { preserveEndpoint: true });
 
     dispatch(
@@ -230,7 +230,7 @@ export const fetchPopularSpecies: ActionCreator<ThunkAction<
   try {
     dispatch(fetchPopularSpeciesAsyncActions.request());
 
-    const url = '/api/popular_genomes';
+    const url = '/api/genomesearch/popular_genomes';
     const response = await apiService.fetch(url);
 
     dispatch(

--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorEpics.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorEpics.ts
@@ -68,7 +68,7 @@ export const fetchSpeciesSearchResultsEpic: Epic<Action, Action, RootState> = (
         limit: 20,
         exclude: committedSpeciesIds
       });
-      const url = `/api/genome_search?${query}`;
+      const url = `/api/genomesearch/genome_search?${query}`;
       return observableApiService.fetch(url);
     }),
     map((response) => {

--- a/src/ensembl/src/gql-client.ts
+++ b/src/ensembl/src/gql-client.ts
@@ -17,7 +17,7 @@
 import { ApolloClient, InMemoryCache } from '@apollo/client';
 
 export const client = new ApolloClient({
-  uri: '/thoas',
+  uri: '/api/thoas',
   cache: new InMemoryCache({
     typePolicies: {
       Gene: {

--- a/src/ensembl/src/shared/components/help-popup/useHelpArticle.ts
+++ b/src/ensembl/src/shared/components/help-popup/useHelpArticle.ts
@@ -69,7 +69,7 @@ const useHelpArticle = (reference: ArticleReference | VideoReference) => {
   );
 
   const query = reference.type === 'article' ? getQuery(reference) : null;
-  const url = query ? `/help-api/article?${query}` : '';
+  const url = query ? `/api/docs/article?${query}` : '';
 
   const { data: article, loadingState } = useApiService<HelpArticle>({
     endpoint: url,

--- a/src/ensembl/src/shared/components/instant-download/instant-download-fetch/fetchForProtein.ts
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-fetch/fetchForProtein.ts
@@ -75,5 +75,5 @@ const buildFetchUrl = (
   ] as keyof TranscriptChecksums;
   const checksum = productGeneratingContext[contextType]?.sequence_checksum;
 
-  return `/refget/sequence/${checksum}?accept=text/x-fasta`;
+  return `/api/refget/sequence/${checksum}?accept=text/x-fasta`;
 };

--- a/src/ensembl/src/shared/components/instant-download/instant-download-fetch/fetchForTranscript.ts
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-fetch/fetchForTranscript.ts
@@ -105,6 +105,6 @@ const buildFetchUrl = (
     const checksum =
       data.checksums && data.checksums[contextType]?.sequence_checksum;
 
-    return `/refget/sequence/${checksum}?accept=text/x-fasta`;
+    return `/api/refget/sequence/${checksum}?accept=text/x-fasta`;
   }
 };

--- a/src/ensembl/src/shared/state/ens-object/ensObjectActions.ts
+++ b/src/ensembl/src/shared/state/ens-object/ensObjectActions.ts
@@ -71,8 +71,8 @@ export const fetchEnsObject = (
     dispatch(fetchEnsObjectAsyncActions.request(ensObjectId));
     const { genomeId, objectId, type } = payload;
 
-    const objectInfoUrl = `/api/object/info?genome_id=${genomeId}&type=${type}&stable_id=${objectId}`;
-    const objectTracksUrl = `/api/object/track_list?genome_id=${genomeId}&type=${type}&stable_id=${objectId}`;
+    const objectInfoUrl = `/api/genomesearch/object/info?genome_id=${genomeId}&type=${type}&stable_id=${objectId}`;
+    const objectTracksUrl = `/api/genomesearch/object/track_list?genome_id=${genomeId}&type=${type}&stable_id=${objectId}`;
     const response: EnsObjectResponse = await apiService.fetch(objectInfoUrl);
     response.object_id = buildEnsObjectId(payload);
 

--- a/src/ensembl/src/shared/state/genome/genomeActions.ts
+++ b/src/ensembl/src/shared/state/genome/genomeActions.ts
@@ -68,7 +68,7 @@ export const fetchGenomeInfo: ActionCreator<ThunkAction<
   }
   try {
     dispatch(fetchGenomeInfoAsyncActions.request());
-    const url = `/api/genome/info?genome_id=${genomeId}`;
+    const url = `/api/genomesearch/genome/info?genome_id=${genomeId}`;
     const response = await apiService.fetch(url);
 
     dispatch(
@@ -108,7 +108,7 @@ export const fetchGenomeTrackCategories: ActionCreator<ThunkAction<
 
     dispatch(fetchGenomeTrackCategoriesAsyncActions.request(genomeId));
 
-    const url = `/api/genome/track_categories?genome_id=${genomeId}`;
+    const url = `/api/genomesearch/genome/track_categories?genome_id=${genomeId}`;
     const response = await apiService.fetch(url);
     updatedGenomeTrackCategories[genomeId] = response.track_categories;
 
@@ -145,7 +145,7 @@ export const fetchGenomeKaryotype: ActionCreator<ThunkAction<
 
     dispatch(fetchGenomeKaryotypeAsyncActions.request(genomeId));
 
-    const url = `/api/genome/karyotype?genome_id=${genomeId}`;
+    const url = `/api/genomesearch/genome/karyotype?genome_id=${genomeId}`;
     const response = await apiService.fetch(url);
 
     dispatch(

--- a/src/ensembl/webpack/environments/webpack.config.dev.js
+++ b/src/ensembl/webpack/environments/webpack.config.dev.js
@@ -32,7 +32,7 @@ const devServerConfig = {
   // rules to proxy requests to the backend server in development
   proxy: {
     '/api': {
-      target: 'http://api-prefix.review.ensembl.org',
+      target: 'https://staging-2020.ensembl.org',
       changeOrigin: true,
       secure: false
     }

--- a/src/ensembl/webpack/environments/webpack.config.dev.js
+++ b/src/ensembl/webpack/environments/webpack.config.dev.js
@@ -35,11 +35,6 @@ const devServerConfig = {
       target: 'http://api-prefix.review.ensembl.org',
       changeOrigin: true,
       secure: false
-    },
-    '/help-api': {
-      target: 'https://staging-2020.ensembl.org',
-      changeOrigin: true,
-      secure: false
     }
   },
 

--- a/src/ensembl/webpack/environments/webpack.config.dev.js
+++ b/src/ensembl/webpack/environments/webpack.config.dev.js
@@ -32,26 +32,11 @@ const devServerConfig = {
   // rules to proxy requests to the backend server in development
   proxy: {
     '/api': {
-      target: 'https://staging-2020.ensembl.org',
-      changeOrigin: true,
-      secure: false
-    },
-    '/browser': {
-      target: 'https://staging-2020.ensembl.org',
-      changeOrigin: true,
-      secure: false
-    },
-    '/thoas': {
-      target: 'https://staging-2020.ensembl.org',
+      target: 'http://api-prefix.review.ensembl.org',
       changeOrigin: true,
       secure: false
     },
     '/help-api': {
-      target: 'https://staging-2020.ensembl.org',
-      changeOrigin: true,
-      secure: false
-    },
-    '/refget': {
       target: 'https://staging-2020.ensembl.org',
       changeOrigin: true,
       secure: false


### PR DESCRIPTION
## Related JIRA Issue(s)
Frontend changes to support the BE ticket https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-978

## Description
Access to different api services is being unified under the /api namespace.

## Deployment URL
http://api-prefix.review.ensembl.org