### PR TITLE
fix chrome warning on making event handlers passive

### DIFF
--- a/src/ensembl/src/shared/hooks/useHover.tsx
+++ b/src/ensembl/src/shared/hooks/useHover.tsx
@@ -44,7 +44,7 @@ export default function useHover<T extends HTMLElement>(): UseHoverType<T> {
       element.addEventListener('mouseenter', handleMouseEnter);
       element.addEventListener('mouseleave', handleMouseLeave);
       element.addEventListener('click', handleMouseLeave);
-      element.addEventListener('touchstart', handleTouch);
+      element.addEventListener('touchstart', handleTouch, { passive: true });
 
       // cancel hover state if user switches to a different tab
       document.addEventListener('visibilitychange', handleMouseLeave);


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
N/A

## Description
A lots of warning started showing up on Chrome on the production as well as sandboxes about making event handlers passive
![Screenshot 2021-09-06 at 16 13 56](https://user-images.githubusercontent.com/6347854/132237595-a519a715-dfc1-4de7-8233-3e9da8a0c7a0.png)


## Deployment URL
http://chrome-warning.review.ensembl.org/

## Views affected
Genome browser

### Other effects
Not sure

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
Hopefully nothing