### PR TITLE
Add transcript filter functionality to entity viewer

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -25,6 +25,8 @@ import {
   defaultSort
 } from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
 
+import { filterTranscriptsBySOTerm } from 'src/content/app/entity-viewer/shared/helpers/transcripts-filter';
+
 import {
   getExpandedTranscriptIds,
   getExpandedTranscriptDownloadIds,
@@ -93,6 +95,9 @@ const DefaultTranscriptslist = (props: Props) => {
 
   const sortingFunction = transcriptSortingFunctions[sortingRule];
   const sortedTranscripts = sortingFunction(gene.transcripts) as Transcript[];
+  const filteredTranscripts = Object.values(filters).some(Boolean)
+    ? (filterTranscriptsBySOTerm(sortedTranscripts, filters) as Transcript[])
+    : sortedTranscripts;
 
   const [isFilterOpen, setFilterOpen] = useState(false);
 
@@ -101,7 +106,7 @@ const DefaultTranscriptslist = (props: Props) => {
 
     // Expand the first transcript by default
     if (!hasExpandedTranscripts) {
-      dispatch(toggleTranscriptInfo(sortedTranscripts[0].stable_id));
+      dispatch(toggleTranscriptInfo(filteredTranscripts[0].stable_id));
     }
   }, []);
 
@@ -129,7 +134,7 @@ const DefaultTranscriptslist = (props: Props) => {
           <TranscriptsFilter
             label={filterLabel}
             toggleFilter={toggleFilter}
-            transcripts={sortedTranscripts}
+            transcripts={filteredTranscripts}
           />
         )}
         <div className={styles.row}>
