### PR TITLE
Add redirect from /help/articles to /help

### DIFF
--- a/src/ensembl/src/content/app/App.tsx
+++ b/src/ensembl/src/content/app/App.tsx
@@ -15,12 +15,10 @@
  */
 
 import React, { useEffect, ReactNode } from 'react';
-import { Route, Switch, Redirect, useLocation } from 'react-router-dom';
+import { Route, Switch, useLocation } from 'react-router-dom';
 import { connect } from 'react-redux';
 
 import routes from 'src/routes/routesConfig';
-
-import * as urlFor from 'src/shared/helpers/urlHelper';
 
 import { changeCurrentApp } from 'src/header/headerActions';
 
@@ -48,14 +46,6 @@ const App = (props: AppProps) => {
     <>
       <Header />
       <Switch>
-        {/*
-            1) Redirect from /help/articles to /help needs to be either in this component
-            before other routes (to match before the rest of /help routes do),
-            or inside the HelpPage component.
-            2) Notice that when react-router v6 is released, the Redirect component will be removed;
-            so our redirect code will need refactoring (might actually be defined just entirely server-side)
-          */}
-        <Redirect exact from="/help/articles" to="/help" />
         {routes.map((route, index) => (
           <Route
             key={index}
@@ -64,7 +54,6 @@ const App = (props: AppProps) => {
             render={(props) => <route.component {...props} />}
           />
         ))}
-        <Redirect exact from="/species" to={urlFor.speciesSelector()} />
         <Route component={NotFound} />
       </Switch>
     </>

--- a/src/ensembl/src/server/middleware/redirectMiddleware.ts
+++ b/src/ensembl/src/server/middleware/redirectMiddleware.ts
@@ -1,0 +1,29 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Router } from 'express';
+
+const router = Router();
+
+router.get('/species', (_, res) => {
+  res.redirect(301, '/species-selector');
+});
+
+router.get('/help/articles', (_, res) => {
+  res.redirect(301, '/help');
+});
+
+export default router;

--- a/src/ensembl/src/server/routes/viewsRouter.tsx
+++ b/src/ensembl/src/server/routes/viewsRouter.tsx
@@ -79,7 +79,7 @@ const viewRouter = async (req: Request, res: Response) => {
   const reduxState = reduxStore.getState();
 
   if ('url' in routerContext) {
-    // a `url` field in filled router context indicates that somewhere a `<Redirect>` was rendered
+    // TODO: revisit after React 18 and react-router 6 are released
     const url = (routerContext as any).url as string;
     res.redirect(301, url);
     return;

--- a/src/ensembl/src/server/server.ts
+++ b/src/ensembl/src/server/server.ts
@@ -18,6 +18,7 @@ import express from 'express';
 
 import proxyMiddleware from './middleware/proxyMiddleware';
 import staticMiddleware from './middleware/staticMiddleware';
+import redirectMiddleware from './middleware/redirectMiddleware';
 import viewsRouter from './routes/viewsRouter';
 
 const app = express();
@@ -25,6 +26,7 @@ const app = express();
 app.disable('x-powered-by'); // no need to announce to the world that we are running on Express
 
 app.use(proxyMiddleware);
+app.use(redirectMiddleware);
 
 if (process.env.NODE_ENV === 'production') {
   // should be able to handle requests for the contents of /static directory by itself


### PR DESCRIPTION
## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1394

## Description
- Add redirect from `/help/articles` to `/help`.
- Move all redirect logic from react-router's `Redirect` component to the server.

Rationale: the upcoming react-router v6 is going to remove the `Redirect` component. See a note in the documentation for migration from react-router 5 to react-router 6:

> Note: The `<Redirect>` element from v5 is no longer supported as part of your route config (inside a `<Routes>`). This is due to upcoming changes in React that make it unsafe to alter the state of the router during the initial render. If you need to redirect immediately, you can either a) do it on your server (probably the best solution) or b) render a `<Navigate>` element in your route component. However, recognize that the navigation will happen in a useEffect.


## Deployment URL
http://help-articles-redirect.review.ensembl.org