### PR TITLE
Add a Chevron component

### DIFF
--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.scss
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.scss
@@ -11,13 +11,9 @@
     width: 16px;
   }
 
-  .expandBtn {
-    margin-left: 10px;
-
-    img {
-      height: 12px;
-      width: 12px;
-    }
+  .chevron {
+    margin-left: 8px;
+    height: 6px;
   }
 
   &:hover,

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.test.tsx
@@ -136,7 +136,7 @@ describe('<TrackPanelListItem />', () => {
 
     it('toggles the expanded/collapsed state of the track when clicked on the expand button', async () => {
       const { container } = wrapInRedux();
-      const expandButton = container.querySelector('.expandBtn') as HTMLElement;
+      const expandButton = container.querySelector('.chevron') as HTMLElement;
 
       userEvent.click(expandButton);
 

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
@@ -23,9 +23,6 @@ import { RootState } from 'src/store';
 import analyticsTracking from 'src/services/analytics-service';
 import browserMessagingService from 'src/content/app/browser/browser-messaging-service';
 
-import ImageButton from 'src/shared/components/image-button/ImageButton';
-import VisibilityIcon from 'src/shared/components/visibility-icon/VisibilityIcon';
-
 import {
   TrackItemColour,
   TrackItemColourKey,
@@ -57,8 +54,10 @@ import {
   getBrowserActiveEnsObjectId
 } from '../../browserSelectors';
 
-import chevronDownIcon from 'static/img/shared/chevron-down.svg';
-import chevronUpIcon from 'static/img/shared/chevron-up.svg';
+import ImageButton from 'src/shared/components/image-button/ImageButton';
+import Chevron from 'src/shared/components/chevron/Chevron';
+import VisibilityIcon from 'src/shared/components/visibility-icon/VisibilityIcon';
+
 import { ReactComponent as Ellipsis } from 'static/img/track-panel/ellipsis.svg';
 import { DrawerView } from 'src/content/app/browser/drawer/drawerState';
 
@@ -225,12 +224,11 @@ export const TrackPanelListItem = (props: TrackPanelListItemProps) => {
             </span>
           )}
           {track.child_tracks && (
-            <button onClick={toggleExpand} className={styles.expandBtn}>
-              <img
-                src={isCollapsed ? chevronDownIcon : chevronUpIcon}
-                alt={isCollapsed ? 'expand' : 'collapse'}
-              />
-            </button>
+            <Chevron
+              onClick={toggleExpand}
+              direction={isCollapsed ? 'down' : 'up'}
+              classNames={{ svg: styles.chevron }}
+            />
           )}
         </label>
         <div className={styles.ellipsisHolder}>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
@@ -80,6 +80,12 @@ $backgroundColor: $black;
   padding-right: 20px;
   padding-bottom: 9px;
   padding-top: 6px;
+
+  // nesting because need higher specificity to override child's CSS rules
+  .chevron {
+    margin-left: 10px;
+    height: 6px;
+  }
 } 
 
 .openFilterLabelContainer {
@@ -117,12 +123,4 @@ $backgroundColor: $black;
     right: -10px;
     top: -2px;
   }
-}
-
-.chevron {
-  margin-left: 10px;
-}
-
-.chevronUp {
-  transform: rotate(180deg);
 }

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
@@ -121,9 +121,6 @@ $backgroundColor: $black;
 
 .chevron {
   margin-left: 10px;
-  margin-bottom: -3px;
-  height: 12px;
-  width: 12px;
 }
 
 .chevronUp {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
@@ -76,16 +76,12 @@ $backgroundColor: $black;
   top: 0;      
 }
 
-.filterLabelWrapper {  
+.filterLabelWrapper {
+  display: flex;
+  justify-content: flex-end;
   padding-right: 20px;
   padding-bottom: 9px;
   padding-top: 6px;
-
-  // nesting because need higher specificity to override child's CSS rules
-  .chevron {
-    margin-left: 10px;
-    height: 6px;
-  }
 } 
 
 .openFilterLabelContainer {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -57,11 +57,10 @@ import GeneRelationships from 'src/content/app/entity-viewer/gene-view/component
 import ViewInApp from 'src/shared/components/view-in-app/ViewInApp';
 import { CircleLoader } from 'src/shared/components/loader/Loader';
 import { TicksAndScale } from 'src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/BasePairsRuler';
+import Chevron from 'src/shared/components/chevron/Chevron';
 
 import { FullGene } from 'src/shared/types/thoas/gene';
 import { SortingRule } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
-
-import { ReactComponent as ChevronDown } from 'static/img/shared/chevron-down.svg';
 
 import styles from './GeneView.scss';
 
@@ -263,10 +262,10 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
                 onClick={toggleFilter}
               >
                 {filterLabel}
-                <ChevronDown
-                  className={classNames([styles.chevron], {
-                    [styles.chevronUp]: isFilterOpen
-                  })}
+                <Chevron
+                  direction={isFilterOpen ? 'up' : 'down'}
+                  animateDirectionChange={true}
+                  classNames={{ svg: styles.chevron }}
                 />
               </div>
             </div>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -57,7 +57,7 @@ import GeneRelationships from 'src/content/app/entity-viewer/gene-view/component
 import ViewInApp from 'src/shared/components/view-in-app/ViewInApp';
 import { CircleLoader } from 'src/shared/components/loader/Loader';
 import { TicksAndScale } from 'src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/BasePairsRuler';
-import Chevron from 'src/shared/components/chevron/Chevron';
+import ShowHide from 'src/shared/components/show-hide/ShowHide';
 
 import { FullGene } from 'src/shared/types/thoas/gene';
 import { SortingRule } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
@@ -255,19 +255,11 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
         >
           {props.gene.transcripts.length > 5 && (
             <div className={styles.filterLabelWrapper}>
-              <div
-                className={classNames([styles.filterLabel], {
-                  [styles.openFilterLabel]: isFilterOpen
-                })}
+              <ShowHide
                 onClick={toggleFilter}
-              >
-                {filterLabel}
-                <Chevron
-                  direction={isFilterOpen ? 'up' : 'down'}
-                  animateDirectionChange={true}
-                  classNames={{ svg: styles.chevron }}
-                />
-              </div>
+                isExpanded={isFilterOpen}
+                label={filterLabel}
+              />
             </div>
           )}
         </div>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
@@ -69,13 +69,6 @@
 
 .chevron {
   margin-left: 10px;
-  margin-bottom: -3px;
-  height: 12px;
-  width: 12px;
-  transition: transform linear 0.2s;
-  &Up {
-    transform: rotate(-180deg);
-  }
 }
 
 .viewInApp {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
@@ -60,15 +60,17 @@
   color: $blue;
   cursor: pointer;
   padding-top: 6px;
+
+  // nesting because need higher specificity to override child's CSS rules
+  .chevron {
+    margin-left: 10px;
+    height: 6px;
+  }
 }
 
 .download {
   grid-area: download;
   padding-top: 6px;
-}
-
-.chevron {
-  margin-left: 10px;
 }
 
 .viewInApp {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
@@ -57,15 +57,7 @@
 
 .downloadLink {
   grid-area: downloadLink;
-  color: $blue;
-  cursor: pointer;
   padding-top: 6px;
-
-  // nesting because need higher specificity to override child's CSS rules
-  .chevron {
-    margin-left: 10px;
-    height: 6px;
-  }
 }
 
 .download {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -35,7 +35,7 @@ import { buildFocusIdForUrl } from 'src/shared/state/ens-object/ensObjectHelpers
 
 import { InstantDownloadTranscript } from 'src/shared/components/instant-download';
 import ViewInApp from 'src/shared/components/view-in-app/ViewInApp';
-import Chevron from 'src/shared/components/chevron/Chevron';
+import ShowHide from 'src/shared/components/show-hide/ShowHide';
 
 import { toggleTranscriptDownload } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 import { clearExpandedProteins } from 'src/content/app/entity-viewer/state/gene-view/proteins/geneViewProteinsSlice';
@@ -172,17 +172,12 @@ export const TranscriptsListItemInfo = (
 
         <div className={styles.moreInformation}>More information</div>
 
-        <div
-          className={styles.downloadLink}
+        <ShowHide
           onClick={() => props.toggleTranscriptDownload(transcript.stable_id)}
-        >
-          Download
-          <Chevron
-            direction={props.expandDownload ? 'up' : 'down'}
-            animateDirectionChange={true}
-            classNames={{ svg: styles.chevron }}
-          />
-        </div>
+          label="Download"
+          isExpanded={props.expandDownload}
+          classNames={{ wrapper: styles.downloadLink }}
+        />
         {props.expandDownload && renderInstantDownload({ ...props, genomeId })}
       </div>
       <div className={transcriptsListStyles.right}>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -35,6 +35,7 @@ import { buildFocusIdForUrl } from 'src/shared/state/ens-object/ensObjectHelpers
 
 import { InstantDownloadTranscript } from 'src/shared/components/instant-download';
 import ViewInApp from 'src/shared/components/view-in-app/ViewInApp';
+import Chevron from 'src/shared/components/chevron/Chevron';
 
 import { toggleTranscriptDownload } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 import { clearExpandedProteins } from 'src/content/app/entity-viewer/state/gene-view/proteins/geneViewProteinsSlice';
@@ -47,8 +48,6 @@ import { View } from 'src/content/app/entity-viewer/state/gene-view/view/geneVie
 
 import transcriptsListStyles from '../DefaultTranscriptsList.scss';
 import styles from './TranscriptsListItemInfo.scss';
-
-import { ReactComponent as ChevronDown } from 'static/img/shared/chevron-down.svg';
 
 type Gene = Pick<FullGene, 'unversioned_stable_id' | 'stable_id'>;
 type Transcript = Pick<
@@ -139,10 +138,6 @@ export const TranscriptsListItemInfo = (
     return urlFor.browser({ genomeId: genomeId, focus: focusIdForUrl });
   };
 
-  const chevronClassForDownload = classNames(styles.chevron, {
-    [styles.chevronUp]: props.expandDownload
-  });
-
   return (
     <div className={mainStyles}>
       <div className={transcriptsListStyles.left}></div>
@@ -182,7 +177,11 @@ export const TranscriptsListItemInfo = (
           onClick={() => props.toggleTranscriptDownload(transcript.stable_id)}
         >
           Download
-          <ChevronDown className={chevronClassForDownload} />
+          <Chevron
+            direction={props.expandDownload ? 'up' : 'down'}
+            animateDirectionChange={true}
+            classNames={{ svg: styles.chevron }}
+          />
         </div>
         {props.expandDownload && renderInstantDownload({ ...props, genomeId })}
       </div>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.scss
@@ -39,13 +39,8 @@
   padding: 0px;
   width: auto;
   padding-right: 60px;
-  display: inline-block;
+  grid-template-columns: max-content max-content;
   margin-left: 20px;
-
-  &:before,
-  &:after {
-    margin-top: -10px;
-  }
 }
 
 .xrefAccordionItem:not(:first-child) {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.scss
@@ -73,13 +73,6 @@ $content-width: $gene_image_width;
 
 .chevron {
   margin-left: 6px;
-  margin-bottom: -1px;
-  height: 12px;
-  width: 12px;
-  transition: transform linear 0.2s;
-  &Up {
-    transform: rotate(-180deg);
-  }
 }
 
 .xrefCountChevronOpen {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
@@ -310,7 +310,7 @@ export const ProteinExternalReferenceGroup = (
               + {xrefs.length - 1}
               <Chevron
                 direction={isXrefGroupOpen ? 'up' : 'down'}
-                animateDirectionChange={true}
+                animate={true}
                 classNames={{ svg: styles.chevron }}
               />
             </span>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
@@ -18,7 +18,6 @@ import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import set from 'lodash/fp/set';
 import { Pick2 } from 'ts-multipick';
-import classNames from 'classnames';
 
 import { CircleLoader } from 'src/shared/components/loader/Loader';
 import ProteinDomainImage from 'src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage';
@@ -26,7 +25,7 @@ import ProteinImage from 'src/content/app/entity-viewer/gene-view/components/pro
 import ProteinFeaturesCount from 'src/content/app/entity-viewer/gene-view/components/protein-features-count/ProteinFeaturesCount';
 import ExternalReference from 'src/shared/components/external-reference/ExternalReference';
 import InstantDownloadProtein from 'src/shared/components/instant-download/instant-download-protein/InstantDownloadProtein';
-import { ReactComponent as ChevronDown } from 'static/img/shared/chevron-down.svg';
+import Chevron from 'src/shared/components/chevron/Chevron';
 
 import {
   ExternalSource,
@@ -101,23 +100,18 @@ const ProteinsListItemInfo = (props: Props) => {
   const params: { [key: string]: string } = useParams();
   const { genomeId } = params;
 
-  const [
-    transcriptWithProteinDomains,
-    setTranscriptWithProteinDomains
-  ] = useState<TranscriptWithProteinDomains | null>(null);
+  const [transcriptWithProteinDomains, setTranscriptWithProteinDomains] =
+    useState<TranscriptWithProteinDomains | null>(null);
 
-  const [proteinSummaryStats, setProteinSummaryStats] = useState<
-    ProteinStats | null | undefined
-  >();
+  const [proteinSummaryStats, setProteinSummaryStats] =
+    useState<ProteinStats | null | undefined>();
 
   const [domainsLoadingState, setDomainsLoadingState] = useState<LoadingState>(
     LoadingState.LOADING
   );
 
-  const [
-    summaryStatsLoadingState,
-    setSummaryStatsLoadingState
-  ] = useState<LoadingState>(LoadingState.LOADING);
+  const [summaryStatsLoadingState, setSummaryStatsLoadingState] =
+    useState<LoadingState>(LoadingState.LOADING);
 
   const proteinId =
     transcript.product_generating_contexts[0].product.unversioned_stable_id;
@@ -296,10 +290,6 @@ export const ProteinExternalReferenceGroup = (
     setXrefGroupOpen(!isXrefGroupOpen);
   };
 
-  const chevronClasses = classNames(styles.chevron, {
-    [styles.chevronUp]: isXrefGroupOpen
-  });
-
   if (xrefs.length > 3) {
     const displayXref = xrefs[0];
     return (
@@ -318,7 +308,11 @@ export const ProteinExternalReferenceGroup = (
               }
             >
               + {xrefs.length - 1}
-              <ChevronDown className={chevronClasses} />
+              <Chevron
+                direction={isXrefGroupOpen ? 'up' : 'down'}
+                animateDirectionChange={true}
+                classNames={{ svg: styles.chevron }}
+              />
             </span>
           </div>
         </div>

--- a/src/ensembl/src/content/app/help/help-menu/HelpMenu.scss
+++ b/src/ensembl/src/content/app/help/help-menu/HelpMenu.scss
@@ -5,6 +5,12 @@ $submenuSidePadding: 30px;
 .helpMenu {
   grid-row: menu;
   position: relative;
+
+  // increase specificity through nesting in order to be able to override child's styles
+  .chevron {
+    height: 7px;
+    fill: $blue;
+  }
 }
 
 .menuBar {
@@ -66,9 +72,4 @@ $submenuSidePadding: 30px;
 
 .submenuItem:hover {
   background: $ice-blue;
-}
-
-.chevron {
-  height: 14px;
-  fill: $blue;
 }

--- a/src/ensembl/src/content/app/help/help-menu/HelpMenu.tsx
+++ b/src/ensembl/src/content/app/help/help-menu/HelpMenu.tsx
@@ -20,7 +20,7 @@ import { useDispatch } from 'react-redux';
 import { push } from 'connected-react-router';
 import { Link } from 'react-router-dom';
 
-import { ReactComponent as Chevron } from 'static/img/shared/chevron-right.svg';
+import Chevron from 'src/shared/components/chevron/Chevron';
 
 import {
   Menu as MenuType,
@@ -129,7 +129,7 @@ const Submenu = (props: SubmenuProps) => {
         {item.type === 'collection' ? (
           <>
             {item.name}
-            <Chevron className={styles.chevron} />
+            <Chevron direction="right" classNames={{ svg: styles.chevron }} />
           </>
         ) : (
           item.name

--- a/src/ensembl/src/server/middleware/devMiddleware.ts
+++ b/src/ensembl/src/server/middleware/devMiddleware.ts
@@ -78,12 +78,31 @@ const devMiddleware = [genomeBrowserRouter, proxyMiddleware, docsProxyMiddleware
 
 */
 
-const proxyMiddleware = createProxyMiddleware('/api', {
+// const proxyMiddleware = createProxyMiddleware('/api', {
+//   target: 'https://staging-2020.ensembl.org',
+//   changeOrigin: true,
+//   secure: false
+// });
+
+const proxyMiddleware = createProxyMiddleware(['/api/**', '!/api/thoas'], {
   target: 'https://staging-2020.ensembl.org',
   changeOrigin: true,
   secure: false
 });
 
-const devMiddleware = [genomeBrowserRouter, proxyMiddleware];
+const thoasProxyMiddleware = createProxyMiddleware('/api/thoas', {
+  target: 'http://localhost:8000',
+  pathRewrite: {
+    '^/api/docs': '/api' // rewrite path
+  },
+  changeOrigin: true,
+  secure: false
+});
+
+const devMiddleware = [
+  genomeBrowserRouter,
+  proxyMiddleware,
+  thoasProxyMiddleware
+];
 
 export default devMiddleware;

--- a/src/ensembl/src/server/middleware/devMiddleware.ts
+++ b/src/ensembl/src/server/middleware/devMiddleware.ts
@@ -78,31 +78,12 @@ const devMiddleware = [genomeBrowserRouter, proxyMiddleware, docsProxyMiddleware
 
 */
 
-// const proxyMiddleware = createProxyMiddleware('/api', {
-//   target: 'https://staging-2020.ensembl.org',
-//   changeOrigin: true,
-//   secure: false
-// });
-
-const proxyMiddleware = createProxyMiddleware(['/api/**', '!/api/thoas'], {
+const proxyMiddleware = createProxyMiddleware('/api', {
   target: 'https://staging-2020.ensembl.org',
   changeOrigin: true,
   secure: false
 });
 
-const thoasProxyMiddleware = createProxyMiddleware('/api/thoas', {
-  target: 'http://localhost:8000',
-  pathRewrite: {
-    '^/api/docs': '/api' // rewrite path
-  },
-  changeOrigin: true,
-  secure: false
-});
-
-const devMiddleware = [
-  genomeBrowserRouter,
-  proxyMiddleware,
-  thoasProxyMiddleware
-];
+const devMiddleware = [genomeBrowserRouter, proxyMiddleware];
 
 export default devMiddleware;

--- a/src/ensembl/src/shared/components/accordion/components/AccordionItemButton.tsx
+++ b/src/ensembl/src/shared/components/accordion/components/AccordionItemButton.tsx
@@ -18,9 +18,12 @@ import React from 'react';
 import noop from 'lodash/noop';
 import classNames from 'classnames';
 
+import { Consumer as ItemConsumer, ItemContext } from './ItemContext';
+
+import Chevron from 'src/shared/components/chevron/Chevron';
+
 import { InjectedButtonAttributes } from '../helpers/AccordionStore';
 import { DivAttributes } from '../helpers/types';
-import { Consumer as ItemConsumer, ItemContext } from './ItemContext';
 
 import defaultStyles from '../css/Accordion.scss';
 
@@ -36,6 +39,7 @@ export const AccordionItemButton = (props: Props) => {
     extendDefaultStyles,
     toggleExpanded,
     disabled,
+    children,
     ...rest
   } = props;
 
@@ -55,7 +59,15 @@ export const AccordionItemButton = (props: Props) => {
       className={styles}
       onClick={disabled ? noop : toggleExpanded}
       data-accordion-component="AccordionItemButton"
-    />
+    >
+      <div>{children}</div>
+      <div>
+        <Chevron
+          direction={rest['aria-expanded'] ? 'up' : 'down'}
+          animateDirectionChange={true}
+        />
+      </div>
+    </div>
   );
 };
 

--- a/src/ensembl/src/shared/components/accordion/components/AccordionItemButton.tsx
+++ b/src/ensembl/src/shared/components/accordion/components/AccordionItemButton.tsx
@@ -61,12 +61,14 @@ export const AccordionItemButton = (props: Props) => {
       data-accordion-component="AccordionItemButton"
     >
       <div>{children}</div>
-      <div>
-        <Chevron
-          direction={rest['aria-expanded'] ? 'up' : 'down'}
-          animate={true}
-        />
-      </div>
+      {!disabled && (
+        <div>
+          <Chevron
+            direction={rest['aria-expanded'] ? 'up' : 'down'}
+            animate={true}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/ensembl/src/shared/components/accordion/components/AccordionItemButton.tsx
+++ b/src/ensembl/src/shared/components/accordion/components/AccordionItemButton.tsx
@@ -64,7 +64,7 @@ export const AccordionItemButton = (props: Props) => {
       <div>
         <Chevron
           direction={rest['aria-expanded'] ? 'up' : 'down'}
-          animateDirectionChange={true}
+          animate={true}
         />
       </div>
     </div>

--- a/src/ensembl/src/shared/components/accordion/css/Accordion.scss
+++ b/src/ensembl/src/shared/components/accordion/css/Accordion.scss
@@ -23,13 +23,10 @@
 }
 
 .accordionButtonDisabled {
+  display: block;
   background-color: $light-grey;
   color: $grey;
   cursor: default;
-  &:after,
-  &:before {
-    display: none;
-  }
 }
 
 .accordionButtonDefault[aria-expanded='true']::before,

--- a/src/ensembl/src/shared/components/accordion/css/Accordion.scss
+++ b/src/ensembl/src/shared/components/accordion/css/Accordion.scss
@@ -10,6 +10,9 @@
 }
 
 .accordionButtonDefault {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  column-gap: 0.6rem;
   color: #444;
   cursor: pointer;
   padding: 18px;
@@ -17,19 +20,6 @@
   text-align: left;
   border: none;
   position: relative;
-}
-
-.accordionButtonDefault:after,
-.accordionButtonDefault:before {
-  display: inline-block;
-  position: absolute;
-  margin-top: 10px;
-  content: '';
-  height: 2px;
-  width: 10px;
-  margin-right: 12px;
-  transition: transform 0.2s linear, top 0.2s linear;
-  background-color: $blue;
 }
 
 .accordionButtonDisabled {
@@ -40,18 +30,6 @@
   &:before {
     display: none;
   }
-}
-
-.accordionButtonDefault:before {
-  right: 21px;
-  top: 20px;
-  transform: rotate(45deg);
-}
-
-.accordionButtonDefault:after {
-  right: 15px;
-  top: 20px;
-  transform: rotate(-45deg);
 }
 
 .accordionButtonDefault[aria-expanded='true']::before,

--- a/src/ensembl/src/shared/components/app-bar/AppBar.scss
+++ b/src/ensembl/src/shared/components/app-bar/AppBar.scss
@@ -12,6 +12,13 @@
   padding: 8px 20px;
   min-height: 80px;
   width: 100%;
+
+  // nesting to increase specificity to override child's styles
+  .chevron {
+    margin-left: 5px;
+    height: 7px;
+    fill: $grey;
+  }
 }
 
 .appBarTop {
@@ -37,15 +44,9 @@
   margin-left: 2em;
   text-align: right;
 
-  a {
+  span {
     color: $black;
     font-size: 12px;
     font-weight: $light;
-  }
-
-  img {
-    height: 14px;
-    margin-left: 5px;
-    width: 14px;
   }
 }

--- a/src/ensembl/src/shared/components/app-bar/AppBar.tsx
+++ b/src/ensembl/src/shared/components/app-bar/AppBar.tsx
@@ -16,7 +16,8 @@
 
 import React from 'react';
 
-import chevronRightIcon from 'static/img/shared/chevron-right-grey.svg';
+import Chevron from 'src/shared/components/chevron/Chevron';
+
 import styles from './AppBar.scss';
 
 type AppBarProps = {
@@ -37,9 +38,10 @@ export const AppBar = (props: AppBarProps) => (
 export const HelpAndDocumentation = () => {
   return (
     <div className={styles.helpLink}>
-      <a className="inactive">
-        Help &amp; documentation <img src={chevronRightIcon} alt="" />
-      </a>
+      <span>
+        Help &amp; documentation
+        <Chevron direction="right" classNames={{ svg: styles.chevron }} />
+      </span>
     </div>
   );
 };

--- a/src/ensembl/src/shared/components/chevron/Chevron.scss
+++ b/src/ensembl/src/shared/components/chevron/Chevron.scss
@@ -5,10 +5,6 @@
   height: 8px;
 }
 
-.chevron_clickable {
-  cursor: pointer;
-}
-
 .chevron_animated {
   transition: transform 0.3s ease-in-out;
 }

--- a/src/ensembl/src/shared/components/chevron/Chevron.scss
+++ b/src/ensembl/src/shared/components/chevron/Chevron.scss
@@ -2,6 +2,7 @@
 
 .chevron {
   fill: $blue;
+  user-select: none;
   height: 8px;
 }
 
@@ -14,7 +15,7 @@
 }
 
 .chevron_up {
-  transform: rotate(180deg);
+  transform: rotate(-180deg);
 }
 
 .chevron_left {

--- a/src/ensembl/src/shared/components/chevron/Chevron.scss
+++ b/src/ensembl/src/shared/components/chevron/Chevron.scss
@@ -1,0 +1,22 @@
+@import 'src/styles/common';
+
+.chevron {
+  fill: $blue;
+  height: 8px;
+}
+
+.chevron_animated {
+  transition: transform 0.3s ease-in-out;
+}
+
+.chevron_up {
+  transform: rotate(180deg);
+}
+
+.chevron_left {
+  transform: rotate(90deg);
+}
+
+.chevron_right {
+  transform: rotate(-90deg);
+}

--- a/src/ensembl/src/shared/components/chevron/Chevron.scss
+++ b/src/ensembl/src/shared/components/chevron/Chevron.scss
@@ -5,6 +5,10 @@
   height: 8px;
 }
 
+.chevron_clickable {
+  cursor: pointer;
+}
+
 .chevron_animated {
   transition: transform 0.3s ease-in-out;
 }

--- a/src/ensembl/src/shared/components/chevron/Chevron.scss
+++ b/src/ensembl/src/shared/components/chevron/Chevron.scss
@@ -3,6 +3,7 @@
 .chevron {
   fill: $blue;
   height: 8px;
+  user-select: none;
 }
 
 .chevron_animated {

--- a/src/ensembl/src/shared/components/chevron/Chevron.scss
+++ b/src/ensembl/src/shared/components/chevron/Chevron.scss
@@ -2,7 +2,6 @@
 
 .chevron {
   fill: $blue;
-  user-select: none;
   height: 8px;
 }
 

--- a/src/ensembl/src/shared/components/chevron/Chevron.test.tsx
+++ b/src/ensembl/src/shared/components/chevron/Chevron.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import Chevron from './Chevron';
+
+describe('<Chevron />', () => {
+  describe('default', () => {
+    it('renders correctly', () => {
+      const { container, rerender } = render(<Chevron direction="down" />);
+      const chevron = container.firstChild as HTMLElement;
+
+      expect(chevron.tagName.toLowerCase()).toBe('svg');
+      expect(chevron.classList.contains('chevron')).toBe(true);
+
+      rerender(<Chevron direction="up" />);
+      expect(chevron.classList.contains('chevron_up')).toBe(true);
+
+      rerender(<Chevron direction="left" />);
+      expect(chevron.classList.contains('chevron_left')).toBe(true);
+
+      rerender(<Chevron direction="right" />);
+      expect(chevron.classList.contains('chevron_right')).toBe(true);
+
+      rerender(<Chevron direction="down" animateDirectionChange={true} />);
+      expect(chevron.classList.contains('chevron_animated')).toBe(true);
+    });
+  });
+
+  describe('with wrapper', () => {
+    it('renders correctly', () => {
+      const wrapperClass = 'this_is_wrapper_class';
+      const iconClass = 'this_is_icon_class';
+      const { container } = render(
+        <Chevron
+          direction="down"
+          classNames={{ wrapper: wrapperClass, svg: iconClass }}
+        />
+      );
+      const chevronWrapper = container.firstChild as HTMLElement;
+      const chevron = chevronWrapper.firstChild as HTMLElement;
+
+      expect(chevronWrapper.tagName.toLowerCase()).toBe('span');
+      expect(chevron.tagName.toLowerCase()).toBe('svg');
+
+      expect(chevronWrapper.classList.contains(wrapperClass)).toBe(true);
+      expect(chevron.classList.contains(iconClass)).toBe(true);
+    });
+  });
+
+  describe('as a button', () => {
+    it('renders correctly', () => {
+      const wrapperClass = 'this_is_wrapper_class';
+      const iconClass = 'this_is_icon_class';
+      const { container } = render(
+        <Chevron
+          direction="down"
+          onClick={jest.fn()}
+          classNames={{ wrapper: wrapperClass, svg: iconClass }}
+        />
+      );
+
+      const chevronButton = container.firstChild as HTMLElement;
+      const chevron = chevronButton.firstChild as HTMLElement;
+
+      expect(chevronButton.tagName.toLowerCase()).toBe('button');
+      expect(chevron.tagName.toLowerCase()).toBe('svg');
+
+      expect(chevronButton.classList.contains(wrapperClass)).toBe(true);
+      expect(chevron.classList.contains(iconClass)).toBe(true);
+    });
+
+    it('registers clicks', () => {
+      const clickHandler = jest.fn();
+      const { container } = render(
+        <Chevron direction="down" onClick={clickHandler} />
+      );
+
+      const chevronButton = container.firstChild as HTMLElement;
+      userEvent.click(chevronButton);
+
+      expect(clickHandler).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/ensembl/src/shared/components/chevron/Chevron.test.tsx
+++ b/src/ensembl/src/shared/components/chevron/Chevron.test.tsx
@@ -38,7 +38,7 @@ describe('<Chevron />', () => {
       rerender(<Chevron direction="right" />);
       expect(chevron.classList.contains('chevron_right')).toBe(true);
 
-      rerender(<Chevron direction="down" animateDirectionChange={true} />);
+      rerender(<Chevron direction="down" animate={true} />);
       expect(chevron.classList.contains('chevron_animated')).toBe(true);
     });
   });

--- a/src/ensembl/src/shared/components/chevron/Chevron.tsx
+++ b/src/ensembl/src/shared/components/chevron/Chevron.tsx
@@ -38,7 +38,6 @@ const Chevron = (props: Props) => {
   const chevronClasses = classNames(
     styles.chevron,
     { [styles[`chevron_${props.direction}`]]: isNonDefaultDirection },
-    { [styles.chevron_clickable]: props.onClick },
     { [styles.chevron_animated]: props.animateDirectionChange },
     props.classNames?.svg
   );

--- a/src/ensembl/src/shared/components/chevron/Chevron.tsx
+++ b/src/ensembl/src/shared/components/chevron/Chevron.tsx
@@ -43,10 +43,21 @@ const Chevron = (props: Props) => {
     props.classNames?.svg
   );
 
+  const Wrapper = props.onClick
+    ? 'button'
+    : props.classNames?.wrapper
+    ? 'span'
+    : React.Fragment;
+
+  const wrapperProps = {
+    onClick: props.onClick,
+    className: props.classNames?.wrapper
+  };
+
   return (
-    <span className={props.classNames?.wrapper}>
-      <ChevronDown className={chevronClasses} onClick={props.onClick} />
-    </span>
+    <Wrapper {...wrapperProps}>
+      <ChevronDown className={chevronClasses} />
+    </Wrapper>
   );
 };
 

--- a/src/ensembl/src/shared/components/chevron/Chevron.tsx
+++ b/src/ensembl/src/shared/components/chevron/Chevron.tsx
@@ -1,0 +1,48 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import classNames from 'classnames';
+
+import { ReactComponent as ChevronDown } from 'static/img/shared/chevron-down.svg';
+
+import styles from './Chevron.scss';
+
+export type Direction = 'up' | 'down' | 'left' | 'right';
+
+type Props = {
+  direction: Direction;
+  animateDirectionChange: boolean;
+  className?: string;
+};
+
+const Chevron = (props: Props) => {
+  const isNonDefaultDirection = props.direction !== 'down';
+  const chevronClasses = classNames(
+    styles.chevron,
+    { [styles[`chevron_${props.direction}`]]: isNonDefaultDirection },
+    { [styles.chevron_animated]: props.animateDirectionChange },
+    props.className
+  );
+
+  return <ChevronDown className={chevronClasses} />;
+};
+
+Chevron.defaultProps = {
+  animateDirectionChange: false
+};
+
+export default Chevron;

--- a/src/ensembl/src/shared/components/chevron/Chevron.tsx
+++ b/src/ensembl/src/shared/components/chevron/Chevron.tsx
@@ -26,7 +26,11 @@ export type Direction = 'up' | 'down' | 'left' | 'right';
 type Props = {
   direction: Direction;
   animateDirectionChange: boolean;
-  className?: string;
+  onClick?: () => void;
+  classNames?: {
+    wrapper?: string;
+    svg?: string;
+  };
 };
 
 const Chevron = (props: Props) => {
@@ -34,11 +38,16 @@ const Chevron = (props: Props) => {
   const chevronClasses = classNames(
     styles.chevron,
     { [styles[`chevron_${props.direction}`]]: isNonDefaultDirection },
+    { [styles.chevron_clickable]: props.onClick },
     { [styles.chevron_animated]: props.animateDirectionChange },
-    props.className
+    props.classNames?.svg
   );
 
-  return <ChevronDown className={chevronClasses} />;
+  return (
+    <span className={props.classNames?.wrapper}>
+      <ChevronDown className={chevronClasses} onClick={props.onClick} />
+    </span>
+  );
 };
 
 Chevron.defaultProps = {

--- a/src/ensembl/src/shared/components/chevron/Chevron.tsx
+++ b/src/ensembl/src/shared/components/chevron/Chevron.tsx
@@ -48,10 +48,13 @@ const Chevron = (props: Props) => {
     ? 'span'
     : React.Fragment;
 
-  const wrapperProps = {
-    onClick: props.onClick,
-    className: props.classNames?.wrapper
-  };
+  const wrapperProps =
+    Wrapper === React.Fragment
+      ? {}
+      : {
+          onClick: props.onClick,
+          className: props.classNames?.wrapper
+        };
 
   return (
     <Wrapper {...wrapperProps}>

--- a/src/ensembl/src/shared/components/chevron/Chevron.tsx
+++ b/src/ensembl/src/shared/components/chevron/Chevron.tsx
@@ -23,7 +23,7 @@ import styles from './Chevron.scss';
 
 export type Direction = 'up' | 'down' | 'left' | 'right';
 
-type Props = {
+export type Props = {
   direction: Direction;
   animateDirectionChange: boolean;
   onClick?: () => void;

--- a/src/ensembl/src/shared/components/chevron/Chevron.tsx
+++ b/src/ensembl/src/shared/components/chevron/Chevron.tsx
@@ -25,7 +25,7 @@ export type Direction = 'up' | 'down' | 'left' | 'right';
 
 export type Props = {
   direction: Direction;
-  animateDirectionChange: boolean;
+  animate: boolean;
   onClick?: () => void;
   classNames?: {
     wrapper?: string;
@@ -38,7 +38,7 @@ const Chevron = (props: Props) => {
   const chevronClasses = classNames(
     styles.chevron,
     { [styles[`chevron_${props.direction}`]]: isNonDefaultDirection },
-    { [styles.chevron_animated]: props.animateDirectionChange },
+    { [styles.chevron_animated]: props.animate },
     props.classNames?.svg
   );
 
@@ -64,7 +64,7 @@ const Chevron = (props: Props) => {
 };
 
 Chevron.defaultProps = {
-  animateDirectionChange: false
+  animate: false
 };
 
 export default Chevron;

--- a/src/ensembl/src/shared/components/expandable-section/ExpandableSection.scss
+++ b/src/ensembl/src/shared/components/expandable-section/ExpandableSection.scss
@@ -5,6 +5,14 @@
   position: relative;
   min-height: 45px;
   padding-right: 55px;
+
+  // nesting to increase specificity to override child's styles
+  .chevron {
+    width: 12px;
+    position: absolute;
+    top: 20px;
+    left: 35px;
+  }
 }
 
 .expandableSection + .expandableSection {
@@ -19,19 +27,4 @@
   height: 45px;
   text-align: center;
   cursor: pointer;
-}
-
-.chevron {
-  cursor: pointer;
-  fill: $blue;
-  height: 20px;
-  width: 20px;
-  top: 12px;
-  position: absolute;
-  left: 35px;
-  transform: rotate(90deg);
-  transition: transform linear 0.2s;
-  &Down {
-    transform: rotate(-90deg);
-  }
 }

--- a/src/ensembl/src/shared/components/expandable-section/ExpandableSection.tsx
+++ b/src/ensembl/src/shared/components/expandable-section/ExpandableSection.tsx
@@ -17,7 +17,7 @@
 import React, { ReactNode, useState, useEffect } from 'react';
 import classNames from 'classnames';
 
-import { ReactComponent as Chevron } from 'static/img/shared/chevron-right.svg';
+import Chevron from 'src/shared/components/chevron/Chevron';
 
 import styles from './ExpandableSection.scss';
 
@@ -41,10 +41,6 @@ const ExpandableSection = (props: ExpandableSectionProps) => {
       setIsExpanded(props.isExpanded);
     }
   }, [props.isExpanded]);
-
-  const chevronClasses = classNames(styles.chevron, {
-    [styles.chevronDown]: isExpanded
-  });
 
   const wrapperClassNames = classNames(
     styles.expandableSection,
@@ -70,7 +66,11 @@ const ExpandableSection = (props: ExpandableSectionProps) => {
     <div className={wrapperClassNames}>
       {props.expandedContent && (
         <div className={styles.toggle} onClick={toggleExpanded}>
-          <Chevron className={chevronClasses} />
+          <Chevron
+            direction={isExpanded ? 'up' : 'down'}
+            animateDirectionChange={true}
+            classNames={{ svg: styles.chevron }}
+          />
         </div>
       )}
 

--- a/src/ensembl/src/shared/components/expandable-section/ExpandableSection.tsx
+++ b/src/ensembl/src/shared/components/expandable-section/ExpandableSection.tsx
@@ -68,7 +68,7 @@ const ExpandableSection = (props: ExpandableSectionProps) => {
         <div className={styles.toggle} onClick={toggleExpanded}>
           <Chevron
             direction={isExpanded ? 'up' : 'down'}
-            animateDirectionChange={true}
+            animate={true}
             classNames={{ svg: styles.chevron }}
           />
         </div>

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
@@ -114,18 +114,7 @@ $drawerWindowWidth: 45px;
 }
 
 .sidebarModeToggle {
-  width: 22px;
-  height: 22px;
   margin-bottom: 55px;
-}
-
-.sidebarModeToggleChevron {
-  cursor: pointer;
-  fill: $blue;
-
-  &Open {
-    transform: rotate(180deg);
-  }
 }
 
 .sidebarTabs {

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.test.tsx
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import faker from 'faker';
 
@@ -215,9 +215,11 @@ describe('StandardAppLayout', () => {
       const props = commonProps;
 
       it('calls onSidebarToggle when sidebar toggle button is clicked', () => {
-        const { rerender } = render(<StandardAppLayout {...props} />);
-        const sidebarToggleButton = screen.getByTestId(
-          'sidebarModeToggle'
+        const { rerender, container } = render(
+          <StandardAppLayout {...props} />
+        );
+        const sidebarToggleButton = container.querySelector(
+          '.sidebarModeToggle button'
         ) as HTMLElement;
         userEvent.click(sidebarToggleButton);
 
@@ -236,9 +238,9 @@ describe('StandardAppLayout', () => {
       const props = { ...commonProps, isDrawerOpen: true };
 
       it('closes drawer when sidebar toggle button is clicked', () => {
-        render(<StandardAppLayout {...props} />);
-        const sidebarToggleButton = screen.getByTestId(
-          'sidebarModeToggle'
+        const { container } = render(<StandardAppLayout {...props} />);
+        const sidebarToggleButton = container.querySelector(
+          '.sidebarModeToggle button'
         ) as HTMLElement;
         userEvent.click(sidebarToggleButton);
 

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
@@ -22,7 +22,7 @@ import { BreakpointWidth } from 'src/global/globalConfig';
 import usePrevious from 'src/shared/hooks/usePrevious';
 
 import CloseButton from 'src/shared/components/close-button/CloseButton';
-import { ReactComponent as Chevron } from 'static/img/shared/chevron-right.svg';
+import Chevron from 'src/shared/components/chevron/Chevron';
 
 import styles from './StandardAppLayout.scss';
 
@@ -122,15 +122,13 @@ StandardAppLayout.defaultProps = {
 };
 
 const SidebarModeToggle = (props: SidebarModeToggleProps) => {
-  const chevronClasses = classNames(styles.sidebarModeToggleChevron, {
-    [styles.sidebarModeToggleChevronOpen]:
-      props.showAction === SidebarModeToggleAction.OPEN
-  });
-
   return (
     <div className={styles.sidebarModeToggle}>
       <Chevron
-        className={chevronClasses}
+        direction={
+          props.showAction === SidebarModeToggleAction.OPEN ? 'left' : 'right'
+        }
+        classNames={{ svg: styles.sidebarModeToggleChevron }}
         onClick={props.onClick}
         data-test-id="sidebarModeToggle"
       />

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.tsx
@@ -130,7 +130,6 @@ const SidebarModeToggle = (props: SidebarModeToggleProps) => {
         }
         classNames={{ svg: styles.sidebarModeToggleChevron }}
         onClick={props.onClick}
-        data-test-id="sidebarModeToggle"
       />
     </div>
   );

--- a/src/ensembl/src/shared/components/show-hide/ShowHide.scss
+++ b/src/ensembl/src/shared/components/show-hide/ShowHide.scss
@@ -1,0 +1,15 @@
+@import 'src/styles/common';
+
+.showHide {
+
+}
+
+.label {
+  color: $blue;
+  cursor: pointer;
+}
+
+.chevron {
+  margin-left: 10px;
+  height: 6px;
+}

--- a/src/ensembl/src/shared/components/show-hide/ShowHide.scss
+++ b/src/ensembl/src/shared/components/show-hide/ShowHide.scss
@@ -1,9 +1,5 @@
 @import 'src/styles/common';
 
-.showHide {
-
-}
-
 .label {
   color: $blue;
   cursor: pointer;

--- a/src/ensembl/src/shared/components/show-hide/ShowHide.scss
+++ b/src/ensembl/src/shared/components/show-hide/ShowHide.scss
@@ -1,11 +1,14 @@
 @import 'src/styles/common';
 
+.showHide {
+  // increase specificity to be sure to override chevron's own styles 
+  .chevron {
+    margin-left: 10px;
+    height: 6px;
+  }
+}
+
 .label {
   color: $blue;
   cursor: pointer;
-}
-
-.chevron {
-  margin-left: 10px;
-  height: 6px;
 }

--- a/src/ensembl/src/shared/components/show-hide/ShowHide.tsx
+++ b/src/ensembl/src/shared/components/show-hide/ShowHide.tsx
@@ -53,7 +53,7 @@ const ShowHide = (props: Props) => {
         {props.label}
         <Chevron
           direction={props.isExpanded ? 'up' : 'down'}
-          animateDirectionChange={true}
+          animate={true}
           classNames={chevronClasses}
         />
       </span>

--- a/src/ensembl/src/shared/components/show-hide/ShowHide.tsx
+++ b/src/ensembl/src/shared/components/show-hide/ShowHide.tsx
@@ -1,0 +1,64 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import classNames from 'classnames';
+
+import Chevron from '../chevron/Chevron';
+
+import styles from './ShowHide.scss';
+
+/**
+ * A ShowHide component is a text with a chevron next to it.
+ * When the chevron is pointing downward, the additional content
+ * that is supposed to be associated with this ShowHide control is expected to be hidden;
+ * whereas when the chevron is pointing upwards, the additional content
+ * is expected to be shown.
+ */
+
+type Props = {
+  label: string | JSX.Element;
+  isExpanded: boolean;
+  onClick: () => void;
+  classNames?: {
+    wrapper?: string;
+    label?: string;
+    chevron?: string;
+  };
+};
+
+const ShowHide = (props: Props) => {
+  const labelClasses = classNames(styles.label, props.classNames?.label);
+
+  const chevronClasses = {
+    svg: classNames(styles.chevron, props.classNames?.chevron)
+  };
+
+  return (
+    <div className={props.classNames?.wrapper}>
+      <span onClick={props.onClick} className={labelClasses}>
+        {props.label}
+        <Chevron
+          direction={props.isExpanded ? 'up' : 'down'}
+          animateDirectionChange={true}
+          classNames={chevronClasses}
+        />
+      </span>
+    </div>
+  );
+};
+
+export default ShowHide;

--- a/src/ensembl/src/shared/components/show-hide/ShowHide.tsx
+++ b/src/ensembl/src/shared/components/show-hide/ShowHide.tsx
@@ -41,6 +41,8 @@ type Props = {
 };
 
 const ShowHide = (props: Props) => {
+  const wrapperClasses = classNames(styles.showHide, props.classNames?.wrapper);
+
   const labelClasses = classNames(styles.label, props.classNames?.label);
 
   const chevronClasses = {
@@ -48,7 +50,7 @@ const ShowHide = (props: Props) => {
   };
 
   return (
-    <div className={props.classNames?.wrapper}>
+    <div className={wrapperClasses}>
       <span onClick={props.onClick} className={labelClasses}>
         {props.label}
         <Chevron

--- a/src/ensembl/src/shared/components/species-tabs-wrapper/SingleLineSpeciesWrapper.scss
+++ b/src/ensembl/src/shared/components/species-tabs-wrapper/SingleLineSpeciesWrapper.scss
@@ -21,8 +21,8 @@
   }
 }
 
-// Increase the specificity of the selector to always win over the selector of the species component
-.species.species {
+// This class needs higher specificity, because it overrides CSS rules in the child
+.species {
   width: 100%;
   margin-bottom: 0;
 }

--- a/src/ensembl/src/shared/components/species-tabs-wrapper/SingleLineSpeciesWrapper.scss
+++ b/src/ensembl/src/shared/components/species-tabs-wrapper/SingleLineSpeciesWrapper.scss
@@ -21,7 +21,8 @@
   }
 }
 
-.species {
+// Increase the specificity of the selector to always win over the selector of the species component
+.species.species {
   width: 100%;
   margin-bottom: 0;
 }

--- a/src/ensembl/static/img/shared/chevron-down.svg
+++ b/src/ensembl/static/img/shared/chevron-down.svg
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 28 28" style="enable-background:new 0 0 28 28;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#0099FF;}
-</style>
-<polygon class="st0" points="7.1,7.9 1.7,7.9 14,20.1 26.3,7.9 20.9,7.9 14,14.8 "/>
+<!-- Generator: Adobe Illustrator 25.2.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="chevron_x5F_down" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
+	 y="0px" viewBox="0 0 30.7 19" style="enable-background:new 0 0 30.7 19;" xml:space="preserve">
+<path d="M17,18.3L30.2,5.1c0.9-0.9,0.6-1.8-0.2-2.8l-1.6-1.6c-0.9-0.9-2.4-0.9-3.3,0l-9.7,9.8L5.6,0.8c-0.9-0.9-2.4-0.9-3.3,0
+	L0.8,2.4c-0.9,0.9-1.1,1.8-0.2,2.8l13.1,13.1C14.7,19.3,16.1,19.2,17,18.3z"/>
 </svg>

--- a/src/ensembl/static/img/shared/chevron-down.svg
+++ b/src/ensembl/static/img/shared/chevron-down.svg
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 25.2.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="chevron_x5F_down" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
-	 y="0px" viewBox="0 0 30.7 19" style="enable-background:new 0 0 30.7 19;" xml:space="preserve">
-<path d="M17,18.3L30.2,5.1c0.9-0.9,0.6-1.8-0.2-2.8l-1.6-1.6c-0.9-0.9-2.4-0.9-3.3,0l-9.7,9.8L5.6,0.8c-0.9-0.9-2.4-0.9-3.3,0
-	L0.8,2.4c-0.9,0.9-1.1,1.8-0.2,2.8l13.1,13.1C14.7,19.3,16.1,19.2,17,18.3z"/>
+	 y="0px" viewBox="0 0 30 19" style="enable-background:new 0 0 30 19;" xml:space="preserve">
+<path d="M29.5,2.8l-2.4-2.4c-0.6-0.6-1.6-0.6-2.2,0l-10,10L5,0.5c-0.6-0.6-1.6-0.6-2.2,0L0.5,2.8c-0.6,0.6-0.6,1.6,0,2.2L11.3,16
+	c0.1,0.1,0.1,0.2,0.2,0.2l2.4,2.4c0.3,0.3,0.7,0.5,1.1,0.5c0.4,0,0.8-0.1,1.1-0.5l2.4-2.4c0.1-0.1,0.1-0.1,0.2-0.2L29.5,5
+	C30.2,4.4,30.2,3.4,29.5,2.8z"/>
 </svg>

--- a/src/ensembl/stories/shared-components/chevron/Chevron.stories.scss
+++ b/src/ensembl/stories/shared-components/chevron/Chevron.stories.scss
@@ -1,0 +1,42 @@
+.storyWrapper {
+  height: 95vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.showRoom {
+  margin-bottom: 4rem;
+}
+
+.label {
+  margin-right: 0.6rem;
+}
+
+.controls {
+  display: grid;
+  grid-template-columns: 100px 100px;
+  grid-template-areas: 
+          'direction animation'
+          'direction class';
+  column-gap: 2rem;
+  row-gap: 1rem;
+}
+
+.controlsDirection {
+  grid-area: direction;
+}
+
+.controlsAnimation {
+  grid-area: animation;
+}
+
+.controlsClass {
+  grid-area: class;
+}
+
+.customChevron {
+  height: 30px;
+  width: 30px;
+}

--- a/src/ensembl/stories/shared-components/chevron/Chevron.stories.tsx
+++ b/src/ensembl/stories/shared-components/chevron/Chevron.stories.tsx
@@ -122,7 +122,7 @@ export const ChevronWrappedInButtonStory = () => {
   return (
     <div className={styles.storyWrapper}>
       <div className={styles.showRoom}>
-        <span className={styles.label}>{'Click the chevron →'}</span>
+        <span className={styles.label}>Click the chevron →</span>
         <Chevron
           direction={direction as ChevronDirection}
           animate={true}

--- a/src/ensembl/stories/shared-components/chevron/Chevron.stories.tsx
+++ b/src/ensembl/stories/shared-components/chevron/Chevron.stories.tsx
@@ -1,0 +1,116 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from 'react';
+
+import Chevron, {
+  Direction as ChevronDirection
+} from 'src/shared/components/chevron/Chevron';
+import RadioGroup from 'src/shared/components/radio-group/RadioGroup';
+
+import styles from './Chevron.stories.scss';
+
+export const ChevronStory = () => {
+  const [direction, setDirection] = useState('down');
+  const [animation, setAnimation] = useState(false);
+  const [customClass, setCustomClass] = useState(false);
+
+  const directionOptions = [
+    {
+      value: 'down',
+      label: 'Down'
+    },
+    {
+      value: 'up',
+      label: 'Up'
+    },
+    {
+      value: 'left',
+      label: 'Left'
+    },
+    {
+      value: 'right',
+      label: 'Right'
+    }
+  ];
+
+  const animationOptions = [
+    {
+      value: false,
+      label: 'No animation'
+    },
+    {
+      value: true,
+      label: 'With animation'
+    }
+  ];
+
+  const classOptions = [
+    {
+      value: false,
+      label: 'Default'
+    },
+    {
+      value: true,
+      label: 'Custom'
+    }
+  ];
+
+  return (
+    <div className={styles.storyWrapper}>
+      <div className={styles.showRoom}>
+        <span className={styles.label}>Some text next to a chevron</span>
+        <Chevron
+          direction={direction as ChevronDirection}
+          animateDirectionChange={animation}
+          className={customClass ? styles.customChevron : undefined}
+        />
+      </div>
+      <div className={styles.controls}>
+        <div className={styles.controlsDirection}>
+          Direction
+          <RadioGroup
+            options={directionOptions}
+            selectedOption={direction}
+            onChange={(direction) => setDirection(direction as string)}
+          />
+        </div>
+        <div className={styles.controlsAnimation}>
+          Animation
+          <RadioGroup
+            options={animationOptions}
+            selectedOption={animation}
+            onChange={(animation) => setAnimation(animation as boolean)}
+          />
+        </div>
+        <div className={styles.controlsClass}>
+          CSS class
+          <RadioGroup
+            options={classOptions}
+            selectedOption={customClass}
+            onChange={(customClass) => setCustomClass(customClass as boolean)}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+ChevronStory.storyName = 'default';
+
+export default {
+  title: 'Components/Shared Components/Chevron'
+};

--- a/src/ensembl/stories/shared-components/chevron/Chevron.stories.tsx
+++ b/src/ensembl/stories/shared-components/chevron/Chevron.stories.tsx
@@ -111,6 +111,30 @@ export const ChevronStory = () => {
 
 ChevronStory.storyName = 'default';
 
+export const ChevronWrappedInButtonStory = () => {
+  const [direction, setDirection] = useState<ChevronDirection>('down');
+
+  const handleClick = () => {
+    const newDirection = direction === 'up' ? 'down' : 'up';
+    setDirection(newDirection);
+  };
+
+  return (
+    <div className={styles.storyWrapper}>
+      <div className={styles.showRoom}>
+        <span className={styles.label}>{'Click the chevron →'}</span>
+        <Chevron
+          direction={direction as ChevronDirection}
+          animateDirectionChange={true}
+          onClick={handleClick}
+        />
+      </div>
+    </div>
+  );
+};
+
+ChevronWrappedInButtonStory.storyName = 'as button';
+
 export default {
   title: 'Components/Shared Components/Chevron'
 };

--- a/src/ensembl/stories/shared-components/chevron/Chevron.stories.tsx
+++ b/src/ensembl/stories/shared-components/chevron/Chevron.stories.tsx
@@ -76,7 +76,7 @@ export const ChevronStory = () => {
         <Chevron
           direction={direction as ChevronDirection}
           animateDirectionChange={animation}
-          className={customClass ? styles.customChevron : undefined}
+          classNames={{ svg: customClass ? styles.customChevron : undefined }}
         />
       </div>
       <div className={styles.controls}>

--- a/src/ensembl/stories/shared-components/chevron/Chevron.stories.tsx
+++ b/src/ensembl/stories/shared-components/chevron/Chevron.stories.tsx
@@ -75,7 +75,7 @@ export const ChevronStory = () => {
         <span className={styles.label}>Some text next to a chevron</span>
         <Chevron
           direction={direction as ChevronDirection}
-          animateDirectionChange={animation}
+          animate={animation}
           classNames={{ svg: customClass ? styles.customChevron : undefined }}
         />
       </div>
@@ -125,7 +125,7 @@ export const ChevronWrappedInButtonStory = () => {
         <span className={styles.label}>{'Click the chevron →'}</span>
         <Chevron
           direction={direction as ChevronDirection}
-          animateDirectionChange={true}
+          animate={true}
           onClick={handleClick}
         />
       </div>

--- a/src/ensembl/stories/shared-components/chevron/Chevron.stories.tsx
+++ b/src/ensembl/stories/shared-components/chevron/Chevron.stories.tsx
@@ -24,7 +24,7 @@ import RadioGroup from 'src/shared/components/radio-group/RadioGroup';
 import styles from './Chevron.stories.scss';
 
 export const ChevronStory = () => {
-  const [direction, setDirection] = useState('down');
+  const [direction, setDirection] = useState<ChevronDirection>('down');
   const [animation, setAnimation] = useState(false);
   const [customClass, setCustomClass] = useState(false);
 
@@ -74,7 +74,7 @@ export const ChevronStory = () => {
       <div className={styles.showRoom}>
         <span className={styles.label}>Some text next to a chevron</span>
         <Chevron
-          direction={direction as ChevronDirection}
+          direction={direction}
           animate={animation}
           classNames={{ svg: customClass ? styles.customChevron : undefined }}
         />
@@ -85,7 +85,9 @@ export const ChevronStory = () => {
           <RadioGroup
             options={directionOptions}
             selectedOption={direction}
-            onChange={(direction) => setDirection(direction as string)}
+            onChange={(direction) =>
+              setDirection(direction as ChevronDirection)
+            }
           />
         </div>
         <div className={styles.controlsAnimation}>

--- a/src/ensembl/stories/shared-components/show-hide/ShowHide.stories.tsx
+++ b/src/ensembl/stories/shared-components/show-hide/ShowHide.stories.tsx
@@ -1,0 +1,39 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from 'react';
+
+import ShowHide from 'src/shared/components/show-hide/ShowHide';
+
+export const ShowHideStory = () => {
+  const [isHiding, setIsHiding] = useState(true);
+
+  return (
+    <div>
+      <ShowHide
+        isExpanded={!isHiding}
+        label="Example text"
+        onClick={() => setIsHiding(!isHiding)}
+      />
+    </div>
+  );
+};
+
+ShowHideStory.storyName = 'default';
+
+export default {
+  title: 'Components/Shared Components/ShowHide'
+};


### PR DESCRIPTION
## Type
- New feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1161

## Description
- Added a single React component to cover all cases of our chevron usage
- Added a ShowHide component, which consists of a label associated with a chevron (used in EntityViewer; will be used more commonly)
- Added Storybook stories for Chevron and ShowHide 

## Deployment URL
http://chevron.review.ensembl.org

## Views affected
- Entity viewer
- Species page (the ExpandableSection component)
- Chevron that opens/closes the sidebar
- Help app menu
- The Accordion component