### PR TITLE
Fix genome browser vertical scrollbar

### DIFF
--- a/src/ensembl/src/content/app/browser/Browser.scss
+++ b/src/ensembl/src/content/app/browser/Browser.scss
@@ -1,5 +1,12 @@
 @import 'src/styles/common';
 
+.genomeBrowser{
+  height: 100%;
+  display: grid;
+  align-items: start;
+  grid-template-rows: auto 1fr;
+}
+
 .exampleLinks {
   margin-top: 50px;
   padding-left: 80px;

--- a/src/ensembl/src/content/app/browser/Browser.tsx
+++ b/src/ensembl/src/content/app/browser/Browser.tsx
@@ -117,7 +117,7 @@ export const Browser = (props: BrowserProps) => {
 
   return (
     <ApolloProvider client={client}>
-      <div>
+      <div className={styles.genomeBrowser}>
         <BrowserAppBar onSpeciesSelect={changeGenomeId} />
         {props.activeGenomeId && props.browserQueryParams.focus ? (
           <StandardAppLayout


### PR DESCRIPTION

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1314

## Description
- Copied the wrapper css from entity viewer to fix the vertical scroll bar appearing on genome browser

## Deployment URL
http://fix-gb-vertical-scroll.review.ensembl.org

## Views affected
http://fix-gb-vertical-scroll.review.ensembl.org/genome-browser/homo_sapiens_GCA_000001405_28?focus=gene:ENSG00000139618&location=13:32274850-32444437