### PR TITLE
ENSWBSITES-1110: Display transcript metadata in transcript accordian

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -154,6 +154,15 @@ const QUERY = gql`
             }
           }
         }
+        external_references {
+          accession_id
+          name
+          url
+          source {
+            id
+            name
+          }
+        }
         metadata {
           canonical {
             value
@@ -164,6 +173,15 @@ const QUERY = gql`
             value
             label
             definition
+          }
+          gencode_basic {
+            label
+          }
+          appris {
+            label
+          }
+          tsl {
+            label
           }
         }
       }

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -26,6 +26,7 @@ import { filterTranscriptsBySOTerm } from 'src/content/app/entity-viewer/shared/
 import {
   getExpandedTranscriptIds,
   getExpandedTranscriptDownloadIds,
+  getExpandedTranscriptMoreInfoIds,
   getFilters,
   getSortingRule
 } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors';
@@ -72,6 +73,9 @@ const DefaultTranscriptslist = (props: Props) => {
   const expandedTranscriptDownloadIds = useSelector(
     getExpandedTranscriptDownloadIds
   );
+  const expandedTranscriptMoreInfoIds = useSelector(
+    getExpandedTranscriptMoreInfoIds
+  );
   const sortingRule = useSelector(getSortingRule);
   const filters = useSelector(getFilters);
   const dispatch = useDispatch();
@@ -109,6 +113,9 @@ const DefaultTranscriptslist = (props: Props) => {
           const expandDownload = expandedTranscriptDownloadIds.includes(
             transcript.stable_id
           );
+          const expandMoreInfo = expandedTranscriptMoreInfoIds.includes(
+            transcript.stable_id
+          );
 
           return (
             <DefaultTranscriptsListItem
@@ -118,6 +125,7 @@ const DefaultTranscriptslist = (props: Props) => {
               rulerTicks={props.rulerTicks}
               expandTranscript={expandTranscript}
               expandDownload={expandDownload}
+              expandMoreInfo={expandMoreInfo}
             />
           );
         })}

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.test.tsx
@@ -51,6 +51,7 @@ describe('<DefaultTranscriptListItem />', () => {
     rulerTicks: createRulerTicks(),
     expandTranscript: false,
     expandDownload: false,
+    expandMoreInfo: false,
     toggleTranscriptInfo: toggleTranscriptInfo
   };
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
@@ -47,6 +47,7 @@ export type DefaultTranscriptListItemProps = {
   rulerTicks: TicksAndScale;
   expandTranscript: boolean;
   expandDownload: boolean;
+  expandMoreInfo: boolean;
   toggleTranscriptInfo: (id: string) => void;
 };
 
@@ -101,6 +102,7 @@ export const DefaultTranscriptListItem = (
           gene={props.gene}
           transcript={props.transcript}
           expandDownload={props.expandDownload}
+          expandMoreInfo={props.expandMoreInfo}
         />
       ) : null}
     </div>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
@@ -31,6 +31,7 @@
 .topLeft {
   grid-area: left;
   width: 190px;
+  margin-bottom: 12px;
   div {
     padding-bottom: 6px;
   }
@@ -53,7 +54,7 @@
 }
 
 .moreInformationLink {
-  padding-top: 16px;
+  padding-top: 6px;
   color: $blue;
   cursor: pointer;
 }
@@ -64,6 +65,7 @@
   grid-template-columns: 190px auto;
   grid-column-gap: 32px;
   padding-top: 6px;
+  margin-bottom: 6px;
 }
 
 .moreInfoColumn {
@@ -71,6 +73,10 @@
   div {
     padding-bottom: 6px;
   }
+}
+
+.normalText {
+  font-weight: $normal;
 }
 
 .downloadLink {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
@@ -62,6 +62,7 @@
   grid-area: moreInformation;
   display: grid;
   grid-template-columns: 190px auto;
+  grid-column-gap: 32px;
   padding-top: 6px;
 }
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
@@ -9,8 +9,9 @@
   display: grid;
   grid-template-areas:
     'left middle right'
