### PR TITLE
Show the conversation icon in production

### DIFF
--- a/src/ensembl/src/shared/components/communication-framework/ConversationIcon.tsx
+++ b/src/ensembl/src/shared/components/communication-framework/ConversationIcon.tsx
@@ -21,16 +21,10 @@ import { toggleCommunicationPanel } from 'src/shared/state/communication/communi
 import { ReactComponent as ConversationImageIcon } from 'static/img/shared/icon_conversation.svg';
 import CommunicationPanel from 'ensemblRoot/src/shared/components/communication-framework/CommunicationPanel';
 
-import { Environment, isEnvironment } from 'src/shared/helpers/environment';
-
 import styles from './ConversationIcon.scss';
 
 const ConversationIcon = () => {
   const dispatch = useDispatch();
-
-  if (isEnvironment([Environment.PRODUCTION])) {
-    return null;
-  }
 
   const onClick = () => {
     dispatch(toggleCommunicationPanel());


### PR DESCRIPTION
## Description
In order to be able to access the Contact Us form, the user must click on the conversation icon. We have been hiding it in production environment until now. Time to make it visible.

_(not including a review url, because you wouldn't be able to see the change in the review branch anyway)_