### PR TITLE
Fix the unexpected expansion of species links on the home page

### DIFF
--- a/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.tsx
+++ b/src/ensembl/src/content/home/components/homepage-app-links/HomepageAppLinks.tsx
@@ -56,7 +56,7 @@ type HomepageAppLinksRowProps = {
 const HomepageAppLinks = (props: Props) => {
   const [expandedRowIndex, setExpandedRowIndex] = useState<number | null>(null);
 
-  const onToggleRow = (index: number) => {
+  const onToggleRow = (index: number | null) => {
     if (index === expandedRowIndex) {
       setExpandedRowIndex(null);
     } else {
@@ -86,7 +86,7 @@ const HomepageAppLinksRow = (props: HomepageAppLinksRowProps) => {
   const dispatch = useDispatch();
 
   const onOutsideClick = () => {
-    toggleExpand();
+    isExpanded && toggleExpand();
   };
 
   useOutsideClick(elementRef, onOutsideClick);


### PR DESCRIPTION
## Type
- Bug fix


## Description
Steps to reproduce the bug (currently in production):
- Select at least one species
- Go to the home page
- Click somewhere on the home page

Bug: a species row will get expanded:

![](https://user-images.githubusercontent.com/6834224/116592998-888a3400-a918-11eb-85b8-de40f8d2237d.gif)

This is a result of my sloppy code that became apparent after we updated React to v.17. I am adding a quick fix here, just to avoid unnecessary confusion for home page visitors; but keep in mind that the home page is going to fundamentally change very soon, before the MAP.

## Deployment URL
http://fix-species-links-on-homepage.review.ensembl.org

## Views affected
Home page