### PR TITLE
Reposition download

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
@@ -69,7 +69,7 @@
   width: 12px;
   transition: transform linear 0.2s;
   &Up {
-    transform: rotate(180deg);
+    transform: rotate(-180deg);
   }
 }
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
@@ -9,9 +9,10 @@
 .middle {
   display: grid;
   grid-template-areas:
-    'left middle right .'
-    '. . . downloadLink'
-    'download download download download';
+    'left middle right'
+    'moreinformation . .'
+    'downloadLink . .'
+    'download download download';
   grid-column-gap: 10px;
   background: $soft-black;
   padding: 15px 20px;
@@ -42,17 +43,16 @@
   width: 210px;
 }
 
+.moreInformation {
+  margin-top: 10px;
+}
+
 .downloadLink {
   grid-area: downloadLink;
   color: $blue;
-  width: 66px;
-  height: 16px;
-  text-align: right;
+  text-align: left;
   line-height: 1;
-
-  span {
-    cursor: pointer;
-  }
+  cursor: pointer;
 }
 
 .download {
@@ -62,8 +62,15 @@
   border-top: 1px solid $dark-grey;
 }
 
-.closeButton {
-  display: inline-block;
+.chevron {
+  margin-left: 10px;
+  margin-bottom: -3px;
+  height: 12px;
+  width: 12px;
+  transition: transform linear 0.2s;
+  &Up {
+    transform: rotate(180deg);
+  }
 }
 
 .viewInApp {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
@@ -15,7 +15,7 @@
     'download download download';
   grid-column-gap: 10px;
   background: $soft-black;
-  padding: 15px 20px;
+  padding: 15px 30px;
 
   strong {
     color: $white;
@@ -51,15 +51,13 @@
   grid-area: downloadLink;
   color: $blue;
   text-align: left;
-  line-height: 1;
+  line-height: 2;
   cursor: pointer;
 }
 
 .download {
   grid-area: download;
-  padding-top: 15px;
-  margin-top: 15px;
-  border-top: 1px solid $dark-grey;
+  padding-top: 6px;
 }
 
 .chevron {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
@@ -2,7 +2,6 @@
 
 .listItemInfo {
   color: $grey;
-  line-height: 2;
   padding-top: 0;
 }
 
@@ -31,28 +30,36 @@
 .topLeft {
   grid-area: left;
   width: 190px;
+  div {
+    padding-bottom: 6px;
+  }
 }
 
 .topMiddle {
   grid-area: middle;
   width: 150px;
+  div {
+    padding-bottom: 6px;
+  }
 }
 
 .topRight {
   grid-area: right;
   width: 210px;
+  div {
+    padding-bottom: 6px;
+  }
 }
 
 .moreInformation {
-  margin-top: 10px;
+  padding-top: 16px;
 }
 
 .downloadLink {
   grid-area: downloadLink;
   color: $blue;
-  text-align: left;
-  line-height: 2;
   cursor: pointer;
+  padding-top: 6px;
 }
 
 .download {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.test.tsx
@@ -64,9 +64,11 @@ describe('<TranscriptsListItemInfo /', () => {
     const { container } = renderComponent();
     const expectedProteinLength =
       defaultProps.transcript.product_generating_contexts[0].product?.length;
-    expect(container.querySelector('.topMiddle strong')?.textContent).toMatch(
-      `${expectedProteinLength}`
-    );
+    const currentProteinLength = container
+      .querySelector('.topMiddle strong')
+      ?.textContent?.split(/\s/)[0]
+      ?.replace(/,/g, '');
+    expect(currentProteinLength).toMatch(`${expectedProteinLength}`);
   });
 
   it('contains the download link', () => {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -107,6 +107,10 @@ export const TranscriptsListItemInfo = (
     getSplicedRNALength(transcript)
   );
 
+  const aminoAcidLength = getCommaSeparatedNumber(
+    getProductAminoAcidLength(transcript)
+  );
+
   const mainStyles = classNames(transcriptsListStyles.row, styles.listItemInfo);
   const midStyles = classNames(transcriptsListStyles.middle, styles.middle);
 
@@ -153,7 +157,7 @@ export const TranscriptsListItemInfo = (
           {isProteinCodingTranscript(transcript) && (
             <>
               <div>
-                <strong>{getProductAminoAcidLength(transcript)} aa</strong>
+                <strong>{aminoAcidLength} aa</strong>
               </div>
               {getLinkToProteinView(
                 transcript.product_generating_contexts[0]?.product.stable_id

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -35,7 +35,6 @@ import { buildFocusIdForUrl } from 'src/shared/state/ens-object/ensObjectHelpers
 
 import { InstantDownloadTranscript } from 'src/shared/components/instant-download';
 import ViewInApp from 'src/shared/components/view-in-app/ViewInApp';
-import CloseButton from 'src/shared/components/close-button/CloseButton';
 
 import { toggleTranscriptDownload } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 import { clearExpandedProteins } from 'src/content/app/entity-viewer/state/gene-view/proteins/geneViewProteinsSlice';
@@ -48,6 +47,8 @@ import { View } from 'src/content/app/entity-viewer/state/gene-view/view/geneVie
 
 import transcriptsListStyles from '../DefaultTranscriptsList.scss';
 import styles from './TranscriptsListItemInfo.scss';
+
+import { ReactComponent as ChevronDown } from 'static/img/shared/chevron-down.svg';
 
 type Gene = Pick<FullGene, 'unversioned_stable_id' | 'stable_id'>;
 type Transcript = Pick<
@@ -133,6 +134,11 @@ export const TranscriptsListItemInfo = (
     const { genomeId } = params;
     return urlFor.browser({ genomeId: genomeId, focus: focusIdForUrl });
   };
+
+  const chevronClassForDownload = classNames(styles.chevron, {
+    [styles.chevronUp]: props.expandDownload
+  });
+
   return (
     <div className={mainStyles}>
       <div className={transcriptsListStyles.left}></div>
@@ -164,23 +170,15 @@ export const TranscriptsListItemInfo = (
             of {transcript.spliced_exons.length}
           </div>
         </div>
-        <div className={styles.downloadLink}>
-          {props.expandDownload ? (
-            <CloseButton
-              className={styles.closeButton}
-              onClick={() =>
-                props.toggleTranscriptDownload(transcript.stable_id)
-              }
-            />
-          ) : (
-            <span
-              onClick={() =>
-                props.toggleTranscriptDownload(transcript.stable_id)
-              }
-            >
-              Download
-            </span>
-          )}
+
+        <div className={styles.moreInformation}>More information</div>
+
+        <div
+          className={styles.downloadLink}
+          onClick={() => props.toggleTranscriptDownload(transcript.stable_id)}
+        >
+          Download
+          <ChevronDown className={chevronClassForDownload} />
         </div>
         {props.expandDownload && renderInstantDownload({ ...props, genomeId })}
       </div>

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.scss
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.scss
@@ -15,7 +15,7 @@
 
   .featureId {
     margin-left: 0.5em;
-    font-weight: $bold;
+    font-weight: $normal;
   }
 }
 
@@ -28,11 +28,6 @@
   background-color: transparent;
   border-color: $dark-grey;
 }
-
-.checkboxLabel {
-  font-size: 13px;
-}
-
 
 .themeDark{
   .label {
@@ -62,7 +57,6 @@
 
 .layout {
   display: grid;
-  font-size: 13px;
 
   &Horizontal {
     grid-template-columns: 1fr 1fr;

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.scss
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.scss
@@ -64,6 +64,7 @@
     grid-template-areas:
       'transcript gene'
       'transcript download';
+    margin-bottom: 12px;
 
     .transcriptSection {
       grid-area: transcript;
@@ -74,16 +75,16 @@
       grid-area: gene;
 
       .checkboxWrapper {
-        margin-left: 12px;
+        margin-left: 6px;
       }
     }
 
     .transcriptVis {
-      margin-left: 18px;
+      margin-left: 12px;
     }
 
     .checkboxGrid {
-      margin-left: 12px;
+      padding-left: 6px;
     }
 
     button {

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.scss
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.scss
@@ -3,7 +3,7 @@
 .checkboxGrid {
   margin-top: 0.5em;
   display: grid;
-  grid-template-columns: 1.5fr 1fr;
+  grid-template-columns: 1fr 1fr;
   grid-template-rows: auto;
   grid-row-gap: 0.2em;
 }
@@ -66,27 +66,30 @@
 
   &Horizontal {
     grid-template-columns: 1fr 1fr;
-    grid-column-gap: 24px;
+    grid-column-gap: 10px;
     grid-template-areas:
       'transcript gene'
       'transcript download';
 
     .transcriptSection {
       grid-area: transcript;
+      width: 393px;
     }
 
     .geneSection {
       grid-area: gene;
 
       .checkboxWrapper {
-        margin-top: 13px;
-        margin-left: 13px;
+        margin-left: 12px;
       }
     }
 
-    .transcriptVis,
-    .checkboxGrid {
+    .transcriptVis {
       margin-left: 18px;
+    }
+
+    .checkboxGrid {
+      margin-left: 12px;
     }
 
     button {


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-965

## Description

- Reposition Transcript Download with a Chevron
- Add More information section but disabled (More functionality on this will be added but in a different ticket)

## Deployment URL
http://reposition-download.review.ensembl.org/entity-viewer/homo_sapiens_GCA_000001405_28/gene:ENSG00000139618?view=transcripts

## Views affected
Entity viewer Transcript Image

### Other effects
/A

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
N/A
