### PR TITLE
Wrap transcript xrefs using accordion

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.scss
@@ -57,10 +57,6 @@
   padding: 5px 0px 5px 20px;
 }
 
-.transcriptWrapper {
-  margin-bottom: 10px;
-}
-
 .transcriptId {
   color: $blue;
   cursor: pointer;

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 import { useQuery, gql } from '@apollo/client';
 import { useParams } from 'react-router';
 import sortBy from 'lodash/sortBy';
@@ -210,7 +210,6 @@ const GeneExternalReferences = () => {
 
 const TranscriptXrefs = (props: { transcript: Transcript }) => {
   const { transcript } = props;
-  const [isExpanded, setIsExpanded] = useState(false);
   const unsortedXrefs = [...transcript.external_references];
 
   // Add protein level xrefs
@@ -225,17 +224,24 @@ const TranscriptXrefs = (props: { transcript: Transcript }) => {
   const xrefGroups = buildExternalReferencesGroups(unsortedXrefs);
 
   return (
-    <div className={styles.transcriptWrapper}>
-      <div
-        onClick={() => setIsExpanded(!isExpanded)}
-        className={styles.transcriptId}
-      >
-        {transcript.stable_id}
-      </div>
-      {transcript.external_references && isExpanded && (
-        <div className={styles.transcriptXrefs}>{renderXrefs(xrefGroups)}</div>
-      )}
-    </div>
+    <Accordion className={styles.xrefAccordion}>
+      <AccordionItem className={styles.xrefAccordionItem}>
+        <AccordionItemHeading className={styles.xrefAccordionHeader}>
+          <AccordionItemButton className={styles.xrefAccordionButton}>
+            <div className={styles.transcriptId}>{transcript.stable_id}</div>
+          </AccordionItemButton>
+        </AccordionItemHeading>
+        <AccordionItemPanel className={styles.xrefAccordionItemContent}>
+          <div>
+            {transcript.external_references && (
+              <div className={styles.transcriptXrefs}>
+                {renderXrefs(xrefGroups)}
+              </div>
+            )}
+          </div>
+        </AccordionItemPanel>
+      </AccordionItem>
+    </Accordion>
   );
 };
 


### PR DESCRIPTION


## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-961

## Description
- Transcript xrefs are displayed within the accordion component similar to gene xref group

## Deployment URL
http://transcript-links.review.ensembl.org

## Views affected
Entity Viewer -> Sidebar -> External References -> Transcript

### Other effects

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.
