### PR TITLE
remove error boundary from Browser.tsx to propagate and use generic e…

### DIFF
--- a/src/ensembl/src/content/app/browser/Browser.tsx
+++ b/src/ensembl/src/content/app/browser/Browser.tsx
@@ -58,8 +58,6 @@ import TrackPanelTabs from './track-panel/track-panel-tabs/TrackPanelTabs';
 import BrowserAppBar from './browser-app-bar/BrowserAppBar';
 import Drawer from './drawer/Drawer';
 import { StandardAppLayout } from 'src/shared/components/layout';
-import ErrorBoundary from 'src/shared/components/error-boundary/ErrorBoundary';
-import { NewTechError } from 'src/shared/components/error-screen';
 import BrowserInterstitial from './interstitial/BrowserInterstitial';
 
 import { RootState } from 'src/store';
@@ -214,11 +212,7 @@ const WasmLoadingBrowserContainer = () => {
 const ErrorWrappedBrowser = () => {
   // if an error happens during loading of the browser,
   // we will be able to show custom error string
-  return (
-    <ErrorBoundary fallbackComponent={NewTechError}>
-      <WasmLoadingBrowserContainer />
-    </ErrorBoundary>
-  );
+  return <WasmLoadingBrowserContainer />;
 };
 
 export default ErrorWrappedBrowser;

--- a/src/ensembl/src/content/app/browser/Browser.tsx
+++ b/src/ensembl/src/content/app/browser/Browser.tsx
@@ -209,10 +209,4 @@ const WasmLoadingBrowserContainer = () => {
   return <ReduxConnectedBrowser />;
 };
 
-const ErrorWrappedBrowser = () => {
-  // if an error happens during loading of the browser,
-  // we will be able to show custom error string
-  return <WasmLoadingBrowserContainer />;
-};
-
-export default ErrorWrappedBrowser;
+export default WasmLoadingBrowserContainer;


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1305

## Description
Remove error boundary so that errors propagate to use the general error screen

## Views affected
GB

### Other effects
NA

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
Hopefully nothing
