### PR TITLE
Fix bug with tracking multiple species selection

### DIFF
--- a/src/ensembl/src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics.ts
+++ b/src/ensembl/src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics.ts
@@ -82,8 +82,7 @@ const useSpeciesSelectorAnalytics = () => {
       category: 'species_selector',
       action: 'select_multiple',
       label: committedSpeciesNames.join(','),
-      value: committedSpeciesNames.length,
-      species: ''
+      value: committedSpeciesNames.length
     });
   };
 


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1393

## Description
Currently, the tracking event that tracks when multiple species are selected doesn't get sent until the 3rd species is selected. 

## Deployment URL
http://species-selector-ga-fix.review.ensembl.org

## Views affected
Species selector

