### PR TITLE
Use unversioned gene id when generating url for EntityViewer in GeneSummary drawer

### DIFF
--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/gene-summary/GeneSummary.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/gene-summary/GeneSummary.tsx
@@ -40,6 +40,7 @@ const GENE_QUERY = gql`
       alternative_symbols
       name
       stable_id
+      unversioned_stable_id
       symbol
       so_term
       transcripts {
@@ -62,6 +63,7 @@ type Gene = Required<
   Pick<
     GeneFromGraphql,
     | 'stable_id'
+    | 'unversioned_stable_id'
     | 'symbol'
     | 'name'
     | 'alternative_symbols'
@@ -96,7 +98,7 @@ const GeneSummary = () => {
 
   const focusId = buildFocusIdForUrl({
     type: 'gene',
-    objectId: gene.stable_id as string
+    objectId: gene.unversioned_stable_id
   });
   const entityViewerUrl = urlFor.entityViewer({
     genomeId: ensObjectGene.genome_id,

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
@@ -174,7 +174,7 @@ const TranscriptSummary = () => {
 
   const focusId = buildFocusIdForUrl({
     type: 'gene',
-    objectId: gene.unversioned_stable_id as string
+    objectId: gene.unversioned_stable_id
   });
 
   const entityViewerUrl = urlFor.entityViewer({
@@ -183,11 +183,11 @@ const TranscriptSummary = () => {
   });
 
   const uniprotXref = product?.external_references.find(
-    (xref) => xref.source.id == 'Uniprot/SWISSPROT'
+    (xref) => xref.source.id === 'Uniprot/SWISSPROT'
   );
 
   const ccdsXref = transcript.external_references.find(
-    (xref) => xref.source.id == 'CCDS'
+    (xref) => xref.source.id === 'CCDS'
   );
 
   const splicedRNALength = getCommaSeparatedNumber(


### PR DESCRIPTION
## Type
- Bug fix

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-992

## Description
ViewInApp component in GeneSummary drawer view in genome browser is generated using the versioned stable id of the gene, when we should be using unversioned stable ids in the urls (in the hope to keep the url of the entity more permanent and better suited for indexing by search engines).

Using versioned stable ids for urls when the app expects unversioned stable ids breaks stuff. For example, in this case, EntityViewer couldn't find the relevant entity in the redux store and thus could not expand or collapse transcripts appropriately.