### PR TITLE
ENSWBSITES-937: show "None" when there is no gene name and synonyms i…

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.test.tsx
@@ -138,7 +138,7 @@ describe('<GeneOverview />', () => {
       expect(geneDetailsElement?.textContent).toBe(stableId);
     });
 
-    it('does not render gene name section if gene name is not available', () => {
+    it('shows "None" message for gene without gene name', () => {
       const geneData = { ...completeGeneData, name: null };
       (useQuery as any).mockImplementation(() => ({
         data: { gene: geneData },
@@ -148,10 +148,10 @@ describe('<GeneOverview />', () => {
       const { container } = render(<GeneOverview />);
 
       const geneNameElement = container.querySelector('.geneName');
-      expect(geneNameElement).toBeFalsy();
+      expect(geneNameElement?.textContent).toBe('None');
     });
 
-    it('shows "no synonyms" message for gene without synonyms', () => {
+    it('shows "None" message for gene without synonyms', () => {
       const geneData = { ...completeGeneData, alternative_symbols: [] };
       (useQuery as any).mockImplementation(() => ({
         data: { gene: geneData },
@@ -161,7 +161,7 @@ describe('<GeneOverview />', () => {
       const { container } = render(<GeneOverview />);
 
       const synonymsElement = container.querySelector('.synonyms');
-      expect(synonymsElement?.textContent).toBe('No synonyms');
+      expect(synonymsElement?.textContent).toBe('None');
     });
   });
 });

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.test.tsx
@@ -138,7 +138,7 @@ describe('<GeneOverview />', () => {
       expect(geneDetailsElement?.textContent).toBe(stableId);
     });
 
-    it('shows "None" message for gene without gene name', () => {
+    it('shows that the gene does not have a name', () => {
       const geneData = { ...completeGeneData, name: null };
       (useQuery as any).mockImplementation(() => ({
         data: { gene: geneData },
@@ -151,7 +151,7 @@ describe('<GeneOverview />', () => {
       expect(geneNameElement?.textContent).toBe('None');
     });
 
-    it('shows "None" message for gene without synonyms', () => {
+    it('shows that the gene does not have synonyms', () => {
       const geneData = { ...completeGeneData, alternative_symbols: [] };
       (useQuery as any).mockImplementation(() => ({
         data: { gene: geneData },

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
@@ -80,9 +80,7 @@ const GeneOverview = () => {
       </div>
 
       <div className={styles.sectionHead}>Gene name</div>
-      <div className={styles.geneName}>
-        {gene.name?.length ? gene.name : 'None'}
-      </div>
+      <div className={styles.geneName}>{gene.name || 'None'}</div>
 
       <div className={styles.sectionHead}>Synonyms</div>
       <div className={styles.synonyms}>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
@@ -79,18 +79,16 @@ const GeneOverview = () => {
         <span>{gene.stable_id}</span>
       </div>
 
-      {!!gene.name && (
-        <>
-          <div className={styles.sectionHead}>Gene name</div>
-          <div className={styles.geneName}>{gene.name}</div>
-        </>
-      )}
+      <div className={styles.sectionHead}>Gene name</div>
+      <div className={styles.geneName}>
+        {gene.name && gene.name.length ? gene.name : 'None'}
+      </div>
 
       <div className={styles.sectionHead}>Synonyms</div>
       <div className={styles.synonyms}>
         {gene.alternative_symbols.length
           ? gene.alternative_symbols.join(', ')
-          : 'No synonyms'}
+          : 'None'}
       </div>
 
       <MainAccordion />

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
@@ -81,7 +81,7 @@ const GeneOverview = () => {
 
       <div className={styles.sectionHead}>Gene name</div>
       <div className={styles.geneName}>
-        {gene.name && gene.name.length ? gene.name : 'None'}
+        {gene.name?.length ? gene.name : 'None'}
       </div>
 
       <div className={styles.sectionHead}>Synonyms</div>


### PR DESCRIPTION
…n Entity Viwer RH panel

## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-937

## Importance
N/A

## Description
Showing "None" in the entity viewer Right Hand Panel when there is no gene name or no synonyms and also updating corresponding test.

## Deployment URL
http://no-genename.review.ensembl.org
Example Gene with no Gene Name and no Synonyms:
http://no-genename.review.ensembl.orgentity-viewer/triticum_aestivum_GCA_900519105_1/gene:TraesCS3D02G273500?view=transcripts

## Views affected
Entity viewer Right Hand Panel

### Other effects
None

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
None
