### PR TITLE
Include biotype definition into the payload for GeneSummary component

### DIFF
--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/gene-summary/GeneSummary.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/gene-summary/GeneSummary.tsx
@@ -66,6 +66,7 @@ const GENE_QUERY = gql`
         biotype {
           label
           value
+          definition
         }
         name {
           accession_id


### PR DESCRIPTION
## Type
- Bug fix

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1373

## Description
Add the forgotten `definition` field to a graphql query.

Before:

![image](https://user-images.githubusercontent.com/6834224/135871962-2073d94a-1811-44b8-a789-d11939a3428b.png)

After:
![image](https://user-images.githubusercontent.com/6834224/135872035-cf33b625-efa9-42c0-b478-7c229f630209.png)


## Deployment URL
http://fix-missing-biotype-definition.review.ensembl.org

## Views affected
Genome browser gene view