### PR TITLE
Remove transcript symbols from EV transcript image and GB drawer

### DIFF
--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
@@ -216,11 +216,6 @@ const TranscriptSummary = () => {
       </div>
 
       <div className={`${styles.row} ${styles.spaceAbove}`}>
-        <div className={styles.label}>Transcript name</div>
-        <div className={styles.value}>{transcript.symbol}</div>
-      </div>
-
-      <div className={styles.row}>
         <div className={styles.label}>Transcript length</div>
         <div className={styles.value}>
           {getCommaSeparatedNumber(transcript.slice.location.length)}{' '}

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
@@ -50,7 +50,6 @@ type Transcript = Pick<
   FullTranscript,
   | 'stable_id'
   | 'unversioned_stable_id'
-  | 'symbol'
   | 'so_term'
   | 'external_references'
   | 'slice'
@@ -78,7 +77,6 @@ const GENE_AND_TRANSCRIPT_QUERY = gql`
       stable_id
       unversioned_stable_id
       so_term
-      symbol
       external_references {
         accession_id
         url

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -86,7 +86,6 @@ const QUERY = gql`
       transcripts {
         stable_id
         unversioned_stable_id
-        symbol
         so_term
         slice {
           location {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
@@ -67,5 +67,5 @@
 }
 
 .viewInApp {
-  padding-top: 32px;
+  padding-top: 12px;
 }

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -185,9 +185,6 @@ export const TranscriptsListItemInfo = (
         {props.expandDownload && renderInstantDownload({ ...props, genomeId })}
       </div>
       <div className={transcriptsListStyles.right}>
-        <div className={styles.transcriptName}>
-          <strong>{transcript.symbol}</strong>
-        </div>
         <div className={styles.viewInApp}>
           <ViewInApp links={{ genomeBrowser: { url: getBrowserLink() } }} />
         </div>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -52,7 +52,7 @@ import styles from './TranscriptsListItemInfo.scss';
 type Gene = Pick<FullGene, 'unversioned_stable_id' | 'stable_id'>;
 type Transcript = Pick<
   FullTranscript,
-  'stable_id' | 'unversioned_stable_id' | 'symbol' | 'so_term'
+  'stable_id' | 'unversioned_stable_id' | 'so_term'
 > &
   Pick2<FullTranscript, 'slice', 'location'> &
   Pick3<FullTranscript, 'slice', 'region', 'name'> & {


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-968

## Description
Remove transcript symbol from GB drawer and EV transcript image

## Deployment URL
http://remove-transcript-symbol.review.ensembl.org/

## Views affected
GB & EV

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
N/A