### PR TITLE
Add Contact us label to conversation icon on help and about app pages

### DIFF
--- a/src/content/app/about/About.scss
+++ b/src/content/app/about/About.scss
@@ -4,10 +4,18 @@
 $article-right-padding: 1.5rem;
 
 .appBar {
-  display: flex;
+  display: grid;
   align-items: center;
   height: 80px;
-  padding: 0 44px;
+  padding-left: 44px;
+  grid-template-columns: 100px auto;
+
+  .conversationIcon {
+    justify-self: end;
+    height: 24px;
+    margin-top: 29px;
+    margin-right: 20px;
+  }
 }
 
 .topMenuBar {

--- a/src/content/app/about/About.tsx
+++ b/src/content/app/about/About.tsx
@@ -29,6 +29,7 @@ import {
   SideMenu
 } from 'src/content/app/about/components/about-menu/AboutMenu';
 import { CircleLoader } from 'src/shared/components/loader';
+import ConversationIcon from 'src/shared/components/communication-framework/ConversationIcon';
 
 import { Menu as MenuType } from 'src/shared/types/help-and-docs/menu';
 import { TextArticleData } from 'src/shared/types/help-and-docs/article';
@@ -81,7 +82,14 @@ const About = () => {
 };
 
 const AppBar = () => {
-  return <div className={styles.appBar}>About Ensembl</div>;
+  return (
+    <div className={styles.appBar}>
+      About Ensembl
+      <div className={styles.conversationIcon}>
+        <ConversationIcon withLabel={true} />
+      </div>
+    </div>
+  );
 };
 
 const TopMenuBar = (props: { children: ReactNode }) => {

--- a/src/content/app/help/Help.scss
+++ b/src/content/app/help/Help.scss
@@ -8,13 +8,12 @@
   display: grid;
   align-items: center;
   height: 86px;
-  padding-left: 44px; 
+  padding-left: 44px;
 
   grid-template-columns: 100px auto;
 
-  .conversationIcon{
+  .conversationIcon {
     justify-self: end;
-    width: 40px;
     height: 24px;
     margin-right: 20px;
     margin-top: 29px;
@@ -26,20 +25,20 @@
   display: grid;
   padding-left: 44px;
   padding-top: 25px;
-  grid-template-areas: "breadcrumbs breadcrumbs navigation"
-                       ".  article  article";
+  grid-template-areas:
+    'breadcrumbs breadcrumbs navigation'
+    '.  article  article';
   grid-template-rows: 40px auto;
   grid-template-columns: 36px 1fr;
 
-  .breadcrumbsContainer{
+  .breadcrumbsContainer {
     grid-area: breadcrumbs;
   }
 
-  .articleContainer{
+  .articleContainer {
     grid-area: article;
   }
 }
-
 
 .articleGrid {
   grid-row: article-grid;

--- a/src/content/app/help/Help.tsx
+++ b/src/content/app/help/Help.tsx
@@ -95,7 +95,7 @@ const AppBar = () => {
     <div className={styles.appBar}>
       Help
       <div className={styles.conversationIcon}>
-        <ConversationIcon />
+        <ConversationIcon withLabel={true} />
       </div>
     </div>
   );

--- a/src/shared/components/communication-framework/ConversationIcon.scss
+++ b/src/shared/components/communication-framework/ConversationIcon.scss
@@ -1,3 +1,13 @@
+@import 'src/styles/common';
+
 .conversationIcon {
+  width: 40px;
+}
+
+.conversationIconWrapper {
+  display: grid;
+  grid-template-columns: 75px 40px;
+  align-items: center;
   cursor: pointer;
+  color: $blue;
 }

--- a/src/shared/components/communication-framework/ConversationIcon.tsx
+++ b/src/shared/components/communication-framework/ConversationIcon.tsx
@@ -25,7 +25,11 @@ import CommunicationPanel from 'src/shared/components/communication-framework/Co
 
 import styles from './ConversationIcon.scss';
 
-const ConversationIcon = () => {
+type Props = {
+  withLabel?: boolean;
+};
+
+const ConversationIcon = (props: Props) => {
   const dispatch = useDispatch();
 
   const { trackContextualHelpOpened } = useCommonAnalytics();
@@ -35,13 +39,15 @@ const ConversationIcon = () => {
 
     dispatch(toggleCommunicationPanel());
   };
+
+  const wrapperClass = props.withLabel ? styles.conversationIconWrapper : '';
   return (
     <>
       <CommunicationPanel />
-      <ConversationImageIcon
-        onClick={onClick}
-        className={styles.conversationIcon}
-      />
+      <div className={wrapperClass} onClick={onClick}>
+        {props.withLabel && 'Contact Us'}
+        <ConversationImageIcon className={styles.conversationIcon} />
+      </div>
     </>
   );
 };


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1455
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1454

## Description
A clickable text link needs to appear in the same style as in other apps in the Help and About us page

## Deployment URL
http://contact-icon-label.review.ensembl.org/

## Views affected
Help and About us page

### Other effects
NA

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
NA