### PR TITLE
genome browser zmenu should use thoas instead of REST

### DIFF
--- a/src/ensembl/src/content/app/browser/zmenu/Zmenu.tsx
+++ b/src/ensembl/src/content/app/browser/zmenu/Zmenu.tsx
@@ -27,7 +27,7 @@ import {
 import ZmenuContent from './ZmenuContent';
 import ZmenuInstantDownload from './ZmenuInstantDownload';
 
-import { ZmenuData, ZmenuAction, ZmenuContentFeature } from './zmenu-types';
+import { ZmenuData, ZmenuAction } from './zmenu-types';
 
 import styles from './Zmenu.scss';
 
@@ -67,7 +67,7 @@ const Zmenu = (props: ZmenuProps) => {
         >
           <ToolboxExpandableContent
             mainContent={mainContent}
-            footerContent={getToolboxFooterContent(props.content)}
+            footerContent={getToolboxFooterContent(props.id)}
           />
         </Toolbox>
       )}
@@ -93,9 +93,9 @@ const chooseDirection = (params: ZmenuProps) => {
   return x > width / 2 ? Direction.LEFT : Direction.RIGHT;
 };
 
-const getToolboxFooterContent = (content: ZmenuContentFeature[]) => (
+const getToolboxFooterContent = (id: string) => (
   <div className={styles.zmenuFooterContent}>
-    <ZmenuInstantDownload features={content} />
+    <ZmenuInstantDownload id={id} />
   </div>
 );
 

--- a/src/ensembl/src/content/app/browser/zmenu/Zmenu.tsx
+++ b/src/ensembl/src/content/app/browser/zmenu/Zmenu.tsx
@@ -27,7 +27,7 @@ import {
 import ZmenuContent from './ZmenuContent';
 import ZmenuInstantDownload from './ZmenuInstantDownload';
 
-import { ZmenuData, ZmenuAction } from './zmenu-types';
+import { ZmenuData, ZmenuAction, ZmenuContentFeature } from './zmenu-types';
 
 import styles from './Zmenu.scss';
 
@@ -44,7 +44,6 @@ export type ZmenuProps = ZmenuData & {
 
 const Zmenu = (props: ZmenuProps) => {
   const anchorRef = useRefWithRerender<HTMLDivElement>(null);
-
   const onOutsideClick = () =>
     browserMessagingService.send('bpane', {
       id: props.id,
@@ -68,7 +67,7 @@ const Zmenu = (props: ZmenuProps) => {
         >
           <ToolboxExpandableContent
             mainContent={mainContent}
-            footerContent={getToolboxFooterContent(props.id)}
+            footerContent={getToolboxFooterContent(props.content)}
           />
         </Toolbox>
       )}
@@ -94,9 +93,9 @@ const chooseDirection = (params: ZmenuProps) => {
   return x > width / 2 ? Direction.LEFT : Direction.RIGHT;
 };
 
-const getToolboxFooterContent = (id: string) => (
+const getToolboxFooterContent = (content: ZmenuContentFeature[]) => (
   <div className={styles.zmenuFooterContent}>
-    <ZmenuInstantDownload id={id} />
+    <ZmenuInstantDownload features={content} />
   </div>
 );
 

--- a/src/ensembl/src/content/app/browser/zmenu/ZmenuInstantDownload.tsx
+++ b/src/ensembl/src/content/app/browser/zmenu/ZmenuInstantDownload.tsx
@@ -23,7 +23,7 @@ import { parseFeatureId } from '../browserHelper';
 import { InstantDownloadTranscript } from 'src/shared/components/instant-download';
 import { CircleLoader } from 'src/shared/components/loader/Loader';
 
-import { FullTranscript } from 'ensemblRoot/src/shared/types/thoas/transcript';
+import { FullTranscript } from 'src/shared/types/thoas/transcript';
 
 import styles from './Zmenu.scss';
 
@@ -58,8 +58,7 @@ const ZmenuInstantDownload = (props: Props) => {
     variables: {
       genomeId,
       transcriptId
-    },
-    skip: !transcriptId
+    }
   });
 
   if (loading) {
@@ -70,7 +69,7 @@ const ZmenuInstantDownload = (props: Props) => {
     );
   }
 
-  if (!data || !transcriptId) {
+  if (!data) {
     return null;
   }
 

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.tsx
@@ -199,6 +199,7 @@ const TranscriptSection = (props: TranscriptSectionProps) => {
     transcriptOptionsOrder,
     Object.keys(options)
   );
+
   const checkboxes = orderedOptionKeys.map((key) => (
     <Checkbox
       key={key}

--- a/src/ensembl/src/shared/types/thoas/transcript.ts
+++ b/src/ensembl/src/shared/types/thoas/transcript.ts
@@ -20,6 +20,7 @@ import { FullProductGeneratingContext } from './productGeneratingContext';
 import { LocationWithinRegion } from './location';
 import { ExternalReference } from './externalReference';
 import { TranscriptMetadata } from './metadata';
+import { FullGene } from './gene';
 
 export type FullTranscript = {
   type: 'Transcript';
@@ -33,4 +34,5 @@ export type FullTranscript = {
   product_generating_contexts: FullProductGeneratingContext[];
   external_references: ExternalReference[];
   metadata: TranscriptMetadata;
+  gene: FullGene;
 };

--- a/src/ensembl/tests/fixtures/entity-viewer/gene.ts
+++ b/src/ensembl/tests/fixtures/entity-viewer/gene.ts
@@ -26,7 +26,7 @@ import { TicksAndScale } from 'src/content/app/entity-viewer/gene-view/component
 
 export const createGene = (fragment: Partial<FullGene> = {}): FullGene => {
   const geneSlice = createSlice();
-  const transcript = createTranscript();
+  const transcripts = fragment.transcripts || [createTranscript()];
 
   const unversionedStableId = faker.datatype.uuid();
   const version = 1;
@@ -40,7 +40,7 @@ export const createGene = (fragment: Partial<FullGene> = {}): FullGene => {
     symbol: faker.lorem.word(),
     name: faker.lorem.words(),
     slice: geneSlice,
-    transcripts: [transcript],
+    transcripts: transcripts,
     alternative_symbols: [],
     external_references: [],
     metadata: {

--- a/src/ensembl/tests/fixtures/entity-viewer/gene.ts
+++ b/src/ensembl/tests/fixtures/entity-viewer/gene.ts
@@ -46,7 +46,7 @@ export const createGene = (
     symbol: faker.lorem.word(),
     name: faker.lorem.words(),
     slice: geneSlice,
-    transcripts: transcripts,
+    transcripts,
     alternative_symbols: [],
     external_references: [],
     metadata: {

--- a/src/ensembl/tests/fixtures/entity-viewer/gene.ts
+++ b/src/ensembl/tests/fixtures/entity-viewer/gene.ts
@@ -19,12 +19,18 @@ import times from 'lodash/times';
 import { scaleLinear } from 'd3';
 
 import { createSlice } from './slice';
-import { createTranscript } from './transcript';
+import { createTranscript, ProteinCodingTranscript } from './transcript';
 
 import { FullGene } from 'src/shared/types/thoas/gene';
 import { TicksAndScale } from 'src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/BasePairsRuler';
 
-export const createGene = (fragment: Partial<FullGene> = {}): FullGene => {
+type GeneFixture = Omit<FullGene, 'transcripts'> & {
+  transcripts: ProteinCodingTranscript[];
+};
+
+export const createGene = (
+  fragment: Partial<GeneFixture> = {}
+): GeneFixture => {
   const geneSlice = createSlice();
   const transcripts = fragment.transcripts || [createTranscript()];
 

--- a/src/ensembl/tests/fixtures/entity-viewer/transcript.ts
+++ b/src/ensembl/tests/fixtures/entity-viewer/transcript.ts
@@ -31,15 +31,14 @@ import { FullProductGeneratingContext } from 'src/shared/types/thoas/productGene
 import { ProductType } from 'src/shared/types/thoas/product';
 import { ExternalReference } from 'src/shared/types/thoas/externalReference';
 import { TranscriptMetadata } from 'ensemblRoot/src/shared/types/thoas/metadata';
-import { createGene } from './gene';
 
 type ProteinCodingProductGeneratingContext = Omit<
   FullProductGeneratingContext,
   'cds'
 > & { cds: FullCDS };
 
-type ProteinCodingTranscript = Omit<
-  FullTranscript,
+export type ProteinCodingTranscript = Omit<
+  Omit<FullTranscript, 'gene'>,
   'product_generating_contexts'
 > & {
   product_generating_contexts: ProteinCodingProductGeneratingContext[];
@@ -74,7 +73,6 @@ export const createTranscript = (
       createProductGeneratingContext(transcriptSlice, exons)
     ],
     metadata: createTranscriptMetadata(),
-    gene: createGene({ transcripts: [] }),
     ...fragment
   };
 };

--- a/src/ensembl/tests/fixtures/entity-viewer/transcript.ts
+++ b/src/ensembl/tests/fixtures/entity-viewer/transcript.ts
@@ -31,7 +31,6 @@ import { FullProductGeneratingContext } from 'src/shared/types/thoas/productGene
 import { ProductType } from 'src/shared/types/thoas/product';
 import { ExternalReference } from 'src/shared/types/thoas/externalReference';
 import { TranscriptMetadata } from 'ensemblRoot/src/shared/types/thoas/metadata';
-import { createGene } from './gene';
 
 type ProteinCodingProductGeneratingContext = Omit<
   FullProductGeneratingContext,
@@ -39,7 +38,7 @@ type ProteinCodingProductGeneratingContext = Omit<
 > & { cds: FullCDS };
 
 type ProteinCodingTranscript = Omit<
-  FullTranscript,
+  Omit<FullTranscript, 'gene'>,
   'product_generating_contexts'
 > & {
   product_generating_contexts: ProteinCodingProductGeneratingContext[];
@@ -74,7 +73,6 @@ export const createTranscript = (
       createProductGeneratingContext(transcriptSlice, exons)
     ],
     metadata: createTranscriptMetadata(),
-    gene: createGene(),
     ...fragment
   };
 };

--- a/src/ensembl/tests/fixtures/entity-viewer/transcript.ts
+++ b/src/ensembl/tests/fixtures/entity-viewer/transcript.ts
@@ -31,6 +31,7 @@ import { FullProductGeneratingContext } from 'src/shared/types/thoas/productGene
 import { ProductType } from 'src/shared/types/thoas/product';
 import { ExternalReference } from 'src/shared/types/thoas/externalReference';
 import { TranscriptMetadata } from 'ensemblRoot/src/shared/types/thoas/metadata';
+import { createGene } from './gene';
 
 type ProteinCodingProductGeneratingContext = Omit<
   FullProductGeneratingContext,
@@ -38,7 +39,7 @@ type ProteinCodingProductGeneratingContext = Omit<
 > & { cds: FullCDS };
 
 type ProteinCodingTranscript = Omit<
-  Omit<FullTranscript, 'gene'>,
+  FullTranscript,
   'product_generating_contexts'
 > & {
   product_generating_contexts: ProteinCodingProductGeneratingContext[];
@@ -73,6 +74,7 @@ export const createTranscript = (
       createProductGeneratingContext(transcriptSlice, exons)
     ],
     metadata: createTranscriptMetadata(),
+    gene: createGene({ transcripts: [] }),
     ...fragment
   };
 };

--- a/src/ensembl/tests/fixtures/entity-viewer/transcript.ts
+++ b/src/ensembl/tests/fixtures/entity-viewer/transcript.ts
@@ -31,6 +31,7 @@ import { FullProductGeneratingContext } from 'src/shared/types/thoas/productGene
 import { ProductType } from 'src/shared/types/thoas/product';
 import { ExternalReference } from 'src/shared/types/thoas/externalReference';
 import { TranscriptMetadata } from 'ensemblRoot/src/shared/types/thoas/metadata';
+import { createGene } from './gene';
 
 type ProteinCodingProductGeneratingContext = Omit<
   FullProductGeneratingContext,
@@ -73,6 +74,7 @@ export const createTranscript = (
       createProductGeneratingContext(transcriptSlice, exons)
     ],
     metadata: createTranscriptMetadata(),
+    gene: createGene(),
     ...fragment
   };
 };


### PR DESCRIPTION
## Type

- [] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1290

## Description
Currently in the genome browser zmenu, we are checking for the transcript biotype by querying rest. This is now available from thoas and should be used instead of rest

## Deployment URL
http://use-thoas-gbzmenu.review.ensembl.org/genome-browser/homo_sapiens_GCA_000001405_28?focus=gene:ENSG00000139618&location=13:32373206-32582905

## Views affected
GB

### Other effects
N/A

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
N?A
