### PR TITLE
add similar_proteins stat from pdb

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/protein-features-count/ProteinFeaturesCount.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/protein-features-count/ProteinFeaturesCount.tsx
@@ -22,6 +22,7 @@ import structuresIcon from 'static/img/entity-viewer/icon_protein_structures.svg
 import ligandsIcon from 'static/img/entity-viewer/icon_protein_ligands.svg';
 import interactionsIcon from 'static/img/entity-viewer/icon_protein_interactions.svg';
 import annotationsIcon from 'static/img/entity-viewer/icon_protein_annotations.svg';
+import similarProteinsIcon from 'static/img/entity-viewer/icon_protein_similar.svg';
 
 import styles from './ProteinFeaturesCount.scss';
 
@@ -33,7 +34,8 @@ enum FeatureCountLabel {
   ANNOTATIONS = 'Functional annotations',
   INTERACTIONS = 'Interactions',
   LIGANDS = 'Ligands',
-  STRUCTURES = 'Structures'
+  STRUCTURES = 'Structures',
+  SIMILAR_PROTEINS = 'Similar proteins'
 }
 
 const ProteinFeaturesCount = (props: ProteinFeaturesCountProps) => {
@@ -60,6 +62,11 @@ const ProteinFeaturesCount = (props: ProteinFeaturesCountProps) => {
         label={FeatureCountLabel.ANNOTATIONS}
         count={proteinStats.annotationsCount}
         icon={annotationsIcon}
+      />
+      <FeatureCount
+        label={FeatureCountLabel.SIMILAR_PROTEINS}
+        count={proteinStats.similarProteinsCount}
+        icon={similarProteinsIcon}
       />
     </div>
   );

--- a/src/ensembl/src/content/app/entity-viewer/shared/rest/rest-adaptors/rest-protein-adaptor.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/rest/rest-adaptors/rest-protein-adaptor.ts
@@ -25,5 +25,6 @@ export const restProteinSummaryAdaptor = (
   structuresCount: proteinStats.pdbs,
   ligandsCount: proteinStats.ligands,
   interactionsCount: proteinStats.interaction_partners,
-  annotationsCount: proteinStats.annotations
+  annotationsCount: proteinStats.annotations,
+  similarProteinsCount: proteinStats.similar_proteins
 });

--- a/src/ensembl/src/content/app/entity-viewer/shared/rest/rest-data-fetchers/proteinData.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/rest/rest-data-fetchers/proteinData.ts
@@ -23,6 +23,7 @@ export type ProteinStatsInResponse = {
   ligands: number;
   interaction_partners: number;
   annotations: number;
+  similar_proteins: number;
 };
 
 export type ProteinAcessionInResponse = {
@@ -42,6 +43,7 @@ export type ProteinStats = {
   ligandsCount: number;
   interactionsCount: number;
   annotationsCount: number;
+  similarProteinsCount: number;
 };
 
 export const fetchProteinSummaryStats = async (
@@ -50,11 +52,10 @@ export const fetchProteinSummaryStats = async (
 ): Promise<ProteinStats | null> => {
   const proteinStatsUrl = `https://www.ebi.ac.uk/pdbe/graph-api/uniprot/summary_stats/${xrefId}`;
 
-  const proteinStatsData:
-    | UniProtSummaryStats
-    | undefined = await apiService.fetch(proteinStatsUrl, {
-    signal
-  });
+  const proteinStatsData: UniProtSummaryStats | undefined =
+    await apiService.fetch(proteinStatsUrl, {
+      signal
+    });
   if (!proteinStatsData) {
     return null;
   }

--- a/src/ensembl/static/img/entity-viewer/icon_protein_similar.svg
+++ b/src/ensembl/static/img/entity-viewer/icon_protein_similar.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.2.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="elipsis" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 32 32" style="enable-background:new 0 0 32 32;" xml:space="preserve">
+<path d="M31,25.5c0,0.5-0.4,0.9-0.9,0.9H20c-0.5,0-0.9-0.4-0.9-0.9l0,0v-4.9c0-0.5,0.4-0.9,0.9-0.9c0,0,0,0,0,0h4.4l-7.5-7.5h-1.5
+	l-7.5,7.5H12c0.5,0,0.9,0.4,0.9,0.9c0,0,0,0,0,0v4.9c0,0.5-0.4,0.9-0.9,0.9h0H1.9C1.4,26.4,1,26,1,25.5l0,0v-4.9
+	c0-0.5,0.4-0.9,0.9-0.9c0,0,0,0,0,0h4l7.5-7.5h-2.3c-0.5,0-0.9-0.4-0.9-0.9V6.5c0-0.5,0.4-0.9,0.9-0.9h10.1c0.5,0,0.9,0.4,0.9,0.9
+	v4.9c0,0.5-0.4,0.9-0.9,0.9h-2.3l7.5,7.5h3.8c0.5,0,0.9,0.4,0.9,0.9C31,20.7,31,25.5,31,25.5z"/>
+</svg>


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1156

## Description
The PDBeKB REST service provides information on 'Similar proteins'. We should add the results of this to 2020, for two reasons. 1) it's genuinely valuable for users and 2) showing the links to PDBeKB when the count for all other data is zero is confusing

## Deployment URL
http://similar-proteins.review.ensembl.org/entity-viewer/homo_sapiens_GCA_000001405_28/gene:ENSG00000108622?view=protein

## Views affected
EV-Geneview

### Other effects
N/A

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
N/A
