### PR TITLE
Fix the import of the web worker for gene sequence fetching

### DIFF
--- a/src/ensembl/src/shared/components/instant-download/instant-download-fetch/fetchForGene.ts
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-fetch/fetchForGene.ts
@@ -21,11 +21,15 @@ import downloadAsFile from 'src/shared/helpers/downloadAsFile';
 import { TranscriptOptions } from '../instant-download-transcript/InstantDownloadTranscript';
 import { fetchGeneSequenceMetadata } from './fetchSequenceChecksums';
 
-import { WorkerApi } from 'src/shared/workers/sequenceFetcher.worker';
 import {
   getGenomicSequenceData,
   prepareDownloadParameters
 } from './fetchForTranscript';
+
+// @ts-expect-error There is in fact no default export in the worker
+import SequenceFetcherWorker, {
+  WorkerApi
+} from 'src/shared/workers/sequenceFetcher.worker';
 
 type GeneOptions = {
   transcript: Partial<TranscriptOptions>;
@@ -69,9 +73,8 @@ export const fetchForGene = async (payload: FetchPayload) => {
     );
   }
 
-  const worker = new Worker('src/shared/workers/sequenceFetcher.worker', {
-    type: 'module'
-  });
+  const worker = new SequenceFetcherWorker();
+
   const service = wrap<WorkerApi>(worker);
   const sequences = await service.downloadSequences(sequenceDownloadParams);
 


### PR DESCRIPTION
## Type
- Bug fix

## Description
Forgot to update the import of the sequence downloading web worker into the gene sequence fetcher. Using the worker loader of webpack 5 now.

## Deployment URL
http://fix-web-worker.review.ensembl.org/

## Views affected
Gene sequence download