### PR TITLE
Genome browser update 0.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "core-js": "3.20.0",
         "cross-fetch": "3.1.4",
         "d3": "6.7.0",
-        "ensembl-genome-browser": "git+https://github.com/Ensembl/ensembl-genome-browser.git#601d57389e314657ef5df59414dd326b0e4bff06",
+        "ensembl-genome-browser": "git+https://github.com/Ensembl/ensembl-genome-browser.git#dd13eb9f585c72319994c3c0ce91087187cac948",
         "express": "4.17.2",
         "filesize": "8.0.6",
         "graphql": "15.5.1",
@@ -19257,8 +19257,8 @@
     },
     "node_modules/ensembl-genome-browser": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/Ensembl/ensembl-genome-browser.git#601d57389e314657ef5df59414dd326b0e4bff06",
-      "integrity": "sha512-8o81tKutH7KajfyOEt0DX+v8w4sPZloynktqoLIkQTqFd0LkjtpVTIaGi02ZtChYlKcNcrRwxVquRB5CoHz3wA==",
+      "resolved": "git+ssh://git@github.com/Ensembl/ensembl-genome-browser.git#dd13eb9f585c72319994c3c0ce91087187cac948",
+      "integrity": "sha512-rrWLEHdhFhTFgztYfB38yfWx/nRkTisllGTj248hSleP8WaJlCX+nmTazvv7vkwYhN9pqkEFZEiURp4t9C54DA==",
       "license": "ISC",
       "dependencies": {
         "tslib": "^2.3.1"
@@ -53966,9 +53966,9 @@
       }
     },
     "ensembl-genome-browser": {
-      "version": "git+ssh://git@github.com/Ensembl/ensembl-genome-browser.git#601d57389e314657ef5df59414dd326b0e4bff06",
-      "integrity": "sha512-8o81tKutH7KajfyOEt0DX+v8w4sPZloynktqoLIkQTqFd0LkjtpVTIaGi02ZtChYlKcNcrRwxVquRB5CoHz3wA==",
-      "from": "ensembl-genome-browser@git+https://github.com/Ensembl/ensembl-genome-browser.git#601d57389e314657ef5df59414dd326b0e4bff06",
+      "version": "git+ssh://git@github.com/Ensembl/ensembl-genome-browser.git#dd13eb9f585c72319994c3c0ce91087187cac948",
+      "integrity": "sha512-rrWLEHdhFhTFgztYfB38yfWx/nRkTisllGTj248hSleP8WaJlCX+nmTazvv7vkwYhN9pqkEFZEiURp4t9C54DA==",
+      "from": "ensembl-genome-browser@git+https://github.com/Ensembl/ensembl-genome-browser.git#dd13eb9f585c72319994c3c0ce91087187cac948",
       "requires": {
         "tslib": "^2.3.1"
       },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "core-js": "3.20.0",
     "cross-fetch": "3.1.4",
     "d3": "6.7.0",
-    "ensembl-genome-browser": "git+https://github.com/Ensembl/ensembl-genome-browser.git#601d57389e314657ef5df59414dd326b0e4bff06",
+    "ensembl-genome-browser": "git+https://github.com/Ensembl/ensembl-genome-browser.git#dd13eb9f585c72319994c3c0ce91087187cac948",
     "express": "4.17.2",
     "filesize": "8.0.6",
     "graphql": "15.5.1",


### PR DESCRIPTION
## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1458

## Description
Updated the ensembl-genome-browser package commit hash.

Version 0.1.3 changes:
-  Fix various scrolling bugs
-  Bug-fixes in chromosome switching
-  Enforce size/position limits in more places
-  Use van Wijk and Nuij's hyperbolic space algorithm for moves and pans rather than pile of buggy heuistics
-  Use fade not animate for very long moves even if on same stick.
-  Misc draw speed bugfixes and instrumentation
-  Fixed version strings so that they survive CI/CD

## Deployment URL
http://gb-update-0-1-3.review.ensembl.org

## Views affected
http://gb-update-0-1-3.review.ensembl.org