### PR TITLE
Hide current entity from previously viewed

### DIFF
--- a/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.test.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.test.tsx
@@ -45,6 +45,9 @@ const exampleEntities = [
   }
 ];
 
+const currentEntityId = `braf`;
+const currentEntityLabel = `BRAF`;
+
 const previouslyViewedEntities = [
   {
     entity_id: 'human-fry',
@@ -54,6 +57,11 @@ const previouslyViewedEntities = [
   {
     entity_id: 'human-tp53',
     label: 'TP53',
+    type: 'gene'
+  },
+  {
+    entity_id: currentEntityId,
+    label: currentEntityLabel,
     type: 'gene'
   }
 ];
@@ -72,7 +80,7 @@ const mockState = {
     general: {
       activeGenomeId: 'human',
       activeEntityIds: {
-        human: 'human:gene:braf'
+        human: `human:gene:${currentEntityId}`
       }
     },
     bookmarks: {
@@ -103,6 +111,19 @@ describe('<EntityViewerSidebarBookmarks />', () => {
     );
     const links = previouslyViewedSection.querySelectorAll('a');
 
-    expect(links.length).toBe(previouslyViewedEntities.length);
+    // -1 is used here as we are ignoring the current entity
+    expect(links.length).toBe(previouslyViewedEntities.length - 1);
+  });
+
+  it('does not display the current entity as previously viewed', () => {
+    wrapInRedux();
+    const previouslyViewedSection = screen.getByTestId(
+      'previously viewed links'
+    );
+    const labels = previouslyViewedSection.querySelectorAll('.label span');
+
+    labels.forEach((label) => {
+      expect(label.textContent).not.toBe(currentEntityLabel);
+    });
   });
 });

--- a/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.tsx
+++ b/src/ensembl/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.tsx
@@ -20,7 +20,10 @@ import { useSelector } from 'react-redux';
 import upperFirst from 'lodash/upperFirst';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
-import { buildFocusIdForUrl } from 'src/shared/state/ens-object/ensObjectHelpers';
+import {
+  buildFocusIdForUrl,
+  parseEnsObjectId
+} from 'src/shared/state/ens-object/ensObjectHelpers';
 import {
   getEntityViewerActiveGenomeId,
   getEntityViewerActiveEntityId
@@ -52,34 +55,42 @@ export const PreviouslyViewedLinks = (props: PreviouslyViewedLinksProps) => {
     });
   };
 
+  const activeEntityStableId = parseEnsObjectId(props.activeEntityId).objectId;
+  const previouslyViewedEntitiesWithoutActiveEntity =
+    props.previouslyViewedEntities.filter(
+      (entity) => entity.entity_id !== activeEntityStableId
+    );
+
   return (
     <div data-test-id="previously viewed links">
-      {props.previouslyViewedEntities.map((previouslyViewedEntity, index) => {
-        const path = urlFor.entityViewer({
-          genomeId: props.activeGenomeId,
-          entityId: buildFocusIdForUrl({
-            type: 'gene',
-            objectId: previouslyViewedEntity.entity_id
-          })
-        });
+      {previouslyViewedEntitiesWithoutActiveEntity.map(
+        (previouslyViewedEntity, index) => {
+          const path = urlFor.entityViewer({
+            genomeId: props.activeGenomeId,
+            entityId: buildFocusIdForUrl({
+              type: 'gene',
+              objectId: previouslyViewedEntity.entity_id
+            })
+          });
 
-        return (
-          <div key={index} className={styles.linkHolder}>
-            <Link
-              to={path}
-              onClick={() => handleClick(previouslyViewedEntity.label, index)}
-            >
-              <TextLine
-                text={previouslyViewedEntity.label}
-                className={styles.label}
-              />
-            </Link>
-            <span className={styles.type}>
-              {upperFirst(previouslyViewedEntity.type)}
-            </span>
-          </div>
-        );
-      })}
+          return (
+            <div key={index} className={styles.linkHolder}>
+              <Link
+                to={path}
+                onClick={() => handleClick(previouslyViewedEntity.label, index)}
+              >
+                <TextLine
+                  text={previouslyViewedEntity.label}
+                  className={styles.label}
+                />
+              </Link>
+              <span className={styles.type}>
+                {upperFirst(previouslyViewedEntity.type)}
+              </span>
+            </div>
+          );
+        }
+      )}
     </div>
   );
 };


### PR DESCRIPTION

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1422

## Description
- Fixed the issue with current entity getting displayed as previously viewed

## Deployment URL
http://fix-ev-previously-viewed.review.ensembl.org

## Views affected
- Entity viewer previously viewed

### Other effects

- [ ] I have checked any requirements for Google Analytics
- [x] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

