### PR TITLE
Circular chromosome indicator

### DIFF
--- a/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.scss
+++ b/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.scss
@@ -30,8 +30,8 @@
   display: inline-block;
   margin: 0 0.5em;
   padding: 5px 5px;
-  width: 20px;
-  height: 20px;
+  width: 24px;
+  height: 24px;
   border-radius: 50%;
 }
 

--- a/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.scss
+++ b/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.scss
@@ -25,8 +25,19 @@
   }
 }
 
-.chrLocationView {
+.circularIndicator {
+  background: $grey;
   display: inline-block;
+  margin: 0 0.5em;
+  padding: 5px 5px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+}
+
+.chrLocationView {
+  display: flex;
+  align-items: center;
 }
 
 .chrLabel {

--- a/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.test.tsx
+++ b/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.test.tsx
@@ -20,6 +20,7 @@ import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import userEvent from '@testing-library/user-event';
 import configureMockStore from 'redux-mock-store';
+import set from 'lodash/fp/set';
 
 import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
 
@@ -78,6 +79,17 @@ describe('BrowserLocationIndicator', () => {
       const { container } = renderComponent();
       const renderedName = container.querySelector('.chrCode');
       expect(renderedName?.textContent).toBe(chrName);
+    });
+
+    it('displays circular chromosome', () => {
+      const newstate = set(
+        'genome.genomeKaryotype.genomeKaryotypeData.human[0].is_circular',
+        true,
+        mockState
+      );
+      const { container } = renderComponent(newstate);
+      const circularIndicator = container.querySelector('.circularIndicator');
+      expect(circularIndicator).toBeTruthy();
     });
 
     it('displays location', () => {

--- a/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.test.tsx
+++ b/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.test.tsx
@@ -49,6 +49,13 @@ const mockState = {
       },
       activeGenomeId: 'human'
     }
+  },
+  genome: {
+    genomeKaryotype: {
+      genomeKaryotypeData: {
+        human: [{ is_circular: false }]
+      }
+    }
   }
 };
 

--- a/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.test.tsx
+++ b/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.test.tsx
@@ -42,11 +42,14 @@ const startPosition = faker.datatype.number({ min: 1, max: 1000000 });
 const endPosition =
   startPosition + faker.datatype.number({ min: 1000, max: 1000000 });
 
+const circularChrName = faker.lorem.word();
+
 const mockState = {
   browser: {
     browserGeneral: {
       actualChrLocations: {
-        human: [chrName, startPosition, endPosition] as ChrLocation
+        human: [chrName, startPosition, endPosition] as ChrLocation,
+        ecoli: [circularChrName, startPosition, endPosition] as ChrLocation
       },
       activeGenomeId: 'human'
     }
@@ -54,7 +57,8 @@ const mockState = {
   genome: {
     genomeKaryotype: {
       genomeKaryotypeData: {
-        human: [{ is_circular: false }]
+        human: [{ is_circular: false, name: chrName }],
+        ecoli: [{ is_circular: true, name: circularChrName }]
       }
     }
   }
@@ -83,8 +87,8 @@ describe('BrowserLocationIndicator', () => {
 
     it('displays circular chromosome', () => {
       const newstate = set(
-        'genome.genomeKaryotype.genomeKaryotypeData.human[0].is_circular',
-        true,
+        'browser.browserGeneral.activeGenomeId',
+        'ecoli',
         mockState
       );
       const { container } = renderComponent(newstate);

--- a/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.tsx
+++ b/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.tsx
@@ -54,7 +54,7 @@ export const BrowserLocationIndicator = (props: Props) => {
     <div className={className}>
       <div className={styles.chrLabel}>Chromosome</div>
       <div className={styles.chrLocationView} {...onClickProps}>
-        {genomeKaryotype && !genomeKaryotype[0].is_circular ? (
+        {genomeKaryotype && genomeKaryotype[0].is_circular ? (
           <CircularChromosomeIndicator />
         ) : (
           <div className={styles.chrCode}>{chrCode}</div>

--- a/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.tsx
+++ b/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.tsx
@@ -23,6 +23,7 @@ import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFor
 import { getBrowserActiveGenomeId } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
 import { getActualChrLocation } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
 import { toggleBrowserNav } from 'src/content/app/genome-browser/state/browser-nav/browserNavSlice';
+import { getGenomeKaryotype } from 'src/shared/state/genome/genomeSelectors';
 
 import styles from './BrowserLocationIndicator.scss';
 
@@ -33,6 +34,7 @@ type Props = {
 export const BrowserLocationIndicator = (props: Props) => {
   const actualChrLocation = useSelector(getActualChrLocation);
   const activeGenomeId = useSelector(getBrowserActiveGenomeId);
+  const genomeKaryotype = useSelector(getGenomeKaryotype);
 
   const dispatch = useDispatch();
 
@@ -48,11 +50,17 @@ export const BrowserLocationIndicator = (props: Props) => {
     ? {}
     : { onClick: () => dispatch(toggleBrowserNav({ activeGenomeId })) };
 
+  const activeKaryotype =
+    genomeKaryotype &&
+    genomeKaryotype.filter((karyotype) => {
+      return karyotype.name === chrCode;
+    });
+
   return (
     <div className={className}>
       <div className={styles.chrLabel}>Chromosome</div>
       <div className={styles.chrLocationView} {...onClickProps}>
-        {chrCode === 'Chromosome' ? (
+        {activeKaryotype && activeKaryotype[0].is_chromosome ? (
           <CircularChromosomeIndicator />
         ) : (
           <div className={styles.chrCode}>{chrCode}</div>

--- a/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.tsx
+++ b/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.tsx
@@ -23,7 +23,6 @@ import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFor
 import { getBrowserActiveGenomeId } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
 import { getActualChrLocation } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
 import { toggleBrowserNav } from 'src/content/app/genome-browser/state/browser-nav/browserNavSlice';
-import { getGenomeKaryotype } from 'src/shared/state/genome/genomeSelectors';
 
 import styles from './BrowserLocationIndicator.scss';
 
@@ -34,7 +33,6 @@ type Props = {
 export const BrowserLocationIndicator = (props: Props) => {
   const actualChrLocation = useSelector(getActualChrLocation);
   const activeGenomeId = useSelector(getBrowserActiveGenomeId);
-  const genomeKaryotype = useSelector(getGenomeKaryotype);
 
   const dispatch = useDispatch();
 
@@ -54,7 +52,7 @@ export const BrowserLocationIndicator = (props: Props) => {
     <div className={className}>
       <div className={styles.chrLabel}>Chromosome</div>
       <div className={styles.chrLocationView} {...onClickProps}>
-        {genomeKaryotype && genomeKaryotype[0].is_circular ? (
+        {chrCode === 'Chromosome' ? (
           <CircularChromosomeIndicator />
         ) : (
           <div className={styles.chrCode}>{chrCode}</div>

--- a/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.tsx
+++ b/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.tsx
@@ -50,9 +50,9 @@ export const BrowserLocationIndicator = (props: Props) => {
     ? {}
     : { onClick: () => dispatch(toggleBrowserNav({ activeGenomeId })) };
 
-  const activeKaryotype =
+  const activeChromosome =
     genomeKaryotype &&
-    genomeKaryotype.filter((karyotype) => {
+    genomeKaryotype.find((karyotype) => {
       return karyotype.name === chrCode;
     });
 
@@ -60,7 +60,7 @@ export const BrowserLocationIndicator = (props: Props) => {
     <div className={className}>
       <div className={styles.chrLabel}>Chromosome</div>
       <div className={styles.chrLocationView} {...onClickProps}>
-        {activeKaryotype && activeKaryotype[0].is_chromosome ? (
+        {activeChromosome?.is_circular ? (
           <CircularChromosomeIndicator />
         ) : (
           <div className={styles.chrCode}>{chrCode}</div>

--- a/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.tsx
+++ b/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.tsx
@@ -23,6 +23,7 @@ import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFor
 import { getBrowserActiveGenomeId } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
 import { getActualChrLocation } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
 import { toggleBrowserNav } from 'src/content/app/genome-browser/state/browser-nav/browserNavSlice';
+import { getGenomeKaryotype } from 'src/shared/state/genome/genomeSelectors';
 
 import styles from './BrowserLocationIndicator.scss';
 
@@ -33,6 +34,8 @@ type Props = {
 export const BrowserLocationIndicator = (props: Props) => {
   const actualChrLocation = useSelector(getActualChrLocation);
   const activeGenomeId = useSelector(getBrowserActiveGenomeId);
+  const genomeKaryotype = useSelector(getGenomeKaryotype);
+
   const dispatch = useDispatch();
 
   const [chrCode, chrStart, chrEnd] = actualChrLocation || [];
@@ -51,7 +54,11 @@ export const BrowserLocationIndicator = (props: Props) => {
     <div className={className}>
       <div className={styles.chrLabel}>Chromosome</div>
       <div className={styles.chrLocationView} {...onClickProps}>
-        <div className={styles.chrCode}>{chrCode}</div>
+        {genomeKaryotype && !genomeKaryotype[0].is_circular ? (
+          <CircularChromosomeIndicator />
+        ) : (
+          <div className={styles.chrCode}>{chrCode}</div>
+        )}
         <div className={styles.chrRegion}>
           <span>{getCommaSeparatedNumber(chrStart as number)}</span>
           <span className={styles.chrSeparator}>-</span>
@@ -62,4 +69,7 @@ export const BrowserLocationIndicator = (props: Props) => {
   );
 };
 
+const CircularChromosomeIndicator = () => {
+  return <div className={styles.circularIndicator}></div>;
+};
 export default BrowserLocationIndicator;


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [x] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-265

## Description
The navigation panel should have an icon when browsing species that have a circular genome. For others we can show the name of the chromosome. Will need the BE to indicate whether we have a circular chromosome or not

Design at:
https://xd.adobe.com/view/37352bdd-fdc5-43f2-93a8-47cba4ee7039-6266/screen/b0fdc853-de27-494e-b07e-ca393e827cab?fullscreen

## Deployment URL
http://circular-chromosome-indicator.review.ensembl.org/

## Views affected
Genome browser

### Other effects
NA

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
NA