### PR TITLE
ENSWBSITES-1330: keep filter & sort panel open

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -237,7 +237,7 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
   const [basePairsRulerTicks, setBasePairsRulerTicks] =
     useState<TicksAndScale | null>(null);
 
-  const isFilterOpen = useSelector(getFilterPanelOpen);
+  const isFilterPanelOpen = useSelector(getFilterPanelOpen);
   const sortingRule = useSelector(getSortingRule);
   const filters = useSelector(getFilters);
   const dispatch = useDispatch();
@@ -268,8 +268,8 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
     </span>
   );
 
-  const toggleFilter = () => {
-    dispatch(setFilterPanel(!isFilterOpen));
+  const toggleFilterPanel = () => {
+    dispatch(setFilterPanel(!isFilterPanelOpen));
   };
 
   useEffect(() => {
@@ -299,26 +299,26 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
       <div className={styles.geneViewTabs}>
         <div
           className={classNames([styles.filterLabelContainer], {
-            [styles.openFilterLabelContainer]: isFilterOpen
+            [styles.openFilterLabelContainer]: isFilterPanelOpen
           })}
         >
           {props.gene.transcripts.length > 5 && (
             <div className={styles.filterLabelWrapper}>
               <ShowHide
-                onClick={toggleFilter}
-                isExpanded={isFilterOpen}
+                onClick={toggleFilterPanel}
+                isExpanded={isFilterPanelOpen}
                 label={filterLabel}
               />
             </div>
           )}
         </div>
         <div className={styles.tabWrapper}>
-          <GeneViewTabs isFilterOpen={isFilterOpen} />
+          <GeneViewTabs isFilterPanelOpen={isFilterPanelOpen} />
         </div>
-        {isFilterOpen && (
+        {isFilterPanelOpen && (
           <div className={styles.filtersWrapper}>
             <TranscriptsFilter
-              toggleFilter={toggleFilter}
+              toggleFilterPanel={toggleFilterPanel}
               transcripts={props.gene.transcripts}
             />
           </div>

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -23,6 +23,8 @@ import { useParams, useLocation } from 'react-router-dom';
 
 import { useRestoreScrollPosition } from 'src/shared/hooks/useRestoreScrollPosition';
 import usePrevious from 'src/shared/hooks/usePrevious';
+import { setFilterPanel } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSlice';
+import { getFilterPanelOpen } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors';
 import {
   getSelectedGeneViewTabs,
   getCurrentView
@@ -235,8 +237,7 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
   const [basePairsRulerTicks, setBasePairsRulerTicks] =
     useState<TicksAndScale | null>(null);
 
-  const [isFilterOpen, setFilterOpen] = useState(false);
-
+  const isFilterOpen = useSelector(getFilterPanelOpen) || false;
   const sortingRule = useSelector(getSortingRule);
   const filters = useSelector(getFilters);
   const dispatch = useDispatch();
@@ -268,7 +269,7 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
   );
 
   const toggleFilter = () => {
-    setFilterOpen(!isFilterOpen);
+    dispatch(setFilterPanel(!isFilterOpen));
   };
 
   useEffect(() => {
@@ -314,7 +315,7 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
         <div className={styles.tabWrapper}>
           <GeneViewTabs isFilterOpen={isFilterOpen} />
         </div>
-        {isFilterOpen && (
+        {props.gene.transcripts.length > 5 && isFilterOpen && (
           <div className={styles.filtersWrapper}>
             <TranscriptsFilter
               toggleFilter={toggleFilter}

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -237,7 +237,7 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
   const [basePairsRulerTicks, setBasePairsRulerTicks] =
     useState<TicksAndScale | null>(null);
 
-  const isFilterOpen = useSelector(getFilterPanelOpen) || false;
+  const isFilterOpen = useSelector(getFilterPanelOpen);
   const sortingRule = useSelector(getSortingRule);
   const filters = useSelector(getFilters);
   const dispatch = useDispatch();

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -23,8 +23,6 @@ import { useParams, useLocation } from 'react-router-dom';
 
 import { useRestoreScrollPosition } from 'src/shared/hooks/useRestoreScrollPosition';
 import usePrevious from 'src/shared/hooks/usePrevious';
-import { setFilterPanel } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSlice';
-import { getFilterPanelOpen } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors';
 import {
   getSelectedGeneViewTabs,
   getCurrentView
@@ -35,9 +33,11 @@ import {
   GeneViewTabName
 } from 'src/content/app/entity-viewer/state/gene-view/view/geneViewViewSlice';
 import { updatePreviouslyViewedEntities } from 'src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSlice';
+import { setFilterPanel } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 import {
   getFilters,
-  getSortingRule
+  getSortingRule,
+  getFilterPanelOpen
 } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
@@ -315,7 +315,7 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
         <div className={styles.tabWrapper}>
           <GeneViewTabs isFilterOpen={isFilterOpen} />
         </div>
-        {props.gene.transcripts.length > 5 && isFilterOpen && (
+        {isFilterOpen && (
           <div className={styles.filtersWrapper}>
             <TranscriptsFilter
               toggleFilter={toggleFilter}

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-tabs/GeneViewTabs.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-tabs/GeneViewTabs.tsx
@@ -49,7 +49,7 @@ type Props = {
   selectedTab: string;
   selectedTabViews?: SelectedTabViews;
   push: Push;
-  isFilterOpen: boolean;
+  isFilterPanelOpen: boolean;
 };
 
 const GeneViewTabs = (props: Props) => {
@@ -57,7 +57,7 @@ const GeneViewTabs = (props: Props) => {
   const tabClassNames = {
     default: styles.geneTab,
     selected: classNames(styles.selectedGeneTab, {
-      [styles.withOpenFilter]: props.isFilterOpen
+      [styles.withOpenFilter]: props.isFilterPanelOpen
     }),
     disabled: styles.disabledGeneTab,
     tabsContainer: styles.geneViewTabs //FIXME: Pass this as a props so that it can be styled from the parent

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.test.tsx
@@ -75,7 +75,7 @@ const defaultTranscripts = [
   nonCodingTranscript2
 ];
 
-const mockToggleFilter = jest.fn();
+const mockToggleFilterPanel = jest.fn();
 let store: ReturnType<typeof mockStore>;
 
 const wrapInRedux = (
@@ -87,7 +87,7 @@ const wrapInRedux = (
     <Provider store={store}>
       <TranscriptsFilter
         transcripts={transcripts}
-        toggleFilter={mockToggleFilter}
+        toggleFilterPanel={mockToggleFilterPanel}
       />
     </Provider>
   );
@@ -100,9 +100,8 @@ describe('<TranscriptsFilter />', () => {
     const defaultSortingLabel = [...container.querySelectorAll('label')].find(
       (el) => el.textContent === 'Default'
     );
-    const defaultSortingRadioButton = defaultSortingLabel?.querySelector(
-      'input'
-    );
+    const defaultSortingRadioButton =
+      defaultSortingLabel?.querySelector('input');
     expect(defaultSortingRadioButton?.checked).toBe(true);
 
     // after we change sorting option

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
@@ -53,7 +53,7 @@ type Transcript = Pick2<
 
 type Props = {
   transcripts: Transcript[];
-  toggleFilter: () => void;
+  toggleFilterPanel: () => void;
 };
 
 type OptionValue = string | number | boolean;
@@ -181,7 +181,7 @@ const TranscriptsFilter = (props: Props) => {
           <div className={styles.header}>Filter by</div>
           <div className={styles.filterContent}>{filterColumns}</div>
         </div>
-        <CloseButton onClick={props.toggleFilter} />
+        <CloseButton onClick={props.toggleFilterPanel} />
       </div>
     </div>
   );

--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors.ts
@@ -23,7 +23,8 @@ import { RootState } from 'src/store';
 import {
   TranscriptsStatePerGene,
   Filters,
-  SortingRule
+  SortingRule,
+  filterPanelOpen
 } from './geneViewTranscriptsSlice';
 
 const getSliceForGene = (
@@ -66,4 +67,9 @@ export const getFilters = (state: RootState): Filters => {
 export const getSortingRule = (state: RootState): SortingRule => {
   const transcriptsSlice = getSliceForGene(state);
   return transcriptsSlice?.sortingRule ?? SortingRule.DEFAULT;
+};
+
+export const getFilterPanelOpen = (state: RootState): filterPanelOpen => {
+  const transcriptsSlice = getSliceForGene(state);
+  return transcriptsSlice?.filterPanelOpen ?? false;
 };

--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors.ts
@@ -23,8 +23,7 @@ import { RootState } from 'src/store';
 import {
   TranscriptsStatePerGene,
   Filters,
-  SortingRule,
-  filterPanelOpen
+  SortingRule
 } from './geneViewTranscriptsSlice';
 
 const getSliceForGene = (
@@ -69,7 +68,7 @@ export const getSortingRule = (state: RootState): SortingRule => {
   return transcriptsSlice?.sortingRule ?? SortingRule.DEFAULT;
 };
 
-export const getFilterPanelOpen = (state: RootState): filterPanelOpen => {
+export const getFilterPanelOpen = (state: RootState): boolean => {
   const transcriptsSlice = getSliceForGene(state);
   return transcriptsSlice?.filterPanelOpen ?? false;
 };

--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
@@ -48,6 +48,7 @@ export type TranscriptsStatePerGene = {
   expandedMoreInfoIds: string[];
   filters: Filters;
   sortingRule: SortingRule;
+  filterPanelOpen: filterPanelOpen;
 };
 
 export type GeneViewTranscriptsState = {
@@ -64,13 +65,54 @@ export type Filter = {
 
 export type Filters = Record<string, Filter>;
 
+export type filterPanelOpen = boolean;
+
 const defaultStatePerGene: TranscriptsStatePerGene = {
   expandedIds: [],
   expandedDownloadIds: [],
   expandedMoreInfoIds: [],
   filters: {},
-  sortingRule: SortingRule.DEFAULT
+  sortingRule: SortingRule.DEFAULT,
+  filterPanelOpen: false
 };
+
+export const resetFilterPanel =
+  (): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const state = getState();
+    const activeGenomeId = getEntityViewerActiveGenomeId(state);
+    const activeEntityId = getEntityViewerActiveEntityId(state);
+    if (!activeGenomeId || !activeEntityId) {
+      return;
+    }
+    dispatch(
+      transcriptsSlice.actions.updateFilterPanel({
+        activeGenomeId,
+        activeEntityId,
+        filterPanelOpen: defaultStatePerGene.filterPanelOpen
+      })
+    );
+  };
+
+export const setFilterPanel =
+  (
+    filterPanelOpen: filterPanelOpen
+  ): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const state = getState();
+    const activeGenomeId = getEntityViewerActiveGenomeId(state);
+    const activeEntityId = getEntityViewerActiveEntityId(state);
+    if (!activeGenomeId || !activeEntityId) {
+      return;
+    }
+    dispatch(
+      transcriptsSlice.actions.updateFilterPanel({
+        activeGenomeId,
+        activeEntityId,
+        filterPanelOpen
+      })
+    );
+  };
 
 export const setFilters =
   (filters: Filters): ThunkAction<void, any, null, Action<string>> =>
@@ -231,6 +273,12 @@ type UpdateSortingRulePayload = {
   sortingRule: SortingRule;
 };
 
+type UpdateFilterPanelOpenPayload = {
+  activeGenomeId: string;
+  activeEntityId: string;
+  filterPanelOpen: filterPanelOpen;
+};
+
 const transcriptsSlice = createSlice({
   name: 'entity-viewer-gene-view-transcripts',
   initialState: {} as GeneViewTranscriptsState,
@@ -262,6 +310,19 @@ const transcriptsSlice = createSlice({
       return set(
         `${activeGenomeId}.${activeEntityId}.expandedMoreInfoIds`,
         expandedIds,
+        updatedState
+      );
+    },
+    updateFilterPanel(
+      state,
+      action: PayloadAction<UpdateFilterPanelOpenPayload>
+    ) {
+      const { activeGenomeId, activeEntityId, filterPanelOpen } =
+        action.payload;
+      const updatedState = ensureGenePresence(state, action.payload);
+      return set(
+        `${activeGenomeId}.${activeEntityId}.filterPanelOpen`,
+        filterPanelOpen,
         updatedState
       );
     },

--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
@@ -48,7 +48,7 @@ export type TranscriptsStatePerGene = {
   expandedMoreInfoIds: string[];
   filters: Filters;
   sortingRule: SortingRule;
-  filterPanelOpen: filterPanelOpen;
+  filterPanelOpen: boolean;
 };
 
 export type GeneViewTranscriptsState = {
@@ -64,8 +64,6 @@ export type Filter = {
 };
 
 export type Filters = Record<string, Filter>;
-
-export type filterPanelOpen = boolean;
 
 const defaultStatePerGene: TranscriptsStatePerGene = {
   expandedIds: [],
@@ -95,9 +93,7 @@ export const resetFilterPanel =
   };
 
 export const setFilterPanel =
-  (
-    filterPanelOpen: filterPanelOpen
-  ): ThunkAction<void, any, null, Action<string>> =>
+  (filterPanelOpen: boolean): ThunkAction<void, any, null, Action<string>> =>
   (dispatch, getState: () => RootState) => {
     const state = getState();
     const activeGenomeId = getEntityViewerActiveGenomeId(state);
@@ -276,7 +272,7 @@ type UpdateSortingRulePayload = {
 type UpdateFilterPanelOpenPayload = {
   activeGenomeId: string;
   activeEntityId: string;
-  filterPanelOpen: filterPanelOpen;
+  filterPanelOpen: boolean;
 };
 
 const transcriptsSlice = createSlice({

--- a/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
@@ -269,7 +269,7 @@ type UpdateSortingRulePayload = {
   sortingRule: SortingRule;
 };
 
-type UpdateFilterPanelOpenPayload = {
+type UpdateFilterPanelPayload = {
   activeGenomeId: string;
   activeEntityId: string;
   filterPanelOpen: boolean;
@@ -309,10 +309,7 @@ const transcriptsSlice = createSlice({
         updatedState
       );
     },
-    updateFilterPanel(
-      state,
-      action: PayloadAction<UpdateFilterPanelOpenPayload>
-    ) {
+    updateFilterPanel(state, action: PayloadAction<UpdateFilterPanelPayload>) {
       const { activeGenomeId, activeEntityId, filterPanelOpen } =
         action.payload;
       const updatedState = ensureGenePresence(state, action.payload);

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors.ts
@@ -33,6 +33,3 @@ export const getEntityViewerActiveEntityId = (state: RootState) => {
 export const getEntityViewerQueryParams = (
   state: RootState
 ): { [key: string]: string } => getQueryParamsMap(state.router.location.search);
-
-export const getFilterPanelOpen = (state: RootState) =>
-  state.entityViewer.general.filterPanelOpen || false;

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors.ts
@@ -33,3 +33,6 @@ export const getEntityViewerActiveEntityId = (state: RootState) => {
 export const getEntityViewerQueryParams = (
   state: RootState
 ): { [key: string]: string } => getQueryParamsMap(state.router.location.search);
+
+export const getFilterPanelOpen = (state: RootState) =>
+  state.entityViewer.general.filterPanelOpen;

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors.ts
@@ -35,4 +35,4 @@ export const getEntityViewerQueryParams = (
 ): { [key: string]: string } => getQueryParamsMap(state.router.location.search);
 
 export const getFilterPanelOpen = (state: RootState) =>
-  state.entityViewer.general.filterPanelOpen;
+  state.entityViewer.general.filterPanelOpen || false;

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralSlice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralSlice.ts
@@ -40,12 +40,16 @@ import { RootState } from 'src/store';
 export type EntityViewerGeneralState = Readonly<{
   activeGenomeId: string | null;
   activeEntityIds: { [genomeId: string]: string };
+  filterPanelOpen: filterPanelOpen;
 }>;
 
 export const initialState: EntityViewerGeneralState = {
   activeGenomeId: null, // FIXME add entity viewer storage service
-  activeEntityIds: {}
+  activeEntityIds: {},
+  filterPanelOpen: false
 };
+
+export type filterPanelOpen = boolean;
 
 export const setDataFromUrl =
   (params: EntityViewerParams): ThunkAction<void, any, null, Action<string>> =>
@@ -101,6 +105,19 @@ export const setDataFromUrl =
     }
   };
 
+export const setFilterPanel =
+  (
+    filterPanelOpen: filterPanelOpen
+  ): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const activeGenomeId = getEntityViewerActiveGenomeId(getState());
+
+    if (!activeGenomeId) {
+      return;
+    }
+    dispatch(updateFilterPanel(filterPanelOpen));
+  };
+
 export const setDefaultActiveGenomeId =
   (): ThunkAction<void, any, null, Action<string>> =>
   (dispatch, getState: () => RootState) => {
@@ -122,6 +139,9 @@ const entityViewerGeneralSlice = createSlice({
     },
     setActiveGenomeId(state, action: PayloadAction<string>) {
       state.activeGenomeId = action.payload;
+    },
+    updateFilterPanel(state, action: PayloadAction<boolean>) {
+      state.filterPanelOpen = action.payload;
     },
     updateActiveEntityForGenome(
       state,
@@ -145,6 +165,7 @@ export const {
   loadInitialState,
   setActiveGenomeId,
   updateActiveEntityForGenome,
+  updateFilterPanel,
   deleteGenome
 } = entityViewerGeneralSlice.actions;
 

--- a/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralSlice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/general/entityViewerGeneralSlice.ts
@@ -26,6 +26,7 @@ import entityViewerStorageService from 'src/content/app/entity-viewer/services/e
 
 import { fetchGenomeData } from 'src/shared/state/genome/genomeActions';
 import { ensureSpeciesIsEnabled } from 'src/content/app/species-selector/state/speciesSelectorActions';
+import { resetFilterPanel } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 
 import {
   getEntityViewerActiveGenomeId,
@@ -40,16 +41,12 @@ import { RootState } from 'src/store';
 export type EntityViewerGeneralState = Readonly<{
   activeGenomeId: string | null;
   activeEntityIds: { [genomeId: string]: string };
-  filterPanelOpen: filterPanelOpen;
 }>;
 
 export const initialState: EntityViewerGeneralState = {
   activeGenomeId: null, // FIXME add entity viewer storage service
-  activeEntityIds: {},
-  filterPanelOpen: false
+  activeEntityIds: {}
 };
-
-export type filterPanelOpen = boolean;
 
 export const setDataFromUrl =
   (params: EntityViewerParams): ThunkAction<void, any, null, Action<string>> =>
@@ -95,6 +92,10 @@ export const setDataFromUrl =
         );
       }
 
+      if (activeGenomeId === genomeIdFromUrl && entityId !== activeEntityId) {
+        dispatch(resetFilterPanel());
+      }
+
       entityViewerStorageService.updateGeneralState({
         activeGenomeId: genomeIdFromUrl
       });
@@ -103,19 +104,6 @@ export const setDataFromUrl =
         activeEntityIds: { [genomeIdFromUrl]: entityId }
       });
     }
-  };
-
-export const setFilterPanel =
-  (
-    filterPanelOpen: filterPanelOpen
-  ): ThunkAction<void, any, null, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
-    const activeGenomeId = getEntityViewerActiveGenomeId(getState());
-
-    if (!activeGenomeId) {
-      return;
-    }
-    dispatch(updateFilterPanel(filterPanelOpen));
   };
 
 export const setDefaultActiveGenomeId =
@@ -140,9 +128,6 @@ const entityViewerGeneralSlice = createSlice({
     setActiveGenomeId(state, action: PayloadAction<string>) {
       state.activeGenomeId = action.payload;
     },
-    updateFilterPanel(state, action: PayloadAction<boolean>) {
-      state.filterPanelOpen = action.payload;
-    },
     updateActiveEntityForGenome(
       state,
       action: PayloadAction<{ genomeId: string; entityId: string }>
@@ -165,7 +150,6 @@ export const {
   loadInitialState,
   setActiveGenomeId,
   updateActiveEntityForGenome,
-  updateFilterPanel,
   deleteGenome
 } = entityViewerGeneralSlice.actions;
 


### PR DESCRIPTION
move isFilterOpen (filter and sort panel) from component state to redux

## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1330

## Importance
N/A

## Description
Currently the filter and sort panel state is only remembered within the component but we want to remember the state more globally. if user open filter and sort panel and navigate to a different gene or app and come back the filter and sort panel should stay open.

## Deployment URL
http://filterpanel-state.review.ensembl.org

## Views affected
Entity Viewer

### Other effects
N/A

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
N/A
