### PR TITLE
ENSWBSITES-1037: show none when gene name is novel transcript

### DIFF
--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/gene-summary/GeneSummary.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/gene-summary/GeneSummary.tsx
@@ -23,6 +23,7 @@ import classNames from 'classnames';
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import { getFormattedLocation } from 'src/shared/helpers/formatters/regionFormatter';
 import { getStrandDisplayName } from 'src/shared/helpers/formatters/strandFormatter';
+import { getGeneName } from 'src/shared/helpers/formatters/geneFormatter';
 import {
   buildFocusIdForUrl,
   getDisplayStableId
@@ -130,9 +131,7 @@ const GeneSummary = () => {
 
       <div className={rowClasses}>
         <div className={styles.label}>Gene name</div>
-        <div className={styles.value}>
-          {gene.name === 'novel transcript' || !gene.name ? 'None' : gene.name}
-        </div>
+        <div className={styles.value}>{getGeneName(gene.name)}</div>
       </div>
 
       {gene.alternative_symbols.length > 0 && (

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/gene-summary/GeneSummary.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/gene-summary/GeneSummary.tsx
@@ -130,7 +130,9 @@ const GeneSummary = () => {
 
       <div className={rowClasses}>
         <div className={styles.label}>Gene name</div>
-        <div className={styles.value}>{gene.name}</div>
+        <div className={styles.value}>
+          {gene.name === 'novel transcript' || !gene.name ? 'None' : gene.name}
+        </div>
       </div>
 
       {gene.alternative_symbols.length > 0 && (

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.scss
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.scss
@@ -65,8 +65,8 @@
   font-weight: $light;
 }
 
-.leftSpacing {
-  margin-left: 12px;
+.geneSymbol {
+  margin-right: 12px;
 }
 
 

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.scss
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.scss
@@ -65,6 +65,10 @@
   font-weight: $light;
 }
 
+.leftSpacing {
+  margin-left: 12px;
+}
+
 
 .downloadLink{
   color: $blue;

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
@@ -315,7 +315,7 @@ const TranscriptSummary = () => {
         <div className={styles.value}>
           <div>
             {gene.symbol && <span>{gene.symbol}</span>}
-            {gene.symbol !== stableId && <span>{stableId}</span>}
+            {gene.symbol !== stableId && <span className={styles.leftSpacing}>{gene.stable_id}</span>}
           </div>
         </div>
       </div>

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
@@ -27,6 +27,7 @@ import {
 } from 'src/shared/state/ens-object/ensObjectHelpers';
 import { getBrowserActiveEnsObject } from 'src/content/app/browser/browserSelectors';
 import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
+import { getGeneName } from 'src/shared/helpers/formatters/geneFormatter';
 
 // TODO: check if this can be moved to a common place
 import {
@@ -321,7 +322,7 @@ const TranscriptSummary = () => {
 
       <div className={styles.row}>
         <div className={styles.label}>Gene name</div>
-        <div className={styles.value}>{gene.name}</div>
+        <div className={styles.value}>{getGeneName(gene.name)}</div>
       </div>
 
       <div className={`${styles.row} ${styles.spaceAbove}`}>

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
@@ -314,8 +314,8 @@ const TranscriptSummary = () => {
         <div className={styles.label}>Gene</div>
         <div className={styles.value}>
           <div>
-            {gene.symbol && <span>{gene.symbol}</span>}
-            {gene.symbol !== stableId && <span className={styles.leftSpacing}>{gene.stable_id}</span>}
+            {gene.symbol && <span className={styles.geneSymbol}>{gene.symbol}</span>}
+            {gene.symbol !== stableId && <span>{gene.stable_id}</span>}
           </div>
         </div>
       </div>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 import { useParams } from 'react-router-dom';
 import { useQuery, gql } from '@apollo/client';
 import { parseEnsObjectIdFromUrl } from 'src/shared/state/ens-object/ensObjectHelpers';
+import { getGeneName } from 'src/shared/helpers/formatters/geneFormatter';
 
 import GenePublications from '../publications/GenePublications';
 import MainAccordion from './MainAccordion';
@@ -80,9 +81,7 @@ const GeneOverview = () => {
       </div>
 
       <div className={styles.sectionHead}>Gene name</div>
-      <div className={styles.geneName}>
-        {gene.name === 'novel transcript' || !gene.name ? 'None' : gene.name}
-      </div>
+      <div className={styles.geneName}>{getGeneName(gene.name)}</div>
 
       <div className={styles.sectionHead}>Synonyms</div>
       <div className={styles.synonyms}>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
@@ -80,7 +80,9 @@ const GeneOverview = () => {
       </div>
 
       <div className={styles.sectionHead}>Gene name</div>
-      <div className={styles.geneName}>{gene.name || 'None'}</div>
+      <div className={styles.geneName}>
+        {gene.name === 'novel transcript' || !gene.name ? 'None' : gene.name}
+      </div>
 
       <div className={styles.sectionHead}>Synonyms</div>
       <div className={styles.synonyms}>

--- a/src/ensembl/src/shared/helpers/formatters/geneFormatter.test.ts
+++ b/src/ensembl/src/shared/helpers/formatters/geneFormatter.test.ts
@@ -20,6 +20,7 @@
    it('returns the correct gene display name', () => {
      expect(getGeneName('novel transcript')).toBe('None');
      expect(getGeneName('')).toBe('None');
-     expect(getGeneName('Heat shock protein 101[Source:UniProtKB/TrEMBL;Acc:Q9SPH4]')).toBe('Heat shock protein 101');
+     expect(getGeneName(null)).toBe('None');
+     expect(getGeneName('Heat shock protein 101 [Source:UniProtKB/TrEMBL;Acc:Q9SPH4]')).toBe('Heat shock protein 101 ');
    });
  });

--- a/src/ensembl/src/shared/helpers/formatters/geneFormatter.test.ts
+++ b/src/ensembl/src/shared/helpers/formatters/geneFormatter.test.ts
@@ -1,0 +1,25 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ import { getGeneName } from './geneFormatter';
+  
+ describe('getGeneName', () => {
+   it('returns the correct gene display name', () => {
+     expect(getGeneName('novel transcript')).toBe('None');
+     expect(getGeneName('')).toBe('None');
+     expect(getGeneName('Heat shock protein 101[Source:UniProtKB/TrEMBL;Acc:Q9SPH4]')).toBe('Heat shock protein 101');
+   });
+ });

--- a/src/ensembl/src/shared/helpers/formatters/geneFormatter.test.ts
+++ b/src/ensembl/src/shared/helpers/formatters/geneFormatter.test.ts
@@ -21,6 +21,6 @@
      expect(getGeneName('novel transcript')).toBe('None');
      expect(getGeneName('')).toBe('None');
      expect(getGeneName(null)).toBe('None');
-     expect(getGeneName('Heat shock protein 101 [Source:UniProtKB/TrEMBL;Acc:Q9SPH4]')).toBe('Heat shock protein 101 ');
+     expect(getGeneName('Heat shock protein 101 [Source:UniProtKB/TrEMBL;Acc:Q9SPH4]')).toBe('Heat shock protein 101');
    });
  });

--- a/src/ensembl/src/shared/helpers/formatters/geneFormatter.ts
+++ b/src/ensembl/src/shared/helpers/formatters/geneFormatter.ts
@@ -16,7 +16,7 @@
 
 export function getGeneName(geneName: string | null) {
   if(geneName && geneName !== 'novel transcript') {
-    return geneName.replace(/\[Source:.*\]/,'');
+    return geneName.replace(/\[Source:.*\]/,'').trim();
   } else {
     return 'None';
   }

--- a/src/ensembl/src/shared/helpers/formatters/geneFormatter.ts
+++ b/src/ensembl/src/shared/helpers/formatters/geneFormatter.ts
@@ -1,0 +1,23 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function getGeneName(geneName: string | null) {
+  if(geneName && geneName != 'novel transcript') {
+    return geneName.replace(/\[Source:.*\]/,'');
+  } else {
+    return 'None';
+  }
+}

--- a/src/ensembl/src/shared/helpers/formatters/geneFormatter.ts
+++ b/src/ensembl/src/shared/helpers/formatters/geneFormatter.ts
@@ -15,7 +15,7 @@
  */
 
 export function getGeneName(geneName: string | null) {
-  if(geneName && geneName != 'novel transcript') {
+  if(geneName && geneName !== 'novel transcript') {
     return geneName.replace(/\[Source:.*\]/,'');
   } else {
     return 'None';


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1037

## Importance
N/A

## Description
Show 'none' when gene name is 'novel transcript' in both Entity Viewer Sidebar panel and in Genome browser track drawer. This is a temporary fix until the data is loaded properly. We will have to revert this change.

As a bonus we are cleaning the gene name where they contains source details for example: 
`Heat shock protein 101[Source:UniProtKB/TrEMBL;Acc:Q9SPH4]` becomes `Heat shock protein 101`

## Deployment URL
http://hide-novel-transcript.review.ensembl.org/

example gene for human: 
gene:ENSG00000270008

## Views affected
Entity viewer sidebar panel
Genome browser track bar

### Other effects
N/A

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
None
