### PR TITLE
Label Ensembl canonical on Transcript Image using data from Thoas

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -160,7 +160,11 @@ const QUERY = gql`
             value
             label
             definition
-            description
+          }
+          mane {
+            value
+            label
+            definition
           }
         }
       }

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -155,6 +155,14 @@ const QUERY = gql`
             }
           }
         }
+        metadata {
+          canonical {
+            value
+            label
+            definition
+            description
+          }
+        }
       }
     }
   }

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Pick2, Pick3 } from 'ts-multipick';
 
 import { getFeatureCoordinates } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
-import {
-  transcriptSortingFunctions,
-  defaultSort
-} from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
+import { transcriptSortingFunctions } from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
 
 import { filterTranscriptsBySOTerm } from 'src/content/app/entity-viewer/shared/helpers/transcripts-filter';
 
@@ -58,6 +55,7 @@ type Transcript = DefaultTranscriptListItemProps['transcript'] & {
 } & {
   spliced_exons: Array<Pick3<SplicedExon, 'exon', 'slice', 'location'>>;
 } & Pick2<FullTranscript, 'slice', 'location'>;
+
 type Gene = DefaultTranscriptListItemProps['gene'] & {
   stable_id: FullGene['stable_id'];
   transcripts: Array<Transcript>;
@@ -79,12 +77,6 @@ const DefaultTranscriptslist = (props: Props) => {
   const dispatch = useDispatch();
 
   const { gene } = props;
-
-  //Using this to get the default order of transcripts in which the first one is selected, this might change later with the data coming directly from thoas
-  const defaultTranscriptId = useMemo(() => {
-    const sortedTranscripts = defaultSort(gene.transcripts);
-    return sortedTranscripts[0].stable_id;
-  }, [gene.stable_id]);
 
   const sortingFunction = transcriptSortingFunctions[sortingRule];
   const sortedTranscripts = sortingFunction(gene.transcripts) as Transcript[];
@@ -121,7 +113,6 @@ const DefaultTranscriptslist = (props: Props) => {
           return (
             <DefaultTranscriptsListItem
               key={index}
-              isDefault={transcript.stable_id === defaultTranscriptId}
               gene={gene}
               transcript={transcript}
               rulerTicks={props.rulerTicks}

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.test.tsx
@@ -92,6 +92,6 @@ describe('<DefaultTranscriptListItem />', () => {
     const { container } = renderComponent();
     expect(
       container.querySelector('.transcriptQualityLabel')?.textContent
-    ).toBe(defaultProps.transcript.metadata.mane.label);
+    ).toBe(defaultProps.transcript.metadata.mane?.label);
   });
 });

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.test.tsx
@@ -88,10 +88,10 @@ describe('<DefaultTranscriptListItem />', () => {
     expect(queryByTestId('transcriptsListItemInfo')).toBeTruthy();
   });
 
-  it('displays selected transcript', () => {
-    const { container } = renderComponent({ isDefault: true });
+  it('displays Ensembl canonical transcript with the correct label', () => {
+    const { container } = renderComponent();
     expect(
       container.querySelector('.transcriptQualityLabel')?.textContent
-    ).toBe('Selected');
+    ).toBe(defaultProps.transcript.metadata.mane.label);
   });
 });

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.test.tsx
@@ -87,11 +87,4 @@ describe('<DefaultTranscriptListItem />', () => {
 
     expect(queryByTestId('transcriptsListItemInfo')).toBeTruthy();
   });
-
-  it('displays Ensembl canonical transcript with the correct label', () => {
-    const { container } = renderComponent();
-    expect(
-      container.querySelector('.transcriptQualityLabel')?.textContent
-    ).toBe(defaultProps.transcript.metadata.mane?.label);
-  });
 });

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
@@ -33,7 +33,10 @@ import { TranscriptQualityLabel } from 'src/content/app/entity-viewer/shared/com
 import transcriptsListStyles from '../DefaultTranscriptsList.scss';
 import styles from './DefaultTranscriptListItem.scss';
 
