### PR TITLE
Use RTK-query to get gene data for track panel

### DIFF
--- a/src/ensembl/package-lock.json
+++ b/src/ensembl/package-lock.json
@@ -25,6 +25,7 @@
         "express": "4.17.1",
         "filesize": "7.0.0",
         "graphql": "15.5.1",
+        "graphql-request": "3.5.0",
         "http-proxy-middleware": "2.0.1",
         "lodash": "4.17.21",
         "query-string": "7.0.1",
@@ -13297,8 +13298,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -15922,7 +15922,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -18198,7 +18197,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -20298,6 +20296,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/extract-files": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
+      "integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==",
+      "engines": {
+        "node": "^10.17.0 || ^12.0.0 || >= 13.7.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jaydenseric"
+      }
+    },
     "node_modules/faker": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
@@ -20978,7 +20987,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
       "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -21881,6 +21889,19 @@
       "integrity": "sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw==",
       "engines": {
         "node": ">= 10.x"
+      }
+    },
+    "node_modules/graphql-request": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-3.5.0.tgz",
+      "integrity": "sha512-Io89QpfU4rqiMbqM/KwMBzKaDLOppi8FU8sEccCE4JqCgz95W9Q8bvxQ4NfPALLSMvg9nafgg8AkYRmgKSlukA==",
+      "dependencies": {
+        "cross-fetch": "^3.0.6",
+        "extract-files": "^9.0.0",
+        "form-data": "^3.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x"
       }
     },
     "node_modules/graphql-tag": {
@@ -52754,8 +52775,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -54848,7 +54868,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -56671,8 +56690,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
@@ -58342,6 +58360,11 @@
         }
       }
     },
+    "extract-files": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
+      "integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ=="
+    },
     "faker": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
@@ -58867,7 +58890,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
       "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -59559,6 +59581,16 @@
       "version": "15.5.1",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.1.tgz",
       "integrity": "sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw=="
