### PR TITLE
Add multiple transcripts support for drawer

### DIFF
--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
@@ -36,6 +36,7 @@ import {
 
 import { useGetTrackPanelGeneQuery } from 'src/content/app/browser/state/genomeBrowserApiSlice';
 import { getBrowserActiveEnsObject } from 'src/content/app/browser/browserSelectors';
+import { getActiveDrawerTranscriptId } from 'src/content/app/browser/drawer/drawerSelectors';
 
 import { InstantDownloadTranscript } from 'src/shared/components/instant-download';
 import ViewInApp from 'src/shared/components/view-in-app/ViewInApp';
@@ -158,6 +159,7 @@ const GENE_AND_TRANSCRIPT_QUERY = gql`
 
 const TranscriptSummary = () => {
   const ensObjectGene = useSelector(getBrowserActiveEnsObject) as EnsObjectGene;
+  const activeDrawerTranscriptId = useSelector(getActiveDrawerTranscriptId);
   const [shouldShowDownload, showDownload] = useState(false);
 
   const { data: geneData } = useGetTrackPanelGeneQuery({
@@ -165,8 +167,8 @@ const TranscriptSummary = () => {
     geneId: ensObjectGene.stable_id
   });
 
-  const canonicalTranscript = geneData?.gene.transcripts.find(
-    (transcript) => transcript.metadata.canonical
+  const activeDrawerTranscript = geneData?.gene.transcripts.find(
+    (transcript) => transcript.stable_id === activeDrawerTranscriptId
   );
 
   const { data, loading } = useQuery<{
@@ -175,10 +177,10 @@ const TranscriptSummary = () => {
   }>(GENE_AND_TRANSCRIPT_QUERY, {
     variables: {
       geneId: ensObjectGene.stable_id,
-      transcriptId: canonicalTranscript?.stable_id,
+      transcriptId: activeDrawerTranscript?.stable_id,
       genomeId: ensObjectGene.genome_id
     },
-    skip: !canonicalTranscript?.stable_id
+    skip: !activeDrawerTranscript?.stable_id
   });
 
   if (loading) {

--- a/src/ensembl/src/content/app/browser/drawer/drawerActions.ts
+++ b/src/ensembl/src/content/app/browser/drawer/drawerActions.ts
@@ -30,46 +30,40 @@ export const changeDrawerViewForGenome = createAction(
     drawerViewForGenome
 )();
 
-export const changeDrawerView = (
-  drawerView: DrawerView
-): ThunkAction<void, any, null, Action<string>> => (
-  dispatch,
-  getState: () => RootState
-) => {
-  const activeGenomeId = getBrowserActiveGenomeId(getState());
+export const changeDrawerView =
+  (drawerView: DrawerView): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const activeGenomeId = getBrowserActiveGenomeId(getState());
 
-  if (!activeGenomeId) {
-    return;
-  }
+    if (!activeGenomeId) {
+      return;
+    }
 
-  dispatch(
-    changeDrawerViewForGenome({
-      [activeGenomeId]: drawerView
-    })
-  );
-};
-
-export const changeDrawerViewAndOpen = (
-  drawerView: DrawerView
-): ThunkAction<void, any, null, Action<string>> => (
-  dispatch,
-  getState: () => RootState
-) => {
-  const activeGenomeId = getBrowserActiveGenomeId(getState());
-
-  if (!activeGenomeId) {
-    return;
-  }
-  batch(() => {
     dispatch(
       changeDrawerViewForGenome({
         [activeGenomeId]: drawerView
       })
     );
+  };
 
-    dispatch(toggleDrawer(true));
-  });
-};
+export const changeDrawerViewAndOpen =
+  (drawerView: DrawerView): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const activeGenomeId = getBrowserActiveGenomeId(getState());
+
+    if (!activeGenomeId) {
+      return;
+    }
+    batch(() => {
+      dispatch(
+        changeDrawerViewForGenome({
+          [activeGenomeId]: drawerView
+        })
+      );
+
+      dispatch(toggleDrawer(true));
+    });
+  };
 
 export const toggleDrawerForGenome = createAction(
   'drawer/toggle-drawer',
@@ -77,50 +71,50 @@ export const toggleDrawerForGenome = createAction(
     isDrawerOpenedForGenome
 )();
 
-export const toggleDrawer = (
-  isDrawerOpened: boolean
-): ThunkAction<void, any, null, Action<string>> => (
-  dispatch,
-  getState: () => RootState
-) => {
-  const activeGenomeId = getBrowserActiveGenomeId(getState());
+export const toggleDrawer =
+  (isDrawerOpened: boolean): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const activeGenomeId = getBrowserActiveGenomeId(getState());
 
-  if (!activeGenomeId) {
-    return;
-  }
+    if (!activeGenomeId) {
+      return;
+    }
 
-  dispatch(
-    toggleDrawerForGenome({
-      [activeGenomeId]: isDrawerOpened
-    })
-  );
-};
-
-export const closeDrawer = (): ThunkAction<void, any, null, Action<string>> => (
-  dispatch,
-  getState: () => RootState
-) => {
-  const activeGenomeId = getBrowserActiveGenomeId(getState());
-
-  if (!activeGenomeId) {
-    return;
-  }
-
-  batch(() => {
     dispatch(
       toggleDrawerForGenome({
-        [activeGenomeId]: false
+        [activeGenomeId]: isDrawerOpened
       })
     );
+  };
 
-    dispatch(
-      changeDrawerViewForGenome({
-        [activeGenomeId]: null
-      })
-    );
-  });
-};
+export const closeDrawer =
+  (): ThunkAction<void, any, null, Action<string>> =>
+  (dispatch, getState: () => RootState) => {
+    const activeGenomeId = getBrowserActiveGenomeId(getState());
+
+    if (!activeGenomeId) {
+      return;
+    }
+
+    batch(() => {
+      dispatch(
+        toggleDrawerForGenome({
+          [activeGenomeId]: false
+        })
+      );
+
+      dispatch(
+        changeDrawerViewForGenome({
+          [activeGenomeId]: null
+        })
+      );
+    });
+  };
 
 export const setActiveDrawerTrackId = createAction(
   'browser/set-active-drawer-track-id'
+)<{ [genomeId: string]: string | null }>();
+
+export const setActiveDrawerTranscriptId = createAction(
+  'browser/set-active-drawer-transcript-id'
 )<{ [genomeId: string]: string | null }>();

--- a/src/ensembl/src/content/app/browser/drawer/drawerReducer.ts
+++ b/src/ensembl/src/content/app/browser/drawer/drawerReducer.ts
@@ -42,6 +42,14 @@ export default function drawer(
           ...action.payload
         }
       };
+    case getType(drawerActions.setActiveDrawerTranscriptId):
+      return {
+        ...state,
+        activeDrawerTranscriptIds: {
+          ...state.activeDrawerTranscriptIds,
+          ...action.payload
+        }
+      };
     default:
       return state;
   }

--- a/src/ensembl/src/content/app/browser/drawer/drawerSelectors.ts
+++ b/src/ensembl/src/content/app/browser/drawer/drawerSelectors.ts
@@ -35,3 +35,10 @@ export const getActiveDrawerTrackId = (state: RootState) => {
     ? state.drawer.activeDrawerTrackIds[activeGenomeId]
     : null;
 };
+
+export const getActiveDrawerTranscriptId = (state: RootState) => {
+  const activeGenomeId = getBrowserActiveGenomeId(state);
+  return activeGenomeId
+    ? state.drawer.activeDrawerTranscriptIds[activeGenomeId]
+    : null;
+};

--- a/src/ensembl/src/content/app/browser/drawer/drawerState.ts
+++ b/src/ensembl/src/content/app/browser/drawer/drawerState.ts
@@ -25,10 +25,12 @@ export type DrawerState = Readonly<{
   isDrawerOpened: { [genomeId: string]: boolean };
   drawerView: { [genomeId: string]: DrawerView | null };
   activeDrawerTrackIds: { [genomeId: string]: string | null };
+  activeDrawerTranscriptIds: { [genomeId: string]: string | null };
 }>;
 
 export const defaultDrawerState = {
   isDrawerOpened: {},
   drawerView: {},
-  activeDrawerTrackIds: {}
+  activeDrawerTrackIds: {},
+  activeDrawerTranscriptIds: {}
 };

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelGene.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelGene.tsx
@@ -22,6 +22,7 @@ import { useGetTrackPanelGeneQuery } from 'src/content/app/browser/state/genomeB
 import { getBrowserTrackStates } from 'src/content/app/browser/browserSelectors';
 
 import { getTranscriptMetadata as getTranscriptSupportLevel } from 'src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel';
+import { defaultSort } from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
 
 import TrackPanelListItem from './TrackPanelListItem';
 
@@ -32,6 +33,7 @@ import type {
   TrackPanelGene as TrackPanelGeneType,
   TrackPanelTranscript as TrackPanelTranscriptType
 } from 'src/content/app/browser/state/types/track-panel-gene';
+import { ProductType } from 'src/shared/types/thoas/product';
 
 type TrackPanelGeneProps = {
   genomeId: string;
@@ -41,7 +43,7 @@ type TrackPanelGeneProps = {
 
 // TODO: change track ids
 const GENE_TRACK_ID = 'track:gene-feat';
-const TRANSCRIPT_TRACK_ID = 'track:gene-feat-1';
+const getTranscriptTrackId = (num: number) => `track:transcript-feat-${num}`;
 
 const TrackPanelGene = (props: TrackPanelGeneProps) => {
   const { genomeId, geneId, ensObjectId } = props;
@@ -63,7 +65,23 @@ const TrackPanelGene = (props: TrackPanelGeneProps) => {
 
   const { gene } = data;
   const geneTrackStatus = trackStatusGetter(GENE_TRACK_ID);
-  const transcriptTrackStatus = trackStatusGetter(TRANSCRIPT_TRACK_ID);
+
+  const getTranscriptTracks = () =>
+    prepareTranscriptsTrackData(gene).map((transcriptTrackData) => {
+      const transcriptTrackStatus = trackStatusGetter(
+        transcriptTrackData.track_id
+      );
+
+      return (
+        <TrackPanelListItem
+          key={transcriptTrackData.label}
+          categoryName="main"
+          trackStatus={transcriptTrackStatus}
+          defaultTrackStatus={Status.SELECTED}
+          track={transcriptTrackData}
+        />
+      );
+    });
 
   return (
     <div>
@@ -73,15 +91,7 @@ const TrackPanelGene = (props: TrackPanelGeneProps) => {
         defaultTrackStatus={Status.SELECTED}
         track={prepareGeneTrackData(gene)}
       >
-        {prepareTranscriptsTrackData(gene).map((transcriptTrackData) => (
-          <TrackPanelListItem
-            key={transcriptTrackData.label}
-            categoryName="main"
-            trackStatus={transcriptTrackStatus}
-            defaultTrackStatus={Status.SELECTED}
-            track={transcriptTrackData}
-          />
-        ))}
+        {getTranscriptTracks()}
       </TrackPanelListItem>
     </div>
   );
@@ -101,22 +111,36 @@ const prepareGeneTrackData = (gene: TrackPanelGeneType): EnsObjectTrack => {
   };
 };
 
+const getTranscriptTrackColour = (transcript: TrackPanelTranscriptType) => {
+  const { product_generating_contexts, metadata } = transcript;
+
+  if (metadata.canonical?.value || metadata.mane?.value) {
+    return 'BLUE';
+  } else if (
+    product_generating_contexts[0].product_type === ProductType.PROTEIN
+  ) {
+    return 'DARK_GREY';
+  } else {
+    return 'GREY';
+  }
+};
+
 const prepareTranscriptsTrackData = (
   gene: TrackPanelGeneType
 ): EnsObjectTrack[] => {
-  const canonicalTranscript = gene.transcripts.find(
-    (transcript) => transcript.metadata.canonical
-  ) as TrackPanelTranscriptType;
-  const canonicalTranscriptTrackData = {
-    label: canonicalTranscript.stable_id,
-    track_id: TRANSCRIPT_TRACK_ID,
-    stable_id: canonicalTranscript.stable_id,
+  const sortedTranscripts = defaultSort(
+    gene.transcripts
+  ) as TrackPanelTranscriptType[];
+
+  return sortedTranscripts.map((transcript, index) => ({
+    label: transcript.stable_id,
+    track_id: getTranscriptTrackId(index),
+    stable_id: transcript.stable_id,
     description: null,
-    colour: 'BLUE',
-    additional_info: canonicalTranscript.metadata.biotype.label,
-    support_level: getTranscriptSupportLevel(canonicalTranscript)?.label
-  };
-  return [canonicalTranscriptTrackData];
+    colour: getTranscriptTrackColour(transcript),
+    additional_info: transcript.metadata.biotype.label,
+    support_level: getTranscriptSupportLevel(transcript)?.label
+  }));
 };
 
 type GetTrackStatusParams = {

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
@@ -36,8 +36,9 @@ import { updateCollapsedTrackIds } from 'src/content/app/browser/track-panel/tra
 import {
   changeDrawerView,
   setActiveDrawerTrackId,
+  setActiveDrawerTranscriptId,
   toggleDrawer
-} from '../../drawer/drawerActions';
+} from 'src/content/app/browser/drawer/drawerActions';
 
 import {
   getHighlightedTrackId,
@@ -48,11 +49,11 @@ import {
   getIsDrawerOpened,
   getDrawerView,
   getActiveDrawerTrackId
-} from '../../drawer/drawerSelectors';
+} from 'src/content/app/browser/drawer/drawerSelectors';
 import {
   getBrowserActiveGenomeId,
   getBrowserActiveEnsObjectId
-} from '../../browserSelectors';
+} from 'src/content/app/browser/browserSelectors';
 
 import ImageButton from 'src/shared/components/image-button/ImageButton';
 import Chevron from 'src/shared/components/chevron/Chevron';
@@ -91,7 +92,7 @@ export const TrackPanelListItem = (props: TrackPanelListItemProps) => {
     let drawerViewToSet = DrawerView.TRACK_DETAILS;
     if (trackId === 'track:gene-feat') {
       drawerViewToSet = DrawerView.GENE_SUMMARY;
-    } else if (trackId === 'track:gene-feat-1') {
+    } else if (trackId.includes('track:transcript')) {
       drawerViewToSet = DrawerView.TRANSCRIPT_SUMMARY;
     }
     dispatch(changeDrawerView(drawerViewToSet));
@@ -109,6 +110,24 @@ export const TrackPanelListItem = (props: TrackPanelListItemProps) => {
     });
   };
 
+  const dispatchDrawerActions = () => {
+    if (activeGenomeId) {
+      dispatch(
+        setActiveDrawerTrackId({
+          [activeGenomeId]: trackId
+        })
+      );
+
+      if (trackId.includes('track:transcript')) {
+        dispatch(
+          setActiveDrawerTranscriptId({
+            [activeGenomeId]: track.stable_id
+          })
+        );
+      }
+    }
+  };
+
   const drawerViewListHandler = (event: MouseEvent) => {
     event.preventDefault();
 
@@ -116,13 +135,7 @@ export const TrackPanelListItem = (props: TrackPanelListItemProps) => {
       return;
     }
 
-    if (activeGenomeId) {
-      dispatch(
-        setActiveDrawerTrackId({
-          [activeGenomeId]: trackId
-        })
-      );
-    }
+    dispatchDrawerActions();
   };
 
   const drawerViewButtonHandler = useCallback(() => {
@@ -134,13 +147,7 @@ export const TrackPanelListItem = (props: TrackPanelListItemProps) => {
       });
     }
 
-    if (activeGenomeId) {
-      dispatch(
-        setActiveDrawerTrackId({
-          [activeGenomeId]: trackId
-        })
-      );
-    }
+    dispatchDrawerActions();
 
     updateDrawerView();
   }, [track.track_id, drawerView, isDrawerOpened, activeGenomeId]);
@@ -160,7 +167,10 @@ export const TrackPanelListItem = (props: TrackPanelListItemProps) => {
       return;
     }
     // FIXME: Temporary hack until we have a set of proper track names
-    if (track.track_id.startsWith('track:gene')) {
+    if (
+      track.track_id.startsWith('track:gene') ||
+      track.track_id.startsWith('track:transcript')
+    ) {
       dispatch(
         updateTrackStatesAndSave({
           [activeGenomeId]: {


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
[ENSWBSITES-1316](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1316)

## Description
This support adds support for multiple transcripts to be displayed in the track panel. Also, each transcript track can now be toggled and the transcript summary will display details of the selected transcript (rather than the canonical/mane transcript).

TODO:

1. Fix type issues in `TrackPanelGene.tsx`
2. The transcript track colours displayed in the track panel are not accurate. Need to fix this as well.

## Deployment URL
http://multiple-transcripts-drawer.review.ensembl.org/

## Views affected
Browser -> Track panel
Browser -> Track panel -> Drawer (Transcript summary)
