### PR TITLE
Update product type and fix External references tab

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.test.tsx
@@ -148,7 +148,7 @@ describe('<TranscriptsListItemInfo /', () => {
   it('calls correct callback when protein link is clicked', () => {
     const { container } = renderComponent();
     const proteinId =
-      defaultProps.transcript.product_generating_contexts[0].product.stable_id;
+      defaultProps.transcript.product_generating_contexts[0].product?.stable_id;
     const proteinLink = [...container.querySelectorAll('a')].find(
       (link) => link.textContent === proteinId
     ) as HTMLElement;

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -67,11 +67,7 @@ type Transcript = Pick<
   } & {
     product_generating_contexts: Array<
       Pick<FullProductGeneratingContext, 'product_type'> &
-        Pick2<
-          FullProductGeneratingContext,
-          'product',
-          'length' | 'stable_id'
-        > & {
+        Pick<FullProductGeneratingContext, 'product'> & {
           phased_exons: Array<
             Pick<PhasedExon, 'start_phase' | 'end_phase'> &
               Pick2<PhasedExon, 'exon', 'stable_id'>
@@ -192,6 +188,7 @@ export const TranscriptsListItemInfo = (
     );
   };
 
+  const product = transcript.product_generating_contexts[0].product;
   return (
     <div className={mainStyles}>
       <div className={transcriptsListStyles.left}></div>
@@ -208,9 +205,7 @@ export const TranscriptsListItemInfo = (
               <div>
                 <strong>{aminoAcidLength} aa</strong>
               </div>
-              {getLinkToProteinView(
-                transcript.product_generating_contexts[0]?.product.stable_id
-              )}
+              {product && getLinkToProteinView(product?.stable_id)}
             </>
           )}
         </div>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.tsx
@@ -108,7 +108,7 @@ type Transcript = {
   slice: Pick2<Slice, 'location', 'length'>;
   product_generating_contexts: Array<
     Pick<FullProductGeneratingContext, 'product_type'> & {
-      product: { external_references: ExternalReferenceType[] };
+      product: { external_references: ExternalReferenceType[] } | null;
     }
   >;
   external_references: ExternalReferenceType[];
@@ -223,9 +223,10 @@ const TranscriptXrefs = (props: { transcript: Transcript }) => {
   // Add protein level xrefs
   transcript.product_generating_contexts.forEach(
     (product_generating_context) => {
-      unsortedXrefs.push(
-        ...product_generating_context.product.external_references
-      );
+      product_generating_context.product &&
+        unsortedXrefs.push(
+          ...product_generating_context.product.external_references
+        );
     }
   );
 

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/entity-helpers.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/entity-helpers.ts
@@ -119,7 +119,7 @@ export type GetProductAminoAcidLengthParam = {
     product_type: ProductType.PROTEIN;
     product: {
       length: number;
-    };
+    } | null;
   }>;
 };
 

--- a/src/ensembl/src/shared/types/thoas/productGeneratingContext.ts
+++ b/src/ensembl/src/shared/types/thoas/productGeneratingContext.ts
@@ -28,7 +28,7 @@ export type FullProductGeneratingContext = {
   cds: FullCDS | null;
   five_prime_utr: UTR | null;
   three_prime_utr: UTR | null;
-  product: Product;
+  product: Product | null;
   phased_exons: PhasedExon[];
   cdna: CDNA;
 };


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1329

## Description
This PR is to fix the External References panel on EV side bar.

With the arrival of product-generating contexts for non-coding transcripts, we started having product-generating contexts with the product field set to null. However, we did not update the code accordingly, and are now attempting to access the external references field on a nullable product.
Need to update our types to reflect that the product in product-generating context can be null, and update our code accordingly.

## Deployment URL
https://fix-xref-panel.review.ensembl.org/entity-viewer/homo_sapiens_GCA_000001405_28/gene:ENSG00000139618?view=transcripts

## Views affected
EV External references panel in the sidebar

### Other effects
N/A

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
Nothing that I am aware
