### PR TITLE
Species page analytics update

### DIFF
--- a/src/ensembl/src/analyticsHelper.ts
+++ b/src/ensembl/src/analyticsHelper.ts
@@ -20,6 +20,8 @@ export type AnalyticsOptions = {
   label?: string;
   nonInteraction?: boolean;
   value?: number;
+  species?: string;
+  app?: string;
 };
 
 /*

--- a/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.test.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.test.tsx
@@ -31,6 +31,12 @@ jest.mock('connected-react-router', () => ({
   push: jest.fn(() => ({ type: 'push' }))
 }));
 
+jest.mock('src/shared/hooks/useAnalyticsService', () =>
+  jest.fn(() => ({
+    trackPopularSpeciesSelect: jest.fn()
+  }))
+);
+
 const handleSelectedSpecies = jest.fn();
 const clearSelectedSpecies = jest.fn();
 
@@ -45,7 +51,7 @@ const commonProps = {
 
 describe('<PopularSpeciesButton />', () => {
   beforeEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
   });
 
   describe('not available', () => {

--- a/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.test.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.test.tsx
@@ -31,10 +31,12 @@ jest.mock('connected-react-router', () => ({
   push: jest.fn(() => ({ type: 'push' }))
 }));
 
-jest.mock('src/shared/hooks/useAnalyticsService', () =>
-  jest.fn(() => ({
-    trackPopularSpeciesSelect: jest.fn()
-  }))
+jest.mock(
+  'src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics',
+  () =>
+    jest.fn(() => ({
+      trackPopularSpeciesSelect: jest.fn()
+    }))
 );
 
 const handleSelectedSpecies = jest.fn();

--- a/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.tsx
@@ -20,7 +20,7 @@ import classNames from 'classnames';
 import find from 'lodash/find';
 import { push } from 'connected-react-router';
 
-import useAnalyticsService from 'src/shared/hooks/useAnalyticsService';
+import useSpeciesSelectorAnalytics from 'src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics';
 import useHover from 'src/shared/hooks/useHover';
 import * as urlFor from 'src/shared/helpers/urlHelper';
 
@@ -63,7 +63,7 @@ export const PopularSpeciesButton = (props: Props) => {
   const { isSelected, isCommitted, species } = props;
   const [hoverRef, isHovered] = useHover<HTMLDivElement>();
 
-  const { trackPopularSpeciesSelect } = useAnalyticsService();
+  const { trackPopularSpeciesSelect } = useSpeciesSelectorAnalytics();
 
   const handleClick = () => {
     const { is_available } = species;

--- a/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/popular-species-button/PopularSpeciesButton.tsx
@@ -20,7 +20,7 @@ import classNames from 'classnames';
 import find from 'lodash/find';
 import { push } from 'connected-react-router';
 
-import analyticsTracking from 'src/services/analytics-service';
+import useAnalyticsService from 'src/shared/hooks/useAnalyticsService';
 import useHover from 'src/shared/hooks/useHover';
 import * as urlFor from 'src/shared/helpers/urlHelper';
 
@@ -32,7 +32,6 @@ import {
   getCurrentSpeciesGenomeId,
   getCommittedSpecies
 } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
-import { getSpeciesAnalyticsName } from 'src/content/app/species-selector/speciesSelectorHelper';
 
 import Tooltip from 'src/shared/components/tooltip/Tooltip';
 import InlineSVG from 'src/shared/components/inline-svg/InlineSvg';
@@ -64,23 +63,18 @@ export const PopularSpeciesButton = (props: Props) => {
   const { isSelected, isCommitted, species } = props;
   const [hoverRef, isHovered] = useHover<HTMLDivElement>();
 
+  const { trackPopularSpeciesSelect } = useAnalyticsService();
+
   const handleClick = () => {
-    const { genome_id, is_available } = species;
-    const speciesName = getSpeciesAnalyticsName(species);
+    const { is_available } = species;
 
     if (!is_available) {
       return;
     }
 
-    analyticsTracking.setSpeciesDimension(genome_id);
-
     if (isSelected) {
       props.clearSelectedSpecies();
-      analyticsTracking.trackEvent({
-        category: 'popular_species',
-        action: 'unpreselect',
-        label: speciesName
-      });
+      trackPopularSpeciesSelect(species, 'unpreselect');
     } else if (isCommitted) {
       props.push(
         urlFor.speciesPage({
@@ -91,12 +85,7 @@ export const PopularSpeciesButton = (props: Props) => {
       // the species is available, not selected and not committed;
       // go ahead and select it
       props.handleSelectedSpecies(props.species);
-
-      analyticsTracking.trackEvent({
-        category: 'popular_species',
-        action: 'preselect',
-        label: speciesName
-      });
+      trackPopularSpeciesSelect(species, 'preselect');
     }
   };
 

--- a/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.test.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.test.tsx
@@ -19,19 +19,20 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { SpeciesCommitButton } from './SpeciesCommitButton';
+import { createSelectedSpecies } from 'ensemblRoot/tests/fixtures/selected-species';
+import { CurrentItem } from 'src/content/app/species-selector/state/speciesSelectorState';
 
 jest.mock(
   'src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics',
   () =>
     jest.fn(() => ({
-      trackCommitedSpecies: jest.fn()
+      trackCommittedSpecies: jest.fn()
     }))
 );
 
 const onCommit = jest.fn();
 const defaultProps = {
-  hasCurrentSpecies: true,
-  selectedItem: null,
+  currentSpecies: createSelectedSpecies() as CurrentItem,
   disabled: false,
   onCommit
 };
@@ -48,7 +49,7 @@ describe('<SpeciesCommitButton />', () => {
 
   it('does not show any button if no species has been selected', () => {
     const { container } = render(
-      <SpeciesCommitButton {...defaultProps} hasCurrentSpecies={false} />
+      <SpeciesCommitButton {...defaultProps} currentSpecies={null} />
     );
     expect(container.querySelector('button')).toBeFalsy();
   });

--- a/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.test.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.test.tsx
@@ -20,6 +20,12 @@ import userEvent from '@testing-library/user-event';
 
 import { SpeciesCommitButton } from './SpeciesCommitButton';
 
+jest.mock('src/shared/hooks/useAnalyticsService', () =>
+  jest.fn(() => ({
+    trackCommitedSpecies: jest.fn()
+  }))
+);
+
 const onCommit = jest.fn();
 const defaultProps = {
   hasCurrentSpecies: true,
@@ -30,7 +36,7 @@ const defaultProps = {
 
 describe('<SpeciesCommitButton />', () => {
   beforeEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
   });
 
   it('shows PrimaryButton if a species has been selected', () => {

--- a/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.test.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.test.tsx
@@ -23,6 +23,7 @@ import { SpeciesCommitButton } from './SpeciesCommitButton';
 const onCommit = jest.fn();
 const defaultProps = {
   hasCurrentSpecies: true,
+  selectedItem: null,
   disabled: false,
   onCommit
 };

--- a/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.test.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.test.tsx
@@ -49,7 +49,7 @@ describe('<SpeciesCommitButton />', () => {
 
   it('does not show any button if no species has been selected', () => {
     const { container } = render(
-      <SpeciesCommitButton {...defaultProps} currentSpecies={null} />
+      <SpeciesCommitButton {...defaultProps} currentSpecies={undefined} />
     );
     expect(container.querySelector('button')).toBeFalsy();
   });

--- a/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.test.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.test.tsx
@@ -20,10 +20,12 @@ import userEvent from '@testing-library/user-event';
 
 import { SpeciesCommitButton } from './SpeciesCommitButton';
 
-jest.mock('src/shared/hooks/useAnalyticsService', () =>
-  jest.fn(() => ({
-    trackCommitedSpecies: jest.fn()
-  }))
+jest.mock(
+  'src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics',
+  () =>
+    jest.fn(() => ({
+      trackCommitedSpecies: jest.fn()
+    }))
 );
 
 const onCommit = jest.fn();

--- a/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.tsx
@@ -17,10 +17,9 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import useSpeciesSelectorAnalytics from 'ensemblRoot/src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics';
+import useSpeciesSelectorAnalytics from 'src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics';
 
 import {
-  hasCurrentSpecies,
   canCommitSpecies,
   getSelectedItem
 } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
@@ -34,8 +33,7 @@ import { RootState } from 'src/store';
 import styles from './SpeciesCommitButton.scss';
 
 type Props = {
-  hasCurrentSpecies: boolean; // tells whether a species has been selected and can be committed
-  selectedItem: CurrentItem | null;
+  currentSpecies: CurrentItem | null;
   disabled: boolean;
   onCommit: () => void;
 };
@@ -45,10 +43,10 @@ export const SpeciesCommitButton = (props: Props) => {
 
   const handleClick = () => {
     props.onCommit();
-    props.selectedItem && trackCommittedSpecies(props.selectedItem);
+    props.currentSpecies && trackCommittedSpecies(props.currentSpecies);
   };
 
-  return props.hasCurrentSpecies ? (
+  return props.currentSpecies ? (
     <div className={styles.speciesCommitButton}>
       <PrimaryButton onClick={handleClick} isDisabled={props.disabled}>
         Add
@@ -58,7 +56,6 @@ export const SpeciesCommitButton = (props: Props) => {
 };
 
 const mapStateToProps = (state: RootState) => ({
-  hasCurrentSpecies: hasCurrentSpecies(state),
   selectedItem: getSelectedItem(state),
   disabled: !canCommitSpecies(state)
 });

--- a/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.tsx
@@ -17,27 +17,36 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
+import useAnalyticsService from 'ensemblRoot/src/shared/hooks/useAnalyticsService';
+
 import {
   hasCurrentSpecies,
-  canCommitSpecies
+  canCommitSpecies,
+  getSelectedItem
 } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 import { commitSelectedSpeciesAndSave } from 'src/content/app/species-selector/state/speciesSelectorActions';
 
 import { PrimaryButton } from 'src/shared/components/button/Button';
 
-import styles from './SpeciesCommitButton.scss';
-
+import { CurrentItem } from 'src/content/app/species-selector/state/speciesSelectorState';
 import { RootState } from 'src/store';
+
+import styles from './SpeciesCommitButton.scss';
 
 type Props = {
   hasCurrentSpecies: boolean; // tells whether a species has been selected and can be committed
+  selectedItem: CurrentItem | null;
   disabled: boolean;
   onCommit: () => void;
 };
 
 export const SpeciesCommitButton = (props: Props) => {
+  const analyticsService = useAnalyticsService();
+
   const handleClick = () => {
     props.onCommit();
+    props.selectedItem &&
+      analyticsService.trackCommitedSpecies(props.selectedItem);
   };
 
   return props.hasCurrentSpecies ? (
@@ -51,6 +60,7 @@ export const SpeciesCommitButton = (props: Props) => {
 
 const mapStateToProps = (state: RootState) => ({
   hasCurrentSpecies: hasCurrentSpecies(state),
+  selectedItem: getSelectedItem(state),
   disabled: !canCommitSpecies(state)
 });
 

--- a/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.tsx
@@ -41,12 +41,11 @@ type Props = {
 };
 
 export const SpeciesCommitButton = (props: Props) => {
-  const analyticsService = useAnalyticsService();
+  const { trackCommitedSpecies } = useAnalyticsService();
 
   const handleClick = () => {
     props.onCommit();
-    props.selectedItem &&
-      analyticsService.trackCommitedSpecies(props.selectedItem);
+    props.selectedItem && trackCommitedSpecies(props.selectedItem);
   };
 
   return props.hasCurrentSpecies ? (

--- a/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import useAnalyticsService from 'ensemblRoot/src/shared/hooks/useAnalyticsService';
+import useSpeciesSelectorAnalytics from 'ensemblRoot/src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics';
 
 import {
   hasCurrentSpecies,
@@ -41,7 +41,7 @@ type Props = {
 };
 
 export const SpeciesCommitButton = (props: Props) => {
-  const { trackCommitedSpecies } = useAnalyticsService();
+  const { trackCommitedSpecies } = useSpeciesSelectorAnalytics();
 
   const handleClick = () => {
     props.onCommit();

--- a/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.tsx
@@ -33,7 +33,7 @@ import { RootState } from 'src/store';
 import styles from './SpeciesCommitButton.scss';
 
 type Props = {
-  currentSpecies: CurrentItem | null;
+  currentSpecies?: CurrentItem;
   disabled: boolean;
   onCommit: () => void;
 };

--- a/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.tsx
@@ -41,11 +41,11 @@ type Props = {
 };
 
 export const SpeciesCommitButton = (props: Props) => {
-  const { trackCommitedSpecies } = useSpeciesSelectorAnalytics();
+  const { trackCommittedSpecies } = useSpeciesSelectorAnalytics();
 
   const handleClick = () => {
     props.onCommit();
-    props.selectedItem && trackCommitedSpecies(props.selectedItem);
+    props.selectedItem && trackCommittedSpecies(props.selectedItem);
   };
 
   return props.hasCurrentSpecies ? (

--- a/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.test.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.test.tsx
@@ -28,6 +28,12 @@ import {
   MatchedFieldName
 } from 'src/content/app/species-selector/types/species-search';
 
+jest.mock('src/shared/hooks/useAnalyticsService', () =>
+  jest.fn(() => ({
+    trackAutocompleteSpeciesSelect: jest.fn()
+  }))
+);
+
 const buildSearchMatch = (): SearchMatch => ({
   genome_id: faker.lorem.word(),
   reference_genome_id: null,
@@ -72,7 +78,7 @@ describe('<SpeciesSearchField />', () => {
   });
 
   afterEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
   });
 
   describe('rendering', () => {

--- a/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.test.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.test.tsx
@@ -28,10 +28,12 @@ import {
   MatchedFieldName
 } from 'src/content/app/species-selector/types/species-search';
 
-jest.mock('src/shared/hooks/useAnalyticsService', () =>
-  jest.fn(() => ({
-    trackAutocompleteSpeciesSelect: jest.fn()
-  }))
+jest.mock(
+  'src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics',
+  () =>
+    jest.fn(() => ({
+      trackAutocompleteSpeciesSelect: jest.fn()
+    }))
 );
 
 const buildSearchMatch = (): SearchMatch => ({

--- a/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx
@@ -17,7 +17,7 @@
 import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 
-import useAnalyticsService from 'src/shared/hooks/useAnalyticsService';
+import useSpeciesSelectorAnalytics from 'src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics';
 
 import {
   updateSearch,
@@ -80,7 +80,7 @@ export const SpeciesSearchField = (props: Props) => {
     return () => clear();
   }, []);
 
-  const { trackAutocompleteSpeciesSelect } = useAnalyticsService();
+  const { trackAutocompleteSpeciesSelect } = useSpeciesSelectorAnalytics();
 
   const onMatchSelected = (match: SearchMatch) => {
     props.onMatchSelected(match);

--- a/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx
@@ -17,6 +17,8 @@
 import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 
+import useAnalyticsService from 'src/shared/hooks/useAnalyticsService';
+
 import {
   updateSearch,
   handleSelectedSpecies,
@@ -42,8 +44,6 @@ import {
   SearchMatch,
   SearchMatches
 } from 'src/content/app/species-selector/types/species-search';
-
-import useAnalyticsService from 'src/shared/hooks/useAnalyticsService';
 
 import { RootState } from 'src/store';
 import { MINIMUM_SEARCH_LENGTH } from 'src/content/app/species-selector/constants/speciesSelectorConstants';

--- a/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx
@@ -43,8 +43,7 @@ import {
   SearchMatches
 } from 'src/content/app/species-selector/types/species-search';
 
-import analyticsTracking from 'src/services/analytics-service';
-import { getSpeciesAnalyticsName } from 'src/content/app/species-selector/speciesSelectorHelper';
+import useAnalyticsService from 'src/shared/hooks/useAnalyticsService';
 
 import { RootState } from 'src/store';
 import { MINIMUM_SEARCH_LENGTH } from 'src/content/app/species-selector/constants/speciesSelectorConstants';
@@ -81,18 +80,11 @@ export const SpeciesSearchField = (props: Props) => {
     return () => clear();
   }, []);
 
+  const { trackAutocompleteSpeciesSelect } = useAnalyticsService();
+
   const onMatchSelected = (match: SearchMatch) => {
     props.onMatchSelected(match);
-
-    const speciesName = getSpeciesAnalyticsName(match);
-
-    analyticsTracking.setSpeciesDimension(match.genome_id);
-
-    analyticsTracking.trackEvent({
-      category: 'species_search',
-      action: 'preselect',
-      label: speciesName
-    });
+    trackAutocompleteSpeciesSelect(match);
   };
 
   const canShowSuggesions =

--- a/src/ensembl/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.test.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.test.tsx
@@ -38,7 +38,7 @@ jest.mock('connected-react-router', () => ({
 }));
 
 jest.mock(
-  'ensemblRoot/src/shared/components/communication-framework/ConversationIcon',
+  'src/shared/components/communication-framework/ConversationIcon',
   () => () => <div>ConversationIcon</div>
 );
 

--- a/src/ensembl/src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics.ts
+++ b/src/ensembl/src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics.ts
@@ -1,0 +1,103 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useSelector } from 'react-redux';
+
+import analyticsTracking from 'src/services/analytics-service';
+
+import { getSpeciesAnalyticsName } from 'ensemblRoot/src/content/app/species-selector/speciesSelectorHelper';
+
+import { getCommittedSpecies } from 'ensemblRoot/src/content/app/species-selector/state/speciesSelectorSelectors';
+
+import {
+  PopularSpecies,
+  SearchMatch
+} from 'src/content/app/species-selector/types/species-search';
+import { CurrentItem } from 'src/content/app/species-selector/state/speciesSelectorState';
+
+enum AnalyticsCategories {
+  SELECTED_SPECIES = 'selected_species',
+  SPECIES_SELECTOR = 'species_selector',
+  POPULAR_SPECIES = 'popular_species',
+  SPECIES_SEARCH = 'species_search'
+}
+
+const useSpeciesSelectorAnalytics = () => {
+  const { trackEvent } = analyticsTracking;
+
+  const committedSpecies = useSelector(getCommittedSpecies);
+
+  /*  Species Selector Page Events */
+  const trackAutocompleteSpeciesSelect = (species: SearchMatch) => {
+    const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
+
+    trackEvent({
+      category: AnalyticsCategories.SPECIES_SEARCH,
+      action: 'preselect',
+      label: speciesNameForAnalytics,
+      species: speciesNameForAnalytics
+    });
+  };
+
+  const trackPopularSpeciesSelect = (
+    species: PopularSpecies,
+    action: string
+  ) => {
+    const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
+
+    trackEvent({
+      category: AnalyticsCategories.POPULAR_SPECIES,
+      action: action,
+      label: speciesNameForAnalytics,
+      species: speciesNameForAnalytics
+    });
+  };
+
+  const trackCommitedSpecies = (species: CurrentItem) => {
+    const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
+
+    trackEvent({
+      category: AnalyticsCategories.SPECIES_SELECTOR,
+      label: speciesNameForAnalytics,
+      action: 'add',
+      species: speciesNameForAnalytics
+    });
+
+    if (committedSpecies.length > 1) {
+      trackFinalSetOfSpecies(species);
+    }
+  };
+
+  const trackFinalSetOfSpecies = (newlyCommittedSpecies: CurrentItem) => {
+    const committedSpeciesNames = [newlyCommittedSpecies, ...committedSpecies]
+      .map((species) => getSpeciesAnalyticsName(species))
+      .sort();
+
+    trackEvent({
+      category: AnalyticsCategories.SPECIES_SELECTOR,
+      action: 'select_multiple',
+      label: committedSpeciesNames.join(','),
+      value: committedSpeciesNames.length,
+      species: ''
+    });
+  };
+
+  return {
+    trackCommitedSpecies,
+    trackPopularSpeciesSelect,
+    trackAutocompleteSpeciesSelect
+  };
+};
+export default useSpeciesSelectorAnalytics;

