### PR TITLE
Fix clean-up of saved contact us form on submission

### DIFF
--- a/src/ensembl/src/shared/components/communication-framework/contact-us/contact-us-form/hooks/useSavedForm.ts
+++ b/src/ensembl/src/shared/components/communication-framework/contact-us/contact-us-form/hooks/useSavedForm.ts
@@ -76,13 +76,20 @@ const useSavedForm: UseSavedForm = (params) => {
     return isEmpty;
   };
 
-  const saveFormState = () => {
-    // only save the form if it is not empty
-    if (isEmptyForm(stateRef.current)) {
+  const hasSavedForm = async () => {
+    const savedForm = await indexedDB.get(STORE_NAME, formName);
+    return Boolean(savedForm);
+  };
+
+  const saveFormState = async () => {
+    // do not save the form if it is currently empty and has not been saved before
+    // (if it has been saved, then saving an empty form to overwrite the previously saved one is fine)
+    const hasPreviouslySavedForm = await hasSavedForm();
+    if (!hasPreviouslySavedForm && isEmptyForm(stateRef.current)) {
       return;
     }
     const formWithoutHugeFiles = withoutHugeFiles(stateRef.current);
-    indexedDB.set(STORE_NAME, params.formName, formWithoutHugeFiles);
+    indexedDB.set(STORE_NAME, formName, formWithoutHugeFiles);
   };
 
   const withoutHugeFiles = (state: Form) => {

--- a/src/ensembl/src/shared/components/communication-framework/contact-us/contact-us-form/hooks/useSavedForm.ts
+++ b/src/ensembl/src/shared/components/communication-framework/contact-us/contact-us-form/hooks/useSavedForm.ts
@@ -65,8 +65,10 @@ const useSavedForm: UseSavedForm = (params) => {
   const isEmptyForm = (state: typeof currentState) => {
     let isEmpty = true;
     for (const value of Object.values(state)) {
-      if (Array.isArray(value) && value.length) {
-        isEmpty = false;
+      if (Array.isArray(value)) {
+        if (value.length) {
+          isEmpty = false;
+        }
       } else if (value !== null && value !== '') {
         isEmpty = false;
       }

--- a/src/ensembl/src/shared/components/communication-framework/contact-us/contact-us-form/initial/ContactUsInitialForm.tsx
+++ b/src/ensembl/src/shared/components/communication-framework/contact-us/contact-us-form/initial/ContactUsInitialForm.tsx
@@ -91,6 +91,10 @@ type ReplaceStateAction = {
   payload: State;
 };
 
+type ClearFormAction = {
+  type: 'clear-form';
+};
+
 type Action =
   | UpdateNameAction
   | UpdateEmailAction
@@ -98,7 +102,8 @@ type Action =
   | UpdateMessageAction
   | AddFileAction
   | RemoveFileAction
-  | ReplaceStateAction;
+  | ReplaceStateAction
+  | ClearFormAction;
 
 const reducer = (state: State, action: Action): State => {
   switch (action.type) {
@@ -118,6 +123,8 @@ const reducer = (state: State, action: Action): State => {
       return { ...state, files: newFiles };
     case 'replace-state':
       return action.payload;
+    case 'clear-form':
+      return initialState;
     default:
       return state;
   }
@@ -210,6 +217,7 @@ const ContactUsInitialForm = () => {
 
     noEarlierThan(submitPromise, 1000)
       .then(() => {
+        dispatch({ type: 'clear-form' });
         clearSavedForm();
         setSubmissionState(LoadingState.SUCCESS);
       })

--- a/src/ensembl/src/shared/components/communication-framework/contact-us/contact-us-form/submit-slider/SubmitSlider.scss
+++ b/src/ensembl/src/shared/components/communication-framework/contact-us/contact-us-form/submit-slider/SubmitSlider.scss
@@ -6,6 +6,7 @@ $sliderHeight: 30px;
 .container {
   width: $trackWidth;
   position: relative;
+  user-select: none;
 }
 
 .track {

--- a/src/ensembl/src/shared/components/tabs/Tabs.test.tsx
+++ b/src/ensembl/src/shared/components/tabs/Tabs.test.tsx
@@ -32,11 +32,11 @@ const createTabGroup = (): Tab[] => {
 
   // Make sure we have atleast one enabled and one disabled entry
   options.push({
-    title: faker.random.words(),
+    title: faker.datatype.uuid(),
     isDisabled: true
   });
   options.push({
-    title: faker.random.words(),
+    title: faker.datatype.uuid(),
     isDisabled: false
   });
 
@@ -100,9 +100,8 @@ describe('<Tabs />', () => {
     const unselectedTabIndex = tabsData.findIndex(
       (tab) => tab.title !== defaultProps.selectedTab && !tab.isDisabled
     );
-    const unselectedTab = container.querySelectorAll('.tab')[
-      unselectedTabIndex
-    ];
+    const unselectedTab =
+      container.querySelectorAll('.tab')[unselectedTabIndex];
 
     userEvent.click(unselectedTab);
 
@@ -114,9 +113,8 @@ describe('<Tabs />', () => {
     const unselectedDisabledTabIndex = tabsData.findIndex(
       (tab) => tab.title !== defaultProps.selectedTab && tab.isDisabled
     );
-    const disabledTab = container.querySelectorAll('.tab')[
-      unselectedDisabledTabIndex
-    ];
+    const disabledTab =
+      container.querySelectorAll('.tab')[unselectedDisabledTabIndex];
 
     userEvent.click(disabledTab);
 


### PR DESCRIPTION
## Type
- Bug fix

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1352

## Description
**Bug:** Contact us form saved in IndexedDB did not get cleared when the form was submitted.
**Cause:** In fact the saved form did get cleared, but then was immediately saved again from the local state of the `ContactUsInitialForm` component, which I forgot to clear.

## Additional changes:
- fix error in the code determining whether the contact us form was empty before saving it to the db
- minor tweak to the test of the Tabs component to, hopefully, prevent occasional failure of tests (see [this failed job](https://gitlab.ebi.ac.uk/ensembl-web/ensembl-client/-/jobs/570986))
- fix visual bug that caused the text after the submission of the form to be selected:

bug:

https://user-images.githubusercontent.com/6834224/134258898-188bef30-e34b-48e8-83d3-55cda50f996e.mp4

after a CSS fix:

https://user-images.githubusercontent.com/6834224/134258914-a7f1ee9e-1a5a-416a-8186-4535fdc815d6.mp4

## Deployment URL
http://fix-saving-contact-us-form.review.ensembl.org