### PR TITLE
Use redux-toolkit-query for entity viewer

### DIFF
--- a/src/content/app/entity-viewer/EntityViewer.tsx
+++ b/src/content/app/entity-viewer/EntityViewer.tsx
@@ -15,12 +15,10 @@
  */
 
 import React, { useEffect } from 'react';
-import { ApolloProvider } from '@apollo/client';
 import { useSelector, useDispatch } from 'react-redux';
 import { replace } from 'connected-react-router';
 import { useParams } from 'react-router-dom';
 
-import { client } from 'src/gql-client';
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import { buildFocusIdForUrl } from 'src/shared/helpers/focusObjectHelpers';
 
@@ -86,28 +84,26 @@ const EntityViewer = () => {
   );
 
   return (
-    <ApolloProvider client={client}>
-      <div className={styles.entityViewer}>
-        <EntityViewerAppBar />
-        {genomeId && entityId ? (
-          <StandardAppLayout
-            mainContent={<GeneView />}
-            topbarContent={
-              <EntityViewerTopbar genomeId={genomeId} entityId={entityId} />
-            }
-            sidebarContent={SideBarContent}
-            sidebarNavigation={<GeneViewSidebarTabs />}
-            sidebarToolstripContent={<EntityViewerSidebarToolstrip />}
-            isSidebarOpen={isSidebarOpen}
-            onSidebarToggle={() => dispatch(toggleSidebar())}
-            isDrawerOpen={false}
-            viewportWidth={viewportWidth}
-          />
-        ) : (
-          <EntityViewerInterstitial />
-        )}
-      </div>
-    </ApolloProvider>
+    <div className={styles.entityViewer}>
+      <EntityViewerAppBar />
+      {genomeId && entityId ? (
+        <StandardAppLayout
+          mainContent={<GeneView />}
+          topbarContent={
+            <EntityViewerTopbar genomeId={genomeId} entityId={entityId} />
+          }
+          sidebarContent={SideBarContent}
+          sidebarNavigation={<GeneViewSidebarTabs />}
+          sidebarToolstripContent={<EntityViewerSidebarToolstrip />}
+          isSidebarOpen={isSidebarOpen}
+          onSidebarToggle={() => dispatch(toggleSidebar())}
+          isDrawerOpen={false}
+          viewportWidth={viewportWidth}
+        />
+      ) : (
+        <EntityViewerInterstitial />
+      )}
+    </div>
   );
 };
 

--- a/src/content/app/entity-viewer/components/example-links/ExampleLinks.tsx
+++ b/src/content/app/entity-viewer/components/example-links/ExampleLinks.tsx
@@ -17,9 +17,9 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { useQuery, gql } from '@apollo/client';
 
 import * as urlHelper from 'src/shared/helpers/urlHelper';
