### PR TITLE
Update zmenu layout in genome browser

### DIFF
--- a/src/ensembl/src/content/app/browser/zmenu/Zmenu.scss
+++ b/src/ensembl/src/content/app/browser/zmenu/Zmenu.scss
@@ -40,6 +40,7 @@
 .zmenuAppLinks {
   display: flex;
   align-items: center;
+  justify-content: space-between;
 }
 
 .zmenuAppButton {

--- a/src/ensembl/src/content/app/browser/zmenu/Zmenu.scss
+++ b/src/ensembl/src/content/app/browser/zmenu/Zmenu.scss
@@ -43,20 +43,6 @@
   justify-content: space-between;
 }
 
-.zmenuAppButton {
-  flex: 0 0 auto;
-  height: 20px;
-  width: 20px;
-  margin-left: 16px;
-
-  svg {
-    width: 20px;
-    height: 20px;
-    fill: $white;
-    background-color: $blue;
-  }
-}
-
 .zmenuToggleFooter {
   margin-left: auto;
   color: $blue;

--- a/src/ensembl/src/content/app/browser/zmenu/ZmenuAppLinks.tsx
+++ b/src/ensembl/src/content/app/browser/zmenu/ZmenuAppLinks.tsx
@@ -21,11 +21,7 @@ import * as urlFor from 'src/shared/helpers/urlHelper';
 import { parseFeatureId } from 'src/content/app/browser/browserHelper';
 import { buildFocusIdForUrl } from 'src/shared/state/ens-object/ensObjectHelpers';
 
-import {
-  getBrowserActiveGenomeId,
-  getBrowserActiveEnsObjectId,
-  isFocusObjectPositionDefault
-} from '../browserSelectors';
+import { getBrowserActiveGenomeId } from '../browserSelectors';
 
 import { ToggleButton as ToolboxToggleButton } from 'src/shared/components/toolbox';
 import ViewInApp, { UrlObj } from 'src/shared/components/view-in-app/ViewInApp';
@@ -38,8 +34,6 @@ type Props = {
 
 const ZmenuAppLinks = (props: Props) => {
   const genomeId = useSelector(getBrowserActiveGenomeId);
-  const activeFeatureId = useSelector(getBrowserActiveEnsObjectId);
-  const isInDefaultPosition = useSelector(isFocusObjectPositionDefault);
 
   const parsedFeatureId = parseFeatureId(props.featureId);
 
@@ -52,33 +46,26 @@ const ZmenuAppLinks = (props: Props) => {
   const getBrowserLink = () =>
     urlFor.browser({ genomeId, focus: featureIdForUrl });
 
-  const getEntityViewerLink = () =>
-    urlFor.entityViewer({
-      genomeId,
-      entityId: featureIdForUrl
-    });
-
-  const shouldShowBrowserButton =
-    props.featureId !== activeFeatureId || !isInDefaultPosition;
-
-  const links: UrlObj = {};
-
-  if (shouldShowBrowserButton) {
-    links['genomeBrowser'] = {
+  const links: UrlObj = {
+    genomeBrowser: {
       url: getBrowserLink(),
       replaceState: true
-    };
-  }
-
-  links['entityViewer'] = { url: getEntityViewerLink() };
+    },
+    entityViewer: {
+      url: urlFor.entityViewer({
+        genomeId,
+        entityId: featureIdForUrl
+      })
+    }
+  };
 
   return (
     <div className={styles.zmenuAppLinks}>
-      <ViewInApp links={links} />
       <ToolboxToggleButton
         className={styles.zmenuToggleFooter}
-        openElement={<span>Download</span>}
+        label="Download"
       />
+      <ViewInApp links={links} />
     </div>
   );
 };

--- a/src/ensembl/src/shared/components/toolbox/toolbox-expandable-content/ToolboxExpandableContent.scss
+++ b/src/ensembl/src/shared/components/toolbox/toolbox-expandable-content/ToolboxExpandableContent.scss
@@ -1,23 +1,5 @@
 @import 'src/styles/common';
 
-$toggleButtonHeight: 14px;
-
 .main {
   position: relative;
 }
-
-.toggleButton {
-  display: inline-block;
-  user-select: none;
-  cursor: pointer;
-
-  .label {
-    color: $blue;
-  }
-
-  .chevron {
-    margin-left: 5px;
-  }
-  
-}
-

--- a/src/ensembl/src/shared/components/toolbox/toolbox-expandable-content/ToolboxExpandableContent.scss
+++ b/src/ensembl/src/shared/components/toolbox/toolbox-expandable-content/ToolboxExpandableContent.scss
@@ -10,4 +10,14 @@ $toggleButtonHeight: 14px;
   display: inline-block;
   user-select: none;
   cursor: pointer;
+
+  .label {
+    color: $blue;
+  }
+
+  .chevron {
+    margin-left: 5px;
+  }
+  
 }
+

--- a/src/ensembl/src/shared/components/toolbox/toolbox-expandable-content/ToolboxExpandableContent.test.tsx
+++ b/src/ensembl/src/shared/components/toolbox/toolbox-expandable-content/ToolboxExpandableContent.test.tsx
@@ -25,7 +25,7 @@ import ToolboxExpandableContent, {
 const MainContent = () => (
   <div data-test-id="main content">
     <span>This is main content</span>
-    <ToggleButton openElement={<span>Click me!</span>} />
+    <ToggleButton label="Click me!" />
   </div>
 );
 const FooterContent = () => (
@@ -51,7 +51,7 @@ describe('<ToolboxExpandableContent />', () => {
     render(<ToolboxExpandableContent {...minimalProps} />);
     const toggleButton = screen.getByText('Click me!');
 
-    userEvent.click(toggleButton);
+    userEvent.click(toggleButton as HTMLElement);
 
     const footerContent = screen.queryByTestId('footer content');
     expect(footerContent).toBeTruthy();

--- a/src/ensembl/src/shared/components/toolbox/toolbox-expandable-content/ToolboxExpandableContent.tsx
+++ b/src/ensembl/src/shared/components/toolbox/toolbox-expandable-content/ToolboxExpandableContent.tsx
@@ -68,13 +68,12 @@ export const ToggleButton = (props: ToggleButtonProps) => {
   };
 
   return (
-    <span className={styles.toggleButton}>
+    <span className={styles.toggleButton} onClick={handleClick}>
       <span className={styles.label}>{props.label}</span>
       <Chevron
         direction={isExpanded ? 'up' : 'down'}
         animate={true}
         classNames={{ svg: styles.chevron }}
-        onClick={handleClick}
       />
     </span>
   );

--- a/src/ensembl/src/shared/components/toolbox/toolbox-expandable-content/ToolboxExpandableContent.tsx
+++ b/src/ensembl/src/shared/components/toolbox/toolbox-expandable-content/ToolboxExpandableContent.tsx
@@ -15,10 +15,9 @@
  */
 
 import React, { useState, useContext, ReactNode } from 'react';
-import classNames from 'classnames';
 import noop from 'lodash/noop';
 
-import CloseButton from 'src/shared/components/close-button/CloseButton';
+import Chevron from 'src/shared/components/chevron/Chevron';
 
 import styles from './ToolboxExpandableContent.scss';
 
@@ -34,12 +33,11 @@ type ToolboxExpandableContentProps = {
 
 type ToggleButtonProps = {
   className?: string;
-  openElement: ReactNode;
+  label: string;
 };
 
-const ToolboxExpandableContentContext = React.createContext<ToolboxContext | null>(
-  null
-);
+const ToolboxExpandableContentContext =
+  React.createContext<ToolboxContext | null>(null);
 
 const ToolboxExpandableContent = (props: ToolboxExpandableContentProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -69,12 +67,15 @@ export const ToggleButton = (props: ToggleButtonProps) => {
     toggleExpanded();
   };
 
-  const buttonClasses = classNames(styles.toggleButton, props.className);
-  return isExpanded ? (
-    <CloseButton className={buttonClasses} onClick={handleClick} />
-  ) : (
-    <span className={buttonClasses} onClick={handleClick}>
-      {props.openElement}
+  return (
+    <span className={styles.toggleButton}>
+      <span className={styles.label}>{props.label}</span>
+      <Chevron
+        direction={isExpanded ? 'up' : 'down'}
+        animate={true}
+        classNames={{ svg: styles.chevron }}
+        onClick={handleClick}
+      />
     </span>
   );
 };

--- a/src/ensembl/src/shared/components/toolbox/toolbox-expandable-content/ToolboxExpandableContent.tsx
+++ b/src/ensembl/src/shared/components/toolbox/toolbox-expandable-content/ToolboxExpandableContent.tsx
@@ -17,7 +17,7 @@
 import React, { useState, useContext, ReactNode } from 'react';
 import noop from 'lodash/noop';
 
-import Chevron from 'src/shared/components/chevron/Chevron';
+import ShowHide from 'src/shared/components/show-hide/ShowHide';
 
 import styles from './ToolboxExpandableContent.scss';
 
@@ -68,14 +68,11 @@ export const ToggleButton = (props: ToggleButtonProps) => {
   };
 
   return (
-    <span className={styles.toggleButton} onClick={handleClick}>
-      <span className={styles.label}>{props.label}</span>
-      <Chevron
-        direction={isExpanded ? 'up' : 'down'}
-        animate={true}
-        classNames={{ svg: styles.chevron }}
-      />
-    </span>
+    <ShowHide
+      label={props.label}
+      onClick={handleClick}
+      isExpanded={isExpanded}
+    />
   );
 };
 

--- a/src/ensembl/stories/shared-components/toolbox/Toolbox.stories.scss
+++ b/src/ensembl/stories/shared-components/toolbox/Toolbox.stories.scss
@@ -18,10 +18,6 @@
     margin-left: 1em;
     float: right;
   }
-  .download {
-    color: $blue;
-    font-size: 12px;
-  }
 }
 
 .mainToolboxContent,

--- a/src/ensembl/stories/shared-components/toolbox/Toolbox.stories.tsx
+++ b/src/ensembl/stories/shared-components/toolbox/Toolbox.stories.tsx
@@ -32,15 +32,13 @@ export const DefaultStory = () => {
     setIsShowing(!isShowing);
   };
 
-  const downloadElement = <span className={styles.download}>Download</span>;
-
   const mainToolboxContent = (
     <div className={styles.mainToolboxContent}>
       <p>This is main toolbox content</p>
       <p>
         This is the second paragraph
         <span className={styles.toggleButton}>
-          <ToolboxToggleButton openElement={downloadElement} />
+          <ToolboxToggleButton label="Download" />
         </span>
       </p>
     </div>


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
[ENSWBSITES-1337](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1337)

## Description
The zmenu layout design was recently changed (https://xd.adobe.com/view/2f3a9ffe-8e84-47fa-a796-54b337e2aa70-7a69/). The following had to be updated in the zmenu layout:

- move 'Download' link to left of panel
- add chevron to 'Download' link (same as EV transcript info panel)
- move 'View in' component to right of panel
- always show all relevant apps (GB & EV for MAP) for focus object

## Deployment URL
https://update-zmenu-layout.review.ensembl.org/

## Views affected
Genome browser -> zmenu

### Other effects
- [ ] I have checked any requirements for Google Analytics
- [x] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.
