### PR TITLE
Transcriptimage bugfix

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/BasePairsRuler.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/BasePairsRuler.tsx
@@ -57,7 +57,7 @@ type Props = {
 const FeatureLengthAxis = (props: Props) => {
   const domain = [1, props.length];
   const range = [0, props.width];
-  const scale = scaleLinear().domain(domain).range(range);
+  const scale = scaleLinear().domain(domain).rangeRound(range);
   const { ticks, labelledTicks } = getTicks(scale);
 
   useEffect(() => {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-overview-image/GeneOverviewImage.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-overview-image/GeneOverviewImage.tsx
@@ -80,7 +80,7 @@ export const GeneImage = (props: GeneOverviewImageProps) => {
   // (it will help with drawing genes of circular chromosomes)
   const scale = scaleLinear()
     .domain([geneStart, geneEnd])
-    .range([0, gene_image_width]);
+    .rangeRound([0, gene_image_width]);
 
   const renderedTranscripts = props.gene.transcripts.map(
     (transcript, index) => {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.tsx
@@ -80,7 +80,7 @@ const ProteinDomainImage = (props: ProteinDomainImageProps) => {
   // Therefore, it is guaranteed that the length of the protein drawn by this component will fall within this domain.
   const scale = scaleLinear()
     .domain([0, trackLength])
-    .range([0, props.width])
+    .rangeRound([0, props.width])
     .clamp(true);
 
   return (

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/protein-image/ProteinImage.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/protein-image/ProteinImage.tsx
@@ -39,7 +39,7 @@ const ProteinImage = (props: ProteinImageProps) => {
   // Therefore, it is guaranteed that the length of the protein drawn by this component will fall within this domain.
   const scale = scaleLinear()
     .domain([0, props.trackLength])
-    .range([0, props.width])
+    .rangeRound([0, props.width])
     .clamp(true);
 
   const trackContainerStyles = transcriptsListStyles.middle;

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript.test.tsx
@@ -41,7 +41,7 @@ describe('<UnsplicedTranscript />', () => {
 
   it('renders the correct number of exons', () => {
     const wrapper = render(<UnsplicedTranscript {...minimalProps} />);
-    expect(wrapper.find('.exon').length).toBe(
+    expect(wrapper.find('[data-test-id=exon]').length).toBe(
       minimalProps.transcript.spliced_exons.length
     );
   });

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript.tsx
@@ -16,7 +16,7 @@
 
 import React from 'react';
 import classNames from 'classnames';
-import { scaleLinear, ScaleLinear, interpolateRound } from 'd3';
+import { scaleLinear, ScaleLinear } from 'd3';
 import { Pick3 } from 'ts-multipick';
 
 import { FullTranscript } from 'src/shared/types/thoas/transcript';
@@ -65,14 +65,10 @@ const UnsplicedTranscript = (props: UnsplicedTranscriptProps) => {
   } = slice;
   const scale = scaleLinear()
     .domain([1, transcriptLength])
-    .range([1, props.width])
-    .interpolate(interpolateRound)
+    .rangeRound([1, props.width])
     .clamp(true);
 
-  const transcriptClasses = classNames(
-    styles.transcript,
-    props.classNames?.transcript
-  );
+  const transcriptClasses = props.classNames?.transcript;
 
   const renderedTranscript = (
     <g className={transcriptClasses}>
@@ -120,10 +116,7 @@ const Backbone = (
     },
     scale
   } = props;
-  const backboneClasses = classNames(
-    styles.backbone,
-    props.classNames?.backbone
-  );
+  const backboneClasses = props.classNames?.backbone || undefined;
 
   if (!spliced_exons.length) {
     return (
@@ -201,12 +194,12 @@ const ExonBlock = (props: ExonBlockProps) => {
   const y = -3;
   const height = BLOCK_HEIGHT;
 
-  const exonClasses = classNames(styles.exon, props.className);
+  const exonClasses = props.className;
 
   if (cds && isNonCodingLeft) {
     const nonCodingPart = (
       <rect
-        className={classNames(exonClasses, styles.emptyBlock)}
+        className={classNames(exonClasses, styles.emptyBlock) || undefined}
         y={y}
         height={height}
         x={props.scale(exonStart)}
@@ -223,7 +216,7 @@ const ExonBlock = (props: ExonBlockProps) => {
       />
     );
     return (
-      <g key={exonStart}>
+      <g key={exonStart} data-test-id="exon">
         {nonCodingPart}
         {codingPart}
       </g>
@@ -240,7 +233,7 @@ const ExonBlock = (props: ExonBlockProps) => {
     );
     const nonCodingPart = (
       <rect
-        className={classNames(exonClasses, styles.emptyBlock)}
+        className={classNames(exonClasses, styles.emptyBlock) || undefined}
         y={y}
         height={height}
         x={props.scale(cds.relative_end)}
@@ -249,18 +242,20 @@ const ExonBlock = (props: ExonBlockProps) => {
     );
 
     return (
-      <g key={exonStart}>
+      <g key={exonStart} data-test-id="exon">
         {codingPart}
         {nonCodingPart}
       </g>
     );
   } else {
-    const classes = classNames(exonClasses, {
-      [styles.emptyBlock]: isCompletelyNonCoding
-    });
+    const classes =
+      classNames(exonClasses, {
+        [styles.emptyBlock]: isCompletelyNonCoding
+      }) || undefined;
     return (
       <rect
         key={exonStart}
+        data-test-id="exon"
         className={classes}
         y={y}
         height={height}

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript.tsx
@@ -16,7 +16,7 @@
 
 import React from 'react';
 import classNames from 'classnames';
-import { scaleLinear, ScaleLinear } from 'd3';
+import { scaleLinear, ScaleLinear, interpolateRound } from 'd3';
 import { Pick3 } from 'ts-multipick';
 
 import { FullTranscript } from 'src/shared/types/thoas/transcript';
@@ -66,6 +66,7 @@ const UnsplicedTranscript = (props: UnsplicedTranscriptProps) => {
   const scale = scaleLinear()
     .domain([1, transcriptLength])
     .range([1, props.width])
+    .interpolate(interpolateRound)
     .clamp(true);
 
   const transcriptClasses = classNames(
@@ -91,8 +92,9 @@ const UnsplicedTranscript = (props: UnsplicedTranscriptProps) => {
   return props.standalone ? (
     <svg
       className={styles.containerSvg}
-      width={scale(length)}
+      width={scale(transcriptLength)}
       height={BLOCK_HEIGHT}
+      viewBox={`0 0 ${scale(transcriptLength)} ${BLOCK_HEIGHT}`}
     >
       {renderedTranscript}
     </svg>

--- a/src/ensembl/tests/fixtures/entity-viewer/gene.ts
+++ b/src/ensembl/tests/fixtures/entity-viewer/gene.ts
@@ -51,7 +51,7 @@ export const createGene = (fragment: Partial<FullGene> = {}): FullGene => {
 const getScale = () => {
   const domain = [1000, faker.random.number({ min: 2000, max: 100000 })];
   const range = [100, faker.random.number({ min: 200, max: 600 })];
-  const scale = scaleLinear().domain(domain).range(range);
+  const scale = scaleLinear().domain(domain).rangeRound(range);
 
   return scale;
 };


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-964

![image](https://user-images.githubusercontent.com/6040010/110099419-32c26100-7d99-11eb-9529-6f6a0b8f74c1.png)


## Importance
N/A

## Description
This is a fix for a bug that showed up only in Chrome on Windows. The bug manifested in incorrect widths of transcripts that got drawn in the default transcripts list of the gene view in Entity Viewer (on the screenshot above, the top transcript, which should span the whole width of the diagram, is only a fraction of that width). The immediate cause of the bug was an incorrect `width` value that got set on the `svg` element. The true cause was that there was a confusion about variable names — we were passing the `length` variable to a function without defining it, which meant that javascript was using the global `length` attribute that's available on `window` element and that refers to the number of iframes in that window ([link to docs](https://developer.mozilla.org/en-US/docs/Web/API/Window/length)) 🤦 . In our case the `length` variable was 0, and the width of the svg element got set to 1 rather than the expected 695. 

## Deployment URL
http://transcriptimage-bugfix.review.ensembl.org

## Views affected
Entity viewer transcript image

### Other effects
N/A

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
N/A
