### PR TITLE
display gene source using gene metadata.name field from thoas

### DIFF
--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/gene-summary/GeneSummary.scss
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/gene-summary/GeneSummary.scss
@@ -21,6 +21,9 @@
   margin-top: 30px;
 }
 
+.marginTop {
+  margin-top: 6px;
+}
 
 .featureDetails {
   display: flex;

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/gene-summary/GeneSummary.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/gene-summary/GeneSummary.tsx
@@ -17,19 +17,21 @@
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { gql, useQuery } from '@apollo/client';
-import { Pick2, Pick3 } from 'ts-multipick';
+import { Pick3 } from 'ts-multipick';
 import classNames from 'classnames';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import { getFormattedLocation } from 'src/shared/helpers/formatters/regionFormatter';
 import { getStrandDisplayName } from 'src/shared/helpers/formatters/strandFormatter';
 import { getGeneName } from 'src/shared/helpers/formatters/geneFormatter';
+
 import {
   buildFocusIdForUrl,
   getDisplayStableId
 } from 'src/shared/state/ens-object/ensObjectHelpers';
 import { getBrowserActiveEnsObject } from 'src/content/app/browser/browserSelectors';
 
+import ExternalReference from 'src/shared/components/external-reference/ExternalReference';
 import InstantDownloadGene from 'src/shared/components/instant-download/instant-download-gene/InstantDownloadGene';
 import ViewInApp from 'src/shared/components/view-in-app/ViewInApp';
 import CloseButton from 'src/shared/components/close-button/CloseButton';
@@ -63,6 +65,14 @@ const GENE_QUERY = gql`
           label
           value
         }
+        name {
+          accession_id
+          url
+          value
+          source {
+            name
+          }
+        }
       }
     }
   }
@@ -75,8 +85,8 @@ type Gene = Pick<
   | 'symbol'
   | 'name'
   | 'alternative_symbols'
+  | 'metadata'
 > &
-  Pick2<FullGene, 'metadata', 'biotype'> &
   Pick3<FullGene, 'slice', 'strand', 'code'> &
   Pick3<FullGene, 'slice', 'location', 'length'> & {
     transcripts: { stable_id: string }[];
@@ -136,7 +146,18 @@ const GeneSummary = () => {
 
       <div className={rowClasses}>
         <div className={styles.label}>Gene name</div>
-        <div className={styles.value}>{getGeneName(gene.name)}</div>
+        {gene.metadata.name ? (
+          <div className={styles.geneName}>
+            {getGeneName(gene.name)}
+            <ExternalReference
+              label={gene.metadata.name.source.name}
+              to={gene.metadata.name.url}
+              linkText={gene.metadata.name.accession_id}
+            />
+          </div>
+        ) : (
+          <div className={styles.geneName}>None</div>
+        )}
       </div>
 
       {gene.alternative_symbols.length > 0 && (

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/gene-summary/GeneSummary.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/gene-summary/GeneSummary.tsx
@@ -68,10 +68,6 @@ const GENE_QUERY = gql`
         name {
           accession_id
           url
-          value
-          source {
-            name
-          }
         }
       }
     }

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/gene-summary/GeneSummary.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/gene-summary/GeneSummary.tsx
@@ -146,18 +146,16 @@ const GeneSummary = () => {
 
       <div className={rowClasses}>
         <div className={styles.label}>Gene name</div>
-        {gene.metadata.name ? (
-          <div className={styles.geneName}>
-            {getGeneName(gene.name)}
+        <div className={styles.geneName}>
+          {getGeneName(gene.name)}
+          {gene.metadata.name && (
             <ExternalReference
               label={gene.metadata.name.source.name}
               to={gene.metadata.name.url}
               linkText={gene.metadata.name.accession_id}
             />
-          </div>
-        ) : (
-          <div className={styles.geneName}>None</div>
-        )}
+          )}
+        </div>
       </div>
 
       {gene.alternative_symbols.length > 0 && (

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/gene-summary/GeneSummary.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/gene-summary/GeneSummary.tsx
@@ -146,6 +146,7 @@ const GeneSummary = () => {
           {getGeneName(gene.name)}
           {gene.metadata.name && (
             <ExternalReference
+              classNames={{ container: styles.marginTop }}
               to={gene.metadata.name.url}
               linkText={gene.metadata.name.accession_id}
             />

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/gene-summary/GeneSummary.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/gene-summary/GeneSummary.tsx
@@ -150,7 +150,6 @@ const GeneSummary = () => {
           {getGeneName(gene.name)}
           {gene.metadata.name && (
             <ExternalReference
-              label={gene.metadata.name.source.name}
               to={gene.metadata.name.url}
               linkText={gene.metadata.name.accession_id}
             />

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
@@ -282,7 +282,6 @@ const TranscriptSummary = () => {
             )}
             {uniprotXref && (
               <ExternalReference
-                classNames={{ label: styles.lightText }}
                 label={'UniProtKB/Swiss-Prot'}
                 to={uniprotXref.url}
                 linkText={uniprotXref.accession_id}

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.scss
@@ -4,6 +4,9 @@
   font-size: 13px;
 }
 
+.marginTop {
+  margin-top: 6px;
+}
 
 .sectionHead {
   color: $dark-grey;

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.scss
@@ -22,7 +22,6 @@
   }
 }
 
-
 .accordionContainer {
   width: 100%;
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.test.tsx
@@ -45,11 +45,25 @@ const alternativeSymbols = [
   'gene_synonym_3'
 ];
 
+const metadata = {
+  name: {
+    accession_id: 'name_accession_id',
+    url: 'name_url',
+    value: 'name_value',
+    source: {
+      name: 'source_name',
+      id: 'source_id',
+      url: 'source_url'
+    }
+  }
+};
+
 const completeGeneData = {
   name: geneName,
   stable_id: stableId,
   symbol: geneSymbol,
-  alternative_symbols: alternativeSymbols
+  alternative_symbols: alternativeSymbols,
+  metadata: metadata
 };
 
 describe('<GeneOverview />', () => {
@@ -110,6 +124,7 @@ describe('<GeneOverview />', () => {
       const geneDetailsElement = container.querySelector('.geneDetails');
       const geneNameElement = container.querySelector('.geneName');
       const synonymsElement = container.querySelector('.synonyms');
+      const xrefElement = container.querySelector('.label');
 
       // child components
       const genePublications = container.querySelector('.genePublications');
@@ -117,6 +132,7 @@ describe('<GeneOverview />', () => {
       expect(geneDetailsElement?.textContent).toMatch(geneSymbol);
       expect(geneDetailsElement?.textContent).toMatch(stableId);
       expect(geneNameElement?.textContent).toMatch(geneName);
+      expect(xrefElement?.textContent).toMatch(metadata.name.source.name);
       expect(synonymsElement?.textContent).toMatch(
         alternativeSymbols.join(', ')
       );

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.test.tsx
@@ -48,13 +48,7 @@ const alternativeSymbols = [
 const metadata = {
   name: {
     accession_id: 'name_accession_id',
-    url: 'name_url',
-    value: 'name_value',
-    source: {
-      name: 'source_name',
-      id: 'source_id',
-      url: 'source_url'
-    }
+    url: 'name_url'
   }
 };
 
@@ -124,7 +118,9 @@ describe('<GeneOverview />', () => {
       const geneDetailsElement = container.querySelector('.geneDetails');
       const geneNameElement = container.querySelector('.geneName');
       const synonymsElement = container.querySelector('.synonyms');
-      const xrefElement = container.querySelector('.label');
+      const xrefElement = container.querySelector(
+        '.externalLinkContainer .link'
+      );
 
       // child components
       const genePublications = container.querySelector('.genePublications');
@@ -132,7 +128,7 @@ describe('<GeneOverview />', () => {
       expect(geneDetailsElement?.textContent).toMatch(geneSymbol);
       expect(geneDetailsElement?.textContent).toMatch(stableId);
       expect(geneNameElement?.textContent).toMatch(geneName);
-      expect(xrefElement?.textContent).toMatch(metadata.name.source.name);
+      expect(xrefElement?.textContent).toMatch(metadata.name.accession_id);
       expect(synonymsElement?.textContent).toMatch(
         alternativeSymbols.join(', ')
       );

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
@@ -22,6 +22,7 @@ import { getGeneName } from 'src/shared/helpers/formatters/geneFormatter';
 
 import GenePublications from '../publications/GenePublications';
 import MainAccordion from './MainAccordion';
+import ExternalReference from 'src/shared/components/external-reference/ExternalReference';
 
 import { EntityViewerParams } from 'src/content/app/entity-viewer/EntityViewer';
 import { FullGene } from 'src/shared/types/thoas/gene';
@@ -40,12 +41,25 @@ export const GENE_OVERVIEW_QUERY = gql`
       name
       stable_id
       symbol
+      metadata {
+        name {
+          accession_id
+          url
+          value
+          source {
+            name
+          }
+        }
+      }
     }
   }
 `;
 
 type Gene = Required<
-  Pick<FullGene, 'stable_id' | 'symbol' | 'name' | 'alternative_symbols'>
+  Pick<
+    FullGene,
+    'stable_id' | 'symbol' | 'name' | 'alternative_symbols' | 'metadata'
+  >
 >;
 
 const GeneOverview = () => {
@@ -81,8 +95,18 @@ const GeneOverview = () => {
       </div>
 
       <div className={styles.sectionHead}>Gene name</div>
-      <div className={styles.geneName}>{getGeneName(gene.name)}</div>
-
+      {gene.metadata.name ? (
+        <>
+          <div className={styles.geneName}>{getGeneName(gene.name)}</div>
+          <ExternalReference
+            label={gene.metadata.name.source.name}
+            to={gene.metadata.name.url}
+            linkText={gene.metadata.name.accession_id}
+          />
+        </>
+      ) : (
+        <div className={styles.geneName}>None</div>
+      )}
       <div className={styles.sectionHead}>Synonyms</div>
       <div className={styles.synonyms}>
         {gene.alternative_symbols.length

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
@@ -95,17 +95,13 @@ const GeneOverview = () => {
       </div>
 
       <div className={styles.sectionHead}>Gene name</div>
-      {gene.metadata.name ? (
-        <>
-          <div className={styles.geneName}>{getGeneName(gene.name)}</div>
-          <ExternalReference
-            label={gene.metadata.name.source.name}
-            to={gene.metadata.name.url}
-            linkText={gene.metadata.name.accession_id}
-          />
-        </>
-      ) : (
-        <div className={styles.geneName}>None</div>
+      <div className={styles.geneName}>{getGeneName(gene.name)}</div>
+      {gene.metadata.name && (
+        <ExternalReference
+          label={gene.metadata.name.source.name}
+          to={gene.metadata.name.url}
+          linkText={gene.metadata.name.accession_id}
+        />
       )}
       <div className={styles.sectionHead}>Synonyms</div>
       <div className={styles.synonyms}>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
@@ -94,6 +94,7 @@ const GeneOverview = () => {
       <div className={styles.geneName}>{getGeneName(gene.name)}</div>
       {gene.metadata.name && (
         <ExternalReference
+          classNames={{ container: styles.marginTop }}
           to={gene.metadata.name.url}
           linkText={gene.metadata.name.accession_id}
         />

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
@@ -98,7 +98,6 @@ const GeneOverview = () => {
       <div className={styles.geneName}>{getGeneName(gene.name)}</div>
       {gene.metadata.name && (
         <ExternalReference
-          label={gene.metadata.name.source.name}
           to={gene.metadata.name.url}
           linkText={gene.metadata.name.accession_id}
         />

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
@@ -45,10 +45,6 @@ export const GENE_OVERVIEW_QUERY = gql`
         name {
           accession_id
           url
-          value
-          source {
-            name
-          }
         }
       }
     }

--- a/src/ensembl/src/shared/helpers/formatters/geneFormatter.test.ts
+++ b/src/ensembl/src/shared/helpers/formatters/geneFormatter.test.ts
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
- import { getGeneName } from './geneFormatter';
-  
- describe('getGeneName', () => {
-   it('returns the correct gene display name', () => {
-     expect(getGeneName('novel transcript')).toBe('None');
-     expect(getGeneName('')).toBe('None');
-     expect(getGeneName(null)).toBe('None');
-     expect(getGeneName('Heat shock protein 101 [Source:UniProtKB/TrEMBL;Acc:Q9SPH4]')).toBe('Heat shock protein 101');
-   });
- });
+import { getGeneName } from './geneFormatter';
+
+describe('getGeneName', () => {
+  it('returns the correct gene display name', () => {
+    expect(getGeneName('novel transcript')).toBe('None');
+    expect(getGeneName('')).toBe('None');
+    expect(getGeneName(null)).toBe('None');
+  });
+});

--- a/src/ensembl/src/shared/helpers/formatters/geneFormatter.ts
+++ b/src/ensembl/src/shared/helpers/formatters/geneFormatter.ts
@@ -15,8 +15,8 @@
  */
 
 export function getGeneName(geneName: string | null) {
-  if(geneName && geneName !== 'novel transcript') {
-    return geneName.replace(/\[Source:.*\]/,'').trim();
+  if (geneName && geneName !== 'novel transcript') {
+    return geneName;
   } else {
     return 'None';
   }

--- a/src/ensembl/src/shared/types/thoas/metadata.ts
+++ b/src/ensembl/src/shared/types/thoas/metadata.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { Source } from './source';
-
 export type ValueSetMetadata = {
   value: string;
   label: string;
@@ -24,9 +22,7 @@ export type ValueSetMetadata = {
 
 export type XrefMetadata = {
   accession_id: string;
-  value: string;
   url: string;
-  source: Source;
 };
 
 type CanonicalMetadata = Omit<ValueSetMetadata, 'value'> & { value: boolean };

--- a/src/ensembl/src/shared/types/thoas/metadata.ts
+++ b/src/ensembl/src/shared/types/thoas/metadata.ts
@@ -14,10 +14,19 @@
  * limitations under the License.
  */
 
+import { Source } from './source';
+
 export type ValueSetMetadata = {
   value: string;
   label: string;
   definition: string;
+};
+
+export type XrefMetadata = {
+  accession_id: string;
+  value: string;
+  url: string;
+  source: Source;
 };
 
 type CanonicalMetadata = Omit<ValueSetMetadata, 'value'> & { value: boolean };
@@ -41,4 +50,5 @@ export type TranscriptMetadata = {
 
 export type GeneMetadata = {
   biotype: ValueSetMetadata;
+  name: XrefMetadata | null;
 };

--- a/src/ensembl/stories/shared-components/instant-download/InstantDownloadTranscript.stories.tsx
+++ b/src/ensembl/stories/shared-components/instant-download/InstantDownloadTranscript.stories.tsx
@@ -37,13 +37,7 @@ const buildProteinCodingGene = () => {
       },
       name: {
         accession_id: 'HGNC:1097',
-        value: 'B-Raf proto-oncogene, serine/threonine kinase',
-        url: 'https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:1097',
-        source: {
-          name: 'HGNC',
-          id: 'HGNC Symbol',
-          url: 'https://www.genenames.org/'
-        }
+        url: 'https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:1097'
       }
     },
     transcripts: [transcript]

--- a/src/ensembl/stories/shared-components/instant-download/InstantDownloadTranscript.stories.tsx
+++ b/src/ensembl/stories/shared-components/instant-download/InstantDownloadTranscript.stories.tsx
@@ -34,6 +34,16 @@ const buildProteinCodingGene = () => {
         label: 'Protein coding',
         value: 'protein_coding',
         definition: 'Protein coding'
+      },
+      name: {
+        accession_id: 'HGNC:1097',
+        value: 'B-Raf proto-oncogene, serine/threonine kinase',
+        url: 'https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:1097',
+        source: {
+          name: 'HGNC',
+          id: 'HGNC Symbol',
+          url: 'https://www.genenames.org/'
+        }
       }
     },
     transcripts: [transcript]

--- a/src/ensembl/stories/shared-components/instant-download/InstantDownloadTranscript.stories.tsx
+++ b/src/ensembl/stories/shared-components/instant-download/InstantDownloadTranscript.stories.tsx
@@ -29,17 +29,6 @@ const buildProteinCodingGene = () => {
   });
   const gene = createGene({
     unversioned_stable_id: 'ENSG00000157764',
-    metadata: {
-      biotype: {
-        label: 'Protein coding',
-        value: 'protein_coding',
-        definition: 'Protein coding'
-      },
-      name: {
-        accession_id: 'HGNC:1097',
-        url: 'https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:1097'
-      }
-    },
     transcripts: [transcript]
   });
   return gene;

--- a/src/ensembl/tests/fixtures/entity-viewer/gene.ts
+++ b/src/ensembl/tests/fixtures/entity-viewer/gene.ts
@@ -51,13 +51,7 @@ export const createGene = (fragment: Partial<FullGene> = {}): FullGene => {
       },
       name: {
         accession_id: faker.lorem.word(),
-        url: faker.internet.url(),
-        value: faker.lorem.words(),
-        source: {
-          name: faker.lorem.words(),
-          id: faker.lorem.word(),
-          url: faker.internet.url()
-        }
+        url: faker.internet.url()
       }
     },
     ...fragment

--- a/src/ensembl/tests/fixtures/entity-viewer/gene.ts
+++ b/src/ensembl/tests/fixtures/entity-viewer/gene.ts
@@ -48,6 +48,16 @@ export const createGene = (fragment: Partial<FullGene> = {}): FullGene => {
         label: faker.lorem.words(),
         value: faker.lorem.word(),
         definition: faker.lorem.sentence()
+      },
+      name: {
+        accession_id: faker.lorem.word(),
+        url: faker.internet.url(),
+        value: faker.lorem.words(),
+        source: {
+          name: faker.lorem.words(),
+          id: faker.lorem.word(),
+          url: faker.internet.url()
+        }
       }
     },
     ...fragment


### PR DESCRIPTION
<!--
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This will normally be the development branch, so please ask your reviewer if you think it needs to go somewhere else. 
-->

## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-958
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-957

## Importance
N/A

## Description
Displaying the gene source (symbol and name with URL) in Entity viewer and genome browser track drawer

## Deployment URL
http://xref-update.review.ensembl.org

## Views affected
Entity viewer and Genome Browser

### Other effects
N/A

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
N/A
