### PR TITLE
Add interstitial screen for Genome Browser and Entity Viewer 

### DIFF
--- a/src/ensembl/src/content/app/browser/Browser.test.tsx
+++ b/src/ensembl/src/content/app/browser/Browser.test.tsx
@@ -87,29 +87,17 @@ describe('<Browser />', () => {
     );
 
   describe('rendering', () => {
-    test('render interstitial page when there is no species selected', () => {
+    it('renders an interstitial if no species is selected', () => {
       const { container } = mountBrowserComponent({ activeGenomeId: null });
       expect(container.querySelector('.browserInterstitial')).toBeTruthy();
     });
 
-    test('renders links to example objects only if there is no selected focus feature', () => {
-      const { container, rerender } = mountBrowserComponent();
-
-      expect(container.querySelectorAll('.exampleLinks')).toHaveLength(1);
-
-      rerender(
-        <Browser
-          {...defaultProps}
-          browserQueryParams={{
-            focus: faker.lorem.words()
-          }}
-        />
-      );
-
-      expect(container.querySelectorAll('.exampleLinks')).toHaveLength(0);
+    it('renders an interstitial if no feature has been selected', () => {
+      const { container } = mountBrowserComponent();
+      expect(container.querySelector('.browserInterstitial')).toBeTruthy();
     });
 
-    test('renders the genome browser and track panel only when there is a selected focus feature', () => {
+    it('renders the genome browser and track panel only when there is a selected focus feature', () => {
       const { container, rerender } = mountBrowserComponent();
 
       expect(container.querySelectorAll('.browserImage')).toHaveLength(0);

--- a/src/ensembl/src/content/app/browser/Browser.test.tsx
+++ b/src/ensembl/src/content/app/browser/Browser.test.tsx
@@ -44,6 +44,9 @@ jest.mock('./track-panel/TrackPanel', () => () => (
 jest.mock('./browser-app-bar/BrowserAppBar', () => () => (
   <div className="browserAppBar">BrowserAppBar</div>
 ));
+jest.mock('./interstitial/BrowserInterstitial', () => () => (
+  <div className="browserInterstitial">BrowserInterstitial</div>
+));
 jest.mock('./track-panel/track-panel-bar/TrackPanelBar', () => () => (
   <div className="trackPanelBar">TrackPanelBar</div>
 ));
@@ -84,9 +87,9 @@ describe('<Browser />', () => {
     );
 
   describe('rendering', () => {
-    test('does not render when no activeGenomeId', () => {
+    test('render interstitial page when there is no species selected', () => {
       const { container } = mountBrowserComponent({ activeGenomeId: null });
-      expect(container.innerHTML).toBeFalsy();
+      expect(container.querySelector('.browserInterstitial')).toBeTruthy();
     });
 
     test('renders links to example objects only if there is no selected focus feature', () => {

--- a/src/ensembl/src/content/app/browser/Browser.tsx
+++ b/src/ensembl/src/content/app/browser/Browser.tsx
@@ -66,6 +66,7 @@ import { ChrLocation } from './browserState';
 import { EnsObject } from 'src/shared/state/ens-object/ensObjectTypes';
 
 import styles from './Browser.scss';
+import BrowserInterstitial from './interstitial/BrowserInterstitial';
 
 export type BrowserProps = {
   activeGenomeId: string | null;
@@ -107,10 +108,6 @@ export const Browser = (props: BrowserProps) => {
   const shouldShowNavBar =
     props.browserActivated && props.browserNavOpenState && !isDrawerOpened;
 
-  if (!props.activeGenomeId) {
-    return null;
-  }
-
   const mainContent = (
     <>
       {shouldShowNavBar && <BrowserNavBar />}
@@ -122,7 +119,7 @@ export const Browser = (props: BrowserProps) => {
     <ApolloProvider client={client}>
       <div className={styles.browserInnerWrapper}>
         <BrowserAppBar onSpeciesSelect={changeGenomeId} />
-        {props.browserQueryParams.focus ? (
+        {props.activeGenomeId && props.browserQueryParams.focus ? (
           <StandardAppLayout
             mainContent={mainContent}
             sidebarContent={<TrackPanel />}
@@ -137,7 +134,7 @@ export const Browser = (props: BrowserProps) => {
             viewportWidth={props.viewportWidth}
           />
         ) : (
-          <ExampleObjectLinks {...props} />
+          <BrowserInterstitial />
         )}
       </div>
     </ApolloProvider>

--- a/src/ensembl/src/content/app/browser/Browser.tsx
+++ b/src/ensembl/src/content/app/browser/Browser.tsx
@@ -60,13 +60,13 @@ import Drawer from './drawer/Drawer';
 import { StandardAppLayout } from 'src/shared/components/layout';
 import ErrorBoundary from 'src/shared/components/error-boundary/ErrorBoundary';
 import { NewTechError } from 'src/shared/components/error-screen';
+import BrowserInterstitial from './interstitial/BrowserInterstitial';
 
 import { RootState } from 'src/store';
 import { ChrLocation } from './browserState';
 import { EnsObject } from 'src/shared/state/ens-object/ensObjectTypes';
 
 import styles from './Browser.scss';
-import BrowserInterstitial from './interstitial/BrowserInterstitial';
 
 export type BrowserProps = {
   activeGenomeId: string | null;

--- a/src/ensembl/src/content/app/browser/browser-app-bar/BrowserAppBar.tsx
+++ b/src/ensembl/src/content/app/browser/browser-app-bar/BrowserAppBar.tsx
@@ -62,10 +62,14 @@ const BrowserAppBar = (props: BrowserAppBarProps) => {
     />
   );
 
+  const mainContent = props.activeGenomeId
+    ? wrappedSpecies
+    : 'To start using this app...';
+
   return (
     <AppBar
       appName={AppName.GENOME_BROWSER}
-      mainContent={wrappedSpecies}
+      mainContent={mainContent}
       aside={<HelpPopupButton slug="genome-browser" />}
     />
   );

--- a/src/ensembl/src/content/app/browser/interstitial/BrowserInterstitial.scss
+++ b/src/ensembl/src/content/app/browser/interstitial/BrowserInterstitial.scss
@@ -1,0 +1,24 @@
+@import 'src/styles/common';
+
+// TODO: this panel is the same as in SpeciesSelector, and in EntityViewer.
+// We should extract it in a component (or at least reuse the same CSS classes)
+.topPanel {
+  background-color: $light-grey;
+  height: 235px;
+  padding: 65px 40px;
+  padding-left: $global-padding-left;
+  box-shadow: 0 3px 5px $global-box-shadow;
+}
+
+.searchField {
+  max-width: 485px;
+  height: 30px;
+}
+
+.exampleLinks {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 40px;
+  padding-left: $global-padding-left;
+}

--- a/src/ensembl/src/content/app/browser/interstitial/BrowserInterstitial.tsx
+++ b/src/ensembl/src/content/app/browser/interstitial/BrowserInterstitial.tsx
@@ -1,0 +1,76 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
+
+import { getBrowserActiveGenomeId } from 'src/content/app/browser/browserSelectors';
+import { getExampleEnsObjects } from 'src/shared/state/ens-object/ensObjectSelectors';
+
+import {
+  parseEnsObjectId,
+  buildFocusIdForUrl
+} from 'src/shared/state/ens-object/ensObjectHelpers';
+import * as urlFor from 'src/shared/helpers/urlHelper';
+
+import BrowserInterstitialInstructions from './browser-interstitial-instructions/BrowserInterstitialInstructions';
+import InAppSearch from 'src/shared/components/in-app-search/InAppSearch';
+
+import styles from './BrowserInterstitial.scss';
+
+const BrowserInterstitial = () => {
+  const activeGenomeId = useSelector(getBrowserActiveGenomeId);
+
+  if (!activeGenomeId) {
+    return <BrowserInterstitialInstructions />;
+  }
+
+  return (
+    <div>
+      <div className={styles.topPanel}>
+        <InAppSearch className={styles.searchField} />
+      </div>
+      <ExampleLinks />
+    </div>
+  );
+};
+
+const ExampleLinks = () => {
+  const activeGenomeId = useSelector(getBrowserActiveGenomeId);
+  const ensObjects = useSelector(getExampleEnsObjects);
+
+  const links = ensObjects.map((exampleObject) => {
+    const parsedEnsObjectId = parseEnsObjectId(exampleObject.object_id);
+    const focusId = buildFocusIdForUrl(parsedEnsObjectId);
+    const path = urlFor.browser({
+      genomeId: activeGenomeId,
+      focus: focusId
+    });
+
+    return (
+      <div key={exampleObject.object_id}>
+        <Link to={path} replace>
+          Example {exampleObject.type}
+        </Link>
+      </div>
+    );
+  });
+
+  return <div className={styles.exampleLinks}>{links}</div>;
+};
+
+export default BrowserInterstitial;

--- a/src/ensembl/src/content/app/browser/interstitial/browser-interstitial-instructions/BrowserInterstitialInstructions.scss
+++ b/src/ensembl/src/content/app/browser/interstitial/browser-interstitial-instructions/BrowserInterstitialInstructions.scss
@@ -1,0 +1,81 @@
+@import 'src/styles/common';
+
+$columnWidth: 230px;
+$columnGap: 60px;
+$rowGap: 60px;
+$leftMargin: 40px;
+
+.instructionsPanel {
+  background-color: $light-grey;
+  height: 235px;
+  padding: 29px $global-padding-left;
+  padding-left: $global-padding-left;
+  box-shadow: 0 3px 5px $global-box-shadow;
+  display: flex;
+}
+
+.instructionsWrapper {
+  margin-left: $leftMargin;
+  display: grid;
+  grid-template-columns: repeat(4, #{$columnWidth});
+  grid-column-gap: $columnGap;
+  grid-row-gap: $rowGap;
+  max-width: calc(4 * #{$columnWidth} + 3 * #{$columnGap});
+}
+
+.description {
+  margin: 25px 40px;
+  display: flex;
+  align-items: center;
+
+  .iconLabel {
+    margin-left: 12px;
+  }
+}
+
+.imageButtonIcon {
+  width: 32px;
+  height: 32px;
+  background-color: $dark-grey;
+
+  svg {
+    fill: $white;
+  }
+}
+
+.searchButtonIcon {
+  width: 30px;
+  height: 30px;
+
+  svg {
+    fill: $dark-grey;
+  }
+}
+
+.searchDescription {
+  margin: 14px 36px;
+  color: $dark-grey;
+
+  .exampleText {
+    margin: 10px 4px;
+  }
+}
+
+.speciesSelectorButton {
+  margin-left: 40px;
+}
+
+
+// @media (max-width: 980px) {
+@media (max-width: $global-padding-left + $leftMargin + 4 * $columnWidth + 3 * $columnGap) {
+
+  .instructionsWrapper {
+    grid-template-columns: repeat(2, #{$columnWidth});
+  }
+  .instructionsPanel {
+    height: auto;
+  }
+  .speciesSelectorButton {
+    margin-left: 0;
+  }
+}

--- a/src/ensembl/src/content/app/browser/interstitial/browser-interstitial-instructions/BrowserInterstitialInstructions.scss
+++ b/src/ensembl/src/content/app/browser/interstitial/browser-interstitial-instructions/BrowserInterstitialInstructions.scss
@@ -7,9 +7,8 @@ $leftMargin: 40px;
 
 .instructionsPanel {
   background-color: $light-grey;
-  height: 235px;
+  min-height: 235px;
   padding: 29px $global-padding-left;
-  padding-left: $global-padding-left;
   box-shadow: 0 3px 5px $global-box-shadow;
   display: flex;
 }
@@ -63,17 +62,15 @@ $leftMargin: 40px;
 
 .speciesSelectorButton {
   margin-left: 40px;
+  align-self: start;
+  justify-self: start;
 }
 
 
-// @media (max-width: 980px) {
-@media (max-width: $global-padding-left + $leftMargin + 4 * $columnWidth + 3 * $columnGap) {
+@media (max-width: 2 * $global-padding-left + $leftMargin + 4 * $columnWidth + 3 * $columnGap) {
 
   .instructionsWrapper {
     grid-template-columns: repeat(2, #{$columnWidth});
-  }
-  .instructionsPanel {
-    height: auto;
   }
   .speciesSelectorButton {
     margin-left: 0;

--- a/src/ensembl/src/content/app/browser/interstitial/browser-interstitial-instructions/BrowserInterstitialInstructions.scss
+++ b/src/ensembl/src/content/app/browser/interstitial/browser-interstitial-instructions/BrowserInterstitialInstructions.scss
@@ -6,11 +6,11 @@ $rowGap: 60px;
 $leftMargin: 40px;
 
 .instructionsPanel {
+  display: flex;
   background-color: $light-grey;
   min-height: 235px;
   padding: 29px $global-padding-left;
   box-shadow: 0 3px 5px $global-box-shadow;
-  display: flex;
 }
 
 .instructionsWrapper {

--- a/src/ensembl/src/content/app/browser/interstitial/browser-interstitial-instructions/BrowserInterstitialInstructions.tsx
+++ b/src/ensembl/src/content/app/browser/interstitial/browser-interstitial-instructions/BrowserInterstitialInstructions.tsx
@@ -1,0 +1,92 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Link } from 'react-router-dom';
+import noop from 'lodash/noop';
+
+import { Step } from 'src/shared/components/step/Step';
+import { ImageButton } from 'src/shared/components/image-button/ImageButton';
+import { PrimaryButton } from 'src/shared/components/button/Button';
+import { Status } from 'src/shared/types/status';
+
+import { ReactComponent as SpeciesSelectorIcon } from 'static/img/launchbar/species-selector.svg';
+import { ReactComponent as BrowserIcon } from 'static/img/launchbar/browser.svg';
+import { ReactComponent as SearchIcon } from 'static/img/sidebar/search.svg';
+
+import styles from './BrowserInterstitialInstructions.scss';
+import classNames from 'classnames';
+
+const speciesSelectorButtonClasses = classNames(
+  styles.stepsWrapper,
+  styles.speciesSelectorButton
+);
+
+const BrowserInterstitialInstructions = () => {
+  return (
+    <section className={styles.instructionsPanel}>
+      <div className={styles.instructionsWrapper}>
+        <div className={styles.stepWrapper}>
+          <Step count={1} title="Find and add a species" />
+          <div className={styles.description}>
+            <ImageButton
+              className={styles.imageButtonIcon}
+              status={Status.DISABLED}
+              image={SpeciesSelectorIcon}
+            />
+            <div className={styles.iconLabel}>Species Selector</div>
+          </div>
+        </div>
+
+        <div className={styles.stepWrapper}>
+          <Step count={2} title="Return to this app" />
+          <div className={styles.description}>
+            <ImageButton
+              className={styles.imageButtonIcon}
+              status={Status.DISABLED}
+              image={BrowserIcon}
+            />
+            <div className={styles.iconLabel}>Genome Browser</div>
+          </div>
+        </div>
+
+        <div className={styles.stepWrapper}>
+          <Step
+            count={3}
+            title="Use Search or the example links to view a gene or region"
+          />
+          <div className={styles.searchDescription}>
+            <ImageButton
+              className={styles.searchButtonIcon}
+              status={Status.DISABLED}
+              image={SearchIcon}
+            />
+            <div className={styles.exampleText}>Example gene</div>
+            <div className={styles.exampleText}>Example region</div>
+          </div>
+        </div>
+
+        <div className={speciesSelectorButtonClasses}>
+          <Link to="/species-selector">
+            <PrimaryButton onClick={noop}>Go to Species Selector</PrimaryButton>
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default BrowserInterstitialInstructions;

--- a/src/ensembl/src/content/app/browser/interstitial/browser-interstitial-instructions/BrowserInterstitialInstructions.tsx
+++ b/src/ensembl/src/content/app/browser/interstitial/browser-interstitial-instructions/BrowserInterstitialInstructions.tsx
@@ -15,8 +15,10 @@
  */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
-import noop from 'lodash/noop';
+import { useDispatch } from 'react-redux';
+import { push } from 'connected-react-router';
+
+import * as urlFor from 'src/shared/helpers/urlHelper';
 
 import { Step } from 'src/shared/components/step/Step';
 import { ImageButton } from 'src/shared/components/image-button/ImageButton';
@@ -28,14 +30,15 @@ import { ReactComponent as BrowserIcon } from 'static/img/launchbar/browser.svg'
 import { ReactComponent as SearchIcon } from 'static/img/sidebar/search.svg';
 
 import styles from './BrowserInterstitialInstructions.scss';
-import classNames from 'classnames';
-
-const speciesSelectorButtonClasses = classNames(
-  styles.stepsWrapper,
-  styles.speciesSelectorButton
-);
 
 const BrowserInterstitialInstructions = () => {
+  const dispatch = useDispatch();
+
+  const goToSpeciesSelector = () => {
+    const url = urlFor.speciesSelector();
+    dispatch(push(url));
+  };
+
   return (
     <section className={styles.instructionsPanel}>
       <div className={styles.instructionsWrapper}>
@@ -79,11 +82,12 @@ const BrowserInterstitialInstructions = () => {
           </div>
         </div>
 
-        <div className={speciesSelectorButtonClasses}>
-          <Link to="/species-selector">
-            <PrimaryButton onClick={noop}>Go to Species Selector</PrimaryButton>
-          </Link>
-        </div>
+        <PrimaryButton
+          className={styles.speciesSelectorButton}
+          onClick={goToSpeciesSelector}
+        >
+          Go to Species Selector
+        </PrimaryButton>
       </div>
     </section>
   );

--- a/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
@@ -88,23 +88,21 @@ const EntityViewer = () => {
   return (
     <ApolloProvider client={client}>
       <div className={styles.entityViewer}>
+        <EntityViewerAppBar />
         {genomeId && entityId ? (
-          <>
-            <EntityViewerAppBar />
-            <StandardAppLayout
-              mainContent={<GeneView />}
-              topbarContent={
-                <EntityViewerTopbar genomeId={genomeId} entityId={entityId} />
-              }
-              sidebarContent={SideBarContent}
-              sidebarNavigation={<GeneViewSidebarTabs />}
-              sidebarToolstripContent={<EntityViewerSidebarToolstrip />}
-              isSidebarOpen={isSidebarOpen}
-              onSidebarToggle={() => dispatch(toggleSidebar())}
-              isDrawerOpen={false}
-              viewportWidth={viewportWidth}
-            />
-          </>
+          <StandardAppLayout
+            mainContent={<GeneView />}
+            topbarContent={
+              <EntityViewerTopbar genomeId={genomeId} entityId={entityId} />
+            }
+            sidebarContent={SideBarContent}
+            sidebarNavigation={<GeneViewSidebarTabs />}
+            sidebarToolstripContent={<EntityViewerSidebarToolstrip />}
+            isSidebarOpen={isSidebarOpen}
+            onSidebarToggle={() => dispatch(toggleSidebar())}
+            isDrawerOpen={false}
+            viewportWidth={viewportWidth}
+          />
         ) : (
           <EntityViewerInterstitial />
         )}

--- a/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/EntityViewer.tsx
@@ -45,7 +45,7 @@ import EntityViewerAppBar from './shared/components/entity-viewer-app-bar/Entity
 import EntityViewerSidebarToolstrip from './shared/components/entity-viewer-sidebar/entity-viewer-sidebar-toolstrip/EntityViewerSidebarToolstrip';
 import EntityViewerSidebarModal from 'src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/EntityViewerSidebarModal';
 import EntityViewerTopbar from './shared/components/entity-viewer-topbar/EntityViewerTopbar';
-import ExampleLinks from './components/example-links/ExampleLinks';
+import EntityViewerInterstitial from './interstitial/EntityViewerInterstitial';
 import GeneView from './gene-view/GeneView';
 import GeneViewSidebar from './gene-view/components/gene-view-sidebar/GeneViewSideBar';
 import GeneViewSidebarTabs from './gene-view/components/gene-view-sidebar-tabs/GeneViewSidebarTabs';
@@ -88,23 +88,25 @@ const EntityViewer = () => {
   return (
     <ApolloProvider client={client}>
       <div className={styles.entityViewer}>
-        <EntityViewerAppBar />
         {genomeId && entityId ? (
-          <StandardAppLayout
-            mainContent={<GeneView />}
-            topbarContent={
-              <EntityViewerTopbar genomeId={genomeId} entityId={entityId} />
-            }
-            sidebarContent={SideBarContent}
-            sidebarNavigation={<GeneViewSidebarTabs />}
-            sidebarToolstripContent={<EntityViewerSidebarToolstrip />}
-            isSidebarOpen={isSidebarOpen}
-            onSidebarToggle={() => dispatch(toggleSidebar())}
-            isDrawerOpen={false}
-            viewportWidth={viewportWidth}
-          />
+          <>
+            <EntityViewerAppBar />
+            <StandardAppLayout
+              mainContent={<GeneView />}
+              topbarContent={
+                <EntityViewerTopbar genomeId={genomeId} entityId={entityId} />
+              }
+              sidebarContent={SideBarContent}
+              sidebarNavigation={<GeneViewSidebarTabs />}
+              sidebarToolstripContent={<EntityViewerSidebarToolstrip />}
+              isSidebarOpen={isSidebarOpen}
+              onSidebarToggle={() => dispatch(toggleSidebar())}
+              isDrawerOpen={false}
+              viewportWidth={viewportWidth}
+            />
+          </>
         ) : (
-          <ExampleLinks />
+          <EntityViewerInterstitial />
         )}
       </div>
     </ApolloProvider>

--- a/src/ensembl/src/content/app/entity-viewer/components/example-links/ExampleLinks.scss
+++ b/src/ensembl/src/content/app/entity-viewer/components/example-links/ExampleLinks.scss
@@ -2,14 +2,7 @@
 
 .exampleLinks {
   margin-top: 50px;
-  padding-left: 120px;
-
-  &__emptyTopbar {
-    height: 40px; // same as top bar height in StandardAppLayout
-    background: $light-grey;
-    box-shadow: 0 2px 3px $grey;
-  }
-  
+  padding-left: 120px;  
 
   a {
     margin-bottom: 30px;

--- a/src/ensembl/src/content/app/entity-viewer/components/example-links/ExampleLinks.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/components/example-links/ExampleLinks.tsx
@@ -85,7 +85,6 @@ const ExampleLinks = () => {
 
   return (
     <div>
-      <div className={styles.exampleLinks__emptyTopbar} />
       <div className={styles.exampleLinks}>
         <Link to={path}>Example gene</Link>
       </div>

--- a/src/ensembl/src/content/app/entity-viewer/interstitial/EntityViewerInterstitial.scss
+++ b/src/ensembl/src/content/app/entity-viewer/interstitial/EntityViewerInterstitial.scss
@@ -1,0 +1,16 @@
+@import 'src/styles/common';
+
+// TODO: this panel is the same as in SpeciesSelector, and in EntityViewer.
+// We should extract it in a component (or at least reuse the same CSS classes)
+.topPanel {
+  background-color: $light-grey;
+  height: 235px;
+  padding: 65px 40px;
+  padding-left: $global-padding-left;
+  box-shadow: 0 3px 5px $global-box-shadow;
+}
+
+.searchField {
+  max-width: 485px;
+  height: 30px;
+}

--- a/src/ensembl/src/content/app/entity-viewer/interstitial/EntityViewerInterstitial.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/interstitial/EntityViewerInterstitial.tsx
@@ -1,0 +1,59 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+import EntityViewerInterstitialInstructions from './entity-viewer-interstitial-instructions/EntityViewerInterstitialInstructions';
+import AppBar from 'src/shared/components/app-bar/AppBar';
+import { EntityViewerParams } from 'src/content/app/entity-viewer/EntityViewer';
+import ExampleLinks from 'src/content/app/entity-viewer/components/example-links/ExampleLinks';
+import EntityViewerAppBar from '../shared/components/entity-viewer-app-bar/EntityViewerAppBar';
+import InAppSearch from 'src/shared/components/in-app-search/InAppSearch';
+
+const EntityViewerInterstitial = () => {
+  const params: EntityViewerParams = useParams(); // NOTE: will likely cause a problem when server-side rendering
+  const { genomeId, entityId } = params;
+
+  return (
+    <>
+      {!genomeId && !entityId ? (
+        <>
+          <AppBar
+            appName="Entity Viewer"
+            mainContent="To start using this app..."
+          />
+          <EntityViewerInterstitialInstructions />
+        </>
+      ) : (
+        <>
+          <EntityViewerAppBar />
+          <InAppSearch />
+          <ExampleLinks />
+        </>
+      )}
+    </>
+  );
+};
+
+export default EntityViewerInterstitial;
+
+{
+  /* <>
+
+<EntityViewerInterstitialInstructions />
+</> */
+}

--- a/src/ensembl/src/content/app/entity-viewer/interstitial/EntityViewerInterstitial.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/interstitial/EntityViewerInterstitial.tsx
@@ -15,45 +15,31 @@
  */
 
 import React from 'react';
-import { useParams } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+
+import { getEntityViewerActiveGenomeId } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors';
 
 import EntityViewerInterstitialInstructions from './entity-viewer-interstitial-instructions/EntityViewerInterstitialInstructions';
-import AppBar from 'src/shared/components/app-bar/AppBar';
-import { EntityViewerParams } from 'src/content/app/entity-viewer/EntityViewer';
 import ExampleLinks from 'src/content/app/entity-viewer/components/example-links/ExampleLinks';
-import EntityViewerAppBar from '../shared/components/entity-viewer-app-bar/EntityViewerAppBar';
 import InAppSearch from 'src/shared/components/in-app-search/InAppSearch';
 
+import styles from './EntityViewerInterstitial.scss';
+
 const EntityViewerInterstitial = () => {
-  const params: EntityViewerParams = useParams(); // NOTE: will likely cause a problem when server-side rendering
-  const { genomeId, entityId } = params;
+  const activeGenomeId = useSelector(getEntityViewerActiveGenomeId);
+
+  if (!activeGenomeId) {
+    return <EntityViewerInterstitialInstructions />;
+  }
 
   return (
-    <>
-      {!genomeId && !entityId ? (
-        <>
-          <AppBar
-            appName="Entity Viewer"
-            mainContent="To start using this app..."
-          />
-          <EntityViewerInterstitialInstructions />
-        </>
-      ) : (
-        <>
-          <EntityViewerAppBar />
-          <InAppSearch />
-          <ExampleLinks />
-        </>
-      )}
-    </>
+    <div>
+      <div className={styles.topPanel}>
+        <InAppSearch className={styles.searchField} />
+      </div>
+      <ExampleLinks />
+    </div>
   );
 };
 
 export default EntityViewerInterstitial;
-
-{
-  /* <>
-
-<EntityViewerInterstitialInstructions />
-</> */
-}

--- a/src/ensembl/src/content/app/entity-viewer/interstitial/entity-viewer-interstitial-instructions/EntityViewerInterstitialInstructions.scss
+++ b/src/ensembl/src/content/app/entity-viewer/interstitial/entity-viewer-interstitial-instructions/EntityViewerInterstitialInstructions.scss
@@ -19,7 +19,7 @@ $leftMargin: 40px;
   display: grid;
   grid-template-columns: repeat(4, #{$columnWidth});
   grid-column-gap: $columnGap;
-  grid-row-gap: $rowGap;;
+  grid-row-gap: $rowGap;
   max-width: calc(4 * #{$columnWidth} + 3 * #{$columnGap});
 }
 

--- a/src/ensembl/src/content/app/entity-viewer/interstitial/entity-viewer-interstitial-instructions/EntityViewerInterstitialInstructions.scss
+++ b/src/ensembl/src/content/app/entity-viewer/interstitial/entity-viewer-interstitial-instructions/EntityViewerInterstitialInstructions.scss
@@ -1,0 +1,81 @@
+@import 'src/styles/common';
+
+$columnWidth: 230px;
+$columnGap: 60px;
+$rowGap: 60px;
+$leftMargin: 40px;
+
+.instructionsPanel {
+  background-color: $light-grey;
+  height: 235px;
+  padding: 29px $global-padding-left;
+  padding-left: $global-padding-left;
+  box-shadow: 0 3px 5px $global-box-shadow;
+  display: flex;
+}
+
+.instructionsWrapper {
+  margin-left: $leftMargin;
+  display: grid;
+  grid-template-columns: repeat(4, #{$columnWidth});
+  grid-column-gap: $columnGap;
+  grid-row-gap: $rowGap;;
+  max-width: calc(4 * #{$columnWidth} + 3 * #{$columnGap});
+}
+
+.description {
+  margin: 25px 40px;
+  display: flex;
+  align-items: center;
+
+  .iconLabel {
+    margin-left: 12px;
+  }
+}
+
+.imageButtonIcon {
+  width: 32px;
+  height: 32px;
+  background-color: $dark-grey;
+
+  svg {
+    fill: $white;
+  }
+}
+
+.searchButtonIcon {
+  width: 30px;
+  height: 30px;
+
+  svg {
+    fill: $dark-grey;
+  }
+}
+
+.searchDescription {
+  margin: 14px 36px;
+  color: $dark-grey;
+
+  .exampleText {
+    margin: 10px 4px;
+  }
+}
+
+.speciesSelectorButton {
+  margin-left: 40px;
+}
+
+
+// @media (max-width: 980px) {
+@media (max-width: $global-padding-left + $leftMargin + 4 * $columnWidth + 3 * $columnGap) {
+
+  .instructionsWrapper {
+    grid-template-columns: repeat(2, #{$columnWidth});
+  }
+  .instructionsPanel {
+    height: auto;
+  }
+  .speciesSelectorButton {
+    margin-left: 0;
+  }
+}

--- a/src/ensembl/src/content/app/entity-viewer/interstitial/entity-viewer-interstitial-instructions/EntityViewerInterstitialInstructions.scss
+++ b/src/ensembl/src/content/app/entity-viewer/interstitial/entity-viewer-interstitial-instructions/EntityViewerInterstitialInstructions.scss
@@ -6,12 +6,11 @@ $rowGap: 60px;
 $leftMargin: 40px;
 
 .instructionsPanel {
-  background-color: $light-grey;
-  height: 235px;
-  padding: 29px $global-padding-left;
-  padding-left: $global-padding-left;
-  box-shadow: 0 3px 5px $global-box-shadow;
   display: flex;
+  background-color: $light-grey;
+  min-height: 235px;
+  padding: 29px $global-padding-left;
+  box-shadow: 0 3px 5px $global-box-shadow;
 }
 
 .instructionsWrapper {
@@ -63,11 +62,12 @@ $leftMargin: 40px;
 
 .speciesSelectorButton {
   margin-left: 40px;
+  align-self: start;
+  justify-self: start;
 }
 
 
-// @media (max-width: 980px) {
-@media (max-width: $global-padding-left + $leftMargin + 4 * $columnWidth + 3 * $columnGap) {
+@media (max-width: 2 * $global-padding-left + $leftMargin + 4 * $columnWidth + 3 * $columnGap) {
 
   .instructionsWrapper {
     grid-template-columns: repeat(2, #{$columnWidth});

--- a/src/ensembl/src/content/app/entity-viewer/interstitial/entity-viewer-interstitial-instructions/EntityViewerInterstitialInstructions.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/interstitial/entity-viewer-interstitial-instructions/EntityViewerInterstitialInstructions.tsx
@@ -15,8 +15,10 @@
  */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
-import classNames from 'classnames';
+import { useDispatch } from 'react-redux';
+import { push } from 'connected-react-router';
+
+import * as urlFor from 'src/shared/helpers/urlHelper';
 
 import { Step } from 'src/shared/components/step/Step';
 import { ImageButton } from 'src/shared/components/image-button/ImageButton';
@@ -29,12 +31,14 @@ import { ReactComponent as SearchIcon } from 'static/img/sidebar/search.svg';
 
 import styles from './EntityViewerInterstitialInstructions.scss';
 
-const speciesSelectorButtonClasses = classNames(
-  styles.stepsWrapper,
-  styles.speciesSelectorButton
-);
-
 const EntityViewerInterstitialInstructions = () => {
+  const dispatch = useDispatch();
+
+  const goToSpeciesSelector = () => {
+    const url = urlFor.speciesSelector();
+    dispatch(push(url));
+  };
+
   return (
     <section className={styles.instructionsPanel}>
       <div className={styles.instructionsWrapper}>
@@ -77,13 +81,12 @@ const EntityViewerInterstitialInstructions = () => {
           </div>
         </div>
 
-        <div className={speciesSelectorButtonClasses}>
-          <Link to="/species-selector">
-            <PrimaryButton onClick={() => null}>
-              Go to Species Selector
-            </PrimaryButton>
-          </Link>
-        </div>
+        <PrimaryButton
+          className={styles.speciesSelectorButton}
+          onClick={goToSpeciesSelector}
+        >
+          Go to Species Selector
+        </PrimaryButton>
       </div>
     </section>
   );

--- a/src/ensembl/src/content/app/entity-viewer/interstitial/entity-viewer-interstitial-instructions/EntityViewerInterstitialInstructions.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/interstitial/entity-viewer-interstitial-instructions/EntityViewerInterstitialInstructions.tsx
@@ -1,0 +1,92 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Link } from 'react-router-dom';
+import classNames from 'classnames';
+
+import { Step } from 'src/shared/components/step/Step';
+import { ImageButton } from 'src/shared/components/image-button/ImageButton';
+import { PrimaryButton } from 'src/shared/components/button/Button';
+import { Status } from 'src/shared/types/status';
+
+import { ReactComponent as SpeciesSelectorIcon } from 'static/img/launchbar/species-selector.svg';
+import { ReactComponent as EntityViewerIcon } from 'static/img/launchbar/entity-viewer.svg';
+import { ReactComponent as SearchIcon } from 'static/img/sidebar/search.svg';
+
+import styles from './EntityViewerInterstitialInstructions.scss';
+
+const speciesSelectorButtonClasses = classNames(
+  styles.stepsWrapper,
+  styles.speciesSelectorButton
+);
+
+const EntityViewerInterstitialInstructions = () => {
+  return (
+    <section className={styles.instructionsPanel}>
+      <div className={styles.instructionsWrapper}>
+        <div className={styles.stepWrapper}>
+          <Step count={1} title="Find and add a species" />
+          <div className={styles.description}>
+            <ImageButton
+              className={styles.imageButtonIcon}
+              status={Status.DISABLED}
+              image={SpeciesSelectorIcon}
+            />
+            <div className={styles.iconLabel}>Species Selector</div>
+          </div>
+        </div>
+
+        <div className={styles.stepWrapper}>
+          <Step count={2} title="Return to this app" />
+          <div className={styles.description}>
+            <ImageButton
+              className={styles.imageButtonIcon}
+              status={Status.DISABLED}
+              image={EntityViewerIcon}
+            />
+            <div className={styles.iconLabel}>Entity Viewer</div>
+          </div>
+        </div>
+
+        <div className={styles.stepWrapper}>
+          <Step
+            count={3}
+            title="Use Search or the example links to view a gene"
+          />
+          <div className={styles.searchDescription}>
+            <ImageButton
+              className={styles.searchButtonIcon}
+              status={Status.DISABLED}
+              image={SearchIcon}
+            />
+            <div className={styles.exampleText}>Example gene</div>
+          </div>
+        </div>
+
+        <div className={speciesSelectorButtonClasses}>
+          <Link to="/species-selector">
+            <PrimaryButton onClick={() => null}>
+              Go to Species Selector
+            </PrimaryButton>
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default EntityViewerInterstitialInstructions;

--- a/src/ensembl/src/content/app/entity-viewer/services/entity-viewer-storage-service.ts
+++ b/src/ensembl/src/content/app/entity-viewer/services/entity-viewer-storage-service.ts
@@ -35,7 +35,7 @@ export class EntityViewerStorageService {
     this.storageService = storageService;
   }
 
-  public getGeneralState(): Partial<EntityViewerGeneralState> {
+  public getGeneralState(): Partial<EntityViewerGeneralState> | null {
     return this.storageService.get(
       StorageKeys.GENERAL_STATE,
       localStorageOptions
@@ -51,7 +51,7 @@ export class EntityViewerStorageService {
   }
 
   public deleteGenome(genomeIdToDelete: string): void {
-    const activeGenomeId = this.getGeneralState().activeGenomeId;
+    const activeGenomeId = this.getGeneralState()?.activeGenomeId;
     if (activeGenomeId === genomeIdToDelete) {
       this.updateGeneralState({
         activeGenomeId: undefined

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-app-bar/EntityViewerAppBar.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-app-bar/EntityViewerAppBar.tsx
@@ -63,10 +63,14 @@ const EntityViewerAppBar = () => {
     />
   );
 
+  const mainContent = activeGenomeId
+    ? wrappedSpecies
+    : 'To start using this app...';
+
   return (
     <AppBar
       appName={AppName.ENTITY_VIEWER}
-      mainContent={wrappedSpecies}
+      mainContent={mainContent}
       aside={<HelpPopupButton slug="entity-viewer" />}
     />
   );

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralSlice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralSlice.ts
@@ -106,8 +106,8 @@ export const setDefaultActiveGenomeId =
   (dispatch, getState: () => RootState) => {
     const state = getState();
     const [firstCommittedSpecies] = getCommittedSpecies(state);
-    const activeGenomeId = firstCommittedSpecies.genome_id;
-    dispatch(setActiveGenomeId(activeGenomeId));
+    const activeGenomeId = firstCommittedSpecies?.genome_id;
+    activeGenomeId && dispatch(setActiveGenomeId(activeGenomeId));
   };
 
 const entityViewerGeneralSlice = createSlice({

--- a/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.scss
+++ b/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.scss
@@ -12,22 +12,23 @@ $rightCornerWidth: 40px;
   height: 36px;
   box-shadow: inset 2px 2px 4px -2px $dark-grey;
   background: white;
-}
 
-.speciesSearchField {
-  width: 100%;
-  background: $white;
-  padding-left: 18px;
-  border: none;
-
-  input {
-    &::placeholder {
-      color: $grey;
-    }
-
-    &:focus {
+  // nesting to increase specificity of the selector (needs to override child rules)
+  .speciesSearchField {
+    width: 100%;
+    background: $white;
+    padding-left: 18px;
+    border: none;
+  
+    input {
       &::placeholder {
-        color: white;
+        color: $grey;
+      }
+  
+      &:focus {
+        &::placeholder {
+          color: white;
+        }
       }
     }
   }

--- a/src/ensembl/src/header/launchbar/Launchbar.tsx
+++ b/src/ensembl/src/header/launchbar/Launchbar.tsx
@@ -63,7 +63,7 @@ const Launchbar = () => {
               app="genome-browser"
               description="Genome browser"
               icon={BrowserIcon}
-              enabled={committedSpecies.length > 0}
+              enabled={true}
             />
           </div>
           <div className={styles.category}>
@@ -71,7 +71,7 @@ const Launchbar = () => {
               app="entity-viewer"
               description="Entity Viewer"
               icon={EntityViewerIcon}
-              enabled={committedSpecies.length > 0}
+              enabled={true}
             />
           </div>
           <div className={styles.category}>

--- a/src/ensembl/src/shared/components/app-bar/AppBar.scss
+++ b/src/ensembl/src/shared/components/app-bar/AppBar.scss
@@ -8,7 +8,6 @@
     'top top'
     'main right';
   align-items: center;
-  font-size: 12px;
   padding: 8px 20px;
   min-height: 80px;
   width: 100%;
@@ -17,6 +16,8 @@
 .appBarTop {
   grid-area: top;
   min-height: 30px;
+  color: $black;
+  font-weight: 300;
 }
 
 .appBarMain {

--- a/src/ensembl/src/shared/components/in-app-search/InAppSearch.scss
+++ b/src/ensembl/src/shared/components/in-app-search/InAppSearch.scss
@@ -4,10 +4,11 @@
   padding: 4px;
   box-shadow: inset 2px 2px 4px -2px $dark-grey;
   background: white;
-}
 
-.searchField {
-  border: none;
-  width: 100%;
-  height: 100%;
+  // nesting to increase specificity of the selector
+  .searchField {
+    border: none;
+    width: 100%;
+    height: 100%;
+  }
 }

--- a/src/ensembl/src/shared/components/in-app-search/InAppSearch.scss
+++ b/src/ensembl/src/shared/components/in-app-search/InAppSearch.scss
@@ -1,0 +1,13 @@
+@import 'src/styles/common';
+
+.searchFieldWrapper {
+  padding: 4px;
+  box-shadow: inset 2px 2px 4px -2px $dark-grey;
+  background: white;
+}
+
+.searchField {
+  border: none;
+  width: 100%;
+  height: 100%;
+}

--- a/src/ensembl/src/shared/components/in-app-search/InAppSearch.scss
+++ b/src/ensembl/src/shared/components/in-app-search/InAppSearch.scss
@@ -12,3 +12,12 @@
     height: 100%;
   }
 }
+
+// TODO: remove this temporary class when in-app search becomes functional
+.fauxSearchField {
+  color: $grey;
+  height: 36px;
+  box-shadow: inset 1px 1px 3px 0 $dark-grey;
+  padding: 12px 20px;
+  width: 485px;
+}

--- a/src/ensembl/src/shared/components/in-app-search/InAppSearch.tsx
+++ b/src/ensembl/src/shared/components/in-app-search/InAppSearch.tsx
@@ -1,0 +1,61 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from 'react';
+import classNames from 'classnames';
+
+import SearchField from 'src/shared/components/search-field/SearchField';
+import QuestionButton, {
+  QuestionButtonOption
+} from 'src/shared/components/question-button/QuestionButton';
+
+import styles from './InAppSearch.scss';
+
+type Props = {
+  className?: string;
+};
+
+const InAppSearch = (props: Props) => {
+  const [value, setValue] = useState('');
+
+  const searchFieldWrapperClasses = classNames(
+    styles.searchFieldWrapper,
+    props.className
+  );
+
+  return (
+    <div>
+      <div className={searchFieldWrapperClasses}>
+        <SearchField
+          placeholder="Gene ID or name..."
+          search={value}
+          onChange={setValue}
+          className={styles.searchField}
+          rightCorner={
+            <QuestionButton
+              helpText="This is a hint"
+              styleOption={QuestionButtonOption.INPUT}
+            />
+          }
+        />
+      </div>
+
+      {/* <InAppCommitButton /> */}
+    </div>
+  );
+};
+
+export default InAppSearch;

--- a/src/ensembl/src/shared/components/in-app-search/InAppSearch.tsx
+++ b/src/ensembl/src/shared/components/in-app-search/InAppSearch.tsx
@@ -17,6 +17,8 @@
 import React, { useState } from 'react';
 import classNames from 'classnames';
 
+import { isEnvironment, Environment } from 'src/shared/helpers/environment';
+
 import SearchField from 'src/shared/components/search-field/SearchField';
 import QuestionButton, {
   QuestionButtonOption
@@ -35,6 +37,10 @@ const InAppSearch = (props: Props) => {
     styles.searchFieldWrapper,
     props.className
   );
+
+  if (isEnvironment([Environment.PRODUCTION])) {
+    return <div className={styles.fauxSearchField}>Gene ID or name...</div>;
+  }
 
   return (
     <div>

--- a/src/ensembl/src/shared/components/step/Step.scss
+++ b/src/ensembl/src/shared/components/step/Step.scss
@@ -1,0 +1,21 @@
+@import 'src/styles/common';
+
+.stepIcon {
+  width: 28px;
+  height: 28px;
+  color: $white;
+  font-weight: $bold;
+  line-height: 28px;
+  text-align: center;
+  border-radius: 14px;
+  background-color: $grey;
+  float: left;
+  margin-right: 12px;
+}
+
+.stepTitle {
+  font-weight: $bold;
+  color: $black;
+  position: relative;
+  top: 5px;
+}

--- a/src/ensembl/src/shared/components/step/Step.tsx
+++ b/src/ensembl/src/shared/components/step/Step.tsx
@@ -1,0 +1,35 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import styles from './Step.scss';
+
+type StepProps = {
+  count: number;
+  title: string;
+};
+
+export const Step = (props: StepProps) => {
+  return (
+    <div>
+      <div className={styles.stepIcon}>
+        <span>{props.count}</span>
+      </div>
+      <div className={styles.stepTitle}>{props.title}</div>
+    </div>
+  );
+};

--- a/src/ensembl/src/shared/helpers/urlHelper.ts
+++ b/src/ensembl/src/shared/helpers/urlHelper.ts
@@ -27,7 +27,7 @@ type BrowserUrlParams = {
 
 type EntityViewerUrlParams = {
   genomeId?: string | null;
-  entityId?: string;
+  entityId?: string | null;
   view?: string | null;
   proteinId?: string | null;
 };

--- a/src/ensembl/stories/shared-components/search-field/SearchField.stories.tsx
+++ b/src/ensembl/stories/shared-components/search-field/SearchField.stories.tsx
@@ -34,11 +34,13 @@ const Wrapper = (props: any) => {
 };
 
 export const DefaultSearchFieldStory = () => (
-  <Wrapper
-    searchField={SearchField}
-    className={styles.searchField}
-    rightCorner={<QuestionButton helpText="This is a hint" />}
-  />
+  <>
+    <Wrapper
+      searchField={SearchField}
+      className={styles.searchField}
+      rightCorner={<QuestionButton helpText="This is a hint" />}
+    />
+  </>
 );
 
 DefaultSearchFieldStory.storyName = 'default';

--- a/src/ensembl/stories/shared-components/step/Step.stories.scss
+++ b/src/ensembl/stories/shared-components/step/Step.stories.scss
@@ -1,0 +1,3 @@
+.stepWrapper {
+  margin: 24px 10px;
+}

--- a/src/ensembl/stories/shared-components/step/Step.stories.tsx
+++ b/src/ensembl/stories/shared-components/step/Step.stories.tsx
@@ -1,0 +1,47 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { Step } from 'src/shared/components/step/Step';
+
+import styles from './Step.stories.scss';
+
+const steps = [
+  'Go to BurgerKing',
+  'Order a burger of your choice',
+  'Eat happily'
+];
+
+export const StepStory = () => {
+  return (
+    <div>
+      {steps.map((step, index) => {
+        return (
+          <div key={index} className={styles.stepWrapper}>
+            <Step count={index} title={step} />
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+StepStory.storyName = 'step';
+
+export default {
+  title: 'Components/Shared Components/Step'
+};


### PR DESCRIPTION
## Type
- New feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1124
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1123

## Description
Currently, Genome Browser and Entity Viewer assumes that the user that visits it will have at least one species selected.

Following Andrea's design, which allows the user access to the these apps even without selecting a species first, we should update the interstitial to support this use case.

Initially I started to work on entity viewer, but then realised that genome browser as well uses the same shared component "Step". So it makes sense to get this both in one PR rather than wait for the PR to get merged to use the shared component.

## Deployment URL
http://ev-interstitial.review.ensembl.org/

## Views affected
Entity viewer
Genome Browser