### PR TITLE
Update E.coli genome id in the configs

### DIFF
--- a/src/ensembl/src/content/app/browser/drawer/sampleData.ts
+++ b/src/ensembl/src/content/app/browser/drawer/sampleData.ts
@@ -238,7 +238,7 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
       description: 'Sequence variants from all sources'
     }
   },
-  escherichia_coli_str_k_12_substr_mg1655_GCA_000005845_2: {
+  escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845_2: {
     'track:gene-pc-fwd': {
       track_id: 'track:gene-pc-fwd',
       track_name: 'Protein coding genes',

--- a/src/ensembl/src/content/app/species/sample-data.ts
+++ b/src/ensembl/src/content/app/species/sample-data.ts
@@ -163,7 +163,7 @@ export const sampleData: RawSpeciesStats = {
       promoters: 21822
     }
   },
-  escherichia_coli_str_k_12_substr_mg1655_GCA_000005845_2: {
+  escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845_2: {
     assembly_stats: {
       contig_n50: null,
       total_genome_length: 4641652,
@@ -604,7 +604,7 @@ export const sidebarData: SpeciesSidebarData = {
     assembly_date: '2013-06-01',
     notes: []
   },
-  escherichia_coli_str_k_12_substr_mg1655_GCA_000005845_2: {
+  escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845_2: {
     id: 'GCA_000005845.2',
     taxonomy_id: '511145',
     strain: null,


### PR DESCRIPTION
This is to support the backend changes made in https://github.com/Ensembl/ensembl-2020-genome-search/pull/27