### PR TITLE
Update contact us form

### DIFF
--- a/src/ensembl/src/shared/components/communication-framework/CommunicationPanel.scss
+++ b/src/ensembl/src/shared/components/communication-framework/CommunicationPanel.scss
@@ -4,9 +4,10 @@ $offsetTop: 110px; // the distance between the top of the window and the top bor
 
 .wrapper {
   position: fixed;
-  width: 100%;
-  height: 100%;
   top: 1px;
+  bottom: 1px;
+  left: 0;
+  right: 0;
   z-index: 11; /* Need to go above the top bar */
 }
 
@@ -42,6 +43,22 @@ $offsetTop: 110px; // the distance between the top of the window and the top bor
 
 .panelHeader {
   margin-bottom: 20px;
+}
+
+.panelTabs {
+  grid-area: tabs;
+  display: flex;
+  align-items: center;
+  gap: 30px;
+  margin-left: 28px;
+
+  .tab {
+    font-size: 12px;
+  }
+
+  .tabDisabled {
+    color: $medium-dark-grey;
+  }
 }
 
 .panelBody {

--- a/src/ensembl/src/shared/components/communication-framework/CommunicationPanel.tsx
+++ b/src/ensembl/src/shared/components/communication-framework/CommunicationPanel.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import Overlay from 'src/shared/components/overlay/Overlay';
@@ -29,25 +29,52 @@ import styles from './CommunicationPanel.scss';
 
 const CommunicationPanel = () => {
   const showCommunicationPanel = useSelector(isCommunicationPanelOpen);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const panelWrapperRef = useRef<HTMLDivElement>(null);
 
   const dispatch = useDispatch();
-  if (!showCommunicationPanel) {
-    return null;
-  }
+
+  useEffect(() => {
+    if (showCommunicationPanel) {
+      wrapperRef.current?.addEventListener('wheel', preventScroll, {
+        passive: false
+      });
+    }
+  }, [showCommunicationPanel]);
 
   const onClose = () => {
     dispatch(toggleCommunicationPanel());
   };
 
+  const preventScroll = (e: Event) => {
+    const eventTarget = e.target as HTMLElement;
+    if (!panelWrapperRef.current?.contains(eventTarget)) {
+      // prevent possible window scrolling
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  };
+
+  if (!showCommunicationPanel) {
+    return null;
+  }
+
   return (
-    <div className={styles.wrapper}>
+    <div className={styles.wrapper} ref={wrapperRef}>
       <Overlay className={styles.overlay} />
-      <div className={styles.panelWrapper}>
+      <div ref={panelWrapperRef} className={styles.panelWrapper}>
         <div className={styles.panel}>
           <ConversationIcon
             className={styles.conversationIcon}
             onClick={onClose}
           />
+          {/* TODO: switch to the proper Tabs component when the tabs become functional */}
+          <nav className={styles.panelTabs}>
+            <span className={`${styles.tab} ${styles.tabDisabled}`}>
+              Messages
+            </span>
+            <span className={styles.tab}>Contact us</span>
+          </nav>
           <CloseButton className={styles.panelCloseButton} onClick={onClose} />
           <div className={styles.panelBody}>
             <ContactUs />

--- a/src/ensembl/src/shared/components/communication-framework/CommunicationPanel.tsx
+++ b/src/ensembl/src/shared/components/communication-framework/CommunicationPanel.tsx
@@ -17,6 +17,8 @@
 import React, { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { CommunicationPanelContextProvider } from './communicationPanelContext';
+
 import Overlay from 'src/shared/components/overlay/Overlay';
 import CloseButton from 'src/shared/components/close-button/CloseButton';
 import ContactUs from './contact-us/ContactUs';
@@ -31,6 +33,7 @@ const CommunicationPanel = () => {
   const showCommunicationPanel = useSelector(isCommunicationPanelOpen);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const panelWrapperRef = useRef<HTMLDivElement>(null);
+  const panelBodyRef = useRef<HTMLDivElement>(null);
 
   const dispatch = useDispatch();
 
@@ -60,28 +63,33 @@ const CommunicationPanel = () => {
   }
 
   return (
-    <div className={styles.wrapper} ref={wrapperRef}>
-      <Overlay className={styles.overlay} />
-      <div ref={panelWrapperRef} className={styles.panelWrapper}>
-        <div className={styles.panel}>
-          <ConversationIcon
-            className={styles.conversationIcon}
-            onClick={onClose}
-          />
-          {/* TODO: switch to the proper Tabs component when the tabs become functional */}
-          <nav className={styles.panelTabs}>
-            <span className={`${styles.tab} ${styles.tabDisabled}`}>
-              Messages
-            </span>
-            <span className={styles.tab}>Contact us</span>
-          </nav>
-          <CloseButton className={styles.panelCloseButton} onClick={onClose} />
-          <div className={styles.panelBody}>
-            <ContactUs />
+    <CommunicationPanelContextProvider value={{ panelBody: panelBodyRef }}>
+      <div className={styles.wrapper} ref={wrapperRef}>
+        <Overlay className={styles.overlay} />
+        <div ref={panelWrapperRef} className={styles.panelWrapper}>
+          <div className={styles.panel}>
+            <ConversationIcon
+              className={styles.conversationIcon}
+              onClick={onClose}
+            />
+            {/* TODO: switch to the proper Tabs component when the tabs become functional */}
+            <nav className={styles.panelTabs}>
+              <span className={`${styles.tab} ${styles.tabDisabled}`}>
+                Messages
+              </span>
+              <span className={styles.tab}>Contact us</span>
+            </nav>
+            <CloseButton
+              className={styles.panelCloseButton}
+              onClick={onClose}
+            />
+            <div className={styles.panelBody} ref={panelBodyRef}>
+              <ContactUs />
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </CommunicationPanelContextProvider>
   );
 };
 

--- a/src/ensembl/src/shared/components/communication-framework/communicationPanelContext.ts
+++ b/src/ensembl/src/shared/components/communication-framework/communicationPanelContext.ts
@@ -1,0 +1,33 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext, RefObject } from 'react';
+
+type CommunicationPanelContextType = {
+  panelBody: RefObject<HTMLDivElement> | null;
+};
+
+const initialContext: CommunicationPanelContextType = {
+  panelBody: null
+};
+
+const CommunicationPanelContext =
+  createContext<CommunicationPanelContextType>(initialContext);
+
+export const { Provider: CommunicationPanelContextProvider } =
+  CommunicationPanelContext;
+
+export default CommunicationPanelContext;

--- a/src/ensembl/src/shared/components/communication-framework/contact-us/ContactUs.tsx
+++ b/src/ensembl/src/shared/components/communication-framework/contact-us/ContactUs.tsx
@@ -33,7 +33,6 @@ const ContactUs = () => {
   if (shouldShowForm) {
     return (
       <div>
-        <Invitation />
         <Header
           title="Send us a message"
           onClick={() => setShouldShowForm(false)}

--- a/src/ensembl/src/shared/components/communication-framework/contact-us/ContactUs.tsx
+++ b/src/ensembl/src/shared/components/communication-framework/contact-us/ContactUs.tsx
@@ -60,14 +60,26 @@ const ContactUs = () => {
           service status updates.
         </p>
         <p>
-          <a href="https://www.ensembl.info/">
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://www.ensembl.info/"
+          >
             <span className={styles.socialMediaLinkText}>Ensembl Blog</span>{' '}
             <BlogIcon className={styles.icon} />{' '}
           </a>
-          <a href="https://www.facebook.com/Ensembl.org/">
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://www.facebook.com/Ensembl.org/"
+          >
             <FacebookIcon className={styles.icon} />{' '}
           </a>
-          <a href="https://twitter.com/ensembl">
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://twitter.com/ensembl"
+          >
             <TwitterIcon className={styles.icon} />
           </a>
         </p>

--- a/src/ensembl/src/shared/components/communication-framework/contact-us/contact-us-form/initial/ContactUsInitialForm.tsx
+++ b/src/ensembl/src/shared/components/communication-framework/contact-us/contact-us-form/initial/ContactUsInitialForm.tsx
@@ -233,7 +233,7 @@ const validate = (formState: State) => {
 
 const areMandatoryFieldsFilled = (formState: State) => {
   return (['name', 'email', 'subject', 'message'] as const).every(
-    (field) => formState[field]
+    (field) => formState[field].trim().length > 0
   );
 };
 

--- a/src/ensembl/src/shared/components/communication-framework/contact-us/contact-us-form/initial/ContactUsInitialForm.tsx
+++ b/src/ensembl/src/shared/components/communication-framework/contact-us/contact-us-form/initial/ContactUsInitialForm.tsx
@@ -125,8 +125,10 @@ const ContactUsInitialForm = () => {
     dispatch({ type: 'update-message', payload: value });
   }, []);
 
-  const onFileChange = useCallback((file: File) => {
-    dispatch({ type: 'add-file', payload: file });
+  const onFileChange = useCallback((fileList: FileList) => {
+    for (const file of fileList) {
+      dispatch({ type: 'add-file', payload: file });
+    }
   }, []);
 
   const deleteFile = (index: number) => {
@@ -201,7 +203,6 @@ const ContactUsInitialForm = () => {
           <Upload
             label="Click or drag a file here to upload"
             callbackWithFiles={true}
-            allowMultiple={false}
             disabled={!isFormValid}
             onChange={onFileChange}
           />

--- a/src/ensembl/src/shared/components/communication-framework/contact-us/contact-us-form/initial/ContactUsInitialForm.tsx
+++ b/src/ensembl/src/shared/components/communication-framework/contact-us/contact-us-form/initial/ContactUsInitialForm.tsx
@@ -149,9 +149,10 @@ const ContactUsInitialForm = () => {
     <div className={commonStyles.container}>
       <div className={commonStyles.grid}>
         <p className={commonStyles.advisory}>
-          <span>All fields are required unless marked optional</span>
-          <span>Second line</span>
-          <span>Third line</span>
+          <span>All fields are required</span>
+          <span>
+            The size of your combined attachments should be no more than 10 MB
+          </span>
         </p>
       </div>
       <form
@@ -201,6 +202,7 @@ const ContactUsInitialForm = () => {
             label="Click or drag a file here to upload"
             callbackWithFiles={true}
             allowMultiple={false}
+            disabled={!isFormValid}
             onChange={onFileChange}
           />
         </div>

--- a/src/ensembl/src/shared/components/communication-framework/contact-us/contact-us-form/submission-success/SubmissionSuccess.scss
+++ b/src/ensembl/src/shared/components/communication-framework/contact-us/contact-us-form/submission-success/SubmissionSuccess.scss
@@ -1,4 +1,5 @@
 .submissionSuccess {
+  min-height: 570px;
 
   p {
     margin-bottom: 1rem;

--- a/src/ensembl/src/shared/components/communication-framework/contact-us/contact-us-form/submission-success/SubmissionSuccess.tsx
+++ b/src/ensembl/src/shared/components/communication-framework/contact-us/contact-us-form/submission-success/SubmissionSuccess.tsx
@@ -15,13 +15,20 @@
  */
 
 import React from 'react';
+import { useDispatch } from 'react-redux';
+
+import { toggleCommunicationPanel } from 'src/shared/state/communication/communicationSlice';
 
 import { PrimaryButton } from 'src/shared/components/button/Button';
 
 import styles from './SubmissionSuccess.scss';
 
 const SubmissionSuccess = () => {
-  const onButtonClick = () => {}; // eslint-disable-line
+  const dispatch = useDispatch();
+
+  const onButtonClick = () => {
+    dispatch(toggleCommunicationPanel());
+  };
 
   return (
     <div className={styles.submissionSuccess}>

--- a/src/ensembl/src/shared/components/communication-framework/contact-us/contact-us-form/submission-success/SubmissionSuccess.tsx
+++ b/src/ensembl/src/shared/components/communication-framework/contact-us/contact-us-form/submission-success/SubmissionSuccess.tsx
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useEffect, useContext } from 'react';
 import { useDispatch } from 'react-redux';
+
+import CommunicationPanelContext from 'src/shared/components/communication-framework/communicationPanelContext';
 
 import { toggleCommunicationPanel } from 'src/shared/state/communication/communicationSlice';
 
@@ -25,6 +27,14 @@ import styles from './SubmissionSuccess.scss';
 
 const SubmissionSuccess = () => {
   const dispatch = useDispatch();
+  const communicationPanelContext = useContext(CommunicationPanelContext);
+
+  useEffect(() => {
+    const { panelBody } = communicationPanelContext;
+    if (panelBody?.current) {
+      panelBody.current.scrollTop = 0;
+    }
+  }, []);
 
   const onButtonClick = () => {
     dispatch(toggleCommunicationPanel());

--- a/src/ensembl/src/shared/components/upload/Upload.scss
+++ b/src/ensembl/src/shared/components/upload/Upload.scss
@@ -7,12 +7,21 @@
   position: relative;
   padding: 15px 27px;
   cursor: pointer;
-  transition: background-color 0.4s;
+  transition: color 0.4s, border-color 0.4s, background-color 0.4s;
 }
 
 .defaultUploadActive {
   transition: background-color 0.4s;
   background-color: rgba(51, 173, 255, 0.2);
+}
+
+.disabledUpload {
+  border: 1px dashed $grey;
+  color: $grey;
+  display: inline-block;
+  padding: 15px 27px;
+  user-select: none;
+  transition: color 0.4s, border-color 0.4s;
 }
 
 .fileInput {

--- a/src/ensembl/src/shared/components/upload/Upload.tsx
+++ b/src/ensembl/src/shared/components/upload/Upload.tsx
@@ -73,8 +73,10 @@ export type UploadProps = {
   classNames?: {
     default?: string;
     active?: string;
+    disabled?: string;
   };
   allowMultiple?: boolean;
+  disabled?: boolean;
 } & OnChangeProps;
 
 const Upload = (props: UploadProps) => {
@@ -112,12 +114,12 @@ const Upload = (props: UploadProps) => {
     const files: FileList | null =
       get(e, 'target.files') || get(e, 'dataTransfer.files') || null;
 
-    if (!files) {
+    if (!files?.length) {
       return;
     }
 
     if (props.callbackWithFiles) {
-      // Just consider the first file if allowMultiple is true
+      // Just pass the first file to the callback if allowMultiple is true
       if (!props.allowMultiple) {
         props.onChange(files[0]);
         return;
@@ -168,6 +170,16 @@ const Upload = (props: UploadProps) => {
 
     return classNames(styles.defaultUploadActive, props.classNames.active);
   };
+
+  if (props.disabled) {
+    const elementClasses = classNames(
+      styles.disabledUpload,
+      props.classNames?.disabled
+    );
+    // using the label html tag even though there is no input
+    // to keep it the same as the label element of the enabled component (to support animations)
+    return <label className={elementClasses}>{props.label}</label>;
+  }
 
   return (
     <label


### PR DESCRIPTION
## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1228

## Description
Update to the contact us form merged in https://github.com/Ensembl/ensembl-client/pull/541

- Adds the Messages and Contact us elements (tabs) to the header of the communication panel
- Adds the disabled state to the Upload component and disables it if one of the fields of the form is empty
- Prevents body scroll when the popup is open
- Fixes the bug in the Upload component during file upload cancellation (undefined got passed to the callback)
- Closes the panel upon a press on the close button
- If the contact us form is tall enough to make the communication panel show a scrollbar, the success screen will make sure to scroll to the top of the communication panel
- Allowing adding multiple files in one go (enabling the `allowMultiple` property on the Upload component)
- Open blog or social media pages in a new tab when user clicks on their links
- When validating the form, remove the trailing white space from form values (a field filled with just white spaces is invalid)

## Remains to be done
- Panel animation on unmount
- The whole state management thing

## Deployment URL
http://contact-us-form-contd.review.ensembl.org/