### PR TITLE
Remove message and retry button for PDBe error responses

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.scss
@@ -52,16 +52,3 @@ $content-width: $gene_image_width;
   justify-content: center;
   margin-left: 177px;
 }
-
-.statusContainer {
-  height: 50px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-top: 40px;
-}
-.errorMessage{
-  color: $red;
-  margin-right:20px;
-  font-weight: $normal;
-}

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.scss
@@ -52,3 +52,11 @@ $content-width: $gene_image_width;
   justify-content: center;
   margin-left: 177px;
 }
+
+.statusContainer {
+  height: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 40px;
+}

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
@@ -176,6 +176,10 @@ const ProteinsListItemInfo = (props: Props) => {
     };
   }, [summaryStatsLoadingState, uniprotXref]);
 
+  const showLoadingIndicator =
+    domainsLoadingState === LoadingState.LOADING ||
+    summaryStatsLoadingState === LoadingState.LOADING;
+
   return (
     <div className={styles.proteinsListItemInfo}>
       {productWithProteinDomains && (
@@ -236,28 +240,16 @@ const ProteinsListItemInfo = (props: Props) => {
               </div>
             )}
         </>
-        <StatusContent
-          summaryLoadingState={summaryStatsLoadingState}
-          domainsLoadingState={domainsLoadingState}
-        />
+        {showLoadingIndicator && (
+          <div className={styles.statusContainer}>
+            <CircleLoader />
+          </div>
+        )}
         <div className={styles.keyline}></div>
       </div>
     </div>
   );
 };
-
-type StatusContentProps = {
-  summaryLoadingState: LoadingState;
-  domainsLoadingState: LoadingState;
-};
-
-const StatusContent = (props: StatusContentProps) =>
-  props.domainsLoadingState === LoadingState.LOADING ||
-  props.summaryLoadingState === LoadingState.LOADING ? (
-    <div className={styles.statusContainer}>
-      <CircleLoader />
-    </div>
-  ) : null;
 
 type ProteinExternalReferenceProps = {
   source: ExternalSource;

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
@@ -19,6 +19,7 @@ import { useParams } from 'react-router-dom';
 import set from 'lodash/fp/set';
 import { Pick2 } from 'ts-multipick';
 
+import { CircleLoader } from 'src/shared/components/loader/Loader';
 import ProteinDomainImage from 'src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage';
 import ProteinImage from 'src/content/app/entity-viewer/gene-view/components/protein-image/ProteinImage';
 import ProteinFeaturesCount from 'src/content/app/entity-viewer/gene-view/components/protein-features-count/ProteinFeaturesCount';
@@ -235,11 +236,28 @@ const ProteinsListItemInfo = (props: Props) => {
               </div>
             )}
         </>
+        <StatusContent
+          summaryLoadingState={summaryStatsLoadingState}
+          domainsLoadingState={domainsLoadingState}
+        />
         <div className={styles.keyline}></div>
       </div>
     </div>
   );
 };
+
+type StatusContentProps = {
+  summaryLoadingState: LoadingState;
+  domainsLoadingState: LoadingState;
+};
+
+const StatusContent = (props: StatusContentProps) =>
+  props.domainsLoadingState === LoadingState.LOADING ||
+  props.summaryLoadingState === LoadingState.LOADING ? (
+    <div className={styles.statusContainer}>
+      <CircleLoader />
+    </div>
+  ) : null;
 
 type ProteinExternalReferenceProps = {
   source: ExternalSource;

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
@@ -19,8 +19,6 @@ import { useParams } from 'react-router-dom';
 import set from 'lodash/fp/set';
 import { Pick2 } from 'ts-multipick';
 
-import { CircleLoader } from 'src/shared/components/loader/Loader';
-import { PrimaryButton } from 'src/shared/components/button/Button';
 import ProteinDomainImage from 'src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage';
 import ProteinImage from 'src/content/app/entity-viewer/gene-view/components/protein-image/ProteinImage';
 import ProteinFeaturesCount from 'src/content/app/entity-viewer/gene-view/components/protein-features-count/ProteinFeaturesCount';
@@ -237,56 +235,10 @@ const ProteinsListItemInfo = (props: Props) => {
               </div>
             )}
         </>
-        <StatusContent
-          summaryLoadingState={summaryStatsLoadingState}
-          domainsLoadingState={domainsLoadingState}
-          setSummaryStatsLoadingState={setSummaryStatsLoadingState}
-          setDomainsLoadingState={setDomainsLoadingState}
-        />
-
         <div className={styles.keyline}></div>
       </div>
     </div>
   );
-};
-
-type StatusContentProps = {
-  summaryLoadingState: LoadingState;
-  domainsLoadingState: LoadingState;
-  setSummaryStatsLoadingState: (loadingState: LoadingState) => void;
-  setDomainsLoadingState: (loadingState: LoadingState) => void;
-};
-
-const StatusContent = (props: StatusContentProps) => {
-  if (
-    props.domainsLoadingState === LoadingState.LOADING ||
-    props.summaryLoadingState === LoadingState.LOADING
-  ) {
-    return (
-      <div className={styles.statusContainer}>
-        <CircleLoader />
-      </div>
-    );
-  }
-
-  const retryHandler = () => {
-    if (props.domainsLoadingState === LoadingState.ERROR) {
-      props.setDomainsLoadingState(LoadingState.LOADING);
-    }
-    if (props.summaryLoadingState === LoadingState.ERROR) {
-      props.setSummaryStatsLoadingState(LoadingState.LOADING);
-    }
-  };
-
-  return props.domainsLoadingState === LoadingState.ERROR ||
-    props.summaryLoadingState === LoadingState.ERROR ? (
-    <div className={styles.statusContainer}>
-      <span className={styles.errorMessage}>
-        Failed to get data from PDBe Knowledge Base.
-      </span>
-      <PrimaryButton onClick={retryHandler}>Try again</PrimaryButton>
-    </div>
-  ) : null;
 };
 
 type ProteinExternalReferenceProps = {


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
[ENSWBSITES-943](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-943)

## Deployment URL
http://pdbe-response-errors.review.ensembl.org/entity-viewer/homo_sapiens_GCA_000001405_28/gene:ENSG00000139618?protein_id=ENSP00000439902.1&view=protein

## Description
Currently, we are showing a status message and 'Try again' button when PDBe responses return with error status code. However, we don't want to do this anymore. Hence this PR removes both of them.

## Views affected
Entity viewer -> protein list -> protein list item
