### PR TITLE
show 20 previously viewed entities

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSlice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSlice.ts
@@ -70,7 +70,7 @@ const bookmarksSlice = createSlice({
       const updatedEntites = [
         newEntity,
         ...savedEntitiesWithoutCurrentEntity
-      ].slice(0, 20);
+      ].slice(0, 21);
       state.previouslyViewed[genomeId] = updatedEntites;
 
       entityViewerBookmarksStorageService.updatePreviouslyViewedEntities({


### PR DESCRIPTION

## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1207

## Description
We show 20 previously viewed but it currently show only 19 as it exclude the current entity from the 20 previously viewed entities in redux.  Fixed bu storing 21 entities in redux

## Deployment URL
N/A

## Views affected
EV

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
NA
