### PR TITLE
Fix missing gene from previously viewed

### DIFF
--- a/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -102,8 +102,8 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
   const { search } = useLocation();
   const { trackFiltersPanelOpen } = useEntityViewerAnalytics();
   const view = new URLSearchParams(search).get('view');
-
-  const uniqueScrollReferenceId = `${COMPONENT_ID}_${props.gene.stable_id}_${view}`;
+  const geneStableId = props.gene.stable_id;
+  const uniqueScrollReferenceId = `${COMPONENT_ID}_${geneStableId}_${view}`;
 
   const { targetElementRef } = useRestoreScrollPosition({
     referenceId: uniqueScrollReferenceId
@@ -149,7 +149,7 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
         })
       );
     };
-  }, [genomeId, geneId]);
+  }, [genomeId, props.gene.stable_id]);
 
   return (
     <div className={styles.geneView} ref={targetElementRef}>

--- a/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -149,7 +149,7 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
         })
       );
     };
-  }, [genomeId, props.gene.stable_id]);
+  }, [genomeId, geneStableId]);
 
   return (
     <div className={styles.geneView} ref={targetElementRef}>


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1478

## Description
- Fixed the bug with previously viewed entities not getting updated when we select a gene from the In-App search

## Deployment URL
http://fix-previously-viewed.review.ensembl.org

## Views affected
Entity viewer -> Previously viewed
