### PR TITLE
Use faker.lorem.word instead of faker.random.word

### DIFF
--- a/src/ensembl/src/shared/components/external-reference/ExternalReference.test.tsx
+++ b/src/ensembl/src/shared/components/external-reference/ExternalReference.test.tsx
@@ -22,7 +22,7 @@ import ExternalReference, { ExternalReferenceProps } from './ExternalReference';
 
 const defaultProps: ExternalReferenceProps = {
   label: faker.random.word(),
-  linkText: faker.random.word(),
+  linkText: faker.lorem.word(),
   to: faker.internet.url(),
   classNames: {
     container: faker.lorem.word(),

--- a/src/ensembl/src/shared/components/slide-toggle/SlideToggle.test.tsx
+++ b/src/ensembl/src/shared/components/slide-toggle/SlideToggle.test.tsx
@@ -49,7 +49,7 @@ describe('SlideToggle', () => {
     });
 
     it('adds class received from parent', () => {
-      const externalClassName = faker.random.word();
+      const externalClassName = faker.lorem.word();
       const props = {
         ...defaultProps,
         className: externalClassName

--- a/src/ensembl/src/shared/components/textarea/Textarea.test.tsx
+++ b/src/ensembl/src/shared/components/textarea/Textarea.test.tsx
@@ -23,8 +23,8 @@ import Textarea from './Textarea';
 describe('<Textarea />', () => {
   const commonTextareaProps = {
     id: faker.random.word(),
-    name: faker.random.word(),
-    className: faker.random.word(),
+    name: faker.lorem.word(),
+    className: faker.lorem.word(),
     onChange: jest.fn(),
     onFocus: jest.fn(),
     onBlur: jest.fn()


### PR DESCRIPTION
To prevent generation of invalid css classnames (faker.random.word sometimes can generate special characters)

## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1401

## Importance
N/A

## Description
use faker.lorem.word instead of faker.random.word because faker.random.word can generate special characters which can break css classnames.

## Deployment URL
N/A since its only test that has been updated.

## Views affected
N/A

### Other effects
<!--
_List any other functionality that may be affected or which requires additional changes, such as saved configurations. Please add an explanation if, for example, no test is needed._
-->

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
N/A
