### PR TITLE
ENSWBSITES-1336: Extend filter and sort state to local storage

### DIFF
--- a/src/ensembl/src/root/useRestoredReduxState.ts
+++ b/src/ensembl/src/root/useRestoredReduxState.ts
@@ -21,6 +21,7 @@ import { loadStoredSpecies } from 'src/content/app/species-selector/state/specie
 import { loadPreviouslyViewedEntities } from 'src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSlice';
 import { restoreUI as restoreSpeciesPageUI } from 'src/content/app/species/state/general/speciesGeneralSlice';
 import { loadInitialState as loadEntityViewerGeneralState } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSlice';
+import { restoreTranscriptsFiltersAndSorting } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 
 // load redux state from browser storage once when the application mounts
 const useRestoredReduxState = () => {
@@ -36,6 +37,7 @@ const useRestoredReduxState = () => {
     // Entity Viewer
     dispatch(loadPreviouslyViewedEntities());
     dispatch(loadEntityViewerGeneralState());
+    dispatch(restoreTranscriptsFiltersAndSorting());
   }, []);
 };
 


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1336

## Importance
N/A

## Description
Extending the filtering and sorting functionality to local storage. This is now stored against the previously viewed entity in local storage.

## Deployment URL
http://filterstate-extension.review.ensembl.org

## Views affected
Entity Viewer

### Other effects
N/A

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
Redux code is getting uglier :)