### PR TITLE
ENSWBSITES-967: Enable download of cDNA sequences for non-coding tran…

### DIFF
--- a/src/ensembl/src/shared/components/instant-download/instant-download-fetch/fetchSequenceChecksums.ts
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-fetch/fetchSequenceChecksums.ts
@@ -52,11 +52,11 @@ type TranscriptInResponse = {
     };
     cds: {
       sequence: Sequence;
-    };
+    } | null;
     product: {
       stable_id: string;
       sequence: Sequence;
-    };
+    } | null;
   }>;
 };
 
@@ -168,14 +168,18 @@ const processTranscriptData = (transcript: TranscriptInResponse) => {
       checksum: productGeneratingContext.cdna.sequence.checksum,
       label: `${stable_id} cdna`
     },
-    cds: {
-      checksum: productGeneratingContext.cds.sequence.checksum,
-      label: `${stable_id} cds`
-    },
-    protein: {
-      checksum: productGeneratingContext.product.sequence.checksum,
-      label: `${productGeneratingContext.product.stable_id} pep`
-    }
+    cds: productGeneratingContext.cds
+      ? {
+          checksum: productGeneratingContext.cds.sequence.checksum,
+          label: `${stable_id} cds`
+        }
+      : undefined,
+    protein: productGeneratingContext.product
+      ? {
+          checksum: productGeneratingContext.product.sequence.checksum,
+          label: `${productGeneratingContext.product.stable_id} pep`
+        }
+      : undefined
   };
 };
 

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.tsx
@@ -118,7 +118,7 @@ const InstantDownloadTranscript = (props: Props) => {
 
   const resetCheckboxes = () => {
     setIsGeneSequenceSelected(false);
-    setTranscriptOptions(defaultTranscriptOptions);
+    setTranscriptOptions(filterTranscriptOptions(biotype));
   };
 
   const onSubmit = async () => {

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.tsx
@@ -98,7 +98,7 @@ export const filterTranscriptOptions = (
 ): Partial<TranscriptOptions> => {
   return biotype === 'protein_coding'
     ? defaultTranscriptOptions
-    : pick(defaultTranscriptOptions, ['genomicSequence']);
+    : pick(defaultTranscriptOptions, ['genomicSequence', 'cdna']);
 };
 
 const InstantDownloadTranscript = (props: Props) => {


### PR DESCRIPTION
…scripts

<!--
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This will normally be the development branch, so please ask your reviewer if you think it needs to go somewhere else. 
-->

## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-967

## Importance
N/A

## Description
Enable download of cDNA sequences for non-coding transcripts

## Deployment URL
http://enable-cdnadownload.review.ensembl.org

## Views affected
Entity viewer (Instant download)
Genome browser ZMenu

### Other effects
None that i know of

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
N/A
