### PR TITLE
Fix the bug with add button not appearing after selecting a species

### DIFF
--- a/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.test.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.test.tsx
@@ -49,7 +49,7 @@ describe('<SpeciesCommitButton />', () => {
 
   it('does not show any button if no species has been selected', () => {
     const { container } = render(
-      <SpeciesCommitButton {...defaultProps} currentSpecies={undefined} />
+      <SpeciesCommitButton {...defaultProps} currentSpecies={null} />
     );
     expect(container.querySelector('button')).toBeFalsy();
   });

--- a/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.tsx
+++ b/src/ensembl/src/content/app/species-selector/components/species-commit-button/SpeciesCommitButton.tsx
@@ -33,7 +33,7 @@ import { RootState } from 'src/store';
 import styles from './SpeciesCommitButton.scss';
 
 type Props = {
-  currentSpecies?: CurrentItem;
+  currentSpecies: CurrentItem | null;
   disabled: boolean;
   onCommit: () => void;
 };
@@ -56,7 +56,7 @@ export const SpeciesCommitButton = (props: Props) => {
 };
 
 const mapStateToProps = (state: RootState) => ({
-  selectedItem: getSelectedItem(state),
+  currentSpecies: getSelectedItem(state),
   disabled: !canCommitSpecies(state)
 });
 


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Description
This PR fixes the bug that broke the `add` button in the species selector which was introduced in the PR https://github.com/Ensembl/ensembl-client/pull/572

## Deployment URL
http://fix-species-page-add-button.review.ensembl.org

## Views affected
Species selector
