### PR TITLE
Fix tests

### DIFF
--- a/src/content/app/genome-browser/components/browser-image/BrowserImage.test.tsx
+++ b/src/content/app/genome-browser/components/browser-image/BrowserImage.test.tsx
@@ -28,12 +28,14 @@ import { BrowserImage } from './BrowserImage';
 import MockGenomeBrowser from 'tests/mocks/mockGenomeBrowser';
 
 const mockGenomeBrowser = jest.fn(() => new MockGenomeBrowser() as any);
+const mockClearGenomeBrowser = jest.fn();
 
 jest.mock(
   'src/content/app/genome-browser/hooks/useGenomeBrowser',
   () => () => ({
     genomeBrowser: mockGenomeBrowser(),
-    activateGenomeBrowser: jest.fn()
+    activateGenomeBrowser: jest.fn(),
+    clearGenomeBrowser: mockClearGenomeBrowser
   })
 );
 
@@ -69,7 +71,9 @@ const renderComponent = (state: typeof mockState = mockState) => {
 };
 
 describe('<BrowserImage />', () => {
-  afterEach(() => {
+  beforeEach(() => {
+    // running this in before each, because it looks that
+    // afterEach completes before cleanup functions called at component's unmounting get executed
     jest.resetAllMocks();
   });
 
@@ -95,6 +99,15 @@ describe('<BrowserImage />', () => {
         set('browser.browserGeneral.regionEditorActive', true, mockState)
       );
       expect(container.querySelector('#overlay')).toBeTruthy();
+    });
+  });
+
+  describe('unmounting', () => {
+    it('runs cleanup code to unregister the unmounted DOM node with genome browser', () => {
+      expect(mockClearGenomeBrowser).not.toHaveBeenCalled();
+      const { unmount } = renderComponent();
+      unmount();
+      expect(mockClearGenomeBrowser).toHaveBeenCalled();
     });
   });
 });

--- a/src/content/app/genome-browser/hooks/useBrowserRouting.test.tsx
+++ b/src/content/app/genome-browser/hooks/useBrowserRouting.test.tsx
@@ -61,6 +61,13 @@ jest.mock(
   })
 );
 
+jest.mock(
+  'src/content/app/genome-browser/state/focus-object/focusObjectSlice',
+  () => ({
+    fetchFocusObject: jest.fn(() => ({ type: 'fetch-focus-object' }))
+  })
+);
+
 const committedHuman = {
   ...createSelectedSpecies(),
   genome_id: 'human'


### PR DESCRIPTION
## Type
- Bug fix

## Description
Currently seen in dev: running a full test suite shows the following problems in the console (although the tests complete successfully):

1) I forgot to mock the `clearGenomeBrowser` function (added in PR https://github.com/Ensembl/ensembl-client/pull/660) in `BrowserImage` tests:

![image](https://user-images.githubusercontent.com/6834224/146985103-c13e10c3-9320-4ff2-8a02-24ad6f9cd4fc.png)

(also can be seen in [CI/CD logs](https://gitlab.ebi.ac.uk/ensembl-web/ensembl-client/-/jobs/671585#L738))

2) `useBrowserRouting` now depends on `focusObjectSlice`, which, in its turn, imports code that runs redux-toolkit-query. As a result the following can be seen in the console ([link to CI/CD logs](https://gitlab.ebi.ac.uk/ensembl-web/ensembl-client/-/jobs/671585#L94)):

![image](https://user-images.githubusercontent.com/6834224/146988020-58fd6380-e211-4067-bf10-652417ab8d1a.png)

This PR fixes this by mocking `focusObjectSlice` in `useBrowserRouting`

To confirm that the tests have improved, see the [logs](https://gitlab.ebi.ac.uk/ensembl-web/ensembl-client/-/jobs/671900) of the pipeline running for this PR.