-    'moreinformation . .'
-    'downloadLink . .'
+    'moreinformationLink . .'
+    'moreInformation moreInformation moreInformation'
+    'downloadLink . .'    
     'download download download';
   grid-column-gap: 10px;
   background: $soft-black;
@@ -51,8 +52,24 @@
   }
 }
 
-.moreInformation {
+.moreInformationLink {
   padding-top: 16px;
+  color: $blue;
+  cursor: pointer;
+}
+
+.moreInformation {
+  grid-area: moreInformation;
+  display: grid;
+  grid-template-columns: 190px auto;
+  padding-top: 6px;
+}
+
+.moreInfoColumn {
+  width: 190px;
+  div {
+    padding-bottom: 6px;
+  }
 }
 
 .downloadLink {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
@@ -63,8 +63,9 @@
   grid-area: moreInformation;
   display: grid;
   grid-template-columns: 190px auto;
-  grid-column-gap: 32px;
+  grid-column-gap: 20px;
   padding-top: 6px;
+  padding-left: 12px;
   margin-bottom: 6px;
 }
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.scss
@@ -13,7 +13,7 @@
     'moreInformation moreInformation moreInformation'
     'downloadLink . .'    
     'download download download';
-  grid-column-gap: 10px;
+  column-gap: 10px;
   background: $soft-black;
   padding: 15px 30px;
 
@@ -63,7 +63,7 @@
   grid-area: moreInformation;
   display: grid;
   grid-template-columns: 190px auto;
-  grid-column-gap: 20px;
+  column-gap: 20px;
   padding-top: 6px;
   padding-left: 12px;
   margin-bottom: 6px;

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.test.tsx
@@ -42,12 +42,15 @@ jest.mock('src/shared/components/instant-download', () => ({
 const transcript = createTranscript();
 const gene = createGene({ transcripts: [transcript] });
 const expandDownload = false;
+const expandMoreInfo = false;
 
 const defaultProps = {
   gene,
   transcript,
   expandDownload,
+  expandMoreInfo,
   toggleTranscriptDownload: jest.fn(),
+  toggleTranscriptMoreInfo: jest.fn(),
   onProteinLinkClick: jest.fn()
 };
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -131,12 +131,6 @@ export const TranscriptsListItemInfo = (
     transcript.metadata?.tsl ||
     transcript.metadata?.appris;
 
-  const moreInfoLinkStyles = classNames(styles.moreInformationLink, {
-    [styles.moreInformationLinkEnabled]: !!(
-      transcriptMetaData || transcriptCCDS
-    )
-  });
-
   const focusIdForUrl = buildFocusIdForUrl({
     type: 'gene',
     objectId: props.gene.unversioned_stable_id
@@ -162,14 +156,6 @@ export const TranscriptsListItemInfo = (
     return urlFor.browser({ genomeId: genomeId, focus: focusIdForUrl });
   };
 
-  const chevronClassForDownload = classNames(styles.chevron, {
-    [styles.chevronUp]: props.expandDownload
-  });
-
-  const chevronClassForMoreInfo = classNames(styles.chevron, {
-    [styles.chevronUp]: props.expandMoreInfo
-  });
-
   const moreInfoContent = () => {
     return (
       <>
@@ -189,6 +175,7 @@ export const TranscriptsListItemInfo = (
         {!!transcriptCCDS && (
           <div className={styles.moreInfoColumn}>
             <ExternalReference
+              classNames={{ label: styles.normalText }}
               label={'CCDS'}
               to={transcriptCCDS.url}
               linkText={transcriptCCDS.accession_id}
@@ -232,14 +219,14 @@ export const TranscriptsListItemInfo = (
         </div>
 
         {!!(transcriptMetaData || transcriptCCDS) && (
-          <ShowHide 
+          <ShowHide
             onClick={() => props.toggleTranscriptMoreInfo(transcript.stable_id)}
-            label="More Information"
+            label="More information"
             isExpanded={props.expandMoreInfo}
-            classNames={{ wrapper: styles.moreInfoLinkStyles }}                
+            classNames={{ wrapper: styles.moreInformationLink }}
           />
         )}
- 
+
         {props.expandMoreInfo && (
           <div className={styles.moreInformation}>{moreInfoContent()}</div>
         )}

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -126,10 +126,10 @@ export const TranscriptsListItemInfo = (
   const transcriptCCDS = transcript.external_references.find(
     (xref) => xref.source.name === 'CCDS'
   );
-  const transcriptMetaData =
-    transcript.metadata.gencode_basic?.label ||
-    transcript.metadata?.tsl ||
-    transcript.metadata?.appris;
+
+  const hasRelevantMetadata = (
+    ['gencode_basic', 'tsl', 'appris'] as const
+  ).some((key) => transcript.metadata[key]);
 
   const focusIdForUrl = buildFocusIdForUrl({
     type: 'gene',
@@ -159,7 +159,7 @@ export const TranscriptsListItemInfo = (
   const moreInfoContent = () => {
     return (
       <>
-        {!!transcriptMetaData && (
+        {hasRelevantMetadata && (
           <div className={styles.moreInfoColumn}>
             {transcript.metadata.gencode_basic?.label && (
               <div>{transcript.metadata.gencode_basic?.label}</div>
@@ -218,7 +218,7 @@ export const TranscriptsListItemInfo = (
           </div>
         </div>
 
-        {!!(transcriptMetaData || transcriptCCDS) && (
+        {(hasRelevantMetadata || !!transcriptCCDS) && (
           <ShowHide
             onClick={() => props.toggleTranscriptMoreInfo(transcript.stable_id)}
             label="More information"

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -123,13 +123,14 @@ export const TranscriptsListItemInfo = (
 
   const mainStyles = classNames(transcriptsListStyles.row, styles.listItemInfo);
   const midStyles = classNames(transcriptsListStyles.middle, styles.middle);
-  const transcriptCCDS = transcript.external_references.find((x) =>
-    x.accession_id.match('CCDS')
+  const transcriptCCDS = transcript.external_references.find(
+    (xref) => xref.source.name === 'CCDS'
   );
   const transcriptMetaData =
     transcript.metadata.gencode_basic?.label ||
     transcript.metadata?.tsl ||
     transcript.metadata?.appris;
+
   const moreInfoLinkStyles = classNames(styles.moreInformationLink, {
     [styles.moreInformationLinkEnabled]: !!(
       transcriptMetaData || transcriptCCDS

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/tests/transcripts-sorter.test.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/tests/transcripts-sorter.test.ts
@@ -119,7 +119,10 @@ const createMANETranscript = () => {
       label: 'MANE Select',
       value: 'select',
       definition: faker.lorem.sentence()
-    }
+    },
+    gencode_basic: null,
+    tsl: null,
+    appris: null
   };
   return transcript;
 };
@@ -132,7 +135,10 @@ const createOtherMANETranscript = () => {
       label: 'MANE Plus Clinical',
       value: 'plus_clinical',
       definition: faker.lorem.sentence()
-    }
+    },
+    gencode_basic: null,
+    tsl: null,
+    appris: null
   };
   return transcript;
 };

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/tests/transcripts-sorter.test.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/tests/transcripts-sorter.test.ts
@@ -109,36 +109,25 @@ const createTranscriptWithSmallestExons = () => {
 
 const createMANETranscript = () => {
   const transcript = createTranscript();
-  transcript.metadata = {
-    canonical: {
-      label: 'Ensembl canonical',
-      value: true,
-      definition: faker.lorem.sentence()
-    },
-    mane: {
-      label: 'MANE Select',
-      value: 'select',
-      definition: faker.lorem.sentence()
-    },
-    gencode_basic: null,
-    tsl: null,
-    appris: null
+  transcript.metadata.canonical = {
+    label: 'Ensembl canonical',
+    value: true,
+    definition: faker.lorem.sentence()
+  };
+  transcript.metadata.mane = {
+    label: 'MANE Select',
+    value: 'select',
+    definition: faker.lorem.sentence()
   };
   return transcript;
 };
 
 const createOtherMANETranscript = () => {
   const transcript = createTranscript();
-  transcript.metadata = {
-    canonical: null,
-    mane: {
-      label: 'MANE Plus Clinical',
-      value: 'plus_clinical',
-      definition: faker.lorem.sentence()
-    },
-    gencode_basic: null,
-    tsl: null,
-    appris: null
+  transcript.metadata.mane = {
+    label: 'MANE Plus Clinical',
+    value: 'plus_clinical',
+    definition: faker.lorem.sentence()
   };
   return transcript;
 };

--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors.ts
@@ -51,6 +51,13 @@ export const getExpandedTranscriptDownloadIds = (
   return transcriptsSlice?.expandedDownloadIds ?? [];
 };
 
+export const getExpandedTranscriptMoreInfoIds = (
+  state: RootState
+): string[] => {
+  const transcriptsSlice = getSliceForGene(state);
+  return transcriptsSlice?.expandedMoreInfoIds ?? [];
+};
+
 export const getFilters = (state: RootState): Filters => {
   const transcriptsSlice = getSliceForGene(state);
   return transcriptsSlice?.filters ?? {};

--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
@@ -26,7 +26,8 @@ import {
 
 import {
   getExpandedTranscriptIds,
-  getExpandedTranscriptDownloadIds
+  getExpandedTranscriptDownloadIds,
+  getExpandedTranscriptMoreInfoIds
 } from './geneViewTranscriptsSelectors';
 
 import { RootState } from 'src/store';
@@ -42,6 +43,7 @@ export enum SortingRule {
 export type TranscriptsStatePerGene = {
   expandedIds: string[];
   expandedDownloadIds: string[];
+  expandedMoreInfoIds: string[];
   filters: Filters;
   sortingRule: SortingRule;
 };
@@ -57,110 +59,129 @@ export type Filters = { [filter: string]: boolean };
 const defaultStatePerGene: TranscriptsStatePerGene = {
   expandedIds: [],
   expandedDownloadIds: [],
+  expandedMoreInfoIds: [],
   filters: {},
   sortingRule: SortingRule.DEFAULT
 };
 
-export const setFilters = (
-  filters: Filters
-): ThunkAction<void, any, null, Action<string>> => (
-  dispatch,
-  getState: () => RootState
-) => {
-  const state = getState();
-  const activeGenomeId = getEntityViewerActiveGenomeId(state);
-  const activeEntityId = getEntityViewerActiveEntityId(state);
-  if (!activeGenomeId || !activeEntityId) {
-    return;
-  }
-  dispatch(
-    transcriptsSlice.actions.updateFilters({
-      activeGenomeId,
-      activeEntityId,
-      filters
-    })
-  );
-};
+export const setFilters =
+  (filters: Filters): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const state = getState();
+    const activeGenomeId = getEntityViewerActiveGenomeId(state);
+    const activeEntityId = getEntityViewerActiveEntityId(state);
+    if (!activeGenomeId || !activeEntityId) {
+      return;
+    }
+    dispatch(
+      transcriptsSlice.actions.updateFilters({
+        activeGenomeId,
+        activeEntityId,
+        filters
+      })
+    );
+  };
 
-export const setSortingRule = (
-  sortingRule: SortingRule
-): ThunkAction<void, any, null, Action<string>> => (
-  dispatch,
-  getState: () => RootState
-) => {
-  const state = getState();
-  const activeGenomeId = getEntityViewerActiveGenomeId(state);
-  const activeEntityId = getEntityViewerActiveEntityId(state);
-  if (!activeGenomeId || !activeEntityId) {
-    return;
-  }
+export const setSortingRule =
+  (sortingRule: SortingRule): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const state = getState();
+    const activeGenomeId = getEntityViewerActiveGenomeId(state);
+    const activeEntityId = getEntityViewerActiveEntityId(state);
+    if (!activeGenomeId || !activeEntityId) {
+      return;
+    }
 
-  dispatch(
-    transcriptsSlice.actions.updateSortingRule({
-      activeGenomeId,
-      activeEntityId,
-      sortingRule
-    })
-  );
-};
+    dispatch(
+      transcriptsSlice.actions.updateSortingRule({
+        activeGenomeId,
+        activeEntityId,
+        sortingRule
+      })
+    );
+  };
 
-export const toggleTranscriptInfo = (
-  transcriptId: string
-): ThunkAction<void, any, null, Action<string>> => (
-  dispatch,
-  getState: () => RootState
-) => {
-  const state = getState();
-  const activeGenomeId = getEntityViewerActiveGenomeId(state);
-  const activeEntityId = getEntityViewerActiveEntityId(state);
-  if (!activeGenomeId || !activeEntityId) {
-    return;
-  }
+export const toggleTranscriptInfo =
+  (transcriptId: string): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const state = getState();
+    const activeGenomeId = getEntityViewerActiveGenomeId(state);
+    const activeEntityId = getEntityViewerActiveEntityId(state);
+    if (!activeGenomeId || !activeEntityId) {
+      return;
+    }
 
-  const expandedIds = new Set<string>(getExpandedTranscriptIds(state));
-  if (expandedIds.has(transcriptId)) {
-    expandedIds.delete(transcriptId);
-  } else {
-    expandedIds.add(transcriptId);
-  }
+    const expandedIds = new Set<string>(getExpandedTranscriptIds(state));
+    if (expandedIds.has(transcriptId)) {
+      expandedIds.delete(transcriptId);
+    } else {
+      expandedIds.add(transcriptId);
+    }
 
-  dispatch(
-    transcriptsSlice.actions.updateExpandedTranscripts({
-      activeGenomeId,
-      activeEntityId,
-      expandedIds: [...expandedIds.values()]
-    })
-  );
-};
+    dispatch(
+      transcriptsSlice.actions.updateExpandedTranscripts({
+        activeGenomeId,
+        activeEntityId,
+        expandedIds: [...expandedIds.values()]
+      })
+    );
+  };
 
-export const toggleTranscriptDownload = (
-  transcriptId: string
-): ThunkAction<void, any, null, Action<string>> => (
-  dispatch,
-  getState: () => RootState
-) => {
-  const state = getState();
-  const activeGenomeId = getEntityViewerActiveGenomeId(state);
-  const activeEntityId = getEntityViewerActiveEntityId(state);
-  if (!activeGenomeId || !activeEntityId) {
-    return;
-  }
+export const toggleTranscriptDownload =
+  (transcriptId: string): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const state = getState();
+    const activeGenomeId = getEntityViewerActiveGenomeId(state);
+    const activeEntityId = getEntityViewerActiveEntityId(state);
+    if (!activeGenomeId || !activeEntityId) {
+      return;
+    }
 
-  const expandedIds = new Set<string>(getExpandedTranscriptDownloadIds(state));
-  if (expandedIds.has(transcriptId)) {
-    expandedIds.delete(transcriptId);
-  } else {
-    expandedIds.add(transcriptId);
-  }
+    const expandedIds = new Set<string>(
+      getExpandedTranscriptDownloadIds(state)
+    );
+    if (expandedIds.has(transcriptId)) {
+      expandedIds.delete(transcriptId);
+    } else {
+      expandedIds.add(transcriptId);
+    }
 
-  dispatch(
-    transcriptsSlice.actions.updateExpandedDownloads({
-      activeGenomeId,
-      activeEntityId,
-      expandedIds: [...expandedIds.values()]
-    })
-  );
-};
+    dispatch(
+      transcriptsSlice.actions.updateExpandedDownloads({
+        activeGenomeId,
+        activeEntityId,
+        expandedIds: [...expandedIds.values()]
+      })
+    );
+  };
+
+export const toggleTranscriptMoreInfo =
+  (transcriptId: string): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const state = getState();
+    const activeGenomeId = getEntityViewerActiveGenomeId(state);
+    const activeEntityId = getEntityViewerActiveEntityId(state);
+    if (!activeGenomeId || !activeEntityId) {
+      return;
+    }
+
+    const expandedIds = new Set<string>(
+      getExpandedTranscriptMoreInfoIds(state)
+    );
+    if (expandedIds.has(transcriptId)) {
+      expandedIds.delete(transcriptId);
+    } else {
+      expandedIds.add(transcriptId);
+    }
+
+    dispatch(
+      transcriptsSlice.actions.updateExpandedMoreInfo({
+        activeGenomeId,
+        activeEntityId,
+        expandedIds: [...expandedIds.values()]
+      })
+    );
+  };
 
 const ensureGenePresence = (
   state: GeneViewTranscriptsState,
@@ -225,6 +246,15 @@ const transcriptsSlice = createSlice({
       const updatedState = ensureGenePresence(state, action.payload);
       return set(
         `${activeGenomeId}.${activeEntityId}.expandedDownloadIds`,
+        expandedIds,
+        updatedState
+      );
+    },
+    updateExpandedMoreInfo(state, action: PayloadAction<ExpandedIdsPayload>) {
+      const { activeGenomeId, activeEntityId, expandedIds } = action.payload;
+      const updatedState = ensureGenePresence(state, action.payload);
+      return set(
+        `${activeGenomeId}.${activeEntityId}.expandedMoreInfoIds`,
         expandedIds,
         updatedState
       );

--- a/src/ensembl/src/shared/types/thoas/metadata.ts
+++ b/src/ensembl/src/shared/types/thoas/metadata.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 type ValueSetMetadata = {
   value: string | number | boolean;
   label: string;
@@ -22,8 +21,14 @@ type ValueSetMetadata = {
 
 type ManeMetadata = ValueSetMetadata;
 type CanonicalMetadata = ValueSetMetadata;
+type GencodeBasicMetadata = ValueSetMetadata;
+type ApprisMetadata = ValueSetMetadata;
+type TSLMetadata = ValueSetMetadata;
 
 export type TranscriptMetadata = {
   mane: ManeMetadata | null;
   canonical: CanonicalMetadata | null;
+  gencode_basic: GencodeBasicMetadata | null;
+  appris: ApprisMetadata | null;
+  tsl: TSLMetadata | null;
 };

--- a/src/ensembl/tests/fixtures/entity-viewer/transcript.ts
+++ b/src/ensembl/tests/fixtures/entity-viewer/transcript.ts
@@ -80,7 +80,10 @@ export const createTranscript = (
 const createTranscriptMetadata = (): TranscriptMetadata => {
   return {
     canonical: null,
-    mane: null
+    mane: null,
+    gencode_basic: null,
+    tsl: null,
+    appris: null
   };
 };
 


### PR DESCRIPTION
- retrieve metadata from thoas (gencode_basic, tsl, appris, ccds)
- update component to display metadata

<!--
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This will normally be the development branch, so please ask your reviewer if you think it needs to go somewhere else. 
-->

## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1110

## Importance
N/A

## Description
As per jira ticket, display the transcript metadata in the accordion. There is a separate ticket to display RefSeq

## Deployment URL
http://expand-transcript.review.ensembl.org

## Views affected
entity viewer

### Other effects
None that i know of

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
None that i know of
