### PR TITLE
Fix assets pipeline for svg files linked from scss files

### DIFF
--- a/src/ensembl/webpack/client/common.ts
+++ b/src/ensembl/webpack/client/common.ts
@@ -70,10 +70,20 @@ export default (env: Record<string, unknown>): Configuration => {
           ]
         },
 
+        {
+          test: /\.svg$/i,
+          issuer: /\.scss$/,
+          type: 'asset/resource',
+          generator: {
+            filename: 'images/[name].[hash][ext]'
+          }
+        },
+
         // use file-loader on svg's (to be able to require them as a path to the image),
         // but also use @svgr/webpack to be able to require svg's directly as React components
         {
           test: /\.svg$/,
+          issuer: { not: [/\.scss$/s] },
           use: ['@svgr/webpack', 'file-loader']
         }
       ]


### PR DESCRIPTION
## Type
- Bug fix

## Description
Fix for the broken display of svg icons used for external links in help and about pages:

<img src="https://user-images.githubusercontent.com/6834224/128435058-6865de29-ed74-4926-9914-68bcc3d54799.png" width="500" />

### Cause of the problem

All svgs were loaded using `svgr`: https://github.com/Ensembl/ensembl-client/blob/52ca46e069bd1be8884ae54d3b38d5077d9a6507/src/ensembl/webpack/client/common.ts#L75-L78 which meant they got saved as React components. Here is how such an svg currently looks like (fetched from internal-2020):

```
var _path;

function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }

import * as React from "react";

function SvgExternalLink(props) {
  return /*#__PURE__*/React.createElement("svg", _extends({
    xmlns: "http://www.w3.org/2000/svg",
    viewBox: "0 0 32 32"
  }, props), _path || (_path = /*#__PURE__*/React.createElement("path", {
    fill: "#f90",
    fillRule: "evenodd",
    clipRule: "evenodd",
    d: "M22 5.2l-.1.1-8.5 8.7c-1 1-1 2.5 0 3.5l1.2 1.2c1 1 2.5 1 3.5 0l8.5-8.7.1-.1 2.6 2.7c1 1 1.7.6 1.7-.7V1.8c0-.4-.4-.8-.8-.8h-9.8c-1.4 0-1.7.8-.7 1.8L22 5.2zM6 1C3.2 1 1 3.2 1 6v20c0 2.8 2.2 5 5 5h20c2.8 0 5-2.2 5-5V13.1v7.1L26 16v7.5c0 1.4-1.1 2.5-2.5 2.5h-15C7.1 26 6 24.9 6 23.5v-15C6 7.1 7.1 6 8.5 6H16l-4.2-5H6z"
  })));
}

export default __webpack_public_path__ + "b61aedaf02d19268d9def87159819533.svg";
```

This, of course, is an invalid svg format; so when such an svg file gets returned for a request initiated by a CSS file, the browser is unable to handle it.

### Solution

Do not use `svgr` when an svg file is requested from an `scss` file. Webpack has a special option, called `issuer`, for enabling this. This PR uses this option to separate imports from scss files from imports from tsx files. For imports from scss files, the svg is just copied to the dist folder without modification.

**Result after the fix**

<img src="https://user-images.githubusercontent.com/6834224/128435893-719da8c9-87d6-4df6-9092-76b22619bd3a.png" width="500" />

## Deployment URL
http://fix-external-links.review.ensembl.org/about