### PR TITLE
Add analytics to Transcript list view

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -118,6 +118,7 @@ const DefaultTranscriptslist = (props: Props) => {
           return (
             <DefaultTranscriptsListItem
               key={index}
+              transcriptPosition={index + 1}
               gene={gene}
               transcript={transcript}
               rulerTicks={props.rulerTicks}

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.test.tsx
@@ -82,6 +82,7 @@ describe('<DefaultTranscriptListItem />', () => {
   });
 
   const defaultProps = {
+    transcriptPosition: 1,
     gene: createGene(),
     transcript: createTranscript(),
     rulerTicks: createRulerTicks(),

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.test.tsx
@@ -49,13 +49,13 @@ const mockState = {
     general: {
       activeGenomeId: 'human',
       activeEntityIds: {
-        human: 'gene:brca2'
+        human: 'human:gene:brca2'
       }
     },
     geneView: {
       transcripts: {
         human: {
-          'gene:brca2': {
+          'human:gene:brca2': {
             expandedIds: [],
             expandedDownloadIds: [],
             filters: [],
@@ -64,6 +64,15 @@ const mockState = {
         }
       }
     }
+  },
+  speciesSelector: {
+    committedItems: [
+      {
+        genome_id: 'human',
+        common_name: 'human',
+        assembly_name: 'grch38'
+      }
+    ]
   }
 };
 

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
@@ -71,10 +71,10 @@ export const DefaultTranscriptListItem = (
   const dispatch = useDispatch();
   const { trackTranscriptListViewToggle } = useEntityViewerAnalytics();
 
+  let transcriptExpandStatus = props.expandTranscript;
+
   const handleTranscriptClick = () => {
-    // let transcriptExpandStatus = props.expandTranscript;
-    // transcriptExpandStatus = !transcriptExpandStatus;
-    const transcriptExpandStatus = !props.expandTranscript;
+    transcriptExpandStatus = !transcriptExpandStatus;
     dispatch(toggleTranscriptInfo(props.transcript.stable_id));
 
     const qualityLabel = getTranscriptMetadata(props.transcript)?.label;

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
@@ -26,9 +26,14 @@ import TranscriptsListItemInfo, {
 
 import { toggleTranscriptInfo } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 
+import useEntityViewerAnalytics from 'src/content/app/entity-viewer/hooks/useEntityViewerAnalytics';
+
 import { FullTranscript } from 'src/shared/types/thoas/transcript';
 import { TicksAndScale } from 'src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/BasePairsRuler';
-import { TranscriptQualityLabel } from 'src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel';
+import {
+  getTranscriptMetadata,
+  TranscriptQualityLabel
+} from 'src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel';
 
 import transcriptsListStyles from '../DefaultTranscriptsList.scss';
 import styles from './DefaultTranscriptListItem.scss';
@@ -41,6 +46,7 @@ type Transcript = Pick<
   UnsplicedTranscriptProps['transcript'];
 
 export type DefaultTranscriptListItemProps = {
+  transcriptPosition?: number;
   gene: TranscriptsListItemInfoProps['gene'];
   transcript: Transcript;
   rulerTicks: TicksAndScale;
@@ -63,9 +69,30 @@ export const DefaultTranscriptListItem = (
   const transcriptWidth = scale(transcriptLength) as number;
 
   const dispatch = useDispatch();
+  const { trackTranscriptListViewToggle } = useEntityViewerAnalytics();
+
+  let transcriptExpandStatus = props.expandTranscript;
 
   const handleTranscriptClick = () => {
+    transcriptExpandStatus = !transcriptExpandStatus;
     dispatch(toggleTranscriptInfo(props.transcript.stable_id));
+
+    if (!props.transcriptPosition) {
+      return;
+    }
+
+    const qualityLabel = getTranscriptMetadata(props.transcript)?.label;
+    const gatranscriptLabel = [qualityLabel, props.transcript.stable_id]
+      .filter(Boolean)
+      .join(' ');
+    const gaToggleAction = transcriptExpandStatus
+      ? 'open_accordion'
+      : 'close_accordion';
+    trackTranscriptListViewToggle(
+      gatranscriptLabel,
+      gaToggleAction,
+      props.transcriptPosition
+    );
   };
 
   return (

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
@@ -74,11 +74,8 @@ export const DefaultTranscriptListItem = (
   const handleTranscriptClick = () => {
     dispatch(toggleTranscriptInfo(props.transcript.stable_id));
 
-    const transcriptQuality =
-      getTranscriptMetadata(props.transcript)?.label ?? null;
-
     trackTranscriptListViewToggle({
-      transcriptQuality,
+      transcriptQuality: getTranscriptMetadata(props.transcript)?.label,
       transcriptId: props.transcript.stable_id,
       action: !props.expandTranscript ? 'open_accordion' : 'close_accordion',
       transcriptPosition: props.transcriptPosition

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
@@ -46,7 +46,7 @@ type Transcript = Pick<
   UnsplicedTranscriptProps['transcript'];
 
 export type DefaultTranscriptListItemProps = {
-  transcriptPosition?: number;
+  transcriptPosition: number;
   gene: TranscriptsListItemInfoProps['gene'];
   transcript: Transcript;
   rulerTicks: TicksAndScale;
@@ -71,25 +71,20 @@ export const DefaultTranscriptListItem = (
   const dispatch = useDispatch();
   const { trackTranscriptListViewToggle } = useEntityViewerAnalytics();
 
-  let transcriptExpandStatus = props.expandTranscript;
-
   const handleTranscriptClick = () => {
-    transcriptExpandStatus = !transcriptExpandStatus;
+    // let transcriptExpandStatus = props.expandTranscript;
+    // transcriptExpandStatus = !transcriptExpandStatus;
+    const transcriptExpandStatus = !props.expandTranscript;
     dispatch(toggleTranscriptInfo(props.transcript.stable_id));
 
-    if (!props.transcriptPosition) {
-      return;
-    }
-
     const qualityLabel = getTranscriptMetadata(props.transcript)?.label;
-    const gatranscriptLabel = [qualityLabel, props.transcript.stable_id]
-      .filter(Boolean)
-      .join(' ');
+
     const gaToggleAction = transcriptExpandStatus
       ? 'open_accordion'
       : 'close_accordion';
     trackTranscriptListViewToggle(
-      gatranscriptLabel,
+      qualityLabel,
+      props.transcript.stable_id,
       gaToggleAction,
       props.transcriptPosition
     );

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
@@ -71,21 +71,15 @@ export const DefaultTranscriptListItem = (
   const dispatch = useDispatch();
   const { trackTranscriptListViewToggle } = useEntityViewerAnalytics();
 
-  let transcriptExpandStatus = props.expandTranscript;
-
   const handleTranscriptClick = () => {
-    transcriptExpandStatus = !transcriptExpandStatus;
     dispatch(toggleTranscriptInfo(props.transcript.stable_id));
 
     const qualityLabel = getTranscriptMetadata(props.transcript)?.label;
 
-    const gaToggleAction = transcriptExpandStatus
-      ? 'open_accordion'
-      : 'close_accordion';
     trackTranscriptListViewToggle(
       qualityLabel,
       props.transcript.stable_id,
-      gaToggleAction,
+      !props.expandTranscript ? 'open_accordion' : 'close_accordion',
       props.transcriptPosition
     );
   };

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
@@ -74,14 +74,15 @@ export const DefaultTranscriptListItem = (
   const handleTranscriptClick = () => {
     dispatch(toggleTranscriptInfo(props.transcript.stable_id));
 
-    const qualityLabel = getTranscriptMetadata(props.transcript)?.label;
+    const transcriptQuality =
+      getTranscriptMetadata(props.transcript)?.label ?? null;
 
-    trackTranscriptListViewToggle(
-      qualityLabel,
-      props.transcript.stable_id,
-      !props.expandTranscript ? 'open_accordion' : 'close_accordion',
-      props.transcriptPosition
-    );
+    trackTranscriptListViewToggle({
+      transcriptQuality,
+      transcriptId: props.transcript.stable_id,
+      action: !props.expandTranscript ? 'open_accordion' : 'close_accordion',
+      transcriptPosition: props.transcriptPosition
+    });
   };
 
   return (

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
@@ -17,6 +17,10 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
 
+import {
+  getTranscriptMetadata,
+  TranscriptQualityLabel
+} from 'src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel';
 import UnsplicedTranscript, {
   UnsplicedTranscriptProps
 } from 'src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript';
@@ -30,10 +34,6 @@ import useEntityViewerAnalytics from 'src/content/app/entity-viewer/hooks/useEnt
 
 import { FullTranscript } from 'src/shared/types/thoas/transcript';
 import { TicksAndScale } from 'src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/BasePairsRuler';
-import {
-  getTranscriptMetadata,
-  TranscriptQualityLabel
-} from 'src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel';
 
 import transcriptsListStyles from '../DefaultTranscriptsList.scss';
 import styles from './DefaultTranscriptListItem.scss';

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.test.tsx
@@ -110,13 +110,13 @@ const mockState = {
     general: {
       activeGenomeId: 'human',
       activeEntityIds: {
-        human: 'gene:brca2'
+        human: 'human:gene:brca2'
       }
     },
     geneView: {
       transcripts: {
         human: {
-          'gene:brca2': {
+          'human:gene:brca2': {
             expandedIds: [],
             expandedDownloadIds: [],
             expandedMoreInfoIds: [],
@@ -126,6 +126,15 @@ const mockState = {
         }
       }
     }
+  },
+  speciesSelector: {
+    committedItems: [
+      {
+        genome_id: 'human',
+        common_name: 'human',
+        assembly_name: 'grch38'
+      }
+    ]
   }
 };
 const renderComponent = (props?: Partial<TranscriptsListItemInfoProps>) => {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -97,7 +97,7 @@ export const TranscriptsListItemInfo = (
 
   const {
     trackTranscriptMoreInfoToggle,
-    trackExternalLinkClick,
+    trackExternalLinkClickInTranscriptList,
     trackInstantDownloadTranscriptList
   } = useEntityViewerAnalytics();
 
@@ -132,7 +132,7 @@ export const TranscriptsListItemInfo = (
   };
 
   const handleExternalReferenceClick = (linkLabel: string) => {
-    trackExternalLinkClick(linkLabel);
+    trackExternalLinkClickInTranscriptList(linkLabel);
   };
 
   const getTranscriptLocation = () => {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -49,12 +49,12 @@ import { SplicedExon, PhasedExon } from 'src/shared/types/thoas/exon';
 import { FullProductGeneratingContext } from 'src/shared/types/thoas/productGeneratingContext';
 import { View } from 'src/content/app/entity-viewer/state/gene-view/view/geneViewViewSlice';
 
-import useEntityViewerAnalytics from '../../../../hooks/useEntityViewerAnalytics';
+import useEntityViewerAnalytics from 'src/content/app/entity-viewer/hooks/useEntityViewerAnalytics';
 
 import transcriptsListStyles from '../DefaultTranscriptsList.scss';
 import styles from './TranscriptsListItemInfo.scss';
-import { getTranscriptMetadata } from '../../../../shared/components/default-transcript-label/TranscriptQualityLabel';
-import { TrackTranscriptDownloadPayload } from 'ensemblRoot/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript';
+import { getTranscriptMetadata } from 'src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel';
+import { TrackTranscriptDownloadPayload } from 'src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript';
 
 type Gene = Pick<FullGene, 'unversioned_stable_id' | 'stable_id' | 'symbol'>;
 type Transcript = Pick<
@@ -105,10 +105,7 @@ export const TranscriptsListItemInfo = (
     dispatch(toggleTranscriptMoreInfo(transcript.stable_id));
 
     const qualityLabel = getTranscriptMetadata(transcript)?.label;
-    const gaTranscriptLabel = [qualityLabel, transcript.stable_id]
-      .filter(Boolean)
-      .join(' ');
-    trackTranscriptMoreInfoToggle(gaTranscriptLabel);
+    trackTranscriptMoreInfoToggle(qualityLabel, transcript.stable_id);
   };
 
   const onDownload = (

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -32,12 +32,12 @@ import {
 } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import { buildFocusIdForUrl } from 'src/shared/state/ens-object/ensObjectHelpers';
+import { getTranscriptMetadata } from 'src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel';
 
 import { InstantDownloadTranscript } from 'src/shared/components/instant-download';
 import ViewInApp from 'src/shared/components/view-in-app/ViewInApp';
 import ShowHide from 'src/shared/components/show-hide/ShowHide';
 import ExternalReference from 'src/shared/components/external-reference/ExternalReference';
-import { getTranscriptMetadata } from 'src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel';
 import { TrackTranscriptDownloadPayload } from 'src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript';
 
 import {

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -37,6 +37,8 @@ import { InstantDownloadTranscript } from 'src/shared/components/instant-downloa
 import ViewInApp from 'src/shared/components/view-in-app/ViewInApp';
 import ShowHide from 'src/shared/components/show-hide/ShowHide';
 import ExternalReference from 'src/shared/components/external-reference/ExternalReference';
+import { getTranscriptMetadata } from 'src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel';
+import { TrackTranscriptDownloadPayload } from 'src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript';
 
 import {
   toggleTranscriptDownload,
@@ -53,8 +55,6 @@ import useEntityViewerAnalytics from 'src/content/app/entity-viewer/hooks/useEnt
 
 import transcriptsListStyles from '../DefaultTranscriptsList.scss';
 import styles from './TranscriptsListItemInfo.scss';
-import { getTranscriptMetadata } from 'src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel';
-import { TrackTranscriptDownloadPayload } from 'src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript';
 
 type Gene = Pick<FullGene, 'unversioned_stable_id' | 'stable_id' | 'symbol'>;
 type Transcript = Pick<

--- a/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item/ProteinsListItem.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item/ProteinsListItem.tsx
@@ -103,8 +103,7 @@ const ProteinsListItem = (props: Props) => {
 
     dispatch(toggleTranscriptInfo(transcript.stable_id));
     trackProteinInfoToggle({
-      transcriptQuality:
-        getTranscriptQualityMetadata(transcript)?.label ?? null,
+      transcriptQuality: getTranscriptQualityMetadata(transcript)?.label,
       transcriptId: transcript.stable_id,
       action: isInfoPanelExpanded ? 'close_accordion' : 'open_accordion',
       transcriptPosition: props.index

--- a/src/ensembl/src/content/app/entity-viewer/hooks/useEntityViewerAnalytics.ts
+++ b/src/ensembl/src/content/app/entity-viewer/hooks/useEntityViewerAnalytics.ts
@@ -131,6 +131,31 @@ const useEntityViewerAnalytics = () => {
     });
   };
 
+  const trackTranscriptListViewToggle = (
+    transcriptLabel: string,
+    toggleAction: string,
+    position: number
+  ) => {
+    analyticsTracking.trackEvent({
+      category: 'gene_view_transcript_list',
+      label: transcriptLabel, //open or close
+      action: toggleAction,
+      value: position
+    });
+  };
+
+  const trackTranscriptMoreInfoToggle = (transcriptLabel: string) => {
+    analyticsTracking.trackEvent({
+      category: 'gene_view_transcript_list',
+      label: transcriptLabel,
+      action: 'more_information'
+    });
+  };
+
+  // "Category: gene_view_transcript_list
+  // Actions: sequence_download
+  // Label: gene_symbol + checkboxes & transcript + checkboxes"
+
   const trackDownload = (params: TrackDownloadPayload) => {
     const selectedOptions = params.options
       .sort()
@@ -155,6 +180,12 @@ const useEntityViewerAnalytics = () => {
     params: Omit<TrackDownloadPayload, 'category'>
   ) => {
     trackDownload({ ...params, category: 'gene_view_proteins_list' });
+  }
+  
+  const trackInstantDownloadTranscriptList = (
+    params: Omit<TrackDownloadPayload, 'category'>
+  ) => {
+    trackDownload({ ...params, category: 'gene_view_transcript_list' });
   };
 
   return {
@@ -164,7 +195,11 @@ const useEntityViewerAnalytics = () => {
     trackAppliedSorting,
     trackProteinInfoToggle,
     trackProteinDownload,
-    trackExternalLinkClickInProteinsList
+    trackExternalLinkClickInProteinsList,
+    trackTranscriptListViewToggle,
+    trackTranscriptMoreInfoToggle,
+    trackExternalLinkClick,
+    trackInstantDownloadTranscriptList
   };
 };
 export default useEntityViewerAnalytics;

--- a/src/ensembl/src/content/app/entity-viewer/hooks/useEntityViewerAnalytics.ts
+++ b/src/ensembl/src/content/app/entity-viewer/hooks/useEntityViewerAnalytics.ts
@@ -117,12 +117,16 @@ const useEntityViewerAnalytics = () => {
     trackExternalLinkClick('gene_view_transcript_list', label);
   };
 
-  const trackProteinInfoToggle = (params: {
+  type TrackTranscriptListViewToggleParam = {
     transcriptQuality: string | null;
     transcriptId: string;
     action: 'open_accordion' | 'close_accordion';
     transcriptPosition: number;
-  }) => {
+  };
+
+  const trackProteinInfoToggle = (
+    params: TrackTranscriptListViewToggleParam
+  ) => {
     const { transcriptId, transcriptQuality } = params;
     const label = transcriptQuality
       ? `${transcriptQuality} ${transcriptId}` // "MANE Plus Clinical ENST00000380152.8"
@@ -136,20 +140,17 @@ const useEntityViewerAnalytics = () => {
   };
 
   const trackTranscriptListViewToggle = (
-    qualityLabel: string | undefined,
-    transcriptId: string,
-    toggleAction: string,
-    position: number
+    params: TrackTranscriptListViewToggleParam
   ) => {
-    const transcriptLabel = [qualityLabel, transcriptId]
+    const transcriptLabel = [params.transcriptQuality, params.transcriptId]
       .filter(Boolean)
       .join(' ');
 
     analyticsTracking.trackEvent({
       category: 'gene_view_transcript_list',
       label: transcriptLabel,
-      action: toggleAction, //open_accordion or close_accordion
-      value: position
+      action: params.action,
+      value: params.transcriptPosition
     });
   };
 

--- a/src/ensembl/src/content/app/entity-viewer/hooks/useEntityViewerAnalytics.ts
+++ b/src/ensembl/src/content/app/entity-viewer/hooks/useEntityViewerAnalytics.ts
@@ -113,6 +113,10 @@ const useEntityViewerAnalytics = () => {
     trackExternalLinkClick('gene_view_proteins_list', label);
   };
 
+  const trackExternalLinkClickInTranscriptList = (label: string) => {
+    trackExternalLinkClick('gene_view_transcript_list', label);
+  };
+
   const trackProteinInfoToggle = (params: {
     transcriptQuality: string | null;
     transcriptId: string;
@@ -180,8 +184,8 @@ const useEntityViewerAnalytics = () => {
     params: Omit<TrackDownloadPayload, 'category'>
   ) => {
     trackDownload({ ...params, category: 'gene_view_proteins_list' });
-  }
-  
+  };
+
   const trackInstantDownloadTranscriptList = (
     params: Omit<TrackDownloadPayload, 'category'>
   ) => {
@@ -196,6 +200,7 @@ const useEntityViewerAnalytics = () => {
     trackProteinInfoToggle,
     trackProteinDownload,
     trackExternalLinkClickInProteinsList,
+    trackExternalLinkClickInTranscriptList,
     trackTranscriptListViewToggle,
     trackTranscriptMoreInfoToggle,
     trackExternalLinkClick,

--- a/src/ensembl/src/content/app/entity-viewer/hooks/useEntityViewerAnalytics.ts
+++ b/src/ensembl/src/content/app/entity-viewer/hooks/useEntityViewerAnalytics.ts
@@ -136,29 +136,37 @@ const useEntityViewerAnalytics = () => {
   };
 
   const trackTranscriptListViewToggle = (
-    transcriptLabel: string,
+    qualityLabel: string | undefined,
+    transcriptId: string,
     toggleAction: string,
     position: number
   ) => {
+    const transcriptLabel = [qualityLabel, transcriptId]
+      .filter(Boolean)
+      .join(' ');
+
     analyticsTracking.trackEvent({
       category: 'gene_view_transcript_list',
-      label: transcriptLabel, //open or close
-      action: toggleAction,
+      label: transcriptLabel,
+      action: toggleAction, //open_accordion or close_accordion
       value: position
     });
   };
 
-  const trackTranscriptMoreInfoToggle = (transcriptLabel: string) => {
+  const trackTranscriptMoreInfoToggle = (
+    qualityLabel: string | undefined,
+    transcriptId: string
+  ) => {
+    const transcriptLabel = [qualityLabel, transcriptId]
+      .filter(Boolean)
+      .join(' ');
+
     analyticsTracking.trackEvent({
       category: 'gene_view_transcript_list',
       label: transcriptLabel,
       action: 'more_information'
     });
   };
-
-  // "Category: gene_view_transcript_list
-  // Actions: sequence_download
-  // Label: gene_symbol + checkboxes & transcript + checkboxes"
 
   const trackDownload = (params: TrackDownloadPayload) => {
     const selectedOptions = params.options

--- a/src/ensembl/src/content/app/entity-viewer/hooks/useEntityViewerAnalytics.ts
+++ b/src/ensembl/src/content/app/entity-viewer/hooks/useEntityViewerAnalytics.ts
@@ -118,7 +118,7 @@ const useEntityViewerAnalytics = () => {
   };
 
   type TrackTranscriptListViewToggleParam = {
-    transcriptQuality: string | null;
+    transcriptQuality?: string;
     transcriptId: string;
     action: 'open_accordion' | 'close_accordion';
     transcriptPosition: number;

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.tsx
@@ -145,7 +145,7 @@ const InstantDownloadTranscript = (props: Props) => {
     try {
       await fetchForTranscript(payload);
       props.onDownloadSuccess?.(payload);
-    } catch (e) {
+    } catch {
       props.onDownloadFailure?.(payload);
     } finally {
       resetCheckboxes();

--- a/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.tsx
+++ b/src/ensembl/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.tsx
@@ -39,10 +39,21 @@ type GeneFields = {
   id: string;
 };
 
+export type TrackTranscriptDownloadPayload = {
+  genomeId: string;
+  transcriptId: string;
+  options: {
+    transcript: Partial<TranscriptOptions>;
+    gene: { genomicSequence: boolean };
+  };
+};
+
 export type InstantDownloadTranscriptEntityProps = {
   genomeId: string;
   transcript: TranscriptFields;
   gene: GeneFields;
+  onDownloadSuccess?: (params: TrackTranscriptDownloadPayload) => void;
+  onDownloadFailure?: (params: TrackTranscriptDownloadPayload) => void;
 };
 
 type Props = InstantDownloadTranscriptEntityProps & {
@@ -131,9 +142,11 @@ const InstantDownloadTranscript = (props: Props) => {
         gene: { genomicSequence: isGeneSequenceSelected }
       }
     };
-
     try {
       await fetchForTranscript(payload);
+      props.onDownloadSuccess?.(payload);
+    } catch (e) {
+      props.onDownloadFailure?.(payload);
     } finally {
       resetCheckboxes();
     }


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1364

## Description
Add analytics tracking events to the entity viewer transcripts list view that are listed in the following spreadsheet:

https://docs.google.com/spreadsheets/d/1CnW-rx212UwAMTXnjZXCPfZ72Kva7_kRiG6X6pfSN94/edit#gid=920651130

## Deployment URL
http://transcript-list-ga.review.ensembl.org/

## Views affected
EV Transcripts list view
 - accordion open/close
 - more info link
 - instant download

### Other effects
NA

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
There are changes to `useEntityViewerAnalytics.ts` in a different PR which may introduce conflicts file merging