### PR TITLE
Fix grid layout for Genome Browser and Entity Viewer

### DIFF
--- a/src/ensembl/src/content/app/browser/Browser.scss
+++ b/src/ensembl/src/content/app/browser/Browser.scss
@@ -2,6 +2,7 @@
 
 .browserInnerWrapper {
   display: grid;
+  align-items: start;
   grid-template-rows: 80px 1fr;
 }
 

--- a/src/ensembl/src/content/app/entity-viewer/EntityViewer.scss
+++ b/src/ensembl/src/content/app/entity-viewer/EntityViewer.scss
@@ -3,5 +3,6 @@
 .entityViewer {
   height: 100%;
   display: grid;
+  align-items: start;
   grid-template-rows: auto 1fr;
 }


### PR DESCRIPTION
## Type
- Bug fix

## Importance
Currently broken in production

## Description
PR https://github.com/Ensembl/ensembl-client/pull/516 updated the grid styles of the `Root` component, which didn't sit well with PR https://github.com/Ensembl/ensembl-client/pull/510.

**Bug:** (notice the large grey block extending to the bottom of the page)
![image](https://user-images.githubusercontent.com/6834224/124390470-b0fd2880-dce3-11eb-820a-b5c220a6ec2c.png)

**After the fix:**
![image](https://user-images.githubusercontent.com/6834224/124390583-2c5eda00-dce4-11eb-94a9-68e02830d38f.png)


## Deployment URL
http://fix-layout.review.ensembl.org/genome-browser

## Views affected
- Genome Browser
- Entity Viewer
(in both cases — it's the interstitial screen when the user has not selected any species)