### PR TITLE
Species do not get removed from Entity Viewer

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/services/entity-viewer-storage-service.ts
+++ b/src/ensembl/src/content/app/entity-viewer/services/entity-viewer-storage-service.ts
@@ -49,6 +49,20 @@ export class EntityViewerStorageService {
       localStorageOptions
     );
   }
+
+  public deleteGenome(genomeIdToDelete: string): void {
+    const activeGenomeId = this.getGeneralState().activeGenomeId;
+    if (activeGenomeId === genomeIdToDelete) {
+      this.updateGeneralState({
+        activeGenomeId: undefined
+      });
+    }
+    this.storageService.removeAt(
+      StorageKeys.GENERAL_STATE,
+      ['activeEntityIds', genomeIdToDelete],
+      localStorageOptions
+    );
+  }
 }
 
 export default new EntityViewerStorageService(storageService);

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralActions.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralActions.ts
@@ -19,7 +19,6 @@ import { Action } from 'redux';
 import { batch } from 'react-redux';
 import { push, replace } from 'connected-react-router';
 import { ThunkAction } from 'redux-thunk';
-import pickBy from 'lodash/pickBy';
 
 import * as urlHelper from 'src/shared/helpers/urlHelper';
 import {
@@ -164,18 +163,8 @@ export const deleteGenome = createAction('entity-viewer/delete-genome')<
 export const deleteSpeciesInEntityViewer = (
   genomeIdToRemove: string
 ): ThunkAction<void, any, null, Action<string>> => {
-  return (dispatch, getState: () => RootState) => {
+  return (dispatch) => {
     dispatch(deleteGenome(genomeIdToRemove));
-
-    const state = getState();
-
-    const updatedActiveEntityIds = pickBy(
-      getEntityViewerActiveEntityIds(state),
-      (value, key) => key !== genomeIdToRemove
-    );
-
-    dispatch(updateActiveEntityForGenome(updatedActiveEntityIds));
-
     entityViewerStorageService.deleteGenome(genomeIdToRemove);
   };
 };

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralReducer.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralReducer.ts
@@ -40,18 +40,18 @@ export default function entityViewerReducer(
     case getType(actions.deleteGenome): {
       const genomeIdToRemove = action.payload;
       const activeGenomeId = state.activeGenomeId;
-      if (activeGenomeId === genomeIdToRemove) {
-        const newState = {
-          ...state,
-          activeGenomeId: null,
-          activeEntityIds: pickBy(
-            state.activeEntityIds,
-            (value, key) => key !== activeGenomeId
-          )
-        };
 
-        return newState;
-      }
+      const newState = {
+        ...state,
+        activeGenomeId:
+          activeGenomeId === genomeIdToRemove ? null : activeGenomeId,
+        activeEntityIds: pickBy(
+          state.activeEntityIds,
+          (value, key) => key !== genomeIdToRemove
+        )
+      };
+
+      return newState;
     }
     default:
       return state;

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralReducer.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralReducer.ts
@@ -15,6 +15,7 @@
  */
 
 import { ActionType, getType } from 'typesafe-actions';
+import pickBy from 'lodash/pickBy';
 
 import {
   buildInitialState,
@@ -35,6 +36,23 @@ export default function entityViewerReducer(
     }
     case getType(actions.updateActiveEntityForGenome):
       return { ...state, activeEntityIds: action.payload };
+
+    case getType(actions.deleteGenome): {
+      const genomeIdToRemove = action.payload;
+      const activeGenomeId = state.activeGenomeId;
+      if (activeGenomeId === genomeIdToRemove) {
+        const newState = {
+          ...state,
+          activeGenomeId: null,
+          activeEntityIds: pickBy(
+            state.activeEntityIds,
+            (value, key) => key !== activeGenomeId
+          )
+        };
+
+        return newState;
+      }
+    }
     default:
       return state;
   }

--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorActions.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorActions.ts
@@ -26,6 +26,7 @@ import speciesSelectorStorageService from 'src/content/app/species-selector/serv
 import analyticsTracking from 'src/services/analytics-service';
 import buildAnalyticsObject from 'src/analyticsHelper';
 import { deleteSpeciesInGenomeBrowser } from 'src/content/app/browser/browserActions';
+import { deleteSpeciesInEntityViewer } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralActions';
 
 import {
   getCommittedSpecies,
@@ -352,6 +353,7 @@ export const deleteSpeciesAndSave = (
 
   dispatch(updateCommittedSpecies(updatedCommittedSpecies));
   dispatch(deleteSpeciesInGenomeBrowser(genomeId));
+  dispatch(deleteSpeciesInEntityViewer(genomeId));
   speciesSelectorStorageService.saveSelectedSpecies(updatedCommittedSpecies);
 };
 


### PR DESCRIPTION

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-916

## Description
- Clearing the local storage entries for a particular genome within the Entity Viewer when the species is removed.

## Deployment URL
http://ev-removed-species.review.ensembl.org

## Views affected
Entity Viewer

### Other effects

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

