### PR TITLE
Apply transcript filtering to protein view and reposition filter & sort box

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
@@ -46,8 +46,7 @@ $backgroundColor: $black;
   z-index: 2;
   position: sticky;
   top: -80px;
-  height: 100%;
-  background-color: $backgroundColor;
+  height: 100%;  
 }
 
 .tabWrapper {
@@ -56,6 +55,7 @@ $backgroundColor: $black;
   display: flex;
   align-items: flex-end;
   padding: 4px;
+  background-color: $backgroundColor;
 }
 
 .filtersWrapper {
@@ -73,7 +73,8 @@ $backgroundColor: $black;
   padding-bottom: 9px;
   padding-top: 6px;
   position: sticky;
-  top: -37px;    
+  top: -37px;  
+  background-color: $backgroundColor;  
 }
 
 .openFilterLabelContainer {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
@@ -47,6 +47,7 @@ $backgroundColor: $black;
   position: sticky;
   top: -80px;
   height: 100%;  
+  background-color: $backgroundColor;
 }
 
 .tabWrapper {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
@@ -67,6 +67,7 @@ $backgroundColor: $black;
 }
 
 .filterLabelContainer {
+  background-color: $backgroundColor;
   grid-area: filter-toggle;  
   display: flex;
   flex-direction: column;

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
@@ -116,3 +116,7 @@ $backgroundColor: $black;
   height: 12px;
   width: 12px;
 }
+
+.chevronUp {
+  transform: rotate(180deg);
+}

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
@@ -47,7 +47,6 @@ $backgroundColor: $black;
   position: sticky;
   top: -80px;
   height: 100%;  
-  background-color: $backgroundColor;
 }
 
 .tabWrapper {
@@ -68,20 +67,29 @@ $backgroundColor: $black;
 }
 
 .filterLabelContainer {
-  grid-area: filter-toggle;
-  align-self: end;
+  grid-area: filter-toggle;  
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  position: sticky;
+  top: 0;      
+}
+
+.filterLabelWrapper {  
   padding-right: 20px;
   padding-bottom: 9px;
   padding-top: 6px;
-  position: sticky;
-  top: -37px;  
-  background-color: $backgroundColor;  
-}
+} 
 
 .openFilterLabelContainer {
-  background-color: $soft-black;
-  border-top-left-radius: 3px;
-  border-top-right-radius: 3px;  
+  background-color: $backgroundColor;
+  top: -80px;
+
+  .filterLabelWrapper {
+    background-color: $soft-black;
+    border-top-left-radius: 3px;
+    border-top-right-radius: 3px;  
+  }  
 }
 
 .filterLabel {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
@@ -16,7 +16,7 @@ $backgroundColor: $black;
   display: grid;
   background-color: $backgroundColor;
   grid-template-columns: 178px 902px 1fr;
-  grid-template-rows: min-content auto 1fr;  
+  grid-template-rows: min-content minmax(76px, auto) minmax(0, 1fr);  
   padding: 60px 20px 10px;
   height: 100%; // may need to change this later
   width: 100%;
@@ -52,6 +52,9 @@ $backgroundColor: $black;
 
 .tabWrapper {
   grid-area: tabs;
+  height: 76px;
+  display: flex;
+  align-items: flex-end;
   padding: 4px;
 }
 
@@ -65,10 +68,11 @@ $backgroundColor: $black;
 
 .filterLabelContainer {
   grid-area: filter-toggle;
+  align-self: end;
   padding-right: 20px;
-  padding-top: 3px;
+  padding-bottom: 9px;
+  padding-top: 6px;
   position: sticky;
-  height: 100%;
   top: -37px;    
 }
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
@@ -79,14 +79,18 @@ $backgroundColor: $black;
 .openFilterLabelContainer {
   background-color: $soft-black;
   border-top-left-radius: 3px;
-  border-top-right-radius: 3px;
+  border-top-right-radius: 3px;  
 }
 
 .filterLabel {
   text-align: right;
   padding-right: 2px;
   cursor: pointer;
-  color: $blue;  
+  color: $blue;
+}
+
+.openFilterLabel {
+  color: $white;
 }
 
 .labelWithActivityIndicator {
@@ -96,10 +100,10 @@ $backgroundColor: $black;
     content: '';
     position: absolute;
     border-radius: 100%;
-    height: 5px;
-    width: 5px;
+    height: 8px;
+    width: 8px;
     background: $red;
-    right: -6px;
+    right: -10px;
     top: -2px;
   }
 }

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
@@ -46,5 +46,51 @@ $backgroundColor: $black;
 }
 
 .geneViewTabContent {
-  grid-area: 3 / 1 / 4 / 4;
+  grid-area: 4 / 1 / 4 / 4;
+}
+
+.filterLabelContainer {
+  grid-area: 2/1;
+  z-index: 3;
+  margin: 44px 1px -5px 2px;  
+  padding-right: 20px;
+  padding-top: 3px;
+  position: sticky;
+  height: 100%;
+  top: -37px;    
+}
+
+.openFilterLabelContainer {
+  background-color: $soft-black;
+  border-radius: 3px;
+}
+
+.filterLabel {
+  grid-column: 1/2;
+  text-align: right;
+  padding-right: 2px;
+  cursor: pointer;
+  color: $blue;  
+}
+
+.labelWithActivityIndicator {
+  position: relative;
+
+  &::after {
+    content: '';
+    position: absolute;
+    border-radius: 100%;
+    height: 5px;
+    width: 5px;
+    background: $red;
+    right: -6px;
+    top: -2px;
+  }
+}
+
+.chevron {
+  margin-left: 10px;
+  margin-bottom: -3px;
+  height: 12px;
+  width: 12px;
 }

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
@@ -16,7 +16,7 @@ $backgroundColor: $black;
   display: grid;
   background-color: $backgroundColor;
   grid-template-columns: 178px 902px 1fr;
