### PR TITLE
Enable click handling, as well as hover, on QuestionButton

### DIFF
--- a/src/ensembl/src/content/app/species-selector/containers/species-search-panel/SpeciesSearchPanel.scss
+++ b/src/ensembl/src/content/app/species-selector/containers/species-search-panel/SpeciesSearchPanel.scss
@@ -13,6 +13,7 @@
   align-items: center;
   margin-bottom: 0.5em;
   margin-left: -22px;
+  user-select: none;
 }
 
 .selectedAssembly {

--- a/src/ensembl/src/shared/components/question-button/QuestionButton.scss
+++ b/src/ensembl/src/shared/components/question-button/QuestionButton.scss
@@ -3,6 +3,8 @@
 .questionButton {
   position: relative;
   display: inline-block;
+  user-select: none;
+  cursor: pointer;
   padding: 2px;
   font-size: 0;
 

--- a/src/ensembl/src/shared/components/question-button/QuestionButton.test.tsx
+++ b/src/ensembl/src/shared/components/question-button/QuestionButton.test.tsx
@@ -46,6 +46,24 @@ describe('<QuestionButton />', () => {
       });
       expect(queryByText(helpMessage)).toBeTruthy();
     });
+
+    it('hides the tooltip on mouseleave', async () => {
+      const { container, queryByText } = render(
+        <QuestionButton helpText={helpText} />
+      );
+      const questionButton = container.querySelector(
+        '.questionButton'
+      ) as HTMLElement;
+
+      userEvent.hover(questionButton);
+
+      act(() => {
+        jest.advanceTimersByTime(TOOLTIP_TIMEOUT + 10);
+      });
+
+      userEvent.unhover(questionButton);
+      expect(queryByText(helpMessage)).toBeFalsy();
+    });
   });
 
   describe('on click', () => {
@@ -85,6 +103,25 @@ describe('<QuestionButton />', () => {
         // give the Tooltip component a little time to complete its async tasks
         jest.advanceTimersByTime(10);
       });
+      expect(queryByText(helpMessage)).toBeTruthy();
+    });
+
+    it('does not hide the tooltip on mouseleave', () => {
+      const { container, queryByText } = render(
+        <QuestionButton helpText={helpText} />
+      );
+      const questionButton = container.querySelector(
+        '.questionButton'
+      ) as HTMLElement;
+
+      userEvent.click(questionButton);
+
+      act(() => {
+        // give the Tooltip component a little time to complete its async tasks
+        jest.advanceTimersByTime(TOOLTIP_TIMEOUT + 10);
+      });
+
+      userEvent.unhover(questionButton); // <-- should have no effect on the tooltip
       expect(queryByText(helpMessage)).toBeTruthy();
     });
   });

