### PR TITLE
Change amino acid image color

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/protein-image/ProteinImage.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/protein-image/ProteinImage.scss
@@ -9,7 +9,7 @@
 }
 
 .protein {
-  fill: $blue;
+  fill: $mustard;
 }
 
 .label {

--- a/src/ensembl/src/styles/_settings.scss
+++ b/src/ensembl/src/styles/_settings.scss
@@ -34,6 +34,7 @@ $dark-grey: #6f8190;
 
 $red: #d90000;
 $orange: #ff9900;
+$mustard: #cc9933;
 
 $green: #47d147;
 
@@ -48,6 +49,7 @@ $global-box-shadow: $medium-light-grey;
   ice-blue: $ice-blue;
   red: $red;
   orange: $orange;
+  mustard: $mustard;
   dark-grey: $dark-grey;
   medium-dark-grey: $medium-dark-grey;
   grey: $grey;

--- a/src/ensembl/stories/design-primitives/colours/Colours.stories.tsx
+++ b/src/ensembl/stories/design-primitives/colours/Colours.stories.tsx
@@ -56,6 +56,11 @@ const colours = [
     value: variables['orange']
   },
   {
+    name: 'Mustard',
+    variableName: '$mustard',
+    value: variables['mustard']
+  },
+  {
     name: 'Grey',
     variableName: '$grey',
     value: variables['grey']


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1126

## Description
The original design coloured the amino acid indicator blue
Following established usage patterns, this would indicate that this element is clickable - it is not

## Deployment URL
http://aminoacid-color-change.review.ensembl.org/entity-viewer/homo_sapiens_GCA_000001405_14/gene:ENSG00000139618?view=protein

## Views affected
Protein view

### Other effects
N/A

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
N/a
