### PR TITLE
Update build script to report compilation errors

### DIFF
--- a/src/ensembl/scripts/build.ts
+++ b/src/ensembl/scripts/build.ts
@@ -24,9 +24,19 @@ const build = async () => {
   });
 
   // the arguments of the callback function are error and webpack stats
-  webpack([webpackClientConfig, webpackServerConfig], (err) => {
+  webpack([webpackClientConfig, webpackServerConfig], (err, stats) => {
     if (err) {
+      // This branch will contain fatal webpack errors (wrong configuration, etc.)
       console.log('error!', err); // eslint-disable-line no-console
+      process.exit(1);
+    } else if (stats.hasErrors()) {
+      // This branch will contain compilation errors (including typescript type checking errors from ForkTsCheckerPlugin)
+      const info = stats.toJson();
+      info.errors.forEach(({ file, message }) => {
+        console.error('Error in', file); // eslint-disable-line no-console
+        console.error(message); // eslint-disable-line no-console
+      });
+      process.exit(1);
     }
     console.log('The production build is ready'); // eslint-disable-line no-console
   });


### PR DESCRIPTION
## Description
This PR addresses the problem that typescript errors do not fail the build.

The problem was caused by me not reading the docs carefully. Turns out, webpack compilation errors are stored in the `stats` object returned after the compilation, and they will contain any typescript errors. This PR adds the code that specifically inspects stats errors, and fails the build script if there are any.

See example of a failed build: https://gitlab.ebi.ac.uk/ensembl-web/ensembl-client/-/jobs/583271

Relevant documentation: https://webpack.js.org/api/node/#webpack

## To test the PR
You can specifically add a type error, and run the build script in the `dev` branch. The script will complete successfully. Then, if you switch to this branch and re-run the build script, you should see the error in the console, e.g.:

![image](https://user-images.githubusercontent.com/6834224/135775483-6458a12a-1301-48c6-82be-e53aa7a85048.png)
