### PR TITLE
Fix invalid query param breaking Entity Viewer

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -345,7 +345,7 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
 };
 
 const ensureGeneViewExists = (view: string) =>
-  !!Object.values(View).some((value) => value === view);
+  Object.values(View).some((value) => value === view);
 
 const useGeneViewRouting = () => {
   const dispatch = useDispatch();

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -345,7 +345,7 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
 };
 
 const ensureGeneViewExists = (view: string) =>
-  !!Object.values(View).find((value) => value === view);
+  !!Object.values(View).some((value) => value === view);
 
 const useGeneViewRouting = () => {
   const dispatch = useDispatch();

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -344,6 +344,9 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
   );
 };
 
+const ensureGeneViewExists = (view: string) =>
+  !!Object.values(View).find((value) => value === view);
+
 const useGeneViewRouting = () => {
   const dispatch = useDispatch();
   const params: { [key: string]: string } = useParams();
@@ -361,7 +364,7 @@ const useGeneViewRouting = () => {
 
   useEffect(() => {
     if (view && viewInRedux !== view) {
-      if (view in View) {
+      if (ensureGeneViewExists(view)) {
         dispatch(updateView(view as View));
       } else {
         const url = urlFor.entityViewer({

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -361,7 +361,17 @@ const useGeneViewRouting = () => {
 
   useEffect(() => {
     if (view && viewInRedux !== view) {
-      dispatch(updateView(view as View));
+      if (view in View) {
+        dispatch(updateView(view as View));
+      } else {
+        const url = urlFor.entityViewer({
+          genomeId,
+          entityId,
+          view: View.TRANSCRIPTS,
+          proteinId
+        });
+        dispatch(replace(url));
+      }
     } else {
       const url = urlFor.entityViewer({
         genomeId,

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -344,7 +344,7 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
   );
 };
 
-const ensureGeneViewExists = (view: string) =>
+const isViewParameterValid = (view: string) =>
   Object.values(View).some((value) => value === view);
 
 const useGeneViewRouting = () => {
@@ -363,18 +363,8 @@ const useGeneViewRouting = () => {
   const selectedTabs = useSelector(getSelectedGeneViewTabs);
 
   useEffect(() => {
-    if (view && viewInRedux !== view) {
-      if (ensureGeneViewExists(view)) {
-        dispatch(updateView(view as View));
-      } else {
-        const url = urlFor.entityViewer({
-          genomeId,
-          entityId,
-          view: View.TRANSCRIPTS,
-          proteinId
-        });
-        dispatch(replace(url));
-      }
+    if (view && isViewParameterValid(view) && viewInRedux !== view) {
+      dispatch(updateView(view as View));
     } else {
       const url = urlFor.entityViewer({
         genomeId,


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
[ENSWBSITES-1274](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1274)

## Description
When we substitute the `view` query parameter in the URL to access Entity viewer, the user gets redirected to the broken error page. However, we should be instead redirect the user to the default transcripts view in Entity Viewer. This PR fixes that.

## Deployment URL
http://ev-query-param.review.ensembl.org/

## Views affected
Entity Viewer