### PR TITLE
Enable About Ensembl link in the Launchbar in production

### DIFF
--- a/src/ensembl/src/header/launchbar/Launchbar.scss
+++ b/src/ensembl/src/header/launchbar/Launchbar.scss
@@ -90,12 +90,3 @@
   margin-left: 0.5rem;
   margin-right: 0.5rem;
 }
-
-// For disabling temporarily the about Ensembl link in production
-.aboutEnsemblDisabled {
-  color: $medium-dark-grey;
-
-  .logotype {
-    fill: $medium-dark-grey;
-  }
-}

--- a/src/ensembl/src/header/launchbar/Launchbar.tsx
+++ b/src/ensembl/src/header/launchbar/Launchbar.tsx
@@ -99,20 +99,12 @@ const Launchbar = () => {
   );
 };
 
-// Temporarily disable the link to About Ensembl in production
-const AboutEnsembl = () =>
-  isEnvironment([Environment.DEVELOPMENT, Environment.INTERNAL]) ? (
-    <Link to="/about" className={styles.aboutEnsembl}>
-      About the
-      <Logotype className={styles.logotype} />
-      team & its work
-    </Link>
-  ) : (
-    <div className={styles.aboutEnsemblDisabled}>
-      About the
-      <Logotype className={styles.logotype} />
-      team & its work
-    </div>
-  );
+const AboutEnsembl = () => (
+  <Link to="/about" className={styles.aboutEnsembl}>
+    About the
+    <Logotype className={styles.logotype} />
+    team & its work
+  </Link>
+);
 
 export default Launchbar;


### PR DESCRIPTION
Allow visitors in production to view the About app.