### PR TITLE
Enable dedicated click handlers for ViewInApp component

### DIFF
--- a/src/ensembl/src/shared/components/in-app-search/InAppSearchMatches.tsx
+++ b/src/ensembl/src/shared/components/in-app-search/InAppSearchMatches.tsx
@@ -96,14 +96,16 @@ const InAppSearchMatch = (props: InAppSearchMatchProps) => {
           classNames={{ box: styles.tooltip, pointer: styles.tooltipTip }}
           onOutsideClick={hideTooltip}
         >
-          <MatchDetails {...props} />
+          <MatchDetails {...props} onClick={onClick} />
         </PointerBox>
       )}
     </>
   );
 };
 
-const MatchDetails = (props: InAppSearchMatchProps) => {
+const MatchDetails = (
+  props: InAppSearchMatchProps & { onClick: () => void }
+) => {
   const { match } = props;
   const { genome_id: genomeId, unversioned_stable_id } = match;
 
@@ -154,7 +156,7 @@ const MatchDetails = (props: InAppSearchMatchProps) => {
       </div>
 
       <div>
-        <ViewInApp links={links} />
+        <ViewInApp links={links} onAnyAppClick={props.onClick} />
       </div>
     </div>
   );

--- a/src/ensembl/src/shared/components/view-in-app/ViewInApp.test.tsx
+++ b/src/ensembl/src/shared/components/view-in-app/ViewInApp.test.tsx
@@ -26,8 +26,6 @@ import sampleSize from 'lodash/sampleSize';
 
 import { ViewInApp, AppName, Apps, ViewInAppProps, UrlObj } from './ViewInApp';
 
-jest.mock('connected-react-router');
-
 const mockStore = configureMockStore([thunk]);
 const store: ReturnType<typeof mockStore> = mockStore({});
 
@@ -121,5 +119,59 @@ describe('<ViewInApp />', () => {
     );
 
     expect(router.replace).toHaveBeenCalledWith(links.genomeBrowser.url);
+  });
+
+  describe('onClick behaviour', () => {
+    it('calls a click handler associated with a single app', () => {
+      const links = {
+        entityViewer: { url: 'http://foo.com' },
+        genomeBrowser: { url: 'http://bar.com' }
+      };
+      const clickHandlerMock = jest.fn();
+      const { getByTestId } = renderComponent({
+        links,
+        onAppClick: { genomeBrowser: clickHandlerMock }
+      });
+      const genomeBrowserButtonWrapper = getByTestId('genomeBrowser');
+      const genomeBrowserButton = genomeBrowserButtonWrapper.querySelector(
+        'button'
+      ) as HTMLButtonElement;
+      const entityViewerButtonWrapper = getByTestId('entityViewer');
+      const entityViewerButton = entityViewerButtonWrapper.querySelector(
+        'button'
+      ) as HTMLButtonElement;
+
+      userEvent.click(entityViewerButton);
+      expect(clickHandlerMock).not.toHaveBeenCalled(); // <-- because click handler is associated with genome browser button
+
+      userEvent.click(genomeBrowserButton);
+      expect(clickHandlerMock).toHaveBeenCalled();
+    });
+
+    it('calls a click handler associated with any app', () => {
+      const links = {
+        entityViewer: { url: 'http://foo.com' },
+        genomeBrowser: { url: 'http://bar.com' }
+      };
+      const clickHandlerMock = jest.fn();
+      const { getByTestId } = renderComponent({
+        links,
+        onAnyAppClick: clickHandlerMock
+      });
+      const genomeBrowserButtonWrapper = getByTestId('genomeBrowser');
+      const genomeBrowserButton = genomeBrowserButtonWrapper.querySelector(
+        'button'
+      ) as HTMLButtonElement;
+      const entityViewerButtonWrapper = getByTestId('entityViewer');
+      const entityViewerButton = entityViewerButtonWrapper.querySelector(
+        'button'
+      ) as HTMLButtonElement;
+
+      userEvent.click(entityViewerButton);
+      expect(clickHandlerMock).toHaveBeenCalledTimes(1);
+
+      userEvent.click(genomeBrowserButton);
+      expect(clickHandlerMock).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/src/ensembl/src/shared/components/view-in-app/ViewInApp.test.tsx
+++ b/src/ensembl/src/shared/components/view-in-app/ViewInApp.test.tsx
@@ -26,6 +26,8 @@ import sampleSize from 'lodash/sampleSize';
 
 import { ViewInApp, AppName, Apps, ViewInAppProps, UrlObj } from './ViewInApp';
 
+jest.mock('connected-react-router');
+
 const mockStore = configureMockStore([thunk]);
 const store: ReturnType<typeof mockStore> = mockStore({});
 
@@ -122,6 +124,12 @@ describe('<ViewInApp />', () => {
   });
 
   describe('onClick behaviour', () => {
+    beforeEach(() => {
+      jest
+        .spyOn(router, 'push')
+        .mockImplementation((link) => ({ type: 'push', link } as any));
+    });
+
     it('calls a click handler associated with a single app', () => {
       const links = {
         entityViewer: { url: 'http://foo.com' },


### PR DESCRIPTION
## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1344

## Description
Turns out, we need to support use cases when user clicks on a `ViewInApp` button, and the app doesn't change, but we need to handle this click in some clever way anyhow. Who knew!

This PR adds click handlers that can be both unique to individual app buttons, or common for all buttons. The immediate use case is hiding the tooltip when user clicks on a search match in the InAppSearch component. 

## Deployment URL
http://view-in-app-update.review.ensembl.org

## Views affected
InAppSearch in GenomeBrowser and EntityViewer.