--- a/src/ensembl/src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics.ts
+++ b/src/ensembl/src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics.ts
@@ -17,22 +17,15 @@ import { useSelector } from 'react-redux';
 
 import analyticsTracking from 'src/services/analytics-service';
 
-import { getSpeciesAnalyticsName } from 'ensemblRoot/src/content/app/species-selector/speciesSelectorHelper';
+import { getSpeciesAnalyticsName } from 'src/content/app/species-selector/speciesSelectorHelper';
 
-import { getCommittedSpecies } from 'ensemblRoot/src/content/app/species-selector/state/speciesSelectorSelectors';
+import { getCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 
 import {
   PopularSpecies,
   SearchMatch
 } from 'src/content/app/species-selector/types/species-search';
 import { CurrentItem } from 'src/content/app/species-selector/state/speciesSelectorState';
-
-enum AnalyticsCategories {
-  SELECTED_SPECIES = 'selected_species',
-  SPECIES_SELECTOR = 'species_selector',
-  POPULAR_SPECIES = 'popular_species',
-  SPECIES_SEARCH = 'species_search'
-}
 
 const useSpeciesSelectorAnalytics = () => {
   const committedSpecies = useSelector(getCommittedSpecies);
@@ -42,7 +35,7 @@ const useSpeciesSelectorAnalytics = () => {
     const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
 
     analyticsTracking.trackEvent({
-      category: AnalyticsCategories.SPECIES_SEARCH,
+      category: 'species_search',
       action: 'preselect',
       label: speciesNameForAnalytics,
       species: speciesNameForAnalytics
@@ -56,7 +49,7 @@ const useSpeciesSelectorAnalytics = () => {
     const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
 
     analyticsTracking.trackEvent({
-      category: AnalyticsCategories.POPULAR_SPECIES,
+      category: 'popular_species',
       action: action,
       label: speciesNameForAnalytics,
       species: speciesNameForAnalytics
@@ -67,7 +60,7 @@ const useSpeciesSelectorAnalytics = () => {
     const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
 
     analyticsTracking.trackEvent({
-      category: AnalyticsCategories.SPECIES_SELECTOR,
+      category: 'species_selector',
       label: speciesNameForAnalytics,
       action: 'add',
       species: speciesNameForAnalytics
@@ -84,7 +77,7 @@ const useSpeciesSelectorAnalytics = () => {
       .sort();
 
     analyticsTracking.trackEvent({
-      category: AnalyticsCategories.SPECIES_SELECTOR,
+      category: 'species_selector',
       action: 'select_multiple',
       label: committedSpeciesNames.join(','),
       value: committedSpeciesNames.length,

--- a/src/ensembl/src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics.ts
+++ b/src/ensembl/src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics.ts
@@ -35,15 +35,13 @@ enum AnalyticsCategories {
 }
 
 const useSpeciesSelectorAnalytics = () => {
-  const { trackEvent } = analyticsTracking;
-
   const committedSpecies = useSelector(getCommittedSpecies);
 
   /*  Species Selector Page Events */
   const trackAutocompleteSpeciesSelect = (species: SearchMatch) => {
     const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
 
-    trackEvent({
+    analyticsTracking.trackEvent({
       category: AnalyticsCategories.SPECIES_SEARCH,
       action: 'preselect',
       label: speciesNameForAnalytics,
@@ -57,7 +55,7 @@ const useSpeciesSelectorAnalytics = () => {
   ) => {
     const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
 
-    trackEvent({
+    analyticsTracking.trackEvent({
       category: AnalyticsCategories.POPULAR_SPECIES,
       action: action,
       label: speciesNameForAnalytics,
@@ -68,7 +66,7 @@ const useSpeciesSelectorAnalytics = () => {
   const trackCommitedSpecies = (species: CurrentItem) => {
     const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
 
-    trackEvent({
+    analyticsTracking.trackEvent({
       category: AnalyticsCategories.SPECIES_SELECTOR,
       label: speciesNameForAnalytics,
       action: 'add',
@@ -85,7 +83,7 @@ const useSpeciesSelectorAnalytics = () => {
       .map((species) => getSpeciesAnalyticsName(species))
       .sort();
 
-    trackEvent({
+    analyticsTracking.trackEvent({
       category: AnalyticsCategories.SPECIES_SELECTOR,
       action: 'select_multiple',
       label: committedSpeciesNames.join(','),

--- a/src/ensembl/src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics.ts
+++ b/src/ensembl/src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics.ts
@@ -63,7 +63,7 @@ const useSpeciesSelectorAnalytics = () => {
     });
   };
 
-  const trackCommitedSpecies = (species: CurrentItem) => {
+  const trackCommittedSpecies = (species: CurrentItem) => {
     const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
 
     analyticsTracking.trackEvent({
@@ -93,7 +93,7 @@ const useSpeciesSelectorAnalytics = () => {
   };
 
   return {
-    trackCommitedSpecies,
+    trackCommittedSpecies,
     trackPopularSpeciesSelect,
     trackAutocompleteSpeciesSelect
   };

--- a/src/ensembl/src/content/app/species-selector/state/speciesSelectorActions.ts
+++ b/src/ensembl/src/content/app/species-selector/state/speciesSelectorActions.ts
@@ -14,295 +14,251 @@
  * limitations under the License.
  */
 
- import { createAsyncAction, createAction } from 'typesafe-actions';
- import { Action } from 'redux';
- import { ThunkAction } from 'redux-thunk';
- import find from 'lodash/find';
- import pickBy from 'lodash/pickBy';
- import apiService from 'src/services/api-service';
- 
- import speciesSelectorStorageService from 'src/content/app/species-selector/services/species-selector-storage-service';
- import analyticsTracking from 'src/services/analytics-service';
- import { deleteSpeciesInGenomeBrowser } from 'src/content/app/browser/browserActions';
- import { deleteGenome as deleteSpeciesInEntityViewer } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSlice';
- 
- import {
-   getCommittedSpecies,
-   getCommittedSpeciesById,
-   getSelectedItem,
-   getSearchText
- } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
- 
- import { getSpeciesAnalyticsName } from 'src/content/app/species-selector/speciesSelectorHelper';
- import {
-   SearchMatch,
-   SearchMatches,
-   PopularSpecies,
-   CommittedItem
- } from 'src/content/app/species-selector/types/species-search';
- 
- import { getGenomeInfoById } from 'src/shared/state/genome/genomeSelectors';
- 
- import { CurrentItem } from './speciesSelectorState';
- 
- const buildCommittedItem = (data: CurrentItem): CommittedItem => ({
-   genome_id: data.genome_id,
-   reference_genome_id: data.reference_genome_id,
-   common_name: data.common_name,
-   scientific_name: data.scientific_name,
-   assembly_name: data.assembly_name as string,
-   isEnabled: true
- });
- 
- enum categories {
-   POPULAR_SPECIES = 'popular_species',
-   ADD_SPECIES = 'add_species',
-   SELECTED_SPECIES = 'selected_Species'
- }
- 
- import { MINIMUM_SEARCH_LENGTH } from 'src/content/app/species-selector/constants/speciesSelectorConstants';
- 
- import { RootState } from 'src/store';
- 
- export const setSearchText = createAction(
-   'species_selector/set_search_text'
- )<string>();
- 
- export const updateSearch =
-   (text: string): ThunkAction<void, any, null, Action<string>> =>
-   (dispatch, getState: () => RootState) => {
-     const state = getState();
-     const selectedItem = getSelectedItem(state);
-     const previousText = getSearchText(state);
-     if (selectedItem) {
-       dispatch(clearSelectedSearchResult());
-     }
- 
-     const trimmedText = text.trim();
-     if (text.length < previousText.length) {
-       // user is deleting their input; clear search results
-       dispatch(clearSearchResults());
-     }
- 
-     if (trimmedText.length >= MINIMUM_SEARCH_LENGTH) {
-       dispatch(fetchSpeciesSearchResults.request(trimmedText));
-     }
- 
-     dispatch(setSearchText(text));
-   };
- 
- export const fetchSpeciesSearchResults = createAsyncAction(
-   'species_selector/species_search_request',
-   'species_selector/species_search_success',
-   'species_selector/species_search_failure'
- )<string, { results: SearchMatches[] }, Error>();
- 
- // TODO: wait for strains
- // export const fetchStrainsAsyncActions = createAsyncAction(
- //   'species_selector/strains_request',
- //   'species_selector/strains_success',
- //   'species_selector/strains_failure'
- // )<undefined, { strains: Strain[] }, Error>();
- 
- export const fetchPopularSpeciesAsyncActions = createAsyncAction(
-   'species_selector/popular_species_request',
-   'species_selector/popular_species_success',
-   'species_selector/popular_species_failure'
- )<undefined, { popularSpecies: PopularSpecies[] }, Error>();
- 
- export const setSelectedSpecies = createAction(
-   'species_selector/species_selected'
- )<SearchMatch | PopularSpecies>();
- 
- export const clearSearchResults = createAction(
-   'species_selector/clear_search_results'
- )();
- 
- export const clearSearch = createAction('species_selector/clear_search')();
- 
- export const clearSelectedSearchResult = createAction(
-   'species_selector/clear_selected_search_result'
- )();
- 
- // TODO: wait for strains
- // export const fetchStrains: ActionCreator<
- //   ThunkAction<void, any, null, Action<string>>
- // > = (genomeId: string) => async (dispatch) => {
- //   try {
- //     dispatch(fetchStrainsAsyncActions.request());
- 
- //     // FIXME: using mock data here
- //     dispatch(
- //       fetchStrainsAsyncActions.success({ strains: mouseStrainsResult.strains })
- //     );
- //   } catch (error) {
- //     dispatch(fetchStrainsAsyncActions.failure(error));
- //   }
- // };
- 
- export const ensureSpeciesIsCommitted =
-   (genomeId: string): ThunkAction<void, any, null, Action<string>> =>
-   async (dispatch, getState: () => RootState) => {
-     const state = getState();
-     const committedSpecies = getCommittedSpecies(state);
-     const genomeInfo = getGenomeInfoById(state, genomeId);
-     if (getCommittedSpeciesById(state, genomeId) || !genomeInfo) {
-       return;
-     }
- 
-     const newCommittedSpecies = [
-       ...committedSpecies,
-       {
-         ...pickBy(genomeInfo, (value, key) => {
-           return key !== 'example_objects';
-         }),
-         isEnabled: true
-       }
-     ] as CommittedItem[];
- 
-     dispatch(updateCommittedSpecies(newCommittedSpecies));
-     speciesSelectorStorageService.saveSelectedSpecies(newCommittedSpecies);
-   };
- 
- export const ensureSpeciesIsEnabled =
-   (genomeId: string): ThunkAction<void, any, null, Action<string>> =>
-   (dispatch, getState: () => RootState) => {
-     const state = getState();
- 
-     const currentSpecies = getCommittedSpeciesById(state, genomeId);
-     if (!currentSpecies || currentSpecies.isEnabled) {
-       return;
-     }
- 
-     dispatch(toggleSpeciesUseAndSave(genomeId));
-   };
- 
- export const loadStoredSpecies =
-   (): ThunkAction<void, any, null, Action<string>> => (dispatch) => {
-     const storedSpecies = speciesSelectorStorageService.getSelectedSpecies();
-     dispatch(updateCommittedSpecies(storedSpecies));
-   };
- 
- export const fetchPopularSpecies =
-   (): ThunkAction<void, any, null, Action<string>> => async (dispatch) => {
-     try {
-       dispatch(fetchPopularSpeciesAsyncActions.request());
- 
-       const url = '/api/genomesearch/popular_genomes';
-       const response = await apiService.fetch(url);
- 
-       dispatch(
-         fetchPopularSpeciesAsyncActions.success({
-           popularSpecies: response.popular_species
-         })
-       );
-     } catch (error) {
-       dispatch(fetchPopularSpeciesAsyncActions.failure(error));
-     }
-   };
- 
- export const handleSelectedSpecies =
-   (
-     item: SearchMatch | PopularSpecies
-   ): ThunkAction<void, any, null, Action<string>> =>
-   (dispatch) => {
-     dispatch(setSelectedSpecies(item));
- 
-     // TODO: fetch strains when they are ready
-     // dispatch(fetchStrains(genome_id));
-   };
- 
- export const updateCommittedSpecies = createAction(
-   'species_selector/update_committed_species'
- )<CommittedItem[]>();
- 
- export const commitSelectedSpeciesAndSave =
-   (): ThunkAction<void, any, null, Action<string>> => (dispatch, getState) => {
-     const committedSpecies = getCommittedSpecies(getState());
-     const selectedItem = getSelectedItem(getState());
- 
-     if (!selectedItem) {
-       return;
-     }
- 
-     const newCommittedSpecies = [
-       ...committedSpecies,
-       buildCommittedItem(selectedItem)
-     ];
- 
-     const speciesName = getSpeciesAnalyticsName(selectedItem);
- 
-     analyticsTracking.setSpeciesDimension(selectedItem.genome_id);
- 
-     analyticsTracking.trackEvent({
-       category: categories.ADD_SPECIES,
-       label: speciesName,
-       action: 'select'
-     });
- 
-     dispatch(updateCommittedSpecies(newCommittedSpecies));
-     dispatch(clearSelectedSearchResult());
- 
-     speciesSelectorStorageService.saveSelectedSpecies(newCommittedSpecies);
-   };
- 
- export const toggleSpeciesUseAndSave =
-   (genomeId: string): ThunkAction<void, any, null, Action<string>> =>
-   (dispatch, getState) => {
-     const state = getState();
-     const committedSpecies = getCommittedSpecies(state);
-     const currentSpecies = getCommittedSpeciesById(state, genomeId);
-     if (!currentSpecies) {
-       return; // should never happen
-     }
-     const speciesNameForAnalytics = getSpeciesAnalyticsName(currentSpecies);
-     const updatedStatus = currentSpecies.isEnabled ? 'do_not_use' : 'use';
- 
-     const updatedCommittedSpecies = committedSpecies.map((item) => {
-       return item.genome_id === genomeId
-         ? {
-             ...item,
-             isEnabled: !item.isEnabled
-           }
-         : item;
-     });
- 
-     analyticsTracking.trackEvent({
-       category: categories.SELECTED_SPECIES,
-       label: speciesNameForAnalytics,
-       action: updatedStatus
-     });
- 
-     dispatch(updateCommittedSpecies(updatedCommittedSpecies));
-     speciesSelectorStorageService.saveSelectedSpecies(updatedCommittedSpecies);
-   };
- 
- export const deleteSpeciesAndSave =
-   (genomeId: string): ThunkAction<void, any, null, Action<string>> =>
-   (dispatch, getState) => {
-     const committedSpecies = getCommittedSpecies(getState());
-     const deletedSpecies = find(
-       committedSpecies,
-       ({ genome_id }) => genome_id === genomeId
-     );
- 
-     if (deletedSpecies) {
-       const deletedSpeciesName = getSpeciesAnalyticsName(deletedSpecies);
- 
-       analyticsTracking.setSpeciesDimension(deletedSpecies.genome_id);
- 
-       analyticsTracking.trackEvent({
-         category: categories.SELECTED_SPECIES,
-         label: deletedSpeciesName,
-         action: 'unselect'
-       });
-     }
-     const updatedCommittedSpecies = committedSpecies.filter(
-       ({ genome_id }) => genome_id !== genomeId
-     );
- 
-     dispatch(updateCommittedSpecies(updatedCommittedSpecies));
-     dispatch(deleteSpeciesInGenomeBrowser(genomeId));
-     dispatch(deleteSpeciesInEntityViewer(genomeId));
-     speciesSelectorStorageService.saveSelectedSpecies(updatedCommittedSpecies);
-   };
+import { createAsyncAction, createAction } from 'typesafe-actions';
+import { Action } from 'redux';
+import { ThunkAction } from 'redux-thunk';
+import pickBy from 'lodash/pickBy';
+import apiService from 'src/services/api-service';
+
+import speciesSelectorStorageService from 'src/content/app/species-selector/services/species-selector-storage-service';
+import { deleteSpeciesInGenomeBrowser } from 'src/content/app/browser/browserActions';
+import { deleteGenome as deleteSpeciesInEntityViewer } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSlice';
+
+import {
+  getCommittedSpecies,
+  getCommittedSpeciesById,
+  getSelectedItem,
+  getSearchText
+} from 'src/content/app/species-selector/state/speciesSelectorSelectors';
+
+import {
+  SearchMatch,
+  SearchMatches,
+  PopularSpecies,
+  CommittedItem
+} from 'src/content/app/species-selector/types/species-search';
+
+import { getGenomeInfoById } from 'src/shared/state/genome/genomeSelectors';
+
+import { CurrentItem } from './speciesSelectorState';
+
+const buildCommittedItem = (data: CurrentItem): CommittedItem => ({
+  genome_id: data.genome_id,
+  reference_genome_id: data.reference_genome_id,
+  common_name: data.common_name,
+  scientific_name: data.scientific_name,
+  assembly_name: data.assembly_name as string,
+  isEnabled: true
+});
+
+import { MINIMUM_SEARCH_LENGTH } from 'src/content/app/species-selector/constants/speciesSelectorConstants';
+
+import { RootState } from 'src/store';
+
+export const setSearchText = createAction(
+  'species_selector/set_search_text'
+)<string>();
+
+export const updateSearch =
+  (text: string): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const state = getState();
+    const selectedItem = getSelectedItem(state);
+    const previousText = getSearchText(state);
+    if (selectedItem) {
+      dispatch(clearSelectedSearchResult());
+    }
+
+    const trimmedText = text.trim();
+    if (text.length < previousText.length) {
+      // user is deleting their input; clear search results
+      dispatch(clearSearchResults());
+    }
+
+    if (trimmedText.length >= MINIMUM_SEARCH_LENGTH) {
+      dispatch(fetchSpeciesSearchResults.request(trimmedText));
+    }
+
+    dispatch(setSearchText(text));
+  };
+
+export const fetchSpeciesSearchResults = createAsyncAction(
+  'species_selector/species_search_request',
+  'species_selector/species_search_success',
+  'species_selector/species_search_failure'
+)<string, { results: SearchMatches[] }, Error>();
+
+// TODO: wait for strains
+// export const fetchStrainsAsyncActions = createAsyncAction(
+//   'species_selector/strains_request',
+//   'species_selector/strains_success',
+//   'species_selector/strains_failure'
+// )<undefined, { strains: Strain[] }, Error>();
+
+export const fetchPopularSpeciesAsyncActions = createAsyncAction(
+  'species_selector/popular_species_request',
+  'species_selector/popular_species_success',
+  'species_selector/popular_species_failure'
+)<undefined, { popularSpecies: PopularSpecies[] }, Error>();
+
+export const setSelectedSpecies = createAction(
+  'species_selector/species_selected'
+)<SearchMatch | PopularSpecies>();
+
+export const clearSearchResults = createAction(
+  'species_selector/clear_search_results'
+)();
+
+export const clearSearch = createAction('species_selector/clear_search')();
+
+export const clearSelectedSearchResult = createAction(
+  'species_selector/clear_selected_search_result'
+)();
+
+// TODO: wait for strains
+// export const fetchStrains: ActionCreator<
+//   ThunkAction<void, any, null, Action<string>>
+// > = (genomeId: string) => async (dispatch) => {
+//   try {
+//     dispatch(fetchStrainsAsyncActions.request());
+
+//     // FIXME: using mock data here
+//     dispatch(
+//       fetchStrainsAsyncActions.success({ strains: mouseStrainsResult.strains })
+//     );
+//   } catch (error) {
+//     dispatch(fetchStrainsAsyncActions.failure(error));
+//   }
+// };
+
+export const ensureSpeciesIsCommitted =
+  (genomeId: string): ThunkAction<void, any, null, Action<string>> =>
+  async (dispatch, getState: () => RootState) => {
+    const state = getState();
+    const committedSpecies = getCommittedSpecies(state);
+    const genomeInfo = getGenomeInfoById(state, genomeId);
+    if (getCommittedSpeciesById(state, genomeId) || !genomeInfo) {
+      return;
+    }
+
+    const newCommittedSpecies = [
+      ...committedSpecies,
+      {
+        ...pickBy(genomeInfo, (value, key) => {
+          return key !== 'example_objects';
+        }),
+        isEnabled: true
+      }
+    ] as CommittedItem[];
+
+    dispatch(updateCommittedSpecies(newCommittedSpecies));
+    speciesSelectorStorageService.saveSelectedSpecies(newCommittedSpecies);
+  };
+
+export const ensureSpeciesIsEnabled =
+  (genomeId: string): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const state = getState();
+
+    const currentSpecies = getCommittedSpeciesById(state, genomeId);
+    if (!currentSpecies || currentSpecies.isEnabled) {
+      return;
+    }
+
+    dispatch(toggleSpeciesUseAndSave(genomeId));
+  };
+
+export const loadStoredSpecies =
+  (): ThunkAction<void, any, null, Action<string>> => (dispatch) => {
+    const storedSpecies = speciesSelectorStorageService.getSelectedSpecies();
+    dispatch(updateCommittedSpecies(storedSpecies));
+  };
+
+export const fetchPopularSpecies =
+  (): ThunkAction<void, any, null, Action<string>> => async (dispatch) => {
+    try {
+      dispatch(fetchPopularSpeciesAsyncActions.request());
+
+      const url = '/api/genomesearch/popular_genomes';
+      const response = await apiService.fetch(url);
+
+      dispatch(
+        fetchPopularSpeciesAsyncActions.success({
+          popularSpecies: response.popular_species
+        })
+      );
+    } catch (error) {
+      dispatch(fetchPopularSpeciesAsyncActions.failure(error));
+    }
+  };
+
+export const handleSelectedSpecies =
+  (
+    item: SearchMatch | PopularSpecies
+  ): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch) => {
+    dispatch(setSelectedSpecies(item));
+
+    // TODO: fetch strains when they are ready
+    // dispatch(fetchStrains(genome_id));
+  };
+
+export const updateCommittedSpecies = createAction(
+  'species_selector/update_committed_species'
+)<CommittedItem[]>();
+
+export const commitSelectedSpeciesAndSave =
+  (): ThunkAction<void, any, null, Action<string>> => (dispatch, getState) => {
+    const committedSpecies = getCommittedSpecies(getState());
+    const selectedItem = getSelectedItem(getState());
+
+    if (!selectedItem) {
+      return;
+    }
+
+    const newCommittedSpecies = [
+      ...committedSpecies,
+      buildCommittedItem(selectedItem)
+    ];
+
+    dispatch(updateCommittedSpecies(newCommittedSpecies));
+    dispatch(clearSelectedSearchResult());
+
+    speciesSelectorStorageService.saveSelectedSpecies(newCommittedSpecies);
+  };
+
+export const toggleSpeciesUseAndSave =
+  (genomeId: string): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState) => {
+    const state = getState();
+    const committedSpecies = getCommittedSpecies(state);
+    const currentSpecies = getCommittedSpeciesById(state, genomeId);
+    if (!currentSpecies) {
+      return; // should never happen
+    }
+    const updatedCommittedSpecies = committedSpecies.map((item) => {
+      return item.genome_id === genomeId
+        ? {
+            ...item,
+            isEnabled: !item.isEnabled
+          }
+        : item;
+    });
+
+    dispatch(updateCommittedSpecies(updatedCommittedSpecies));
+    speciesSelectorStorageService.saveSelectedSpecies(updatedCommittedSpecies);
+  };
+
+export const deleteSpeciesAndSave =
+  (genomeId: string): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState) => {
+    const committedSpecies = getCommittedSpecies(getState());
+    const updatedCommittedSpecies = committedSpecies.filter(
+      ({ genome_id }) => genome_id !== genomeId
+    );
+
+    dispatch(updateCommittedSpecies(updatedCommittedSpecies));
+    dispatch(deleteSpeciesInGenomeBrowser(genomeId));
+    dispatch(deleteSpeciesInEntityViewer(genomeId));
+    speciesSelectorStorageService.saveSelectedSpecies(updatedCommittedSpecies);
+  };

--- a/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
+++ b/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
@@ -18,6 +18,8 @@ import React, { useEffect, ReactNode } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 
+import useAnalyticsService from 'ensemblRoot/src/shared/hooks/useAnalyticsService';
+
 import ViewInAppPopup from 'src/shared/components/view-in-app-popup/ViewInAppPopup';
 import SpeciesStats from 'src/content/app/species/components/species-stats/SpeciesStats';
 import ExpandableSection from 'src/shared/components/expandable-section/ExpandableSection';
@@ -77,12 +79,20 @@ const ExampleLinkWithPopup = (props: ExampleLinkPopupProps) => {
 type ContentProps = {
   statsSection: StatsSection;
   species: CommittedItem;
+  trackSpeciesPageExampleLink: (
+    species: CommittedItem,
+    linkText: string
+  ) => void;
 };
 
 const getCollapsedContent = (props: ContentProps) => {
   const { species, statsSection } = props;
   const { summaryStats, section, exampleLinks } = statsSection;
   const { title, helpText, exampleLinkText } = sectionGroupsMap[section];
+
+  const onExampleLinkClick = () => {
+    props.trackSpeciesPageExampleLink(props.species, exampleLinkText as string);
+  };
 
   return (
     <div className={styles.collapsedContent}>
@@ -107,7 +117,7 @@ const getCollapsedContent = (props: ContentProps) => {
 
       {exampleLinks && species.isEnabled && (
         <ExampleLinkWithPopup links={exampleLinks}>
-          {exampleLinkText}
+          <span onClick={onExampleLinkClick}>{exampleLinkText}</span>
         </ExampleLinkWithPopup>
       )}
     </div>
@@ -118,6 +128,10 @@ const getExpandedContent = (props: ContentProps) => {
   const { species, statsSection } = props;
   const { groups, exampleLinks, section } = statsSection;
   const { exampleLinkText } = sectionGroupsMap[section];
+
+  const onExampleLinkClick = () => {
+    props.trackSpeciesPageExampleLink(props.species, exampleLinkText as string);
+  };
 
   const expandedContent = groups
     .map((group, group_index) => {
@@ -143,7 +157,9 @@ const getExpandedContent = (props: ContentProps) => {
                   exampleLinks &&
                   species.isEnabled && (
                     <ExampleLinkWithPopup links={exampleLinks}>
-                      {exampleLinkText}
+                      <span onClick={onExampleLinkClick}>
+                        {exampleLinkText}
+                      </span>
                     </ExampleLinkWithPopup>
                   )}
               </div>
@@ -165,6 +181,9 @@ const SpeciesMainViewStats = (props: Props) => {
     }
   }, [props.genomeStats, props.activeGenomeId, props.exampleFocusObjects]);
 
+  const { trackSpeciesPageExampleLink, trackSpeciesStatsSectionOpen } =
+    useAnalyticsService();
+
   const expandedSections = props.genomeUIState
     ? props.genomeUIState.expandedSections
     : [];
@@ -182,6 +201,7 @@ const SpeciesMainViewStats = (props: Props) => {
     isExpanded: boolean
   ) => {
     if (isExpanded) {
+      props.species && trackSpeciesStatsSectionOpen(props.species, section);
       props.setExpandedSections([...expandedSections, section]);
     } else {
       props.setExpandedSections(expandedSections.filter((s) => s !== section));
@@ -193,7 +213,8 @@ const SpeciesMainViewStats = (props: Props) => {
       {props.genomeStats.map((statsSection, key) => {
         const contentProps = {
           statsSection,
-          species: props.species as CommittedItem
+          species: props.species as CommittedItem,
+          trackSpeciesPageExampleLink
         };
         return (
           <ExpandableSection

--- a/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
+++ b/src/ensembl/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
@@ -18,7 +18,7 @@ import React, { useEffect, ReactNode } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 
-import useAnalyticsService from 'ensemblRoot/src/shared/hooks/useAnalyticsService';
+import useSpeciesAnalytics from '../../hooks/useSpeciesAnalytics';
 
 import ViewInAppPopup from 'src/shared/components/view-in-app-popup/ViewInAppPopup';
 import SpeciesStats from 'src/content/app/species/components/species-stats/SpeciesStats';
@@ -182,7 +182,7 @@ const SpeciesMainViewStats = (props: Props) => {
   }, [props.genomeStats, props.activeGenomeId, props.exampleFocusObjects]);
 
   const { trackSpeciesPageExampleLink, trackSpeciesStatsSectionOpen } =
-    useAnalyticsService();
+    useSpeciesAnalytics();
 
   const expandedSections = props.genomeUIState
     ? props.genomeUIState.expandedSections

--- a/src/ensembl/src/content/app/species/components/species-title-area/species-remove/SpeciesRemove.test.tsx
+++ b/src/ensembl/src/content/app/species/components/species-title-area/species-remove/SpeciesRemove.test.tsx
@@ -39,6 +39,11 @@ jest.mock(
     deleteSpeciesAndSave: jest.fn(() => ({ type: 'deleteSpeciesAndSave' }))
   })
 );
+jest.mock('src/shared/hooks/useAnalyticsService', () =>
+  jest.fn(() => ({
+    trackDeletedSpecies: jest.fn()
+  }))
+);
 
 const selectedSpecies = createSelectedSpecies();
 

--- a/src/ensembl/src/content/app/species/components/species-title-area/species-remove/SpeciesRemove.test.tsx
+++ b/src/ensembl/src/content/app/species/components/species-title-area/species-remove/SpeciesRemove.test.tsx
@@ -39,7 +39,7 @@ jest.mock(
     deleteSpeciesAndSave: jest.fn(() => ({ type: 'deleteSpeciesAndSave' }))
   })
 );
-jest.mock('src/shared/hooks/useAnalyticsService', () =>
+jest.mock('src/content/app/species/hooks/useSpeciesAnalytics', () =>
   jest.fn(() => ({
     trackDeletedSpecies: jest.fn()
   }))

--- a/src/ensembl/src/content/app/species/components/species-title-area/species-remove/SpeciesRemove.tsx
+++ b/src/ensembl/src/content/app/species/components/species-title-area/species-remove/SpeciesRemove.tsx
@@ -19,6 +19,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { push } from 'connected-react-router';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
+import useAnalyticsService from 'ensemblRoot/src/shared/hooks/useAnalyticsService';
 
 import { getActiveGenomeId } from 'src/content/app/species/state/general/speciesGeneralSelectors';
 import { getCommittedSpeciesById } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
@@ -39,6 +40,8 @@ const SpeciesRemove = () => {
   );
   const dispatch = useDispatch();
 
+  const { trackDeletedSpecies } = useAnalyticsService();
+
   if (!genomeId || !species) {
     return null;
   }
@@ -50,6 +53,7 @@ const SpeciesRemove = () => {
   const onRemove = () => {
     dispatch(push(urlFor.speciesSelector()));
     dispatch(deleteSpeciesAndSave(genomeId));
+    trackDeletedSpecies(species);
   };
 
   return (

--- a/src/ensembl/src/content/app/species/components/species-title-area/species-remove/SpeciesRemove.tsx
+++ b/src/ensembl/src/content/app/species/components/species-title-area/species-remove/SpeciesRemove.tsx
@@ -19,7 +19,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { push } from 'connected-react-router';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
-import useAnalyticsService from 'ensemblRoot/src/shared/hooks/useAnalyticsService';
+import useSpeciesAnalytics from 'src/content/app/species/hooks/useSpeciesAnalytics';
 
 import { getActiveGenomeId } from 'src/content/app/species/state/general/speciesGeneralSelectors';
 import { getCommittedSpeciesById } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
@@ -40,7 +40,7 @@ const SpeciesRemove = () => {
   );
   const dispatch = useDispatch();
 
-  const { trackDeletedSpecies } = useAnalyticsService();
+  const { trackDeletedSpecies } = useSpeciesAnalytics();
 
   if (!genomeId || !species) {
     return null;

--- a/src/ensembl/src/content/app/species/components/species-title-area/species-usage-toggle/SpeciesUsageToggle.test.tsx
+++ b/src/ensembl/src/content/app/species/components/species-title-area/species-usage-toggle/SpeciesUsageToggle.test.tsx
@@ -40,6 +40,12 @@ jest.mock('src/shared/components/slide-toggle/SlideToggle', () =>
   jest.fn(() => null)
 );
 
+jest.mock('src/shared/hooks/useAnalyticsService', () =>
+  jest.fn(() => ({
+    trackSpeciesUse: jest.fn()
+  }))
+);
+
 const selectedSpecies = createSelectedSpecies();
 const disabledSpecies = {
   ...selectedSpecies,

--- a/src/ensembl/src/content/app/species/components/species-title-area/species-usage-toggle/SpeciesUsageToggle.test.tsx
+++ b/src/ensembl/src/content/app/species/components/species-title-area/species-usage-toggle/SpeciesUsageToggle.test.tsx
@@ -40,7 +40,7 @@ jest.mock('src/shared/components/slide-toggle/SlideToggle', () =>
   jest.fn(() => null)
 );
 
-jest.mock('src/shared/hooks/useAnalyticsService', () =>
+jest.mock('src/content/app/species/hooks/useSpeciesAnalytics', () =>
   jest.fn(() => ({
     trackSpeciesUse: jest.fn()
   }))

--- a/src/ensembl/src/content/app/species/components/species-title-area/species-usage-toggle/SpeciesUsageToggle.tsx
+++ b/src/ensembl/src/content/app/species/components/species-title-area/species-usage-toggle/SpeciesUsageToggle.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
-import useAnalyticsService from 'src/shared/hooks/useAnalyticsService';
+import useSpeciesAnalytics from 'src/content/app/species/hooks/useSpeciesAnalytics';
 
 import { getActiveGenomeId } from 'src/content/app/species/state/general/speciesGeneralSelectors';
 import { getCommittedSpeciesById } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
@@ -43,7 +43,7 @@ const SpeciesUsageToggle = () => {
   );
   const dispatch = useDispatch();
 
-  const { trackSpeciesUse } = useAnalyticsService();
+  const { trackSpeciesUse } = useSpeciesAnalytics();
 
   if (!genomeId || !species) {
     return null;

--- a/src/ensembl/src/content/app/species/components/species-title-area/species-usage-toggle/SpeciesUsageToggle.tsx
+++ b/src/ensembl/src/content/app/species/components/species-title-area/species-usage-toggle/SpeciesUsageToggle.tsx
@@ -17,6 +17,8 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
+import useAnalyticsService from 'src/shared/hooks/useAnalyticsService';
+
 import { getActiveGenomeId } from 'src/content/app/species/state/general/speciesGeneralSelectors';
 import { getCommittedSpeciesById } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 
@@ -41,11 +43,14 @@ const SpeciesUsageToggle = () => {
   );
   const dispatch = useDispatch();
 
+  const { trackSpeciesUse } = useAnalyticsService();
+
   if (!genomeId || !species) {
     return null;
   }
 
   const onToggleUse = () => {
+    trackSpeciesUse(species);
     dispatch(toggleSpeciesUseAndSave(genomeId));
   };
 

--- a/src/ensembl/src/content/app/species/hooks/useSpeciesAnalytics.ts
+++ b/src/ensembl/src/content/app/species/hooks/useSpeciesAnalytics.ts
@@ -16,20 +16,16 @@
 
 import analyticsTracking from 'src/services/analytics-service';
 
-import { getSpeciesAnalyticsName } from 'ensemblRoot/src/content/app/species-selector/speciesSelectorHelper';
+import { getSpeciesAnalyticsName } from 'src/content/app/species-selector/speciesSelectorHelper';
 
 import { CommittedItem } from 'src/content/app/species-selector/types/species-search';
-
-enum AnalyticsCategories {
-  SPECIES_PAGE = 'species_page'
-}
 
 const useSpeciesAnalytics = () => {
   const trackDeletedSpecies = (species: CommittedItem) => {
     const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
 
     analyticsTracking.trackEvent({
-      category: AnalyticsCategories.SPECIES_PAGE,
+      category: 'species_page',
       label: speciesNameForAnalytics,
       action: 'remove',
       species: speciesNameForAnalytics
@@ -42,7 +38,7 @@ const useSpeciesAnalytics = () => {
     const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
 
     analyticsTracking.trackEvent({
-      category: AnalyticsCategories.SPECIES_PAGE,
+      category: 'species_page',
       label: speciesNameForAnalytics,
       action: updatedStatus,
       species: speciesNameForAnalytics
@@ -54,7 +50,7 @@ const useSpeciesAnalytics = () => {
     sectionName: string
   ) => {
     analyticsTracking.trackEvent({
-      category: AnalyticsCategories.SPECIES_PAGE,
+      category: 'species_page',
       action: 'open_section',
       label: sectionName,
       species: getSpeciesAnalyticsName(species)
@@ -66,7 +62,7 @@ const useSpeciesAnalytics = () => {
     exampleLinkType: string
   ) => {
     analyticsTracking.trackEvent({
-      category: AnalyticsCategories.SPECIES_PAGE,
+      category: 'species_page',
       action: 'example_link_selected',
       label: exampleLinkType,
       species: getSpeciesAnalyticsName(species)

--- a/src/ensembl/src/content/app/species/hooks/useSpeciesAnalytics.ts
+++ b/src/ensembl/src/content/app/species/hooks/useSpeciesAnalytics.ts
@@ -1,0 +1,85 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import analyticsTracking from 'src/services/analytics-service';
+
+import { getSpeciesAnalyticsName } from 'ensemblRoot/src/content/app/species-selector/speciesSelectorHelper';
+
+import { CommittedItem } from 'src/content/app/species-selector/types/species-search';
+
+enum AnalyticsCategories {
+  SPECIES_PAGE = 'species_page'
+}
+
+const useSpeciesAnalytics = () => {
+  const { trackEvent } = analyticsTracking;
+
+  const trackDeletedSpecies = (species: CommittedItem) => {
+    const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
+
+    trackEvent({
+      category: AnalyticsCategories.SPECIES_PAGE,
+      label: speciesNameForAnalytics,
+      action: 'remove',
+      species: speciesNameForAnalytics
+    });
+  };
+
+  const trackSpeciesUse = (species: CommittedItem) => {
+    const updatedStatus = species.isEnabled ? 'do_not_use' : 'use';
+
+    const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
+
+    trackEvent({
+      category: AnalyticsCategories.SPECIES_PAGE,
+      label: speciesNameForAnalytics,
+      action: updatedStatus,
+      species: speciesNameForAnalytics
+    });
+  };
+
+  const trackSpeciesStatsSectionOpen = (
+    species: CommittedItem,
+    sectionName: string
+  ) => {
+    trackEvent({
+      category: AnalyticsCategories.SPECIES_PAGE,
+      action: 'open_section',
+      label: sectionName,
+      species: getSpeciesAnalyticsName(species)
+    });
+  };
+
+  const trackSpeciesPageExampleLink = (
+    species: CommittedItem,
+    exampleLinkType: string
+  ) => {
+    trackEvent({
+      category: AnalyticsCategories.SPECIES_PAGE,
+      action: 'example_link_selected',
+      label: exampleLinkType,
+      species: getSpeciesAnalyticsName(species)
+    });
+  };
+
+  return {
+    trackDeletedSpecies,
+    trackSpeciesUse,
+    trackSpeciesStatsSectionOpen,
+    trackSpeciesPageExampleLink
+  };
+};
+export default useSpeciesAnalytics;

--- a/src/ensembl/src/content/app/species/hooks/useSpeciesAnalytics.ts
+++ b/src/ensembl/src/content/app/species/hooks/useSpeciesAnalytics.ts
@@ -25,12 +25,10 @@ enum AnalyticsCategories {
 }
 
 const useSpeciesAnalytics = () => {
-  const { trackEvent } = analyticsTracking;
-
   const trackDeletedSpecies = (species: CommittedItem) => {
     const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
 
-    trackEvent({
+    analyticsTracking.trackEvent({
       category: AnalyticsCategories.SPECIES_PAGE,
       label: speciesNameForAnalytics,
       action: 'remove',
@@ -43,7 +41,7 @@ const useSpeciesAnalytics = () => {
 
     const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
 
-    trackEvent({
+    analyticsTracking.trackEvent({
       category: AnalyticsCategories.SPECIES_PAGE,
       label: speciesNameForAnalytics,
       action: updatedStatus,
@@ -55,7 +53,7 @@ const useSpeciesAnalytics = () => {
     species: CommittedItem,
     sectionName: string
   ) => {
-    trackEvent({
+    analyticsTracking.trackEvent({
       category: AnalyticsCategories.SPECIES_PAGE,
       action: 'open_section',
       label: sectionName,
@@ -67,7 +65,7 @@ const useSpeciesAnalytics = () => {
     species: CommittedItem,
     exampleLinkType: string
   ) => {
-    trackEvent({
+    analyticsTracking.trackEvent({
       category: AnalyticsCategories.SPECIES_PAGE,
       action: 'example_link_selected',
       label: exampleLinkType,

--- a/src/ensembl/src/server/helpers/getConfigForClient.ts
+++ b/src/ensembl/src/server/helpers/getConfigForClient.ts
@@ -39,7 +39,7 @@ const getEnvironment = () => {
 // TODO: Revert the following change before merging
 const getKeys = () => {
   return {
-    googleAnalyticsKey: process.env.GOOGLE_ANALYTICS_KEY ?? 'UA-58710484-17'
+    googleAnalyticsKey: process.env.GOOGLE_ANALYTICS_KEY ?? ''
   };
 };
 

--- a/src/ensembl/src/server/helpers/getConfigForClient.ts
+++ b/src/ensembl/src/server/helpers/getConfigForClient.ts
@@ -36,7 +36,6 @@ const getEnvironment = () => {
   };
 };
 
-// TODO: Revert the following change before merging
 const getKeys = () => {
   return {
     googleAnalyticsKey: process.env.GOOGLE_ANALYTICS_KEY ?? ''

--- a/src/ensembl/src/server/helpers/getConfigForClient.ts
+++ b/src/ensembl/src/server/helpers/getConfigForClient.ts
@@ -36,9 +36,10 @@ const getEnvironment = () => {
   };
 };
 
+// TODO: Revert the following change before merging
 const getKeys = () => {
   return {
-    googleAnalyticsKey: process.env.GOOGLE_ANALYTICS_KEY ?? ''
+    googleAnalyticsKey: process.env.GOOGLE_ANALYTICS_KEY ?? 'UA-58710484-17'
   };
 };
 

--- a/src/ensembl/src/services/analytics-service.ts
+++ b/src/ensembl/src/services/analytics-service.ts
@@ -38,6 +38,9 @@ class AnalyticsTracking {
 
   // Track an event
   public trackEvent(ga: AnalyticsOptions) {
+    typeof ga.species === 'string' && this.setSpeciesDimension(ga.species);
+    typeof ga.app === 'string' && this.setAppDimension(ga.app);
+
     this.reactGA.event({
       action: ga.action,
       category: ga.category,
@@ -49,13 +52,13 @@ class AnalyticsTracking {
   }
 
   // Set app custom dimension
-  public setAppDimension(page: string) {
-    this.reactGA.ga('set', CustomDimensions.APP, page);
+  public setAppDimension(app: string) {
+    this.reactGA.ga('set', CustomDimensions.APP, app);
   }
 
   // Set species custom dimension
-  public setSpeciesDimension(genomeId: string) {
-    this.reactGA.ga('set', CustomDimensions.SPECIES, genomeId);
+  public setSpeciesDimension(speciesAnalyticsName: string) {
+    this.reactGA.ga('set', CustomDimensions.SPECIES, speciesAnalyticsName);
   }
 }
 

--- a/src/ensembl/src/shared/components/communication-framework/ConversationIcon.tsx
+++ b/src/ensembl/src/shared/components/communication-framework/ConversationIcon.tsx
@@ -17,6 +17,8 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
 
+import useAnalyticsService from 'ensemblRoot/src/shared/hooks/useAnalyticsService';
+
 import { toggleCommunicationPanel } from 'src/shared/state/communication/communicationSlice';
 import { ReactComponent as ConversationImageIcon } from 'static/img/shared/icon_conversation.svg';
 import CommunicationPanel from 'ensemblRoot/src/shared/components/communication-framework/CommunicationPanel';
@@ -26,7 +28,11 @@ import styles from './ConversationIcon.scss';
 const ConversationIcon = () => {
   const dispatch = useDispatch();
 
+  const { trackContextualHelpOpened } = useAnalyticsService();
+
   const onClick = () => {
+    trackContextualHelpOpened();
+
     dispatch(toggleCommunicationPanel());
   };
   return (

--- a/src/ensembl/src/shared/components/communication-framework/ConversationIcon.tsx
+++ b/src/ensembl/src/shared/components/communication-framework/ConversationIcon.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
 
-import useAnalyticsService from 'ensemblRoot/src/shared/hooks/useAnalyticsService';
+import useCommonAnalytics from 'ensemblRoot/src/shared/hooks/useCommonAnalytics';
 
 import { toggleCommunicationPanel } from 'src/shared/state/communication/communicationSlice';
 import { ReactComponent as ConversationImageIcon } from 'static/img/shared/icon_conversation.svg';
@@ -28,7 +28,7 @@ import styles from './ConversationIcon.scss';
 const ConversationIcon = () => {
   const dispatch = useDispatch();
 
-  const { trackContextualHelpOpened } = useAnalyticsService();
+  const { trackContextualHelpOpened } = useCommonAnalytics();
 
   const onClick = () => {
     trackContextualHelpOpened();

--- a/src/ensembl/src/shared/hooks/useAnalyticsService.ts
+++ b/src/ensembl/src/shared/hooks/useAnalyticsService.ts
@@ -17,137 +17,12 @@ import { useSelector } from 'react-redux';
 
 import analyticsTracking from 'src/services/analytics-service';
 
-import { getSpeciesAnalyticsName } from 'ensemblRoot/src/content/app/species-selector/speciesSelectorHelper';
-
-import { getCommittedSpecies } from 'ensemblRoot/src/content/app/species-selector/state/speciesSelectorSelectors';
 import { getCurrentApp } from 'ensemblRoot/src/header/headerSelectors';
-
-import {
-  CommittedItem,
-  PopularSpecies,
-  SearchMatch
-} from 'src/content/app/species-selector/types/species-search';
-import { CurrentItem } from 'src/content/app/species-selector/state/speciesSelectorState';
-
-enum AnalyticsCategories {
-  SPECIES_PAGE = 'species_page',
-  SELECTED_SPECIES = 'selected_species',
-  SPECIES_SELECTOR = 'species_selector',
-  POPULAR_SPECIES = 'popular_species',
-  SPECIES_SEARCH = 'species_search'
-}
 
 const useAnalyticsService = () => {
   const { trackEvent } = analyticsTracking;
 
   const currentAppName = useSelector(getCurrentApp);
-
-  const committedSpecies = useSelector(getCommittedSpecies);
-
-  /*  Species Selector Page Events */
-  const trackAutocompleteSpeciesSelect = (species: SearchMatch) => {
-    const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
-
-    trackEvent({
-      category: AnalyticsCategories.SPECIES_SEARCH,
-      action: 'preselect',
-      label: speciesNameForAnalytics,
-      species: speciesNameForAnalytics
-    });
-  };
-
-  const trackPopularSpeciesSelect = (
-    species: PopularSpecies,
-    action: string
-  ) => {
-    const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
-
-    trackEvent({
-      category: AnalyticsCategories.POPULAR_SPECIES,
-      action: action,
-      label: speciesNameForAnalytics,
-      species: speciesNameForAnalytics
-    });
-  };
-
-  const trackCommitedSpecies = (species: CurrentItem) => {
-    const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
-
-    trackEvent({
-      category: AnalyticsCategories.SPECIES_SELECTOR,
-      label: speciesNameForAnalytics,
-      action: 'add',
-      species: speciesNameForAnalytics
-    });
-
-    if (committedSpecies.length > 1) {
-      trackFinalSetOfSpecies(species);
-    }
-  };
-
-  const trackFinalSetOfSpecies = (newlyCommittedSpecies: CurrentItem) => {
-    const committedSpeciesNames = [newlyCommittedSpecies, ...committedSpecies]
-      .map((species) => getSpeciesAnalyticsName(species))
-      .sort();
-
-    trackEvent({
-      category: AnalyticsCategories.SPECIES_SELECTOR,
-      action: 'select_multiple',
-      label: committedSpeciesNames.join(','),
-      value: committedSpeciesNames.length,
-      species: ''
-    });
-  };
-
-  /*  Species Home Page Events */
-
-  const trackDeletedSpecies = (species: CommittedItem) => {
-    const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
-
-    trackEvent({
-      category: AnalyticsCategories.SPECIES_PAGE,
-      label: speciesNameForAnalytics,
-      action: 'remove',
-      species: speciesNameForAnalytics
-    });
-  };
-
-  const trackSpeciesUse = (species: CommittedItem) => {
-    const updatedStatus = species.isEnabled ? 'do_not_use' : 'use';
-
-    const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
-
-    trackEvent({
-      category: AnalyticsCategories.SPECIES_PAGE,
-      label: speciesNameForAnalytics,
-      action: updatedStatus,
-      species: speciesNameForAnalytics
-    });
-  };
-
-  const trackSpeciesStatsSectionOpen = (
-    species: CommittedItem,
-    sectionName: string
-  ) => {
-    trackEvent({
-      category: AnalyticsCategories.SPECIES_PAGE,
-      action: 'open_section',
-      label: sectionName,
-      species: getSpeciesAnalyticsName(species)
-    });
-  };
-
-  const trackSpeciesPageExampleLink = (
-    species: CommittedItem,
-    exampleLinkType: string
-  ) => {
-    trackEvent({
-      category: AnalyticsCategories.SPECIES_PAGE,
-      action: 'example_link_selected',
-      label: exampleLinkType,
-      species: getSpeciesAnalyticsName(species)
-    });
-  };
 
   /* Contextual Help */
   const trackContextualHelpOpened = () => {
@@ -158,13 +33,6 @@ const useAnalyticsService = () => {
   };
 
   return {
-    trackDeletedSpecies,
-    trackSpeciesUse,
-    trackCommitedSpecies,
-    trackPopularSpeciesSelect,
-    trackAutocompleteSpeciesSelect,
-    trackSpeciesStatsSectionOpen,
-    trackSpeciesPageExampleLink,
     trackContextualHelpOpened
   };
 };

--- a/src/ensembl/src/shared/hooks/useAnalyticsService.ts
+++ b/src/ensembl/src/shared/hooks/useAnalyticsService.ts
@@ -20,13 +20,11 @@ import analyticsTracking from 'src/services/analytics-service';
 import { getCurrentApp } from 'ensemblRoot/src/header/headerSelectors';
 
 const useAnalyticsService = () => {
-  const { trackEvent } = analyticsTracking;
-
   const currentAppName = useSelector(getCurrentApp);
 
   /* Contextual Help */
   const trackContextualHelpOpened = () => {
-    trackEvent({
+    analyticsTracking.trackEvent({
       category: currentAppName,
       action: 'open_contextual_help'
     });

--- a/src/ensembl/src/shared/hooks/useAnalyticsService.ts
+++ b/src/ensembl/src/shared/hooks/useAnalyticsService.ts
@@ -1,0 +1,171 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useSelector } from 'react-redux';
+
+import analyticsTracking from 'src/services/analytics-service';
+
+import { getSpeciesAnalyticsName } from 'ensemblRoot/src/content/app/species-selector/speciesSelectorHelper';
+
+import { getCommittedSpecies } from 'ensemblRoot/src/content/app/species-selector/state/speciesSelectorSelectors';
+import { getCurrentApp } from 'ensemblRoot/src/header/headerSelectors';
+
+import {
+  CommittedItem,
+  PopularSpecies,
+  SearchMatch
+} from 'src/content/app/species-selector/types/species-search';
+import { CurrentItem } from 'src/content/app/species-selector/state/speciesSelectorState';
+
+enum AnalyticsCategories {
+  SPECIES_PAGE = 'species_page',
+  SELECTED_SPECIES = 'selected_species',
+  SPECIES_SELECTOR = 'species_selector',
+  POPULAR_SPECIES = 'popular_species',
+  SPECIES_SEARCH = 'species_search'
+}
+
+const useAnalyticsService = () => {
+  const { trackEvent } = analyticsTracking;
+
+  const currentAppName = useSelector(getCurrentApp);
+
+  const committedSpecies = useSelector(getCommittedSpecies);
+
+  /*  Species Selector Page Events */
+  const trackAutocompleteSpeciesSelect = (species: SearchMatch) => {
+    const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
+
+    trackEvent({
+      category: AnalyticsCategories.SPECIES_SEARCH,
+      action: 'preselect',
+      label: speciesNameForAnalytics,
+      species: speciesNameForAnalytics
+    });
+  };
+
+  const trackPopularSpeciesSelect = (
+    species: PopularSpecies,
+    action: string
+  ) => {
+    const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
+
+    trackEvent({
+      category: AnalyticsCategories.POPULAR_SPECIES,
+      action: action,
+      label: speciesNameForAnalytics,
+      species: speciesNameForAnalytics
+    });
+  };
+
+  const trackCommitedSpecies = (species: CurrentItem) => {
+    const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
+
+    trackEvent({
+      category: AnalyticsCategories.SPECIES_SELECTOR,
+      label: speciesNameForAnalytics,
+      action: 'add',
+      species: speciesNameForAnalytics
+    });
+
+    if (committedSpecies.length > 1) {
+      trackFinalSetOfSpecies(species);
+    }
+  };
+
+  const trackFinalSetOfSpecies = (newlyCommittedSpecies: CurrentItem) => {
+    const committedSpeciesNames = [newlyCommittedSpecies, ...committedSpecies]
+      .map((species) => getSpeciesAnalyticsName(species))
+      .sort();
+
+    trackEvent({
+      category: AnalyticsCategories.SPECIES_SELECTOR,
+      action: 'select_multiple',
+      label: committedSpeciesNames.join(','),
+      value: committedSpeciesNames.length,
+      species: ''
+    });
+  };
+
+  /*  Species Home Page Events */
+
+  const trackDeletedSpecies = (species: CommittedItem) => {
+    const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
+
+    trackEvent({
+      category: AnalyticsCategories.SPECIES_PAGE,
+      label: speciesNameForAnalytics,
+      action: 'remove',
+      species: speciesNameForAnalytics
+    });
+  };
+
+  const trackSpeciesUse = (species: CommittedItem) => {
+    const updatedStatus = species.isEnabled ? 'do_not_use' : 'use';
+
+    const speciesNameForAnalytics = getSpeciesAnalyticsName(species);
+
+    trackEvent({
+      category: AnalyticsCategories.SPECIES_PAGE,
+      label: speciesNameForAnalytics,
+      action: updatedStatus,
+      species: speciesNameForAnalytics
+    });
+  };
+
+  const trackSpeciesStatsSectionOpen = (
+    species: CommittedItem,
+    sectionName: string
+  ) => {
+    trackEvent({
+      category: AnalyticsCategories.SPECIES_PAGE,
+      action: 'open_section',
+      label: sectionName,
+      species: getSpeciesAnalyticsName(species)
+    });
+  };
+
+  const trackSpeciesPageExampleLink = (
+    species: CommittedItem,
+    exampleLinkType: string
+  ) => {
+    trackEvent({
+      category: AnalyticsCategories.SPECIES_PAGE,
+      action: 'example_link_selected',
+      label: exampleLinkType,
+      species: getSpeciesAnalyticsName(species)
+    });
+  };
+
+  /* Contextual Help */
+  const trackContextualHelpOpened = () => {
+    trackEvent({
+      category: currentAppName,
+      action: 'open_contextual_help'
+    });
+  };
+
+  return {
+    trackDeletedSpecies,
+    trackSpeciesUse,
+    trackCommitedSpecies,
+    trackPopularSpeciesSelect,
+    trackAutocompleteSpeciesSelect,
+    trackSpeciesStatsSectionOpen,
+    trackSpeciesPageExampleLink,
+    trackContextualHelpOpened
+  };
+};
+export default useAnalyticsService;

--- a/src/ensembl/src/shared/hooks/useCommonAnalytics.ts
+++ b/src/ensembl/src/shared/hooks/useCommonAnalytics.ts
@@ -19,7 +19,7 @@ import analyticsTracking from 'src/services/analytics-service';
 
 import { getCurrentApp } from 'ensemblRoot/src/header/headerSelectors';
 
-const useAnalyticsService = () => {
+const useCommonAnalytics = () => {
   const currentAppName = useSelector(getCurrentApp);
 
   /* Contextual Help */
@@ -34,4 +34,4 @@ const useAnalyticsService = () => {
     trackContextualHelpOpened
   };
 };
-export default useAnalyticsService;
+export default useCommonAnalytics;

--- a/src/ensembl/tests/fixtures/selected-species.ts
+++ b/src/ensembl/tests/fixtures/selected-species.ts
@@ -22,5 +22,7 @@ export const createSelectedSpecies = () => ({
   common_name: null,
   scientific_name: faker.lorem.words(),
   assembly_name: faker.lorem.word(),
-  isEnabled: true
+  isEnabled: true,
+  selectedStrainId: null,
+  strains: []
 });


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [x] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
<!--_Please provide the URL(s) for any JIRA issues related to this PR._-->

## Description
- Added the analytics to the species home page & species selector page that are defined in the following sheet:
https://docs.google.com/spreadsheets/d/1CnW-rx212UwAMTXnjZXCPfZ72Kva7_kRiG6X6pfSN94/edit#gid=759172321

- Created the hook `useAnalyticsService` and updated the existing GA events to use the hook

## Deployment URL
http://species-page-analytics.review.ensembl.org


## Views affected
- Species selector
- Species home page

### Other effects
- [x] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.
