### PR TITLE
Do not sort previously viewed entries in GB & EV

### DIFF
--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
@@ -134,10 +134,13 @@ export const updatePreviouslyViewedObjectsAndSave =
       ...getActiveGenomePreviouslyViewedObjects(state)
     ];
 
-    const savedEntitiesWithoutCurrentEntity =
-      previouslyViewedObjects?.filter(
-        (entity) => entity.object_id !== activeEnsObject.object_id
-      ) || [];
+    const isCurrentEntityPreviouslyViewed = previouslyViewedObjects?.some(
+      (entity) => entity.object_id === activeEnsObject.object_id
+    );
+
+    if (isCurrentEntityPreviouslyViewed) {
+      return;
+    }
 
     const stable_id =
       activeEnsObject.type === 'gene'
@@ -162,10 +165,7 @@ export const updatePreviouslyViewedObjectsAndSave =
       label: label
     };
 
-    const updatedEntitiesArray = [
-      newObject,
-      ...savedEntitiesWithoutCurrentEntity
-    ];
+    const updatedEntitiesArray = [newObject, ...previouslyViewedObjects];
 
     // Limit the total number of previously viewed objects to 250
     const previouslyViewedObjectsSlice = updatedEntitiesArray.slice(-250);

--- a/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
+++ b/src/ensembl/src/content/app/browser/track-panel/trackPanelActions.ts
@@ -134,7 +134,7 @@ export const updatePreviouslyViewedObjectsAndSave =
       ...getActiveGenomePreviouslyViewedObjects(state)
     ];
 