+import { useGeneSummaryQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
 import { buildFocusIdForUrl } from 'src/shared/helpers/focusObjectHelpers';
 
 import { getEntityViewerActiveGenomeId } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors';
@@ -31,21 +31,6 @@ import { RootState } from 'src/store';
 
 import styles from './ExampleLinks.scss';
 
-type ExampleGene = {
-  unversioned_stable_id: string;
-  symbol: string;
-};
-
-const QUERY = gql`
-  query Gene($genomeId: String!, $geneId: String!) {
-    gene(byId: { genome_id: $genomeId, stable_id: $geneId }) {
-      stable_id
-      unversioned_stable_id
-      symbol
-    }
-  }
-`;
-
 // NOTE: the component currently handles only example gene
 const ExampleLinks = () => {
   const activeGenomeId = useSelector(getEntityViewerActiveGenomeId);
@@ -53,12 +38,17 @@ const ExampleLinks = () => {
     getGenomeExampleFocusObjects(state, activeGenomeId || '')
   );
   const exampleGeneId = exampleEntities.find(({ type }) => type === 'gene')?.id;
-  const { loading, data, error } = useQuery<{ gene: ExampleGene }>(QUERY, {
-    variables: { geneId: exampleGeneId, genomeId: activeGenomeId },
-    skip: !exampleGeneId || !activeGenomeId
-  });
+  const { isLoading, data, error } = useGeneSummaryQuery(
+    {
+      geneId: exampleGeneId || '',
+      genomeId: activeGenomeId || ''
+    },
+    {
+      skip: !exampleGeneId || !activeGenomeId
+    }
+  );
 
-  if (loading) {
+  if (isLoading) {
     return (
       <div>
         <div className={styles.exampleLinks__emptyTopbar} />

--- a/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.tsx
@@ -16,7 +16,6 @@
 
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { Pick2, Pick3 } from 'ts-multipick';
 
 import { getFeatureLength } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
 import { getTranscriptSortingFunction } from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
@@ -32,38 +31,18 @@ import {
   getSortingRule
 } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors';
 
-import DefaultTranscriptsListItem, {
-  DefaultTranscriptListItemProps
-} from './default-transcripts-list-item/DefaultTranscriptListItem';
+import DefaultTranscriptsListItem from './default-transcripts-list-item/DefaultTranscriptListItem';
 
-import { TicksAndScale } from 'src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/BasePairsRuler';
-import { FullGene } from 'src/shared/types/thoas/gene';
-import { FullTranscript } from 'src/shared/types/thoas/transcript';
-import { FullProductGeneratingContext } from 'src/shared/types/thoas/productGeneratingContext';
-import { FullCDS } from 'src/shared/types/thoas/cds';
-import { SplicedExon } from 'src/shared/types/thoas/exon';
-import { Slice } from 'src/shared/types/thoas/slice';
+import type { TicksAndScale } from 'src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/BasePairsRuler';
+import type { DefaultEntityViewerGeneQueryResult } from 'src/content/app/entity-viewer/state/api/queries/defaultGeneQuery';
 
 import styles from './DefaultTranscriptsList.scss';
 
-type ProductGeneratingContext = {
-  product_type: FullProductGeneratingContext['product_type'];
-  cds: Pick<FullCDS, 'relative_start' | 'relative_end'>;
-};
-type Transcript = DefaultTranscriptListItemProps['transcript'] & {
-  product_generating_contexts: ProductGeneratingContext[];
-} & {
-  spliced_exons: Array<Pick3<SplicedExon, 'exon', 'slice', 'location'>>;
-} & Pick2<FullTranscript, 'slice', 'location'>;
-
-type Gene = DefaultTranscriptListItemProps['gene'] & {
-  stable_id: FullGene['stable_id'];
-  transcripts: Array<Transcript>;
-  slice: Pick2<Slice, 'location', 'length'>;
-};
+type Transcript =
+  DefaultEntityViewerGeneQueryResult['gene']['transcripts'][number];
 
 export type Props = {
-  gene: Gene;
+  gene: DefaultEntityViewerGeneQueryResult['gene'];
   rulerTicks: TicksAndScale;
 };
 

--- a/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/default-transcripts-list-item/DefaultTranscriptListItem.tsx
@@ -21,34 +21,23 @@ import {
   getTranscriptMetadata,
   TranscriptQualityLabel
 } from 'src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel';
-import UnsplicedTranscript, {
-  UnsplicedTranscriptProps
-} from 'src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript';
-import TranscriptsListItemInfo, {
-  TranscriptsListItemInfoProps
-} from '../transcripts-list-item-info/TranscriptsListItemInfo';
+import UnsplicedTranscript from 'src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript';
+import TranscriptsListItemInfo from '../transcripts-list-item-info/TranscriptsListItemInfo';
 
 import { toggleTranscriptInfo } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 
 import useEntityViewerAnalytics from 'src/content/app/entity-viewer/hooks/useEntityViewerAnalytics';
 
-import { FullTranscript } from 'src/shared/types/thoas/transcript';
-import { TicksAndScale } from 'src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/BasePairsRuler';
+import type { TicksAndScale } from 'src/content/app/entity-viewer/gene-view/components/base-pairs-ruler/BasePairsRuler';
+import type { DefaultEntityViewerGeneQueryResult } from 'src/content/app/entity-viewer/state/api/queries/defaultGeneQuery';
 
 import transcriptsListStyles from '../DefaultTranscriptsList.scss';
 import styles from './DefaultTranscriptListItem.scss';
 
-type Transcript = Pick<
-  FullTranscript,
-  'stable_id' | 'relative_location' | 'metadata'
-> &
-  TranscriptsListItemInfoProps['transcript'] &
-  UnsplicedTranscriptProps['transcript'];
-
 export type DefaultTranscriptListItemProps = {
   transcriptPosition: number;
-  gene: TranscriptsListItemInfoProps['gene'];
-  transcript: Transcript;
+  gene: DefaultEntityViewerGeneQueryResult['gene'];
+  transcript: DefaultEntityViewerGeneQueryResult['gene']['transcripts'][number];
   rulerTicks: TicksAndScale;
   expandTranscript: boolean;
   expandDownload: boolean;

--- a/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -18,7 +18,6 @@ import React from 'react';
 import { useParams, Link } from 'react-router-dom';
 import classNames from 'classnames';
 import { useDispatch } from 'react-redux';
-import { Pick2, Pick3, Pick4 } from 'ts-multipick';
 
 import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
 import { getFormattedLocation } from 'src/shared/helpers/formatters/regionFormatter';
@@ -45,43 +44,17 @@ import {
   toggleTranscriptMoreInfo
 } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 
-import { FullGene } from 'src/shared/types/thoas/gene';
-import { FullTranscript } from 'src/shared/types/thoas/transcript';
-import { SplicedExon, PhasedExon } from 'src/shared/types/thoas/exon';
-import { FullProductGeneratingContext } from 'src/shared/types/thoas/productGeneratingContext';
 import { View } from 'src/content/app/entity-viewer/state/gene-view/view/geneViewViewSlice';
+import type { DefaultEntityViewerGeneQueryResult } from 'src/content/app/entity-viewer/state/api/queries/defaultGeneQuery';
 
 import useEntityViewerAnalytics from 'src/content/app/entity-viewer/hooks/useEntityViewerAnalytics';
 
 import transcriptsListStyles from '../DefaultTranscriptsList.scss';
 import styles from './TranscriptsListItemInfo.scss';
 
-type Gene = Pick<FullGene, 'unversioned_stable_id' | 'stable_id' | 'symbol'>;
-type Transcript = Pick<
-  FullTranscript,
-  'stable_id' | 'unversioned_stable_id' | 'external_references' | 'metadata'
-> &
-  Pick2<FullTranscript, 'slice', 'location'> &
-  Pick3<FullTranscript, 'slice', 'region', 'name'> & {
-    spliced_exons: Array<
-      Pick2<SplicedExon, 'exon', 'stable_id'> &
-        Pick4<SplicedExon, 'exon', 'slice', 'location', 'length'>
-    >;
-  } & {
-    product_generating_contexts: Array<
-      Pick<FullProductGeneratingContext, 'product_type'> &
-        Pick<FullProductGeneratingContext, 'product'> & {
-          phased_exons: Array<
-            Pick<PhasedExon, 'start_phase' | 'end_phase'> &
-              Pick2<PhasedExon, 'exon', 'stable_id'>
-          >;
-        }
-    >;
-  };
-
 export type TranscriptsListItemInfoProps = {
-  gene: Gene;
-  transcript: Transcript;
+  gene: DefaultEntityViewerGeneQueryResult['gene'];
+  transcript: DefaultEntityViewerGeneQueryResult['gene']['transcripts'][number];
   expandDownload: boolean;
   expandMoreInfo: boolean;
 };

--- a/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.tsx
@@ -33,7 +33,9 @@ import useEntityViewerAnalytics from 'src/content/app/entity-viewer/hooks/useEnt
 
 import Tabs, { Tab } from 'src/shared/components/tabs/Tabs';
 import Panel from 'src/shared/components/panel/Panel';
-import ProteinsList, { ProteinsListProps } from '../proteins-list/ProteinsList';
+import ProteinsList from '../proteins-list/ProteinsList';
+
+import type { DefaultEntityViewerGeneQueryResult } from 'src/content/app/entity-viewer/state/api/queries/defaultGeneQuery';
 
 import styles from './GeneFunction.scss';
 
@@ -52,7 +54,7 @@ const tabClassNames = {
 };
 
 export type Props = {
-  gene: ProteinsListProps['gene'];
+  gene: DefaultEntityViewerGeneQueryResult['gene'];
 };
 
 const GeneFunction = (props: Props) => {

--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.test.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.test.tsx
@@ -16,19 +16,26 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
-import { useParams } from 'react-router-dom';
-import { useQuery } from '@apollo/client';
+
+import { useGeneOverviewQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
 
 import GeneOverview from './GeneOverview';
 
 jest.mock('react-router-dom', () => ({
-  useParams: jest.fn()
+  useParams: jest.fn(() => ({
+    params: {
+      entityId: geneId,
+      genomeId
+    }
+  }))
 }));
 
-jest.mock('@apollo/client', () => ({
-  gql: jest.fn(),
-  useQuery: jest.fn()
-}));
+jest.mock(
+  'src/content/app/entity-viewer/state/api/entityViewerThoasSlice',
+  () => ({
+    useGeneOverviewQuery: jest.fn()
+  })
+);
 
 jest.mock('../publications/GenePublications', () => () => (
   <div className="genePublications" />
@@ -66,22 +73,15 @@ const completeGeneData = {
 };
 
 describe('<GeneOverview />', () => {
-  beforeEach(() => {
-    jest.resetAllMocks();
-
-    (useParams as any).mockImplementation(() => ({
-      params: {
-        entityId: geneId,
-        genomeId
-      }
-    }));
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   describe('loading', () => {
     beforeEach(() => {
-      (useQuery as any).mockImplementation(() => ({
+      (useGeneOverviewQuery as any).mockImplementation(() => ({
         data: null,
-        loading: true
+        isLoading: true
       }));
     });
 
@@ -95,9 +95,9 @@ describe('<GeneOverview />', () => {
 
   describe('empty data', () => {
     beforeEach(() => {
-      (useQuery as any).mockImplementation(() => ({
+      (useGeneOverviewQuery as any).mockImplementation(() => ({
         data: null,
-        loading: false
+        isLoading: false
       }));
     });
 
@@ -111,9 +111,9 @@ describe('<GeneOverview />', () => {
 
   describe('full data', () => {
     beforeEach(() => {
-      (useQuery as any).mockImplementation(() => ({
+      (useGeneOverviewQuery as any).mockImplementation(() => ({
         data: { gene: completeGeneData },
-        loading: false
+        isLoading: false
       }));
     });
 
@@ -145,9 +145,10 @@ describe('<GeneOverview />', () => {
   describe('partial data', () => {
     it('renders only stable id if gene symbol is not available', () => {
       const geneData = { ...completeGeneData, symbol: null };
-      (useQuery as any).mockImplementation(() => ({
+
+      (useGeneOverviewQuery as any).mockImplementation(() => ({
         data: { gene: geneData },
-        loading: false
+        isLoading: false
       }));
 
       const { queryByTestId } = render(<GeneOverview />);
@@ -158,9 +159,10 @@ describe('<GeneOverview />', () => {
 
     it('shows that the gene does not have a name', () => {
       const geneData = { ...completeGeneData, name: null };
-      (useQuery as any).mockImplementation(() => ({
+
+      (useGeneOverviewQuery as any).mockImplementation(() => ({
         data: { gene: geneData },
-        loading: false
+        isLoading: false
       }));
 
       const { container } = render(<GeneOverview />);
@@ -171,9 +173,10 @@ describe('<GeneOverview />', () => {
 
     it('shows that the gene does not have synonyms', () => {
       const geneData = { ...completeGeneData, alternative_symbols: [] };
-      (useQuery as any).mockImplementation(() => ({
+
+      (useGeneOverviewQuery as any).mockImplementation(() => ({
         data: { gene: geneData },
-        loading: false
+        isLoading: false
       }));
 
       const { container } = render(<GeneOverview />);

--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
@@ -16,51 +16,21 @@
 
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import { useQuery, gql } from '@apollo/client';
 
 import { parseFocusObjectIdFromUrl } from 'src/shared/helpers/focusObjectHelpers';
 import { getGeneName } from 'src/shared/helpers/formatters/geneFormatter';
 
 import useEntityViewerAnalytics from 'src/content/app/entity-viewer/hooks/useEntityViewerAnalytics';
+import { useGeneOverviewQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
 
 import GenePublications from '../publications/GenePublications';
 import MainAccordion from './MainAccordion';
 import ExternalReference from 'src/shared/components/external-reference/ExternalReference';
 
 import { EntityViewerParams } from 'src/content/app/entity-viewer/EntityViewer';
-import { FullGene } from 'src/shared/types/thoas/gene';
 import { SidebarTabName } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSlice';
 
 import styles from './GeneOverview.scss';
-
-/*  
-  TODO: When more data becomes available
-  Please refer to the PR https://github.com/Ensembl/ensembl-client/pull/422
-  and check if some of the deleted code segments can be reused to display the new data.
-*/
-export const GENE_OVERVIEW_QUERY = gql`
-  query Gene($genomeId: String!, $geneId: String!) {
-    gene(byId: { genome_id: $genomeId, stable_id: $geneId }) {
-      alternative_symbols
-      name
-      stable_id
-      symbol
-      metadata {
-        name {
-          accession_id
-          url
-        }
-      }
-    }
-  }
-`;
-
-type Gene = Required<
-  Pick<
-    FullGene,
-    'stable_id' | 'symbol' | 'name' | 'alternative_symbols' | 'metadata'
-  >
->;
 
 const GeneOverview = () => {
   const params: EntityViewerParams = useParams();
@@ -69,15 +39,17 @@ const GeneOverview = () => {
 
   const { trackExternalReferenceLinkClick } = useEntityViewerAnalytics();
 
-  const { data, loading } = useQuery<{ gene: Gene }>(GENE_OVERVIEW_QUERY, {
-    variables: {
-      geneId,
-      genomeId
+  const { data, isLoading } = useGeneOverviewQuery(
+    {
+      geneId: geneId || '',
+      genomeId: genomeId as string
     },
-    skip: !geneId
-  });
+    {
+      skip: !geneId
+    }
+  );
 
-  if (loading) {
+  if (isLoading) {
     return <div>Loading...</div>;
   }
 

--- a/src/content/app/entity-viewer/gene-view/components/proteins-list/ProteinsList.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/proteins-list/ProteinsList.tsx
@@ -17,7 +17,6 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router';
-import { Pick3 } from 'ts-multipick';
 
 import {
   getLongestProteinLength,
@@ -33,29 +32,24 @@ import {
   getSortingRule
 } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors';
 
-import ProteinsListItem, {
-  Props as ProteinListItemProps
-} from './proteins-list-item/ProteinsListItem';
+import ProteinsListItem from './proteins-list-item/ProteinsListItem';
 
-import { FullGene } from 'src/shared/types/thoas/gene';
-import { FullTranscript } from 'src/shared/types/thoas/transcript';
-import { Exon } from 'src/shared/types/thoas/exon';
+import type { DefaultEntityViewerGeneQueryResult } from 'src/content/app/entity-viewer/state/api/queries/defaultGeneQuery';
 
 import styles from './ProteinsList.scss';
 
-type Transcript = ProteinListItemProps['transcript'] &
-  Pick3<FullTranscript, 'slice', 'location', 'length'> & {
-    spliced_exons: Array<{
-      exon: Pick3<Exon, 'slice', 'location', 'length'>;
-    }>;
-  };
-
-type Gene = Pick<FullGene, 'stable_id' | 'symbol'> & {
-  transcripts: Transcript[];
+type Transcript =
+  DefaultEntityViewerGeneQueryResult['gene']['transcripts'][number];
+export type ProteinCodingTranscript = Transcript & {
+  product_generating_contexts: {
+    product: NonNullable<
+      Transcript['product_generating_contexts'][number]['product']
+    >;
+  }[];
 };
 
 export type ProteinsListProps = {
-  gene: Gene;
+  gene: DefaultEntityViewerGeneQueryResult['gene'];
 };
 
 const ProteinsList = (props: ProteinsListProps) => {
@@ -75,7 +69,7 @@ const ProteinsList = (props: ProteinsListProps) => {
 
   const proteinCodingTranscripts = sortedTranscripts.filter(
     isProteinCodingTranscript
-  ) as Transcript[];
+  ) as ProteinCodingTranscript[];
 
   useExpandedDefaultTranscript({
     geneStableId: props.gene.stable_id,

--- a/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
@@ -42,58 +42,44 @@ import {
   ProteinStats
 } from 'src/content/app/entity-viewer/shared/rest/rest-data-fetchers/proteinData';
 
-import { FullGene } from 'src/shared/types/thoas/gene';
 import { LoadingState } from 'src/shared/types/loading-state';
-import { FullTranscript } from 'src/shared/types/thoas/transcript';
-import { Product } from 'src/shared/types/thoas/product';
 import { ProteinDomain } from 'src/shared/types/thoas/product';
 import { ExternalReference as ExternalReferenceType } from 'src/shared/types/thoas/externalReference';
 
 import { SWISSPROT_SOURCE } from 'src/content/app/entity-viewer/gene-view/components/proteins-list/protein-list-constants';
 
+import type { DefaultEntityViewerGeneQueryResult } from 'src/content/app/entity-viewer/state/api/queries/defaultGeneQuery';
+import type { ProteinCodingTranscript } from 'src/content/app/entity-viewer/gene-view/components/proteins-list/ProteinsList';
+
 import styles from './ProteinsListItemInfo.scss';
 import settings from 'src/content/app/entity-viewer/gene-view/styles/_constants.scss';
 
-export type ProductWithoutDomains = Pick<
-  Product,
-  'length' | 'unversioned_stable_id'
-> & {
-  external_references: Array<
-    Pick<ExternalReferenceType, 'accession_id' | 'name'> &
-      Pick2<ExternalReferenceType, 'source', 'id'>
-  >;
-};
+type ProductWithoutDomains = NonNullable<
+  DefaultEntityViewerGeneQueryResult['gene']['transcripts'][number]['product_generating_contexts'][number]['product']
+>;
 
 type ProductWithDomains = ProductWithoutDomains & {
   protein_domains: ProteinDomain[];
 };
 
-type Gene = Pick<FullGene, 'symbol' | 'stable_id'>;
-
-type Transcript = Pick<FullTranscript, 'unversioned_stable_id'> & {
-  product_generating_contexts: Array<{
-    product: ProductWithoutDomains;
-  }>;
-};
-
-type TranscriptWithProteinDomains = Transcript & {
+type TranscriptWithProteinDomains = ProteinCodingTranscript & {
   product_generating_contexts: Array<
-    Transcript['product_generating_contexts'][number] & {
+    ProteinCodingTranscript['product_generating_contexts'][number] & {
       product: ProductWithDomains;
     }
   >;
 };
 
 export type Props = {
-  gene: Gene;
-  transcript: Transcript;
+  gene: DefaultEntityViewerGeneQueryResult['gene'];
+  transcript: ProteinCodingTranscript;
   trackLength: number;
 };
 
 const gene_image_width = Number(settings.gene_image_width);
 
 const addProteinDomains = (
-  transcript: Transcript,
+  transcript: ProteinCodingTranscript,
   proteinDomains: ProteinDomain[]
 ) => {
   return set(

--- a/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item/ProteinsListItem.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item/ProteinsListItem.tsx
@@ -19,7 +19,6 @@ import { useSelector, useDispatch } from 'react-redux';
 import { useLocation, useParams } from 'react-router';
 import { replace } from 'connected-react-router';
 import classNames from 'classnames';
-import { Pick2 } from 'ts-multipick';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import { getProductAminoAcidLength } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
@@ -29,46 +28,24 @@ import useEntityViewerAnalytics from 'src/content/app/entity-viewer/hooks/useEnt
 import { getExpandedTranscriptIds } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors';
 import { toggleTranscriptInfo } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 
-import ProteinsListItemInfo, {
-  Props as ProteinsListItemInfoProps
-} from '../proteins-list-item-info/ProteinsListItemInfo';
+import ProteinsListItemInfo from '../proteins-list-item-info/ProteinsListItemInfo';
 import {
   TranscriptQualityLabel,
   getTranscriptMetadata as getTranscriptQualityMetadata
 } from 'src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel';
-import { FullTranscript } from 'src/shared/types/thoas/transcript';
-import { FullProductGeneratingContext } from 'src/shared/types/thoas/productGeneratingContext';
-import { Product as FullProduct } from 'src/shared/types/thoas/product';
-import { ExternalReference as FullExternalReference } from 'src/shared/types/thoas/externalReference';
 import { View } from 'src/content/app/entity-viewer/state/gene-view/view/geneViewViewSlice';
 
 import { SWISSPROT_SOURCE } from '../protein-list-constants';
 
+import type { DefaultEntityViewerGeneQueryResult } from 'src/content/app/entity-viewer/state/api/queries/defaultGeneQuery';
+import type { ProteinCodingTranscript } from 'src/content/app/entity-viewer/gene-view/components/proteins-list/ProteinsList';
+
 import transcriptsListStyles from 'src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.scss';
 import styles from './ProteinsListItem.scss';
 
-type Product = Pick<
-  FullProduct,
-  'stable_id' | 'length' | 'unversioned_stable_id'
-> & {
-  external_references: Array<
-    Pick<FullExternalReference, 'accession_id' | 'name' | 'description'> &
-      Pick2<FullExternalReference, 'source', 'id'>
-  >;
-};
-
-type Transcript = Pick<FullTranscript, 'stable_id' | 'metadata'> &
-  ProteinsListItemInfoProps['transcript'] & {
-    product_generating_contexts: Array<
-      Pick<FullProductGeneratingContext, 'product_type'> & {
-        product: Product;
-      }
-    >;
-  };
-
 export type Props = {
-  gene: ProteinsListItemInfoProps['gene'];
-  transcript: Transcript;
+  gene: DefaultEntityViewerGeneQueryResult['gene'];
+  transcript: ProteinCodingTranscript;
   trackLength: number;
   index: number; // <-- ranking in the list created by the parent component, 0-based
 };
@@ -114,7 +91,7 @@ const ProteinsListItem = (props: Props) => {
   const itemRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    if (product.stable_id === proteinIdToFocus) {
+    if (product?.stable_id === proteinIdToFocus) {
       setTimeout(() => {
         itemRef.current?.scrollIntoView({
           behavior: 'smooth'
@@ -128,9 +105,8 @@ const ProteinsListItem = (props: Props) => {
   }, [proteinIdToFocus]);
 
   const getProteinDescription = () => {
-    const swissprotReference = product.external_references.find(
-      (reference: Product['external_references'][number]) =>
-        reference.source.id === SWISSPROT_SOURCE
+    const swissprotReference = product?.external_references.find(
+      (reference) => reference.source.id === SWISSPROT_SOURCE
     );
 
     return swissprotReference?.description;

--- a/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
@@ -17,7 +17,6 @@
 import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import classNames from 'classnames';
-import { Pick2 } from 'ts-multipick';
 
 import useEntityViewerAnalytics from 'src/content/app/entity-viewer/hooks/useEntityViewerAnalytics';
 
@@ -43,15 +42,20 @@ import Checkbox from 'src/shared/components/checkbox/Checkbox';
 
 import CloseButton from 'src/shared/components/close-button/CloseButton';
 
-import { FullTranscript } from 'src/shared/types/thoas/transcript';
+import { TranscriptMetadata } from 'src/shared/types/thoas/metadata';
 
 import styles from './TranscriptsFilter.scss';
 
-type Transcript = Pick2<
-  FullTranscript,
-  'metadata',
-  'biotype' | 'tsl' | 'appris'
->;
+type Transcript = {
+  metadata: {
+    biotype: TranscriptMetadata['biotype'];
+    tsl: Pick<NonNullable<TranscriptMetadata['tsl']>, 'label' | 'value'> | null;
+    appris: Pick<
+      NonNullable<TranscriptMetadata['appris']>,
+      'label' | 'value'
+    > | null;
+  };
+};
 
 type Props = {
   transcripts: Transcript[];

--- a/src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript.tsx
@@ -17,7 +17,7 @@
 import React, { ReactNode } from 'react';
 import classNames from 'classnames';
 import { scaleLinear, ScaleLinear } from 'd3';
-import { Pick3 } from 'ts-multipick';
+import { Pick2, Pick3 } from 'ts-multipick';
 
 import { FullTranscript } from 'src/shared/types/thoas/transcript';
 import { SplicedExon } from 'src/shared/types/thoas/exon';
@@ -28,10 +28,12 @@ import styles from './UnsplicedTranscript.scss';
 const BLOCK_HEIGHT = 7;
 
 type ProductGeneratingContext = {
-  cds: Pick<FullCDS, 'relative_start' | 'relative_end'>;
+  cds: Pick<FullCDS, 'relative_start' | 'relative_end'> | null;
 };
 type Transcript = {
-  spliced_exons: Array<Pick<SplicedExon, 'relative_location'>>;
+  spliced_exons: Array<
+    Pick2<SplicedExon, 'relative_location', 'start' | 'end'>
+  >;
   product_generating_contexts: ProductGeneratingContext[];
 } & Pick3<FullTranscript, 'slice', 'location', 'length'>;
 
@@ -197,7 +199,7 @@ const ExonBlock = (props: ExonBlockProps) => {
 const getLength = (start: number, end: number) => end - start + 1;
 
 type CalculateExonRectanglesParams = {
-  spliced_exons: Pick<SplicedExon, 'relative_location'>[];
+  spliced_exons: Pick2<SplicedExon, 'relative_location', 'start' | 'end'>[];
   cds?: {
     relative_start: number;
     relative_end: number;

--- a/src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel.tsx
+++ b/src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel.tsx
@@ -22,8 +22,17 @@ import { TranscriptMetadata } from 'src/shared/types/thoas/metadata';
 
 import styles from './TranscriptQualityLabel.scss';
 
-type Props = {
-  metadata: Pick<TranscriptMetadata, 'canonical' | 'mane'>;
+export type Props = {
+  metadata: {
+    canonical: Pick<
+      NonNullable<TranscriptMetadata['canonical']>,
+      'label' | 'definition'
+    > | null;
+    mane: Pick<
+      NonNullable<TranscriptMetadata['mane']>,
+      'label' | 'definition'
+    > | null;
+  };
 };
 
 export const getTranscriptMetadata = (props: Props) => {

--- a/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerDownloads.tsx
+++ b/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerDownloads.tsx
@@ -16,7 +16,8 @@
 
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { gql, useQuery } from '@apollo/client';
+
+import { useGeneForSequenceDownloadQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
 
 import {
   getEntityViewerActiveEntityId,
@@ -32,40 +33,24 @@ import InstantDownloadGene, {
   OnDownloadPayload
 } from 'src/shared/components/instant-download/instant-download-gene/InstantDownloadGene';
 
-import { FullProductGeneratingContext } from 'src/shared/types/thoas/productGeneratingContext';
-
-const QUERY = gql`
-  query Gene($genomeId: String!, $entityId: String!) {
-    gene(byId: { genome_id: $genomeId, stable_id: $entityId }) {
-      stable_id
-      transcripts {
-        product_generating_contexts {
-          product_type
-        }
-      }
-    }
-  }
-`;
-
-type Transcript = {
-  product_generating_contexts: Pick<
-    FullProductGeneratingContext,
-    'product_type'
-  >[];
-};
-
 const EntityViewerSidebarDownloads = () => {
   const genomeId = useSelector(getEntityViewerActiveGenomeId);
-  const geneId = useSelector(getEntityViewerActiveEntityId);
+  const activeEntityId = useSelector(getEntityViewerActiveEntityId);
   const { trackGeneDownload } = useEntityViewerAnalytics();
 
-  const entityId = geneId ? parseFocusObjectId(geneId).objectId : null;
+  const geneId = activeEntityId
+    ? parseFocusObjectId(activeEntityId).objectId
+    : null;
 
-  const { data } = useQuery<{
-    gene: { stable_id: string; transcripts: Transcript[] };
-  }>(QUERY, {
-    variables: { genomeId, entityId }
-  });
+  const { data } = useGeneForSequenceDownloadQuery(
+    {
+      genomeId: genomeId || '',
+      geneId: geneId || ''
+    },
+    {
+      skip: !genomeId || !geneId
+    }
+  );
 
   if (!data) {
     return null;

--- a/src/content/app/entity-viewer/shared/components/entity-viewer-topbar/EntityViewerTopbar.tsx
+++ b/src/content/app/entity-viewer/shared/components/entity-viewer-topbar/EntityViewerTopbar.tsx
@@ -15,12 +15,12 @@
  */
 
 import React from 'react';
-import { useQuery, gql } from '@apollo/client';
+
+import { useGeneSummaryQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
 
 import { GeneSummaryStrip } from 'src/shared/components/feature-summary-strip';
 
-import { Slice } from 'src/shared/types/thoas/slice';
-import { GeneMetadata } from 'src/shared/types/thoas/metadata';
+import type { GeneSummary } from 'src/content/app/entity-viewer/state/api/queries/geneSummaryQuery';
 
 import styles from './EntityViewerTopbar.scss';
 
@@ -29,47 +29,10 @@ export type EntityViewerTopbarProps = {
   entityId: string;
 };
 
-const QUERY = gql`
-  query Gene($genomeId: String!, $entityId: String!) {
-    gene(byId: { genome_id: $genomeId, stable_id: $entityId }) {
-      stable_id
-      unversioned_stable_id
-      symbol
-      slice {
-        location {
-          start
-          end
-        }
-        strand {
-          code
-        }
-        region {
-          name
-        }
-      }
-      metadata {
-        biotype {
-          label
-        }
-      }
-    }
-  }
-`;
-
-type Gene = {
-  stable_id: string;
-  unversioned_stable_id: string;
-  symbol: string;
-  metadata: GeneMetadata;
-  slice: Slice;
-};
-
 export const EntityViewerTopbar = (props: EntityViewerTopbarProps) => {
   const { genomeId } = props;
-  const entityId = props.entityId.split(':').pop();
-  const { data } = useQuery<{ gene: Gene }>(QUERY, {
-    variables: { entityId, genomeId }
-  });
+  const entityId = props.entityId.split(':').pop() as string;
+  const { data } = useGeneSummaryQuery({ geneId: entityId, genomeId });
 
   return (
     <div className={styles.container}>
@@ -81,11 +44,11 @@ export const EntityViewerTopbar = (props: EntityViewerTopbarProps) => {
 };
 
 // NOTE: temporary adaptor
-const geneToFocusObjectFields = (gene: Gene) => {
+const geneToFocusObjectFields = (gene: GeneSummary) => {
   return {
     stable_id: gene.unversioned_stable_id,
     versioned_stable_id: gene.stable_id,
-    label: gene.symbol,
+    label: gene.symbol ?? '',
     bio_type: gene.metadata.biotype.label,
     strand: gene.slice.strand.code,
     location: {

--- a/src/content/app/entity-viewer/shared/helpers/transcripts-filter.ts
+++ b/src/content/app/entity-viewer/shared/helpers/transcripts-filter.ts
@@ -16,15 +16,15 @@
 
 import { Filters } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 
-import { FullTranscript } from 'src/shared/types/thoas/transcript';
-import { Pick2 } from 'ts-multipick';
 import { metadataFields } from '../../gene-view/components/transcripts-filter/TranscriptsFilter';
 
-type Transcript = Pick2<
-  FullTranscript,
-  'metadata',
-  'biotype' | 'tsl' | 'appris'
->;
+type Transcript = {
+  metadata: {
+    biotype: { value: string } | null;
+    tsl: { value: string } | null;
+    appris: { value: string } | null;
+  };
+};
 
 export function filterTranscripts<T extends Transcript>(
   transcripts: T[],

--- a/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
+++ b/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
@@ -1,0 +1,92 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import thoasApiSlice from 'src/shared/state/api-slices/thoasSlice';
+
+import {
+  defaultGeneQuery,
+  type DefaultEntityViewerGeneQueryResult
+} from './queries/defaultGeneQuery';
+import {
+  geneSummaryQuery,
+  type GeneSummaryQueryResult
+} from './queries/geneSummaryQuery';
+import {
+  geneExternalReferencesQuery,
+  GeneExternalReferencesQueryResult
+} from './queries/geneExternalReferencesQuery';
+import {
+  geneOverviewQuery,
+  GeneOverviewQueryResult
+} from './queries/geneOverviewQuery';
+import {
+  geneForSequenceDownloadQuery,
+  GeneForSequenceDownloadQueryResult
+} from './queries/geneForSequenceDownloadQuery';
+
+type GeneQueryParams = { genomeId: string; geneId: string };
+
+const entityViewerThoasSlice = thoasApiSlice.injectEndpoints({
+  endpoints: (builder) => ({
+    defaultEntityViewerGene: builder.query<
+      DefaultEntityViewerGeneQueryResult,
+      GeneQueryParams
+    >({
+      query: (params) => ({
+        body: defaultGeneQuery,
+        variables: params
+      })
+    }),
+    geneSummary: builder.query<GeneSummaryQueryResult, GeneQueryParams>({
+      query: (params) => ({
+        body: geneSummaryQuery,
+        variables: params
+      })
+    }),
+    geneOverview: builder.query<GeneOverviewQueryResult, GeneQueryParams>({
+      query: (params) => ({
+        body: geneOverviewQuery,
+        variables: params
+      })
+    }),
+    geneExternalReferences: builder.query<
+      GeneExternalReferencesQueryResult,
+      GeneQueryParams
+    >({
+      query: (params) => ({
+        body: geneExternalReferencesQuery,
+        variables: params
+      })
+    }),
+    geneForSequenceDownload: builder.query<
+      GeneForSequenceDownloadQueryResult,
+      GeneQueryParams
+    >({
+      query: (params) => ({
+        body: geneForSequenceDownloadQuery,
+        variables: params
+      })
+    })
+  })
+});
+
+export const {
+  useDefaultEntityViewerGeneQuery,
+  useGeneSummaryQuery,
+  useGeneOverviewQuery,
+  useGeneExternalReferencesQuery,
+  useGeneForSequenceDownloadQuery
+} = entityViewerThoasSlice;

--- a/src/content/app/entity-viewer/state/api/queries/defaultGeneQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/defaultGeneQuery.ts
@@ -1,0 +1,258 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from 'graphql-request';
+import { Pick2, Pick3, Pick4 } from 'ts-multipick';
+
+import type { FullGene } from 'src/shared/types/thoas/gene';
+import type { FullTranscript } from 'src/shared/types/thoas/transcript';
+import type { SplicedExon, PhasedExon } from 'src/shared/types/thoas/exon';
+import type { FullProductGeneratingContext } from 'src/shared/types/thoas/productGeneratingContext';
+import type { Product } from 'src/shared/types/thoas/product';
+import type { TranscriptMetadata } from 'src/shared/types/thoas/metadata';
+
+export const defaultGeneQuery = gql`
+  query DefaultEntityViewerGene($genomeId: String!, $geneId: String!) {
+    gene(byId: { genome_id: $genomeId, stable_id: $geneId }) {
+      stable_id
+      symbol
+      unversioned_stable_id
+      version
+      slice {
+        location {
+          start
+          end
+          length
+        }
+        strand {
+          code
+        }
+      }
+      transcripts {
+        stable_id
+        unversioned_stable_id
+        slice {
+          location {
+            start
+            end
+            length
+          }
+          region {
+            name
+          }
+          strand {
+            code
+          }
+        }
+        relative_location {
+          start
+          end
+        }
+        spliced_exons {
+          relative_location {
+            start
+            end
+          }
+          exon {
+            stable_id
+            slice {
+              location {
+                length
+              }
+            }
+          }
+        }
+        product_generating_contexts {
+          product_type
+          cds {
+            relative_start
+            relative_end
+          }
+          cdna {
+            length
+          }
+          phased_exons {
+            start_phase
+            end_phase
+            exon {
+              stable_id
+            }
+          }
+          product {
+            stable_id
+            unversioned_stable_id
+            length
+            external_references {
+              accession_id
+              name
+              description
+              source {
+                id
+              }
+            }
+          }
+        }
+        external_references {
+          accession_id
+          name
+          url
+          source {
+            id
+            name
+          }
+        }
+        metadata {
+          biotype {
+            label
+            value
+            definition
+          }
+          tsl {
+            label
+            value
+          }
+          appris {
+            label
+            value
+          }
+          canonical {
+            value
+            label
+            definition
+          }
+          mane {
+            value
+            label
+            definition
+            ncbi_transcript {
+              id
+              url
+            }
+          }
+          gencode_basic {
+            label
+          }
+        }
+      }
+    }
+  }
+`;
+
+type GeneFields = Pick<
+  FullGene,
+  'stable_id' | 'unversioned_stable_id' | 'symbol' | 'version'
+>;
+type GeneSlice = Pick2<FullGene, 'slice', 'location'> &
+  Pick3<FullGene, 'slice', 'strand', 'code'>;
+
+type SplicedExonOnDefaultTranscript = Pick2<
+  SplicedExon,
+  'relative_location',
+  'start' | 'end'
+> &
+  Pick2<SplicedExon, 'exon', 'stable_id'> &
+  Pick4<SplicedExon, 'exon', 'slice', 'location', 'length'>;
+
+type PhasedExonOfDefaultTranscript = Pick<
+  PhasedExon,
+  'start_phase' | 'end_phase'
+> &
+  Pick2<PhasedExon, 'exon', 'stable_id'>;
+
+type ProductOnDefaultTranscript = Pick<
+  Product,
+  'stable_id' | 'unversioned_stable_id' | 'length'
+> & {
+  external_references: ExternalReferenceInProduct[];
+};
+
+type ExternalReferenceInProduct = Pick<
+  Product['external_references'][number],
+  'accession_id' | 'name' | 'description'
+> &
+  Pick2<Product['external_references'][number], 'source', 'id'>;
+
+type TranscriptExternalReference = Pick<
+  FullTranscript['external_references'][number],
+  'accession_id' | 'name' | 'url'
+> &
+  Pick2<FullTranscript['external_references'][number], 'source', 'name' | 'id'>;
+
+type ProductGeneratingContextOnDefaultTranscript = Pick<
+  FullProductGeneratingContext,
+  'product_type'
+> & {
+  cds: {
+    relative_start: NonNullable<
+      FullProductGeneratingContext['cds']
+    >['relative_start'];
+    relative_end: NonNullable<
+      FullProductGeneratingContext['cds']
+    >['relative_end'];
+  } | null;
+  cdna: {
+    length: NonNullable<FullProductGeneratingContext['cdna']>['length'];
+  } | null;
+  phased_exons: PhasedExonOfDefaultTranscript[];
+  product: ProductOnDefaultTranscript | null;
+};
+
+type DefaultEntityViewerTranscript = Pick<
+  FullTranscript,
+  'stable_id' | 'unversioned_stable_id'
+> &
+  Pick2<FullTranscript, 'slice', 'location'> &
+  Pick3<FullTranscript, 'slice', 'region', 'name'> &
+  Pick3<FullTranscript, 'slice', 'strand', 'code'> &
+  Pick2<FullTranscript, 'relative_location', 'start' | 'end'> & {
+    spliced_exons: SplicedExonOnDefaultTranscript[];
+    external_references: TranscriptExternalReference[];
+    product_generating_contexts: ProductGeneratingContextOnDefaultTranscript[];
+    metadata: DefaultEntityViewerTranscriptMetadata;
+  };
+
+type DefaultEntityViewerTranscriptMetadata = Pick2<
+  TranscriptMetadata,
+  'biotype',
+  'label' | 'value' | 'definition'
+> & {
+  tsl: Pick<NonNullable<TranscriptMetadata['tsl']>, 'label' | 'value'> | null;
+  appris: Pick<
+    NonNullable<TranscriptMetadata['appris']>,
+    'label' | 'value'
+  > | null;
+  gencode_basic: Pick<
+    NonNullable<TranscriptMetadata['gencode_basic']>,
+    'label'
+  > | null;
+  canonical: Pick<
+    NonNullable<TranscriptMetadata['canonical']>,
+    'label' | 'value' | 'definition'
+  > | null;
+  mane: Pick<
+    NonNullable<TranscriptMetadata['mane']>,
+    'label' | 'value' | 'definition' | 'ncbi_transcript'
+  > | null;
+};
+
+type DefaultEntityViewerGene = GeneFields &
+  GeneSlice & {
+    transcripts: DefaultEntityViewerTranscript[];
+  };
+
+export type DefaultEntityViewerGeneQueryResult = {
+  gene: DefaultEntityViewerGene;
+};

--- a/src/content/app/entity-viewer/state/api/queries/geneExternalReferencesQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/geneExternalReferencesQuery.ts
@@ -1,0 +1,123 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from 'graphql-request';
+import { Pick2, Pick3 } from 'ts-multipick';
+
+import type { FullGene } from 'src/shared/types/thoas/gene';
+import type { FullTranscript } from 'src/shared/types/thoas/transcript';
+import type { FullProductGeneratingContext } from 'src/shared/types/thoas/productGeneratingContext';
+import type { TranscriptMetadata } from 'src/shared/types/thoas/metadata';
+import type { ExternalReference } from 'src/shared/types/thoas/externalReference';
+
+export const geneExternalReferencesQuery = gql`
+  query GeneExternalReferences($geneId: String!, $genomeId: String!) {
+    gene(byId: { stable_id: $geneId, genome_id: $genomeId }) {
+      stable_id
+      symbol
+      external_references {
+        accession_id
+        name
+        description
+        url
+        source {
+          id
+          name
+        }
+      }
+      transcripts {
+        stable_id
+        slice {
+          location {
+            length
+          }
+        }
+        external_references {
+          accession_id
+          name
+          description
+          url
+          source {
+            id
+            name
+          }
+        }
+        product_generating_contexts {
+          product_type
+          product {
+            external_references {
+              accession_id
+              name
+              description
+              url
+              source {
+                id
+                name
+              }
+            }
+          }
+        }
+        metadata {
+          canonical {
+            value
+          }
+          mane {
+            value
+          }
+        }
+      }
+    }
+  }
+`;
+
+export type QueriedExternalReference = Pick<
+  ExternalReference,
+  'accession_id' | 'name' | 'description' | 'url'
+> &
+  Pick2<ExternalReference, 'source', 'id' | 'name'>;
+
+export type QueriedTranscript = Pick<FullTranscript, 'stable_id'> &
+  Pick3<FullTranscript, 'slice', 'location', 'length'> & {
+    metadata: {
+      canonical: Pick<
+        NonNullable<TranscriptMetadata['canonical']>,
+        'label' | 'value' | 'definition'
+      > | null;
+      mane: Pick<NonNullable<TranscriptMetadata['mane']>, 'value'> | null;
+    };
+    external_references: QueriedExternalReference[];
+    product_generating_contexts: QueriedProductGeneratingContext[];
+  };
+
+type QueriedProductGeneratingContext = Pick<
+  FullProductGeneratingContext,
+  'product_type'
+> & {
+  product: QueriedProduct;
+};
+
+type QueriedProduct = {
+  external_references: QueriedExternalReference[];
+};
+
+type QueriedGene = Pick<FullGene, 'stable_id' | 'symbol'> & {
+  external_references: QueriedExternalReference[];
+  transcripts: QueriedTranscript[];
+};
+
+export type GeneExternalReferencesQueryResult = {
+  gene: QueriedGene;
+};

--- a/src/content/app/entity-viewer/state/api/queries/geneForSequenceDownloadQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/geneForSequenceDownloadQuery.ts
@@ -1,0 +1,46 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from 'graphql-request';
+
+import type { FullGene } from 'src/shared/types/thoas/gene';
+import type { FullProductGeneratingContext } from 'src/shared/types/thoas/productGeneratingContext';
+
+export const geneForSequenceDownloadQuery = gql`
+  query GeneForSequenceDownload($genomeId: String!, $geneId: String!) {
+    gene(byId: { genome_id: $genomeId, stable_id: $geneId }) {
+      stable_id
+      transcripts {
+        product_generating_contexts {
+          product_type
+        }
+      }
+    }
+  }
+`;
+
+export type GeneForSequenceDownload = Pick<FullGene, 'stable_id'> & {
+  transcripts: {
+    product_generating_contexts: Pick<
+      FullProductGeneratingContext,
+      'product_type'
+    >[];
+  }[];
+};
+
+export type GeneForSequenceDownloadQueryResult = {
+  gene: GeneForSequenceDownload;
+};

--- a/src/content/app/entity-viewer/state/api/queries/geneOverviewQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/geneOverviewQuery.ts
@@ -1,0 +1,54 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from 'graphql-request';
+
+import type { FullGene } from 'src/shared/types/thoas/gene';
+
+// This query is intended to populate the right-hand sidebar for the gene view
+// It looks very similar to geneSummaryQuery; but has a potential of becoming heavier
+export const geneOverviewQuery = gql`
+  query GeneOverview($genomeId: String!, $geneId: String!) {
+    gene(byId: { genome_id: $genomeId, stable_id: $geneId }) {
+      alternative_symbols
+      name
+      stable_id
+      symbol
+      metadata {
+        name {
+          accession_id
+          url
+        }
+      }
+    }
+  }
+`;
+
+export type GeneOverview = Pick<
+  FullGene,
+  'alternative_symbols' | 'name' | 'stable_id' | 'symbol'
+> & {
+  metadata: {
+    name: Pick<
+      NonNullable<FullGene['metadata']['name']>,
+      'accession_id' | 'url'
+    > | null;
+  };
+};
+
+export type GeneOverviewQueryResult = {
+  gene: GeneOverview;
+};

--- a/src/content/app/entity-viewer/state/api/queries/geneSummaryQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/geneSummaryQuery.ts
@@ -1,0 +1,62 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from 'graphql-request';
+import { Pick3 } from 'ts-multipick';
+
+import type { FullGene } from 'src/shared/types/thoas/gene';
+
+// A light query to get brief information about a gene.
+// Useful for populating the top bar and example links in the interstitial.
+export const geneSummaryQuery = gql`
+  query GeneSummary($genomeId: String!, $geneId: String!) {
+    gene(byId: { genome_id: $genomeId, stable_id: $geneId }) {
+      stable_id
+      unversioned_stable_id
+      symbol
+      slice {
+        location {
+          start
+          end
+        }
+        strand {
+          code
+        }
+        region {
+          name
+        }
+      }
+      metadata {
+        biotype {
+          label
+        }
+      }
+    }
+  }
+`;
+
+export type GeneSummary = Pick<
+  FullGene,
+  'stable_id' | 'unversioned_stable_id' | 'symbol'
+> &
+  Pick3<FullGene, 'slice', 'location', 'start' | 'end'> &
+  Pick3<FullGene, 'slice', 'strand', 'code'> &
+  Pick3<FullGene, 'slice', 'region', 'name'> &
+  Pick3<FullGene, 'metadata', 'biotype', 'label'>;
+
+export type GeneSummaryQueryResult = {
+  gene: GeneSummary;
+};

--- a/src/content/app/genome-browser/state/genomeBrowserApiSlice.ts
+++ b/src/content/app/genome-browser/state/genomeBrowserApiSlice.ts
@@ -14,35 +14,15 @@
  * limitations under the License.
  */
 
-import { createApi } from '@reduxjs/toolkit/query/react';
-import { request, ClientError } from 'graphql-request';
+import thoasApiSlice from 'src/shared/state/api-slices/thoasSlice';
 
 import trackPanelGeneQuery from './queries/trackPanelGeneQuery';
 
 import type { TrackPanelGene } from './types/track-panel-gene';
 
-// FIXME: move some place more generic
-const graphqlBaseQuery =
-  ({ baseUrl }: { baseUrl: string }) =>
-  async ({ body }: { body: string }) => {
-    try {
-      const result = await request(baseUrl, body);
-      return { data: result };
-    } catch (error) {
-      if (error instanceof ClientError) {
-        return { error: { status: error.response.status, data: error } };
-      }
-      return { error: { status: 500, data: error } };
-    }
-  };
-
 type GeneQueryParams = { genomeId: string; geneId: string };
 
-export const genomeBrowserApiSlice = createApi({
-  reducerPath: 'genomeBrowserApi',
-  baseQuery: graphqlBaseQuery({
-    baseUrl: '/api/thoas'
-  }),
+const genomeBrowserApiSlice = thoasApiSlice.injectEndpoints({
   endpoints: (builder) => ({
     getTrackPanelGene: builder.query<{ gene: TrackPanelGene }, GeneQueryParams>(
       {

--- a/src/root/rootReducer.ts
+++ b/src/root/rootReducer.ts
@@ -18,7 +18,7 @@ import { combineReducers } from 'redux';
 import { connectRouter } from 'connected-react-router';
 
 import browser from 'src/content/app/genome-browser/state/genomeBrowserReducer';
-import { genomeBrowserApiSlice } from 'src/content/app/genome-browser/state/genomeBrowserApiSlice';
+import thoasApiSlice from 'src/shared/state/api-slices/thoasSlice';
 import genome from 'src/shared/state/genome/genomeSlice';
 import customDownload from 'src/content/app/custom-download/state/customDownloadReducer';
 import global from 'src/global/globalSlice';
@@ -41,7 +41,7 @@ const createRootReducer = (history: any) =>
     speciesPage,
     entityViewer,
 
-    [genomeBrowserApiSlice.reducerPath]: genomeBrowserApiSlice.reducer
+    [thoasApiSlice.reducerPath]: thoasApiSlice.reducer
   });
 
 export const createServerSideRootReducer = () =>

--- a/src/shared/state/api-slices/thoasSlice.ts
+++ b/src/shared/state/api-slices/thoasSlice.ts
@@ -1,0 +1,46 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createApi } from '@reduxjs/toolkit/query/react';
+import { request, ClientError } from 'graphql-request';
+
+const graphqlBaseQuery =
+  ({ baseUrl }: { baseUrl: string }) =>
+  async ({
+    body,
+    variables = {}
+  }: {
+    body: string;
+    variables?: Record<string, string | number | boolean>;
+  }) => {
+    try {
+      const result = await request(baseUrl, body, variables);
+      return { data: result };
+    } catch (error) {
+      if (error instanceof ClientError) {
+        return { error: { status: error.response.status, data: error } };
+      }
+      return { error: { status: 500, data: error } };
+    }
+  };
+
+export default createApi({
+  reducerPath: 'thoasApi',
+  baseQuery: graphqlBaseQuery({
+    baseUrl: '/api/thoas'
+  }),
+  endpoints: () => ({}) // will inject endpoints in other files
+});

--- a/src/store.ts
+++ b/src/store.ts
@@ -22,7 +22,7 @@ import { createEpicMiddleware } from 'redux-observable';
 
 import config from 'config';
 
-import { genomeBrowserApiSlice } from './content/app/genome-browser/state/genomeBrowserApiSlice';
+import thoasApiSlice from 'src/shared/state/api-slices/thoasSlice';
 
 import createRootReducer from './root/rootReducer';
 import { analyticsMiddleWare } from './analyticsMiddleware';
@@ -40,7 +40,7 @@ const middleware = [
   routerMiddleware(history),
   epicMiddleware,
   analyticsMiddleWare,
-  genomeBrowserApiSlice.middleware
+  thoasApiSlice.middleware
 ];
 
 const preloadedState = (window as any).__PRELOADED_STATE__ || {};


### PR DESCRIPTION
## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1384

## Description
After some consideration, we decided that requx-toolkit query may be a better data fetching option than apollo client for ensembl-client, because:
- we use different kinds of apis, whereas apollo focuses on graphql apis
- we are already using redux for global state management

This PR is switching the Entity Viewer from apollo client to redux-toolkit query. 

## Deployment URL
http://redux-toolkit-for-entity-viewer.review.ensembl.org

## Views affected
Entity viewer pages