### PR TITLE
Copy the dist folder into the docker image generated from Dockerfile.node

### DIFF
--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -7,6 +7,7 @@ WORKDIR /srv/ensembl-client/
 
 ENV NODE_ENV=production
 COPY package*.json ./
+COPY dist ./dist/
 
 RUN npm ci --only=production --ignore-scripts
 


### PR DESCRIPTION
During the project rearrangement, forgot to copy the dist folder into the production docker image (built from Dockerfile.node).