-    const isCurrentEntityPreviouslyViewed = previouslyViewedObjects?.some(
+    const isCurrentEntityPreviouslyViewed = previouslyViewedObjects.some(
       (entity) => entity.object_id === activeEnsObject.object_id
     );
 

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.tsx
@@ -42,31 +42,29 @@ type PreviouslyViewedLinksProps = {
 export const PreviouslyViewedLinks = (props: PreviouslyViewedLinksProps) => {
   return (
     <div data-test-id="previously viewed links">
-      {[...props.previouslyViewedEntities].map(
-        (previouslyViewedEntity, index) => {
-          const path = urlFor.entityViewer({
-            genomeId: props.activeGenomeId,
-            entityId: buildFocusIdForUrl({
-              type: 'gene',
-              objectId: previouslyViewedEntity.entity_id
-            })
-          });
+      {props.previouslyViewedEntities.map((previouslyViewedEntity, index) => {
+        const path = urlFor.entityViewer({
+          genomeId: props.activeGenomeId,
+          entityId: buildFocusIdForUrl({
+            type: 'gene',
+            objectId: previouslyViewedEntity.entity_id
+          })
+        });
 
-          return (
-            <div key={index} className={styles.linkHolder}>
-              <Link to={path}>
-                <TextLine
-                  text={previouslyViewedEntity.label}
-                  className={styles.label}
-                />
-              </Link>
-              <span className={styles.type}>
-                {upperFirst(previouslyViewedEntity.type)}
-              </span>
-            </div>
-          );
-        }
-      )}
+        return (
+          <div key={index} className={styles.linkHolder}>
+            <Link to={path}>
+              <TextLine
+                text={previouslyViewedEntity.label}
+                className={styles.label}
+              />
+            </Link>
+            <span className={styles.type}>
+              {upperFirst(previouslyViewedEntity.type)}
+            </span>
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.tsx
@@ -20,10 +20,7 @@ import { useSelector } from 'react-redux';
 import upperFirst from 'lodash/upperFirst';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
-import {
-  buildFocusIdForUrl,
-  parseEnsObjectId
-} from 'src/shared/state/ens-object/ensObjectHelpers';
+import { buildFocusIdForUrl } from 'src/shared/state/ens-object/ensObjectHelpers';
 import {
   getEntityViewerActiveGenomeId,
   getEntityViewerActiveEntityId
@@ -43,15 +40,9 @@ type PreviouslyViewedLinksProps = {
 };
 
 export const PreviouslyViewedLinks = (props: PreviouslyViewedLinksProps) => {
-  const activeEntityStableId = parseEnsObjectId(props.activeEntityId).objectId;
-  const previouslyViewedEntitiesWithoutActiveEntity =
-    props.previouslyViewedEntities.filter(
-      (entity) => entity.entity_id !== activeEntityStableId
-    );
-
   return (
     <div data-test-id="previously viewed links">
-      {[...previouslyViewedEntitiesWithoutActiveEntity].map(
+      {[...props.previouslyViewedEntities].map(
         (previouslyViewedEntity, index) => {
           const path = urlFor.entityViewer({
             genomeId: props.activeGenomeId,

--- a/src/ensembl/src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSelectors.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSelectors.ts
@@ -18,6 +18,7 @@ import { RootState } from 'src/store';
 
 export const getAllPreviouslyViewedEntities = (state: RootState) =>
   state.entityViewer.bookmarks.previouslyViewed;
+
 export const getPreviouslyViewedEntities = (
   state: RootState,
   genomeId: string

--- a/src/ensembl/src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSlice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSlice.ts
@@ -57,25 +57,25 @@ const bookmarksSlice = createSlice({
       action: PayloadAction<UpdatePreviouslyViewedPayload>
     ) {
       const { genomeId, gene } = action.payload;
-      const savedEntitiesWithoutCurrentEntity =
-        state.previouslyViewed[genomeId]?.filter(
-          (entity) => entity.entity_id !== gene.unversioned_stable_id
-        ) || [];
+      const isCurrentEntityPreviouslyViewed = state.previouslyViewed[
+        genomeId
+      ]?.some((entity) => entity.entity_id === gene.unversioned_stable_id);
+      if (!isCurrentEntityPreviouslyViewed) {
+        const newEntity = {
+          entity_id: gene.unversioned_stable_id,
+          label: gene.symbol ? [gene.symbol, gene.stable_id] : gene.stable_id,
+          type: 'gene' as const
+        };
+        const updatedEntites = [
+          newEntity,
+          ...state.previouslyViewed[genomeId]
+        ].slice(0, 21);
+        state.previouslyViewed[genomeId] = updatedEntites;
 
-      const newEntity = {
-        entity_id: gene.unversioned_stable_id,
-        label: gene.symbol ? [gene.symbol, gene.stable_id] : gene.stable_id,
-        type: 'gene' as const
-      };
-      const updatedEntites = [
-        newEntity,
-        ...savedEntitiesWithoutCurrentEntity
-      ].slice(0, 21);
-      state.previouslyViewed[genomeId] = updatedEntites;
-
-      entityViewerBookmarksStorageService.updatePreviouslyViewedEntities({
-        [genomeId]: updatedEntites
-      });
+        entityViewerBookmarksStorageService.updatePreviouslyViewedEntities({
+          [genomeId]: updatedEntites
+        });
+      }
     }
   }
 });

--- a/src/ensembl/src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSlice.ts
+++ b/src/ensembl/src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSlice.ts
@@ -57,19 +57,23 @@ const bookmarksSlice = createSlice({
       action: PayloadAction<UpdatePreviouslyViewedPayload>
     ) {
       const { genomeId, gene } = action.payload;
-      const isCurrentEntityPreviouslyViewed = state.previouslyViewed[
-        genomeId
-      ]?.some((entity) => entity.entity_id === gene.unversioned_stable_id);
+
+      const previouslyViewedEntities = state.previouslyViewed[genomeId] || [];
+
+      const isCurrentEntityPreviouslyViewed = previouslyViewedEntities?.some(
+        (entity) => entity.entity_id === gene.unversioned_stable_id
+      );
+
       if (!isCurrentEntityPreviouslyViewed) {
         const newEntity = {
           entity_id: gene.unversioned_stable_id,
           label: gene.symbol ? [gene.symbol, gene.stable_id] : gene.stable_id,
           type: 'gene' as const
         };
-        const updatedEntites = [
-          newEntity,
-          ...state.previouslyViewed[genomeId]
-        ].slice(0, 21);
+        const updatedEntites = [newEntity, ...previouslyViewedEntities].slice(
+          0,
+          21
+        );
         state.previouslyViewed[genomeId] = updatedEntites;
 
         entityViewerBookmarksStorageService.updatePreviouslyViewedEntities({


### PR DESCRIPTION

## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1363

## Description
- Previously viewed entries will not be sorted and new entries will get added to the top

## Deployment URL
http://do-not-sort-previously-viewed.review.ensembl.org

## Views affected
GB & EV -> Sidebar -> Previousy viewed
