### PR TITLE
Save the sidebar state for genomes in Genome browser and Entity viewer

### DIFF
--- a/src/ensembl/package-lock.json
+++ b/src/ensembl/package-lock.json
@@ -102,7 +102,7 @@
         "dotenv-webpack": "7.0.2",
         "eslint": "7.27.0",
         "eslint-config-prettier": "8.3.0",
-        "eslint-plugin-jest": "^24.3.6",
+        "eslint-plugin-jest": "24.3.6",
         "eslint-plugin-prettier": "3.4.0",
         "eslint-plugin-react": "7.23.2",
         "eslint-plugin-react-hooks": "4.2.0",

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelReducer.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelReducer.ts
@@ -19,7 +19,8 @@ import pickBy from 'lodash/pickBy';
 
 import {
   getInitialTrackPanelState,
-  getTrackPanelStateForGenome,
+  getInitialTrackPanelStateForGenome,
+  getPersistentTrackPanelStateForGenome,
   TrackPanelState
 } from './trackPanelState';
 import * as browserActions from 'src/content/app/browser/browserActions';
@@ -34,9 +35,18 @@ export default function trackPanel(
   switch (action.type) {
     case getType(browserActions.setDataFromUrl):
       const { activeGenomeId } = action.payload;
+      const newTrackPanelStateForGenome = state[activeGenomeId]
+        ? {
+            ...state[activeGenomeId],
+            ...getPersistentTrackPanelStateForGenome(activeGenomeId)
+          }
+        : {
+            ...getInitialTrackPanelStateForGenome(activeGenomeId)
+          };
+
       return {
         ...state,
-        [activeGenomeId]: getTrackPanelStateForGenome(activeGenomeId)
+        [activeGenomeId]: newTrackPanelStateForGenome
       };
     case getType(trackPanelActions.updateTrackPanelForGenome):
       return {

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelReducer.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelReducer.ts
@@ -18,16 +18,15 @@ import { ActionType, getType } from 'typesafe-actions';
 import pickBy from 'lodash/pickBy';
 
 import {
-  getInitialTrackPanelState,
-  getInitialTrackPanelStateForGenome,
-  getPersistentTrackPanelStateForGenome,
+  getTrackPanelState,
+  getTrackPanelStateForGenome,
   TrackPanelState
 } from './trackPanelState';
 import * as browserActions from 'src/content/app/browser/browserActions';
 import * as trackPanelActions from './trackPanelActions';
 
 export default function trackPanel(
-  state: TrackPanelState = getInitialTrackPanelState(),
+  state: TrackPanelState = getTrackPanelState(),
   action:
     | ActionType<typeof trackPanelActions>
     | ActionType<typeof browserActions>
@@ -35,19 +34,15 @@ export default function trackPanel(
   switch (action.type) {
     case getType(browserActions.setDataFromUrl):
       const { activeGenomeId } = action.payload;
-      const newTrackPanelStateForGenome = state[activeGenomeId]
-        ? {
-            ...state[activeGenomeId],
-            ...getPersistentTrackPanelStateForGenome(activeGenomeId)
-          }
-        : {
-            ...getInitialTrackPanelStateForGenome(activeGenomeId)
-          };
 
-      return {
-        ...state,
-        [activeGenomeId]: newTrackPanelStateForGenome
-      };
+      if (!state[activeGenomeId]) {
+        return {
+          ...state,
+          [activeGenomeId]: getTrackPanelStateForGenome(activeGenomeId)
+        };
+      } else {
+        return state;
+      }
     case getType(trackPanelActions.updateTrackPanelForGenome):
       return {
         ...state,

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
@@ -55,19 +55,21 @@ export const defaultTrackPanelStateForGenome: TrackPanelStateForGenome = {
   collapsedTrackIds: []
 };
 
-export const getInitialTrackPanelState = (): TrackPanelState => {
+export const getTrackPanelState = (): TrackPanelState => {
   const genomeId = browserStorageService.getActiveGenomeId();
-  return genomeId
-    ? { [genomeId]: getInitialTrackPanelStateForGenome(genomeId) }
-    : {};
+  return genomeId ? { [genomeId]: getTrackPanelStateForGenome(genomeId) } : {};
 };
 
-export const getInitialTrackPanelStateForGenome = (
+export const getTrackPanelStateForGenome = (
   genomeId: string
-): TrackPanelStateForGenome => ({
-  ...defaultTrackPanelStateForGenome,
-  ...getPersistentTrackPanelStateForGenome(genomeId)
-});
+): TrackPanelStateForGenome => {
+  return genomeId
+    ? {
+        ...defaultTrackPanelStateForGenome,
+        ...getPersistentTrackPanelStateForGenome(genomeId)
+      }
+    : defaultTrackPanelStateForGenome;
+};
 
 export const getPersistentTrackPanelStateForGenome = (
   genomeId: string

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelState.ts
@@ -57,19 +57,22 @@ export const defaultTrackPanelStateForGenome: TrackPanelStateForGenome = {
 
 export const getInitialTrackPanelState = (): TrackPanelState => {
   const genomeId = browserStorageService.getActiveGenomeId();
-  return genomeId ? { [genomeId]: getTrackPanelStateForGenome(genomeId) } : {};
+  return genomeId
+    ? { [genomeId]: getInitialTrackPanelStateForGenome(genomeId) }
+    : {};
 };
 
-export const getTrackPanelStateForGenome = (
+export const getInitialTrackPanelStateForGenome = (
   genomeId: string
-): TrackPanelStateForGenome => {
-  const storedTrackPanel =
-    browserStorageService.getTrackPanels()[genomeId] || {};
-  return {
-    ...defaultTrackPanelStateForGenome,
-    ...storedTrackPanel
-  };
-};
+): TrackPanelStateForGenome => ({
+  ...defaultTrackPanelStateForGenome,
+  ...getPersistentTrackPanelStateForGenome(genomeId)
+});
+
+export const getPersistentTrackPanelStateForGenome = (
+  genomeId: string
+): Partial<TrackPanelStateForGenome> =>
+  browserStorageService.getTrackPanels()[genomeId] || {};
 
 export const pickPersistentTrackPanelProperties = (
   trackPanel: Partial<TrackPanelStateForGenome>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -33,8 +33,6 @@ import {
   GeneViewTabName
 } from 'src/content/app/entity-viewer/state/gene-view/view/geneViewViewSlice';
 import { updatePreviouslyViewedEntities } from 'src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSlice';
-import { closeSidebarModal } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSlice';
-import { isEntityViewerSidebarOpen } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors';
 import {
   getFilters,
   getSortingRule
@@ -209,8 +207,6 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
   const focusId = buildFocusIdForUrl({ type: 'gene', objectId: geneId });
   const gbUrl = urlFor.browser({ genomeId, focus: focusId });
 
-  const isSidebarOpen = useSelector(isEntityViewerSidebarOpen);
-
   const shouldShowFilterIndicator =
     sortingRule !== SortingRule.DEFAULT || Object.values(filters).some(Boolean);
 
@@ -231,10 +227,6 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
   useEffect(() => {
     if (!genomeId || !props.gene) {
       return;
-    }
-
-    if (isSidebarOpen) {
-      dispatch(closeSidebarModal());
     }
 
     dispatch(

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors.ts
@@ -35,7 +35,7 @@ export const getEntityViewerGenomeState = (state: RootState) => {
 export const getEntityViewerSidebarUIState = (state: RootState) => {
   const activeEntityId = getEntityViewerActiveEntityId(state);
   return activeEntityId
-    ? getEntityViewerGenomeState(state)?.entities[activeEntityId]?.uIState ||
+    ? getEntityViewerGenomeState(state)?.entities[activeEntityId]?.uiState ||
         null
     : null;
 };
@@ -54,5 +54,9 @@ export const isEntityViewerSidebarOpen = (state: RootState): boolean => {
     : false;
 };
 
-export const getEntityViewerSidebarModalView = (state: RootState) =>
-  getEntityViewerGenomeState(state)?.sidebarModalView ?? null;
+export const getEntityViewerSidebarModalView = (state: RootState) => {
+  const activeGenomeId = getEntityViewerActiveGenomeId(state);
+  return activeGenomeId
+    ? getEntityViewerGenomeState(state)?.sidebarModalView
+    : null;
+};

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors.ts
@@ -54,9 +54,5 @@ export const isEntityViewerSidebarOpen = (state: RootState): boolean => {
     : false;
 };
 
-export const getEntityViewerSidebarModalView = (state: RootState) => {
-  const activeGenomeId = getEntityViewerActiveGenomeId(state);
-  return activeGenomeId
-    ? getEntityViewerGenomeState(state)?.sidebarModalView
-    : null;
-};
+export const getEntityViewerSidebarModalView = (state: RootState) =>
+  getEntityViewerGenomeState(state)?.sidebarModalView ?? null;

--- a/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSlice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSlice.ts
@@ -56,7 +56,7 @@ export type EntityViewerSidebarGenomeState = Readonly<{
   selectedTabName: SidebarTabName;
   entities: {
     [entityId: string]: {
-      uIState: EntityViewerSidebarUIState;
+      uiState: EntityViewerSidebarUIState;
     };
   };
   sidebarModalView: SidebarModalView | null;
@@ -222,7 +222,7 @@ const entityViewerSidebarSlice = createSlice({
       };
 
       mergeWith(
-        state[genomeId].entities[entityId].uIState,
+        state[genomeId].entities[entityId].uiState,
         newFragment,
         overwriteArray
       );


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
[ENSWBSITES-1088](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1088)

## Description
The sidebar (or track panel in Genome browser) behaviour needed some improvements by saving (or using?) the previous state in Entity viewer and Genome browser. When a user switches between species in either of these apps, the last state of the sidebar before switching has to be saved for the previously selected species. And when you switch back to that species, the saved state needs to be the default state.

This PR saves the following states in order to achieve this:

1. Sidebar state (open or close)
2. Sidebar modal state (open or close as well as view if open)
3. Drawer state in Genome browser (open or close as well as view if open)

## Deployment URL
https://trackpanel-modal-behaviour.review.ensembl.org/

## Views affected
Entity viewer -> sidebar
Genome browser -> track panel
Genome browser -> track panel -> drawer