@@ -144,7 +149,7 @@ const DefaultTranscriptslist = (props: Props) => {
       </div>
       <div className={styles.content}>
         <StripedBackground {...props} />
-        {sortedTranscripts.map((transcript, index) => {
+        {filteredTranscripts.map((transcript, index) => {
           const expandTranscript = expandedTranscriptIds.includes(
             transcript.stable_id
           );

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/tests/transcripts-filter.test.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/tests/transcripts-filter.test.ts
@@ -1,0 +1,136 @@
+import { filterTranscriptsBySOTerm } from '../transcripts-filter';
+
+import { createTranscript } from 'tests/fixtures/entity-viewer/transcript';
+
+/* Creating filters with different filter set to true */
+const proteinCodingfilters = {
+  protein_coding: true,
+  retained_intron: false,
+  processed_transcript: false,
+  nonsense_mediated_decay: false
+};
+
+const retainedIntronfilters = {
+  protein_coding: false,
+  retained_intron: true,
+  processed_transcript: false,
+  nonsense_mediated_decay: false
+};
+
+const processedTranscriptfilters = {
+  protein_coding: false,
+  retained_intron: false,
+  processed_transcript: true,
+  nonsense_mediated_decay: false
+};
+
+const nonsenseMediatedDecayfilters = {
+  protein_coding: false,
+  retained_intron: false,
+  processed_transcript: false,
+  nonsense_mediated_decay: true
+};
+
+/* Creating dummy transcripts with different different so_term  to test so_term filtering */
+const createProteinCodingTranscript = () => {
+  const transcript = createTranscript();
+  transcript.so_term = 'protein_coding';
+  return transcript;
+};
+
+const createProcessedTranscript = () => {
+  const transcript = createTranscript();
+  transcript.so_term = 'processed_transcript';
+  return transcript;
+};
+
+const createRetainedIntronTranscript = () => {
+  const transcript = createTranscript();
+  transcript.so_term = 'retained_intron';
+  return transcript;
+};
+
+const createNonsenseMediatedDecayTranscript = () => {
+  const transcript = createTranscript();
+  transcript.so_term = 'nonsense_mediated_decay';
+  return transcript;
+};
+
+const ProteinCodingTranscript = createProteinCodingTranscript();
+const ProcessedTranscript = createProcessedTranscript();
+const RetainedIntronTranscript = createRetainedIntronTranscript();
+const NonsenseMediatedDecayTranscript = createNonsenseMediatedDecayTranscript();
+
+describe('filter transcripts by so_term', () => {
+  it('filters transcripts by protein_coding correctly', () => {
+    const Transcripts = [
+      ProteinCodingTranscript,
+      ProcessedTranscript,
+      RetainedIntronTranscript,
+      NonsenseMediatedDecayTranscript
+    ];
+
+    const expectedTranscripts = [ProteinCodingTranscript];
+
+    const filteredTranscripts = filterTranscriptsBySOTerm(
+      Transcripts,
+      proteinCodingfilters
+    );
+
+    expect(filteredTranscripts).toEqual(expectedTranscripts);
+  });
+
+  it('filters transcripts by retained_intron correctly', () => {
+    const Transcripts = [
+      ProteinCodingTranscript,
+      ProcessedTranscript,
+      RetainedIntronTranscript,
+      NonsenseMediatedDecayTranscript
+    ];
+
+    const expectedTranscripts = [RetainedIntronTranscript];
+
+    const filteredTranscripts = filterTranscriptsBySOTerm(
+      Transcripts,
+      retainedIntronfilters
+    );
+
+    expect(filteredTranscripts).toEqual(expectedTranscripts);
+  });
+
+  it('filters transcripts by processed_transcript correctly', () => {
+    const Transcripts = [
+      ProteinCodingTranscript,
+      ProcessedTranscript,
+      RetainedIntronTranscript,
+      NonsenseMediatedDecayTranscript
+    ];
+
+    const expectedTranscripts = [ProcessedTranscript];
+
+    const filteredTranscripts = filterTranscriptsBySOTerm(
+      Transcripts,
+      processedTranscriptfilters
+    );
+
+    expect(filteredTranscripts).toEqual(expectedTranscripts);
+  });
+
+  it('filters transcripts by nonsense_mediated_decay correctly', () => {
+    const Transcripts = [
+      ProteinCodingTranscript,
+      ProcessedTranscript,
+      RetainedIntronTranscript,
+      NonsenseMediatedDecayTranscript
+    ];
+
+    const expectedTranscripts = [NonsenseMediatedDecayTranscript];
+
+    const filteredTranscripts = filterTranscriptsBySOTerm(
+      Transcripts,
+      nonsenseMediatedDecayfilters
+    );
+
+    expect(filteredTranscripts).toEqual(expectedTranscripts);
+  });
+});

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/tests/transcripts-filter.test.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/tests/transcripts-filter.test.ts
@@ -2,7 +2,7 @@ import { filterTranscriptsBySOTerm } from '../transcripts-filter';
 
 import { createTranscript } from 'tests/fixtures/entity-viewer/transcript';
 
-/* Creating filters with different filter set to true */
+/* Creating filters with different filter set to true/false */
 const proteinCodingfilters = {
   protein_coding: true,
   retained_intron: false,
@@ -10,28 +10,8 @@ const proteinCodingfilters = {
   nonsense_mediated_decay: false
 };
 
-const retainedIntronfilters = {
-  protein_coding: false,
-  retained_intron: true,
-  processed_transcript: false,
-  nonsense_mediated_decay: false
-};
-
-const processedTranscriptfilters = {
-  protein_coding: false,
-  retained_intron: false,
-  processed_transcript: true,
-  nonsense_mediated_decay: false
-};
-
-const nonsenseMediatedDecayfilters = {
-  protein_coding: false,
-  retained_intron: false,
-  processed_transcript: false,
-  nonsense_mediated_decay: true
-};
-
 /* Creating dummy transcripts with different different so_term  to test so_term filtering */
+/* note that the so_term can be any string matching the filters object above */
 const createProteinCodingTranscript = () => {
   const transcript = createTranscript();
   transcript.so_term = 'protein_coding';
@@ -61,8 +41,8 @@ const ProcessedTranscript = createProcessedTranscript();
 const RetainedIntronTranscript = createRetainedIntronTranscript();
 const NonsenseMediatedDecayTranscript = createNonsenseMediatedDecayTranscript();
 
-describe('filter transcripts by so_term', () => {
-  it('filters transcripts by protein_coding correctly', () => {
+describe('filterTranscriptsBySOTerm', () => {
+  it('filters transcripts by so_term correctly', () => {
     const Transcripts = [
       ProteinCodingTranscript,
       ProcessedTranscript,
@@ -75,60 +55,6 @@ describe('filter transcripts by so_term', () => {
     const filteredTranscripts = filterTranscriptsBySOTerm(
       Transcripts,
       proteinCodingfilters
-    );
-
-    expect(filteredTranscripts).toEqual(expectedTranscripts);
-  });
-
-  it('filters transcripts by retained_intron correctly', () => {
-    const Transcripts = [
-      ProteinCodingTranscript,
-      ProcessedTranscript,
-      RetainedIntronTranscript,
-      NonsenseMediatedDecayTranscript
-    ];
-
-    const expectedTranscripts = [RetainedIntronTranscript];
-
-    const filteredTranscripts = filterTranscriptsBySOTerm(
-      Transcripts,
-      retainedIntronfilters
-    );
-
-    expect(filteredTranscripts).toEqual(expectedTranscripts);
-  });
-
-  it('filters transcripts by processed_transcript correctly', () => {
-    const Transcripts = [
-      ProteinCodingTranscript,
-      ProcessedTranscript,
-      RetainedIntronTranscript,
-      NonsenseMediatedDecayTranscript
-    ];
-
-    const expectedTranscripts = [ProcessedTranscript];
-
-    const filteredTranscripts = filterTranscriptsBySOTerm(
-      Transcripts,
-      processedTranscriptfilters
-    );
-
-    expect(filteredTranscripts).toEqual(expectedTranscripts);
-  });
-
-  it('filters transcripts by nonsense_mediated_decay correctly', () => {
-    const Transcripts = [
-      ProteinCodingTranscript,
-      ProcessedTranscript,
-      RetainedIntronTranscript,
-      NonsenseMediatedDecayTranscript
-    ];
-
-    const expectedTranscripts = [NonsenseMediatedDecayTranscript];
-
-    const filteredTranscripts = filterTranscriptsBySOTerm(
-      Transcripts,
-      nonsenseMediatedDecayfilters
     );
 
     expect(filteredTranscripts).toEqual(expectedTranscripts);

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/tests/transcripts-filter.test.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/tests/transcripts-filter.test.ts
@@ -3,7 +3,7 @@ import { filterTranscriptsBySOTerm } from '../transcripts-filter';
 import { createTranscript } from 'tests/fixtures/entity-viewer/transcript';
 
 /* Creating filters with different filter set to true/false */
-const proteinCodingfilters = {
+const proteinCodingFilters = {
   protein_coding: true,
   retained_intron: false,
   processed_transcript: false,
@@ -54,7 +54,7 @@ describe('filterTranscriptsBySOTerm', () => {
 
     const filteredTranscripts = filterTranscriptsBySOTerm(
       Transcripts,
-      proteinCodingfilters
+      proteinCodingFilters
     );
 
     expect(filteredTranscripts).toEqual(expectedTranscripts);

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/transcripts-filter.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/transcripts-filter.ts
@@ -1,0 +1,17 @@
+import { Filters } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
+
+import { FullTranscript } from 'src/shared/types/thoas/transcript';
+
+type TranscriptSOTerm = Pick<FullTranscript, 'so_term'>;
+
+export function filterTranscriptsBySOTerm(
+  transcripts: TranscriptSOTerm[],
+  filters: Filters
+) {
+  const soTerms = Object.keys(filters).filter((key) => filters[key]);
+  const filteredTranscripts = transcripts.filter((transcript) => {
+    return soTerms.includes(transcript.so_term);
+  });
+
+  return filteredTranscripts;
+}


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [x] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-888

## Importance
N/A

## Description
This is for the filtering functionality in Entity viewer.  The component was already implemented together with the test script. This PR is for adding the functionality to filter the transcripts. When you click on one of the filters, it will only show the transcripts with that filter. 

For now we are only doing the filter by so_term category, there might be more in the future and we can make the code more generic then as we know more about design and requirements.

## Deployment URL
http://entityviewer-filter.review.ensembl.org/

## Views affected
Entity Viewer (Transcript Image)

### Other effects
None

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
None
