### PR TITLE
Use environment variable to control whether analytics is reported

### DIFF
--- a/src/ensembl/config.ts
+++ b/src/ensembl/config.ts
@@ -69,6 +69,10 @@ const getKeys = (): PublicKeys => {
   return defaultKeys;
 };
 
+const shouldReportAnalytics = () =>
+  isClient() &&
+  (window as any)[CONFIG_FIELD_ON_WINDOW]?.environment.shouldReportAnalytics;
+
 const buildEnvironment = readEnvironment().buildEnvironment;
 
 export default {
@@ -78,6 +82,8 @@ export default {
   // build environment
   isDevelopment: buildEnvironment === 'development',
   isProduction: buildEnvironment !== 'development',
+
+  shouldReportAnalytics: shouldReportAnalytics(),
 
   // TODO: remove this from the config in the future (will require refactoring of the apiService)
   // We will instead be passing base urls for differeent microservices individually

--- a/src/ensembl/src/server/helpers/getConfigForClient.ts
+++ b/src/ensembl/src/server/helpers/getConfigForClient.ts
@@ -32,7 +32,8 @@ const getBaseApiUrls = (): BaseApiUrls => {
 const getEnvironment = () => {
   return {
     buildEnvironment: process.env.NODE_ENV ?? 'production',
-    deploymentEnvironment: process.env.ENVIRONMENT ?? 'development'
+    deploymentEnvironment: process.env.ENVIRONMENT ?? 'development',
+    shouldReportAnalytics: shouldReportAnalytics()
   };
 };
 
@@ -41,6 +42,9 @@ const getKeys = () => {
     googleAnalyticsKey: process.env.GOOGLE_ANALYTICS_KEY ?? ''
   };
 };
+
+const shouldReportAnalytics = () =>
+  `${process.env.REPORT_ANALYTICS}`.toLowerCase() === 'true';
 
 export const getConfigForClient = () => {
   return {

--- a/src/ensembl/src/services/analytics-service.ts
+++ b/src/ensembl/src/services/analytics-service.ts
@@ -18,7 +18,6 @@ import ReactGA from 'react-ga';
 import { AnalyticsOptions, CustomDimensions } from 'src/analyticsHelper';
 
 import config from 'config';
-import { isEnvironment, Environment } from 'src/shared/helpers/environment';
 
 const { googleAnalyticsKey } = config;
 
@@ -39,7 +38,7 @@ class AnalyticsTracking {
     }
 
     // don't send analytics other than in production deployment
-    if (!isEnvironment([Environment.PRODUCTION])) {
+    if (!config.shouldReportAnalytics) {
       this.reactGA.ga('set', 'sendHitTask', null);
     }
   }


### PR DESCRIPTION
## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1407

## Description
Add an environment variable that explicitly controls whether analytics events are reported or not. This allows us to distinguish between production deployment and staging deployment, which both use the `production` deployment environment variable.

## Deployment URL
http://report-analytics-env-var.review.ensembl.org