### PR TITLE
Do not close sidebar on clicking a previously viewed link

### DIFF
--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.test.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.test.tsx
@@ -28,7 +28,6 @@ import { TrackPanelBookmarks } from './TrackPanelBookmarks';
 
 import { DrawerView } from 'src/content/app/browser/drawer/drawerState';
 import { PreviouslyViewedObject } from '../../trackPanelState';
-import * as trackPanelActions from '../../trackPanelActions';
 
 jest.mock('react-router-dom', () => ({
   Link: (props: any) => (
@@ -169,18 +168,6 @@ describe('<TrackPanelBookmarks />', () => {
 
     expect(geneLink.getAttribute('href')).toBe(expectedGeneHref);
     expect(regionLink.getAttribute('href')).toBe(expectedRegionHref);
-  });
-
-  it('closes the bookmarks modal when a bookmark link is clicked', () => {
-    jest.spyOn(trackPanelActions, 'closeTrackPanelModal');
-    const { container } = wrapInRedux();
-    const firstLink = container.querySelector('a');
-
-    userEvent.click(firstLink as HTMLElement);
-
-    expect(trackPanelActions.closeTrackPanelModal).toHaveBeenCalled();
-
-    (trackPanelActions.closeTrackPanelModal as any).mockRestore();
   });
 
   it('shows link to view more only when there are more than 20 objects', () => {

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-modal/modal-views/TrackPanelBookmarks.tsx
@@ -24,7 +24,6 @@ import * as urlFor from 'src/shared/helpers/urlHelper';
 import { buildFocusIdForUrl } from 'src/shared/state/ens-object/ensObjectHelpers';
 
 import { getActiveGenomePreviouslyViewedObjects } from 'src/content/app/browser/track-panel/trackPanelSelectors';
-import { closeTrackPanelModal } from '../../trackPanelActions';
 import { changeDrawerViewAndOpen } from 'src/content/app/browser/drawer/drawerActions';
 
 import TextLine from 'src/shared/components/text-line/TextLine';
@@ -37,7 +36,6 @@ export const PreviouslyViewedLinks = () => {
   const previouslyViewedObjects = useSelector(
     getActiveGenomePreviouslyViewedObjects
   ).slice(0, 20);
-  const dispatch = useDispatch();
 
   const onLinkClick = (objectType: string, index: number) => {
     analyticsTracking.trackEvent({
@@ -46,8 +44,6 @@ export const PreviouslyViewedLinks = () => {
       action: 'clicked',
       value: index + 1
     });
-
-    dispatch(closeTrackPanelModal());
   };
 
   return (

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.tsx
@@ -16,7 +16,7 @@
 
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import upperFirst from 'lodash/upperFirst';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
@@ -29,8 +29,6 @@ import {
   getEntityViewerActiveEntityId
 } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors';
 import { getPreviouslyViewedEntities } from 'src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSelectors';
-
-import { closeSidebarModal } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSlice';
 
 import TextLine from 'src/shared/components/text-line/TextLine';
 
@@ -45,8 +43,6 @@ type PreviouslyViewedLinksProps = {
 };
 
 export const PreviouslyViewedLinks = (props: PreviouslyViewedLinksProps) => {
-  const dispatch = useDispatch();
-
   const activeEntityStableId = parseEnsObjectId(props.activeEntityId).objectId;
   const previouslyViewedEntitiesWithoutActiveEntity =
     props.previouslyViewedEntities.filter(
@@ -67,7 +63,7 @@ export const PreviouslyViewedLinks = (props: PreviouslyViewedLinksProps) => {
 
           return (
             <div key={index} className={styles.linkHolder}>
-              <Link to={path} onClick={() => dispatch(closeSidebarModal())}>
+              <Link to={path}>
                 <TextLine
                   text={previouslyViewedEntity.label}
                   className={styles.label}


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1338

## Description
Based on review from UX team we decided not to close the sidebar on clicking a previously viewed link, same as search or downloads.

## Deployment URL
http://updated-previously-viewed-behavior.review.ensembl.org

## Views affected
GB and EV

### Other effects
NA

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
NA
