### PR TITLE
Change from faker.random to faker.lorem in tests of ExternalReference component

### DIFF
--- a/src/ensembl/src/shared/components/external-reference/ExternalReference.test.tsx
+++ b/src/ensembl/src/shared/components/external-reference/ExternalReference.test.tsx
@@ -25,10 +25,10 @@ const defaultProps: ExternalReferenceProps = {
   linkText: faker.random.word(),
   to: faker.internet.url(),
   classNames: {
-    container: faker.random.word(),
-    label: faker.random.word(),
-    icon: faker.random.word(),
-    link: faker.random.word()
+    container: faker.lorem.word(),
+    label: faker.lorem.word(),
+    icon: faker.lorem.word(),
+    link: faker.lorem.word()
   }
 };
 


### PR DESCRIPTION
## Description
Tests for `ExternalReference` component are using the functions in the `faker.random` namespace to generate class names, which sometimes produces invalid class names that fail the tests.

[Example of the latest test failure](https://gitlab.ebi.ac.uk/ensembl-web/ensembl-client/-/jobs/600157):

![image](https://user-images.githubusercontent.com/6834224/137721042-ed32597a-6566-45cf-b2e2-f62501c1f5f7.png)


This PR changes `faker.random` to `faker.lorem` for `ExternalReference` tests.