### PR TITLE
Add tests for useBrowserRouting hook

### DIFF
--- a/src/ensembl/src/content/app/browser/browser-region-field/BrowserRegionField.test.tsx
+++ b/src/ensembl/src/content/app/browser/browser-region-field/BrowserRegionField.test.tsx
@@ -42,8 +42,10 @@ jest.mock('../browserHelper', () => {
   };
 });
 
-const mockChangeBrowserLocation = jest.fn();
-const mockChangeFocusObject = jest.fn();
+const mockChangeBrowserLocation = jest.fn(() => ({
+  type: 'changeBrowserLocation'
+}));
+const mockChangeFocusObject = jest.fn(() => ({ type: 'changeFocusObject' }));
 jest.mock('src/content/app/browser/hooks/useGenomeBrowser', () => () => ({
   changeBrowserLocation: mockChangeBrowserLocation,
   changeFocusObject: mockChangeFocusObject

--- a/src/ensembl/src/content/app/browser/hooks/useBrowserRouting.test.tsx
+++ b/src/ensembl/src/content/app/browser/hooks/useBrowserRouting.test.tsx
@@ -1,0 +1,262 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import thunk from 'redux-thunk';
+import { MemoryRouter, Route, useLocation } from 'react-router';
+import { push, replace } from 'connected-react-router';
+import configureMockStore from 'redux-mock-store';
+import set from 'lodash/fp/set';
+
+import * as browserActions from '../browserActions';
+import * as genomeActions from 'src/shared/state/genome/genomeActions';
+
+import useBrowserRouting from './useBrowserRouting';
+
+import { createSelectedSpecies } from 'tests/fixtures/selected-species';
+
+// NOTE: scrary stuff, but if you prefix function name with the word "mock",
+// jest will allow passing them to the factory function of jest.mock
+const mockChangeFocusObject = jest.fn();
+const mockChangeBrowserLocation = jest.fn();
+
+jest.mock('connected-react-router', () => ({
+  push: jest.fn(() => ({ type: 'push' })),
+  replace: jest.fn(() => ({ type: 'replace' }))
+}));
+
+jest.mock('../browserActions', () => ({
+  setActiveGenomeId: jest.fn(() => ({ type: 'setActiveGenomeId' })),
+  setDataFromUrlAndSave: jest.fn(() => ({ type: 'setDataFromUrlAndSave' }))
+}));
+
+jest.mock('src/shared/state/genome/genomeActions', () => ({
+  fetchGenomeData: jest.fn(() => ({ type: 'fetchGenomeData' }))
+}));
+
+jest.mock('src/content/app/browser/hooks/useGenomeBrowser', () => () => ({
+  genomeBrowser: {},
+  changeFocusObject: mockChangeFocusObject,
+  changeBrowserLocation: mockChangeBrowserLocation
+}));
+
+const committedHuman = {
+  ...createSelectedSpecies(),
+  genome_id: 'human'
+};
+
+const committedWheat = {
+  ...createSelectedSpecies(),
+  genome_id: 'wheat'
+};
+
+const mockState = {
+  browser: {
+    browserEntity: {
+      activeGenomeId: 'human',
+      activeEnsObjectIds: {
+        human: 'human:gene:ENSG00000139618'
+      }
+    },
+    browserLocation: {
+      chrLocations: {
+        human: ['13', 100, 200]
+      }
+    }
+  },
+  speciesSelector: {
+    committedItems: [committedHuman, committedWheat]
+  }
+};
+
+const mockStore = configureMockStore([thunk]);
+
+// This component isn't that useful now; but will become so
+// after we have migrated to react-router v6 and removed connected-react-router
+const TestComponent = () => {
+  const location = useLocation();
+  useBrowserRouting();
+  const { pathname, search } = location;
+
+  return (
+    <div>
+      <div data-test-id="pathname-and-search">{`${pathname}${search}`}</div>
+      <div data-test-id="pathname">{pathname}</div>
+      <div data-test-id="search">{search}</div>
+    </div>
+  );
+};
+
+const renderComponent = ({
+  state = mockState,
+  path
+}: {
+  state?: typeof mockState;
+  path: string;
+}) => {
+  return render(
+    <Provider store={mockStore(state)}>
+      <MemoryRouter initialEntries={[path]}>
+        <Route path="/genome-browser/:genomeId?">
+          <TestComponent />
+        </Route>
+      </MemoryRouter>
+    </Provider>
+  );
+};
+
+describe('useBrowserRouting', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('navigation to /genome-browser (no species, focus object or location in the url)', () => {
+    it('redirects to url for active genome', () => {
+      const updatedState = set(
+        'browser.browserEntity.activeGenomeId',
+        'wheat',
+        mockState
+      );
+      renderComponent({ state: updatedState, path: '/genome-browser' });
+
+      // this is useless, because this route will be handled by the interstitial;
+      // yet this is how the code currently behaves
+      expect(replace).toHaveBeenCalledWith('/genome-browser/wheat');
+    });
+
+    it('redirects to url for active genome using focus id and location from redux', () => {
+      // human is set as active genome in mock redux state
+      renderComponent({ path: '/genome-browser' });
+
+      // notice how the identifier "human:gene:ENSG00000139618" that was used in the mock store
+      // is reformatted to gene:ENSG00000139618 in the url;
+      // this can be tested by examining TestComponent after a switch to react-router v6
+      expect(replace).toHaveBeenCalledWith(
+        '/genome-browser/human?focus=gene:ENSG00000139618&location=13:100-200'
+      );
+    });
+
+    it('redirects to url for the first of the selected species in absence of active genome id', () => {
+      let updatedState = set(
+        'browser.browserEntity.activeGenomeId',
+        null,
+        mockState
+      );
+      updatedState = set(
+        'speciesSelector.committedItems',
+        [committedWheat, committedHuman],
+        updatedState
+      );
+
+      renderComponent({ state: updatedState, path: '/genome-browser' });
+
+      // this is useless behaviour; yet this is how the code currently behaves
+      expect(replace).toHaveBeenCalledWith('/genome-browser/wheat');
+    });
+  });
+
+  describe('navigation to /genome-browser/:genome_id', () => {
+    it('sets the data from the url in redux', () => {
+      // jest.spyOn(browserActions, 'setDataFromUrlAndSave');
+      renderComponent({ path: '/genome-browser/human' });
+
+      expect(browserActions.setDataFromUrlAndSave).toHaveBeenCalledWith({
+        activeGenomeId: 'human',
+        activeEnsObjectId: null,
+        chrLocation: null
+      });
+    });
+
+    it('fetches the genome using the genome id from the url', async () => {
+      // jest.spyOn(browserActions, 'setDataFromUrlAndSave');
+      renderComponent({ path: '/genome-browser/human' });
+
+      expect(genomeActions.fetchGenomeData).toHaveBeenCalledWith('human');
+    });
+
+    it('redirects to url containing focus id if available in redux', () => {
+      renderComponent({ path: '/genome-browser/human' });
+
+      expect(replace).toHaveBeenCalledWith(
+        '/genome-browser/human?focus=gene:ENSG00000139618'
+      );
+    });
+  });
+
+  describe('navigation to /genome-browser/:genome_id with focus object', () => {
+    it('sets the data from the url in redux', () => {
+      renderComponent({
+        path: '/genome-browser/human?focus=gene:ENSG00000139618'
+      });
+
+      expect(browserActions.setDataFromUrlAndSave).toHaveBeenCalledWith({
+        activeGenomeId: 'human',
+        activeEnsObjectId: 'human:gene:ENSG00000139618', // <-- notice how genome id is included in ens object id
+        chrLocation: null
+      });
+
+      // no navigation actions expected
+      expect(push).not.toHaveBeenCalled();
+      expect(replace).not.toHaveBeenCalled();
+    });
+
+    it('tells genome browser to switch to the focus object from the url', () => {
+      renderComponent({
+        path: '/genome-browser/human?focus=gene:ENSG00000139618'
+      });
+
+      expect(mockChangeFocusObject).toHaveBeenCalledWith(
+        'human:gene:ENSG00000139618'
+      );
+      expect(mockChangeBrowserLocation).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('navigation to /genome-browser/:genome_id with focus object and location', () => {
+    it('sets the data from the url in redux', () => {
+      renderComponent({
+        path: '/genome-browser/human?focus=gene:ENSG00000139618&location=13:100-200'
+      });
+
+      expect(browserActions.setDataFromUrlAndSave).toHaveBeenCalledWith({
+        activeGenomeId: 'human',
+        activeEnsObjectId: 'human:gene:ENSG00000139618', // <-- notice how genome id is included in ens object id
+        chrLocation: ['13', 100, 200]
+      });
+
+      // no navigation actions expected
+      expect(push).not.toHaveBeenCalled();
+      expect(replace).not.toHaveBeenCalled();
+    });
+
+    it('tells genome browser to set the focus object and the location from the url', () => {
+      renderComponent({
+        path: '/genome-browser/human?focus=gene:ENSG00000139618&location=13:100-200'
+      });
+
+      expect(mockChangeFocusObject).toHaveBeenCalledWith(
+        'human:gene:ENSG00000139618'
+      );
+      expect(mockChangeBrowserLocation).toHaveBeenCalledWith({
+        genomeId: 'human',
+        ensObjectId: 'human:gene:ENSG00000139618',
+        chrLocation: ['13', 100, 200]
+      });
+    });
+  });
+});

--- a/src/ensembl/src/content/app/browser/hooks/useBrowserRouting.ts
+++ b/src/ensembl/src/content/app/browser/hooks/useBrowserRouting.ts
@@ -79,7 +79,7 @@ const useBrowserRouting = () => {
     if (!genomeId) {
       // handling navigation to /browser
       // select either the species that the user viewed during the previous visit,
-      // of the first selected species
+      // or the first selected species
       const selectedSpecies = committedSpecies.find(
         ({ genome_id }) => genome_id === activeGenomeId
       );

--- a/src/ensembl/src/content/app/browser/zmenu/ZmenuContent.test.tsx
+++ b/src/ensembl/src/content/app/browser/zmenu/ZmenuContent.test.tsx
@@ -152,7 +152,9 @@ describe('<ZmenuContent />', () => {
 
       userEvent.click(container.firstChild as HTMLDivElement);
 
-      expect(mockChangeFocusObjectFromZmenu).toHaveBeenCalledTimes(1);
+      expect(mockChangeFocusObjectFromZmenu).toHaveBeenCalledWith(
+        defaultZmenuContentItemProps.featureId
+      );
     });
   });
 });

--- a/src/ensembl/tests/setup-jest.js
+++ b/src/ensembl/tests/setup-jest.js
@@ -1,1 +1,6 @@
 jest.mock('react-ga');
+
+// from https://github.com/facebook/jest/issues/10784#issuecomment-824931509 — suggestion for tracking unhandled rejection warnings
+process.on('unhandledRejection', (reason, promise) => {
+  console.log('unhandledRejection', reason, promise);
+});


### PR DESCRIPTION
Included in this PR:

- tests for useBrowserRouting hook
- minor update to a test of ZmenuContent (check what is being passed to the function rather than just the fact of a function being called)
- fix mock functions in `BrowserRegionField.test.tsx` (mocks of redux actions should return actions)