### PR TITLE
Fix transcript diagram errors

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -84,6 +84,7 @@ const QUERY = gql`
         location {
           start
           end
+          length
         }
         strand {
           code

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -18,7 +18,7 @@ import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Pick2, Pick3 } from 'ts-multipick';
 
-import { getFeatureCoordinates } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
+import { getFeatureLength } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
 import { getTranscriptSortingFunction } from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
 
 import { filterTranscripts } from 'src/content/app/entity-viewer/shared/helpers/transcripts-filter';
@@ -59,7 +59,7 @@ type Transcript = DefaultTranscriptListItemProps['transcript'] & {
 type Gene = DefaultTranscriptListItemProps['gene'] & {
   stable_id: FullGene['stable_id'];
   transcripts: Array<Transcript>;
-  slice: Pick2<Slice, 'location', 'start' | 'end'>;
+  slice: Pick2<Slice, 'location', 'length'>;
 };
 
 export type Props = {
@@ -134,8 +134,7 @@ const DefaultTranscriptslist = (props: Props) => {
 
 const StripedBackground = (props: Props) => {
   const { scale, ticks } = props.rulerTicks;
-  const { start: geneStart, end: geneEnd } = getFeatureCoordinates(props.gene);
-  const geneLength = geneEnd - geneStart; // FIXME should use gene length property
+  const geneLength = getFeatureLength(props.gene);
   const extendedTicks = [1, ...ticks, geneLength];
 
   const stripes = extendedTicks.map((tick) => {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript.tsx
@@ -54,11 +54,8 @@ It's possible that later we will switch to using UTRs for this purpose
 */
 
 const UnsplicedTranscript = (props: UnsplicedTranscriptProps) => {
-  const {
-    spliced_exons,
-    product_generating_contexts,
-    slice
-  } = props.transcript;
+  const { spliced_exons, product_generating_contexts, slice } =
+    props.transcript;
   const cds = product_generating_contexts[0]?.cds;
   const {
     location: { length: transcriptLength }
@@ -108,12 +105,7 @@ const Backbone = (
 ) => {
   let intervals: [number, number][] = [];
   const {
-    transcript: {
-      spliced_exons,
-      slice: {
-        location: { length: transcriptLength }
-      }
-    },
+    transcript: { spliced_exons },
     scale
   } = props;
   const backboneClasses = props.classNames?.backbone || undefined;
@@ -132,20 +124,14 @@ const Backbone = (
 
   for (let i = 0; i < spliced_exons.length; i++) {
     const {
-      relative_location: { start: exonStart, end: exonEnd }
+      relative_location: { end: exonEnd }
     } = spliced_exons[i];
-    if (i === 0) {
-      intervals.push([1, exonStart]);
-    } else {
-      const previousExon = spliced_exons[i - 1];
-      const {
-        relative_location: { end: previousExonEnd }
-      } = previousExon;
-      intervals.push([previousExonEnd, exonStart]);
-    }
 
-    if (i === spliced_exons.length - 1) {
-      intervals.push([exonEnd, transcriptLength]);
+    if (i < spliced_exons.length - 1) {
+      const {
+        relative_location: { start: nextExonStart }
+      } = spliced_exons[i + 1];
+      intervals.push([exonEnd, nextExonStart]);
     }
   }
 
@@ -163,8 +149,8 @@ const Backbone = (
           className={backboneClasses}
           y={0}
           height={1}
-          x={scale(start)}
-          width={Math.max(0, (scale(end - start) as number) - 2)}
+          x={scale(start) + 1}
+          width={Math.max(0, scale(end - start) - 2)}
         />
       ))}
     </g>


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
[ENSWBSITES-1248](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1248)

## Description
There were some issues in the transcript diagram in Entity viewer such as, gaps between some introns and exons as well as introns running into exons. I've fixed these issues to some extent, however the latter is still present in some places albeit to a lesser extent. A screenshot of a list of these transcripts is below.

Before the changes:

![image](https://user-images.githubusercontent.com/32512909/130492853-611ad2b3-45a1-40fb-a2ed-286c176fc69a.png)

After the changes:

![image](https://user-images.githubusercontent.com/32512909/130487312-d08e34e5-2340-42c5-9e0f-ffe118391d30.png)

## Deployment URL
http://transcript-diagram-errors.review.ensembl.org/

## Views affected
Entity viewer -> transcript