### PR TITLE
[WIP] Fix the error due to opening the Proteins tab for a non-coding gene 

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.tsx
@@ -112,7 +112,9 @@ const GeneFunction = (props: Props) => {
   const getCurrentTabContent = () => {
     switch (selectedTabName) {
       case GeneFunctionTabName.PROTEINS:
-        return <ProteinsList gene={props.gene} />;
+        return hasProteinCodingTranscripts ? (
+          <ProteinsList gene={props.gene} />
+        ) : null;
       default:
         return <>Data for these views will be available soon...</>;
     }


### PR DESCRIPTION
## Type
- Bug fix

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1096

## Description
The Proteins tab assumes that it will receive a gene with at least some protein-coding transcripts; but we are not checking that in our code, and sometimes pass non-coding genes to the Proteins tab. This is when the Proteins tab breaks.

## Deployment URL
TODO

## Views affected
Entity Viewer -> Proteins view