### PR TITLE
Correctly reset sequence download options in InstantDownloadGene

### DIFF
--- a/src/ensembl/src/shared/components/instant-download/instant-download-gene/InstantDownloadGene.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-gene/InstantDownloadGene.tsx
@@ -19,10 +19,7 @@ import intersection from 'lodash/intersection';
 import classNames from 'classnames';
 
 import { fetchForGene } from '../instant-download-fetch/fetchForGene';
-import {
-  filterTranscriptOptions,
-  defaultTranscriptOptions
-} from '../instant-download-transcript/InstantDownloadTranscript';
+import { filterTranscriptOptions } from '../instant-download-transcript/InstantDownloadTranscript';
 
 import Checkbox from 'src/shared/components/checkbox/Checkbox';
 import InstantDownloadButton from '../instant-download-button/InstantDownloadButton';
@@ -105,7 +102,7 @@ const InstantDownloadGene = (props: Props) => {
 
   const resetCheckboxes = () => {
     setIsGeneSequenceSelected(false);
-    setTranscriptOptions(defaultTranscriptOptions);
+    setTranscriptOptions(filterTranscriptOptions(biotype));
   };
 
   const onSubmit = async () => {


### PR DESCRIPTION

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1304

## Description
Gene Download options not resetting correctly.

## Deployment URL
N/A

## Views affected
GB

### Other effects
N/A

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
N/A
