### PR TITLE
Fix the bug that prevented users from leaving genome browser page using the back button

### DIFF
--- a/src/ensembl/src/content/app/browser/hooks/useBrowserRouting.ts
+++ b/src/ensembl/src/content/app/browser/hooks/useBrowserRouting.ts
@@ -149,15 +149,25 @@ const useBrowserRouting = () => {
         ? buildFocusIdForUrl(activeEnsObjectId)
         : null;
 
-      const params = {
+      const nextUrlParams = {
         genomeId,
         focus: focusIdForUrl,
         location: chrLocation ? getChrLocationStr(chrLocation) : null
       };
 
-      dispatch(push(urlFor.browser(params)));
+      // In case the url is simply /genome-browser, use the `replace` history method to redirect the user further.
+      // This will allow the user to return from the next page (genome browser with genome id selected)
+      // back to the page from which they have navigated to the current one. If the `push` method is used,
+      // the user will not be able to get back past this page, because the url without genome id will remain
+      // in the history, and the user will be forcefully redirected to the url with the genome id.
+      // 
+      // NOTE: the logic will likely change in the future when /genome-browser without the selected genome id
+      // becomes a valid searchable page in its own right.
+      const historyMethod = params.genomeId ? push : replace;
+
+      dispatch(historyMethod(urlFor.browser(nextUrlParams)));
     },
-    [genomeId]
+    [params.genomeId]
   );
 
   return {


### PR DESCRIPTION
## Type
- Bug fix

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1043

## Description
**Steps to reproduce the bug**
1) Select a new species in species selector (or delete the current one and select it again)
2) Go to Genome Browser and see the interstitial screen
3) Click on the browser back button to return to Species Selector.
4) (bug) You can't; the browser immediately returns you to the interstitial screen.

## Deployment URL
http://fix-genome-browser-page-navigation.review.ensembl.org

## Views affected
Genome browser