### PR TITLE
[ENSWBSITES-642] Preserve filters and sortRule for bookmarks

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -59,7 +59,10 @@ import { CircleLoader } from 'src/shared/components/loader/Loader';
 import { TicksAndScale } from 'src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/BasePairsRuler';
 
 import { FullGene } from 'src/shared/types/thoas/gene';
-import { SortingRule } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
+import {
+  restoreFiltersAndSort,
+  SortingRule
+} from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 
 import { ReactComponent as ChevronDown } from 'static/img/shared/chevron-down.svg';
 
@@ -198,14 +201,18 @@ const GeneView = () => {
 const COMPONENT_ID = 'entity_viewer_gene_view';
 
 const GeneViewWithData = (props: GeneViewWithDataProps) => {
+  const params: { [key: string]: string } = useParams();
+  const { entityId } = params;
+
   const [basePairsRulerTicks, setBasePairsRulerTicks] =
     useState<TicksAndScale | null>(null);
 
   const [isFilterOpen, setFilterOpen] = useState(false);
+  const dispatch = useDispatch();
 
   const sortingRule = useSelector(getSortingRule);
   const filters = useSelector(getFilters);
-  const dispatch = useDispatch();
+
   const { search } = useLocation();
   const view = new URLSearchParams(search).get('view');
 
@@ -240,6 +247,7 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
     if (!genomeId || !props.gene) {
       return;
     }
+    dispatch(restoreFiltersAndSort());
 
     dispatch(
       updatePreviouslyViewedEntities({
@@ -292,6 +300,8 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
             <TranscriptsFilter
               toggleFilter={toggleFilter}
               transcripts={props.gene.transcripts}
+              genomeId={genomeId}
+              entityId={entityId}
             />
           </div>
         )}

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.test.tsx
@@ -88,6 +88,8 @@ const wrapInRedux = (
       <TranscriptsFilter
         transcripts={transcripts}
         toggleFilter={mockToggleFilter}
+        genomeId={'mock_genome_id'}
+        entityId={'mock_entity_id'}
       />
     </Provider>
   );
@@ -100,9 +102,8 @@ describe('<TranscriptsFilter />', () => {
     const defaultSortingLabel = [...container.querySelectorAll('label')].find(
       (el) => el.textContent === 'Default'
     );
-    const defaultSortingRadioButton = defaultSortingLabel?.querySelector(
-      'input'
-    );
+    const defaultSortingRadioButton =
+      defaultSortingLabel?.querySelector('input');
     expect(defaultSortingRadioButton?.checked).toBe(true);
 
     // after we change sorting option

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
@@ -24,6 +24,12 @@ import {
   getSortingRule
 } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors';
 import {
+  updatePreviouslyViewedEntitiyFilters,
+  updatePreviouslyViewedEntitiySorting
+} from 'ensemblRoot/src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSlice';
+
+import {
+  Filters,
   setFilters,
   setSortingRule,
   SortingRule
@@ -45,6 +51,8 @@ type Transcript = Pick<FullTranscript, 'so_term'>;
 
 type Props = {
   transcripts: Transcript[];
+  genomeId: string;
+  entityId: string;
   toggleFilter: () => void;
 };
 
@@ -69,7 +77,8 @@ const TranscriptsFilter = (props: Props) => {
   const isSidebarOpen = useSelector(isEntityViewerSidebarOpen);
   const dispatch = useDispatch();
 
-  const biotypes = props.transcripts
+  const { genomeId, entityId, transcripts } = props;
+  const biotypes = transcripts
     .map((a) => a.so_term)
     .filter(Boolean) as string[];
 
@@ -99,13 +108,29 @@ const TranscriptsFilter = (props: Props) => {
 
   const onSortingRuleChange = (value: OptionValue) => {
     dispatch(setSortingRule(value as SortingRule));
+
+    dispatch(
+      updatePreviouslyViewedEntitiySorting({
+        genomeId,
+        entityId,
+        sortingRule: value as SortingRule
+      })
+    );
   };
 
   const onFilterChange = (filterName: string, isChecked: boolean) => {
-    const updatedFilters = {
+    const updatedFilters: Filters = {
       ...filters,
       [filterName]: isChecked
     };
+
+    dispatch(
+      updatePreviouslyViewedEntitiyFilters({
+        genomeId,
+        entityId,
+        filters: updatedFilters
+      })
+    );
 
     dispatch(setFilters(updatedFilters));
   };

--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
@@ -23,11 +23,14 @@ import {
   getEntityViewerActiveGenomeId,
   getEntityViewerActiveEntityId
 } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors';
+import entityViewerBookmarksStorageService from 'src/content/app/entity-viewer/services/bookmarks/entity-viewer-bookmarks-storage-service';
 
 import {
   getExpandedTranscriptIds,
   getExpandedTranscriptDownloadIds
 } from './geneViewTranscriptsSelectors';
+
+import { parseEnsObjectId } from 'ensemblRoot/src/shared/state/ens-object/ensObjectHelpers';
 
 import { RootState } from 'src/store';
 
@@ -61,106 +64,113 @@ const defaultStatePerGene: TranscriptsStatePerGene = {
   sortingRule: SortingRule.DEFAULT
 };
 
-export const setFilters = (
-  filters: Filters
-): ThunkAction<void, any, null, Action<string>> => (
-  dispatch,
-  getState: () => RootState
-) => {
-  const state = getState();
-  const activeGenomeId = getEntityViewerActiveGenomeId(state);
-  const activeEntityId = getEntityViewerActiveEntityId(state);
-  if (!activeGenomeId || !activeEntityId) {
-    return;
-  }
-  dispatch(
-    transcriptsSlice.actions.updateFilters({
-      activeGenomeId,
-      activeEntityId,
-      filters
-    })
-  );
-};
+export const restoreFiltersAndSort =
+  (): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const state = getState();
+    const activeGenomeId = getEntityViewerActiveGenomeId(state);
+    const activeEntityId = getEntityViewerActiveEntityId(state);
+    if (!activeGenomeId || !activeEntityId) {
+      return;
+    }
+    dispatch(
+      transcriptsSlice.actions.restoreFiltersAndSort({
+        activeGenomeId,
+        activeEntityId
+      })
+    );
+  };
 
-export const setSortingRule = (
-  sortingRule: SortingRule
-): ThunkAction<void, any, null, Action<string>> => (
-  dispatch,
-  getState: () => RootState
-) => {
-  const state = getState();
-  const activeGenomeId = getEntityViewerActiveGenomeId(state);
-  const activeEntityId = getEntityViewerActiveEntityId(state);
-  if (!activeGenomeId || !activeEntityId) {
-    return;
-  }
+export const setFilters =
+  (filters: Filters): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const state = getState();
+    const activeGenomeId = getEntityViewerActiveGenomeId(state);
+    const activeEntityId = getEntityViewerActiveEntityId(state);
+    if (!activeGenomeId || !activeEntityId) {
+      return;
+    }
+    dispatch(
+      transcriptsSlice.actions.updateFilters({
+        activeGenomeId,
+        activeEntityId,
+        filters
+      })
+    );
+  };
 
-  dispatch(
-    transcriptsSlice.actions.updateSortingRule({
-      activeGenomeId,
-      activeEntityId,
-      sortingRule
-    })
-  );
-};
+export const setSortingRule =
+  (sortingRule: SortingRule): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const state = getState();
+    const activeGenomeId = getEntityViewerActiveGenomeId(state);
+    const activeEntityId = getEntityViewerActiveEntityId(state);
+    if (!activeGenomeId || !activeEntityId) {
+      return;
+    }
 
-export const toggleTranscriptInfo = (
-  transcriptId: string
-): ThunkAction<void, any, null, Action<string>> => (
-  dispatch,
-  getState: () => RootState
-) => {
-  const state = getState();
-  const activeGenomeId = getEntityViewerActiveGenomeId(state);
-  const activeEntityId = getEntityViewerActiveEntityId(state);
-  if (!activeGenomeId || !activeEntityId) {
-    return;
-  }
+    dispatch(
+      transcriptsSlice.actions.updateSortingRule({
+        activeGenomeId,
+        activeEntityId,
+        sortingRule
+      })
+    );
+  };
 
-  const expandedIds = new Set<string>(getExpandedTranscriptIds(state));
-  if (expandedIds.has(transcriptId)) {
-    expandedIds.delete(transcriptId);
-  } else {
-    expandedIds.add(transcriptId);
-  }
+export const toggleTranscriptInfo =
+  (transcriptId: string): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const state = getState();
+    const activeGenomeId = getEntityViewerActiveGenomeId(state);
+    const activeEntityId = getEntityViewerActiveEntityId(state);
+    if (!activeGenomeId || !activeEntityId) {
+      return;
+    }
 
-  dispatch(
-    transcriptsSlice.actions.updateExpandedTranscripts({
-      activeGenomeId,
-      activeEntityId,
-      expandedIds: [...expandedIds.values()]
-    })
-  );
-};
+    const expandedIds = new Set<string>(getExpandedTranscriptIds(state));
+    if (expandedIds.has(transcriptId)) {
+      expandedIds.delete(transcriptId);
+    } else {
+      expandedIds.add(transcriptId);
+    }
 
-export const toggleTranscriptDownload = (
-  transcriptId: string
-): ThunkAction<void, any, null, Action<string>> => (
-  dispatch,
-  getState: () => RootState
-) => {
-  const state = getState();
-  const activeGenomeId = getEntityViewerActiveGenomeId(state);
-  const activeEntityId = getEntityViewerActiveEntityId(state);
-  if (!activeGenomeId || !activeEntityId) {
-    return;
-  }
+    dispatch(
+      transcriptsSlice.actions.updateExpandedTranscripts({
+        activeGenomeId,
+        activeEntityId,
+        expandedIds: [...expandedIds.values()]
+      })
+    );
+  };
 
-  const expandedIds = new Set<string>(getExpandedTranscriptDownloadIds(state));
-  if (expandedIds.has(transcriptId)) {
-    expandedIds.delete(transcriptId);
-  } else {
-    expandedIds.add(transcriptId);
-  }
+export const toggleTranscriptDownload =
+  (transcriptId: string): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const state = getState();
+    const activeGenomeId = getEntityViewerActiveGenomeId(state);
+    const activeEntityId = getEntityViewerActiveEntityId(state);
+    if (!activeGenomeId || !activeEntityId) {
+      return;
+    }
 
-  dispatch(
-    transcriptsSlice.actions.updateExpandedDownloads({
-      activeGenomeId,
-      activeEntityId,
-      expandedIds: [...expandedIds.values()]
-    })
-  );
-};
+    const expandedIds = new Set<string>(
+      getExpandedTranscriptDownloadIds(state)
+    );
+    if (expandedIds.has(transcriptId)) {
+      expandedIds.delete(transcriptId);
+    } else {
+      expandedIds.add(transcriptId);
+    }
+
+    dispatch(
+      transcriptsSlice.actions.updateExpandedDownloads({
+        activeGenomeId,
+        activeEntityId,
+        expandedIds: [...expandedIds.values()]
+      })
+    );
+  };
 
 const ensureGenePresence = (
   state: GeneViewTranscriptsState,
@@ -190,6 +200,11 @@ type ExpandedIdsPayload = {
   expandedIds: string[];
 };
 
+type FiltersAndSortPayload = {
+  activeGenomeId: string;
+  activeEntityId: string;
+};
+
 type UpdateFiltersPayload = {
   activeGenomeId: string;
   activeEntityId: string;
@@ -208,6 +223,34 @@ const transcriptsSlice = createSlice({
   name: 'entity-viewer-gene-view-transcripts',
   initialState: {} as GeneViewTranscriptsState,
   reducers: {
+    restoreFiltersAndSort(state, action: PayloadAction<FiltersAndSortPayload>) {
+      const { activeGenomeId, activeEntityId } = action.payload;
+
+      const previouslyViewedEntities =
+        entityViewerBookmarksStorageService.getPreviouslyViewedEntities();
+
+      const unversionedStableId = parseEnsObjectId(activeEntityId).objectId;
+
+      const previouslyViewedActiveEntitiy = previouslyViewedEntities[
+        activeGenomeId
+      ]?.find((entry) => entry.entity_id === unversionedStableId);
+      const filters = previouslyViewedActiveEntitiy?.filters || {};
+      const sortingRule =
+        previouslyViewedActiveEntitiy?.sortingRule || 'default';
+
+      const updatedState = ensureGenePresence(state, action.payload);
+      const updatedStateWithFilters = set(
+        `${activeGenomeId}.${activeEntityId}.filters`,
+        filters,
+        updatedState
+      );
+
+      return set(
+        `${activeGenomeId}.${activeEntityId}.sortingRule`,
+        sortingRule,
+        updatedStateWithFilters
+      );
+    },
     updateExpandedTranscripts(
       state,
       action: PayloadAction<ExpandedIdsPayload>


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-642


## Description
- Entity viewer gene view will now preserve the selected filters and sorting rule for each gene, along with the previously viewed entry stored in the local storage


## Deployment URL
http://filter-and-sort-state.review.ensembl.org

## Views affected
- Entity viewer -> Gene view -> Filters

### Other effects

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

