### PR TITLE
Enable Entity Viewer in production

### DIFF
--- a/src/ensembl/src/content/app/browser/browser-app-bar/BrowserAppBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-app-bar/BrowserAppBar.tsx
@@ -66,7 +66,7 @@ const BrowserAppBar = (props: BrowserAppBarProps) => {
     <AppBar
       appName={AppName.GENOME_BROWSER}
       mainContent={wrappedSpecies}
-      aside={<HelpPopupButton slug="using-the-genome-browser" />}
+      aside={<HelpPopupButton slug="genome-browser" />}
     />
   );
 };

--- a/src/ensembl/src/content/app/browser/zmenu/ZmenuAppLinks.tsx
+++ b/src/ensembl/src/content/app/browser/zmenu/ZmenuAppLinks.tsx
@@ -18,7 +18,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
 
-import { isEnvironment, Environment } from 'src/shared/helpers/environment';
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import { parseFeatureId } from 'src/content/app/browser/browserHelper';
 import { buildFocusIdForUrl } from 'src/shared/state/ens-object/ensObjectHelpers';
@@ -45,9 +44,6 @@ type Props = {
 };
 
 const ZmenuAppLinks = (props: Props) => {
-  if (!isEnvironment([Environment.DEVELOPMENT, Environment.INTERNAL])) {
-    return null;
-  }
   const parsedFeatureId = parseFeatureId(props.featureId);
 
   if (parsedFeatureId.type !== 'gene') {

--- a/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
+++ b/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
@@ -17,12 +17,10 @@
 import React, { useEffect, ReactNode } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { Link } from 'react-router-dom';
 
 import ViewInAppPopup from 'src/shared/components/view-in-app-popup/ViewInAppPopup';
 import SpeciesStats from 'src/content/app/species/components/species-stats/SpeciesStats';
 import ExpandableSection from 'src/shared/components/expandable-section/ExpandableSection';
-import { isEnvironment, Environment } from 'src/shared/helpers/environment';
 
 import {
   getActiveGenomeId,
@@ -66,18 +64,6 @@ type ExampleLinkPopupProps = {
 };
 
 const ExampleLinkWithPopup = (props: ExampleLinkPopupProps) => {
-  const isProduction = isEnvironment([Environment.PRODUCTION]);
-
-  if (isProduction) {
-    const linkToGenomeBrowser = props.links?.genomeBrowser;
-
-    return linkToGenomeBrowser ? (
-      <div className={styles.exampleLink}>
-        <Link to={linkToGenomeBrowser}>{props.children}</Link>
-      </div>
-    ) : null;
-  }
-
   return (
     <div className={styles.exampleLink}>
       <ViewInAppPopup links={props.links}>

--- a/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.tsx
+++ b/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.tsx
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-import React, { useState, useEffect, useRef } from 'react';
-import { Link } from 'react-router-dom';
+import React, { useState, useRef } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import { push } from 'connected-react-router';
 import classNames from 'classnames';
 
-import { isEnvironment, Environment } from 'src/shared/helpers/environment';
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import useOutsideClick from 'src/shared/hooks/useOutsideClick';
 
@@ -66,24 +64,20 @@ const HomepageAppLinks = (props: Props) => {
     }
   };
 
-  if (isEnvironment([Environment.DEVELOPMENT, Environment.INTERNAL])) {
-    const links = props.species.map((species, index) => (
-      <HomepageAppLinksRow
-        key={species.genome_id}
-        species={species}
-        isExpanded={expandedRowIndex === index}
-        toggleExpand={() => onToggleRow(index)}
-      />
-    ));
-    return (
-      <section className={styles.homepageAppLinks}>
-        <h2>Previously viewed</h2>
-        {links}
-      </section>
-    );
-  } else {
-    return <PreviouslyViewedLinks {...props} />;
-  }
+  const links = props.species.map((species, index) => (
+    <HomepageAppLinksRow
+      key={species.genome_id}
+      species={species}
+      isExpanded={expandedRowIndex === index}
+      toggleExpand={() => onToggleRow(index)}
+    />
+  ));
+  return (
+    <section className={styles.homepageAppLinks}>
+      <h2>Previously viewed</h2>
+      {links}
+    </section>
+  );
 };
 
 const HomepageAppLinksRow = (props: HomepageAppLinksRowProps) => {
@@ -137,39 +131,6 @@ const HomepageAppLinksRow = (props: HomepageAppLinksRowProps) => {
     </div>
   ) : (
     <div className={rowClasses}>{speciesName}</div>
-  );
-};
-
-// Legacy component that stays there until we have a presentable EntityViewer
-const PreviouslyViewedLinks = (props: Props) => {
-  useEffect(() => {
-    props.fetchDataForLastVisitedObjects();
-  }, []);
-
-  if (
-    !props.species.length ||
-    props.previouslyViewedGenomeBrowserObjects.areLoading
-  ) {
-    return null;
-  }
-
-  const previouslyViewedLinks = props.previouslyViewedGenomeBrowserObjects.objects.map(
-    (object, index) => (
-      <div key={index} className={styles.previouslyViewedItem}>
-        <Link to={object.link}>{object.speciesName}</Link>
-        <span className={styles.previouslyViewedItemAssemblyName}>
-          {' '}
-          {object.assemblyName}
-        </span>
-      </div>
-    )
-  );
-
-  return (
-    <section className={styles.previouslyViewed}>
-      <h2>Previously viewed</h2>
-      {previouslyViewedLinks}
-    </section>
   );
 };
 

--- a/src/ensembl/src/header/launchbar/Launchbar.tsx
+++ b/src/ensembl/src/header/launchbar/Launchbar.tsx
@@ -71,12 +71,7 @@ const Launchbar = (props: LaunchbarProps) => {
               app="entity-viewer"
               description="Entity Viewer"
               icon={EntityViewerIcon}
-              enabled={
-                isEnvironment([
-                  Environment.DEVELOPMENT,
-                  Environment.INTERNAL
-                ]) && props.committedSpecies.length > 0
-              }
+              enabled={props.committedSpecies.length > 0}
             />
           </div>
           <div className={styles.category}>


### PR DESCRIPTION
## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-980

## Description
Now that the backend is capable of providing us with reasonable data and the frontend can display it accordingly, we feel that the time has come to expose Entity Viewer to the world at large.

Removing environment-dependent guards from:
- Launchbar (rules for enabling EV button are now the same as rules for enabling GB button)
- Home page (enabling the button leading to Entity Viewer)
- Species page (enabling the button leading to Entity Viewer)
- Zmenu in Genome Browser (enabling the buttons and the Instant Download component)

## Deployment URL
After merging to dev, but before merging to master, it might be a good idea to check the site on staging-2020.