### PR TITLE
Entity viewer panels padding update

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
@@ -15,7 +15,13 @@ $backgroundColor: $black;
   color: $white;
   display: grid;
   background-color: $backgroundColor;
-  grid-template-columns: 178px max-content;
+
+  grid-template-areas:
+  'feature-image feature-image view-in'
+  'tabs-and-filters tabs-and-filters tabs-and-filters'
+  'tab-content tab-content tab-content';
+
+  grid-template-columns: 178px 902px 1fr;
   grid-template-rows: min-content minmax(76px, auto) minmax(0, 1fr);  
   padding: 60px 20px 10px;
   height: 100%; // may need to change this later
@@ -24,11 +30,11 @@ $backgroundColor: $black;
 }
 
 .featureImage {
-  grid-area: 1 / 1 / 2 / 3;
+  grid-area: feature-image;
 }
 
 .viewInLinks {
-  grid-area: 1 / 3 / 2 / 4;
+  grid-area: view-in;
   display: grid;
   grid-template-rows: 1fr 1fr;
   align-items: end;
@@ -36,7 +42,7 @@ $backgroundColor: $black;
 }
 
 .geneViewTabs {
-  grid-area: 2 / 1 / 3 / 4;
+  grid-area: tabs-and-filters;
   display: grid;
   grid-template-areas:
                   "filter-toggle tabs"
@@ -63,7 +69,7 @@ $backgroundColor: $black;
 }
 
 .geneViewTabContent {
-  grid-area: 3 / 1 / 4 / 4;
+  grid-area: tab-content;
 }
 
 .filterLabelContainer {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.scss
@@ -15,7 +15,7 @@ $backgroundColor: $black;
   color: $white;
   display: grid;
   background-color: $backgroundColor;
-  grid-template-columns: 178px 902px 1fr;
+  grid-template-columns: 178px max-content;
   grid-template-rows: min-content minmax(76px, auto) minmax(0, 1fr);  
   padding: 60px 20px 10px;
   height: 100%; // may need to change this later

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.scss
@@ -8,8 +8,8 @@
 .panelBody {
   color: $black;
   min-height: 300px;
-  padding-right: 30px;
-  padding-bottom: 100px;
+  margin-right: 30px;
+  margin-bottom: 100px;
 }
 
 .header {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.scss
@@ -9,7 +9,7 @@
   color: $black;
   min-height: 300px;
   margin-right: 30px;
-  margin-bottom: 100px;
+  padding-bottom: 100px;
 }
 
 .header {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.scss
@@ -8,6 +8,8 @@
 .panelBody {
   color: $black;
   min-height: 300px;
+  padding-right: 30px;
+  padding-bottom: 100px;
 }
 
 .header {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-relationships/GeneRelationships.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-relationships/GeneRelationships.scss
@@ -8,8 +8,8 @@
 .panelBody {
   color: $black;
   min-height: 300px;
-  padding-right: 30px;
-  padding-bottom: 100px;
+  margin-right: 30px;
+  margin-bottom: 100px;
 }
 
 .selectedTabName {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-relationships/GeneRelationships.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-relationships/GeneRelationships.scss
@@ -9,7 +9,7 @@
   color: $black;
   min-height: 300px;
   margin-right: 30px;
-  margin-bottom: 100px;
+  padding-bottom: 100px;
 }
 
 .selectedTabName {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-relationships/GeneRelationships.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-relationships/GeneRelationships.scss
@@ -8,6 +8,8 @@
 .panelBody {
   color: $black;
   min-height: 300px;
+  padding-right: 30px;
+  padding-bottom: 100px;
 }
 
 .selectedTabName {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.scss
@@ -25,7 +25,7 @@
 
 .resourceGroup {
   display: grid;
-  grid-template-columns: [type] 178px [images] 902px;
+  grid-template-columns: [type] 178px [images] max-content;
   margin-bottom: 10px;
 
   & .resourceName {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.scss
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.scss
@@ -25,7 +25,7 @@
 
 .resourceGroup {
   display: grid;
-  grid-template-columns: [type] 178px [images] max-content;
+  grid-template-columns: [type] 178px [images] 902px;
   margin-bottom: 10px;
 
   & .resourceName {


### PR DESCRIPTION

## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1106

## Description
- Added 30px right padding & 100px bottom padding to entity viewer gene view panels
- Changed the tabContent width from `902px` to `max-content` as `padding-right: 30px` doesn't have much effect when the labels are long

## Deployment URL
http://ev-panel-padding.review.ensembl.org

## Views affected
- Entity viewer -> Gene Function panel
- Entity viewer -> Gene Relationships panel