-  grid-template-rows: min-content 75px 1fr;
+  grid-template-rows: min-content auto 1fr;  
   padding: 60px 20px 10px;
   height: 100%; // may need to change this later
   width: 100%;
@@ -37,22 +37,34 @@ $backgroundColor: $black;
 
 .geneViewTabs {
   grid-area: 2 / 1 / 3 / 4;
+  display: grid;
+  grid-template-areas:
+                  "filter-toggle tabs"
+                  "filters filters";
+  grid-template-columns: 170px auto;
+  grid-template-rows: auto auto;
   z-index: 2;
   position: sticky;
   top: -80px;
   height: 100%;
   background-color: $backgroundColor;
-  padding-left: 180px;
+}
+
+.tabWrapper {
+  grid-area: tabs;
+  padding: 4px;
+}
+
+.filtersWrapper {
+  grid-area: filters;
 }
 
 .geneViewTabContent {
-  grid-area: 4 / 1 / 4 / 4;
+  grid-area: 3 / 1 / 4 / 4;
 }
 
 .filterLabelContainer {
-  grid-area: 2/1;
-  z-index: 3;
-  margin: 44px 1px -5px 2px;  
+  grid-area: filter-toggle;
   padding-right: 20px;
   padding-top: 3px;
   position: sticky;
@@ -62,11 +74,11 @@ $backgroundColor: $black;
 
 .openFilterLabelContainer {
   background-color: $soft-black;
-  border-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
 }
 
 .filterLabel {
-  grid-column: 1/2;
   text-align: right;
   padding-right: 2px;
   cursor: pointer;

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -264,28 +264,32 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
       <div className={styles.viewInLinks}>
         <ViewInApp links={{ genomeBrowser: { url: gbUrl } }} />
       </div>
-
-      <div
-        className={classNames([styles.filterLabelContainer], {
-          [styles.openFilterLabelContainer]: isFilterOpen
-        })}
-      >
-        {props.gene.transcripts.length > 5 && (
-          <div className={styles.filterLabel} onClick={toggleFilter}>
-            {filterLabel}
-            {chevron}
+      <div className={styles.geneViewTabs}>
+        <div
+          className={classNames([styles.filterLabelContainer], {
+            [styles.openFilterLabelContainer]: isFilterOpen
+          })}
+        >
+          {props.gene.transcripts.length > 5 && (
+            <div className={styles.filterLabel} onClick={toggleFilter}>
+              {filterLabel}
+              {chevron}
+            </div>
+          )}
+        </div>
+        <div className={styles.tabWrapper}>
+          <GeneViewTabs />
+        </div>
+        {isFilterOpen && (
+          <div className={styles.filtersWrapper}>
+            <TranscriptsFilter
+              toggleFilter={toggleFilter}
+              transcripts={props.gene.transcripts}
+            />
           </div>
         )}
       </div>
-      {isFilterOpen && (
-        <TranscriptsFilter
-          toggleFilter={toggleFilter}
-          transcripts={props.gene.transcripts}
-        />
-      )}
-      <div className={styles.geneViewTabs}>
-        <GeneViewTabs />
-      </div>
+
       <div className={styles.geneViewTabContent}>
         {selectedTabs.primaryTab === GeneViewTabName.TRANSCRIPTS &&
           basePairsRulerTicks && (

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -271,7 +271,12 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
           })}
         >
           {props.gene.transcripts.length > 5 && (
-            <div className={styles.filterLabel} onClick={toggleFilter}>
+            <div
+              className={classNames([styles.filterLabel], {
+                [styles.openFilterLabel]: isFilterOpen
+              })}
+              onClick={toggleFilter}
+            >
               {filterLabel}
               {chevron}
             </div>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -265,23 +265,25 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
           })}
         >
           {props.gene.transcripts.length > 5 && (
-            <div
-              className={classNames([styles.filterLabel], {
-                [styles.openFilterLabel]: isFilterOpen
-              })}
-              onClick={toggleFilter}
-            >
-              {filterLabel}
-              <ChevronDown
-                className={classNames([styles.chevron], {
-                  [styles.chevronUp]: isFilterOpen
+            <div className={styles.filterLabelWrapper}>
+              <div
+                className={classNames([styles.filterLabel], {
+                  [styles.openFilterLabel]: isFilterOpen
                 })}
-              />
+                onClick={toggleFilter}
+              >
+                {filterLabel}
+                <ChevronDown
+                  className={classNames([styles.chevron], {
+                    [styles.chevronUp]: isFilterOpen
+                  })}
+                />
+              </div>
             </div>
           )}
         </div>
         <div className={styles.tabWrapper}>
-          <GeneViewTabs />
+          <GeneViewTabs isFilterOpen={isFilterOpen} />
         </div>
         {isFilterOpen && (
           <div className={styles.filtersWrapper}>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -32,7 +32,6 @@ import {
   View,
   GeneViewTabName
 } from 'src/content/app/entity-viewer/state/gene-view/view/geneViewViewSlice';
-import { SortingRule } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 import { updatePreviouslyViewedEntities } from 'src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSlice';
 import { closeSidebarModal } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarActions';
 import { isEntityViewerSidebarOpen } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors';
@@ -62,9 +61,9 @@ import { CircleLoader } from 'src/shared/components/loader/Loader';
 import { TicksAndScale } from 'src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/BasePairsRuler';
 
 import { FullGene } from 'src/shared/types/thoas/gene';
+import { SortingRule } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 
 import { ReactComponent as ChevronDown } from 'static/img/shared/chevron-down.svg';
-import { ReactComponent as ChevronUp } from 'static/img/shared/chevron-up.svg';
 
 import styles from './GeneView.scss';
 
@@ -226,11 +225,6 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
       Filter & sort
     </span>
   );
-  const chevron = !isFilterOpen ? (
-    <ChevronDown className={styles.chevron} />
-  ) : (
-    <ChevronUp className={styles.chevron} />
-  );
 
   const toggleFilter = () => {
     setFilterOpen(!isFilterOpen);
@@ -278,7 +272,11 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
               onClick={toggleFilter}
             >
               {filterLabel}
-              {chevron}
+              <ChevronDown
+                className={classNames([styles.chevron], {
+                  [styles.chevronUp]: isFilterOpen
+                })}
+              />
             </div>
           )}
         </div>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.scss
@@ -12,15 +12,6 @@
   font-weight: 300;
 }
 
-.headerChevron {
-  width: 16px;
-  height: 16px;
-  cursor: pointer;
-  margin-left: 0.5em;
-  top: 5px;
-  position: relative;
-}
-
 .content {
   position: relative;
   padding-top: 36px;
@@ -63,37 +54,4 @@
 
 .right {
   grid-column: 5/6;
-}
-
-.filterLabel {
-  grid-column: 1/2;
-  text-align: right;
-  padding-right: 2px;
-  cursor: pointer;
-}
-
-.labelWithActivityIndicator {
-  position: relative;
-
-  &::after {
-    content: '';
-    position: absolute;
-    border-radius: 100%;
-    height: 5px;
-    width: 5px;
-    background: $red;
-    right: -6px;
-    top: -2px;
-  }
-}
-
-.chevron {
-  margin-left: 10px;
-  margin-bottom: -3px;
-  height: 12px;
-  width: 12px;
-}
-
-.hidden {
-  display: none;
 }

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import classNames from 'classnames';
 import { Pick2, Pick3 } from 'ts-multipick';
 
 import { getFeatureCoordinates } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
@@ -33,15 +32,11 @@ import {
   getFilters,
   getSortingRule
 } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors';
-import {
-  toggleTranscriptInfo,
-  SortingRule
-} from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
+import { toggleTranscriptInfo } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 
 import DefaultTranscriptsListItem, {
   DefaultTranscriptListItemProps
 } from './default-transcripts-list-item/DefaultTranscriptListItem';
-import TranscriptsFilter from 'src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter';
 
 import { TicksAndScale } from 'src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/BasePairsRuler';
 import { FullGene } from 'src/shared/types/thoas/gene';
@@ -50,8 +45,6 @@ import { FullProductGeneratingContext } from 'src/shared/types/thoas/productGene
 import { FullCDS } from 'src/shared/types/thoas/cds';
 import { SplicedExon } from 'src/shared/types/thoas/exon';
 import { Slice } from 'src/shared/types/thoas/slice';
-
-import { ReactComponent as ChevronDown } from 'static/img/shared/chevron-down.svg';
 
 import styles from './DefaultTranscriptsList.scss';
 
@@ -99,8 +92,6 @@ const DefaultTranscriptslist = (props: Props) => {
     ? (filterTranscriptsBySOTerm(sortedTranscripts, filters) as Transcript[])
     : sortedTranscripts;
 
-  const [isFilterOpen, setFilterOpen] = useState(false);
-
   useEffect(() => {
     const hasExpandedTranscripts = !!expandedTranscriptIds.length;
 
@@ -110,40 +101,10 @@ const DefaultTranscriptslist = (props: Props) => {
     }
   }, []);
 
-  const shouldShowFilterIndicator =
-    sortingRule !== SortingRule.DEFAULT || Object.values(filters).some(Boolean);
-
-  const filterLabel = (
-    <span
-      className={classNames({
-        [styles.labelWithActivityIndicator]: shouldShowFilterIndicator
-      })}
-    >
-      Filter & sort
-    </span>
-  );
-
-  const toggleFilter = () => {
-    setFilterOpen(!isFilterOpen);
-  };
-
   return (
     <div>
       <div className={styles.header}>
-        {isFilterOpen && (
-          <TranscriptsFilter
-            label={filterLabel}
-            toggleFilter={toggleFilter}
-            transcripts={filteredTranscripts}
-          />
-        )}
         <div className={styles.row}>
-          {gene.transcripts.length > 5 && !isFilterOpen && (
-            <div className={styles.filterLabel} onClick={toggleFilter}>
-              {filterLabel}
-              <ChevronDown className={styles.chevron} />
-            </div>
-          )}
           <div className={styles.right}>Transcript ID</div>
         </div>
       </div>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.scss
@@ -7,6 +7,7 @@
 
 .panelBody {
   color: $black;
+  min-height: 300px;
 }
 
 .header {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-relationships/GeneRelationships.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-relationships/GeneRelationships.scss
@@ -7,6 +7,7 @@
 
 .panelBody {
   color: $black;
+  min-height: 300px;
 }
 
 .selectedTabName {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-tabs/GeneViewTabs.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-tabs/GeneViewTabs.scss
@@ -15,8 +15,10 @@
 }
 
 .geneViewTabs {
-  position: absolute;
-  bottom: -9px;
+  padding: 0;
+  height: auto;
+  z-index: 2;
+  overflow-y: visible;
 }
 
 .disabledGeneTab {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-tabs/GeneViewTabs.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-tabs/GeneViewTabs.scss
@@ -44,6 +44,12 @@
   }
 }
 
+.selectedGeneTab.withOpenFilter {
+  &::after {
+    display: none;
+  }
+}
+
 .geneTab:first-of-type {
   &::after {
     display: none;

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-tabs/GeneViewTabs.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-tabs/GeneViewTabs.tsx
@@ -56,7 +56,7 @@ const GeneViewTabs = (props: Props) => {
     default: styles.geneTab,
     selected: styles.selectedGeneTab,
     disabled: styles.disabledGeneTab,
-    tabsContainer: styles.geneViewTabs
+    tabsContainer: styles.geneViewTabs //FIXME: Pass this as a props so that it can be styled from the parent
   };
 
   const onTabChange = (selectedTabName: string) => {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-tabs/GeneViewTabs.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-tabs/GeneViewTabs.tsx
@@ -15,6 +15,7 @@
  */
 
 import React from 'react';
+import classNames from 'classnames';
 import { useParams } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { push, Push } from 'connected-react-router';
@@ -48,13 +49,16 @@ type Props = {
   selectedTab: string;
   selectedTabViews?: SelectedTabViews;
   push: Push;
+  isFilterOpen: boolean;
 };
 
 const GeneViewTabs = (props: Props) => {
   const { genomeId, entityId } = useParams() as { [key: string]: string };
   const tabClassNames = {
     default: styles.geneTab,
-    selected: styles.selectedGeneTab,
+    selected: classNames(styles.selectedGeneTab, {
+      [styles.withOpenFilter]: props.isFilterOpen
+    }),
     disabled: styles.disabledGeneTab,
     tabsContainer: styles.geneViewTabs //FIXME: Pass this as a props so that it can be styled from the parent
   };

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/ProteinsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/ProteinsList.tsx
@@ -31,10 +31,14 @@ import {
   transcriptSortingFunctions,
   defaultSort
 } from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
+import { filterTranscriptsBySOTerm } from 'src/content/app/entity-viewer/shared/helpers/transcripts-filter';
 
 import { toggleExpandedProtein } from 'src/content/app/entity-viewer/state/gene-view/proteins/geneViewProteinsSlice';
 import { getExpandedTranscriptIds } from 'src/content/app/entity-viewer/state/gene-view/proteins/geneViewProteinsSelectors';
-import { getSortingRule } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors';
+import {
+  getFilters,
+  getSortingRule
+} from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors';
 
 import { FullGene } from 'src/shared/types/thoas/gene';
 import { FullTranscript } from 'src/shared/types/thoas/transcript';
@@ -72,7 +76,13 @@ const ProteinsList = (props: ProteinsListProps) => {
 
   const sortingFunction = transcriptSortingFunctions[sortingRule];
   const sortedTranscripts = sortingFunction(props.gene.transcripts);
-  const proteinCodingTranscripts = sortedTranscripts.filter(
+
+  const filters = useSelector(getFilters);
+  const filteredTranscripts = Object.values(filters).some(Boolean)
+    ? (filterTranscriptsBySOTerm(sortedTranscripts, filters) as Transcript[])
+    : sortedTranscripts;
+
+  const proteinCodingTranscripts = filteredTranscripts.filter(
     isProteinCodingTranscript
   ) as Transcript[];
 
@@ -89,7 +99,9 @@ const ProteinsList = (props: ProteinsListProps) => {
 
   const longestProteinLength = getLongestProteinLength(props.gene);
 
-  return (
+  return !proteinCodingTranscripts.length ? (
+    <div>No transcripts to show with the filters selected</div>
+  ) : (
     <div className={styles.proteinsList}>
       {proteinCodingTranscripts.map((transcript) => (
         <ProteinsListItem

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/ProteinsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/ProteinsList.tsx
@@ -87,6 +87,9 @@ const ProteinsList = (props: ProteinsListProps) => {
   ) as Transcript[];
 
   useEffect(() => {
+    if (!proteinCodingTranscripts.length) {
+      return;
+    }
     const hasExpandedTranscripts = !!expandedTranscriptIds.length;
     const firstProteinId =
       proteinCodingTranscripts[0].product_generating_contexts[0].product

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.scss
@@ -2,29 +2,17 @@
 @import 'src/content/app/entity-viewer/gene-view/styles/constants';
 
 .container {
-  display: grid;
-  grid-template-columns: $left_column $middle_column_left_gap auto;
-  padding: 9px 0;
-}
-
-.filterLabel {
-  grid-column: 1/2;
-  text-align: right;
-  padding-right: 2px;
-  cursor: pointer;
-}
-
-.chevron {
-  margin-left: 10px;
-  height: 12px;
-  width: 12px;
-  margin-bottom: -3px;
+  grid-area: 3/1/3/4;  
+  position: sticky;
+  height: 100%;
+  top: -5px;
+  z-index: 3;  
 }
 
 .filterBox {
   display: grid;
-  grid-column: 3;
-  grid-template-columns: 270px minmax(210px, auto) 20px;
+  grid-column: 4;
+  grid-template-columns: 160px 270px minmax(210px, auto) 20px;
   background-color: $soft-black;
   color: $white;
   text-align: left;
@@ -32,14 +20,17 @@
   margin-top: 2px;
   margin-left: 2px;
   font-weight: 300;
+  border-radius: 3px;
 
-  @media screen and (min-width: 1600px) {
-    width: calc(100% - 320px);
+  // Keeping this here as we might need to revise this fix when
+  // we have the horizontal scrollbar
+  // @media screen and (min-width: 1600px) {
+  //   width: calc(100% - 320px);
 
-    &FullWidth {
-      width: 100%;
-    }
-  }
+  //   &FullWidth {
+  //     width: 100%;
+  //   }
+  // }
 }
 
 .filterContent {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.scss
@@ -17,10 +17,9 @@
   color: $white;
   text-align: left;
   padding: 15px 15px 45px 20px;
-  margin-top: 2px;
-  margin-left: 2px;
   font-weight: 300;
-  border-radius: 3px;
+  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 3px;
 
   // Keeping this here as we might need to revise this fix when
   // we have the horizontal scrollbar

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.scss
@@ -20,6 +20,7 @@
   font-weight: 300;
   border-bottom-left-radius: 3px;
   border-bottom-right-radius: 3px;
+  box-shadow: -1px 3px 9px 2px rgba(0, 0, 0, 0.5);
 
   // Keeping this here as we might need to revise this fix when
   // we have the horizontal scrollbar

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.scss
@@ -6,9 +6,8 @@
   position: sticky;
   height: 100%;
   top: -5px;
-  z-index: 1;  
-  overflow: hidden;
-  padding: 0 9px 9px 0;
+  z-index: 1;     
+  padding-bottom: 9px;
 }
 
 .filterBox {
@@ -21,7 +20,7 @@
   font-weight: 300;
   border-bottom-left-radius: 3px;
   border-bottom-right-radius: 3px;
-  box-shadow: -1px 3px 9px 2px rgba(0, 0, 0, 0.5);
+  box-shadow: -1px 16px 18px 0px rgba(0, 0, 0, 0.25);
 }
 
 .sortContainer {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.scss
@@ -13,7 +13,6 @@
 
 .filterBox {
   display: grid;
-  grid-column: 3;
   grid-template-columns: 430px minmax(210px, auto) 20px;
   background-color: $soft-black;
   color: $white;

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.scss
@@ -6,13 +6,15 @@
   position: sticky;
   height: 100%;
   top: -5px;
-  z-index: 3;  
+  z-index: 1;  
+  overflow: hidden;
+  padding: 0 9px 9px 0;
 }
 
 .filterBox {
   display: grid;
-  grid-column: 4;
-  grid-template-columns: 160px 270px minmax(210px, auto) 20px;
+  grid-column: 3;
+  grid-template-columns: 430px minmax(210px, auto) 20px;
   background-color: $soft-black;
   color: $white;
   text-align: left;
@@ -21,16 +23,10 @@
   border-bottom-left-radius: 3px;
   border-bottom-right-radius: 3px;
   box-shadow: -1px 3px 9px 2px rgba(0, 0, 0, 0.5);
+}
 
-  // Keeping this here as we might need to revise this fix when
-  // we have the horizontal scrollbar
-  // @media screen and (min-width: 1600px) {
-  //   width: calc(100% - 320px);
-
-  //   &FullWidth {
-  //     width: 100%;
-  //   }
-  // }
+.sortContainer {
+    padding-left: 160px;
 }
 
 .filterContent {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.test.tsx
@@ -82,12 +82,10 @@ const wrapInRedux = (
   state: typeof mockState = mockState,
   transcripts = defaultTranscripts
 ) => {
-  const filterLabel = <span>Filter & sort</span>;
   store = mockStore(state);
   return render(
     <Provider store={store}>
       <TranscriptsFilter
-        label={filterLabel}
         transcripts={transcripts}
         toggleFilter={mockToggleFilter}
       />

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactNode, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import classNames from 'classnames';
 
@@ -36,7 +36,6 @@ import RadioGroup, {
 import Checkbox from 'src/shared/components/checkbox/Checkbox';
 
 import CloseButton from 'src/shared/components/close-button/CloseButton';
-import { ReactComponent as ChevronUp } from 'static/img/shared/chevron-up.svg';
 
 import { FullTranscript } from 'src/shared/types/thoas/transcript';
 
@@ -45,7 +44,6 @@ import styles from './TranscriptsFilter.scss';
 type Transcript = Pick<FullTranscript, 'so_term'>;
 
 type Props = {
-  label: ReactNode;
   transcripts: Transcript[];
   toggleFilter: () => void;
 };
@@ -126,11 +124,8 @@ const TranscriptsFilter = (props: Props) => {
 
   return (
     <div className={styles.container}>
-      <div className={styles.filterLabel} onClick={props.toggleFilter}>
-        {props.label}
-        <ChevronUp className={styles.chevron} />
-      </div>
       <div className={filterBoxClassnames}>
+        <div></div>
         <div className={styles.sort}>
           <div className={styles.header}>Sort by</div>
           <div className={styles.sortContent}>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
@@ -125,8 +125,7 @@ const TranscriptsFilter = (props: Props) => {
   return (
     <div className={styles.container}>
       <div className={filterBoxClassnames}>
-        <div></div>
-        <div className={styles.sort}>
+        <div className={styles.sortContainer}>
           <div className={styles.header}>Sort by</div>
           <div className={styles.sortContent}>
             <RadioGroup

--- a/src/ensembl/src/shared/components/panel/Panel.scss
+++ b/src/ensembl/src/shared/components/panel/Panel.scss
@@ -22,6 +22,7 @@
 }
 
 .body {
+  min-height: 300px;
   position: relative;
   padding: 0 20px 10px 10px;
   border-bottom-right-radius: 5px;

--- a/src/ensembl/src/shared/components/panel/Panel.scss
+++ b/src/ensembl/src/shared/components/panel/Panel.scss
@@ -21,8 +21,7 @@
   line-height: 24px;
 }
 
-.body {
-  min-height: 300px;
+.body { 
   position: relative;
   padding: 0 20px 10px 10px;
   border-bottom-right-radius: 5px;


### PR DESCRIPTION
- Applying transcript filters to protein view 
- showing message when there are no transcripts after applying filters on protein view

## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1038

## Importance
N/A

## Description
Applying transcript filters on the entity viewer and show message when there is no transcripts after applying filters. Also moving the filter box as shown in the XD on the jira ticket.

## Deployment URL
http://reposition-filter-box.review.ensembl.org 

## Views affected
Entity viewer

### Other effects
N/A

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
N/A