-type Transcript = Pick<FullTranscript, 'stable_id' | 'relative_location'> &
+type Transcript = Pick<
+  FullTranscript,
+  'stable_id' | 'relative_location' | 'metadata'
+> &
   TranscriptsListItemInfoProps['transcript'] &
   UnsplicedTranscriptProps['transcript'];
 
@@ -63,7 +66,7 @@ export const DefaultTranscriptListItem = (
   return (
     <div className={styles.defaultTranscriptListItem}>
       <div className={transcriptsListStyles.row}>
-        {props.isDefault && <TranscriptQualityLabel />}
+        <TranscriptQualityLabel metadata={props.transcript.metadata} />
 
         <div className={transcriptsListStyles.middle}>
           <div

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.tsx
@@ -39,6 +39,7 @@ import {
 import { EntityViewerParams } from 'src/content/app/entity-viewer/EntityViewer';
 import { Slice } from 'src/shared/types/thoas/slice';
 import { FullProductGeneratingContext } from 'src/shared/types/thoas/productGeneratingContext';
+import { TranscriptMetadata } from 'ensemblRoot/src/shared/types/thoas/metadata';
 
 import styles from './GeneExternalReferences.scss';
 
@@ -90,6 +91,23 @@ const QUERY = gql`
             }
           }
         }
+        metadata {
+          biotype {
+            label
+            value
+            definition
+          }
+          canonical {
+            value
+            label
+            definition
+          }
+          mane {
+            value
+            label
+            definition
+          }
+        }
       }
     }
   }
@@ -105,6 +123,7 @@ type Transcript = {
     }
   >;
   external_references: ExternalReferenceType[];
+  metadata: Pick<TranscriptMetadata, 'canonical' | 'mane'>;
 };
 
 type Gene = {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.tsx
@@ -92,20 +92,11 @@ const QUERY = gql`
           }
         }
         metadata {
-          biotype {
-            label
-            value
-            definition
-          }
           canonical {
             value
-            label
-            definition
           }
           mane {
             value
-            label
-            definition
           }
         }
       }

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item/ProteinsListItem.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item/ProteinsListItem.tsx
@@ -53,6 +53,7 @@ type Product = Pick<
 };
 
 type Transcript = Pick<FullTranscript, 'stable_id'> &
