### PR TITLE
ENSWBSITES-642: filter and sorting state update

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.tsx
@@ -31,7 +31,6 @@ import {
 import { getPreviouslyViewedEntities } from 'src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSelectors';
 
 import { closeSidebarModal } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSlice';
-import { clearFilterSorting } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 
 import TextLine from 'src/shared/components/text-line/TextLine';
 
@@ -47,11 +46,6 @@ type PreviouslyViewedLinksProps = {
 
 export const PreviouslyViewedLinks = (props: PreviouslyViewedLinksProps) => {
   const dispatch = useDispatch();
-
-  const onClick = () => {
-    dispatch(clearFilterSorting());
-    dispatch(closeSidebarModal());
-  };
 
   const activeEntityStableId = parseEnsObjectId(props.activeEntityId).objectId;
   const previouslyViewedEntitiesWithoutActiveEntity =
@@ -73,7 +67,7 @@ export const PreviouslyViewedLinks = (props: PreviouslyViewedLinksProps) => {
 
           return (
             <div key={index} className={styles.linkHolder}>
-              <Link to={path} onClick={onClick}>
+              <Link to={path} onClick={() => dispatch(closeSidebarModal())}>
                 <TextLine
                   text={previouslyViewedEntity.label}
                   className={styles.label}

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.tsx
@@ -31,6 +31,7 @@ import {
 import { getPreviouslyViewedEntities } from 'src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSelectors';
 
 import { closeSidebarModal } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSlice';
+import { clearFilterSorting } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 
 import TextLine from 'src/shared/components/text-line/TextLine';
 
@@ -46,6 +47,11 @@ type PreviouslyViewedLinksProps = {
 
 export const PreviouslyViewedLinks = (props: PreviouslyViewedLinksProps) => {
   const dispatch = useDispatch();
+
+  const onClick = () => {
+    dispatch(clearFilterSorting());
+    dispatch(closeSidebarModal());
+  };
 
   const activeEntityStableId = parseEnsObjectId(props.activeEntityId).objectId;
   const previouslyViewedEntitiesWithoutActiveEntity =
@@ -67,7 +73,7 @@ export const PreviouslyViewedLinks = (props: PreviouslyViewedLinksProps) => {
 
           return (
             <div key={index} className={styles.linkHolder}>
-              <Link to={path} onClick={() => dispatch(closeSidebarModal())}>
+              <Link to={path} onClick={onClick}>
                 <TextLine
                   text={previouslyViewedEntity.label}
                   className={styles.label}

--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
@@ -109,6 +109,31 @@ export const setSortingRule =
     );
   };
 
+export const clearFilterSorting =
+  (): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const state = getState();
+    const activeGenomeId = getEntityViewerActiveGenomeId(state);
+    const activeEntityId = getEntityViewerActiveEntityId(state);
+    if (!activeGenomeId || !activeEntityId) {
+      return;
+    }
+    dispatch(
+      transcriptsSlice.actions.updateFilters({
+        activeGenomeId,
+        activeEntityId,
+        filters: defaultStatePerGene.filters
+      })
+    );
+    dispatch(
+      transcriptsSlice.actions.updateSortingRule({
+        activeGenomeId,
+        activeEntityId,
+        sortingRule: defaultStatePerGene.sortingRule
+      })
+    );
+  };
+
 export const toggleTranscriptInfo =
   (transcriptId: string): ThunkAction<void, any, null, Action<string>> =>
   (dispatch, getState: () => RootState) => {

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralSlice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralSlice.ts
@@ -26,6 +26,7 @@ import entityViewerStorageService from 'src/content/app/entity-viewer/services/e
 
 import { fetchGenomeData } from 'src/shared/state/genome/genomeActions';
 import { ensureSpeciesIsEnabled } from 'src/content/app/species-selector/state/speciesSelectorActions';
+import { clearFilterSorting } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 
 import {
   getEntityViewerActiveGenomeId,
@@ -89,6 +90,9 @@ export const setDataFromUrl =
             entityId
           })
         );
+      }
+      if (activeGenomeId === genomeIdFromUrl && entityId !== activeEntityId) {
+        dispatch(clearFilterSorting());
       }
 
       entityViewerStorageService.updateGeneralState({


### PR DESCRIPTION
Only remember state for filtering and sorting when viewing gene or switching from app back to same gene
Do not remember filtering and sorting state for previously viewed objects
Resetting filter and sorting when clicking on previously viewed objects

## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-642

## Importance
N/A

## Description
Currently we are storing the filters and sorting state on the gene and when switching app or browsing away we still keep the filter and sorting state on that gene. 
New way of doing it (more detailed description in Jira) is to only store the state on the gene thats being viewed, once you navigate to another gene, the state is reset.

## Deployment URL
http://filter-reset.review.ensembl.org

## Views affected
Entity Viewer

### Other effects
N/A

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
N/A
