### PR TITLE
Remove PAR information

### DIFF
--- a/src/ensembl/src/content/app/species/sample-data.ts
+++ b/src/ensembl/src/content/app/species/sample-data.ts
@@ -627,12 +627,7 @@ export const sidebarData: SpeciesSidebarData = {
     assembly_level: 'complete genome',
     annotation_method: 'full genebuild',
     assembly_date: '2019-02-01',
-    notes: [
-      {
-        heading: 'Pseudoautosomal regions',
-        body: 'The Y chromosome in this assembly contains two psuedoautosomal regions (PARs) that were taken from the corresponding X chromosoles and are exact duplicates:\nchrX:10,000-2,781,479 = chrY:10,000-2,781,479\nchrX:155,701,382-156,030,895 = chrY:56,887,02-57,217,415'
-      }
-    ]
+    notes: []
   },
   homo_sapiens_GCA_000001405_14: {
     id: 'GCA_000001405.14',


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1295

## Description
We are not showing any annotation on the PAR regions, so we should remove it.

## Deployment URL
http://remove-par-info.review.ensembl.org/species/homo_sapiens_GCA_000001405_28

## Views affected
Species homepage

### Other effects
N/A

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
N/A
