### PR TITLE
Fix the position of the ViewInApp popup while scrolling

### DIFF
--- a/src/ensembl/src/shared/components/view-in-app-popup/ViewInAppPopup.scss
+++ b/src/ensembl/src/shared/components/view-in-app-popup/ViewInAppPopup.scss
@@ -1,5 +1,9 @@
 @import 'src/styles/common';
 
+.wrapper {
+  position: relative;
+}
+
 .pointerBox {
   padding: 6px 12px;
   background: $black;

--- a/src/ensembl/src/shared/components/view-in-app-popup/ViewInAppPopup.tsx
+++ b/src/ensembl/src/shared/components/view-in-app-popup/ViewInAppPopup.tsx
@@ -34,11 +34,12 @@ const ViewInAppPopup = (props: ViewInAppPopupProps) => {
   const anchorRef = useRef<HTMLSpanElement>(null);
 
   return (
-    <span ref={anchorRef} onClick={() => setShowPointerBox(!showPointerBox)}>
+    <span className={styles.wrapper} ref={anchorRef} onClick={() => setShowPointerBox(!showPointerBox)}>
       {children}
       {showPointerBox && anchorRef.current && (
         <PointerBox
           anchor={anchorRef.current}
+          renderInsideAnchor={true}
           onOutsideClick={() => setShowPointerBox(false)}
           position={props.position}
           autoAdjust={true}


### PR DESCRIPTION
## Type
- Bug fix

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1102 (although it doesn't describe precisely the bug that is being fixed in this PR).

## Description
**Steps to reproduce the bug:**
- visit the species page
- expand the first section (the one that contains the "Example gene" link)
- click on the Example gene link to see the "View in App" popup appear
- scroll the page

Bug: the popup will float on the page instead of sticking to the Example gene link:

![](https://user-images.githubusercontent.com/6834224/116154557-b38a4300-a6e0-11eb-983e-c8fdeb88852a.gif)

## Deployment URL
http://fix-view-in-app-on-species-page.review.ensembl.org/

## Views affected
Species page