### PR TITLE
Disable analytics tracking in non-production environments

### DIFF
--- a/src/ensembl/src/services/analytics-service.ts
+++ b/src/ensembl/src/services/analytics-service.ts
@@ -18,6 +18,7 @@ import ReactGA from 'react-ga';
 import { AnalyticsOptions, CustomDimensions } from 'src/analyticsHelper';
 
 import config from 'config';
+import { isEnvironment, Environment } from 'src/shared/helpers/environment';
 
 const { googleAnalyticsKey } = config;
 
@@ -29,6 +30,18 @@ class AnalyticsTracking {
       titleCase: false
     });
     this.reactGA = ReactGA;
+    this.setReporting();
+  }
+
+  private setReporting() {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    // don't send analytics other than in production deployment
+    if (!isEnvironment([Environment.PRODUCTION])) {
+      this.reactGA.ga('set', 'sendHitTask', null);
+    }
   }
 
   // Track a pageview


### PR DESCRIPTION
## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1391

We should be able to test this when Kamal enables environment variable for GA key on all deployments.

[Relevant documentation](https://developers.google.com/analytics/devguides/collection/analyticsjs/debugging#testing_your_implementation_without_sending_hits)

## Deployment URL
http://disable-analytics-on-non-prod.review.ensembl.org