### PR TITLE
Remove example region link from GB interstitial page

### DIFF
--- a/src/ensembl/src/content/app/browser/interstitial/BrowserInterstitial.tsx
+++ b/src/ensembl/src/content/app/browser/interstitial/BrowserInterstitial.tsx
@@ -19,7 +19,7 @@ import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 
 import { getBrowserActiveGenomeId } from 'src/content/app/browser/browserSelectors';
-import { getExampleEnsObjects } from 'src/shared/state/ens-object/ensObjectSelectors';
+import { getExampleGenes } from 'src/shared/state/ens-object/ensObjectSelectors';
 
 import {
   parseEnsObjectId,
@@ -55,7 +55,7 @@ const BrowserInterstitial = () => {
 
 const ExampleLinks = () => {
   const activeGenomeId = useSelector(getBrowserActiveGenomeId);
-  const ensObjects = useSelector(getExampleEnsObjects);
+  const ensObjects = useSelector(getExampleGenes);
 
   const links = ensObjects.map((exampleObject) => {
     const parsedEnsObjectId = parseEnsObjectId(exampleObject.object_id);


### PR DESCRIPTION

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1374

## Description
Temporarily removed the example region link from GB interstitial page

## Deployment URL
http://remove-example-region-links.review.ensembl.org

## Views affected
GB interstitial page
