### PR TITLE
Prevent wrapping of track panel item's contents

### DIFF
--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.scss
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.scss
@@ -1,54 +1,21 @@
 @import 'src/styles/common';
 
 .track {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr [controls] auto;
+  align-items: center;
   font-size: 12px;
   margin-left: 0;
   padding: 4px 10px;
+  white-space: nowrap;
 
-  img {
-    height: 16px;
-    width: 16px;
-  }
-
-  .chevron {
-    margin-left: 8px;
-    height: 6px;
+  &WithChildren {
+    grid-template-columns: auto 1fr [controls] auto;
   }
 
   &:hover,
   &.trackHighlighted {
     background: $ice-blue;
-  }
-
-  &.main {
-    font-weight: $bold;
-  }
-
-  label {
-    width: calc(100% - 50px);
-
-    button {
-      margin-left: 0;
-    }
-
-    .mainText {
-      margin-right: 10px;
-    }
-
-    .selectedInfo {
-      color: $black;
-      display: inline-block;
-      font-size: 10px;
-      font-weight: $normal;
-      margin-right: 10px;
-    }
-
-    .additionalInfo {
-      display: inline-block;
-      font-size: 10px;
-      font-weight: $light;
-    }
   }
 
   .box {
@@ -79,6 +46,54 @@
       background: $white;
     }
   }
+}
+
+.labelTextPrimary {
+  margin-right: 10px;
+}
+
+.main {
+  .labelTextPrimary {
+    font-weight: $bold;
+  }
+}
+
+// TODO: would sure be nice to rename this class
+.selectedInfo {
+  color: $black;
+  font-size: 10px;
+  font-weight: $normal;
+  margin-right: 10px;
+}
+
+// TODO: would sure be nice to rename this class
+.additionalInfo {
+  font-size: 10px;
+  font-weight: $light;
+}
+
+.controls {
+  display: flex;
+  grid-column: controls;
+  margin-left: 26px;
+
+  & > * {
+    flex: 0 0 auto;
+  }
+}
+
+.label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chevronWrapper {
+  justify-self: start;
+}
+
+.chevron {
+  margin-left: 8px;
+  height: 6px;
 }
 
 .ellipsisHolder {

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.scss
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.scss
@@ -61,21 +61,21 @@
 // TODO: would sure be nice to rename this class
 .selectedInfo {
   color: $black;
-  font-size: 10px;
+  font-size: 11px;
   font-weight: $normal;
   margin-right: 10px;
 }
 
 // TODO: would sure be nice to rename this class
 .additionalInfo {
-  font-size: 10px;
+  font-size: 11px;
   font-weight: $light;
 }
 
 .controls {
   display: flex;
   grid-column: controls;
-  margin-left: 26px;
+  margin-left: 15px;
 
   & > * {
     flex: 0 0 auto;

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
@@ -200,6 +200,7 @@ export const TrackPanelListItem = (props: TrackPanelListItemProps) => {
   };
 
   const trackClassNames = classNames(styles.track, {
+    [styles.trackWithChildren]: props.children,
     [styles.main]: track.track_id === TrackId.GENE,
     [styles.trackHighlighted]:
       track.track_id === drawerView || track.track_id === highlightedTrackId
@@ -207,46 +208,51 @@ export const TrackPanelListItem = (props: TrackPanelListItemProps) => {
 
   return (
     <>
-      <dd className={trackClassNames} onClick={drawerViewListHandler}>
-        <label>
+      <div className={trackClassNames} onClick={drawerViewListHandler}>
+        <div className={styles.label}>
           {track.colour && (
             <span
               className={getBoxClasses(track.colour as TrackItemColourKey)}
             />
           )}
-          <span className={styles.mainText}>{track.label}</span>
-          {track.support_level && (
-            <span className={styles.selectedInfo}>{track.support_level}</span>
-          )}
-          {track.additional_info && (
-            <span className={styles.additionalInfo}>
-              {track.additional_info}
-            </span>
-          )}
-          {props.children && (
-            <Chevron
-              onClick={toggleExpand}
-              direction={isCollapsed ? 'down' : 'up'}
-              classNames={{ svg: styles.chevron }}
+          <span>
+            <span className={styles.labelTextPrimary}>{track.label}</span>
+            {track.support_level ? (
+              <span className={styles.selectedInfo}>{track.support_level}</span>
+            ) : (
+              track.additional_info && (
+                <span className={styles.additionalInfo}>
+                  {track.additional_info}
+                </span>
+              )
+            )}
+          </span>
+        </div>
+        {props.children && (
+          <Chevron
+            onClick={toggleExpand}
+            direction={isCollapsed ? 'down' : 'up'}
+            classNames={{ wrapper: styles.chevronWrapper, svg: styles.chevron }}
+          />
+        )}
+        <div className={styles.controls}>
+          <div className={styles.ellipsisHolder}>
+            <ImageButton
+              status={Status.DEFAULT}
+              description={`Go to ${track.label}`}
+              onClick={drawerViewButtonHandler}
+              image={Ellipsis}
             />
-          )}
-        </label>
-        <div className={styles.ellipsisHolder}>
-          <ImageButton
-            status={Status.DEFAULT}
-            description={`Go to ${track.label}`}
-            onClick={drawerViewButtonHandler}
-            image={Ellipsis}
-          />
+          </div>
+          <div className={styles.eyeHolder}>
+            <VisibilityIcon
+              status={trackStatus}
+              description={'enable/disable track'}
+              onClick={toggleTrack}
+            />
+          </div>
         </div>
-        <div className={styles.eyeHolder}>
-          <VisibilityIcon
-            status={trackStatus}
-            description={'enable/disable track'}
-            onClick={toggleTrack}
-          />
-        </div>
-      </dd>
+      </div>
       {!isCollapsed && props.children}
     </>
   );

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
@@ -239,7 +239,7 @@ export const TrackPanelListItem = (props: TrackPanelListItemProps) => {
           <div className={styles.ellipsisHolder}>
             <ImageButton
               status={Status.DEFAULT}
-              description={`Go to ${track.label}`}
+              description="More information"
               onClick={drawerViewButtonHandler}
               image={Ellipsis}
             />
@@ -247,7 +247,7 @@ export const TrackPanelListItem = (props: TrackPanelListItemProps) => {
           <div className={styles.eyeHolder}>
             <VisibilityIcon
               status={trackStatus}
-              description={'enable/disable track'}
+              description={getVisibilityIconHelpText(trackStatus)}
               onClick={toggleTrack}
             />
           </div>
@@ -256,6 +256,11 @@ export const TrackPanelListItem = (props: TrackPanelListItemProps) => {
       {!isCollapsed && props.children}
     </>
   );
+};
+
+const getVisibilityIconHelpText = (status: TrackActivityStatus) => {
+  // TODO: check whether the message is still correct after the half-highlighted eye icon is introduced
+  return status === Status.SELECTED ? 'Hide this track' : 'Show this track';
 };
 
 export default TrackPanelListItem;

--- a/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
+++ b/src/ensembl/src/shared/components/layout/StandardAppLayout.scss
@@ -89,7 +89,7 @@ $drawerWindowWidth: 45px;
   height: 100%;
   width: $sidebarContentWidth;
   border-left: 1px solid $grey;
-  padding: 15px;
+  padding: 15px 12px;
   background-color: white;
   overflow: auto;
 }


### PR DESCRIPTION
## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1323

## Description
The problem this PR is trying to solve is the line wrapping inside of track panel items with long contents, which leads to this:

<img src="https://user-images.githubusercontent.com/6834224/134778634-d1677da1-42bb-4c6e-abed-f1d0b5e6056e.png" width="400" />

This PR prevents line wrapping inside track panel items, and also fixes the text shown in tooltips for the buttons in a track panel item.


## Deployment URL
http://track-panel-item-styles.review.ensembl.org

## Views affected
Genome browser page