### PR TITLE
Add eslint rule for equals operator

### DIFF
--- a/src/ensembl/.eslintrc.js
+++ b/src/ensembl/.eslintrc.js
@@ -30,7 +30,8 @@ module.exports = {
     'react-hooks/rules-of-hooks': 2,
     'prettier/prettier': 0,
     'no-unused-vars': ['warn', { args: 'after-used' }],
-    'no-unneeded-ternary': 'error'
+    'no-unneeded-ternary': 'error',
+    'eqeqeq': 'error'
   },
   settings: {
     react: {

--- a/src/ensembl/src/content/app/custom-download/components/checkbox-with-selects/CheckboxWithSelects.tsx
+++ b/src/ensembl/src/content/app/custom-download/components/checkbox-with-selects/CheckboxWithSelects.tsx
@@ -133,7 +133,7 @@ const CheckboxWithSelects = (props: CheckboxWithSelectsProps) => {
           const options = [...props.options]
             .filter((option: Option) => {
               if (
-                (selectedOptionsClone.indexOf(option.value) == -1 &&
+                (selectedOptionsClone.indexOf(option.value) === -1 &&
                   firstSelectedOption !== option.value) ||
                 selectedOption === option.value
               ) {

--- a/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
+++ b/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
@@ -176,7 +176,7 @@ const SpeciesMainViewStats = (props: Props) => {
     if (isExpanded) {
       props.setExpandedSections([...expandedSections, section]);
     } else {
-      props.setExpandedSections(expandedSections.filter((s) => s != section));
+      props.setExpandedSections(expandedSections.filter((s) => s !== section));
     }
   };
 

--- a/src/ensembl/src/shared/components/accordion/components/AccordionContext.tsx
+++ b/src/ensembl/src/shared/components/accordion/components/AccordionContext.tsx
@@ -63,7 +63,7 @@ export const Provider = (props: ProviderProps) => {
       (uuid) => !props.preExpanded.includes(uuid)
     ).length;
 
-    if (store.expanded.length != props.preExpanded.length || differences) {
+    if (store.expanded.length !== props.preExpanded.length || differences) {
       setStore(store.setExpanded(props.preExpanded));
     }
   }, [props.preExpanded]);


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Description
ESLint doesn't check if we have used triple equals (`===`) instead of double equals (`==`) by default. So this PR adds it into our ESLint rules.

I ran `npm run lint` and it showed three places where the double equals is used. I've fixed them in this PR itself.