+  Pick2<FullTranscript, 'metadata', 'mane' | 'canonical'> &
   ProteinsListItemInfoProps['transcript'] & {
     product_generating_contexts: Array<
       Pick<FullProductGeneratingContext, 'product_type'> & {
@@ -68,7 +69,7 @@ export type Props = {
 };
 
 const ProteinsListItem = (props: Props) => {
-  const { isDefault, transcript, trackLength } = props;
+  const { transcript, trackLength } = props;
   const expandedTranscriptIds = useSelector(getExpandedTranscriptIds);
   const dispatch = useDispatch();
 
@@ -124,7 +125,7 @@ const ProteinsListItem = (props: Props) => {
       <span className={styles.scrollRef} ref={itemRef}></span>
       <div className={transcriptsListStyles.row}>
         <div className={transcriptsListStyles.left}>
-          {isDefault && <TranscriptQualityLabel />}
+          <TranscriptQualityLabel metadata={transcript.metadata} />
         </div>
         <div onClick={toggleListItemInfo} className={midStyles}>
           <div>{getProductAminoAcidLength(transcript)} aa</div>

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel.test.tsx
@@ -39,7 +39,7 @@ describe('<TranscriptQualityLabel />', () => {
   });
 
   it('displays correct labels for transcript metadata', () => {
-    const { queryByText, rerender } = render(
+    const { container, queryByText, rerender } = render(
       <TranscriptQualityLabel metadata={metadata} />
     );
     let label = queryByText(metadata.mane.label);
@@ -54,5 +54,12 @@ describe('<TranscriptQualityLabel />', () => {
     );
     label = queryByText(metadata.mane.label);
     expect(label).toBeTruthy();
+
+    rerender(
+      <TranscriptQualityLabel
+        metadata={{ ...metadata, canonical: null, mane: null }}
+      />
+    );
+    expect(container.firstChild).toBe(null);
   });
 });

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel.test.tsx
@@ -20,47 +20,17 @@ import { render } from '@testing-library/react';
 
 import { TranscriptQualityLabel } from './TranscriptQualityLabel';
 
-const createMANETranscriptMetadata = () => {
-  return {
-    metadata: {
-      canonical: {
-        label: 'Ensembl canonical',
-        value: true,
-        definition: faker.lorem.sentence()
-      },
-      mane: {
-        label: 'MANE Select',
-        value: 'select',
-        definition: faker.lorem.sentence()
-      }
-    }
-  };
-};
-
-const createCanonicalTranscriptMetadata = () => {
-  return {
-    metadata: {
-      canonical: {
-        label: 'Ensembl canonical',
-        value: true,
-        definition: faker.lorem.sentence()
-      },
-      mane: null
-    }
-  };
-};
-
-const createOtherMANETranscriptMetadata = () => {
-  return {
-    metadata: {
-      canonical: null,
-      mane: {
-        label: 'MANE Plus Clinical',
-        value: 'plus_clinical',
-        definition: faker.lorem.sentence()
-      }
-    }
-  };
+const metadata = {
+  canonical: {
+    label: faker.lorem.word(),
+    value: true,
+    definition: faker.lorem.sentence()
+  },
+  mane: {
+    label: faker.lorem.word(),
+    value: faker.lorem.word(),
+    definition: faker.lorem.sentence()
+  }
 };
 
 describe('<TranscriptQualityLabel />', () => {
@@ -70,21 +40,19 @@ describe('<TranscriptQualityLabel />', () => {
 
   it('displays correct labels for transcript metadata', () => {
     const { queryByText, rerender } = render(
-      <TranscriptQualityLabel {...createMANETranscriptMetadata()} />
+      <TranscriptQualityLabel metadata={metadata} />
     );
-    let label = queryByText('MANE Select');
+    let label = queryByText(metadata.mane.label);
+    expect(label).toBeTruthy();
+
+    rerender(<TranscriptQualityLabel metadata={{ ...metadata, mane: null }} />);
+    label = queryByText(metadata.canonical.label);
     expect(label).toBeTruthy();
 
     rerender(
-      <TranscriptQualityLabel {...createCanonicalTranscriptMetadata()} />
+      <TranscriptQualityLabel metadata={{ ...metadata, canonical: null }} />
     );
-    label = queryByText('Ensembl canonical');
-    expect(label).toBeTruthy();
-
-    rerender(
-      <TranscriptQualityLabel {...createOtherMANETranscriptMetadata()} />
-    );
-    label = queryByText('MANE Plus Clinical');
+    label = queryByText(metadata.mane.label);
     expect(label).toBeTruthy();
   });
 });

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import faker from 'faker';
+import { render } from '@testing-library/react';
+
+import { TranscriptQualityLabel } from './TranscriptQualityLabel';
+
+const createMANETranscriptMetadata = () => {
+  return {
+    metadata: {
+      canonical: {
+        label: 'Ensembl canonical',
+        value: true,
+        definition: faker.lorem.sentence()
+      },
+      mane: {
+        label: 'MANE Select',
+        value: 'select',
+        definition: faker.lorem.sentence()
+      }
+    }
+  };
+};
+
+const createCanonicalTranscriptMetadata = () => {
+  return {
+    metadata: {
+      canonical: {
+        label: 'Ensembl canonical',
+        value: true,
+        definition: faker.lorem.sentence()
+      },
+      mane: null
+    }
+  };
+};
+
+const createOtherMANETranscriptMetadata = () => {
+  return {
+    metadata: {
+      canonical: null,
+      mane: {
+        label: 'MANE Plus Clinical',
+        value: 'plus_clinical',
+        definition: faker.lorem.sentence()
+      }
+    }
+  };
+};
+
+describe('<TranscriptQualityLabel />', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('displays correct labels for transcript metadata', () => {
+    const { queryByText, rerender } = render(
+      <TranscriptQualityLabel {...createMANETranscriptMetadata()} />
+    );
+    let label = queryByText('MANE Select');
+    expect(label).toBeTruthy();
+
+    rerender(
+      <TranscriptQualityLabel {...createCanonicalTranscriptMetadata()} />
+    );
+    label = queryByText('Ensembl canonical');
+    expect(label).toBeTruthy();
+
+    rerender(
+      <TranscriptQualityLabel {...createOtherMANETranscriptMetadata()} />
+    );
+    label = queryByText('MANE Plus Clinical');
+    expect(label).toBeTruthy();
+  });
+});

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 
 import QuestionButton from 'src/shared/components/question-button/QuestionButton';
+
 import { TranscriptMetadata } from 'ensemblRoot/src/shared/types/thoas/metadata';
 
 import styles from './TranscriptQualityLabel.scss';
@@ -26,20 +27,21 @@ type Props = {
 };
 
 const getTranscriptMetadata = (props: Props) => {
-  if (props.metadata.canonical && props.metadata.mane?.value === 'select') {
+  const { canonical, mane } = props.metadata;
+  if (canonical && mane?.value === 'select') {
     return {
-      label: props.metadata.mane.label,
-      definition: props.metadata.mane.definition
+      label: mane.label,
+      definition: mane.definition
     };
-  } else if (props.metadata.canonical) {
+  } else if (canonical) {
     return {
-      label: props.metadata.canonical.label,
-      definition: props.metadata.canonical.definition
+      label: canonical.label,
+      definition: canonical.definition
     };
-  } else if (props.metadata.mane) {
+  } else if (mane) {
     return {
-      label: props.metadata.mane.label,
-      definition: props.metadata.mane.definition
+      label: mane.label,
+      definition: mane.definition
     };
   }
 };

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel.tsx
@@ -17,32 +17,43 @@
 import React from 'react';
 
 import QuestionButton from 'src/shared/components/question-button/QuestionButton';
+import { TranscriptMetadata } from 'ensemblRoot/src/shared/types/thoas/metadata';
 
 import styles from './TranscriptQualityLabel.scss';
 
-const transcriptLabelMap = {
-  selected: {
-    label: 'Selected',
-    helpText:
-      'The selected transcript is a default single transcript per protein coding gene that is representative of biology, well-supported, expressed and highly conserved'
+type Props = {
+  metadata: Pick<TranscriptMetadata, 'canonical' | 'mane'>;
+};
+
+const getTranscriptMetadata = (props: Props) => {
+  if (props.metadata.canonical && props.metadata.mane?.value === 'select') {
+    return {
+      label: props.metadata.mane.label,
+      definition: props.metadata.mane.definition
+    };
+  } else if (props.metadata.canonical) {
+    return {
+      label: props.metadata.canonical.label,
+      definition: props.metadata.canonical.definition
+    };
+  } else if (props.metadata.mane) {
+    return {
+      label: props.metadata.mane.label,
+      definition: props.metadata.mane.definition
+    };
   }
 };
 
-export const TranscriptQualityLabel = () => {
-  // TODO show more meaningful labels by using transcript metadata when the api starts returning it
-  const transcriptQuality = 'selected';
-
-  const labelText = transcriptLabelMap[transcriptQuality]?.label;
-  if (!labelText) {
+export const TranscriptQualityLabel = (props: Props) => {
+  const metadata = getTranscriptMetadata(props);
+  if (!metadata) {
     return null;
   }
 
   return (
     <div className={styles.transcriptQualityLabel}>
-      <span>{labelText}</span>
-      <QuestionButton
-        helpText={transcriptLabelMap[transcriptQuality]?.helpText}
-      />
+      <span>{metadata.label}</span>
+      <QuestionButton helpText={metadata.definition} />
     </div>
   );
 };

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel.tsx
@@ -28,7 +28,7 @@ type Props = {
 
 const getTranscriptMetadata = (props: Props) => {
   const { canonical, mane } = props.metadata;
-  if (canonical && mane?.value === 'select') {
+  if (canonical && mane) {
     return {
       label: mane.label,
       definition: mane.definition

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/tests/transcripts-sorter.test.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/tests/transcripts-sorter.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import faker from 'faker';
+
 import {
   defaultSort,
   sortBySplicedLengthDesc,
@@ -24,32 +26,26 @@ import {
 
 import { createTranscript } from 'tests/fixtures/entity-viewer/transcript';
 
-const createTranscriptWithEmptyMetadata = () => {
-  const transcript = createTranscript();
-  transcript.metadata.canonical = transcript.metadata.mane = null;
-  return transcript;
-};
-
 /* Creating dummy transcritps with different protein coding and non coding length  to test default sort*/
 const createLongProteinCodingTranscript = () => {
-  const transcript = createTranscriptWithEmptyMetadata();
+  const transcript = createTranscript();
   transcript.slice.location.length = 100_000;
   return transcript;
 };
 const createShortProteinCodingTranscript = () => {
-  const transcript = createTranscriptWithEmptyMetadata();
+  const transcript = createTranscript();
   transcript.slice.location.length = 10_000;
   return transcript;
 };
 const createLongNonCodingTranscript = () => {
-  const transcript = createTranscriptWithEmptyMetadata();
+  const transcript = createTranscript();
   transcript.slice.location.length = 150_000;
   transcript.so_term = 'xyz'; // <- to make sure that during default sorting we put this last
   transcript.product_generating_contexts = [];
   return transcript;
 };
 const createShortNonCodingTranscript = () => {
-  const transcript = createTranscriptWithEmptyMetadata();
+  const transcript = createTranscript();
   transcript.slice.location.length = 5_000;
   transcript.so_term = 'abc'; // <- to make sure that during default sorting we put this first
   transcript.product_generating_contexts = [];
@@ -58,7 +54,7 @@ const createShortNonCodingTranscript = () => {
 
 /* Creating dummy transcritps with different spliced length */
 const createTranscriptWithGreatestSplicedLength = () => {
-  const transcript = createTranscriptWithEmptyMetadata();
+  const transcript = createTranscript();
   const splicedExon = transcript.spliced_exons[0];
   transcript.stable_id = 'transcript_with_greatest_spliced_length';
   splicedExon.exon.slice.location.length = 15_000;
@@ -66,7 +62,7 @@ const createTranscriptWithGreatestSplicedLength = () => {
   return transcript;
 };
 const createTranscriptWithMediumSplicedLength = () => {
-  const transcript = createTranscriptWithEmptyMetadata();
+  const transcript = createTranscript();
   transcript.stable_id = 'transcript_with_medium_spliced_length';
   const splicedExon = transcript.spliced_exons[0];
   splicedExon.exon.slice.location.length = 10_000;
@@ -74,7 +70,7 @@ const createTranscriptWithMediumSplicedLength = () => {
   return transcript;
 };
 const createTranscriptWithSmallestSplicedLength = () => {
-  const transcript = createTranscriptWithEmptyMetadata();
+  const transcript = createTranscript();
   transcript.stable_id = 'transcript_with_smallest_spliced_length';
   const splicedExon = transcript.spliced_exons[0];
   splicedExon.exon.slice.location.length = 5_000;
@@ -84,7 +80,7 @@ const createTranscriptWithSmallestSplicedLength = () => {
 
 /* Creating dummy transcritps with different numbers of Exons */
 const createTranscriptWithGreatestExons = () => {
-  const transcript = createTranscriptWithEmptyMetadata();
+  const transcript = createTranscript();
   const splicedExon = transcript.spliced_exons[0];
   transcript.stable_id = 'transcript_with_greatest_exons';
   transcript.spliced_exons = [
@@ -96,7 +92,7 @@ const createTranscriptWithGreatestExons = () => {
   return transcript;
 };
 const createTranscriptWithMediumExons = () => {
-  const transcript = createTranscriptWithEmptyMetadata();
+  const transcript = createTranscript();
   transcript.stable_id = 'transcript_with_medium_exons';
   const splicedExon = transcript.spliced_exons[0];
   splicedExon.exon.slice.location.length = 10_000;
@@ -104,15 +100,40 @@ const createTranscriptWithMediumExons = () => {
   return transcript;
 };
 const createTranscriptWithSmallestExons = () => {
-  const transcript = createTranscriptWithEmptyMetadata();
+  const transcript = createTranscript();
   transcript.stable_id = 'transcript_with_smallest_exons';
   const splicedExon = transcript.spliced_exons[0];
   transcript.spliced_exons = [splicedExon, splicedExon];
   return transcript;
 };
-const createOtherManeTranscript = () => {
+
+const createMANETranscript = () => {
   const transcript = createTranscript();
-  transcript.metadata.canonical = null;
+  transcript.metadata = {
+    canonical: {
+      label: 'Ensembl canonical',
+      value: true,
+      definition: faker.lorem.sentence()
+    },
+    mane: {
+      label: 'MANE Select',
+      value: 'select',
+      definition: faker.lorem.sentence()
+    }
+  };
+  return transcript;
+};
+
+const createOtherMANETranscript = () => {
+  const transcript = createTranscript();
+  transcript.metadata = {
+    canonical: null,
+    mane: {
+      label: 'MANE Plus Clinical',
+      value: 'plus_clinical',
+      definition: faker.lorem.sentence()
+    }
+  };
   return transcript;
 };
 
@@ -129,8 +150,8 @@ const transcriptWithSmallestSplicedLength =
 const transcriptWithGreatestExons = createTranscriptWithGreatestExons();
 const transcriptWithMediumExons = createTranscriptWithMediumExons();
 const transcriptWithSmallestExons = createTranscriptWithSmallestExons();
-const maneSelectTranscript = createTranscript();
-const otherManeTranscript = createOtherManeTranscript();
+const maneSelectTranscript = createMANETranscript();
+const otherManeTranscript = createOtherMANETranscript();
 
 describe('default sort', () => {
   it('sorts transcripts correctly', () => {

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/tests/transcripts-sorter.test.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/tests/transcripts-sorter.test.ts
@@ -110,6 +110,11 @@ const createTranscriptWithSmallestExons = () => {
   transcript.spliced_exons = [splicedExon, splicedExon];
   return transcript;
 };
+const createOtherManeTranscript = () => {
+  const transcript = createTranscript();
+  transcript.metadata.canonical = null;
+  return transcript;
+};
 
 const longProteinCodingTranscript = createLongProteinCodingTranscript();
 const shortProteinCodingTranscript = createShortProteinCodingTranscript();
@@ -124,7 +129,8 @@ const transcriptWithSmallestSplicedLength =
 const transcriptWithGreatestExons = createTranscriptWithGreatestExons();
 const transcriptWithMediumExons = createTranscriptWithMediumExons();
 const transcriptWithSmallestExons = createTranscriptWithSmallestExons();
-const canonicalTranscript = createTranscript();
+const maneSelectTranscript = createTranscript();
+const otherManeTranscript = createOtherManeTranscript();
 
 describe('default sort', () => {
   it('sorts transcripts correctly', () => {
@@ -141,12 +147,14 @@ describe('default sort', () => {
       shortNonCodingTranscript,
       shortProteinCodingTranscript,
       longNonCodingTranscript, // this is the longest
+      otherManeTranscript,
       longProteinCodingTranscript,
-      canonicalTranscript
+      maneSelectTranscript
     ];
 
     const expectedTranscripts = [
-      canonicalTranscript,
+      maneSelectTranscript,
+      otherManeTranscript,
       longProteinCodingTranscript,
       shortProteinCodingTranscript,
       longNonCodingTranscript, // its so_term is "xyz"

--- a/src/ensembl/src/shared/types/thoas/metadata.ts
+++ b/src/ensembl/src/shared/types/thoas/metadata.ts
@@ -24,6 +24,6 @@ type ManeMetadata = ValueSetMetadata;
 type CanonicalMetadata = ValueSetMetadata;
 
 export type TranscriptMetadata = {
-  mane: ManeMetadata;
-  canonical: CanonicalMetadata;
+  mane: ManeMetadata | null;
+  canonical: CanonicalMetadata | null;
 };

--- a/src/ensembl/src/shared/types/thoas/metadata.ts
+++ b/src/ensembl/src/shared/types/thoas/metadata.ts
@@ -14,13 +14,16 @@
  * limitations under the License.
  */
 
-import { Source } from './source';
+type ValueSetMetadata = {
+  value: string | number | boolean;
+  label: string;
+  definition: string;
+};
 
-export type Metadata = {
-  [key: string]: {
-    description: string;
-    value?: string;
-    source_uri?: string;
-    source?: Source;
-  };
+type ManeMetadata = ValueSetMetadata;
+type CanonicalMetadata = ValueSetMetadata;
+
+export type TranscriptMetadata = {
+  mane: ManeMetadata;
+  canonical: CanonicalMetadata;
 };

--- a/src/ensembl/src/shared/types/thoas/transcript.ts
+++ b/src/ensembl/src/shared/types/thoas/transcript.ts
@@ -19,6 +19,7 @@ import { SplicedExon } from './exon';
 import { FullProductGeneratingContext } from './productGeneratingContext';
 import { LocationWithinRegion } from './location';
 import { ExternalReference } from './externalReference';
+import { TranscriptMetadata } from './metadata';
 
 export type FullTranscript = {
   type: 'Transcript';
@@ -32,4 +33,5 @@ export type FullTranscript = {
   spliced_exons: SplicedExon[];
   product_generating_contexts: FullProductGeneratingContext[];
   external_references: ExternalReference[];
+  metadata: TranscriptMetadata;
 };

--- a/src/ensembl/tests/fixtures/entity-viewer/transcript.ts
+++ b/src/ensembl/tests/fixtures/entity-viewer/transcript.ts
@@ -79,16 +79,8 @@ export const createTranscript = (
 
 const createTranscriptMetadata = (): TranscriptMetadata => {
   return {
-    canonical: {
-      label: 'Ensembl canonical',
-      value: true,
-      definition: faker.lorem.sentence()
-    },
-    mane: {
-      label: 'MANE Select',
-      value: 'select',
-      definition: faker.lorem.sentence()
-    }
+    canonical: null,
+    mane: null
   };
 };
 

--- a/src/ensembl/tests/fixtures/entity-viewer/transcript.ts
+++ b/src/ensembl/tests/fixtures/entity-viewer/transcript.ts
@@ -29,6 +29,7 @@ import { CDNA } from 'src/shared/types/thoas/cdna';
 import { FullProductGeneratingContext } from 'src/shared/types/thoas/productGeneratingContext';
 import { ProductType } from 'src/shared/types/thoas/product';
 import { ExternalReference } from 'src/shared/types/thoas/externalReference';
+import { TranscriptMetadata } from 'ensemblRoot/src/shared/types/thoas/metadata';
 
 type ProteinCodingProductGeneratingContext = Omit<
   FullProductGeneratingContext,
@@ -71,7 +72,23 @@ export const createTranscript = (
     product_generating_contexts: [
       createProductGeneratingContext(transcriptSlice, exons)
     ],
+    metadata: createTranscriptMetadata(),
     ...fragment
+  };
+};
+
+const createTranscriptMetadata = (): TranscriptMetadata => {
+  return {
+    canonical: {
+      label: 'Ensembl canonical',
+      value: true,
+      definition: faker.lorem.sentence()
+    },
+    mane: {
+      label: 'MANE Select',
+      value: 'select',
+      definition: faker.lorem.sentence()
+    }
   };
 };
 


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-520

## Description
The default (topmost) transcript in the transcripts table will be identified with a label:

1) Labelled transcript as 'MANE Select' or 'Ensembl canonical' depending on the evidence used to identify it
2) Added logic to display additional 'MANE Plus Clinical' transcripts if any
3) Tooltip updated from the definition field coming from metadata

~NOTE: Currently it is not the topmost, we will have to tweak the sorting algorithm which will be done in another ticket.~

## Deployment URL
MANE select - http://add-ensembl-canonical.review.ensembl.org/entity-viewer/homo_sapiens_GCA_000001405_28/gene:ENSG00000139618?view=transcripts

Ensembl canonical (not Mane select) http://add-ensembl-canonical.review.ensembl.org/entity-viewer/homo_sapiens_GCA_000001405_28/gene:ENSG00000278704?view=transcripts

Multiple MANE labels http://add-ensembl-canonical.review.ensembl.org/entity-viewer/homo_sapiens_GCA_000001405_28/gene:ENSG00000187098?view=transcripts

## Views affected
Entity Viewer

### Other effects
NA

- [ ] I have created any required tests
- [ ] I have checked any requirements for Google Analytics
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
NA