### PR TITLE
Add redirect from /about/articles to /about

### DIFF
--- a/src/ensembl/src/server/middleware/redirectMiddleware.ts
+++ b/src/ensembl/src/server/middleware/redirectMiddleware.ts
@@ -26,4 +26,8 @@ router.get('/help/articles', (_, res) => {
   res.redirect(301, '/help');
 });
 
+router.get('/about/articles', (_, res) => {
+  res.redirect(301, '/about');
+});
+
 export default router;


### PR DESCRIPTION
Forgotten in PR https://github.com/Ensembl/ensembl-client/pull/627

In addition to the redirect from `/help/articles` to `/help`, we would also want to redirect from `/about/articles` to `/about`.


## Deployment URL
http://about-articles-redirect.review.ensembl.org/