### PR TITLE
Increase verbosity of npm logs to see when build fails due to npm

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ variables:
   before_script:
   - cd src/ensembl
   - npm install --global npm@7.12.1
-  - npm ci
+  - npm ci --loglevel warn
 
   script:
   - npm run test
@@ -153,7 +153,7 @@ Test:
   before_script:
   - cd src/ensembl
   - npm install --global npm@7.12.1
-  - npm ci
+  - npm ci --loglevel warn
 
   script:
   - npm run check-types


### PR DESCRIPTION
Logs before the change (between running the npm ci command and the husky command):

![image](https://user-images.githubusercontent.com/6834224/138915757-014ff57f-d129-4f2e-b977-f725ef5c9abe.png)

Logs after the change (same part of the script):

![image](https://user-images.githubusercontent.com/6834224/138915955-b100832e-c227-4599-a673-77bc4bf172ff.png)

If there are errors during the execution of npm ci, error messages will show up in the log.

**P.S.:** we will address some of the most obvious warnings in a different PR.