### PR TITLE
Fix test for ExternalLink

### DIFF
--- a/src/ensembl/src/shared/components/external-link/ExternalLink.test.tsx
+++ b/src/ensembl/src/shared/components/external-link/ExternalLink.test.tsx
@@ -24,8 +24,8 @@ const defaultProps: ExternalLinkProps = {
   linkText: faker.random.words(),
   to: faker.internet.url(),
   classNames: {
-    icon: faker.random.word(),
-    link: faker.random.word()
+    icon: faker.lorem.word(),
+    link: faker.lorem.word()
   }
 };
 


### PR DESCRIPTION
## Type
- Bug fix

## Description
Tests for ExternalLink component may occasionally break, because the test is using the `faker.random.word` generator to generate random class names, and one of such random words is "24/7", which is not a valid classname. [Example](https://gitlab.ebi.ac.uk/ensembl-web/ensembl-client/-/jobs/581332):

<img src="https://user-images.githubusercontent.com/6834224/135734282-91e3f7e3-a878-4043-a255-8ec523d9a62b.png" width="600" />

`faker.lorem.word` does not have this problem 