### PR TITLE
Fix transcripts count for production deployment

### DIFF
--- a/src/ensembl/src/content/app/browser/track-panel/track-panel-list/track-panel-items/TrackPanelGene.tsx
+++ b/src/ensembl/src/content/app/browser/track-panel/track-panel-list/track-panel-items/TrackPanelGene.tsx
@@ -50,7 +50,8 @@ const getTranscriptTrackId = (num: number) => `track:transcript-feat-${num}`;
 
 const TrackPanelGene = (props: TrackPanelGeneProps) => {
   const { genomeId, geneId, ensObjectId } = props;
-  const [isCollapsed, setIsCollapsed] = useState(true);
+  const startWithCollapsed = !isEnvironment([Environment.PRODUCTION]); // TODO: remove after multiple transcripts are available
+  const [isCollapsed, setIsCollapsed] = useState(startWithCollapsed);
   const { data } = useGetTrackPanelGeneQuery({
     genomeId,
     geneId
@@ -129,10 +130,16 @@ const TrackPanelGene = (props: TrackPanelGeneProps) => {
   };
 
   const { gene } = data;
-  const sortedTranscripts =
-    isEnvironment([Environment.PRODUCTION]) || isCollapsed
+  let sortedTranscripts;
+
+  if (isEnvironment([Environment.PRODUCTION])) {
+    // TODO: remove this branch when multiple transcripts become available
+    sortedTranscripts = isCollapsed ? [] : [defaultSort(gene.transcripts)[0]];
+  } else {
+    sortedTranscripts = isCollapsed
       ? [defaultSort(gene.transcripts)[0]]
       : defaultSort(gene.transcripts);
+  }
 
   return (
     <>
@@ -169,12 +176,14 @@ const TrackPanelGene = (props: TrackPanelGeneProps) => {
           />
         );
       })}
-      {isCollapsed && gene.transcripts.length > 1 && (
-        <TrackPanelItemsCount
-          itemName="transcript"
-          count={gene.transcripts.length - 1}
-        />
-      )}
+      {!isEnvironment([Environment.PRODUCTION]) &&
+        isCollapsed &&
+        gene.transcripts.length > 1 && (
+          <TrackPanelItemsCount
+            itemName="transcript"
+            count={gene.transcripts.length - 1}
+          />
+        )}
     </>
   );
 };


### PR DESCRIPTION
A bugfix for how we display transcripts in track panel in production deployment.

### Currently on staging

https://user-images.githubusercontent.com/6834224/142254503-eabffe5a-3c6a-443d-b629-fc12e6284bef.mp4

### After fix

**In development environment**

https://user-images.githubusercontent.com/6834224/142254657-d4a81545-6932-40da-b6c7-ddb74bfcf8d2.mp4

**In production environment**

https://user-images.githubusercontent.com/6834224/142254742-0d3285a9-ef79-42b2-bb9f-990490c475c4.mp4

## Deployment URL
http://fix-transcripts-count.review.ensembl.org

## Views affected
Genome browser page