### PR TITLE
Reset genome browser track panel tabs on refresh

### DIFF
--- a/src/ensembl/src/content/app/browser/browser-storage-service.ts
+++ b/src/ensembl/src/content/app/browser/browser-storage-service.ts
@@ -33,8 +33,7 @@ export enum StorageKeys {
   CHR_LOCATION = 'browser.chrLocation',
   DEFAULT_CHR_LOCATION = 'browser.defaultChrLocation',
   TRACK_STATES = 'browser.trackStates',
-  TRACK_PANELS = 'browser.trackPanels',
-  SELECTED_TRACK_PANEL_TAB = 'browser.selectedTrackPanelTab'
+  TRACK_PANELS = 'browser.trackPanels'
 }
 
 export class BrowserStorageService {

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
@@ -74,10 +74,6 @@ export const getTrackPanelStateForGenome = (
 export const pickPersistentTrackPanelProperties = (
   trackPanel: Partial<TrackPanelStateForGenome>
 ) => {
-  const persistentProperties = [
-    'selectedTrackPanelTab',
-    'collapsedTrackIds',
-    'previouslyViewedObjects'
-  ];
+  const persistentProperties = ['collapsedTrackIds', 'previouslyViewedObjects'];
   return pick(trackPanel, persistentProperties);
 };


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
[ENSWBSITES-926](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-926)

## Description
The track panel tabs in the genome browser needs to be reset when the user refreshes the page.

The current behaviour in the dev branch is that when the user selects either 'Variation' or 'Expression' and then refreshes the page, nothing changes.

## Deployment URL
http://reset-gb-track-panel-tabs.review.ensembl.org/

## Views affected
Genome browser -> track panel -> tabs
