### PR TITLE
Fetch focus object while bootstrapping genome browser page

### DIFF
--- a/src/content/app/genome-browser/Browser.tsx
+++ b/src/content/app/genome-browser/Browser.tsx
@@ -120,7 +120,7 @@ export const Browser = () => {
 
 type GenomeBrowserContextType = {
   genomeBrowser: EnsemblGenomeBrowser | null;
-  setGenomeBrowser: (genomeBrowser: EnsemblGenomeBrowser) => void;
+  setGenomeBrowser: (genomeBrowser: EnsemblGenomeBrowser | null) => void;
   zmenus: StateZmenu;
   setZmenus: (zmenus: StateZmenu) => void;
 };

--- a/src/content/app/genome-browser/components/browser-image/BrowserImage.tsx
+++ b/src/content/app/genome-browser/components/browser-image/BrowserImage.tsx
@@ -48,7 +48,8 @@ import styles from './BrowserImage.scss';
 export const BrowserImage = () => {
   const browserRef = useRef<HTMLDivElement>(null);
 
-  const { activateGenomeBrowser, genomeBrowser } = useGenomeBrowser();
+  const { activateGenomeBrowser, clearGenomeBrowser, genomeBrowser } =
+    useGenomeBrowser();
 
   const isNavbarOpen = useSelector(getBrowserNavOpenState);
   const isRegionEditorActive = useSelector(getRegionEditorActive);
@@ -94,6 +95,8 @@ export const BrowserImage = () => {
     if (!genomeBrowser) {
       activateGenomeBrowser();
     }
+
+    return () => clearGenomeBrowser();
   }, []);
 
   const browserContainerClassNames = classNames(styles.browserStage, {

--- a/src/content/app/genome-browser/hooks/useBrowserRouting.ts
+++ b/src/content/app/genome-browser/hooks/useBrowserRouting.ts
@@ -39,13 +39,18 @@ import {
   setActiveGenomeId,
   setDataFromUrlAndSave
 } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSlice';
+import { fetchFocusObject } from 'src/content/app/genome-browser/state/focus-object/focusObjectSlice';
+
 import { getEnabledCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 import {
   getBrowserActiveGenomeId,
   getBrowserActiveFocusObjectIds
 } from '../state/browser-general/browserGeneralSelectors';
+import { getFocusObjectById } from 'src/content/app/genome-browser/state/focus-object/focusObjectSelectors';
 
 import { getAllChrLocations } from '../state/browser-general/browserGeneralSelectors';
+
+import { RootState } from 'src/store';
 
 /*
  * Possible urls that the GenomeBrowser page has to deal with:
@@ -79,6 +84,10 @@ const useBrowserRouting = () => {
   const activeFocusObjectId = genomeId
     ? allActiveFocusObjectIds[genomeId]
     : null;
+  const focusObject = useSelector((state: RootState) =>
+    getFocusObjectById(state, activeFocusObjectId || '')
+  );
+
   const newFocusId = focus ? buildNewFocusObjectId(genomeId, focus) : null;
   const chrLocation = location ? getChrLocationFromStr(location) : null;
   const { genomeBrowser, changeFocusObject, changeBrowserLocation } =
@@ -154,6 +163,12 @@ const useBrowserRouting = () => {
       dispatch(fetchGenomeData(genomeId));
     }
   }, [genomeId]);
+
+  useEffect(() => {
+    if (!focusObject && activeFocusObjectId) {
+      dispatch(fetchFocusObject(activeFocusObjectId));
+    }
+  }, [focusObject, activeFocusObjectId]);
 
   const changeGenomeId = useCallback(
     (genomeId: string) => {

--- a/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { useContext } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import get from 'lodash/get';
 import EnsemblGenomeBrowser, {
   OutgoingAction,
@@ -35,8 +35,6 @@ import {
   getBrowserActiveFocusObjectId,
   getBrowserActiveGenomeId
 } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
-import { updatePreviouslyViewedObjectsAndSave } from 'src/content/app/genome-browser/state/track-panel/trackPanelSlice';
-import { updateBrowserActiveFocusObjectIdsAndSave } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSlice';
 
 import { GenomeBrowserContext } from 'src/content/app/genome-browser/Browser';
 import { TrackStates } from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
@@ -44,8 +42,6 @@ import { Status } from 'src/shared/types/status';
 import { ChrLocation } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSlice';
 
 const useGenomeBrowser = () => {
-  const dispatch = useDispatch();
-
   const activeFocusObjectId = useSelector(getBrowserActiveFocusObjectId);
   const activeGenomeId = useSelector(getBrowserActiveGenomeId);
   const { allTrackLabelsOn, allTrackNamesOn } =
@@ -62,15 +58,20 @@ const useGenomeBrowser = () => {
     genomeBrowserContext;
 
   const activateGenomeBrowser = async () => {
-    const genomeBrowserService = new EnsemblGenomeBrowser();
-    await genomeBrowserService.init({
+    const genomeBrowser = new EnsemblGenomeBrowser();
+    await genomeBrowser.init({
       backend_url: config.genomeBrowserBackendBaseUrl,
       target_element_id: BROWSER_CONTAINER_ID,
       'debug.show-incoming-messages': isEnvironment([Environment.PRODUCTION])
         ? 'false'
         : 'true'
     });
-    setGenomeBrowser(genomeBrowserService);
+    setGenomeBrowser(genomeBrowser);
+  };
+
+  const clearGenomeBrowser = () => {
+    // TODO: run genome browser cleanup logic when it becomes available
+    setGenomeBrowser(null);
   };
 
   const changeFocusObject = (focusObjectId: string) => {
@@ -79,9 +80,6 @@ const useGenomeBrowser = () => {
     }
 
     const { genomeId, objectId } = parseFocusObjectId(focusObjectId);
-
-    dispatch(updatePreviouslyViewedObjectsAndSave());
-    dispatch(updateBrowserActiveFocusObjectIdsAndSave(focusObjectId));
 
     const action: OutgoingAction = {
       type: OutgoingActionType.SET_FOCUS,
@@ -223,6 +221,7 @@ const useGenomeBrowser = () => {
 
   return {
     activateGenomeBrowser,
+    clearGenomeBrowser,
     changeFocusObject,
     changeFocusObjectFromZmenu,
     changeBrowserLocation,

--- a/src/content/app/genome-browser/state/browser-general/browserGeneralSlice.ts
+++ b/src/content/app/genome-browser/state/browser-general/browserGeneralSlice.ts
@@ -21,6 +21,7 @@ import {
   PayloadAction,
   ThunkAction
 } from '@reduxjs/toolkit';
+import { batch } from 'react-redux';
 import { replace } from 'connected-react-router';
 import pickBy from 'lodash/pickBy';
 import isEqual from 'lodash/isEqual';
@@ -38,6 +39,8 @@ import {
   setInitialTrackPanelDataForGenome
 } from 'src/content/app/genome-browser/state/track-panel/trackPanelSlice';
 import { ensureSpeciesIsEnabled } from 'src/content/app/species-selector/state/speciesSelectorSlice';
+import { updatePreviouslyViewedObjectsAndSave } from 'src/content/app/genome-browser/state/track-panel/trackPanelSlice';
+
 import {
   getBrowserActiveFocusObjectIds,
   getBrowserTrackStates,
@@ -99,14 +102,27 @@ export const updateTrackStatesAndSave: ActionCreator<
 
 export const setDataFromUrlAndSave: ActionCreator<
   ThunkAction<void, any, null, Action<string>>
-> = (payload: ParsedUrlPayload) => (dispatch) => {
-  dispatch(browserGeneralSlice.actions.setDataFromUrl(payload));
-  dispatch(setInitialTrackPanelDataForGenome(payload));
-
+> = (payload: ParsedUrlPayload) => (dispatch, getState: () => RootState) => {
   const { activeGenomeId, activeFocusObjectId, chrLocation } = payload;
+  const state = getState();
+  const currentActiveGenomeId = getBrowserActiveGenomeId(state);
+  const currentActiveFocusObjectId = getBrowserActiveFocusObjectId(state);
 
-  dispatch(ensureSpeciesIsEnabled(payload.activeGenomeId));
-  browserStorageService.saveActiveGenomeId(payload.activeGenomeId);
+  batch(() => {
+    // update previously viewed objects before active genome id or active focus object id have changed
+    if (
+      activeGenomeId === currentActiveGenomeId &&
+      activeFocusObjectId !== currentActiveFocusObjectId
+    ) {
+      dispatch(updatePreviouslyViewedObjectsAndSave()); // FIXME: actually pass the genome id and the focus object id?
+    }
+
+    dispatch(browserGeneralSlice.actions.setDataFromUrl(payload));
+    dispatch(setInitialTrackPanelDataForGenome(payload));
+    dispatch(ensureSpeciesIsEnabled(activeGenomeId));
+  });
+
+  browserStorageService.saveActiveGenomeId(activeGenomeId);
   chrLocation &&
     browserStorageService.updateChrLocation({ [activeGenomeId]: chrLocation });
 

--- a/src/content/app/genome-browser/state/browser-general/browserGeneralSlice.ts
+++ b/src/content/app/genome-browser/state/browser-general/browserGeneralSlice.ts
@@ -114,7 +114,7 @@ export const setDataFromUrlAndSave: ActionCreator<
       activeGenomeId === currentActiveGenomeId &&
       activeFocusObjectId !== currentActiveFocusObjectId
     ) {
-      dispatch(updatePreviouslyViewedObjectsAndSave()); // FIXME: actually pass the genome id and the focus object id?
+      dispatch(updatePreviouslyViewedObjectsAndSave());
     }
 
     dispatch(browserGeneralSlice.actions.setDataFromUrl(payload));


### PR DESCRIPTION
## Type
- Bug fix

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1445

## Description
### Bug 1: focus object not fetched during genome browser page load
Steps to reproduce:
- Open the genome browser page for an example gene (e.g. human BRCA2)
- Focus on any other gene (e.g. click on FRY and then on the "view in genome browser" button in zmenu)
- Refresh the page
**Bug:** the genome browser page only loads a skeleton, without any data about the gene displayed anywhere, and with a blank genome browser canvas.

**Cause:** There was a coupling of data fetching for active focus object with the changing of focus of the genome browser. If we did not run the function to change browser's focus (as was the case at page load), it meant that we wouldn't fetch data for the active focus object.

### Bug 2: blank canvas when switching from the interstitial back to a species with initialised genome browser
Steps to reproduce:
- Select two species (e.g. human and wheat)
- Open the genome browser page for an example gene for one species (e.g. human BRCA2)
- Switch to the other species to see the interstitial screen
- Without selecting any gene on the interstitial screen, click back to the previous species
**Bug:** the canvas is now completely blank

https://user-images.githubusercontent.com/6834224/146280889-a8a544af-164b-4993-af83-4e0c9730713a.mp4

**Cause:** Switching from a species with active genome browser to a species with an interstitial screen unmounted the canvas from the DOM; and we were missing the code to re-initialise the genome browser with a new canvas upon switching back.

## Deployment URL
http://fix-bootstrap-load-focus-object.review.ensembl.org