### PR TITLE
Using back button with multiple species tabs for genome browser

### DIFF
--- a/src/ensembl/src/content/app/browser/hooks/useBrowserRouting.ts
+++ b/src/ensembl/src/content/app/browser/hooks/useBrowserRouting.ts
@@ -16,7 +16,7 @@
 
 import { useEffect, useRef, useCallback } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
-import { replace } from 'connected-react-router';
+import { push, replace } from 'connected-react-router';
 import { useSelector, useDispatch } from 'react-redux';
 import isEqual from 'lodash/isEqual';
 
@@ -155,7 +155,7 @@ const useBrowserRouting = () => {
         location: chrLocation ? getChrLocationStr(chrLocation) : null
       };
 
-      dispatch(replace(urlFor.browser(params)));
+      dispatch(push(urlFor.browser(params)));
     },
     [genomeId]
   );


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-920

## Description
- Pressing the browser back button will now take the user back to the previously selected species

## Views affected
Browser - > Species

### Other effects

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.
