### PR TITLE
Update SearchField styles

### DIFF
--- a/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.scss
+++ b/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.scss
@@ -6,19 +6,17 @@ $rightCornerWidth: 40px;
   display: inline-flex;
   align-items: center;
   position: relative;
-  padding: 4px;
   width: 100%;
   max-width: 485px;
-  height: 36px;
-  box-shadow: inset 2px 2px 4px -2px $dark-grey;
-  background: white;
 
   // nesting to increase specificity of the selector (needs to override child rules)
   .speciesSearchField {
     width: 100%;
     background: $white;
-    padding-left: 18px;
     border: none;
+    height: 36px;
+    padding-left: 22px;
+    padding-right: 12px;
   
     input {
       &::placeholder {

--- a/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.scss
+++ b/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.scss
@@ -13,10 +13,8 @@ $rightCornerWidth: 40px;
   .speciesSearchField {
     width: 100%;
     background: $white;
-    border: none;
     height: 36px;
     padding-left: 22px;
-    padding-right: 12px;
   
     input {
       &::placeholder {

--- a/src/ensembl/src/shared/components/in-app-search/InAppSearch.scss
+++ b/src/ensembl/src/shared/components/in-app-search/InAppSearch.scss
@@ -22,8 +22,6 @@
 
 .searchFieldWrapper {
   grid-area: search-field;
-  padding: 4px;
-  box-shadow: inset 2px 2px 4px -2px $dark-grey;
   background: white;
 
   &Interstitial {
@@ -32,9 +30,7 @@
 
   // nesting to increase specificity of the selector
   .searchField {
-    border: none;
     width: 100%;
-    height: 100%;
   }
 }
 

--- a/src/ensembl/src/shared/components/search-field/SearchField.scss
+++ b/src/ensembl/src/shared/components/search-field/SearchField.scss
@@ -2,8 +2,6 @@
 
 .searchField {
   box-shadow: $form-field-shadow;
-  border: none;
-  padding: 0 15px;
   height: 30px;
   display: inline-flex;
   padding: 0 12px;

--- a/src/ensembl/src/shared/components/search-field/SearchField.scss
+++ b/src/ensembl/src/shared/components/search-field/SearchField.scss
@@ -1,9 +1,16 @@
 @import 'src/styles/common';
 
 .searchField {
-  border: 1px solid $grey;
+  box-shadow: $form-field-shadow;
+  border: none;
+  padding: 0 15px;
+  height: 30px;
   display: inline-flex;
-  padding: 0 0.6em;
+  padding: 0 12px;
+
+  input {
+    background-color: transparent;
+  }
 }
 
 .searchFieldRightCorner {


### PR DESCRIPTION
## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1176

## Description
- Moved the box-shadow to the SearchField component.
- Used the same box-shadow and height as for the ShadedInput component

## Deployment URL
http://search-field-styles.review.ensembl.org/

## Views affected
- Species Selector
- Interstitial screen for Genome Browser and Entity Viewer
- InAppSearch in the sidebar modal for Genome Browser and Entity Viewer