### PR TITLE
fix view-in app text wrapping issue

### DIFF
--- a/src/ensembl/src/shared/components/view-in-app/ViewInApp.scss
+++ b/src/ensembl/src/shared/components/view-in-app/ViewInApp.scss
@@ -1,8 +1,8 @@
 @import 'src/styles/common';
 
-.viewInLabel {
+.label {
   color: $grey;
-  width: 50px;
+  white-space: nowrap;
   font-size: 12px;
 }
 .viewInAppLinkButtons {


### PR DESCRIPTION

## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1307

## Description
Minor css fix to show View In app label on a single line

## Deployment URL
Very minor, can create one if needed.

## Views affected
All places where we use view in app component

### Other effects
NA

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
NA
