### PR TITLE
Update test of the Upload component with a better waiting mechanism

### DIFF
--- a/src/shared/components/upload/Upload.test.tsx
+++ b/src/shared/components/upload/Upload.test.tsx
@@ -15,8 +15,7 @@
  */
 
 import React from 'react';
-import { setTimeout } from 'timers/promises';
-import { render, fireEvent, act } from '@testing-library/react';
+import { render, fireEvent, act, waitFor } from '@testing-library/react';
 import noop from 'lodash/noop';
 import Upload from './Upload';
 
@@ -103,11 +102,9 @@ describe('Upload', () => {
         fireEvent.change(container.querySelector('input') as HTMLElement, {
           target: { files: [file1, file2] }
         });
-        // bump to the end of event loop to give file reader time to read the file, and for React component to update
-        await setTimeout(0);
       });
 
-      expect(textFromFile).toBe('Lorem ipsum');
+      await waitFor(() => expect(textFromFile).toBe('Lorem ipsum'));
     });
 
     it('can read text contents of several files', async () => {
@@ -125,11 +122,11 @@ describe('Upload', () => {
         fireEvent.change(container.querySelector('input') as HTMLElement, {
           target: { files: [file1, file2] }
         });
-        // bump to the end of event loop to give file reader time to read the file, and for React component to update
-        await setTimeout(0);
       });
 
-      expect(textFromFile).toBe('Lorem ipsum dolor sit amet');
+      await waitFor(() =>
+        expect(textFromFile).toBe('Lorem ipsum dolor sit amet')
+      );
     });
   });
 


### PR DESCRIPTION
This PR contains a fix for a randomly failing test of the Upload component.

<img width="727" alt="image" src="https://user-images.githubusercontent.com/6834224/152897097-d282f1f8-a7d8-4bca-801e-b26e2df22c9b.png">

The test is failing because it is doing a time-consuming asynchronous operation, and sometimes it doesn't have enough processing power to complete the work within one event loop.

Instead of guessing and hard-coding the duration of the timeout, a smarter option would be to use the `waitFor` utility function from the testing library. 