### PR TITLE
Convert Entity Viewer components to redux-hooks

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-relationships/GeneRelationships.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-relationships/GeneRelationships.tsx
@@ -15,19 +15,17 @@
  */
 
 import React from 'react';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
-import { push, Push } from 'connected-react-router';
+import { push } from 'connected-react-router';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
 
-import { isEntityViewerSidebarOpen } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors';
 import { getSelectedGeneViewTabs } from 'src/content/app/entity-viewer/state/gene-view/view/geneViewViewSelectors';
 
 import Tabs, { Tab } from 'src/shared/components/tabs/Tabs';
 import Panel from 'src/shared/components/panel/Panel';
 
-import { RootState } from 'src/store';
 import {
   GeneViewTabMap,
   GeneViewTabName,
@@ -49,15 +47,11 @@ const tabClassNames = {
   selected: styles.selectedTabName
 };
 
-type Props = {
-  isSidebarOpen: boolean;
-  selectedTabName: GeneRelationshipsTabName | null;
-  push: Push;
-};
-
-const GeneRelationships = (props: Props) => {
+const GeneRelationships = () => {
   const { genomeId, entityId } = useParams() as { [key: string]: string };
-  let { selectedTabName } = props;
+  const selectedTabNameFromRedux = useSelector(getSelectedGeneViewTabs)
+    .secondaryTab as GeneRelationshipsTabName;
+  const dispatch = useDispatch();
 
   const changeTab = (tab: string) => {
     const match = [...GeneViewTabMap.entries()].find(
@@ -72,20 +66,16 @@ const GeneRelationships = (props: Props) => {
       entityId,
       view
     });
-    props.push(url);
+
+    dispatch(push(url));
   };
 
   // If the selectedTab is disabled or if there is no selectedtab, pick the first available tab
-  const selectedTabIndex = tabsData.findIndex(
-    (tab) => tab.title === selectedTabName
-  );
-
-  if (selectedTabIndex === -1 || tabsData[selectedTabIndex].isDisabled) {
-    const nextAvailableTab = tabsData.find((tab) => !tab.isDisabled);
-
-    selectedTabName =
-      (nextAvailableTab?.title as GeneRelationshipsTabName) || null;
-  }
+  const selectedTab =
+    tabsData.find(
+      (tab) => tab.title === selectedTabNameFromRedux && !tab.isDisabled
+    ) || tabsData.find((tab) => !tab.isDisabled);
+  const selectedTabName = selectedTab?.title || null;
 
   const TabWrapper = () => {
     return (
@@ -120,14 +110,4 @@ const GeneRelationships = (props: Props) => {
   );
 };
 
-const mapStateToProps = (state: RootState) => ({
-  isSidebarOpen: isEntityViewerSidebarOpen(state),
-  selectedTabName: getSelectedGeneViewTabs(state)
-    .secondaryTab as GeneRelationshipsTabName
-});
-
-const mapDispatchToProps = {
-  push
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(GeneRelationships);
+export default GeneRelationships;

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-tabs/GeneViewTabs.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/gene-view-tabs/GeneViewTabs.tsx
@@ -17,8 +17,8 @@
 import React from 'react';
 import classNames from 'classnames';
 import { useParams } from 'react-router-dom';
-import { connect } from 'react-redux';
-import { push, Push } from 'connected-react-router';
+import { useDispatch, useSelector } from 'react-redux';
+import { push } from 'connected-react-router';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import {
@@ -29,11 +29,9 @@ import useEntityViewerAnalytics from 'src/content/app/entity-viewer/hooks/useEnt
 
 import Tabs, { Tab } from 'src/shared/components/tabs/Tabs';
 
-import { RootState } from 'src/store';
 import {
   GeneViewTabName,
-  View,
-  SelectedTabViews
+  View
 } from 'src/content/app/entity-viewer/state/gene-view/view/geneViewViewSlice';
 
 import styles from './GeneViewTabs.scss';
@@ -47,15 +45,16 @@ const tabsData: Tab[] = [
 const DEFAULT_TAB = tabsData[0].title;
 
 type Props = {
-  selectedTab: string;
-  selectedTabViews?: SelectedTabViews;
-  push: Push;
   isFilterPanelOpen: boolean;
 };
 
 const GeneViewTabs = (props: Props) => {
   const { genomeId, entityId } = useParams() as { [key: string]: string };
+  const selectedTab = useSelector(getSelectedGeneViewTabs).primaryTab;
+  const selectedTabViews = useSelector(getSelectedTabViews);
+  const dispatch = useDispatch();
   const { trackTabChange } = useEntityViewerAnalytics();
+
   const tabClassNames = {
     default: styles.geneTab,
     selected: classNames(styles.selectedGeneTab, {
@@ -68,9 +67,9 @@ const GeneViewTabs = (props: Props) => {
   const onTabChange = (selectedTabName: string) => {
     let view = View.TRANSCRIPTS;
     if (selectedTabName === GeneViewTabName.GENE_FUNCTION) {
-      view = props.selectedTabViews?.geneFunctionTab || View.PROTEIN;
+      view = selectedTabViews?.geneFunctionTab || View.PROTEIN;
     } else if (selectedTabName === GeneViewTabName.GENE_RELATIONSHIPS) {
-      view = props.selectedTabViews?.geneRelationshipsTab || View.ORTHOLOGUES;
+      view = selectedTabViews?.geneRelationshipsTab || View.ORTHOLOGUES;
     }
 
     trackTabChange(selectedTabName);
@@ -79,26 +78,17 @@ const GeneViewTabs = (props: Props) => {
       entityId,
       view
     });
-    props.push(url);
+    dispatch(push(url));
   };
 
   return (
     <Tabs
       classNames={tabClassNames}
       tabs={tabsData}
-      selectedTab={props.selectedTab || DEFAULT_TAB}
+      selectedTab={selectedTab || DEFAULT_TAB}
       onTabChange={onTabChange}
     />
   );
 };
 
-const mapStateToProps = (state: RootState) => ({
-  selectedTab: getSelectedGeneViewTabs(state).primaryTab,
-  selectedTabViews: getSelectedTabViews(state)
-});
-
-const mapDispatchToProps = {
-  push
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(GeneViewTabs);
+export default GeneViewTabs;


### PR DESCRIPTION
## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1356

## Description
Convert a couple of remaining Entity Viewer components from the react-redux `connect` function to react-redux hooks. 

## Deployment URL
http://refactor-entity-viewer-to-hooks.review.ensembl.org