### PR TITLE
Change instant download logic to use product_type than biotype

### DIFF
--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
@@ -32,7 +32,8 @@ import { getGeneName } from 'src/shared/helpers/formatters/geneFormatter';
 // TODO: check if this can be moved to a common place
 import {
   getNumberOfCodingExons,
-  getSplicedRNALength
+  getSplicedRNALength,
+  isProteinCodingTranscript
 } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
 
 import { useGetTrackPanelGeneQuery } from 'src/content/app/browser/state/genomeBrowserApiSlice';
@@ -70,7 +71,7 @@ type ProductGeneratingContext =
 
 type Gene = Pick<
   FullGene,
-  'stable_id' | 'unversioned_stable_id' | 'symbol' | 'name'
+  'stable_id' | 'unversioned_stable_id' | 'symbol' | 'name' | 'transcripts'
 >;
 
 const GENE_AND_TRANSCRIPT_QUERY = gql`
@@ -343,7 +344,7 @@ const TranscriptSummary = () => {
                 genomeId={ensObjectGene.genome_id}
                 transcript={{
                   id: transcript.unversioned_stable_id,
-                  biotype: metadata.biotype.value
+                  isProteinCoding: isProteinCodingTranscript(transcript)
                 }}
                 gene={{ id: gene.unversioned_stable_id }}
                 theme="light"

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -262,7 +262,7 @@ const renderInstantDownload = ({
         genomeId={genomeId}
         transcript={{
           id: transcript.stable_id,
-          biotype: transcript.metadata.biotype.value
+          isProteinCoding: isProteinCodingTranscript(transcript)
         }}
         gene={{ id: gene.stable_id }}
       />

--- a/src/ensembl/src/content/app/entity-viewer/shared/helpers/entity-helpers.ts
+++ b/src/ensembl/src/content/app/entity-viewer/shared/helpers/entity-helpers.ts
@@ -59,6 +59,15 @@ export type IsProteinCodingTranscriptParam = {
   }>;
 };
 
+type IsProteinCodingGeneParam = {
+  transcripts: IsProteinCodingTranscriptParam[];
+};
+export const isProteinCodingGene = (gene: IsProteinCodingGeneParam) => {
+  return gene.transcripts.some((transcript) =>
+    isProteinCodingTranscript(transcript)
+  );
+};
+
 export const isProteinCodingTranscript = (
   transcript: IsProteinCodingTranscriptParam
 ) => {

--- a/src/ensembl/src/shared/components/instant-download/instant-download-gene/InstantDownloadGene.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-gene/InstantDownloadGene.tsx
@@ -30,7 +30,7 @@ type Theme = 'light' | 'dark';
 
 type GeneFields = {
   id: string;
-  biotype: string;
+  isProteinCoding: boolean;
 };
 
 export type InstantDownloadGeneEntityProps = {
@@ -80,10 +80,10 @@ const transcriptOptionLabels: Record<keyof TranscriptOptions, string> = {
 const InstantDownloadGene = (props: Props) => {
   const {
     genomeId,
-    gene: { id: geneId, biotype }
+    gene: { id: geneId, isProteinCoding }
   } = props;
   const [transcriptOptions, setTranscriptOptions] = useState(
-    filterTranscriptOptions(biotype)
+    filterTranscriptOptions(isProteinCoding)
   );
   const [isGeneSequenceSelected, setIsGeneSequenceSelected] = useState(false);
 
@@ -102,7 +102,7 @@ const InstantDownloadGene = (props: Props) => {
 
   const resetCheckboxes = () => {
     setIsGeneSequenceSelected(false);
-    setTranscriptOptions(filterTranscriptOptions(biotype));
+    setTranscriptOptions(filterTranscriptOptions(isProteinCoding));
   };
 
   const onSubmit = async () => {

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.tsx
@@ -32,7 +32,7 @@ type Theme = 'light' | 'dark';
 
 type TranscriptFields = {
   id: string;
-  biotype: string;
+  isProteinCoding: boolean;
 };
 
 type GeneFields = {
@@ -94,9 +94,9 @@ const transcriptOptionLabels: Record<keyof TranscriptOptions, string> = {
 };
 
 export const filterTranscriptOptions = (
-  biotype: string
+  isProteinCoding: boolean
 ): Partial<TranscriptOptions> => {
-  return biotype === 'protein_coding'
+  return isProteinCoding
     ? defaultTranscriptOptions
     : pick(defaultTranscriptOptions, ['genomicSequence', 'cdna']);
 };
@@ -105,20 +105,20 @@ const InstantDownloadTranscript = (props: Props) => {
   const {
     genomeId,
     gene: { id: geneId },
-    transcript: { id: transcriptId, biotype }
+    transcript: { id: transcriptId, isProteinCoding }
   } = props;
   const [transcriptOptions, setTranscriptOptions] = useState(
-    filterTranscriptOptions(biotype)
+    filterTranscriptOptions(isProteinCoding)
   );
   const [isGeneSequenceSelected, setIsGeneSequenceSelected] = useState(false);
 
   useEffect(() => {
-    setTranscriptOptions(filterTranscriptOptions(biotype));
-  }, [biotype]);
+    setTranscriptOptions(filterTranscriptOptions(isProteinCoding));
+  }, [isProteinCoding]);
 
   const resetCheckboxes = () => {
     setIsGeneSequenceSelected(false);
-    setTranscriptOptions(filterTranscriptOptions(biotype));
+    setTranscriptOptions(filterTranscriptOptions(isProteinCoding));
   };
 
   const onSubmit = async () => {

--- a/src/ensembl/stories/shared-components/instant-download/InstantDownloadTranscript.stories.tsx
+++ b/src/ensembl/stories/shared-components/instant-download/InstantDownloadTranscript.stories.tsx
@@ -19,6 +19,8 @@ import React, { useState } from 'react';
 import { createGene } from 'tests/fixtures/entity-viewer/gene';
 import { createTranscript } from 'tests/fixtures/entity-viewer/transcript';
 
+import { isProteinCodingTranscript } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
+
 import { InstantDownloadTranscript } from 'src/shared/components/instant-download';
 
 import styles from './InstantDownload.stories.scss';
@@ -77,7 +79,7 @@ export const InstantDownloadTranscriptStory = () => {
           gene={{ id: gene.unversioned_stable_id }}
           transcript={{
             id: transcript.unversioned_stable_id,
-            biotype: transcript.metadata.biotype?.value as string
+            isProteinCoding: isProteinCodingTranscript(transcript)
           }}
         />
       </div>


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1291

## Importance
We cannot always rely on biotypes to see if a transcript codes for protein. A more stable way is to use the product_type in product_generating_contexts.

## Description
The InstantDownloadTranscript and InstantDownloadGene components show a list of checkboxes to select what kinds of sequences can be downloaded. If a transcript encodes a protein, we expect to be able to download the genomic sequence, cDNA, CDS and the protein sequence. If a transcript does not encode a protein, we expect to be able to download only the genomic sequence and cDNA.

Currently we are checking whether a transcript encodes a protein (or whether a gene has transcripts that encode a protein) by checking whether the biotype of the transcript is protein_coding. This, however, is insufficient, because there are other transcripts, with different biotypes, that encode proteins.

Option 1
For transcript loaded from Thoas, check product_generating_context->product_type. If it says "Protein", then assume that the transcript will have all four kinds of sequences available for download. Otherwise, assume that there will be only genomic and cDNA sequences available.

Similarly, for InstantDownloadGene, check the list of gene transcripts to determine whether any of them encodes a protein. Note that the instant download components are used both in Entity viewer and in the Genome browser, including the zMenu.

You may use the examples in the JIRA ticket to test.

## Deployment URL
http://instant-download-logic.review.ensembl.org/
http://instant-download-logic.review.ensembl.org/entity-viewer/homo_sapiens_GCA_000001405_28/gene:ENSG00000205702?view=transcripts

## Views affected
GB drawer, zmenu, EV gene and transcript downloads

### Other effects
NA

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
Hopefully not