### PR TITLE
Disable text selection in buttons

### DIFF
--- a/src/ensembl/src/shared/components/button/Button.scss
+++ b/src/ensembl/src/shared/components/button/Button.scss
@@ -24,6 +24,7 @@
 .button {
   padding: 7px 18px;
   border-radius: 4px;
+  user-select: none;
   &:active,
   &:focus {
     outline: none;

--- a/src/ensembl/src/shared/utils/noEarlierThan.ts
+++ b/src/ensembl/src/shared/utils/noEarlierThan.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { from, timer, combineLatest, firstValueFrom } from 'rxjs';
-import { take } from 'rxjs/operators';
+import { of, from, timer, combineLatest, firstValueFrom } from 'rxjs';
+import { take, catchError } from 'rxjs/operators';
 
 const noEarlierThan = async <P extends Promise<any>>(
   promise: P,
@@ -23,11 +23,15 @@ const noEarlierThan = async <P extends Promise<any>>(
 ) => {
   const source$ = combineLatest([
     timer(minimumTime).pipe(take(1)),
-    from(promise)
+    from(promise).pipe(catchError((error) => of(error)))
   ]);
 
   const [, result] = await firstValueFrom(source$);
-  return result;
+  if (result instanceof Error) {
+    throw result;
+  } else {
+    return result;
+  }
 };
 
 export default noEarlierThan;


### PR DESCRIPTION
## Description

### 1. Selected text in the submission button

Looking at Ridwan's shared screen, I noticed that after the completion of the slide gesture, the button has its text selected. It isn't that noticeable on my screen, so this is what it would look like if I artificially styled text selection:

https://user-images.githubusercontent.com/6834224/130111229-95c7f986-75e0-4252-9fd1-5c7571e375a5.mp4

This PR disables text selection in buttons completely.

### 2. Instant rejection in case of errors

The helper function I wrote to delay the result of an asynchronous task for a given period of time (`noEarlierThan`) was rejecting immediately if there was an error:

https://user-images.githubusercontent.com/6834224/130116525-af004d5a-1b8a-4709-9e57-00881568361e.mp4

I've updated the function to correctly delay the errors as well as the successful results:

https://user-images.githubusercontent.com/6834224/130116634-e5fc84cf-4cbf-4e2d-8f2d-72a7c22fbf1c.mp4


## Deployment URL
http://contact-form-fixes.review.ensembl.org