### PR TITLE
Show stable id on GeneView sequence download

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -49,7 +49,7 @@ import { View } from 'src/content/app/entity-viewer/state/gene-view/view/geneVie
 import transcriptsListStyles from '../DefaultTranscriptsList.scss';
 import styles from './TranscriptsListItemInfo.scss';
 
-type Gene = Pick<FullGene, 'unversioned_stable_id'>;
+type Gene = Pick<FullGene, 'unversioned_stable_id' | 'stable_id'>;
 type Transcript = Pick<
   FullTranscript,
   'stable_id' | 'unversioned_stable_id' | 'symbol' | 'so_term'
@@ -211,7 +211,7 @@ const renderInstantDownload = ({
           id: transcript.stable_id,
           so_term: transcript.so_term
         }}
-        gene={{ id: gene.unversioned_stable_id }}
+        gene={{ id: gene.stable_id }}
       />
     </div>
   );

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -208,7 +208,7 @@ const renderInstantDownload = ({
       <InstantDownloadTranscript
         genomeId={genomeId}
         transcript={{
-          id: transcript.unversioned_stable_id,
+          id: transcript.stable_id,
           so_term: transcript.so_term
         }}
         gene={{ id: gene.unversioned_stable_id }}

--- a/src/ensembl/src/shared/components/instant-download/instant-download-fetch/fetchForTranscript.ts
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-fetch/fetchForTranscript.ts
@@ -57,6 +57,7 @@ export const fetchForTranscript = async (payload: FetchPayload) => {
     transcriptId,
     options: { transcript: transcriptOptions, gene: geneOptions }
   } = payload;
+
   const transcriptSequenceData = await fetchTranscriptSequenceMetadata({
     genomeId,
     transcriptId
@@ -74,6 +75,7 @@ export const fetchForTranscript = async (payload: FetchPayload) => {
       stableId: geneId,
       type: 'gene'
     });
+
     sequenceDownloadParams.push(
       getGenomicSequenceData(unversioned_gene_stable_id)
     );
@@ -167,20 +169,25 @@ const getUnversionedStableId = async (
     query = gql`
       query Transcript($genomeId: String!, $stableId: String!) {
         transcript(byId: { genome_id: $genomeId, stable_id: $stableId }) {
+          stable_id
           unversioned_stable_id
         }
       }
     `;
-  } else {
+  } else if (variables.type === 'gene') {
     query = gql`
       query Gene($genomeId: String!, $stableId: String!) {
         gene(byId: { genome_id: $genomeId, stable_id: $stableId }) {
+          stable_id
           unversioned_stable_id
         }
       }
     `;
   }
 
+  if (!query) {
+    return '';
+  }
   return client
     .query<TranscriptQueryResult | GeneQueryResult>({
       query,


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-785

## Description
Currently shows unversioned stable id (may be because we use REST to get genomic sequences which doesnt like versioned stable ids) 
This PR displays stable ids and fetch unversioned stable id in the fetcher script

## Deployment URL
http://add-stableid-versions.review.ensembl.org/

## Views affected
Entity viewer - GeneView

## Possible complications
GeneView Sidebar Downloads?
