### PR TITLE
Update redux-toolkit to 1.7 release candidate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@loadable/component": "5.15.0",
         "@loadable/server": "5.15.1",
         "@react-spring/web": "9.3.1",
-        "@reduxjs/toolkit": "1.6.2",
+        "@reduxjs/toolkit": "1.7.0-rc.0",
         "@sentry/browser": "6.15.0",
         "classnames": "2.3.1",
         "comlink": "4.3.1",
@@ -3450,18 +3450,18 @@
       }
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.6.2.tgz",
-      "integrity": "sha512-HbfI/hOVrAcMGAYsMWxw3UJyIoAS9JTdwddsjlr5w3S50tXhWb+EMyhIw+IAvCVCLETkzdjgH91RjDSYZekVBA==",
+      "version": "1.7.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.7.0-rc.0.tgz",
+      "integrity": "sha512-M1rAhiZK2oTnTaagtN+RHhsOJtUtK5fW2360HMn4rzhm99OELkgrIM9PWTFIIb//JRI1ejyPj5EW9O9BUYemIg==",
       "dependencies": {
-        "immer": "^9.0.6",
-        "redux": "^4.1.0",
-        "redux-thunk": "^2.3.0",
-        "reselect": "^4.0.0"
+        "immer": "^9.0.7",
+        "redux": "^4.1.2",
+        "redux-thunk": "^2.4.1",
+        "reselect": "^4.1.5"
       },
       "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0",
-        "react-redux": "^7.2.1"
+        "react": "^16.9.0 || ^17.0.0 || 18.0.0-beta",
+        "react-redux": "^7.2.1 || ^8.0.0-beta"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -41345,14 +41345,14 @@
       }
     },
     "@reduxjs/toolkit": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.6.2.tgz",
-      "integrity": "sha512-HbfI/hOVrAcMGAYsMWxw3UJyIoAS9JTdwddsjlr5w3S50tXhWb+EMyhIw+IAvCVCLETkzdjgH91RjDSYZekVBA==",
+      "version": "1.7.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.7.0-rc.0.tgz",
+      "integrity": "sha512-M1rAhiZK2oTnTaagtN+RHhsOJtUtK5fW2360HMn4rzhm99OELkgrIM9PWTFIIb//JRI1ejyPj5EW9O9BUYemIg==",
       "requires": {
-        "immer": "^9.0.6",
-        "redux": "^4.1.0",
-        "redux-thunk": "^2.3.0",
-        "reselect": "^4.0.0"
+        "immer": "^9.0.7",
+        "redux": "^4.1.2",
+        "redux-thunk": "^2.4.1",
+        "reselect": "^4.1.5"
       }
     },
     "@rollup/plugin-babel": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@loadable/component": "5.15.0",
     "@loadable/server": "5.15.1",
     "@react-spring/web": "9.3.1",
-    "@reduxjs/toolkit": "1.6.2",
+    "@reduxjs/toolkit": "1.7.0-rc.0",
     "@sentry/browser": "6.15.0",
     "classnames": "2.3.1",
     "comlink": "4.3.1",


### PR DESCRIPTION
The version of redux-toolkit that we are currently using (1.6) has an unfortunate behaviour (not quite a bug; it's just that RTK developers didn't quite think this through): if a function generated by `createApi` has sent a request but has not yet received a response, then repeated calls of that function will return a promise that won't have the response data on it; and there was no way to wait until the response data was available.

The appropriate behaviour, of course, would be to return a promise that resolves only when the response comes back. This has been introduced in redux-toolkit 1.7. Although it hasn't quite been released yet, a release candidate should be good enough for us, especially since it fixes our bug.

The behaviour of redux-toolkit v.1.6 causes the following bug in our code (during the execution of [this block](https://github.com/Ensembl/ensembl-client/blob/629e81c02d7139632d586c8a978f6c5eb930a754/src/shared/state/ens-object/ensObjectActions.ts#L74-L90), where we are reading `result.data?.gene` field from the response to request sent by RTK-Query):


**Redux-toolkit v.1.6** (notice no `data` field in the response object, and an error resulting from this): 

![image](https://user-images.githubusercontent.com/6834224/144469743-c7395d03-5b8b-44dc-9aeb-13b5e6506ceb.png)

**Redux-toolkit v.1.7** (notice that there now is the `data` field with the gene in the response object, as expected):

![image](https://user-images.githubusercontent.com/6834224/144470383-398eb7fb-7535-4e3d-9d7a-cab44585a5d1.png)