### PR TITLE
Do not persist sidebar open/close state

### DIFF
--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
@@ -76,7 +76,6 @@ export const pickPersistentTrackPanelProperties = (
 ) => {
   const persistentProperties = [
     'selectedTrackPanelTab',
-    'isTrackPanelOpened',
     'collapsedTrackIds',
     'previouslyViewedObjects'
   ];


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-921

## Description
 - The sidebar open/close state is now lost after a browser refresh


## Views affected
Browser -> Sidebar