### PR TITLE
Rename bookmarks

### DIFF
--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerBookmarks.scss
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerBookmarks.scss
@@ -33,9 +33,12 @@
     font-size: 13px;
   }
 
-  .previouslyViewedType {
+  .label {
+    margin-right: 8px;
+  }
+
+  .type {
     color: $dark-grey;
-    margin-left: 8px;
     font-size: 12px;
     font-weight: 300;
   }

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerBookmarks.tsx
@@ -72,9 +72,16 @@ const DrawerBookmarks = (props: DrawerBookmarksProps) => {
                       onClickHandler(previouslyViewedObject.type, index)
                     }
                   >
-                    {previouslyViewedObject.label}
+                    <span className={styles.label}>
+                      {previouslyViewedObject.label[0]}
+                    </span>
+                    {previouslyViewedObject.label[1] && (
+                      <span className={styles.label}>
+                        {previouslyViewedObject.label[1]}
+                      </span>
+                    )}
                   </Link>
-                  <span className={styles.previouslyViewedType}>
+                  <span className={styles.type}>
                     {upperFirst(previouslyViewedObject.type)}
                   </span>
                 </span>

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerBookmarks.tsx
@@ -69,13 +69,13 @@ const DrawerBookmarks = (props: DrawerBookmarksProps) => {
                   <Link
                     to={path}
                     onClick={() =>
-                      onClickHandler(previouslyViewedObject.object_type, index)
+                      onClickHandler(previouslyViewedObject.type, index)
                     }
                   >
                     {previouslyViewedObject.label}
                   </Link>
                   <span className={styles.previouslyViewedType}>
-                    {upperFirst(previouslyViewedObject.object_type)}
+                    {upperFirst(previouslyViewedObject.type)}
                   </span>
                 </span>
               );

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerBookmarks.tsx
@@ -26,6 +26,7 @@ import { closeTrackPanelModal } from 'src/content/app/browser/track-panel/trackP
 import { closeDrawer } from 'src/content/app/browser/drawer/drawerActions';
 import { getActiveGenomePreviouslyViewedObjects } from 'src/content/app/browser/track-panel/trackPanelSelectors';
 import analyticsTracking from 'src/services/analytics-service';
+import { buildFocusIdForUrl } from 'src/shared/state/ens-object/ensObjectHelpers';
 
 import styles from './DrawerBookmarks.scss';
 
@@ -36,10 +37,8 @@ export type DrawerBookmarksProps = {
 };
 
 const DrawerBookmarks = (props: DrawerBookmarksProps) => {
-  const limitedPreviouslyViewedObjects = props.previouslyViewedObjects.slice(
-    0,
-    props.previouslyViewedObjects.length - 20
-  );
+  const limitedPreviouslyViewedObjects =
+    props.previouslyViewedObjects.slice(20);
 
   const onClickHandler = (objectType: string, index: number) => {
     analyticsTracking.trackEvent({
@@ -58,12 +57,11 @@ const DrawerBookmarks = (props: DrawerBookmarksProps) => {
       <div className={styles.drawerTitle}>Previously viewed</div>
       <div className={styles.contentWrapper}>
         <div className={styles.linksWrapper}>
-          {[...limitedPreviouslyViewedObjects]
-            .reverse()
-            .map((previouslyViewedObject, index) => {
+          {[...limitedPreviouslyViewedObjects].map(
+            (previouslyViewedObject, index) => {
               const path = urlFor.browser({
                 genomeId: previouslyViewedObject.genome_id,
-                focus: previouslyViewedObject.object_id
+                focus: buildFocusIdForUrl(previouslyViewedObject.object_id)
               });
 
               return (
@@ -81,7 +79,8 @@ const DrawerBookmarks = (props: DrawerBookmarksProps) => {
                   </span>
                 </span>
               );
-            })}
+            }
+          )}
         </div>
       </div>
     </>

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/DrawerBookmarks.tsx
@@ -57,7 +57,7 @@ const DrawerBookmarks = (props: DrawerBookmarksProps) => {
       <div className={styles.drawerTitle}>Previously viewed</div>
       <div className={styles.contentWrapper}>
         <div className={styles.linksWrapper}>
-          {[...limitedPreviouslyViewedObjects].map(
+          {limitedPreviouslyViewedObjects.map(
             (previouslyViewedObject, index) => {
               const path = urlFor.browser({
                 genomeId: previouslyViewedObject.genome_id,

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBar.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBar.test.tsx
@@ -31,9 +31,8 @@ import { DrawerView } from 'src/content/app/browser/drawer/drawerState';
 
 jest.mock(
   'src/shared/components/image-button/ImageButton',
-  () => (props: { description: string; onClick: () => void }) => (
+  () => (props: { description: string; onClick: () => void }) =>
     <button onClick={props.onClick}>{props.description}</button>
-  )
 );
 
 const fakeGenomeId = 'human';
@@ -88,7 +87,7 @@ describe('<TrackPanelBar />', () => {
         )
       );
       const bookmarksButton = [...container.querySelectorAll('button')].find(
-        (button) => button.innerHTML === 'Bookmarks'
+        (button) => button.innerHTML === 'Previously viewed'
       ) as HTMLButtonElement;
 
       userEvent.click(bookmarksButton);
@@ -121,7 +120,7 @@ describe('<TrackPanelBar />', () => {
         )
       );
       const bookmarksButton = [...container.querySelectorAll('button')].find(
-        (button) => button.innerHTML === 'Bookmarks'
+        (button) => button.innerHTML === 'Previously viewed'
       ) as HTMLButtonElement;
 
       userEvent.click(bookmarksButton);
@@ -146,7 +145,7 @@ describe('<TrackPanelBar />', () => {
     it('causes track panel modal to close if a pressed button is clicked again', () => {
       const { container } = wrapInRedux();
       const bookmarksButton = [...container.querySelectorAll('button')].find(
-        (button) => button.innerHTML === 'Bookmarks'
+        (button) => button.innerHTML === 'Previously viewed'
       ) as HTMLButtonElement;
 
       userEvent.click(bookmarksButton);
@@ -176,7 +175,7 @@ describe('<TrackPanelBar />', () => {
         set(`drawer.isDrawerOpened.${fakeGenomeId}`, true, mockState)
       );
       const bookmarksButton = [...container.querySelectorAll('button')].find(
-        (button) => button.innerHTML === 'Bookmarks'
+        (button) => button.innerHTML === 'Previously viewed'
       ) as HTMLButtonElement;
 
       userEvent.click(bookmarksButton);

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBar.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-bar/TrackPanelBar.tsx
@@ -91,7 +91,7 @@ export const TrackPanelBar = () => {
       <div className={styles.sidebarIcon} key="bookmarks">
         <ImageButton
           status={getViewIconStatus('bookmarks')}
-          description="Bookmarks"
+          description="Previously viewed"
           onClick={() => toggleModalView('bookmarks')}
           image={bookmarkIcon}
         />

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.scss
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.scss
@@ -1,7 +1,11 @@
 @import 'src/styles/common';
 
+.trackPanelBookmarks {
+  margin-left: 10px;
+}
+
 .linkHolder {
-  margin: 5px 0 0 20px;
+  margin-top: 6px;
   text-overflow: ellipsis;
   overflow: hidden;
   a {
@@ -26,22 +30,22 @@
 
 .title {
   font-size: 14px;
-  margin: 5px 0 10px 10px;
+  margin: 5px 0 25px 0px;
   font-weight: $bold;
 }
 
-.sectionTitle {
-  color: $dark-grey;
+.more {
   font-size: 12px;
-  border-bottom: 1px solid $grey;
-  margin-bottom: 15px;
   position: relative;
-  margin-top: 20px;
+  margin-top: 25px;
+  display: inline-flex;
+  cursor: pointer;
+  color: $blue;
+  font-weight: $normal;
 
   .ellipsis {
-    position: absolute;
-    right: 5px;
-    top: -2px;
-    width: 25px;
+    width: 14px;
+    top: 4px;
+    position: relative;
   }
 }

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.scss
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.scss
@@ -33,9 +33,11 @@
 }
 
 .more {
-  font-size: 12px;
   margin-top: 25px;
-  cursor: pointer;
-  color: $blue;
-  font-weight: $normal;
+  span {
+    font-size: 12px;
+    cursor: pointer;
+    color: $blue;
+    font-weight: $normal;
+  }
 }

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.scss
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.scss
@@ -20,6 +20,10 @@
   font-weight: 300;
 }
 
+.previouslyViewedVersionedStableId {
+  margin-left: 8px;
+}
+
 .title {
   font-size: 14px;
   margin: 5px 0 10px 10px;

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.scss
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.scss
@@ -15,17 +15,15 @@
     font-size: 13px;
     font-weight: $normal;
   }
+  .label {
+    margin-right: 8px;
+  }
 }
 
-.objectType {
+.type {
   color: $dark-grey;
-  margin-left: 8px;
   font-size: 12px;
   font-weight: 300;
-}
-
-.objectId {
-  margin-left: 8px;
 }
 
 .title {

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.scss
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.scss
@@ -36,16 +36,8 @@
 
 .more {
   font-size: 12px;
-  position: relative;
   margin-top: 25px;
-  display: inline-flex;
   cursor: pointer;
   color: $blue;
   font-weight: $normal;
-
-  .ellipsis {
-    width: 14px;
-    top: 4px;
-    position: relative;
-  }
 }

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.scss
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.scss
@@ -17,20 +17,20 @@
   }
 }
 
-.previouslyViewedType {
+.objectType {
   color: $dark-grey;
   margin-left: 8px;
   font-size: 12px;
   font-weight: 300;
 }
 
-.previouslyViewedVersionedStableId {
+.objectId {
   margin-left: 8px;
 }
 
 .title {
   font-size: 14px;
-  margin: 5px 0 25px 0px;
+  margin: 5px 0 25px 0;
   font-weight: $bold;
 }
 

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.test.tsx
@@ -40,6 +40,7 @@ jest.mock('react-router-dom', () => ({
 
 const genomeId = 'triticum_aestivum_GCA_900519105_1';
 const geneId = 'TraesCS3D02G273600';
+const versionedStableId = 'TraesCS3D02G273600.1';
 const region = '3D:2585940-2634711';
 const geneObjectId = `${genomeId}:gene:${geneId}`;
 const regionObjectId = `${genomeId}:region:${region}`;
@@ -48,7 +49,8 @@ const createRandomPreviouslyViewedObject = (): PreviouslyViewedObject => ({
   genome_id: faker.random.word(),
   object_id: `${faker.random.word()}:gene:${faker.datatype.uuid()}`,
   object_type: 'gene',
-  label: faker.random.word()
+  label: faker.random.word(),
+  versioned_stable_id: faker.random.word()
 });
 
 const previouslyViewedObjects = [
@@ -56,7 +58,8 @@ const previouslyViewedObjects = [
     genome_id: genomeId,
     object_id: geneObjectId,
     object_type: 'gene',
-    label: geneId
+    label: geneId,
+    versioned_stable_id: versionedStableId
   },
   {
     genome_id: genomeId,
@@ -158,18 +161,6 @@ describe('<TrackPanelBookmarks />', () => {
     jest.resetAllMocks();
   });
 
-  it('renders example links', () => {
-    wrapInRedux();
-    const exampleGeneLink = screen.getByText('Example gene') as HTMLElement;
-    const exampleRegionLink = screen.getByText('Example region') as HTMLElement;
-
-    const expectedGeneHref = `/genome-browser/${genomeId}?focus=gene:${geneId}`;
-    const expectedRegionHref = `/genome-browser/${genomeId}?focus=region:${region}`;
-
-    expect(exampleGeneLink.getAttribute('href')).toBe(expectedGeneHref);
-    expect(exampleRegionLink.getAttribute('href')).toBe(expectedRegionHref);
-  });
-
   it('renders previously viewed links', () => {
     wrapInRedux();
     const geneLink = screen.getByText(geneId) as HTMLElement;
@@ -252,13 +243,5 @@ describe('<TrackPanelBookmarks />', () => {
       DrawerView.BOOKMARKS
     );
     expect(toggleDrawerAction.payload[genomeId]).toEqual(true);
-  });
-
-  it('renders correct number of links to example objects', () => {
-    const { container } = wrapInRedux();
-
-    expect(container.querySelectorAll('.exampleLinks a').length).toBe(
-      example_objects.length
-    );
   });
 });

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.test.tsx
@@ -220,7 +220,7 @@ describe('<TrackPanelBookmarks />', () => {
     );
 
     const ellipsisButton = container.querySelector(
-      '.trackPanelBookmarks .more'
+      '.trackPanelBookmarks .more span'
     ) as HTMLElement;
 
     userEvent.click(ellipsisButton);

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.test.tsx
@@ -48,23 +48,21 @@ const regionObjectId = `${genomeId}:region:${region}`;
 const createRandomPreviouslyViewedObject = (): PreviouslyViewedObject => ({
   genome_id: faker.random.word(),
   object_id: `${faker.random.word()}:gene:${faker.datatype.uuid()}`,
-  object_type: 'gene',
-  label: faker.random.word(),
-  versioned_stable_id: faker.random.word()
+  type: 'gene',
+  label: [faker.random.words(2)]
 });
 
 const previouslyViewedObjects = [
   {
     genome_id: genomeId,
     object_id: geneObjectId,
-    object_type: 'gene',
-    label: geneId,
-    versioned_stable_id: versionedStableId
+    type: 'gene',
+    label: [geneId, versionedStableId]
   },
   {
     genome_id: genomeId,
     object_id: regionObjectId,
-    object_type: 'region',
+    type: 'region',
     label: region
   }
 ];

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.test.tsx
@@ -219,11 +219,11 @@ describe('<TrackPanelBookmarks />', () => {
       )
     );
 
-    const ellipsisButton = container.querySelector(
+    const moreLink = container.querySelector(
       '.trackPanelBookmarks .more span'
     ) as HTMLElement;
 
-    userEvent.click(ellipsisButton);
+    userEvent.click(moreLink);
 
     const dispatchedDrawerActions = store.getActions();
 

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.test.tsx
@@ -185,7 +185,7 @@ describe('<TrackPanelBookmarks />', () => {
     (trackPanelActions.closeTrackPanelModal as any).mockRestore();
   });
 
-  it('shows the ellipsis only when there are more than 20 objects', () => {
+  it('shows link to view more only when there are more than 20 objects', () => {
     let wrapper = wrapInRedux(
       set(
         `browser.trackPanel.${genomeId}.previouslyViewedObjects`,
@@ -193,10 +193,9 @@ describe('<TrackPanelBookmarks />', () => {
         mockState
       )
     );
+
     expect(
-      wrapper.container.querySelector(
-        '.trackPanelBookmarks .sectionTitle button'
-      )
+      wrapper.container.querySelector('.trackPanelBookmarks .more')
     ).toBeFalsy();
 
     // Add 21 links to see if ellipsis is shown
@@ -209,13 +208,11 @@ describe('<TrackPanelBookmarks />', () => {
     );
 
     expect(
-      wrapper.container.querySelector(
-        '.trackPanelBookmarks .sectionTitle button'
-      )
+      wrapper.container.querySelector('.trackPanelBookmarks .more')
     ).toBeTruthy();
   });
 
-  it('changes drawer view and toggles drawer when the ellipsis is clicked', () => {
+  it('changes drawer view and toggles drawer when the "more" link is clicked', () => {
     const { container } = wrapInRedux(
       set(
         `browser.trackPanel.${genomeId}.previouslyViewedObjects`,
@@ -225,7 +222,7 @@ describe('<TrackPanelBookmarks />', () => {
     );
 
     const ellipsisButton = container.querySelector(
-      '.sectionTitle button'
+      '.trackPanelBookmarks .more'
     ) as HTMLElement;
 
     userEvent.click(ellipsisButton);

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.test.tsx
@@ -49,7 +49,7 @@ const createRandomPreviouslyViewedObject = (): PreviouslyViewedObject => ({
   genome_id: faker.random.word(),
   object_id: `${faker.random.word()}:gene:${faker.datatype.uuid()}`,
   type: 'gene',
-  label: [faker.random.words(2)]
+  label: [faker.random.word(), faker.random.word()]
 });
 
 const previouslyViewedObjects = [
@@ -63,7 +63,7 @@ const previouslyViewedObjects = [
     genome_id: genomeId,
     object_id: regionObjectId,
     type: 'region',
-    label: region
+    label: [region]
   }
 ];
 
@@ -161,8 +161,8 @@ describe('<TrackPanelBookmarks />', () => {
 
   it('renders previously viewed links', () => {
     wrapInRedux();
-    const geneLink = screen.getByText(geneId) as HTMLElement;
-    const regionLink = screen.getByText(region) as HTMLElement;
+    const geneLink = screen.getByText(geneId).closest('a') as HTMLElement;
+    const regionLink = screen.getByText(region).closest('a') as HTMLElement;
 
     const expectedGeneHref = `/genome-browser/${genomeId}?focus=gene:${geneId}`;
     const expectedRegionHref = `/genome-browser/${genomeId}?focus=region:${region}`;

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
@@ -70,9 +70,11 @@ export const PreviouslyViewedLinks = () => {
               <span className={styles.label}>
                 {previouslyViewedObject.label[0]}
               </span>
-              <span className={styles.label}>
-                {previouslyViewedObject.label[1]}
-              </span>
+              {previouslyViewedObject.label[1] && (
+                <span className={styles.label}>
+                  {previouslyViewedObject.label[1]}
+                </span>
+              )}
             </Link>
             <span className={styles.type}>
               {upperFirst(previouslyViewedObject.type)}

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
@@ -65,19 +65,17 @@ export const PreviouslyViewedLinks = () => {
             <Link
               replace
               to={path}
-              onClick={() =>
-                onLinkClick(previouslyViewedObject.object_type, index)
-              }
+              onClick={() => onLinkClick(previouslyViewedObject.type, index)}
             >
-              {previouslyViewedObject.label}
-              {previouslyViewedObject.versioned_stable_id && (
-                <span className={styles.objectId}>
-                  {previouslyViewedObject.versioned_stable_id}
-                </span>
-              )}
+              <span className={styles.label}>
+                {previouslyViewedObject.label[0]}
+              </span>
+              <span className={styles.label}>
+                {previouslyViewedObject.label[1]}
+              </span>
             </Link>
-            <span className={styles.objectType}>
-              {upperFirst(previouslyViewedObject.object_type)}
+            <span className={styles.type}>
+              {upperFirst(previouslyViewedObject.type)}
             </span>
           </div>
         );

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
@@ -52,9 +52,11 @@ export const PreviouslyViewedLinks = () => {
     dispatch(closeTrackPanelModal());
   };
 
+  const limitedPreviouslyViewedObjects = previouslyViewedObjects.slice(-20);
+
   return (
     <div data-test-id="previously viewed links">
-      {[...previouslyViewedObjects]
+      {[...limitedPreviouslyViewedObjects]
         .reverse()
         .map((previouslyViewedObject, index) => {
           const path = urlFor.browser({
@@ -95,8 +97,6 @@ export const TrackPanelBookmarks = () => {
   );
   const dispatch = useDispatch();
 
-  const limitedPreviouslyViewedObjects = previouslyViewedObjects.slice(-20);
-
   const onEllipsisClick = () => {
     analyticsTracking.trackEvent({
       category: 'drawer_open',
@@ -111,7 +111,7 @@ export const TrackPanelBookmarks = () => {
   return (
     <section className="trackPanelBookmarks">
       <div className={styles.title}>Previously viewed</div>
-      {limitedPreviouslyViewedObjects.length ? (
+      {previouslyViewedObjects.length ? (
         <>
           <div data-test-id="previously viewed" className={styles.sectionTitle}>
             Previously viewed

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
@@ -27,11 +27,6 @@ import { getActiveGenomePreviouslyViewedObjects } from 'src/content/app/browser/
 import { closeTrackPanelModal } from '../../trackPanelActions';
 import { changeDrawerViewAndOpen } from 'src/content/app/browser/drawer/drawerActions';
 
-import ImageButton from 'src/shared/components/image-button/ImageButton';
-import { ReactComponent as EllipsisIcon } from 'static/img/track-panel/ellipsis.svg';
-
-import { Status } from 'src/shared/types/status';
-
 import styles from './TrackPanelBookmarks.scss';
 import { DrawerView } from 'src/content/app/browser/drawer/drawerState';
 
@@ -56,39 +51,37 @@ export const PreviouslyViewedLinks = () => {
 
   return (
     <div data-test-id="previously viewed links">
-      {[...limitedPreviouslyViewedObjects].map(
-        (previouslyViewedObject, index) => {
-          const path = urlFor.browser({
-            genomeId: previouslyViewedObject.genome_id,
-            focus: buildFocusIdForUrl(previouslyViewedObject.object_id)
-          });
+      {limitedPreviouslyViewedObjects.map((previouslyViewedObject, index) => {
+        const path = urlFor.browser({
+          genomeId: previouslyViewedObject.genome_id,
+          focus: buildFocusIdForUrl(previouslyViewedObject.object_id)
+        });
 
-          return (
-            <div
-              key={previouslyViewedObject.object_id}
-              className={styles.linkHolder}
+        return (
+          <div
+            key={previouslyViewedObject.object_id}
+            className={styles.linkHolder}
+          >
+            <Link
+              replace
+              to={path}
+              onClick={() =>
+                onLinkClick(previouslyViewedObject.object_type, index)
+              }
             >
-              <Link
-                replace
-                to={path}
-                onClick={() =>
-                  onLinkClick(previouslyViewedObject.object_type, index)
-                }
-              >
-                {previouslyViewedObject.label}
-                {previouslyViewedObject.versioned_stable_id && (
-                  <span className={styles.objectId}>
-                    {previouslyViewedObject.versioned_stable_id}
-                  </span>
-                )}
-              </Link>
-              <span className={styles.objectType}>
-                {upperFirst(previouslyViewedObject.object_type)}
-              </span>
-            </div>
-          );
-        }
-      )}
+              {previouslyViewedObject.label}
+              {previouslyViewedObject.versioned_stable_id && (
+                <span className={styles.objectId}>
+                  {previouslyViewedObject.versioned_stable_id}
+                </span>
+              )}
+            </Link>
+            <span className={styles.objectType}>
+              {upperFirst(previouslyViewedObject.object_type)}
+            </span>
+          </div>
+        );
+      })}
     </div>
   );
 };
@@ -99,7 +92,7 @@ export const TrackPanelBookmarks = () => {
   );
   const dispatch = useDispatch();
 
-  const onEllipsisClick = () => {
+  const onMoreClick = () => {
     analyticsTracking.trackEvent({
       category: 'drawer_open',
       label: 'recent_bookmarks',
@@ -117,15 +110,8 @@ export const TrackPanelBookmarks = () => {
         <>
           <PreviouslyViewedLinks />
           {previouslyViewedObjects.length > 20 && (
-            <div className={styles.more} onClick={onEllipsisClick}>
-              <span>more</span>
-              <div className={styles.ellipsis}>
-                <ImageButton
-                  status={Status.DEFAULT}
-                  description={'View all'}
-                  image={EllipsisIcon}
-                />
-              </div>
+            <div className={styles.more} onClick={onMoreClick}>
+              more...
             </div>
           )}
         </>

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
@@ -23,9 +23,7 @@ import analyticsTracking from 'src/services/analytics-service';
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import { buildFocusIdForUrl } from 'src/shared/state/ens-object/ensObjectHelpers';
 
-import { getBrowserActiveGenomeId } from 'src/content/app/browser/browserSelectors';
 import { getActiveGenomePreviouslyViewedObjects } from 'src/content/app/browser/track-panel/trackPanelSelectors';
-import { getExampleEnsObjects } from 'src/shared/state/ens-object/ensObjectSelectors';
 import { closeTrackPanelModal } from '../../trackPanelActions';
 import { changeDrawerViewAndOpen } from 'src/content/app/browser/drawer/drawerActions';
 
@@ -36,34 +34,6 @@ import { Status } from 'src/shared/types/status';
 
 import styles from './TrackPanelBookmarks.scss';
 import { DrawerView } from 'src/content/app/browser/drawer/drawerState';
-
-export const ExampleLinks = () => {
-  const exampleEnsObjects = useSelector(getExampleEnsObjects);
-  const activeGenomeId = useSelector(getBrowserActiveGenomeId);
-  const dispatch = useDispatch();
-
-  const onLinkClick = () => dispatch(closeTrackPanelModal());
-
-  return (
-    <div data-test-id="example links" className="exampleLinks">
-      <div className={styles.sectionTitle}>Example links</div>
-      {exampleEnsObjects.map((exampleObject) => {
-        const path = urlFor.browser({
-          genomeId: activeGenomeId,
-          focus: buildFocusIdForUrl(exampleObject.object_id)
-        });
-
-        return (
-          <div key={exampleObject.object_id} className={styles.linkHolder}>
-            <Link to={path} onClick={onLinkClick} replace>
-              Example {exampleObject.type}
-            </Link>
-          </div>
-        );
-      })}
-    </div>
-  );
-};
 
 export const PreviouslyViewedLinks = () => {
   const previouslyViewedObjects = useSelector(
@@ -105,6 +75,9 @@ export const PreviouslyViewedLinks = () => {
                 }
               >
                 {previouslyViewedObject.label}
+                <span className={styles.previouslyViewedVersionedStableId}>
+                  {previouslyViewedObject.versioned_stable_id}
+                </span>
               </Link>
               <span className={styles.previouslyViewedType}>
                 {upperFirst(previouslyViewedObject.object_type)}
@@ -120,7 +93,6 @@ export const TrackPanelBookmarks = () => {
   const previouslyViewedObjects = useSelector(
     getActiveGenomePreviouslyViewedObjects
   );
-  const exampleEnsObjects = useSelector(getExampleEnsObjects);
   const dispatch = useDispatch();
 
   const limitedPreviouslyViewedObjects = previouslyViewedObjects.slice(-20);
@@ -138,8 +110,7 @@ export const TrackPanelBookmarks = () => {
 
   return (
     <section className="trackPanelBookmarks">
-      <div className={styles.title}>Bookmarks</div>
-      {exampleEnsObjects.length ? <ExampleLinks /> : null}
+      <div className={styles.title}>Previously viewed</div>
       {limitedPreviouslyViewedObjects.length ? (
         <>
           <div data-test-id="previously viewed" className={styles.sectionTitle}>

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
@@ -67,14 +67,13 @@ export const PreviouslyViewedLinks = () => {
               to={path}
               onClick={() => onLinkClick(previouslyViewedObject.type, index)}
             >
-              <span className={styles.label}>
-                {previouslyViewedObject.label[0]}
-              </span>
-              {previouslyViewedObject.label[1] && (
-                <span className={styles.label}>
-                  {previouslyViewedObject.label[1]}
-                </span>
-              )}
+              {previouslyViewedObject.label.map((label, index) => {
+                return (
+                  <span key={index} className={styles.label}>
+                    {label}
+                  </span>
+                );
+              })}
             </Link>
             <span className={styles.type}>
               {upperFirst(previouslyViewedObject.type)}

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
@@ -52,13 +52,12 @@ export const PreviouslyViewedLinks = () => {
     dispatch(closeTrackPanelModal());
   };
 
-  const limitedPreviouslyViewedObjects = previouslyViewedObjects.slice(-20);
+  const limitedPreviouslyViewedObjects = previouslyViewedObjects.slice(0, 20);
 
   return (
     <div data-test-id="previously viewed links">
-      {[...limitedPreviouslyViewedObjects]
-        .reverse()
-        .map((previouslyViewedObject, index) => {
+      {[...limitedPreviouslyViewedObjects].map(
+        (previouslyViewedObject, index) => {
           const path = urlFor.browser({
             genomeId: previouslyViewedObject.genome_id,
             focus: buildFocusIdForUrl(previouslyViewedObject.object_id)
@@ -77,16 +76,19 @@ export const PreviouslyViewedLinks = () => {
                 }
               >
                 {previouslyViewedObject.label}
-                <span className={styles.previouslyViewedVersionedStableId}>
-                  {previouslyViewedObject.versioned_stable_id}
-                </span>
+                {previouslyViewedObject.versioned_stable_id && (
+                  <span className={styles.objectId}>
+                    {previouslyViewedObject.versioned_stable_id}
+                  </span>
+                )}
               </Link>
-              <span className={styles.previouslyViewedType}>
+              <span className={styles.objectType}>
                 {upperFirst(previouslyViewedObject.object_type)}
               </span>
             </div>
           );
-        })}
+        }
+      )}
     </div>
   );
 };

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
@@ -110,8 +110,8 @@ export const TrackPanelBookmarks = () => {
         <>
           <PreviouslyViewedLinks />
           {previouslyViewedObjects.length > 20 && (
-            <div className={styles.more} onClick={onMoreClick}>
-              more...
+            <div className={styles.more}>
+              <span onClick={onMoreClick}>more...</span>
             </div>
           )}
         </>

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
@@ -109,24 +109,23 @@ export const TrackPanelBookmarks = () => {
   };
 
   return (
-    <section className="trackPanelBookmarks">
+    <section className={styles.trackPanelBookmarks}>
       <div className={styles.title}>Previously viewed</div>
       {previouslyViewedObjects.length ? (
         <>
-          <div data-test-id="previously viewed" className={styles.sectionTitle}>
-            Previously viewed
-            {previouslyViewedObjects.length > 20 && (
-              <span className={styles.ellipsis}>
+          <PreviouslyViewedLinks />
+          {previouslyViewedObjects.length > 20 && (
+            <div className={styles.more} onClick={onEllipsisClick}>
+              <span>more</span>
+              <div className={styles.ellipsis}>
                 <ImageButton
                   status={Status.DEFAULT}
                   description={'View all'}
                   image={EllipsisIcon}
-                  onClick={onEllipsisClick}
                 />
-              </span>
-            )}
-          </div>
-          <PreviouslyViewedLinks />
+              </div>
+            </div>
+          )}
         </>
       ) : null}
     </section>

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
@@ -92,18 +92,18 @@ export const selectTrackPanelTab = (
     action: 'selected'
   });
 
-  dispatch(
-    updateTrackPanelForGenome({
-      activeGenomeId,
-      data: {
-        ...getActiveTrackPanel(getState()),
-        selectedTrackPanelTab,
-        isTrackPanelModalOpened: false,
-        trackPanelModalView: ''
-      }
-    })
-  );
-};
+    dispatch(
+      updateTrackPanelForGenome({
+        activeGenomeId,
+        data: {
+          ...getActiveTrackPanel(getState()),
+          selectedTrackPanelTab,
+          isTrackPanelModalOpened: false,
+          trackPanelModalView: ''
+        }
+      })
+    );
+  };
 
 export const changeTrackPanelModalViewForGenome = (
   trackPanelModalView: string
@@ -148,13 +148,18 @@ export const updatePreviouslyViewedObjectsAndSave = (): ThunkAction<
     (previouslyViewedObject) =>
       previouslyViewedObject.object_id === activeEnsObject.object_id
   );
+
   if (existingIndex === -1) {
     // IF it is not present, add it to the end
     previouslyViewedObjects.push({
       genome_id: activeEnsObject.genome_id,
       object_id: activeEnsObject.object_id,
       object_type: activeEnsObject.type,
-      label: activeEnsObject.label
+      label: activeEnsObject.label,
+      versioned_stable_id:
+        activeEnsObject.type === 'gene'
+          ? activeEnsObject?.versioned_stable_id
+          : null
     });
   }
 

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
@@ -142,7 +142,7 @@ export const updatePreviouslyViewedObjectsAndSave =
     const versioned_stable_id =
       activeEnsObject.type === 'gene'
         ? activeEnsObject.versioned_stable_id
-        : null;
+        : activeEnsObject.label;
 
     //FIXME Hack to find if gene symbol is available or not
     const geneSymbolAvailable =
@@ -152,9 +152,7 @@ export const updatePreviouslyViewedObjectsAndSave =
     const label =
       geneSymbolAvailable && versioned_stable_id
         ? [activeEnsObject.label, versioned_stable_id]
-        : activeEnsObject.type === 'gene'
-        ? [versioned_stable_id]
-        : [activeEnsObject.label];
+        : [versioned_stable_id];
 
     const newObject = {
       genome_id: activeEnsObject.genome_id,

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
@@ -51,46 +51,42 @@ export const updateTrackPanelForGenome = createAction(
   }
 )();
 
-export const toggleTrackPanel = (
-  isTrackPanelOpened: boolean
-): ThunkAction<void, any, null, Action<string>> => (
-  dispatch,
-  getState: () => RootState
-) => {
-  const activeGenomeId = getBrowserActiveGenomeId(getState());
+export const toggleTrackPanel =
+  (isTrackPanelOpened: boolean): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const activeGenomeId = getBrowserActiveGenomeId(getState());
 
-  if (!activeGenomeId) {
-    return;
-  }
+    if (!activeGenomeId) {
+      return;
+    }
 
-  dispatch(
-    updateTrackPanelForGenome({
-      activeGenomeId,
-      data: {
-        ...getActiveTrackPanel(getState()),
-        isTrackPanelOpened
-      }
-    })
-  );
-};
+    dispatch(
+      updateTrackPanelForGenome({
+        activeGenomeId,
+        data: {
+          ...getActiveTrackPanel(getState()),
+          isTrackPanelOpened
+        }
+      })
+    );
+  };
 
-export const selectTrackPanelTab = (
-  selectedTrackPanelTab: TrackSet
-): ThunkAction<void, any, null, Action<string>> => (
-  dispatch,
-  getState: () => RootState
-) => {
-  const activeGenomeId = getBrowserActiveGenomeId(getState());
+export const selectTrackPanelTab =
+  (
+    selectedTrackPanelTab: TrackSet
+  ): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const activeGenomeId = getBrowserActiveGenomeId(getState());
 
-  if (!activeGenomeId) {
-    return;
-  }
+    if (!activeGenomeId) {
+      return;
+    }
 
-  analyticsTracking.trackEvent({
-    category: 'track_panel_tab',
-    label: selectedTrackPanelTab,
-    action: 'selected'
-  });
+    analyticsTracking.trackEvent({
+      category: 'track_panel_tab',
+      label: selectedTrackPanelTab,
+      action: 'selected'
+    });
 
     dispatch(
       updateTrackPanelForGenome({
@@ -105,187 +101,173 @@ export const selectTrackPanelTab = (
     );
   };
 
-export const changeTrackPanelModalViewForGenome = (
-  trackPanelModalView: string
-): ThunkAction<void, any, null, Action<string>> => (
-  dispatch,
-  getState: () => RootState
-) => {
-  const activeGenomeId = getBrowserActiveGenomeId(getState());
+export const changeTrackPanelModalViewForGenome =
+  (trackPanelModalView: string): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const activeGenomeId = getBrowserActiveGenomeId(getState());
 
-  if (!activeGenomeId) {
-    return;
-  }
-  dispatch(
-    updateTrackPanelForGenome({
-      activeGenomeId,
-      data: {
-        ...getActiveTrackPanel(getState()),
-        trackPanelModalView
-      }
-    })
-  );
-};
+    if (!activeGenomeId) {
+      return;
+    }
+    dispatch(
+      updateTrackPanelForGenome({
+        activeGenomeId,
+        data: {
+          ...getActiveTrackPanel(getState()),
+          trackPanelModalView
+        }
+      })
+    );
+  };
 
-export const updatePreviouslyViewedObjectsAndSave = (): ThunkAction<
-  void,
-  any,
-  null,
-  Action<string>
-> => (dispatch, getState: () => RootState) => {
-  const state = getState();
-  const activeGenomeId = getBrowserActiveGenomeId(state);
-  const activeEnsObject = getBrowserActiveEnsObject(state);
-  if (!activeGenomeId || !activeEnsObject) {
-    return;
-  }
+export const updatePreviouslyViewedObjectsAndSave =
+  (): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const state = getState();
+    const activeGenomeId = getBrowserActiveGenomeId(state);
+    const activeEnsObject = getBrowserActiveEnsObject(state);
+    if (!activeGenomeId || !activeEnsObject) {
+      return;
+    }
 
-  const previouslyViewedObjects = [
-    ...getActiveGenomePreviouslyViewedObjects(state)
-  ];
+    const previouslyViewedObjects = [
+      ...getActiveGenomePreviouslyViewedObjects(state)
+    ];
 
-  const existingIndex = previouslyViewedObjects.findIndex(
-    (previouslyViewedObject) =>
-      previouslyViewedObject.object_id === activeEnsObject.object_id
-  );
+    const savedEntitiesWithoutCurrentEntity =
+      previouslyViewedObjects?.filter(
+        (entity) => entity.object_id !== activeEnsObject.object_id
+      ) || [];
 
-  if (existingIndex === -1) {
-    // IF it is not present, add it to the end
-    previouslyViewedObjects.push({
+    const newObject = {
       genome_id: activeEnsObject.genome_id,
       object_id: activeEnsObject.object_id,
       object_type: activeEnsObject.type,
       label: activeEnsObject.label,
       versioned_stable_id:
         activeEnsObject.type === 'gene'
-          ? activeEnsObject?.versioned_stable_id
+          ? activeEnsObject.versioned_stable_id
           : null
+    };
+
+    const updatedEntitiesArray = [
+      newObject,
+      ...savedEntitiesWithoutCurrentEntity
+    ];
+
+    // Limit the total number of previously viewed objects to 250
+    const limitedPreviouslyViewedObjects = updatedEntitiesArray.slice(-250);
+
+    trackPanelStorageService.updatePreviouslyViewedObjects({
+      [activeGenomeId]: limitedPreviouslyViewedObjects
     });
-  }
 
-  // Limit the total number of previously viewed objects to 250
-  const limitedPreviouslyViewedObjects = previouslyViewedObjects.slice(-250);
-
-  trackPanelStorageService.updatePreviouslyViewedObjects({
-    [activeGenomeId]: limitedPreviouslyViewedObjects
-  });
-
-  dispatch(
-    updateTrackPanelForGenome({
-      activeGenomeId,
-      data: {
-        ...getActiveTrackPanel(state),
-        previouslyViewedObjects: limitedPreviouslyViewedObjects
-      }
-    })
-  );
-};
-
-export const changeHighlightedTrackId = (
-  highlightedTrackId: string
-): ThunkAction<void, any, null, Action<string>> => (
-  dispatch,
-  getState: () => RootState
-) => {
-  const state = getState();
-  const activeGenomeId = getBrowserActiveGenomeId(state);
-
-  if (!activeGenomeId) {
-    return;
-  }
-
-  dispatch(
-    updateTrackPanelForGenome({
-      activeGenomeId,
-      data: {
-        ...getActiveTrackPanel(state),
-        highlightedTrackId
-      }
-    })
-  );
-};
-
-export const openTrackPanelModal = (
-  trackPanelModalView: string
-): ThunkAction<void, any, null, Action<string>> => (
-  dispatch,
-  getState: () => RootState
-) => {
-  const state = getState();
-
-  const activeGenomeId = getBrowserActiveGenomeId(state);
-
-  if (!activeGenomeId) {
-    return;
-  }
-
-  dispatch(
-    updateTrackPanelForGenome({
-      activeGenomeId,
-      data: {
-        ...getActiveTrackPanel(state),
-        isTrackPanelModalOpened: true,
-        trackPanelModalView
-      }
-    })
-  );
-};
-
-export const closeTrackPanelModal = (): ThunkAction<
-  void,
-  any,
-  null,
-  Action<string>
-> => (dispatch, getState: () => RootState) => {
-  const state = getState();
-  const activeGenomeId = getBrowserActiveGenomeId(state);
-
-  if (!activeGenomeId) {
-    return;
-  }
-
-  dispatch(
-    updateTrackPanelForGenome({
-      activeGenomeId,
-      data: {
-        ...getActiveTrackPanel(state),
-        isTrackPanelModalOpened: false,
-        trackPanelModalView: ''
-      }
-    })
-  );
-};
-
-export const updateCollapsedTrackIds = (payload: {
-  trackId: string;
-  isCollapsed: boolean;
-}): ThunkAction<void, any, null, Action<string>> => (
-  dispatch,
-  getState: () => RootState
-) => {
-  const state = getState();
-  const activeGenomeId = getBrowserActiveGenomeId(state);
-  const trackPanel = getActiveTrackPanel(state);
-  let { collapsedTrackIds } = trackPanel;
-
-  if (!activeGenomeId) {
-    return;
-  }
-
-  if (payload.isCollapsed) {
-    collapsedTrackIds = uniq([...collapsedTrackIds, payload.trackId]);
-  } else {
-    collapsedTrackIds = collapsedTrackIds.filter(
-      (id) => id !== payload.trackId
+    dispatch(
+      updateTrackPanelForGenome({
+        activeGenomeId,
+        data: {
+          ...getActiveTrackPanel(state),
+          previouslyViewedObjects: limitedPreviouslyViewedObjects
+        }
+      })
     );
-  }
+  };
 
-  dispatch(
-    updateTrackPanelForGenome({
-      activeGenomeId,
-      data: {
-        collapsedTrackIds
-      }
-    })
-  );
-};
+export const changeHighlightedTrackId =
+  (highlightedTrackId: string): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const state = getState();
+    const activeGenomeId = getBrowserActiveGenomeId(state);
+
+    if (!activeGenomeId) {
+      return;
+    }
+
+    dispatch(
+      updateTrackPanelForGenome({
+        activeGenomeId,
+        data: {
+          ...getActiveTrackPanel(state),
+          highlightedTrackId
+        }
+      })
+    );
+  };
+
+export const openTrackPanelModal =
+  (trackPanelModalView: string): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const state = getState();
+
+    const activeGenomeId = getBrowserActiveGenomeId(state);
+
+    if (!activeGenomeId) {
+      return;
+    }
+
+    dispatch(
+      updateTrackPanelForGenome({
+        activeGenomeId,
+        data: {
+          ...getActiveTrackPanel(state),
+          isTrackPanelModalOpened: true,
+          trackPanelModalView
+        }
+      })
+    );
+  };
+
+export const closeTrackPanelModal =
+  (): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const state = getState();
+    const activeGenomeId = getBrowserActiveGenomeId(state);
+
+    if (!activeGenomeId) {
+      return;
+    }
+
+    dispatch(
+      updateTrackPanelForGenome({
+        activeGenomeId,
+        data: {
+          ...getActiveTrackPanel(state),
+          isTrackPanelModalOpened: false,
+          trackPanelModalView: ''
+        }
+      })
+    );
+  };
+
+export const updateCollapsedTrackIds =
+  (payload: {
+    trackId: string;
+    isCollapsed: boolean;
+  }): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const state = getState();
+    const activeGenomeId = getBrowserActiveGenomeId(state);
+    const trackPanel = getActiveTrackPanel(state);
+    let { collapsedTrackIds } = trackPanel;
+
+    if (!activeGenomeId) {
+      return;
+    }
+
+    if (payload.isCollapsed) {
+      collapsedTrackIds = uniq([...collapsedTrackIds, payload.trackId]);
+    } else {
+      collapsedTrackIds = collapsedTrackIds.filter(
+        (id) => id !== payload.trackId
+      );
+    }
+
+    dispatch(
+      updateTrackPanelForGenome({
+        activeGenomeId,
+        data: {
+          collapsedTrackIds
+        }
+      })
+    );
+  };

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
@@ -139,15 +139,20 @@ export const updatePreviouslyViewedObjectsAndSave =
         (entity) => entity.object_id !== activeEnsObject.object_id
       ) || [];
 
+    const versioned_stable_id =
+      activeEnsObject.type === 'gene'
+        ? activeEnsObject.versioned_stable_id
+        : null;
+
+    const label = versioned_stable_id
+      ? [activeEnsObject.label, versioned_stable_id]
+      : [activeEnsObject.label];
+
     const newObject = {
       genome_id: activeEnsObject.genome_id,
       object_id: activeEnsObject.object_id,
-      object_type: activeEnsObject.type,
-      label: activeEnsObject.label,
-      versioned_stable_id:
-        activeEnsObject.type === 'gene'
-          ? activeEnsObject.versioned_stable_id
-          : null
+      type: activeEnsObject.type,
+      label: label
     };
 
     const updatedEntitiesArray = [

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
@@ -144,9 +144,15 @@ export const updatePreviouslyViewedObjectsAndSave =
         ? activeEnsObject.versioned_stable_id
         : null;
 
-    const label = versioned_stable_id
-      ? [activeEnsObject.label, versioned_stable_id]
-      : [activeEnsObject.label];
+    //FIXME Hack to find if gene symbol is available or not
+    const geneSymbolAvailable =
+      activeEnsObject.type === 'gene' &&
+      activeEnsObject.label !== activeEnsObject.stable_id;
+
+    const label =
+      geneSymbolAvailable && versioned_stable_id
+        ? [activeEnsObject.label, versioned_stable_id]
+        : [versioned_stable_id];
 
     const newObject = {
       genome_id: activeEnsObject.genome_id,

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
@@ -141,7 +141,7 @@ export const updatePreviouslyViewedObjectsAndSave =
 
     const versioned_stable_id =
       activeEnsObject.type === 'gene'
-        ? activeEnsObject.versioned_stable_id
+        ? activeEnsObject.versioned_stable_id || activeEnsObject.label
         : activeEnsObject.label;
 
     //FIXME Hack to find if gene symbol is available or not

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
@@ -152,7 +152,9 @@ export const updatePreviouslyViewedObjectsAndSave =
     const label =
       geneSymbolAvailable && versioned_stable_id
         ? [activeEnsObject.label, versioned_stable_id]
-        : [versioned_stable_id];
+        : activeEnsObject.type === 'gene'
+        ? [versioned_stable_id]
+        : [activeEnsObject.label];
 
     const newObject = {
       genome_id: activeEnsObject.genome_id,

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
@@ -141,18 +141,19 @@ export const updatePreviouslyViewedObjectsAndSave =
 
     const versioned_stable_id =
       activeEnsObject.type === 'gene'
-        ? activeEnsObject.versioned_stable_id || activeEnsObject.label
-        : activeEnsObject.label;
+        ? activeEnsObject.versioned_stable_id
+        : null;
 
-    //FIXME Hack to find if gene symbol is available or not
-    const geneSymbolAvailable =
+    const geneSymbol =
       activeEnsObject.type === 'gene' &&
-      activeEnsObject.label !== activeEnsObject.stable_id;
+      activeEnsObject.label !== activeEnsObject.stable_id
+        ? activeEnsObject.label
+        : null;
 
     const label =
-      geneSymbolAvailable && versioned_stable_id
-        ? [activeEnsObject.label, versioned_stable_id]
-        : [versioned_stable_id];
+      activeEnsObject.type === 'gene'
+        ? ([geneSymbol, versioned_stable_id].filter(Boolean) as string[])
+        : [activeEnsObject.label];
 
     const newObject = {
       genome_id: activeEnsObject.genome_id,

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
@@ -22,7 +22,7 @@ export type PreviouslyViewedObject = {
   genome_id: string;
   object_id: string;
   type: string;
-  label: (string | null)[];
+  label: string[];
 };
 
 export type PreviouslyViewedObjects = {

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
@@ -21,9 +21,8 @@ import pick from 'lodash/pick';
 export type PreviouslyViewedObject = {
   genome_id: string;
   object_id: string;
-  object_type: string;
-  label: string;
-  versioned_stable_id: string | null;
+  type: string;
+  label: string[];
 };
 
 export type PreviouslyViewedObjects = {

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
@@ -23,6 +23,7 @@ export type PreviouslyViewedObject = {
   object_id: string;
   object_type: string;
   label: string;
+  versioned_stable_id: string | null;
 };
 
 export type PreviouslyViewedObjects = {

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
@@ -22,7 +22,7 @@ export type PreviouslyViewedObject = {
   genome_id: string;
   object_id: string;
   type: string;
-  label: string[];
+  label: (string | null)[];
 };
 
 export type PreviouslyViewedObjects = {

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.scss
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.scss
@@ -7,9 +7,12 @@
   white-space: nowrap;
 }
 
-.entityType {
+.label {
+  margin-right: 8px;
+}
+
+.type {
   color: $dark-grey;
-  margin-left: 8px;
   font-size: 12px;
   font-weight: $light;
 }
@@ -18,8 +21,4 @@
   font-size: 14px;
   margin: 5px 0 25px 10px;
   font-weight: $bold;
-}
-
-.entityId {
-  margin-left: 8px;
 }

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.scss
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.scss
@@ -1,7 +1,7 @@
 @import 'src/styles/common';
 
 .linkHolder {
-  margin: 5px 0 0 20px;
+  margin: 5px 0 0 10px;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -16,6 +16,10 @@
 
 .title{
   font-size: 14px;
-  margin: 5px 0 10px 10px;
+  margin: 5px 0 25px 10px;
   font-weight: $bold;
+}
+
+.versionedStableId {
+  margin-left: 8px;
 }

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.scss
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.scss
@@ -7,7 +7,7 @@
   white-space: nowrap;
 }
 
-.previouslyViewedType {
+.entityType {
   color: $dark-grey;
   margin-left: 8px;
   font-size: 12px;
@@ -20,6 +20,6 @@
   font-weight: $bold;
 }
 
-.versionedStableId {
+.entityId {
   margin-left: 8px;
 }

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.test.tsx
@@ -89,14 +89,6 @@ describe('<EntityViewerSidebarBookmarks />', () => {
     jest.resetAllMocks();
   });
 
-  it('shows example links if they are present', () => {
-    wrapInRedux();
-    const exampleLinksSection = screen.getByTestId('example links');
-    const links = exampleLinksSection.querySelectorAll('a');
-
-    expect(links.length).toBe(exampleEntities.length);
-  });
-
   it('shows previously viewed entities if present', () => {
     wrapInRedux();
     const previouslyViewedSection = screen.getByTestId(

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.test.tsx
@@ -40,11 +40,13 @@ const exampleEntities = [
 
 const previouslyViewedEntities = [
   {
+    versioned_stable_id: 'human-fry.1',
     stable_id: 'human-fry',
     label: 'FRY',
     type: 'gene'
   },
   {
+    versioned_stable_id: 'human-tp53.1',
     stable_id: 'human-tp53',
     label: 'TP53',
     type: 'gene'

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.test.tsx
@@ -40,14 +40,12 @@ const exampleEntities = [
 
 const previouslyViewedEntities = [
   {
-    versioned_stable_id: 'human-fry.1',
-    stable_id: 'human-fry',
+    entity_id: 'human-fry',
     label: 'FRY',
     type: 'gene'
   },
   {
-    versioned_stable_id: 'human-tp53.1',
-    stable_id: 'human-tp53',
+    entity_id: 'human-tp53',
     label: 'TP53',
     type: 'gene'
   }

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.tsx
@@ -28,52 +28,13 @@ import {
   getEntityViewerActiveGenomeId,
   getEntityViewerActiveEntityId
 } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors';
-import { getGenomeExampleFocusObjects } from 'src/shared/state/genome/genomeSelectors';
 import { getPreviouslyViewedEntities } from 'src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSelectors';
 
 import { closeSidebarModal } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSlice';
 
-import { ExampleFocusObject } from 'src/shared/state/genome/genomeTypes';
-
 import { RootState } from 'src/store';
 
 import styles from './EntityViewerBookmarks.scss';
-import modalStyles from '../EntityViewerSidebarModal.scss';
-
-export type ExampleLinksProps = {
-  activeGenomeId: string | null;
-  exampleEntities: ExampleFocusObject[];
-};
-
-export const ExampleLinks = (props: ExampleLinksProps) => {
-  const exampleGene = props.exampleEntities.find(({ type }) => type === 'gene');
-  const dispatch = useDispatch();
-
-  if (!exampleGene?.id) {
-    return null;
-  }
-
-  const featureIdInUrl = buildFocusIdForUrl({
-    type: 'gene',
-    objectId: exampleGene.id
-  });
-  const path = urlFor.entityViewer({
-    genomeId: props.activeGenomeId,
-    entityId: featureIdInUrl,
-    view: 'transcripts'
-  });
-
-  return (
-    <div data-test-id="example links">
-      <div className={modalStyles.sectionTitle}>Example links</div>
-      <div key={exampleGene.id} className={styles.linkHolder}>
-        <Link to={path} onClick={() => dispatch(closeSidebarModal())}>
-          Example {exampleGene.type}
-        </Link>
-      </div>
-    </div>
-  );
-};
 
 type PreviouslyViewedLinksProps = {
   activeGenomeId: string;
@@ -109,6 +70,9 @@ export const PreviouslyViewedLinks = (props: PreviouslyViewedLinksProps) => {
             >
               <Link to={path} onClick={() => dispatch(closeSidebarModal())}>
                 {previouslyViewedEntity.label}
+                <span className={styles.versionedStableId}>
+                  {previouslyViewedEntity.versioned_stable_id}
+                </span>
               </Link>
               <span className={styles.previouslyViewedType}>
                 {upperFirst(previouslyViewedEntity.type)}
@@ -125,9 +89,6 @@ export const EntityViewerSidebarBookmarks = () => {
   const activeGenomeId = useSelector(getEntityViewerActiveGenomeId) || '';
   const activeEntityId = useSelector(getEntityViewerActiveEntityId) || '';
 
-  const exampleEntities = useSelector((state: RootState) =>
-    getGenomeExampleFocusObjects(state, activeGenomeId)
-  );
   const previouslyViewedEntities = useSelector((state: RootState) =>
     getPreviouslyViewedEntities(state, activeGenomeId)
   );
@@ -139,15 +100,8 @@ export const EntityViewerSidebarBookmarks = () => {
   return (
     <section>
       <div className={styles.title}>Bookmarks</div>
-      {exampleEntities.length ? (
-        <ExampleLinks
-          exampleEntities={exampleEntities}
-          activeGenomeId={activeGenomeId}
-        />
-      ) : null}
       {previouslyViewedEntities.length ? (
         <>
-          <div className={modalStyles.sectionTitle}>Previously viewed</div>
           <PreviouslyViewedLinks
             activeGenomeId={activeGenomeId}
             activeEntityId={activeEntityId}

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.tsx
@@ -70,11 +70,11 @@ export const PreviouslyViewedLinks = (props: PreviouslyViewedLinksProps) => {
             >
               <Link to={path} onClick={() => dispatch(closeSidebarModal())}>
                 {previouslyViewedEntity.label}
-                <span className={styles.versionedStableId}>
+                <span className={styles.entityId}>
                   {previouslyViewedEntity.versioned_stable_id}
                 </span>
               </Link>
-              <span className={styles.previouslyViewedType}>
+              <span className={styles.entityType}>
                 {upperFirst(previouslyViewedEntity.type)}
               </span>
             </div>
@@ -99,7 +99,7 @@ export const EntityViewerSidebarBookmarks = () => {
 
   return (
     <section>
-      <div className={styles.title}>Bookmarks</div>
+      <div className={styles.title}>Previously viewed</div>
       {previouslyViewedEntities.length ? (
         <>
           <PreviouslyViewedLinks

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.tsx
@@ -48,33 +48,32 @@ export const PreviouslyViewedLinks = (props: PreviouslyViewedLinksProps) => {
   const activeEntityStableId = parseEnsObjectId(props.activeEntityId).objectId;
   const previouslyViewedEntitiesWithoutActiveEntity =
     props.previouslyViewedEntities.filter(
-      (entity) => entity.stable_id !== activeEntityStableId
+      (entity) => entity.entity_id !== activeEntityStableId
     );
 
   return (
     <div data-test-id="previously viewed links">
       {[...previouslyViewedEntitiesWithoutActiveEntity].map(
-        (previouslyViewedEntity) => {
+        (previouslyViewedEntity, index) => {
           const path = urlFor.entityViewer({
             genomeId: props.activeGenomeId,
             entityId: buildFocusIdForUrl({
               type: 'gene',
-              objectId: previouslyViewedEntity.stable_id
+              objectId: previouslyViewedEntity.entity_id
             })
           });
 
           return (
-            <div
-              key={previouslyViewedEntity.label}
-              className={styles.linkHolder}
-            >
+            <div key={index} className={styles.linkHolder}>
               <Link to={path} onClick={() => dispatch(closeSidebarModal())}>
-                {previouslyViewedEntity.label}
-                <span className={styles.entityId}>
-                  {previouslyViewedEntity.versioned_stable_id}
+                <span className={styles.label}>
+                  {previouslyViewedEntity.label[0]}
+                </span>
+                <span className={styles.label}>
+                  {previouslyViewedEntity.label[1]}
                 </span>
               </Link>
-              <span className={styles.entityType}>
+              <span className={styles.type}>
                 {upperFirst(previouslyViewedEntity.type)}
               </span>
             </div>

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.tsx
@@ -69,9 +69,11 @@ export const PreviouslyViewedLinks = (props: PreviouslyViewedLinksProps) => {
                 <span className={styles.label}>
                   {previouslyViewedEntity.label[0]}
                 </span>
-                <span className={styles.label}>
-                  {previouslyViewedEntity.label[1]}
-                </span>
+                {previouslyViewedEntity.label[1] && (
+                  <span className={styles.label}>
+                    {previouslyViewedEntity.label[1]}
+                  </span>
+                )}
               </Link>
               <span className={styles.type}>
                 {upperFirst(previouslyViewedEntity.type)}

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-toolstrip/EntityViewerSidebarToolstrip.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-toolstrip/EntityViewerSidebarToolstrip.tsx
@@ -74,7 +74,7 @@ export const EntityViewerSidebarToolstrip = () => {
       />
       <ImageButton
         status={getViewIconStatus(SidebarModalView.BOOKMARKS)}
-        description="Bookmarks"
+        description="Previously viewed"
         className={styles.sidebarIcon}
         key={SidebarModalView.BOOKMARKS}
         onClick={() => toggleModalView(SidebarModalView.BOOKMARKS)}

--- a/src/ensembl/src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSlice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSlice.ts
@@ -18,9 +18,8 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import entityViewerBookmarksStorageService from 'src/content/app/entity-viewer/services/bookmarks/entity-viewer-bookmarks-storage-service';
 
 type PreviouslyViewedEntity = {
-  versioned_stable_id: string;
-  stable_id: string;
-  label: string;
+  entity_id: string;
+  label: string[];
   type: 'gene';
 };
 
@@ -60,13 +59,12 @@ const bookmarksSlice = createSlice({
       const { genomeId, gene } = action.payload;
       const savedEntitiesWithoutCurrentEntity =
         state.previouslyViewed[genomeId]?.filter(
-          (entity) => entity.stable_id !== gene.unversioned_stable_id
+          (entity) => entity.entity_id !== gene.unversioned_stable_id
         ) || [];
 
       const newEntity = {
-        versioned_stable_id: gene.stable_id,
-        stable_id: gene.unversioned_stable_id,
-        label: gene.symbol || gene.stable_id,
+        entity_id: gene.unversioned_stable_id,
+        label: gene.symbol ? [gene.symbol, gene.stable_id] : [gene.stable_id],
         type: 'gene' as const
       };
       const updatedEntites = [

--- a/src/ensembl/src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSlice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSlice.ts
@@ -18,6 +18,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import entityViewerBookmarksStorageService from 'src/content/app/entity-viewer/services/bookmarks/entity-viewer-bookmarks-storage-service';
 
 type PreviouslyViewedEntity = {
+  versioned_stable_id: string;
   stable_id: string;
   label: string;
   type: 'gene';
@@ -61,7 +62,9 @@ const bookmarksSlice = createSlice({
         state.previouslyViewed[genomeId]?.filter(
           (entity) => entity.stable_id !== gene.unversioned_stable_id
         ) || [];
+
       const newEntity = {
+        versioned_stable_id: gene.stable_id,
         stable_id: gene.unversioned_stable_id,
         label: gene.symbol || gene.stable_id,
         type: 'gene' as const


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1119

## Description
The section we call 'Bookmarks' should be renamed 'Previously viewed' (we have used this phrase elsewhere, and it is an more accurate description of what is being displayed).

Also remove the 'Example links' section

## Deployment URL
http://rename-bookmarks.review.ensembl.org/

## Views affected
GB and EV

### Other effects
N/A

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
Nothing I am aware of. Though I have noticed bookmarks being closed when interacting with browser chrome. Will have to fix this in another ticket.
