### PR TITLE
Fix empty drawer transcript summary

### DIFF
--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelGene.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelGene.tsx
@@ -139,7 +139,7 @@ const prepareTranscriptsTrackData = (
     ) as TrackPanelTranscriptType;
     const canonicalTranscriptTrackData = {
       label: canonicalTranscript.stable_id,
-      track_id: 'track:gene-feat-1',
+      track_id: 'track:transcript-feat-1',
       stable_id: canonicalTranscript.stable_id,
       description: null,
       colour: 'BLUE',

--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/TrackPanelListItem.tsx
@@ -91,11 +91,7 @@ export const TrackPanelListItem = (props: TrackPanelListItemProps) => {
     let drawerViewToSet = DrawerView.TRACK_DETAILS;
     if (trackId === 'track:gene-feat') {
       drawerViewToSet = DrawerView.GENE_SUMMARY;
-      // TODO: Remove `trackId === 'track:gene-feat-1'` form the if below when we enable multiple transcripts on production
-    } else if (
-      trackId.includes('track:transcript') ||
-      trackId === 'track:gene-feat-1'
-    ) {
+    } else if (trackId.includes('track:transcript')) {
       drawerViewToSet = DrawerView.TRANSCRIPT_SUMMARY;
     }
     dispatch(changeDrawerView(drawerViewToSet));
@@ -116,12 +112,7 @@ export const TrackPanelListItem = (props: TrackPanelListItemProps) => {
   const dispatchDrawerActions = () => {
     if (activeGenomeId) {
       dispatch(setActiveDrawerTrackId(trackId));
-
-      // TODO: Remove `trackId === 'track:gene-feat-1'` form the if below when we enable multiple transcripts on production
-      if (
-        trackId.includes('track:transcript') ||
-        trackId === 'track:gene-feat-1'
-      ) {
+      if (trackId.includes('track:transcript')) {
         dispatch(setActiveDrawerTranscriptId(track.stable_id));
       }
     }


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1405

## Description
Fixed the issue that breaks the drawer transcript view on the production

## Deployment URL
http://fix-drawer-transcript-summary.review.ensembl.org

## Views affected
GB -> Drawer -> Transcript summary