### PR TITLE
Fix species list layout in species selector and species homepage

### DIFF
--- a/src/ensembl/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
@@ -78,7 +78,9 @@ const SelectedSpeciesList = (props: Props) => {
     />
   ));
 
-  return <SpeciesTabsWrapper speciesTabs={selectedSpecies} />;
+  return (
+    <SpeciesTabsWrapper isWrappable={false} speciesTabs={selectedSpecies} />
+  );
 };
 
 const mapStateToProps = (state: RootState) => ({

--- a/src/ensembl/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
@@ -78,9 +78,7 @@ const SelectedSpeciesList = (props: Props) => {
     />
   ));
 
-  return (
-    <SpeciesTabsWrapper isWrappable={false} speciesTabs={selectedSpecies} />
-  );
+  return <SpeciesTabsWrapper speciesTabs={selectedSpecies} />;
 };
 
 const mapStateToProps = (state: RootState) => ({

--- a/src/ensembl/src/content/app/species/components/species-app-bar/SpeciesAppBar.tsx
+++ b/src/ensembl/src/content/app/species/components/species-app-bar/SpeciesAppBar.tsx
@@ -46,9 +46,7 @@ const SpeciesAppBar = (props: SpeciesAppBarProps) => {
     />
   ));
 
-  const wrappedSpecies = (
-    <SpeciesTabsWrapper isWrappable={false} speciesTabs={speciesTabs} />
-  );
+  const wrappedSpecies = <SpeciesTabsWrapper speciesTabs={speciesTabs} />;
 
   return (
     <AppBar

--- a/src/ensembl/src/content/app/species/components/species-app-bar/SpeciesAppBar.tsx
+++ b/src/ensembl/src/content/app/species/components/species-app-bar/SpeciesAppBar.tsx
@@ -47,7 +47,7 @@ const SpeciesAppBar = (props: SpeciesAppBarProps) => {
   ));
 
   const wrappedSpecies = (
-    <SpeciesTabsWrapper isWrappable={true} speciesTabs={speciesTabs} />
+    <SpeciesTabsWrapper isWrappable={false} speciesTabs={speciesTabs} />
   );
 
   return (

--- a/src/ensembl/src/shared/components/app-bar/AppBar.scss
+++ b/src/ensembl/src/shared/components/app-bar/AppBar.scss
@@ -3,7 +3,6 @@
 .appBar {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(250px, auto);
-  grid-template-rows: auto 40px;
   align-content: start;
   grid-template-areas:
     'top top'
@@ -40,6 +39,8 @@
   display: flex;
   align-items: flex-start;
   justify-content: flex-end;
+  position: relative;
+  top: 2px;
 
   .conversationIcon {
     width: 40px;


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
[ENSWBSITES-1299](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1299)

## Description
~~The species list in the app bar doesn't appear properly when it overflows after adding many species.~~

![image](https://user-images.githubusercontent.com/32512909/131163535-907b7691-5f48-4f8e-86db-acd583a95da8.png)

~~So I've made the species list to appear in one line like how it does in other places like genome browser and entity viewer.~~

![image](https://user-images.githubusercontent.com/32512909/131163847-e8765a56-d229-4982-ab9d-24dbcb16aad7.png)

However I am not sure if this was what was intended in the design as I couldn't find anything similar to it.

**Edit:** As Andrey pointed in the PR comment below, it was the wrong solution. Instead the task required to wrap the species in multi lines. I have updated the PR accordingly. The species list now looks like this.

![image](https://user-images.githubusercontent.com/32512909/131879629-9fa6fa6e-6cb3-4d60-9118-3b612ae07b03.png)

## Deployment URL
http://fix-species-list.review.ensembl.org/

## Views affected
Species selector -> App bar
Species homepage -> App bar
