### PR TITLE
Fix drawing of exons of non-coding transcripts

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript.tsx
@@ -211,7 +211,7 @@ const calculateExonRectangles = (params: CalculateExonRectanglesParams) => {
   return spliced_exons.map((exon) => {
     const { start: exonStart, end: exonEnd } = exon.relative_location;
     const isCompletelyNonCoding =
-      cds && (exonEnd < cds.relative_start || exonStart > cds.relative_end);
+      !cds || exonEnd < cds.relative_start || exonStart > cds.relative_end;
     const isNonCodingLeft =
       cds && exonStart < cds.relative_start && exonEnd > cds.relative_start;
     const isNonCodingRight =


### PR DESCRIPTION
## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1390

## Description
Bug: exons of non-coding transcripts are painted as filled:

![image](https://user-images.githubusercontent.com/6834224/137175224-d29e13ca-2b44-4af4-9778-2c2b9a44954c.png)

Same gene after the fix:

![image](https://user-images.githubusercontent.com/6834224/137175363-a652e953-7d2a-44e1-8974-29119d1ff871.png)


## Deployment URL
http://fix-non-coding-transcripts-in-ev.review.ensembl.org
(specifically, [this gene](http://fix-non-coding-transcripts-in-ev.review.ensembl.org/entity-viewer/homo_sapiens_GCA_000001405_28/gene:ENSG00000205702?view=transcripts))

## Views affected
Default transcripts list in Entity Viewer