--- a/src/ensembl/src/shared/components/question-button/QuestionButton.test.tsx
+++ b/src/ensembl/src/shared/components/question-button/QuestionButton.test.tsx
@@ -117,7 +117,26 @@ describe('<QuestionButton />', () => {
       userEvent.click(questionButton);
 
       act(() => {
-        // give the Tooltip component a little time to complete its async tasks
+        jest.advanceTimersByTime(TOOLTIP_TIMEOUT + 10);
+      });
+
+      userEvent.unhover(questionButton); // <-- should have no effect on the tooltip
+      expect(queryByText(helpMessage)).toBeTruthy();
+    });
+
+    it('prevents a new hover from registering', () => {
+      const { container, queryByText } = render(
+        <QuestionButton helpText={helpText} />
+      );
+      const questionButton = container.querySelector(
+        '.questionButton'
+      ) as HTMLElement;
+
+      userEvent.click(questionButton);
+
+      userEvent.hover(questionButton); // <-- notice that the hover starts after a click; we expect it not to have any effect
+
+      act(() => {
         jest.advanceTimersByTime(TOOLTIP_TIMEOUT + 10);
       });
 

--- a/src/ensembl/src/shared/components/question-button/QuestionButton.test.tsx
+++ b/src/ensembl/src/shared/components/question-button/QuestionButton.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import QuestionButton from './QuestionButton';
+import { TOOLTIP_TIMEOUT } from 'src/shared/components/tooltip/tooltip-constants';
+
+describe('<QuestionButton />', () => {
+  const helpMessage = 'I am a helpful message that will appear in the tooltip';
+  const helpText = <span>{helpMessage}</span>;
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  describe('on hover', () => {
+    it('shows the tooltip after a delay', async () => {
+      const { container, queryByText } = render(
+        <QuestionButton helpText={helpText} />
+      );
+      const questionButton = container.querySelector(
+        '.questionButton'
+      ) as HTMLElement;
+
+      userEvent.hover(questionButton);
+      expect(questionButton.querySelector('.pointerBox')).toBeFalsy();
+
+      act(() => {
+        jest.advanceTimersByTime(TOOLTIP_TIMEOUT + 10);
+      });
+      expect(queryByText(helpMessage)).toBeTruthy();
+    });
+  });
+
+  describe('on click', () => {
+    it('toggles the tooltip', () => {
+      const { container, queryByText } = render(
+        <QuestionButton helpText={helpText} />
+      );
+      const questionButton = container.querySelector(
+        '.questionButton'
+      ) as HTMLElement;
+
+      userEvent.click(questionButton);
+
+      act(() => {
+        // give the Tooltip component a little time to complete its async tasks
+        jest.advanceTimersByTime(10);
+      });
+      expect(queryByText(helpMessage)).toBeTruthy();
+
+      // clicking again to hide the tooltip
+      userEvent.click(questionButton);
+      expect(queryByText(helpMessage)).toBeFalsy();
+    });
+
+    it('takes precedence over hover', () => {
+      const { container, queryByText } = render(
+        <QuestionButton helpText={helpText} />
+      );
+      const questionButton = container.querySelector(
+        '.questionButton'
+      ) as HTMLElement;
+
+      userEvent.hover(questionButton); // would start the timer
+      userEvent.click(questionButton); // would clear the timer and toggle the state to show the tooltip
+
+      act(() => {
+        // give the Tooltip component a little time to complete its async tasks
+        jest.advanceTimersByTime(10);
+      });
+      expect(queryByText(helpMessage)).toBeTruthy();
+    });
+  });
+});

--- a/src/ensembl/src/shared/components/question-button/QuestionButton.tsx
+++ b/src/ensembl/src/shared/components/question-button/QuestionButton.tsx
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 
-import useHover from 'src/shared/hooks/useHover';
-
-import { TOOLTIP_TIMEOUT } from 'src/shared/components/tooltip/tooltip-constants';
+import { useQuestionButtonBehavior } from './useQuestionButtonBehavior';
 
 import Tooltip from 'src/shared/components/tooltip/Tooltip';
 import { ReactComponent as QuestionIcon } from './question_circle.svg';
@@ -39,36 +37,12 @@ type Props = {
 };
 
 const QuestionButton = (props: Props) => {
-  const [hoverRef, isHovered] = useHover<HTMLDivElement>();
-  const [shouldShowTooltip, setShouldShowTooltip] = useState(isHovered);
-  let timeoutId: number | null = null;
-
-  useEffect(() => {
-    if (isHovered) {
-      timeoutId = window.setTimeout(() => {
-        setShouldShowTooltip(isHovered);
-      }, TOOLTIP_TIMEOUT);
-    }
-
-    return () => {
-      timeoutId && clearTimeout(timeoutId);
-    };
-  }, [isHovered]);
-
-  const handleClick = () => {
-    timeoutId && clearTimeout(timeoutId); // overrides the timer started by hover
-    timeoutId = null;
-    setShouldShowTooltip(!shouldShowTooltip);
-  };
-
-  const hideTooltip = () => {
-    // tooltip will detect when user starts scrolling
-    // and will send a signal to the parent component so that it can be removed
-    setTimeout(() => {
-      // bump this to the next event loop to give the click event time to register and call the click handler
-      shouldShowTooltip && setShouldShowTooltip(false);
-    }, 0);
-  };
+  const {
+    questionButtonRef,
+    onClick,
+    onTooltipCloseSignal,
+    shouldShowTooltip
+  } = useQuestionButtonBehavior();
 
   const className = classNames(
     defaultStyles.questionButton,
@@ -79,13 +53,13 @@ const QuestionButton = (props: Props) => {
   );
 
   return (
-    <div ref={hoverRef} className={className} onClick={handleClick}>
+    <div ref={questionButtonRef} className={className} onClick={onClick}>
       <QuestionIcon />
       {shouldShowTooltip && (
         <Tooltip
-          anchor={hoverRef.current}
+          anchor={questionButtonRef.current}
           autoAdjust={true}
-          onClose={hideTooltip}
+          onClose={onTooltipCloseSignal}
           delay={0}
         >
           {props.helpText}

--- a/src/ensembl/src/shared/components/question-button/QuestionButton.tsx
+++ b/src/ensembl/src/shared/components/question-button/QuestionButton.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { useQuestionButtonBehavior } from './useQuestionButtonBehavior';
+import { useQuestionButtonBehaviour } from './useQuestionButtonBehaviour';
 
 import Tooltip from 'src/shared/components/tooltip/Tooltip';
 import { ReactComponent as QuestionIcon } from './question_circle.svg';
@@ -42,7 +42,7 @@ const QuestionButton = (props: Props) => {
     onClick,
     onTooltipCloseSignal,
     shouldShowTooltip
-  } = useQuestionButtonBehavior();
+  } = useQuestionButtonBehaviour();
 
   const className = classNames(
     defaultStyles.questionButton,

--- a/src/ensembl/src/shared/components/question-button/useQuestionButtonBehavior.tsx
+++ b/src/ensembl/src/shared/components/question-button/useQuestionButtonBehavior.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useReducer, useEffect } from 'react';
+
 import useHover from 'src/shared/hooks/useHover';
 
 import { TOOLTIP_TIMEOUT } from 'src/shared/components/tooltip/tooltip-constants';

--- a/src/ensembl/src/shared/components/question-button/useQuestionButtonBehavior.tsx
+++ b/src/ensembl/src/shared/components/question-button/useQuestionButtonBehavior.tsx
@@ -1,0 +1,109 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useReducer, useEffect } from 'react';
+import useHover from 'src/shared/hooks/useHover';
+
+import { TOOLTIP_TIMEOUT } from 'src/shared/components/tooltip/tooltip-constants';
+
+type EventType = 'click' | 'hover';
+
+type State = {
+  event: EventType | null;
+  isTooltipShown: boolean;
+};
+
+type ShowOnHoverAction = {
+  type: 'showTooltipOnHover';
+};
+
+type ShowOnClickAction = {
+  type: 'showTooltipOnClick';
+};
+
+type HideAction = {
+  type: 'hideTooltip';
+};
+
+type Action = ShowOnHoverAction | ShowOnClickAction | HideAction;
+
+const reducer = (_: State, action: Action): State => {
+  switch (action.type) {
+    case 'showTooltipOnHover':
+      return { event: 'hover', isTooltipShown: true };
+    case 'showTooltipOnClick':
+      return { event: 'click', isTooltipShown: true };
+    case 'hideTooltip':
+      return initialState;
+  }
+};
+
+const initialState: State = {
+  event: null,
+  isTooltipShown: false
+};
+
+export const useQuestionButtonBehavior = () => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const [hoverRef, isHovered] = useHover<HTMLDivElement>();
+
+  let timeoutId: number | null = null;
+
+  useEffect(() => {
+    if (isHovered) {
+      timeoutId = window.setTimeout(() => {
+        dispatch({ type: 'showTooltipOnHover' });
+      }, TOOLTIP_TIMEOUT);
+    } else if (state.isTooltipShown && state.event === 'hover') {
+      // only hide the tooltip on mouseout if the tooltip was shown due to a hover event
+      dispatch({ type: 'hideTooltip' });
+    }
+
+    return () => {
+      timeoutId && clearTimeout(timeoutId);
+    };
+  }, [isHovered]);
+
+  const handleClick = () => {
+    cancelTimeout(); // cancel the timer started by hover
+    if (!state.isTooltipShown) {
+      dispatch({ type: 'showTooltipOnClick' });
+    } else {
+      dispatch({ type: 'hideTooltip' });
+    }
+  };
+
+  const cancelTimeout = () => {
+    timeoutId && clearTimeout(timeoutId);
+    timeoutId = null;
+  };
+
+  const onTooltipCloseSignal = () => {
+    // tooltip will send a signal to hide it when user click outside of the tooltip
+    // or when they start scrolling
+    setTimeout(() => {
+      // bump this to the next event loop to give the click event time to register and call the click handler
+      dispatch({ type: 'hideTooltip' });
+    }, 0);
+  };
+
+  return {
+    questionButtonRef: hoverRef,
+    onClick: handleClick,
+    onTooltipCloseSignal,
+    shouldShowTooltip: state.isTooltipShown
+  };
+};

--- a/src/ensembl/src/shared/components/question-button/useQuestionButtonBehaviour.tsx
+++ b/src/ensembl/src/shared/components/question-button/useQuestionButtonBehaviour.tsx
@@ -57,7 +57,7 @@ const initialState: State = {
   isTooltipShown: false
 };
 
-export const useQuestionButtonBehavior = () => {
+export const useQuestionButtonBehaviour = () => {
   const [state, dispatch] = useReducer(reducer, initialState);
   const [hoverRef, isHovered] = useHover<HTMLDivElement>();
 

--- a/src/ensembl/src/shared/components/question-button/useQuestionButtonBehaviour.tsx
+++ b/src/ensembl/src/shared/components/question-button/useQuestionButtonBehaviour.tsx
@@ -64,7 +64,7 @@ export const useQuestionButtonBehaviour = () => {
   let timeoutId: number | null = null;
 
   useEffect(() => {
-    if (isHovered) {
+    if (isHovered && state.event === null) {
       timeoutId = window.setTimeout(() => {
         dispatch({ type: 'showTooltipOnHover' });
       }, TOOLTIP_TIMEOUT);


### PR DESCRIPTION
## Type
- Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1343

## Description
- Add click handling to `QuestionButton`. A click on `QuestionButton` will show the tooltip; the next click will hide it, and so on.
- Also, keep the previous behaviour on hover (wait for a while and show the tooltip)
- Update some CSS to prevent text selection and other nuisance on repeat clicks

## Deployment URL
http://question-button.review.ensembl.org