+    },
+    "graphql-request": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-3.5.0.tgz",
+      "integrity": "sha512-Io89QpfU4rqiMbqM/KwMBzKaDLOppi8FU8sEccCE4JqCgz95W9Q8bvxQ4NfPALLSMvg9nafgg8AkYRmgKSlukA==",
+      "requires": {
+        "cross-fetch": "^3.0.6",
+        "extract-files": "^9.0.0",
+        "form-data": "^3.0.0"
+      }
     },
     "graphql-tag": {
       "version": "2.12.4",

--- a/src/ensembl/package.json
+++ b/src/ensembl/package.json
@@ -47,6 +47,7 @@
     "express": "4.17.1",
     "filesize": "7.0.0",
     "graphql": "15.5.1",
+    "graphql-request": "3.5.0",
     "http-proxy-middleware": "2.0.1",
     "lodash": "4.17.21",
     "query-string": "7.0.1",

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.scss
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.scss
@@ -21,6 +21,7 @@
 
   .value {
     grid-column: value;
+    // width: calc(100vw - 320px - 45px - 46px - 220px); // FIXME: decide whether we want to explicitly set the max-width
 
     & > span + span {
       margin-left: 10px;
@@ -47,19 +48,24 @@
 }
 
 
-.value .featureDetails {
+.transcriptQuality {
+  margin-left: 10px;
+  font-weight: $light;
+}
+
+.featureDetails {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.featureDetail {
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
-  white-space: nowrap;
   flex-wrap: nowrap;
-  overflow: hidden;
-
-  & > span:not(:nth-child(1)) {
-    margin-left: 40px;
-  }
-  & > span:nth-child(2) {
-    margin-left: 10px;
-  }
+  padding-right: 30px;
 }
 
 .featureSymbol {
@@ -87,7 +93,7 @@
 .downloadWrapper{
   display: inline-block;
   margin-left: 40px;
-  min-width: 600px;
+  min-width: 300px;
   position: relative;
 }
 

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
@@ -232,22 +232,31 @@ const TranscriptSummary = () => {
         <div className={styles.label}>Transcript</div>
         <div className={styles.value}>
           <div className={styles.featureDetails}>
-            <span className={styles.featureSymbol}>{stableId}</span>
-            <span className={styles.label}>
-              <TranscriptQualityLabel metadata={metadata} />
-            </span>
+            <div className={styles.featureDetail}>
+              <span className={styles.featureSymbol}>{stableId}</span>
+              <div className={styles.transcriptQuality}>
+                <TranscriptQualityLabel metadata={metadata} />
+              </div>
+            </div>
+
             {metadata.biotype && (
-              <>
+              <div className={styles.featureDetail}>
                 <span>{metadata.biotype.label}</span>
                 <div className={styles.questionButton}>
                   <QuestionButton helpText={metadata.biotype.definition} />
                 </div>
-              </>
+              </div>
             )}
             {transcript.slice.strand.code && (
-              <span>{getStrandDisplayName(transcript.slice.strand.code)}</span>
+              <div className={styles.featureDetail}>
+                <span>
+                  {getStrandDisplayName(transcript.slice.strand.code)}
+                </span>
+              </div>
             )}
-            <span>{getFormattedLocation(ensObjectGene.location)}</span>
+            <div className={styles.featureDetail}>
+              <span>{getFormattedLocation(ensObjectGene.location)}</span>
+            </div>
           </div>
         </div>
       </div>
@@ -330,6 +339,7 @@ const TranscriptSummary = () => {
                 }}
                 gene={{ id: gene.unversioned_stable_id }}
                 theme="light"
+                layout="vertical"
               />
               <CloseButton
                 className={styles.closeButton}

--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
@@ -25,7 +25,6 @@ import {
   getDisplayStableId,
   buildFocusIdForUrl
 } from 'src/shared/state/ens-object/ensObjectHelpers';
-import { getBrowserActiveEnsObject } from 'src/content/app/browser/browserSelectors';
 import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
 import { getGeneName } from 'src/shared/helpers/formatters/geneFormatter';
 
@@ -34,6 +33,9 @@ import {
   getNumberOfCodingExons,
   getSplicedRNALength
 } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
+
+import { useGetTrackPanelGeneQuery } from 'src/content/app/browser/state/genomeBrowserApiSlice';
+import { getBrowserActiveEnsObject } from 'src/content/app/browser/browserSelectors';
 
 import { InstantDownloadTranscript } from 'src/shared/components/instant-download';
 import ViewInApp from 'src/shared/components/view-in-app/ViewInApp';
@@ -156,10 +158,16 @@ const GENE_AND_TRANSCRIPT_QUERY = gql`
 
 const TranscriptSummary = () => {
   const ensObjectGene = useSelector(getBrowserActiveEnsObject) as EnsObjectGene;
-
-  const transcriptTrack = ensObjectGene?.track?.child_tracks?.[0];
-
   const [shouldShowDownload, showDownload] = useState(false);
+
+  const { data: geneData } = useGetTrackPanelGeneQuery({
+    genomeId: ensObjectGene.genome_id,
+    geneId: ensObjectGene.stable_id
+  });
+
+  const canonicalTranscript = geneData?.gene.transcripts.find(
+    (transcript) => transcript.metadata.canonical
+  );
 
   const { data, loading } = useQuery<{
     gene: Gene;
@@ -167,10 +175,10 @@ const TranscriptSummary = () => {
   }>(GENE_AND_TRANSCRIPT_QUERY, {
     variables: {
       geneId: ensObjectGene.stable_id,
-      transcriptId: transcriptTrack?.stable_id,
+      transcriptId: canonicalTranscript?.stable_id,
       genomeId: ensObjectGene.genome_id
     },
-    skip: !transcriptTrack?.stable_id
+    skip: !canonicalTranscript?.stable_id
   });
 
   if (loading) {

--- a/src/ensembl/src/content/app/browser/state/genomeBrowserApiSlice.ts
+++ b/src/ensembl/src/content/app/browser/state/genomeBrowserApiSlice.ts
@@ -1,0 +1,58 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createApi } from '@reduxjs/toolkit/query/react';
+import { request, ClientError } from 'graphql-request';
+
+import trackPanelGeneQuery from './queries/trackPanelGeneQuery';
+
+import type { TrackPanelGene } from './types/track-panel-gene';
+
+// FIXME: move some place more generic
+const graphqlBaseQuery =
+  ({ baseUrl }: { baseUrl: string }) =>
+  async ({ body }: { body: string }) => {
+    try {
+      const result = await request(baseUrl, body);
+      return { data: result };
+    } catch (error) {
+      if (error instanceof ClientError) {
+        return { error: { status: error.response.status, data: error } };
+      }
+      return { error: { status: 500, data: error } };
+    }
+  };
+
+type GeneQueryParams = { genomeId: string; geneId: string };
+
+export const genomeBrowserApiSlice = createApi({
+  reducerPath: 'genomeBrowserApi',
+  baseQuery: graphqlBaseQuery({
+    baseUrl: '/api/thoas'
+  }),
+  endpoints: (builder) => ({
+    getTrackPanelGene: builder.query<{ gene: TrackPanelGene }, GeneQueryParams>(
+      {
+        query: (params) => ({
+          body: trackPanelGeneQuery(params)
+        })
+      }
+    )
+  })
+});
+
+export const { getTrackPanelGene } = genomeBrowserApiSlice.endpoints;
+export const { useGetTrackPanelGeneQuery } = genomeBrowserApiSlice;

--- a/src/ensembl/src/content/app/browser/state/queries/trackPanelGeneQuery.ts
+++ b/src/ensembl/src/content/app/browser/state/queries/trackPanelGeneQuery.ts
@@ -1,0 +1,79 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from 'graphql-request';
+
+type Params = {
+  genomeId: string;
+  geneId: string;
+};
+
+const trackPanelGeneQuery = (params: Params) => gql`
+  query TrackPanelGene {
+    gene(byId: { genome_id: "${params.genomeId}", stable_id: "${params.geneId}" }) {
+      stable_id
+      unversioned_stable_id
+      symbol
+      slice {
+        region {
+          name
+        }
+        location {
+          start
+          end
+        }
+        strand {
+          code
+        }
+      }
+      metadata {
+        biotype {
+          label
+        }
+      }
+      transcripts {
+        stable_id
+        slice {
+          location {
+            length
+          }
+        }
+        product_generating_contexts {
+          product_type
+        }
+        metadata {
+          biotype {
+            label
+          }
+          canonical {
+            value
+            label
+          }
+          mane {
+            value
+            label
+            ncbi_transcript {
+              id
+              url
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export default trackPanelGeneQuery;

--- a/src/ensembl/src/content/app/browser/state/types/track-panel-gene.ts
+++ b/src/ensembl/src/content/app/browser/state/types/track-panel-gene.ts
@@ -1,0 +1,56 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Pick2, Pick3 } from 'ts-multipick';
+
+import type { FullGene } from 'src/shared/types/thoas/gene';
+import type { FullTranscript } from 'src/shared/types/thoas/transcript';
+
+type GeneFields = Pick<
+  FullGene,
+  'stable_id' | 'unversioned_stable_id' | 'symbol'
+>;
+type GeneMetadata = Pick3<FullGene, 'metadata', 'biotype', 'label'>;
+type GeneSlice = Pick3<FullGene, 'slice', 'region', 'name'> &
+  Pick3<FullGene, 'slice', 'location', 'start' | 'end'> &
+  Pick3<FullGene, 'slice', 'strand', 'code'>;
+type TranscriptFields = Pick<FullTranscript, 'stable_id'>;
+type TranscriptSlice = Pick3<FullTranscript, 'slice', 'location', 'length'>;
+type TranscriptPGCs = Pick3<
+  FullTranscript,
+  'product_generating_contexts',
+  number,
+  'product_type'
+>;
+type TranscriptMetadata = Pick3<
+  FullTranscript,
+  'metadata',
+  'biotype',
+  'label'
+> &
+  Pick2<FullTranscript, 'metadata', 'canonical'> & // FIXME: this is not quite right
+  Pick2<FullTranscript, 'metadata', 'mane'>; // FIXME: this is not quite right
+
+export type TrackPanelTranscript = TranscriptFields &
+  TranscriptSlice &
+  TranscriptPGCs &
+  TranscriptMetadata;
+
+export type TrackPanelGene = GeneFields &
+  GeneMetadata &
+  GeneSlice & {
+    transcripts: TrackPanelTranscript[];
+  };

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelGene.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelGene.tsx
@@ -21,6 +21,8 @@ import { useGetTrackPanelGeneQuery } from 'src/content/app/browser/state/genomeB
 
 import { getBrowserTrackStates } from 'src/content/app/browser/browserSelectors';
 
+import { getTranscriptMetadata as getTranscriptSupportLevel } from 'src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel';
+
 import TrackPanelListItem from './TrackPanelListItem';
 
 import { Status } from 'src/shared/types/status';
@@ -94,7 +96,8 @@ const prepareGeneTrackData = (gene: TrackPanelGeneType): EnsObjectTrack => {
     label: gene.symbol ?? gene.stable_id,
     track_id: GENE_TRACK_ID,
     stable_id: gene.stable_id,
-    description: null // FIXME: why do we need this field?
+    additional_info: gene.metadata.biotype.label,
+    description: null // FIXME: remove this field from EnsObjectTrack
   };
 };
 
@@ -110,7 +113,8 @@ const prepareTranscriptsTrackData = (
     stable_id: canonicalTranscript.stable_id,
     description: null,
     colour: 'BLUE',
-    additional_info: canonicalTranscript.metadata.biotype.label
+    additional_info: canonicalTranscript.metadata.biotype.label,
+    support_level: getTranscriptSupportLevel(canonicalTranscript)?.label
   };
   return [canonicalTranscriptTrackData];
 };

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelGene.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelGene.tsx
@@ -1,0 +1,140 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+import { useGetTrackPanelGeneQuery } from 'src/content/app/browser/state/genomeBrowserApiSlice';
+
+import { getBrowserTrackStates } from 'src/content/app/browser/browserSelectors';
+
+import TrackPanelListItem from './TrackPanelListItem';
+
+import { Status } from 'src/shared/types/status';
+import type { TrackActivityStatus } from 'src/content/app/browser/track-panel/trackPanelConfig';
+import type { EnsObjectTrack } from 'src/shared/state/ens-object/ensObjectTypes';
+import type {
+  TrackPanelGene as TrackPanelGeneType,
+  TrackPanelTranscript as TrackPanelTranscriptType
+} from 'src/content/app/browser/state/types/track-panel-gene';
+
+type TrackPanelGeneProps = {
+  genomeId: string;
+  geneId: string;
+  ensObjectId: string;
+};
+
+// TODO: change track ids
+const GENE_TRACK_ID = 'track:gene-feat';
+const TRANSCRIPT_TRACK_ID = 'track:gene-feat-1';
+
+const TrackPanelGene = (props: TrackPanelGeneProps) => {
+  const { genomeId, geneId, ensObjectId } = props;
+  const { data } = useGetTrackPanelGeneQuery({
+    genomeId,
+    geneId
+  });
+  const trackStates = useSelector(getBrowserTrackStates);
+  const trackStatusGetter = prepareTrackStatusGetter({
+    trackStates,
+    genomeId,
+    objectId: ensObjectId,
+    categoryName: 'main'
+  });
+
+  if (!data) {
+    return null;
+  }
+
+  const { gene } = data;
+  const geneTrackStatus = trackStatusGetter(GENE_TRACK_ID);
+  const transcriptTrackStatus = trackStatusGetter(TRANSCRIPT_TRACK_ID);
+
+  return (
+    <div>
+      <TrackPanelListItem
+        categoryName="main"
+        trackStatus={geneTrackStatus}
+        defaultTrackStatus={Status.SELECTED}
+        track={prepareGeneTrackData(gene)}
+      >
+        {prepareTranscriptsTrackData(gene).map((transcriptTrackData) => (
+          <TrackPanelListItem
+            key={transcriptTrackData.label}
+            categoryName="main"
+            trackStatus={transcriptTrackStatus}
+            defaultTrackStatus={Status.SELECTED}
+            track={transcriptTrackData}
+          />
+        ))}
+      </TrackPanelListItem>
+    </div>
+  );
+};
+
+// TODO: examine EnsObjectTrack
+// as we change our thinking about the EnsObject type, the EnsObjectTrack type,
+// and the TrackPanelListItem components, the functions below will need changing
+
+const prepareGeneTrackData = (gene: TrackPanelGeneType): EnsObjectTrack => {
+  return {
+    label: gene.symbol ?? gene.stable_id,
+    track_id: GENE_TRACK_ID,
+    stable_id: gene.stable_id,
+    description: null // FIXME: why do we need this field?
+  };
+};
+
+const prepareTranscriptsTrackData = (
+  gene: TrackPanelGeneType
+): EnsObjectTrack[] => {
+  const canonicalTranscript = gene.transcripts.find(
+    (transcript) => transcript.metadata.canonical
+  ) as TrackPanelTranscriptType;
+  const canonicalTranscriptTrackData = {
+    label: canonicalTranscript.stable_id,
+    track_id: TRANSCRIPT_TRACK_ID,
+    stable_id: canonicalTranscript.stable_id,
+    description: null,
+    colour: 'BLUE',
+    additional_info: canonicalTranscript.metadata.biotype.label
+  };
+  return [canonicalTranscriptTrackData];
+};
+
+type GetTrackStatusParams = {
+  trackStates: ReturnType<typeof getBrowserTrackStates>;
+  genomeId: string;
+  objectId: string;
+  categoryName: string;
+  trackId: string;
+};
+
+const prepareTrackStatusGetter =
+  (params: Omit<GetTrackStatusParams, 'trackId'>) => (trackId: string) =>
+    getTrackStatus({ ...params, trackId });
+
+const getTrackStatus = (params: GetTrackStatusParams): TrackActivityStatus => {
+  const { trackStates, genomeId, objectId, categoryName, trackId } = params;
+  const defaultTrackStatus = Status.SELECTED;
+  return (
+    trackStates?.[genomeId]?.objectTracks?.[objectId]?.[categoryName]?.[
+      trackId
+    ] ?? defaultTrackStatus
+  );
+};
+
+export default TrackPanelGene;

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.test.tsx
@@ -25,6 +25,8 @@ import { TrackSet } from '../trackPanelConfig';
 import { createGenomeCategories } from 'tests/fixtures/genomes';
 import { createTrackStates } from 'tests/fixtures/track-panel';
 
+jest.mock('./TrackPanelGene', () => () => <div className="trackPanelGene" />);
+
 jest.mock('./TrackPanelListItem', () => () => (
   <div className="trackPanelListItem" />
 ));
@@ -47,11 +49,9 @@ describe('<TrackPanelList />', () => {
     render(<TrackPanelList {...defaultProps} {...props} />);
 
   describe('rendering', () => {
-    it('renders track panel items', () => {
+    it('renders gene tracks', () => {
       const { container } = mountTrackPanelList();
-      expect(
-        container.querySelectorAll('.trackPanelListItem').length
-      ).toBeGreaterThan(0);
+      expect(container.querySelectorAll('.trackPanelGene').length).toBe(1);
     });
 
     it('does not render main track if the focus feature is a region', () => {

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelList.tsx
@@ -35,6 +35,7 @@ import { getSelectedTrackPanelTab } from '../trackPanelSelectors';
 import { getGenomeTrackCategoriesById } from 'src/shared/state/genome/genomeSelectors';
 
 import TrackPanelListItem from './TrackPanelListItem';
+import TrackPanelGene from './TrackPanelGene';
 
 import { TrackActivityStatus } from 'src/content/app/browser/track-panel/trackPanelConfig';
 import { Status } from 'src/shared/types/status';
@@ -115,13 +116,17 @@ export const TrackPanelList = (props: TrackPanelListProps) => {
 
   return (
     <div className={styles.trackPanelList}>
-      {activeEnsObject && activeEnsObject.type === 'region' ? null : (
+      {activeEnsObject?.type === 'gene' &&
+      activeGenomeId &&
+      activeEnsObject.stable_id ? (
         <section className="mainTrackItem">
-          <dl>
-            {getTrackListItem('main', activeEnsObject && activeEnsObject.track)}
-          </dl>
+          <TrackPanelGene
+            ensObjectId={activeEnsObject.object_id}
+            genomeId={activeGenomeId}
+            geneId={activeEnsObject.stable_id}
+          />
         </section>
-      )}
+      ) : null}
       {currentTrackCategories.map((category: GenomeTrackCategory) => (
         <section key={category.track_category_id}>
           <h4>{category.label}</h4>

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.test.tsx
@@ -135,7 +135,14 @@ describe('<TrackPanelListItem />', () => {
     });
 
     it('toggles the expanded/collapsed state of the track when clicked on the expand button', async () => {
-      const { container } = wrapInRedux();
+      store = mockStore(mockState);
+      const { container } = render(
+        <Provider store={store}>
+          <TrackPanelListItem {...defaultProps}>
+            <TrackPanelListItem {...defaultProps} />
+          </TrackPanelListItem>
+        </Provider>
+      );
       const expandButton = container.querySelector('.chevron') as HTMLElement;
 
       userEvent.click(expandButton);

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
@@ -66,7 +66,7 @@ import styles from './TrackPanelListItem.scss';
 // the types have been separated since the component's own props is used in the mapStateToProps function (see at the bottom)
 export type TrackPanelListItemProps = {
   categoryName: string;
-  children?: ReactNode[];
+  children?: ReactNode;
   trackStatus: TrackActivityStatus;
   defaultTrackStatus: TrackActivityStatus;
   track: EnsObjectTrack;

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
@@ -223,7 +223,7 @@ export const TrackPanelListItem = (props: TrackPanelListItemProps) => {
               {track.additional_info}
             </span>
           )}
-          {track.child_tracks && (
+          {props.children && (
             <Chevron
               onClick={toggleExpand}
               direction={isCollapsed ? 'down' : 'up'}

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel.tsx
@@ -26,7 +26,7 @@ type Props = {
   metadata: Pick<TranscriptMetadata, 'canonical' | 'mane'>;
 };
 
-const getTranscriptMetadata = (props: Props) => {
+export const getTranscriptMetadata = (props: Props) => {
   const { canonical, mane } = props.metadata;
   if (canonical && mane) {
     return {

--- a/src/ensembl/src/root/rootReducer.ts
+++ b/src/ensembl/src/root/rootReducer.ts
@@ -18,6 +18,7 @@ import { combineReducers } from 'redux';
 import { connectRouter } from 'connected-react-router';
 
 import browser from '../content/app/browser/browserReducer';
+import { genomeBrowserApiSlice } from '../content/app/browser/state/genomeBrowserApiSlice';
 import drawer from '../content/app/browser/drawer/drawerReducer';
 import genome from '../shared/state/genome/genomeReducer';
 import customDownload from '../content/app/custom-download/state/customDownloadReducer';
@@ -44,7 +45,9 @@ const createRootReducer = (history: any) =>
     router: connectRouter(history),
     speciesSelector,
     speciesPage,
-    entityViewer
+    entityViewer,
+
+    [genomeBrowserApiSlice.reducerPath]: genomeBrowserApiSlice.reducer
   });
 
 export const createServerSideRootReducer = () =>

--- a/src/ensembl/src/shared/state/ens-object/ensObjectActions.ts
+++ b/src/ensembl/src/shared/state/ens-object/ensObjectActions.ts
@@ -133,8 +133,6 @@ const buildGeneObject = (params: any): EnsObjectGene => {
     stable_id: params.gene.unversioned_stable_id,
     versioned_stable_id: params.gene.stable_id,
     bio_type: '',
-    strand,
-    description: null,
-    track: null
+    strand
   };
 };

--- a/src/ensembl/src/shared/state/ens-object/ensObjectActions.ts
+++ b/src/ensembl/src/shared/state/ens-object/ensObjectActions.ts
@@ -32,6 +32,7 @@ import { getGenomeExampleFocusObjects } from 'src/shared/state/genome/genomeSele
 import { getEnsObjectLoadingStatus } from 'src/shared/state/ens-object/ensObjectSelectors';
 
 import { EnsObject, EnsObjectGene } from './ensObjectTypes';
+import type { TrackPanelGene } from 'src/content/app/browser/state/types/track-panel-gene';
 import { RootState } from 'src/store';
 
 export const fetchEnsObjectAsyncActions = createAsyncAction(
@@ -85,7 +86,7 @@ export const fetchEnsObject =
       const geneEnsObject = buildGeneObject({
         objectId: buildEnsObjectId(payload),
         genomeId,
-        gene: result.data?.gene
+        gene: result.data?.gene as TrackPanelGene
       });
 
       dispatch(
@@ -110,8 +111,14 @@ export const fetchExampleEnsObjects =
     });
   };
 
+type BuildGeneObjectParams = {
+  genomeId: string;
+  objectId: string;
+  gene: TrackPanelGene;
+};
+
 // FIXME: many fields here are unnecessary for an ensObject
-const buildGeneObject = (params: any): EnsObjectGene => {
+const buildGeneObject = (params: BuildGeneObjectParams): EnsObjectGene => {
   const {
     slice: {
       location: { start, end },
@@ -124,7 +131,7 @@ const buildGeneObject = (params: any): EnsObjectGene => {
     type: 'gene',
     object_id: params.objectId,
     genome_id: params.genomeId,
-    label: params.gene.symbol,
+    label: params.gene.symbol || params.gene.stable_id,
     location: {
       chromosome,
       start,
@@ -132,7 +139,7 @@ const buildGeneObject = (params: any): EnsObjectGene => {
     },
     stable_id: params.gene.unversioned_stable_id,
     versioned_stable_id: params.gene.stable_id,
-    bio_type: '',
+    bio_type: params.gene.metadata.biotype.label,
     strand
   };
 };

--- a/src/ensembl/src/shared/state/ens-object/ensObjectTypes.ts
+++ b/src/ensembl/src/shared/state/ens-object/ensObjectTypes.ts
@@ -34,8 +34,8 @@ type BasicEnsObject = {
 
 export type EnsObjectGene = BasicEnsObject & {
   type: 'gene';
-  stable_id: string | null;
-  versioned_stable_id: string | null;
+  stable_id: string;
+  versioned_stable_id: string;
   bio_type: string;
   strand: Strand;
   description: string | null;
@@ -60,11 +60,4 @@ export type EnsObjectTrack = {
   description: string | null;
 };
 
-/*
-TODO: discuss with BE whether they want to put ensObject data inside
-a root-level namespace key, so the response type becomes:
-{
-  ens_object: EnsObject
-}
-*/
 export type EnsObjectResponse = EnsObjectGene;

--- a/src/ensembl/src/shared/state/ens-object/ensObjectTypes.ts
+++ b/src/ensembl/src/shared/state/ens-object/ensObjectTypes.ts
@@ -38,8 +38,6 @@ export type EnsObjectGene = BasicEnsObject & {
   versioned_stable_id: string;
   bio_type: string;
   strand: Strand;
-  description: string | null;
-  track: EnsObjectTrack | null;
 };
 
 export type EnsObjectRegion = BasicEnsObject & {

--- a/src/ensembl/src/store.ts
+++ b/src/ensembl/src/store.ts
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-import { configureStore, getDefaultMiddleware } from '@reduxjs/toolkit';
+import { configureStore } from '@reduxjs/toolkit';
 import { createBrowserHistory } from 'history';
 import { routerMiddleware } from 'connected-react-router';
 import { StateType } from 'typesafe-actions';
 import { createEpicMiddleware } from 'redux-observable';
 
 import config from 'config';
+
+import { genomeBrowserApiSlice } from './content/app/browser/state/genomeBrowserApiSlice';
 
 import createRootReducer from './root/rootReducer';
 import { analyticsMiddleWare } from './analyticsMiddleware';
@@ -35,10 +37,10 @@ const rootReducer = createRootReducer(history);
 export type RootState = StateType<typeof rootReducer>;
 
 const middleware = [
-  ...getDefaultMiddleware(),
   routerMiddleware(history),
   epicMiddleware,
-  analyticsMiddleWare
+  analyticsMiddleWare,
+  genomeBrowserApiSlice.middleware
 ];
 
 const preloadedState = (window as any).__PRELOADED_STATE__ || {};
@@ -46,7 +48,8 @@ const preloadedState = (window as any).__PRELOADED_STATE__ || {};
 export default function getReduxStore() {
   const store = configureStore({
     reducer: rootReducer,
-    middleware,
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware().concat(middleware),
     devTools: config.isDevelopment,
     preloadedState
   });

--- a/src/ensembl/tests/fixtures/ens-object.ts
+++ b/src/ensembl/tests/fixtures/ens-object.ts
@@ -35,9 +35,7 @@ export const createEnsObject = (objectType?: EnsObjectType): EnsObject => {
     type,
     stable_id: faker.lorem.word(),
     versioned_stable_id: faker.lorem.word(),
-    strand: Strand.FORWARD,
-    description: faker.lorem.words(),
-    track: createTrackInfo()
+    strand: Strand.FORWARD
   };
 };
 
@@ -51,12 +49,3 @@ const createLocation = () => {
     end: endPosition
   };
 };
-
-const createTrackInfo = () => ({
-  label: faker.lorem.word(),
-  object_id: faker.lorem.word(),
-  support_level: null,
-  track_id: faker.lorem.word(),
-  description: null,
-  stable_id: faker.lorem.words()
-});


### PR DESCRIPTION
## Description
Proposed as an alternative for https://github.com/Ensembl/ensembl-client/pull/552

- Uses redux-toolkit query rather than Apollo client to fetch gene data from Thoas
- The result of the query is currently used to display the tracks for the gene and its transcript; but there are other components on the genome browser page that can use this query (specifically, the top bar with a brief gene summary).

## Questions
- Should the query for the gene fetch the extra information that will appear in the drawer, or will we send a dedicated request when the user opens the drawer
- What is the best name for the typescript type that describes the gene data that has been fetched? I've called it `TrackPanelGene`, but I don't particularly like this name, because the fetched data will be used in several components, not just in the track panel.

## Future steps (in subsequent PRs)
- Remove the `bio_type` and the  `strand` fields from following the `EnsObjectGene` type
- Review and simplify `EnsObjectTrack` type
- Figure out how to properly pass information about transcript from the track panel to the `TranscriptSummary` component in the drawer (we are currently losing this information)
- Possibly rework the props of the `TrackPanelListItem` component to move from biological field names defined in the `track` prop to presentational field names, so that this component can support different track types
- Remove data fetching via Apollo client and move to RTK-query

## Deployment URL
http://track-panel-alternative.review.ensembl.org/

## Views affected
Genome browser