### PR TITLE
Update SvgrMock module name

### DIFF
--- a/src/ensembl/src/shared/components/external-link/ExternalLink.test.tsx
+++ b/src/ensembl/src/shared/components/external-link/ExternalLink.test.tsx
@@ -41,9 +41,8 @@ describe('<ExternalLink />', () => {
 
     expect(
       container
-        .querySelector(`icon-mock`)
-        ?.getAttribute('classname')
-        ?.includes(defaultProps.classNames?.icon as string)
+        .querySelector(`svg`)
+        ?.classList.contains(defaultProps.classNames?.icon as string)
     ).toBeTruthy();
 
     expect(

--- a/src/ensembl/src/shared/components/external-reference/ExternalReference.test.tsx
+++ b/src/ensembl/src/shared/components/external-reference/ExternalReference.test.tsx
@@ -67,9 +67,8 @@ describe('<ExternalReference />', () => {
 
     expect(
       container
-        .querySelector(`.externalLinkContainer icon-mock`)
-        ?.getAttribute('classname')
-        ?.includes(defaultProps.classNames?.icon as string)
+        .querySelector(`.externalLinkContainer svg`)
+        ?.classList.contains(defaultProps.classNames?.icon as string)
     ).toBeTruthy();
 
     expect(

--- a/src/ensembl/tests/svgrMock.js
+++ b/src/ensembl/tests/svgrMock.js
@@ -3,6 +3,6 @@
 // https://github.com/facebook/jest/issues/5258#issuecomment-356251559
 
 module.exports = {
-  default: 'icon-mock',
-  ReactComponent: 'icon-mock'
+  default: 'svg',
+  ReactComponent: 'svg'
 };


### PR DESCRIPTION

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1066


## Description
Updated the SvgrMock tag name from `icon-mock` to `svg`.

Please refer to the following comment for more info regarding why we are doing this:
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1066?focusedCommentId=356406&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-356406

