### PR TITLE
Fix missing ruler on GB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "core-js": "3.20.2",
         "cross-fetch": "3.1.4",
         "d3": "6.7.0",
-        "ensembl-genome-browser": "git+https://github.com/Ensembl/ensembl-genome-browser.git#dd13eb9f585c72319994c3c0ce91087187cac948",
+        "ensembl-genome-browser": "git+https://github.com/Ensembl/ensembl-genome-browser.git#75edbf709db5111b870ed5507ab1d14d6389909f",
         "express": "4.17.2",
         "filesize": "8.0.6",
         "graphql": "15.5.1",
@@ -19204,17 +19204,9 @@
     },
     "node_modules/ensembl-genome-browser": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/Ensembl/ensembl-genome-browser.git#dd13eb9f585c72319994c3c0ce91087187cac948",
-      "integrity": "sha512-rrWLEHdhFhTFgztYfB38yfWx/nRkTisllGTj248hSleP8WaJlCX+nmTazvv7vkwYhN9pqkEFZEiURp4t9C54DA==",
-      "license": "ISC",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/ensembl-genome-browser/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "resolved": "git+ssh://git@github.com/Ensembl/ensembl-genome-browser.git#75edbf709db5111b870ed5507ab1d14d6389909f",
+      "integrity": "sha512-c+45tERnRCmNKIns4UISTEGo9tn/mOn/WTPpB6sbGAlpA/SzKVF0NIoKhxIeCEiWeOOfK8le3HMObJGwWWq2Sg==",
+      "license": "ISC"
     },
     "node_modules/entities": {
       "version": "3.0.1",
@@ -53690,19 +53682,9 @@
       }
     },
     "ensembl-genome-browser": {
-      "version": "git+ssh://git@github.com/Ensembl/ensembl-genome-browser.git#dd13eb9f585c72319994c3c0ce91087187cac948",
-      "integrity": "sha512-rrWLEHdhFhTFgztYfB38yfWx/nRkTisllGTj248hSleP8WaJlCX+nmTazvv7vkwYhN9pqkEFZEiURp4t9C54DA==",
-      "from": "ensembl-genome-browser@git+https://github.com/Ensembl/ensembl-genome-browser.git#dd13eb9f585c72319994c3c0ce91087187cac948",
-      "requires": {
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-        }
-      }
+      "version": "git+ssh://git@github.com/Ensembl/ensembl-genome-browser.git#75edbf709db5111b870ed5507ab1d14d6389909f",
+      "integrity": "sha512-c+45tERnRCmNKIns4UISTEGo9tn/mOn/WTPpB6sbGAlpA/SzKVF0NIoKhxIeCEiWeOOfK8le3HMObJGwWWq2Sg==",
+      "from": "ensembl-genome-browser@git+https://github.com/Ensembl/ensembl-genome-browser.git#75edbf709db5111b870ed5507ab1d14d6389909f"
     },
     "entities": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "core-js": "3.20.2",
         "cross-fetch": "3.1.4",
         "d3": "6.7.0",
-        "ensembl-genome-browser": "git+https://github.com/Ensembl/ensembl-genome-browser.git#75edbf709db5111b870ed5507ab1d14d6389909f",
+        "ensembl-genome-browser": "git+https://github.com/Ensembl/ensembl-genome-browser.git#9a754f64b9c48d83d0d3188352f14ae3264ed4f3",
         "express": "4.17.2",
         "filesize": "8.0.6",
         "graphql": "15.5.1",
@@ -19204,8 +19204,8 @@
     },
     "node_modules/ensembl-genome-browser": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/Ensembl/ensembl-genome-browser.git#75edbf709db5111b870ed5507ab1d14d6389909f",
-      "integrity": "sha512-c+45tERnRCmNKIns4UISTEGo9tn/mOn/WTPpB6sbGAlpA/SzKVF0NIoKhxIeCEiWeOOfK8le3HMObJGwWWq2Sg==",
+      "resolved": "git+ssh://git@github.com/Ensembl/ensembl-genome-browser.git#9a754f64b9c48d83d0d3188352f14ae3264ed4f3",
+      "integrity": "sha512-bAOKxCBiUZWMbXM9xWeuPOcap5zCMr6jbhW5yurQtDym9IkicVHhevOabtM2Pad9rQBYim0UcXBt6kIlwCzcuQ==",
       "license": "ISC"
     },
     "node_modules/entities": {
@@ -53682,9 +53682,9 @@
       }
     },
     "ensembl-genome-browser": {
-      "version": "git+ssh://git@github.com/Ensembl/ensembl-genome-browser.git#75edbf709db5111b870ed5507ab1d14d6389909f",
-      "integrity": "sha512-c+45tERnRCmNKIns4UISTEGo9tn/mOn/WTPpB6sbGAlpA/SzKVF0NIoKhxIeCEiWeOOfK8le3HMObJGwWWq2Sg==",
-      "from": "ensembl-genome-browser@git+https://github.com/Ensembl/ensembl-genome-browser.git#75edbf709db5111b870ed5507ab1d14d6389909f"
+      "version": "git+ssh://git@github.com/Ensembl/ensembl-genome-browser.git#9a754f64b9c48d83d0d3188352f14ae3264ed4f3",
+      "integrity": "sha512-bAOKxCBiUZWMbXM9xWeuPOcap5zCMr6jbhW5yurQtDym9IkicVHhevOabtM2Pad9rQBYim0UcXBt6kIlwCzcuQ==",
+      "from": "ensembl-genome-browser@git+https://github.com/Ensembl/ensembl-genome-browser.git#9a754f64b9c48d83d0d3188352f14ae3264ed4f3"
     },
     "entities": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "core-js": "3.20.2",
     "cross-fetch": "3.1.4",
     "d3": "6.7.0",
-    "ensembl-genome-browser": "git+https://github.com/Ensembl/ensembl-genome-browser.git#dd13eb9f585c72319994c3c0ce91087187cac948",
+    "ensembl-genome-browser": "git+https://github.com/Ensembl/ensembl-genome-browser.git#75edbf709db5111b870ed5507ab1d14d6389909f",
     "express": "4.17.2",
     "filesize": "8.0.6",
     "graphql": "15.5.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "core-js": "3.20.2",
     "cross-fetch": "3.1.4",
     "d3": "6.7.0",
-    "ensembl-genome-browser": "git+https://github.com/Ensembl/ensembl-genome-browser.git#75edbf709db5111b870ed5507ab1d14d6389909f",
+    "ensembl-genome-browser": "git+https://github.com/Ensembl/ensembl-genome-browser.git#9a754f64b9c48d83d0d3188352f14ae3264ed4f3",
     "express": "4.17.2",
     "filesize": "8.0.6",
     "graphql": "15.5.1",


### PR DESCRIPTION

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Description
The bug was caused by some missing changes in the 0.1.3 wasm files.

## Deployment URL
http://fix-gb-missing-ruler.review.ensembl.org
