### PR TITLE
Update GeneMetadata type to match with Thoas

### DIFF
--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
@@ -56,15 +56,18 @@ const GeneOverview = () => {
   }
 
   const { gene } = data;
+  const {
+    metadata: { name: geneNameMetadata }
+  } = gene;
 
   const trackLink = () => {
-    if (!gene.metadata.name) {
+    if (!geneNameMetadata?.accession_id) {
       return;
     }
 
     trackExternalReferenceLinkClick({
       tabName: SidebarTabName.OVERVIEW,
-      linkLabel: gene.metadata.name.accession_id
+      linkLabel: geneNameMetadata.accession_id
     });
   };
 
@@ -83,14 +86,14 @@ const GeneOverview = () => {
         <div className={styles.sectionHead}>Gene name</div>
         <div className={styles.sectionContent}>
           <div className={styles.geneName}>{getGeneName(gene.name)}</div>
-          {gene.metadata.name && (
+          {geneNameMetadata?.accession_id && geneNameMetadata?.url && (
             <ExternalReference
               classNames={{
                 container: styles.externalRefContainer,
                 link: styles.externalRefLink
               }}
-              to={gene.metadata.name.url}
-              linkText={gene.metadata.name.accession_id}
+              to={geneNameMetadata.url}
+              linkText={geneNameMetadata.accession_id}
               onClick={trackLink}
             />
           )}

--- a/src/content/app/genome-browser/components/drawer/drawer-views/gene-summary/GeneSummary.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/gene-summary/GeneSummary.tsx
@@ -64,6 +64,9 @@ const GeneSummary = () => {
   }
 
   const { gene } = data;
+  const {
+    metadata: { name: geneNameMetadata }
+  } = gene;
 
   const stableId = getDisplayStableId(gene);
 
@@ -112,11 +115,11 @@ const GeneSummary = () => {
         <div className={styles.label}>Gene name</div>
         <div className={styles.geneName}>
           {getGeneName(gene.name)}
-          {gene.metadata.name && (
+          {geneNameMetadata?.accession_id && geneNameMetadata?.url && (
             <ExternalReference
               classNames={{ container: styles.marginTop }}
-              to={gene.metadata.name.url}
-              linkText={gene.metadata.name.accession_id}
+              to={geneNameMetadata.url}
+              linkText={geneNameMetadata.accession_id}
             />
           )}
         </div>

--- a/src/shared/types/thoas/metadata.ts
+++ b/src/shared/types/thoas/metadata.ts
@@ -21,8 +21,8 @@ export type ValueSetMetadata = {
 };
 
 export type XrefMetadata = {
-  accession_id: string;
-  url: string;
+  accession_id: string | null;
+  url: string | null;
 };
 
 type CanonicalMetadata = Omit<ValueSetMetadata, 'value'> & { value: boolean };

--- a/src/shared/types/thoas/metadata.ts
+++ b/src/shared/types/thoas/metadata.ts
@@ -20,7 +20,7 @@ export type ValueSetMetadata = {
   definition: string;
 };
 
-export type XrefMetadata = {
+export type GeneNameMetadata = {
   accession_id: string | null;
   url: string | null;
 };
@@ -46,5 +46,5 @@ export type TranscriptMetadata = {
 
 export type GeneMetadata = {
   biotype: ValueSetMetadata;
-  name: XrefMetadata | null;
+  name: GeneNameMetadata | null;
 };


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1459


## Description
- Up the type definition for gene metadata name and relevant pages

## Deployment URL
http://update-gene-metadata-type.review.ensembl.org

## Views affected
- Genome browser -> Gene summary: http://localhost:8080/genome-browser/triticum_aestivum_GCA_900519105_1?focus=gene:TraesCS2D02G468600
- Entity viewer -> Gene overview: http://localhost:8080/entity-viewer/plasmodium_falciparum_GCA_000002765_2/gene:PF3D7_1314600?view=transcripts
