### PR TITLE
Add analytics on help page

### DIFF
--- a/src/content/app/help/hooks/useHelpAppAnalytics.ts
+++ b/src/content/app/help/hooks/useHelpAppAnalytics.ts
@@ -14,22 +14,30 @@
  * limitations under the License.
  */
 
-export type Menu = {
-  name: string;
-  items: MenuItem[];
-};
+import analyticsTracking from 'src/services/analytics-service';
 
-export type MenuItem = MenuArticleItem | MenuCollectionItem;
+const useHelpAppAnalytics = () => {
+  const trackTopLevelMenu = (navLabel: string) => {
+    analyticsTracking.trackEvent({
+      category: 'help_mega_nav',
+      label: navLabel,
+      action: 'opened'
+    });
+  };
 
-type MenuCollectionItem = {
-  name: string;
-  type: 'collection';
-  url?: string; // if a menu directory has an index page associated with it
-  items: MenuItem[];
-};
+  const trackMegaNavItemClick = (linkLabel: string, type: string) => {
+    const action =
+      type === 'article' ? 'text_article_opened' : 'video_article_opened';
+    analyticsTracking.trackEvent({
+      category: 'help_mega_nav',
+      label: linkLabel,
+      action
+    });
+  };
 
-export type MenuArticleItem = {
-  name: string;
-  type: 'article' | 'video';
-  url: string;
+  return {
+    trackTopLevelMenu,
+    trackMegaNavItemClick
+  };
 };
+export default useHelpAppAnalytics;


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [x] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1408

## Description
Create a hook for help app analytics and to add tracking events to the help app mega nav that are listed in the following spreadsheet:

https://docs.google.com/spreadsheets/d/1CnW-rx212UwAMTXnjZXCPfZ72Kva7_kRiG6X6pfSN94/edit#gid=2090835159

- [x] - Track clicks on the 3 links on the meganav
- [x] - Do not track the click which closes the menu
- [x] - Consider Overview as a meganav item and not an article even though it doesnt open a nav menu

## Deployment URL
http://help-app-ga.review.ensembl.org

## Views affected
Help app mega nav and submenu links

### Other effects
NA

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
NA
