### PR TITLE
Update CSS to fix the height of the loading button spinner

### DIFF
--- a/src/ensembl/src/shared/components/loading-button/LoadingButton.scss
+++ b/src/ensembl/src/shared/components/loading-button/LoadingButton.scss
@@ -23,12 +23,13 @@
   align-items: center;
   justify-content: center;
   z-index: 1;
-}
 
-.spinner {
-  width: 20px;
-  height: 20px;
-  border-width: 2px;
+  // increase specificity to override own styles of the loader component
+  .spinner {
+    width: 20px;
+    height: 20px;
+    border-width: 2px;
+  }
 }
 
 .checkmark {


### PR DESCRIPTION
## Type
- Bug fix

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1217

## Description
A styling bug occurring occasionally due to the order in which CSS files get loaded in the browser.

Steps to reproduce the bug:
- clear site data to remove all cached files
- navigate as follows: Home page > EV icon > Species selector button > add Human38 > go to EV in launchbar > search for a gene > click on a result and view in EV from the info box > open download link in transcript image > Select anything and Download

**Bug:**
<img src="https://user-images.githubusercontent.com/6834224/126646557-ae18b0d8-cec5-44e3-8e85-941a804e5399.png" width="400" />

**After the fix:**
<img src="https://user-images.githubusercontent.com/6834224/126646520-5bb6dcf4-0881-491f-b295-0594eaaa0d5c.png" width="600"/>


## Deployment URL
http://fix-loading-button-spinner.review.ensembl.org/


## Views affected
Entity Viewer