### PR TITLE
Generate reverse complement when fetching reverse-strand sequences

### DIFF
--- a/src/shared/components/instant-download/instant-download-fetch/fetchForProtein.ts
+++ b/src/shared/components/instant-download/instant-download-fetch/fetchForProtein.ts
@@ -16,18 +16,19 @@
 
 import { wrap } from 'comlink';
 
+import * as urlFor from 'src/shared/helpers/urlHelper';
 import downloadAsFile from 'src/shared/helpers/downloadAsFile';
 import {
-  ProteinOptions,
-  ProteinOption,
-  proteinOptionsOrder
+  proteinOptionsOrder,
+  type ProteinOptions,
+  type ProteinOption
 } from 'src/shared/components/instant-download/instant-download-protein/InstantDownloadProtein';
 import {
   fetchTranscriptSequenceMetadata,
-  TranscriptSequenceMetadata
+  type TranscriptSequenceMetadata
 } from './fetchSequenceChecksums';
 
-import {
+import type {
   WorkerApi,
   SingleSequenceFetchParams
 } from 'src/shared/workers/sequenceFetcher.worker';
@@ -92,7 +93,7 @@ const prepareDownloadParameters = (params: PrepareDownloadParametersParams) => {
       }
       return {
         label: dataForSingleSequence.label,
-        url: `/api/refget/sequence/${dataForSingleSequence.checksum}?accept=text/plain`
+        url: urlFor.refget({ checksum: dataForSingleSequence.checksum })
       };
     })
     .filter(Boolean) as SingleSequenceFetchParams[];

--- a/src/shared/components/instant-download/instant-download-fetch/fetchForTranscript.ts
+++ b/src/shared/components/instant-download/instant-download-fetch/fetchForTranscript.ts
@@ -32,6 +32,7 @@ import type {
   WorkerApi,
   SingleSequenceFetchParams
 } from 'src/shared/workers/sequenceFetcher.worker';
+import { Strand } from 'src/shared/types/thoas/strand';
 
 type Options = {
   transcript: Partial<TranscriptOptions>;
@@ -138,11 +139,13 @@ export const prepareGenomicDownloadParameters = (params: {
   checksum: string;
   start: number;
   end: number;
+  strand: Strand;
 }) => {
-  const { label, start, end, checksum } = params;
+  const { label, start, end, checksum, strand } = params;
   const url = `/api/refget/sequence/${checksum}?start=${start}&end=${end}&accept=text/plain`;
   return {
     label,
-    url
+    url,
+    reverseComplement: strand === Strand.REVERSE
   };
 };

--- a/src/shared/components/instant-download/instant-download-fetch/fetchForTranscript.ts
+++ b/src/shared/components/instant-download/instant-download-fetch/fetchForTranscript.ts
@@ -16,16 +16,17 @@
 
 import { wrap } from 'comlink';
 
+import * as urlFor from 'src/shared/helpers/urlHelper';
 import downloadAsFile from 'src/shared/helpers/downloadAsFile';
 
 import {
-  TranscriptOptions,
-  TranscriptOption,
-  transcriptOptionsOrder
+  transcriptOptionsOrder,
+  type TranscriptOptions,
+  type TranscriptOption
 } from 'src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript';
 import {
   fetchGeneAndTranscriptSequenceMetadata,
-  TranscriptSequenceMetadata
+  type TranscriptSequenceMetadata
 } from './fetchSequenceChecksums';
 
 import type {
@@ -128,7 +129,7 @@ export const prepareDownloadParameters = (
 
         return {
           label: dataForSingleSequence.label,
-          url: `/api/refget/sequence/${dataForSingleSequence.checksum}?accept=text/plain`
+          url: urlFor.refget({ checksum: dataForSingleSequence.checksum })
         };
       }
     })
