### PR TITLE
Track panel - close drawer view when modal view changes

### DIFF
--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBar.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBar.tsx
@@ -15,10 +15,9 @@
  */
 
 import React from 'react';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import {
-  getIsTrackPanelModalOpened,
   getIsTrackPanelOpened,
   getTrackPanelModalView
 } from '../trackPanelSelectors';
@@ -27,6 +26,8 @@ import {
   closeTrackPanelModal,
   openTrackPanelModal
 } from '../trackPanelActions';
+import { toggleDrawer } from 'src/content/app/browser/drawer/drawerActions';
+import { getIsDrawerOpened } from 'src/content/app/browser/drawer/drawerSelectors';
 
 import ImageButton from 'src/shared/components/image-button/ImageButton';
 
@@ -37,36 +38,34 @@ import { ReactComponent as personalDataIcon } from 'static/img/sidebar/own-data.
 import { ReactComponent as shareIcon } from 'static/img/sidebar/share.svg';
 import { ReactComponent as downloadIcon } from 'static/img/sidebar/download.svg';
 
-import { RootState } from 'src/store';
 import { Status } from 'src/shared/types/status';
 
 import styles from 'src/shared/components/layout/StandardAppLayout.scss';
 
-export type TrackPanelBarProps = {
-  isTrackPanelModalOpened: boolean;
-  isTrackPanelOpened: boolean;
-  trackPanelModalView: string;
-  closeTrackPanelModal: () => void;
-  openTrackPanelModal: (trackPanelModalView: string) => void;
-  toggleTrackPanel: (isTrackPanelOpened?: boolean) => void;
-};
+export const TrackPanelBar = () => {
+  const isTrackPanelOpened = useSelector(getIsTrackPanelOpened);
+  const trackPanelModalView = useSelector(getTrackPanelModalView);
+  const isDrawerOpened = useSelector(getIsDrawerOpened);
+  const dispatch = useDispatch();
 
-export const TrackPanelBar = (props: TrackPanelBarProps) => {
   const toggleModalView = (selectedItem: string) => {
-    if (!props.isTrackPanelOpened) {
-      props.toggleTrackPanel(true);
+    if (!isTrackPanelOpened) {
+      dispatch(toggleTrackPanel(true));
     }
 
-    if (selectedItem === props.trackPanelModalView) {
-      props.closeTrackPanelModal();
+    if (isDrawerOpened) {
+      dispatch(toggleDrawer(false));
+    }
+
+    if (selectedItem === trackPanelModalView) {
+      dispatch(closeTrackPanelModal());
     } else {
-      props.openTrackPanelModal(selectedItem);
+      dispatch(openTrackPanelModal(selectedItem));
     }
   };
 
   const getViewIconStatus = (selectedItem: string) => {
-    return selectedItem === props.trackPanelModalView &&
-      props.isTrackPanelOpened
+    return selectedItem === trackPanelModalView && isTrackPanelOpened
       ? Status.SELECTED
       : Status.UNSELECTED;
   };
@@ -125,16 +124,4 @@ export const TrackPanelBar = (props: TrackPanelBarProps) => {
   );
 };
 
-const mapStateToProps = (state: RootState) => ({
-  isTrackPanelModalOpened: getIsTrackPanelModalOpened(state),
-  isTrackPanelOpened: getIsTrackPanelOpened(state),
-  trackPanelModalView: getTrackPanelModalView(state)
-});
-
-const mapDispatchToProps = {
-  closeTrackPanelModal,
-  openTrackPanelModal,
-  toggleTrackPanel
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(TrackPanelBar);
+export default TrackPanelBar;

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
@@ -16,7 +16,7 @@
 
 import { createAction } from 'typesafe-actions';
 import { ThunkAction } from 'redux-thunk';
-import { Action, ActionCreator } from 'redux';
+import { Action } from 'redux';
 import uniq from 'lodash/uniq';
 
 import { RootState } from 'src/store';
@@ -51,12 +51,12 @@ export const updateTrackPanelForGenome = createAction(
   }
 )();
 
-export const toggleTrackPanel: ActionCreator<ThunkAction<
-  void,
-  any,
-  null,
-  Action<string>
->> = (isTrackPanelOpened: boolean) => (dispatch, getState: () => RootState) => {
+export const toggleTrackPanel = (
+  isTrackPanelOpened: boolean
+): ThunkAction<void, any, null, Action<string>> => (
+  dispatch,
+  getState: () => RootState
+) => {
   const activeGenomeId = getBrowserActiveGenomeId(getState());
 
   if (!activeGenomeId) {
@@ -74,12 +74,9 @@ export const toggleTrackPanel: ActionCreator<ThunkAction<
   );
 };
 
-export const selectTrackPanelTab: ActionCreator<ThunkAction<
-  void,
-  any,
-  null,
-  Action<string>
->> = (selectedTrackPanelTab: TrackSet) => (
+export const selectTrackPanelTab = (
+  selectedTrackPanelTab: TrackSet
+): ThunkAction<void, any, null, Action<string>> => (
   dispatch,
   getState: () => RootState
 ) => {
@@ -108,12 +105,12 @@ export const selectTrackPanelTab: ActionCreator<ThunkAction<
   );
 };
 
-export const changeTrackPanelModalViewForGenome: ActionCreator<ThunkAction<
-  void,
-  any,
-  null,
-  Action<string>
->> = (trackPanelModalView: string) => (dispatch, getState: () => RootState) => {
+export const changeTrackPanelModalViewForGenome = (
+  trackPanelModalView: string
+): ThunkAction<void, any, null, Action<string>> => (
+  dispatch,
+  getState: () => RootState
+) => {
   const activeGenomeId = getBrowserActiveGenomeId(getState());
 
   if (!activeGenomeId) {
@@ -130,12 +127,12 @@ export const changeTrackPanelModalViewForGenome: ActionCreator<ThunkAction<
   );
 };
 
-export const updatePreviouslyViewedObjectsAndSave: ActionCreator<ThunkAction<
+export const updatePreviouslyViewedObjectsAndSave = (): ThunkAction<
   void,
   any,
   null,
   Action<string>
->> = () => (dispatch, getState: () => RootState) => {
+> => (dispatch, getState: () => RootState) => {
   const state = getState();
   const activeGenomeId = getBrowserActiveGenomeId(state);
   const activeEnsObject = getBrowserActiveEnsObject(state);
@@ -179,12 +176,12 @@ export const updatePreviouslyViewedObjectsAndSave: ActionCreator<ThunkAction<
   );
 };
 
-export const changeHighlightedTrackId: ActionCreator<ThunkAction<
-  void,
-  any,
-  null,
-  Action<string>
->> = (highlightedTrackId: string) => (dispatch, getState: () => RootState) => {
+export const changeHighlightedTrackId = (
+  highlightedTrackId: string
+): ThunkAction<void, any, null, Action<string>> => (
+  dispatch,
+  getState: () => RootState
+) => {
   const state = getState();
   const activeGenomeId = getBrowserActiveGenomeId(state);
 
@@ -203,12 +200,12 @@ export const changeHighlightedTrackId: ActionCreator<ThunkAction<
   );
 };
 
-export const openTrackPanelModal: ActionCreator<ThunkAction<
-  void,
-  any,
-  null,
-  Action<string>
->> = (trackPanelModalView: string) => (dispatch, getState: () => RootState) => {
+export const openTrackPanelModal = (
+  trackPanelModalView: string
+): ThunkAction<void, any, null, Action<string>> => (
+  dispatch,
+  getState: () => RootState
+) => {
   const state = getState();
 
   const activeGenomeId = getBrowserActiveGenomeId(state);
@@ -229,12 +226,12 @@ export const openTrackPanelModal: ActionCreator<ThunkAction<
   );
 };
 
-export const closeTrackPanelModal: ActionCreator<ThunkAction<
+export const closeTrackPanelModal = (): ThunkAction<
   void,
   any,
   null,
   Action<string>
->> = () => (dispatch, getState: () => RootState) => {
+> => (dispatch, getState: () => RootState) => {
   const state = getState();
   const activeGenomeId = getBrowserActiveGenomeId(state);
 
@@ -254,12 +251,10 @@ export const closeTrackPanelModal: ActionCreator<ThunkAction<
   );
 };
 
-export const updateCollapsedTrackIds: ActionCreator<ThunkAction<
-  void,
-  any,
-  null,
-  Action<string>
->> = (payload: { trackId: string; isCollapsed: boolean }) => (
+export const updateCollapsedTrackIds = (payload: {
+  trackId: string;
+  isCollapsed: boolean;
+}): ThunkAction<void, any, null, Action<string>> => (
   dispatch,
   getState: () => RootState
 ) => {


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1087


## Description
- The drawer view will now be closed when the modal view is changed

## Deployment URL
http://track-drawer-behaviour.review.ensembl.org

## Views affected
Browser -> Track panel -> Drawer

### Other effects

- [ ] I have checked any requirements for Google Analytics
- [x] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

