### PR TITLE
Use thoas to fetch checksums for genomic sequences

### DIFF
--- a/src/server/middleware/proxyMiddleware.ts
+++ b/src/server/middleware/proxyMiddleware.ts
@@ -56,22 +56,13 @@ const staticAssetsMiddleware = createProxyMiddleware('/static', {
   target: 'http://localhost:8081'
 });
 
-const apiProxyMiddleware = createProxyMiddleware(['/api/**', '!/api/thoas'], {
+const apiProxyMiddleware = createProxyMiddleware('/api', {
   target: 'https://staging-2020.ensembl.org',
   changeOrigin: true,
   secure: false
 });
 
-const thoasProxyMiddleware = createProxyMiddleware('/api/thoas', {
-  target: 'http://map-thoas.review.ensembl.org',
-  pathRewrite: {
-    '^/api/docs': '/api' // rewrite path
-  },
-  changeOrigin: true,
-  secure: false
-});
-
-let proxyMiddleware = [apiProxyMiddleware, thoasProxyMiddleware];
+let proxyMiddleware = [apiProxyMiddleware];
 
 if (process.env.NODE_ENV === 'development') {
   proxyMiddleware = proxyMiddleware.concat([

--- a/src/server/middleware/proxyMiddleware.ts
+++ b/src/server/middleware/proxyMiddleware.ts
@@ -56,13 +56,22 @@ const staticAssetsMiddleware = createProxyMiddleware('/static', {
   target: 'http://localhost:8081'
 });
 
-const apiProxyMiddleware = createProxyMiddleware('/api', {
+const apiProxyMiddleware = createProxyMiddleware(['/api/**', '!/api/thoas'], {
   target: 'https://staging-2020.ensembl.org',
   changeOrigin: true,
   secure: false
 });
 
-let proxyMiddleware = [apiProxyMiddleware];
+const thoasProxyMiddleware = createProxyMiddleware('/api/thoas', {
+  target: 'http://map-thoas.review.ensembl.org',
+  pathRewrite: {
+    '^/api/docs': '/api' // rewrite path
+  },
+  changeOrigin: true,
+  secure: false
+});
+
+let proxyMiddleware = [apiProxyMiddleware, thoasProxyMiddleware];
 
 if (process.env.NODE_ENV === 'development') {
   proxyMiddleware = proxyMiddleware.concat([

--- a/src/shared/components/instant-download/instant-download-fetch/fetchForGene.ts
+++ b/src/shared/components/instant-download/instant-download-fetch/fetchForGene.ts
@@ -22,7 +22,7 @@ import { TranscriptOptions } from '../instant-download-transcript/InstantDownloa
 import { fetchGeneSequenceMetadata } from './fetchSequenceChecksums';
 
 import {
-  getGenomicSequenceData,
+  prepareGeneDownloadParameters,
   prepareDownloadParameters
 } from './fetchForTranscript';
 
@@ -63,10 +63,7 @@ export const fetchForGene = async (payload: FetchPayload) => {
 
   if (geneOptions.genomicSequence) {
     sequenceDownloadParams.unshift(
-      getGenomicSequenceData(
-        geneSequenceData.stable_id,
-        geneSequenceData.unversioned_stable_id
-      )
+      prepareGeneDownloadParameters(geneSequenceData)
     );
   }
 

--- a/src/shared/components/instant-download/instant-download-fetch/fetchForGene.ts
+++ b/src/shared/components/instant-download/instant-download-fetch/fetchForGene.ts
@@ -22,7 +22,7 @@ import { TranscriptOptions } from '../instant-download-transcript/InstantDownloa
 import { fetchGeneSequenceMetadata } from './fetchSequenceChecksums';
 
 import {
-  prepareGeneDownloadParameters,
+  prepareGenomicDownloadParameters,
   prepareDownloadParameters
 } from './fetchForTranscript';
 
@@ -63,7 +63,7 @@ export const fetchForGene = async (payload: FetchPayload) => {
 
   if (geneOptions.genomicSequence) {
     sequenceDownloadParams.unshift(
-      prepareGeneDownloadParameters(geneSequenceData)
+      prepareGenomicDownloadParameters(geneSequenceData.genomic)
     );
   }
 

--- a/src/shared/components/instant-download/instant-download-fetch/fetchForTranscript.ts
+++ b/src/shared/components/instant-download/instant-download-fetch/fetchForTranscript.ts
@@ -24,8 +24,7 @@ import {
   transcriptOptionsOrder
 } from 'src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript';
 import {
-  fetchTranscriptSequenceMetadata,
-  fetchGeneWithoutTranscriptsSequenceMetadata,
+  fetchGeneAndTranscriptSequenceMetadata,
   TranscriptSequenceMetadata
 } from './fetchSequenceChecksums';
 
@@ -55,22 +54,20 @@ export const fetchForTranscript = async (payload: FetchPayload) => {
     transcriptId,
     options: { transcript: transcriptOptions, gene: geneOptions }
   } = payload;
-  const transcriptSequenceData = await fetchTranscriptSequenceMetadata({
-    genomeId,
-    transcriptId
-  });
+  const { transcript: transcriptSequenceData, gene: geneSequenceData } =
+    await fetchGeneAndTranscriptSequenceMetadata({
+      genomeId,
+      geneId,
+      transcriptId
+    });
   const sequenceDownloadParams = prepareDownloadParameters({
     transcriptSequenceData,
     options: transcriptOptions
   });
 
   if (geneOptions.genomicSequence) {
-    const metadata = await fetchGeneWithoutTranscriptsSequenceMetadata({
-      genomeId,
-      geneId
-    });
     sequenceDownloadParams.unshift(
-      getGenomicSequenceData(metadata.stable_id, metadata.unversioned_stable_id)
+      prepareGeneDownloadParameters(geneSequenceData)
     );
   }
 
@@ -117,10 +114,13 @@ export const prepareDownloadParameters = (
     .map((option) => labelTypeToSequenceType[option]) // 'genomic', 'cdna', 'cds', 'protein'
     .map((option) => {
       if (option === 'genomic') {
-        return getGenomicSequenceData(
-          params.transcriptSequenceData.stable_id,
-          params.transcriptSequenceData.unversioned_stable_id
-        );
+        const { label, start, end, checksum } =
+          params.transcriptSequenceData.genomic;
+        const url = `/api/refget/sequence/${checksum}?start=${start}&end=${end}&accept=text/plain`;
+        return {
+          label,
+          url
+        };
       } else {
         const dataForSingleSequence = params.transcriptSequenceData[option];
 
@@ -137,10 +137,17 @@ export const prepareDownloadParameters = (
     })
     .filter(Boolean) as SingleSequenceFetchParams[];
 
-export const getGenomicSequenceData = (
-  versionedStableId: string,
-  unversionedStableId: string
-) => ({
-  label: `${versionedStableId} genomic`,
-  url: `https://rest.ensembl.org/sequence/id/${unversionedStableId}?content-type=text/plain&type=genomic`
-});
+export const prepareGeneDownloadParameters = (
+  geneData: Awaited<
+    ReturnType<typeof fetchGeneAndTranscriptSequenceMetadata>
+  >['gene']
+) => {
+  const {
+    genomic: { label, start, end, checksum }
+  } = geneData;
+  const url = `/api/refget/sequence/${checksum}?start=${start}&end=${end}&accept=text/plain`;
+  return {
+    label,
+    url
+  };
+};

--- a/src/shared/components/instant-download/instant-download-fetch/fetchForTranscript.ts
+++ b/src/shared/components/instant-download/instant-download-fetch/fetchForTranscript.ts
@@ -67,7 +67,7 @@ export const fetchForTranscript = async (payload: FetchPayload) => {
 
   if (geneOptions.genomicSequence) {
     sequenceDownloadParams.unshift(
-      prepareGeneDownloadParameters(geneSequenceData)
+      prepareGenomicDownloadParameters(geneSequenceData.genomic)
     );
   }
 
@@ -114,13 +114,9 @@ export const prepareDownloadParameters = (
     .map((option) => labelTypeToSequenceType[option]) // 'genomic', 'cdna', 'cds', 'protein'
     .map((option) => {
       if (option === 'genomic') {
-        const { label, start, end, checksum } =
-          params.transcriptSequenceData.genomic;
-        const url = `/api/refget/sequence/${checksum}?start=${start}&end=${end}&accept=text/plain`;
-        return {
-          label,
-          url
-        };
+        return prepareGenomicDownloadParameters(
+          params.transcriptSequenceData.genomic
+        );
       } else {
         const dataForSingleSequence = params.transcriptSequenceData[option];
 
@@ -137,14 +133,13 @@ export const prepareDownloadParameters = (
     })
     .filter(Boolean) as SingleSequenceFetchParams[];
 
-export const prepareGeneDownloadParameters = (
-  geneData: Awaited<
-    ReturnType<typeof fetchGeneAndTranscriptSequenceMetadata>
-  >['gene']
-) => {
-  const {
-    genomic: { label, start, end, checksum }
-  } = geneData;
+export const prepareGenomicDownloadParameters = (params: {
+  label: string;
+  checksum: string;
+  start: number;
+  end: number;
+}) => {
+  const { label, start, end, checksum } = params;
   const url = `/api/refget/sequence/${checksum}?start=${start}&end=${end}&accept=text/plain`;
   return {
     label,

--- a/src/shared/components/instant-download/instant-download-fetch/fetchSequenceChecksums.ts
+++ b/src/shared/components/instant-download/instant-download-fetch/fetchSequenceChecksums.ts
@@ -212,13 +212,21 @@ const geneChecksumsQuery = gql`
   query Gene($genomeId: String!, $geneId: String!) {
     gene(byId: { genome_id: $genomeId, stable_id: $geneId }) {
       ...GeneDetails
-      }
-      transcripts {
-        ...TranscriptDetails
-      }
+    }
+    transcripts {
+      ...TranscriptDetails
     }
   }
   ${geneQueryFragment}
+  ${transcriptQueryFragment}
+`;
+
+const transcriptChecksumsQuery = gql`
+  query Transcript($genomeId: String!, $transcriptId: String!) {
+    transcript(byId: { genome_id: $genomeId, stable_id: $transcriptId }) {
+      ...TranscriptDetails
+    }
+  }
   ${transcriptQueryFragment}
 `;
 
@@ -316,7 +324,7 @@ export const fetchTranscriptSequenceMetadata = (
 ): Promise<TranscriptSequenceMetadata> => {
   return client
     .query<TranscriptQueryResult>({
-      query: geneChecksumsQuery,
+      query: transcriptChecksumsQuery,
       variables
     })
     .then(({ data }) => processTranscriptData(data.transcript));

--- a/src/shared/components/instant-download/instant-download-fetch/fetchSequenceChecksums.ts
+++ b/src/shared/components/instant-download/instant-download-fetch/fetchSequenceChecksums.ts
@@ -20,7 +20,6 @@ import { Sequence } from 'src/shared/types/thoas/sequence';
 
 export type TranscriptSequenceMetadata = {
   stable_id: string;
-  unversioned_stable_id: string;
   genomic: {
     label: string;
     checksum: string;
@@ -43,7 +42,6 @@ export type TranscriptSequenceMetadata = {
 
 export type GeneSequenceMetadata = {
   stable_id: string;
-  unversioned_stable_id: string;
   genomic: {
     label: string;
     checksum: string;
@@ -73,7 +71,6 @@ type SliceInResponse = {
 
 type GeneInResponse = {
   stable_id: string;
-  unversioned_stable_id: string;
   slice: SliceInResponse;
 };
 
@@ -83,7 +80,6 @@ type GeneWithTranscriptsInResponse = GeneInResponse & {
 
 type TranscriptInResponse = {
   stable_id: string;
-  unversioned_stable_id: string;
   slice: {
     location: {
       start: number;
@@ -156,7 +152,6 @@ const geneQueryFragment = gql`
 const transcriptQueryFragment = gql`
   fragment TranscriptDetails on Transcript {
     stable_id
-    unversioned_stable_id
     slice {
       location {
         start
@@ -238,15 +233,10 @@ const processGeneAndTranscriptData = (data: GeneAndTranscriptQueryResult) => {
 };
 
 const processGeneData = (gene: GeneInResponse) => {
-  const {
-    stable_id: geneStableId,
-    unversioned_stable_id: geneUnversionedStableId,
-    slice: geneSlice
-  } = gene;
+  const { stable_id: geneStableId, slice: geneSlice } = gene;
 
   return {
     stable_id: geneStableId,
-    unversioned_stable_id: geneUnversionedStableId,
     genomic: {
       label: `${geneStableId} genomic`,
       checksum: geneSlice.region.sequence.checksum,
@@ -257,16 +247,11 @@ const processGeneData = (gene: GeneInResponse) => {
 };
 
 const processTranscriptData = (transcript: TranscriptInResponse) => {
-  const {
-    stable_id: transcriptStableId,
-    unversioned_stable_id: transcriptUnversionedStableId, // FIXME no longer needed? only required when we requested genomic sequences from REST?
-    slice: transcriptSlice
-  } = transcript;
+  const { stable_id: transcriptStableId, slice: transcriptSlice } = transcript;
   const productGeneratingContext = transcript.product_generating_contexts[0];
 
   return {
     stable_id: transcriptStableId,
-    unversioned_stable_id: transcriptUnversionedStableId,
     genomic: {
       label: `${transcriptStableId} genomic`,
       checksum: transcriptSlice.region.sequence.checksum,


### PR DESCRIPTION
## WARNING
- ❗❗❗ Merge only after appropriate changes in Thoas have been shipped to production ❗❗❗
- Remove the changes in the development proxy before merging

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-960

## Description
Switch from Ensembl Rest to the combination of Thoas and RefGet proxy for fetching genomic sequences of genes and transcripts:
- Fetch the checksum of the full genomic region (chromosome) where the gene or the transcript is located, as well as genomic start and end positions of the gene/transcript
- Request the sequence from refget proxy by specifying the checksum of the full region sequence, and the start and the end positions of the genomic feature

## Deployment URL
http://thoas-for-genomic-sequences.review.ensembl.org

## Views affected
- Entity viewer
  - default transcript list
  - proteins list
  - gene download modal
- Genome browser
  - zmenu
  - gene download and transcript download components in the drawer