### PR TITLE
show versioned stable ids on transcript summary view download

### DIFF
--- a/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
+++ b/src/ensembl/src/content/app/browser/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
@@ -343,10 +343,10 @@ const TranscriptSummary = () => {
               <InstantDownloadTranscript
                 genomeId={ensObjectGene.genome_id}
                 transcript={{
-                  id: transcript.unversioned_stable_id,
+                  id: transcript.stable_id,
                   isProteinCoding: isProteinCodingTranscript(transcript)
                 }}
-                gene={{ id: gene.unversioned_stable_id }}
+                gene={{ id: gene.stable_id }}
                 theme="light"
                 layout="vertical"
               />


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1371

## Description
Show versioned stable ids on transcript summary view instant download

## Deployment URL
add-transcript-versions.review.ensembl.org

## Views affected
GB transcript summary view

### Other effects
NA

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
Nothing
