### PR TITLE
ENSWBSITES-1170: Ordering filters alphabetically

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
@@ -158,6 +158,8 @@ const TranscriptsFilter = (props: Props) => {
 const sortBiotypes = (a: string, b: string) => {
   if (a === 'protein_coding') {
     return -1;
+  } else if (b === 'protein_coding') {
+    return 1;
   } else {
     return a.localeCompare(b);
   }

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
@@ -73,14 +73,9 @@ const TranscriptsFilter = (props: Props) => {
     .map((a) => a.so_term)
     .filter(Boolean) as string[];
 
-  const uniqueBiotypes = Array.from(new Set(biotypes)).sort((a, b) =>
-    a.localeCompare(b)
-  );
-  //Bring protein coding to the top of the array if exist
-  if (uniqueBiotypes.includes('protein_coding')) {
-    uniqueBiotypes.splice(uniqueBiotypes.indexOf('protein_coding'), 1);
-    uniqueBiotypes.unshift('protein_coding');
-  }
+  const uniqueBiotypes = Array.from(new Set(biotypes)).sort((a, b) => {
+    return sortBiotypes(a, b);
+  });
 
   // TODO: Add protein coding options in RadioOptions if there are protein coding biotype
   const initialFilters = uniqueBiotypes.reduce((accumulator, biotype): {
@@ -158,6 +153,14 @@ const TranscriptsFilter = (props: Props) => {
       </div>
     </div>
   );
+};
+
+const sortBiotypes = (a: string, b: string) => {
+  if (a === 'protein_coding') {
+    return -1;
+  } else {
+    return a.localeCompare(b);
+  }
 };
 
 export default TranscriptsFilter;

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
@@ -73,7 +73,14 @@ const TranscriptsFilter = (props: Props) => {
     .map((a) => a.so_term)
     .filter(Boolean) as string[];
 
-  const uniqueBiotypes = Array.from(new Set(biotypes));
+  const uniqueBiotypes = Array.from(new Set(biotypes)).sort((a, b) =>
+    a.localeCompare(b)
+  );
+  //Bring protein coding to the top of the array if exist
+  if (uniqueBiotypes.includes('protein_coding')) {
+    uniqueBiotypes.splice(uniqueBiotypes.indexOf('protein_coding'), 1);
+    uniqueBiotypes.unshift('protein_coding');
+  }
 
   // TODO: Add protein coding options in RadioOptions if there are protein coding biotype
   const initialFilters = uniqueBiotypes.reduce((accumulator, biotype): {


### PR DESCRIPTION
protein coding comes first and then the rest are alphabetically ordered

## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1170

## Importance
N/A

## Description
Ordering the filteres alphabetically. If protein coding exists, protein coding comes first and then the rest are displayed alphabetically

## Deployment URL
http://filters-order.review.ensembl.org 

## Views affected
Entity viewer filtering

### Other effects
N/A

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
None that i am aware of
