### PR TITLE
Don't open transcript/protein accordion by default if user closed all

### DIFF
--- a/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -25,7 +25,7 @@ import { filterTranscripts } from 'src/content/app/entity-viewer/shared/helpers/
 
 import {
   getExpandedTranscriptIds,
-  getAccordionUserInteraction,
+  getExpandedTranscriptsModified,
   getExpandedTranscriptDownloadIds,
   getExpandedTranscriptMoreInfoIds,
   getFilters,
@@ -70,7 +70,9 @@ export type Props = {
 
 const DefaultTranscriptslist = (props: Props) => {
   const expandedTranscriptIds = useSelector(getExpandedTranscriptIds);
-  const accordionUserInteraction = useSelector(getAccordionUserInteraction);
+  const expandedTranscriptsModified = useSelector(
+    getExpandedTranscriptsModified
+  );
   const expandedTranscriptDownloadIds = useSelector(
     getExpandedTranscriptDownloadIds
   );
@@ -92,7 +94,7 @@ const DefaultTranscriptslist = (props: Props) => {
     const hasExpandedTranscripts = !!expandedTranscriptIds.length;
 
     // Expand the first transcript by default when the user hasnt interacted with the accordion
-    if (!hasExpandedTranscripts && !accordionUserInteraction) {
+    if (!hasExpandedTranscripts && !expandedTranscriptsModified) {
       dispatch(toggleTranscriptInfo(sortedTranscripts[0].stable_id));
     }
   }, []);

--- a/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -14,24 +14,23 @@
  * limitations under the License.
  */
 
-import React, { useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import React from 'react';
+import { useSelector } from 'react-redux';
 import { Pick2, Pick3 } from 'ts-multipick';
 
 import { getFeatureLength } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
 import { getTranscriptSortingFunction } from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
-
 import { filterTranscripts } from 'src/content/app/entity-viewer/shared/helpers/transcripts-filter';
+
+import useExpandedCanonicalTranscript from 'src/content/app/entity-viewer/gene-view/hooks/useExpandedDefaultTranscript';
 
 import {
   getExpandedTranscriptIds,
-  getExpandedTranscriptsModified,
   getExpandedTranscriptDownloadIds,
   getExpandedTranscriptMoreInfoIds,
   getFilters,
   getSortingRule
 } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors';
-import { toggleTranscriptInfo } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 
 import DefaultTranscriptsListItem, {
   DefaultTranscriptListItemProps
@@ -70,9 +69,6 @@ export type Props = {
 
 const DefaultTranscriptslist = (props: Props) => {
   const expandedTranscriptIds = useSelector(getExpandedTranscriptIds);
-  const expandedTranscriptsModified = useSelector(
-    getExpandedTranscriptsModified
-  );
   const expandedTranscriptDownloadIds = useSelector(
     getExpandedTranscriptDownloadIds
   );
@@ -81,7 +77,6 @@ const DefaultTranscriptslist = (props: Props) => {
   );
   const sortingRule = useSelector(getSortingRule);
   const filters = useSelector(getFilters);
-  const dispatch = useDispatch();
 
   const { gene } = props;
 
@@ -90,14 +85,10 @@ const DefaultTranscriptslist = (props: Props) => {
   const sortingFunction = getTranscriptSortingFunction<Transcript>(sortingRule);
   const sortedTranscripts = sortingFunction(filteredTranscripts);
 
-  useEffect(() => {
-    const hasExpandedTranscripts = !!expandedTranscriptIds.length;
-
-    // Expand the first transcript by default when the user hasnt interacted with the accordion
-    if (!hasExpandedTranscripts && !expandedTranscriptsModified) {
-      dispatch(toggleTranscriptInfo(sortedTranscripts[0].stable_id));
-    }
-  }, []);
+  useExpandedCanonicalTranscript({
+    geneStableId: gene.stable_id,
+    transcripts: gene.transcripts
+  });
 
   return (
     <div className={styles.transcriptsList}>

--- a/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -25,6 +25,7 @@ import { filterTranscripts } from 'src/content/app/entity-viewer/shared/helpers/
 
 import {
   getExpandedTranscriptIds,
+  getAccordionUserInteraction,
   getExpandedTranscriptDownloadIds,
   getExpandedTranscriptMoreInfoIds,
   getFilters,
@@ -69,6 +70,7 @@ export type Props = {
 
 const DefaultTranscriptslist = (props: Props) => {
   const expandedTranscriptIds = useSelector(getExpandedTranscriptIds);
+  const accordionUserInteraction = useSelector(getAccordionUserInteraction);
   const expandedTranscriptDownloadIds = useSelector(
     getExpandedTranscriptDownloadIds
   );
@@ -89,8 +91,8 @@ const DefaultTranscriptslist = (props: Props) => {
   useEffect(() => {
     const hasExpandedTranscripts = !!expandedTranscriptIds.length;
 
-    // Expand the first transcript by default
-    if (!hasExpandedTranscripts) {
+    // Expand the first transcript by default when the user hasnt interacted with the accordion
+    if (!hasExpandedTranscripts && !accordionUserInteraction) {
       dispatch(toggleTranscriptInfo(sortedTranscripts[0].stable_id));
     }
   }, []);

--- a/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -22,7 +22,7 @@ import { getFeatureLength } from 'src/content/app/entity-viewer/shared/helpers/e
 import { getTranscriptSortingFunction } from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
 import { filterTranscripts } from 'src/content/app/entity-viewer/shared/helpers/transcripts-filter';
 
-import useExpandedCanonicalTranscript from 'src/content/app/entity-viewer/gene-view/hooks/useExpandedDefaultTranscript';
+import useExpandedDefaultTranscript from 'src/content/app/entity-viewer/gene-view/hooks/useExpandedDefaultTranscript';
 
 import {
   getExpandedTranscriptIds,
@@ -85,7 +85,7 @@ const DefaultTranscriptslist = (props: Props) => {
   const sortingFunction = getTranscriptSortingFunction<Transcript>(sortingRule);
   const sortedTranscripts = sortingFunction(filteredTranscripts);
 
-  useExpandedCanonicalTranscript({
+  useExpandedDefaultTranscript({
     geneStableId: gene.stable_id,
     transcripts: gene.transcripts
   });

--- a/src/content/app/entity-viewer/gene-view/components/proteins-list/ProteinsList.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/proteins-list/ProteinsList.tsx
@@ -26,7 +26,7 @@ import {
 import { getTranscriptSortingFunction } from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
 import { filterTranscripts } from 'src/content/app/entity-viewer/shared/helpers/transcripts-filter';
 
-import useExpandedCanonicalTranscript from 'src/content/app/entity-viewer/gene-view/hooks/useExpandedDefaultTranscript';
+import useExpandedDefaultTranscript from 'src/content/app/entity-viewer/gene-view/hooks/useExpandedDefaultTranscript';
 
 import {
   getFilters,
@@ -77,7 +77,7 @@ const ProteinsList = (props: ProteinsListProps) => {
     isProteinCodingTranscript
   ) as Transcript[];
 
-  useExpandedCanonicalTranscript({
+  useExpandedDefaultTranscript({
     geneStableId: props.gene.stable_id,
     transcripts: props.gene.transcripts,
     skip: Boolean(proteinIdToFocus)

--- a/src/content/app/entity-viewer/gene-view/components/proteins-list/ProteinsList.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/proteins-list/ProteinsList.tsx
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-import React, { useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import React from 'react';
+import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router';
 import { Pick3 } from 'ts-multipick';
-
-import ProteinsListItem, {
-  Props as ProteinListItemProps
-} from './proteins-list-item/ProteinsListItem';
 
 import {
   getLongestProteinLength,
@@ -30,13 +26,16 @@ import {
 import { getTranscriptSortingFunction } from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
 import { filterTranscripts } from 'src/content/app/entity-viewer/shared/helpers/transcripts-filter';
 
-import { toggleTranscriptInfo } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
+import useExpandedCanonicalTranscript from 'src/content/app/entity-viewer/gene-view/hooks/useExpandedDefaultTranscript';
+
 import {
-  getExpandedTranscriptIds,
-  getExpandedTranscriptsModified,
   getFilters,
   getSortingRule
 } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors';
+
+import ProteinsListItem, {
+  Props as ProteinListItemProps
+} from './proteins-list-item/ProteinsListItem';
 
 import { FullGene } from 'src/shared/types/thoas/gene';
 import { FullTranscript } from 'src/shared/types/thoas/transcript';
@@ -60,11 +59,6 @@ export type ProteinsListProps = {
 };
 
 const ProteinsList = (props: ProteinsListProps) => {
-  const expandedProteinIds = useSelector(getExpandedTranscriptIds);
-  const expandedTranscriptsModified = useSelector(
-    getExpandedTranscriptsModified
-  );
-  const dispatch = useDispatch();
   const { search } = useLocation();
   const proteinIdToFocus = new URLSearchParams(search).get('protein_id');
 
@@ -83,20 +77,11 @@ const ProteinsList = (props: ProteinsListProps) => {
     isProteinCodingTranscript
   ) as Transcript[];
 
-  useEffect(() => {
-    if (!proteinCodingTranscripts.length) {
-      return;
-    }
-    const hasExpandedTranscripts = !!expandedProteinIds.length;
-    // Expand the first transcript by default when the user hasnt interacted with the accordion
-    if (
-      !hasExpandedTranscripts &&
-      !proteinIdToFocus &&
-      !expandedTranscriptsModified
-    ) {
-      dispatch(toggleTranscriptInfo(proteinCodingTranscripts[0].stable_id));
-    }
-  }, []);
+  useExpandedCanonicalTranscript({
+    geneStableId: props.gene.stable_id,
+    transcripts: props.gene.transcripts,
+    skip: Boolean(proteinIdToFocus)
+  });
 
   const longestProteinLength = getLongestProteinLength(props.gene);
 

--- a/src/content/app/entity-viewer/gene-view/components/proteins-list/ProteinsList.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/proteins-list/ProteinsList.tsx
@@ -33,7 +33,7 @@ import { filterTranscripts } from 'src/content/app/entity-viewer/shared/helpers/
 import { toggleTranscriptInfo } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 import {
   getExpandedTranscriptIds,
-  getAccordionUserInteraction,
+  getExpandedTranscriptsModified,
   getFilters,
   getSortingRule
 } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors';
@@ -61,7 +61,9 @@ export type ProteinsListProps = {
 
 const ProteinsList = (props: ProteinsListProps) => {
   const expandedProteinIds = useSelector(getExpandedTranscriptIds);
-  const accordionUserInteraction = useSelector(getAccordionUserInteraction);
+  const expandedTranscriptsModified = useSelector(
+    getExpandedTranscriptsModified
+  );
   const dispatch = useDispatch();
   const { search } = useLocation();
   const proteinIdToFocus = new URLSearchParams(search).get('protein_id');
@@ -90,7 +92,7 @@ const ProteinsList = (props: ProteinsListProps) => {
     if (
       !hasExpandedTranscripts &&
       !proteinIdToFocus &&
-      !accordionUserInteraction
+      !expandedTranscriptsModified
     ) {
       dispatch(toggleTranscriptInfo(proteinCodingTranscripts[0].stable_id));
     }

--- a/src/content/app/entity-viewer/gene-view/components/proteins-list/ProteinsList.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/proteins-list/ProteinsList.tsx
@@ -33,6 +33,7 @@ import { filterTranscripts } from 'src/content/app/entity-viewer/shared/helpers/
 import { toggleTranscriptInfo } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 import {
   getExpandedTranscriptIds,
+  getAccordionUserInteraction,
   getFilters,
   getSortingRule
 } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors';
@@ -60,6 +61,7 @@ export type ProteinsListProps = {
 
 const ProteinsList = (props: ProteinsListProps) => {
   const expandedProteinIds = useSelector(getExpandedTranscriptIds);
+  const accordionUserInteraction = useSelector(getAccordionUserInteraction);
   const dispatch = useDispatch();
   const { search } = useLocation();
   const proteinIdToFocus = new URLSearchParams(search).get('protein_id');
@@ -84,8 +86,12 @@ const ProteinsList = (props: ProteinsListProps) => {
       return;
     }
     const hasExpandedTranscripts = !!expandedProteinIds.length;
-    // Expand the first transcript by default
-    if (!hasExpandedTranscripts && !proteinIdToFocus) {
+    // Expand the first transcript by default when the user hasnt interacted with the accordion
+    if (
+      !hasExpandedTranscripts &&
+      !proteinIdToFocus &&
+      !accordionUserInteraction
+    ) {
       dispatch(toggleTranscriptInfo(proteinCodingTranscripts[0].stable_id));
     }
   }, []);

--- a/src/content/app/entity-viewer/gene-view/hooks/useExpandedDefaultTranscript.ts
+++ b/src/content/app/entity-viewer/gene-view/hooks/useExpandedDefaultTranscript.ts
@@ -37,7 +37,7 @@ type Params = {
 // the canonical transcript is always put on the first place.
 // Knowing this, and also knowing that every gene will always have a canonical transcript,
 // we can simply find the canonical transcript among gene's transcripts, and expand it in the initial view
-const useExpandedCanonicalTranscript = (params: Params) => {
+const useExpandedDefaultTranscript = (params: Params) => {
   const { transcripts, skip = false } = params;
   const dispatch = useDispatch();
   const haveTranscriptsBeenExpanded = useSelector(
@@ -62,4 +62,4 @@ const useExpandedCanonicalTranscript = (params: Params) => {
   }, [params.geneStableId]);
 };
 
-export default useExpandedCanonicalTranscript;
+export default useExpandedDefaultTranscript;

--- a/src/content/app/entity-viewer/gene-view/hooks/useExpandedDefaultTranscript.ts
+++ b/src/content/app/entity-viewer/gene-view/hooks/useExpandedDefaultTranscript.ts
@@ -30,6 +30,7 @@ type TranscriptWithCanonicalMetadata = {
 type Params = {
   geneStableId: string;
   transcripts: TranscriptWithCanonicalMetadata[];
+  skip?: boolean;
 };
 
 // When the default sorting rule is applied to the list of gene's transcripts,
@@ -37,17 +38,17 @@ type Params = {
 // Knowing this, and also knowing that every gene will always have a canonical transcript,
 // we can simply find the canonical transcript among gene's transcripts, and expand it in the initial view
 const useExpandedCanonicalTranscript = (params: Params) => {
+  const { transcripts, skip = false } = params;
   const dispatch = useDispatch();
   const isExpandedTranscriptsListModified = useSelector(
     getExpandedTranscriptsModified
   );
 
   useEffect(() => {
-    if (isExpandedTranscriptsListModified) {
+    if (isExpandedTranscriptsListModified || skip) {
       return; // nothing to do
     }
 
-    const { transcripts } = params;
     const canonicalTranscript = transcripts.find((transcript) =>
       Boolean(transcript.metadata.canonical)
     );

--- a/src/content/app/entity-viewer/gene-view/hooks/useExpandedDefaultTranscript.ts
+++ b/src/content/app/entity-viewer/gene-view/hooks/useExpandedDefaultTranscript.ts
@@ -17,7 +17,7 @@
 import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
-import { getExpandedTranscriptsModified } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors';
+import { isExpandedTranscriptsListModified } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors';
 import { toggleTranscriptInfo } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 
 type TranscriptWithCanonicalMetadata = {
@@ -40,12 +40,12 @@ type Params = {
 const useExpandedCanonicalTranscript = (params: Params) => {
   const { transcripts, skip = false } = params;
   const dispatch = useDispatch();
-  const isExpandedTranscriptsListModified = useSelector(
-    getExpandedTranscriptsModified
+  const haveTranscriptsBeenExpanded = useSelector(
+    isExpandedTranscriptsListModified
   );
 
   useEffect(() => {
-    if (isExpandedTranscriptsListModified || skip) {
+    if (haveTranscriptsBeenExpanded || skip) {
       return; // nothing to do
     }
 

--- a/src/content/app/entity-viewer/gene-view/hooks/useExpandedDefaultTranscript.ts
+++ b/src/content/app/entity-viewer/gene-view/hooks/useExpandedDefaultTranscript.ts
@@ -1,0 +1,64 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
+import { getExpandedTranscriptsModified } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors';
+import { toggleTranscriptInfo } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
+
+type TranscriptWithCanonicalMetadata = {
+  stable_id: string;
+  metadata: {
+    canonical: unknown; // we don't really care; what's important is whether this field is null or not
+  };
+};
+
+type Params = {
+  geneStableId: string;
+  transcripts: TranscriptWithCanonicalMetadata[];
+};
+
+// When the default sorting rule is applied to the list of gene's transcripts,
+// the canonical transcript is always put on the first place.
+// Knowing this, and also knowing that every gene will always have a canonical transcript,
+// we can simply find the canonical transcript among gene's transcripts, and expand it in the initial view
+const useExpandedCanonicalTranscript = (params: Params) => {
+  const dispatch = useDispatch();
+  const isExpandedTranscriptsListModified = useSelector(
+    getExpandedTranscriptsModified
+  );
+
+  useEffect(() => {
+    if (isExpandedTranscriptsListModified) {
+      return; // nothing to do
+    }
+
+    const { transcripts } = params;
+    const canonicalTranscript = transcripts.find((transcript) =>
+      Boolean(transcript.metadata.canonical)
+    );
+
+    if (canonicalTranscript?.stable_id) {
+      // a bit of defensive programming:
+      // there's something very wrong with our data if a gene doesn't have a canonical transcript;
+      // but at least the code won't crash here
+      dispatch(toggleTranscriptInfo(canonicalTranscript.stable_id));
+    }
+  }, [params.geneStableId]);
+};
+
+export default useExpandedCanonicalTranscript;

--- a/src/content/app/entity-viewer/shared/helpers/transcripts-sorter.ts
+++ b/src/content/app/entity-viewer/shared/helpers/transcripts-sorter.ts
@@ -123,7 +123,7 @@ export function sortByExonCountAsc<
   });
 }
 
-type GeneViewSortableTranscript = IsProteinCodingTranscriptParam &
+export type GeneViewSortableTranscript = IsProteinCodingTranscriptParam &
   GetSplicedRNALengthParam & {
     slice: SliceWithOnlyLength;
     spliced_exons: unknown[];

--- a/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors.ts
+++ b/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors.ts
@@ -72,3 +72,8 @@ export const getFilterPanelOpen = (state: RootState): boolean => {
   const transcriptsSlice = getSliceForGene(state);
   return transcriptsSlice?.filterPanelOpen ?? false;
 };
+
+export const getAccordionUserInteraction = (state: RootState): boolean => {
+  const transcriptsSlice = getSliceForGene(state);
+  return transcriptsSlice?.accordionUserInteraction ?? false;
+};

--- a/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors.ts
+++ b/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors.ts
@@ -73,7 +73,7 @@ export const getFilterPanelOpen = (state: RootState): boolean => {
   return transcriptsSlice?.filterPanelOpen ?? false;
 };
 
-export const getAccordionUserInteraction = (state: RootState): boolean => {
+export const getExpandedTranscriptsModified = (state: RootState): boolean => {
   const transcriptsSlice = getSliceForGene(state);
-  return transcriptsSlice?.accordionUserInteraction ?? false;
+  return transcriptsSlice?.expandedTranscriptsModified ?? false;
 };

--- a/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors.ts
+++ b/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors.ts
@@ -73,7 +73,9 @@ export const getFilterPanelOpen = (state: RootState): boolean => {
   return transcriptsSlice?.filterPanelOpen ?? false;
 };
 
-export const getExpandedTranscriptsModified = (state: RootState): boolean => {
+export const isExpandedTranscriptsListModified = (
+  state: RootState
+): boolean => {
   const transcriptsSlice = getSliceForGene(state);
-  return transcriptsSlice?.expandedTranscriptsModified ?? false;
+  return transcriptsSlice?.isExpandedTranscriptsListModified ?? false;
 };

--- a/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
+++ b/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
@@ -188,13 +188,16 @@ export const toggleTranscriptInfo =
       expandedIds.delete(transcriptId);
     } else {
       expandedIds.add(transcriptId);
+      expandedIds.delete('noselection');
     }
 
     dispatch(
       transcriptsSlice.actions.updateExpandedTranscripts({
         activeGenomeId,
         activeEntityId,
-        expandedIds: [...expandedIds.values()]
+        expandedIds: [...expandedIds.values()].length
+          ? [...expandedIds.values()]
+          : ['noselection']
       })
     );
   };

--- a/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
+++ b/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
@@ -46,7 +46,7 @@ export enum SortingRule {
 
 export type TranscriptsStatePerGene = {
   expandedIds: string[];
-  expandedTranscriptsModified: boolean;
+  isExpandedTranscriptsListModified: boolean;
   expandedDownloadIds: string[];
   expandedMoreInfoIds: string[];
   filters: Filters;
@@ -78,7 +78,7 @@ export type Filters = Record<string, Filter>;
 
 const defaultStatePerGene: TranscriptsStatePerGene = {
   expandedIds: [],
-  expandedTranscriptsModified: false,
+  isExpandedTranscriptsListModified: false,
   expandedDownloadIds: [],
   expandedMoreInfoIds: [],
   filters: {},
@@ -309,7 +309,8 @@ const transcriptsSlice = createSlice({
       const { activeGenomeId, activeEntityId, expandedIds } = action.payload;
       ensureGenePresence(state, action.payload);
       state[activeGenomeId][activeEntityId].expandedIds = expandedIds;
-      state[activeGenomeId][activeEntityId].expandedTranscriptsModified = true;
+      state[activeGenomeId][activeEntityId].isExpandedTranscriptsListModified =
+        true;
     },
     updateExpandedDownloads(state, action: PayloadAction<ExpandedIdsPayload>) {
       const { activeGenomeId, activeEntityId, expandedIds } = action.payload;

--- a/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
+++ b/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
@@ -46,6 +46,7 @@ export enum SortingRule {
 
 export type TranscriptsStatePerGene = {
   expandedIds: string[];
+  accordionUserInteraction: boolean;
   expandedDownloadIds: string[];
   expandedMoreInfoIds: string[];
   filters: Filters;
@@ -77,6 +78,7 @@ export type Filters = Record<string, Filter>;
 
 const defaultStatePerGene: TranscriptsStatePerGene = {
   expandedIds: [],
+  accordionUserInteraction: false,
   expandedDownloadIds: [],
   expandedMoreInfoIds: [],
   filters: {},
@@ -188,16 +190,21 @@ export const toggleTranscriptInfo =
       expandedIds.delete(transcriptId);
     } else {
       expandedIds.add(transcriptId);
-      expandedIds.delete('noselection');
     }
 
     dispatch(
       transcriptsSlice.actions.updateExpandedTranscripts({
         activeGenomeId,
         activeEntityId,
-        expandedIds: [...expandedIds.values()].length
-          ? [...expandedIds.values()]
-          : ['noselection']
+        expandedIds: [...expandedIds.values()]
+      })
+    );
+
+    dispatch(
+      transcriptsSlice.actions.updateAccordionUserInteraction({
+        activeGenomeId,
+        activeEntityId,
+        accordionUserInteraction: true
       })
     );
   };
@@ -248,7 +255,6 @@ export const toggleTranscriptMoreInfo =
     } else {
       expandedIds.add(transcriptId);
     }
-
     dispatch(
       transcriptsSlice.actions.updateExpandedMoreInfo({
         activeGenomeId,
@@ -300,6 +306,12 @@ type UpdateFilterPanelPayload = {
   filterPanelOpen: boolean;
 };
 
+type UpdateAccordionUserInteractionPayload = {
+  activeGenomeId: string;
+  activeEntityId: string;
+  accordionUserInteraction: boolean;
+};
+
 const transcriptsSlice = createSlice({
   name: 'entity-viewer-gene-view-transcripts',
   initialState: {} as GeneViewTranscriptsState,
@@ -327,6 +339,19 @@ const transcriptsSlice = createSlice({
         action.payload;
       ensureGenePresence(state, action.payload);
       state[activeGenomeId][activeEntityId].filterPanelOpen = filterPanelOpen;
+    },
+    updateAccordionUserInteraction(
+      state,
+      action: PayloadAction<UpdateAccordionUserInteractionPayload>
+    ) {
+      const { activeGenomeId, activeEntityId, accordionUserInteraction } =
+        action.payload;
+      const updatedState = ensureGenePresence(state, action.payload);
+      return set(
+        `${activeGenomeId}.${activeEntityId}.accordionUserInteraction`,
+        accordionUserInteraction,
+        updatedState
+      );
     },
     updateFilters(state, action: PayloadAction<UpdateFiltersPayload>) {
       const { activeGenomeId, activeEntityId, filters } = action.payload;

--- a/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
+++ b/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
@@ -46,7 +46,7 @@ export enum SortingRule {
 
 export type TranscriptsStatePerGene = {
   expandedIds: string[];
-  accordionUserInteraction: boolean;
+  expandedTranscriptsModified: boolean;
   expandedDownloadIds: string[];
   expandedMoreInfoIds: string[];
   filters: Filters;
@@ -78,7 +78,7 @@ export type Filters = Record<string, Filter>;
 
 const defaultStatePerGene: TranscriptsStatePerGene = {
   expandedIds: [],
-  accordionUserInteraction: false,
+  expandedTranscriptsModified: false,
   expandedDownloadIds: [],
   expandedMoreInfoIds: [],
   filters: {},
@@ -199,14 +199,6 @@ export const toggleTranscriptInfo =
         expandedIds: [...expandedIds.values()]
       })
     );
-
-    dispatch(
-      transcriptsSlice.actions.updateAccordionUserInteraction({
-        activeGenomeId,
-        activeEntityId,
-        accordionUserInteraction: true
-      })
-    );
   };
 
 export const toggleTranscriptDownload =
@@ -306,12 +298,6 @@ type UpdateFilterPanelPayload = {
   filterPanelOpen: boolean;
 };
 
-type UpdateAccordionUserInteractionPayload = {
-  activeGenomeId: string;
-  activeEntityId: string;
-  accordionUserInteraction: boolean;
-};
-
 const transcriptsSlice = createSlice({
   name: 'entity-viewer-gene-view-transcripts',
   initialState: {} as GeneViewTranscriptsState,
@@ -323,6 +309,7 @@ const transcriptsSlice = createSlice({
       const { activeGenomeId, activeEntityId, expandedIds } = action.payload;
       ensureGenePresence(state, action.payload);
       state[activeGenomeId][activeEntityId].expandedIds = expandedIds;
+      state[activeGenomeId][activeEntityId].expandedTranscriptsModified = true;
     },
     updateExpandedDownloads(state, action: PayloadAction<ExpandedIdsPayload>) {
       const { activeGenomeId, activeEntityId, expandedIds } = action.payload;
@@ -339,19 +326,6 @@ const transcriptsSlice = createSlice({
         action.payload;
       ensureGenePresence(state, action.payload);
       state[activeGenomeId][activeEntityId].filterPanelOpen = filterPanelOpen;
-    },
-    updateAccordionUserInteraction(
-      state,
-      action: PayloadAction<UpdateAccordionUserInteractionPayload>
-    ) {
-      const { activeGenomeId, activeEntityId, accordionUserInteraction } =
-        action.payload;
-      const updatedState = ensureGenePresence(state, action.payload);
-      return set(
-        `${activeGenomeId}.${activeEntityId}.accordionUserInteraction`,
-        accordionUserInteraction,
-        updatedState
-      );
     },
     updateFilters(state, action: PayloadAction<UpdateFiltersPayload>) {
       const { activeGenomeId, activeEntityId, filters } = action.payload;


### PR DESCRIPTION
## Description
### Intended behaviour
1. If the user visits the list of transcripts, or of proteins, for a given gene for the first time, expand the default (canonical) transcript.
2. If the user collapses the default transcript, keep its info panel hidden until the user refreshes the page (should work while user switches between different entity viewer views, and between apps)
3. If the user has selected a particular set of filters, or a non-default sorting rule, only expand the default transcript if it is included in the list of displayed transcripts. For example, if the canonical transcript happens to be protein-coding, and the user has filtered out protein-coding transcripts, then when he refreshes the page, no transcript should expand by default.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1351

## Deployment URL
http://transcript-accordion.review.ensembl.org