@@ -142,7 +143,7 @@ export const prepareGenomicDownloadParameters = (params: {
   strand: Strand;
 }) => {
   const { label, start, end, checksum, strand } = params;
-  const url = `/api/refget/sequence/${checksum}?start=${start}&end=${end}&accept=text/plain`;
+  const url = urlFor.refget({ checksum, start, end });
   return {
     label,
     url,

--- a/src/shared/helpers/sequenceHelpers.test.ts
+++ b/src/shared/helpers/sequenceHelpers.test.ts
@@ -1,0 +1,23 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getReverseComplement } from './sequenceHelpers';
+
+describe('getReverseComplement', () => {
+  it('generates a reverse complement for the provided sequence', () => {
+    expect(getReverseComplement('ACCTTGAAA')).toBe('TTTCAAGGT');
+  });
+});

--- a/src/shared/helpers/sequenceHelpers.ts
+++ b/src/shared/helpers/sequenceHelpers.ts
@@ -1,0 +1,31 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const forwardStrandNucleotides = 'ACGTURYWSMKBDHVNXacgturywsmkbdhvnx';
+const reverseStrandNucleotides = 'TGCAAYRWSKMVHDBNXtgcaayrwskmvhdbnx';
+
+const forwardToReverseStrandMap: Map<string, string> = new Map();
+
+forwardStrandNucleotides.split('').forEach((character, index) => {
+  forwardToReverseStrandMap.set(character, reverseStrandNucleotides[index]);
+});
+
+export const getReverseComplement = (sequence: string) =>
+  sequence
+    .split('')
+    .map((character) => forwardToReverseStrandMap.get(character) as string)
+    .reverse()
+    .join('');

--- a/src/shared/helpers/urlHelper.ts
+++ b/src/shared/helpers/urlHelper.ts
@@ -16,6 +16,8 @@
 
 import queryString from 'query-string';
 
+import config from 'config';
+
 export const home = () => '/';
 export const speciesSelector = () => '/species-selector';
 export const customDownload = () => '/custom-download';
@@ -90,4 +92,34 @@ export const entityViewer = (params?: EntityViewerUrlParams) => {
   );
 
   return query ? `${path}?${query}` : path;
+};
+
+type RefgetUrlParams = {
+  checksum: string;
+  start?: number;
+  end?: number;
+};
+
+/**
+ * Refget is using a zero-based coordinate space,
+ * with start coordinate inclusive and end exclusive.
+ * To translate from Ensembl coordinate space to Refget's,
+ * we subtract 1 from the start coordinate
+ * and leave the end coordinate as is.
+ */
+export const refget = (params: RefgetUrlParams) => {
+  const { checksum, start, end } = params;
+  const searchParams = new URLSearchParams();
+  if (typeof start === 'number') {
+    const refgetStart = start - 1;
+    searchParams.append('start', `${refgetStart}`);
+  }
+  if (typeof end === 'number') {
+    searchParams.append('end', `${end}`);
+  }
+  searchParams.append('accept', 'text/plain');
+
+  return `${
+    config.refgetBaseUrl
+  }/sequence/${checksum}?${searchParams.toString()}`;
 };

--- a/src/shared/workers/sequenceFetcher.worker.ts
+++ b/src/shared/workers/sequenceFetcher.worker.ts
@@ -16,20 +16,27 @@
 
 import { expose } from 'comlink';
 
+import { getReverseComplement } from 'src/shared/helpers/sequenceHelpers';
 import { toFasta } from 'src/shared/helpers/formatters/fastaFormatter';
 
 export type SingleSequenceFetchParams = {
   label: string;
   url: string;
+  reverseComplement?: boolean; // this is only relevant when requesting genomic sequences
 };
 
 export type SequenceFetcherParams = Array<SingleSequenceFetchParams>;
 
 const downloadSequences = async (params: SequenceFetcherParams) => {
-  const sequencePromises = params.map(({ label, url }) => {
+  const sequencePromises = params.map(({ label, url, reverseComplement }) => {
     return fetch(url)
       .then((response) => response.text())
-      .then((sequence) => toFasta({ header: label, value: sequence }));
+      .then((sequence) => {
+        if (reverseComplement) {
+          sequence = getReverseComplement(sequence);
+        }
+        return toFasta({ header: label, value: sequence });
+      });
   });
 
   const sequences = await Promise.all(sequencePromises);


### PR DESCRIPTION
## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1470

## Description
Genomic sequences are fetched from refget only as forward-strand sequences. When fetching a sequence for a reverse-strand feature, we need to generate a reverse complement of the forward-strand sequence.

## Deployment URL
http://reverse-strand-sequences.review.ensembl.org (**Note:** sequence download probably won't work because of refget proxy database not populated with chromosome sequence checksums in review deployments. Please test locally!)