### PR TITLE
Fix transcripts loading indicator

### DIFF
--- a/src/content/app/entity-viewer/components/example-links/ExampleLinks.tsx
+++ b/src/content/app/entity-viewer/components/example-links/ExampleLinks.tsx
@@ -38,7 +38,7 @@ const ExampleLinks = () => {
     getGenomeExampleFocusObjects(state, activeGenomeId || '')
   );
   const exampleGeneId = exampleEntities.find(({ type }) => type === 'gene')?.id;
-  const { isLoading, data, error } = useGeneSummaryQuery(
+  const { isFetching, currentData, error } = useGeneSummaryQuery(
     {
       geneId: exampleGeneId || '',
       genomeId: activeGenomeId || ''
@@ -48,7 +48,7 @@ const ExampleLinks = () => {
     }
   );
 
-  if (isLoading) {
+  if (isFetching) {
     return (
       <div>
         <div className={styles.exampleLinks__emptyTopbar} />
@@ -60,13 +60,13 @@ const ExampleLinks = () => {
   }
 
   // TODO: Data doesn't get changed when there is an error?
-  if (!data || error) {
+  if (!currentData || error) {
     return null;
   }
 
   const featureIdInUrl = buildFocusIdForUrl({
     type: 'gene',
-    objectId: data.gene.unversioned_stable_id
+    objectId: currentData.gene.unversioned_stable_id
   });
   const path = urlHelper.entityViewer({
     genomeId: activeGenomeId,

--- a/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -70,23 +70,23 @@ const GeneView = () => {
   const { genomeId, entityId } = params;
   const { objectId: geneId } = parseFocusIdFromUrl(entityId as string);
 
-  const { data, isLoading } = useDefaultEntityViewerGeneQuery({
+  const { currentData, isFetching } = useDefaultEntityViewerGeneQuery({
     geneId,
     genomeId: genomeId as string
   });
 
   // TODO decide about error handling
-  if (isLoading) {
+  if (isFetching) {
     return (
       <div className={styles.geneViewLoadingContainer}>
         <CircleLoader />
       </div>
     );
-  } else if (!data) {
+  } else if (!currentData) {
     return null;
   }
 
-  return <GeneViewWithData gene={data.gene} />;
+  return <GeneViewWithData gene={currentData.gene} />;
 };
 
 const COMPONENT_ID = 'entity_viewer_gene_view';

--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.tsx
@@ -46,7 +46,7 @@ const GeneExternalReferences = () => {
 
   const { trackExternalReferenceLinkClick } = useEntityViewerAnalytics();
 
-  const { data, isLoading } = useGeneExternalReferencesQuery(
+  const { currentData, isFetching } = useGeneExternalReferencesQuery(
     {
       geneId: geneId || '',
       genomeId: genomeId || ''
@@ -56,18 +56,18 @@ const GeneExternalReferences = () => {
     }
   );
 
-  if (isLoading) {
+  if (isFetching) {
     return <div>Loading...</div>;
   }
 
-  if (!data || !data.gene) {
+  if (!currentData || !currentData.gene) {
     return <div>No data to display</div>;
   }
 
   const externalReferencesGroups = buildExternalReferencesGroups(
-    data.gene.external_references
+    currentData.gene.external_references
   );
-  const { transcripts } = data.gene;
+  const { transcripts } = currentData.gene;
   const sortedTranscripts = defaultSort(transcripts);
 
   const clickHandler = (linkLabel: string) => {
@@ -81,13 +81,13 @@ const GeneExternalReferences = () => {
     <div>
       <section>
         <div className={styles.sectionContent}>
-          <span className={styles.geneSymbol}>{data.gene.symbol}</span>
-          <span>{data.gene.stable_id}</span>
+          <span className={styles.geneSymbol}>{currentData.gene.symbol}</span>
+          <span>{currentData.gene.stable_id}</span>
         </div>
       </section>
       <section>
         <div className={styles.sectionHead}>Gene</div>
-        {data.gene.external_references && (
+        {currentData.gene.external_references && (
           <div className={styles.sectionContent}>
             {renderExternalReferencesGroups(
               externalReferencesGroups,

--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.test.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.test.tsx
@@ -80,8 +80,8 @@ describe('<GeneOverview />', () => {
   describe('loading', () => {
     beforeEach(() => {
       (useGeneOverviewQuery as any).mockImplementation(() => ({
-        data: null,
-        isLoading: true
+        currentData: null,
+        isFetching: true
       }));
     });
 
@@ -96,8 +96,8 @@ describe('<GeneOverview />', () => {
   describe('empty data', () => {
     beforeEach(() => {
       (useGeneOverviewQuery as any).mockImplementation(() => ({
-        data: null,
-        isLoading: false
+        currentData: null,
+        isFetching: false
       }));
     });
 
@@ -112,8 +112,8 @@ describe('<GeneOverview />', () => {
   describe('full data', () => {
     beforeEach(() => {
       (useGeneOverviewQuery as any).mockImplementation(() => ({
-        data: { gene: completeGeneData },
-        isLoading: false
+        currentData: { gene: completeGeneData },
+        isFetching: false
       }));
     });
 
@@ -147,8 +147,8 @@ describe('<GeneOverview />', () => {
       const geneData = { ...completeGeneData, symbol: null };
 
       (useGeneOverviewQuery as any).mockImplementation(() => ({
-        data: { gene: geneData },
-        isLoading: false
+        currentData: { gene: geneData },
+        isFetching: false
       }));
 
       const { queryByTestId } = render(<GeneOverview />);
@@ -161,8 +161,8 @@ describe('<GeneOverview />', () => {
       const geneData = { ...completeGeneData, name: null };
 
       (useGeneOverviewQuery as any).mockImplementation(() => ({
-        data: { gene: geneData },
-        isLoading: false
+        currentData: { gene: geneData },
+        isFetching: false
       }));
 
       const { container } = render(<GeneOverview />);
@@ -175,8 +175,8 @@ describe('<GeneOverview />', () => {
       const geneData = { ...completeGeneData, alternative_symbols: [] };
 
       (useGeneOverviewQuery as any).mockImplementation(() => ({
-        data: { gene: geneData },
-        isLoading: false
+        currentData: { gene: geneData },
+        isFetching: false
       }));
 
       const { container } = render(<GeneOverview />);

--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
@@ -37,7 +37,7 @@ const GeneOverview = () => {
 
   const { trackExternalReferenceLinkClick } = useEntityViewerAnalytics();
 
-  const { data, isLoading } = useGeneOverviewQuery(
+  const { currentData, isFetching } = useGeneOverviewQuery(
     {
       geneId: geneId || '',
       genomeId: genomeId as string
@@ -47,15 +47,15 @@ const GeneOverview = () => {
     }
   );
 
-  if (isLoading) {
+  if (isFetching) {
     return <div>Loading...</div>;
   }
 
-  if (!data || !data.gene) {
+  if (!currentData || !currentData.gene) {
     return <div>No data to display</div>;
   }
 
-  const { gene } = data;
+  const { gene } = currentData;
   const {
     metadata: { name: geneNameMetadata }
   } = gene;

--- a/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
@@ -80,7 +80,7 @@ const ProteinsListItemInfo = (props: Props) => {
   const proteinXrefs = getProteinXrefs(transcript);
   const displayXref = proteinXrefs[0];
 
-  const { data } = useProteinDomainsQuery({
+  const { currentData } = useProteinDomainsQuery({
     productId: productId,
     genomeId: genomeId as string
   });
@@ -134,15 +134,15 @@ const ProteinsListItemInfo = (props: Props) => {
 
   return (
     <div className={styles.proteinsListItemInfo}>
-      {data && (
+      {currentData && (
         <>
           <ProteinDomainImage
-            proteinDomains={data.product.family_matches}
+            proteinDomains={currentData.product.family_matches}
             trackLength={trackLength}
             width={gene_image_width}
           />
           <ProteinImage
-            proteinLength={data.product.length}
+            proteinLength={currentData.product.length}
             trackLength={trackLength}
             width={gene_image_width}
           />

--- a/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerDownloads.tsx
+++ b/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerDownloads.tsx
@@ -42,7 +42,7 @@ const EntityViewerSidebarDownloads = () => {
     ? parseFocusObjectId(activeEntityId).objectId
     : null;
 
-  const { data } = useGeneForSequenceDownloadQuery(
+  const { currentData } = useGeneForSequenceDownloadQuery(
     {
       genomeId: genomeId || '',
       geneId: geneId || ''
@@ -52,7 +52,7 @@ const EntityViewerSidebarDownloads = () => {
     }
   );
 
-  if (!data) {
+  if (!currentData) {
     return null;
   }
 
@@ -72,7 +72,7 @@ const EntityViewerSidebarDownloads = () => {
     }
 
     trackGeneDownload({
-      geneSymbol: data.gene.stable_id,
+      geneSymbol: currentData.gene.stable_id,
       options: downloadOptions,
       downloadStatus
     });
@@ -83,8 +83,8 @@ const EntityViewerSidebarDownloads = () => {
       <InstantDownloadGene
         genomeId={genomeId as string}
         gene={{
-          id: data.gene.stable_id,
-          isProteinCoding: isProteinCodingGene(data.gene)
+          id: currentData.gene.stable_id,
+          isProteinCoding: isProteinCodingGene(currentData.gene)
         }}
         onDownloadSuccess={(payload) => onDownload(payload, 'success')}
         onDownloadFailure={(payload) => onDownload(payload, 'failure')}

--- a/src/content/app/entity-viewer/shared/components/entity-viewer-topbar/EntityViewerTopbar.tsx
+++ b/src/content/app/entity-viewer/shared/components/entity-viewer-topbar/EntityViewerTopbar.tsx
@@ -32,12 +32,12 @@ export type EntityViewerTopbarProps = {
 export const EntityViewerTopbar = (props: EntityViewerTopbarProps) => {
   const { genomeId } = props;
   const entityId = props.entityId.split(':').pop() as string;
-  const { data } = useGeneSummaryQuery({ geneId: entityId, genomeId });
+  const { currentData } = useGeneSummaryQuery({ geneId: entityId, genomeId });
 
   return (
     <div className={styles.container}>
-      {data ? (
-        <GeneSummaryStrip gene={geneToFocusObjectFields(data.gene)} />
+      {currentData ? (
+        <GeneSummaryStrip gene={geneToFocusObjectFields(currentData.gene)} />
       ) : null}
     </div>
   );

--- a/src/content/app/genome-browser/components/drawer/drawer-views/gene-summary/GeneSummary.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/gene-summary/GeneSummary.tsx
@@ -51,19 +51,19 @@ const GeneSummary = () => {
     geneId: focusGene.stable_id,
     genomeId: focusGene.genome_id
   };
-  const { data, isLoading } = useGbGeneSummaryQuery(geneQueryParams, {
+  const { currentData, isFetching } = useGbGeneSummaryQuery(geneQueryParams, {
     skip: !focusGene.stable_id
   });
 
-  if (isLoading) {
+  if (isFetching) {
     return null;
   }
 
-  if (!data?.gene) {
+  if (!currentData?.gene) {
     return <div>No data available</div>;
   }
 
-  const { gene } = data;
+  const { gene } = currentData;
   const {
     metadata: { name: geneNameMetadata }
   } = gene;

--- a/src/content/app/genome-browser/components/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
@@ -57,7 +57,7 @@ const TranscriptSummary = (props: Props) => {
   const activeGenomeId = useSelector(getBrowserActiveGenomeId);
   const [shouldShowDownload, showDownload] = useState(false);
 
-  const { data, isLoading } = useGbTranscriptSummaryQuery(
+  const { currentData, isFetching } = useGbTranscriptSummaryQuery(
     {
       genomeId: activeGenomeId || '',
       transcriptId
@@ -67,15 +67,15 @@ const TranscriptSummary = (props: Props) => {
     }
   );
 
-  if (!activeGenomeId || isLoading) {
+  if (!activeGenomeId || isFetching) {
     return null;
   }
 
-  if (!data?.transcript) {
+  if (!currentData?.transcript) {
     return <div>No data available</div>;
   }
 
-  const { transcript } = data;
+  const { transcript } = currentData;
   const { gene } = transcript;
   const metadata = transcript.metadata;
 

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelGene.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelGene.tsx
@@ -52,7 +52,7 @@ const TrackPanelGene = (props: TrackPanelGeneProps) => {
   const { genomeId, geneId, focusObjectId } = props;
   const startWithCollapsed = !isEnvironment([Environment.PRODUCTION]); // TODO: remove after multiple transcripts are available
   const [isCollapsed, setIsCollapsed] = useState(startWithCollapsed);
-  const { data } = useGetTrackPanelGeneQuery({
+  const { currentData } = useGetTrackPanelGeneQuery({
     genomeId,
     geneId
   });
@@ -73,7 +73,7 @@ const TrackPanelGene = (props: TrackPanelGeneProps) => {
     toggleTrack({ trackId: GENE_TRACK_ID, status: trackStatus });
   }, [genomeBrowser]);
 
-  if (!data) {
+  if (!currentData) {
     return null;
   }
 
@@ -119,7 +119,7 @@ const TrackPanelGene = (props: TrackPanelGeneProps) => {
     );
   };
 
-  const { gene } = data;
+  const { gene } = currentData;
   let sortedTranscripts;
 
   if (isEnvironment([Environment.PRODUCTION])) {

--- a/src/content/app/genome-browser/components/zmenu/ZmenuInstantDownload.tsx
+++ b/src/content/app/genome-browser/components/zmenu/ZmenuInstantDownload.tsx
@@ -37,7 +37,7 @@ const ZmenuInstantDownload = (props: Props) => {
 
   const genomeId = useSelector(getBrowserActiveGenomeId) || '';
 
-  const { data, isLoading } = useGbTranscriptInZmenuQuery(
+  const { currentData, isFetching } = useGbTranscriptInZmenuQuery(
     {
       genomeId,
       transcriptId
@@ -47,23 +47,23 @@ const ZmenuInstantDownload = (props: Props) => {
     }
   );
 
-  if (isLoading) {
+  if (isFetching) {
     return (
       <div className={styles.zmenuInstantDowloadLoading}>
         <CircleLoader />
       </div>
     );
-  } else if (!data || !genomeId) {
+  } else if (!currentData || !genomeId) {
     return null;
   }
 
   const payload = {
     transcript: {
       id: transcriptId,
-      isProteinCoding: isProteinCodingTranscript(data.transcript)
+      isProteinCoding: isProteinCodingTranscript(currentData.transcript)
     },
     gene: {
-      id: data.transcript.gene.stable_id
+      id: currentData.transcript.gene.stable_id
     }
   };
 


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1476

## Importance
- There is a high chance of similar issues occurring in other areas where we use RTK

## Description
According to the RTK docs, `isLoading` :
> When true, indicates that the query is currently loading for the first time, and has no data yet. This will be true for the first request fired off, but not for subsequent requests.

This means that `isLoading` will only be true for the first time.

Also, `data`:
> The latest returned result regardless of hook arg, if present.

This would mean that `data` will still be the value of the previous request (different gene). `currentData` is what will have the result of the latest query

## Deployment URL
http://ev-transcript-loading.review.ensembl.org

## Views affected
Entity viewer - > transcripts
