### PR TITLE
Add sequence guessing code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "@svgr/webpack": "6.1.2",
         "@testing-library/jest-dom": "5.16.1",
         "@testing-library/react": "12.1.2",
+        "@testing-library/react-hooks": "7.0.2",
         "@testing-library/user-event": "13.5.0",
         "@types/compression-webpack-plugin": "9.1.1",
         "@types/copy-webpack-plugin": "10.1.0",
@@ -11449,6 +11450,35 @@
         "react-dom": "*"
       }
     },
+    "node_modules/@testing-library/react-hooks": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz",
+      "integrity": "sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/react": ">=16.9.0",
+        "@types/react-dom": ">=16.9.0",
+        "@types/react-test-renderer": ">=16.9.0",
+        "react-error-boundary": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0",
+        "react-test-renderer": ">=16.9.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-test-renderer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@testing-library/user-event": {
       "version": "13.5.0",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
@@ -12269,6 +12299,15 @@
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.5.tgz",
       "integrity": "sha512-VIOi9i2Oj5XsmWWoB72p3KlZoEbdRAcechJa8Ztebw7bDl2YmR+odxIqhtJGp1q2EozHs02US+gzxJ9nuf56qg==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-test-renderer": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
+      "integrity": "sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"
@@ -31829,6 +31868,22 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-error-overlay": {
       "version": "6.0.10",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.10.tgz",
@@ -47272,6 +47327,19 @@
         "@testing-library/dom": "^8.0.0"
       }
     },
+    "@testing-library/react-hooks": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz",
+      "integrity": "sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@types/react": ">=16.9.0",
+        "@types/react-dom": ">=16.9.0",
+        "@types/react-test-renderer": ">=16.9.0",
+        "react-error-boundary": "^3.1.0"
+      }
+    },
     "@testing-library/user-event": {
       "version": "13.5.0",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
@@ -48083,6 +48151,15 @@
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.5.tgz",
       "integrity": "sha512-VIOi9i2Oj5XsmWWoB72p3KlZoEbdRAcechJa8Ztebw7bDl2YmR+odxIqhtJGp1q2EozHs02US+gzxJ9nuf56qg==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-test-renderer": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
+      "integrity": "sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -63165,6 +63242,15 @@
           "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
           "dev": true
         }
+      }
+    },
+    "react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "react-error-overlay": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@svgr/webpack": "6.1.2",
     "@testing-library/jest-dom": "5.16.1",
     "@testing-library/react": "12.1.2",
+    "@testing-library/react-hooks": "7.0.2",
     "@testing-library/user-event": "13.5.0",
     "@types/compression-webpack-plugin": "9.1.1",
     "@types/copy-webpack-plugin": "10.1.0",

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.scss
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.scss
@@ -5,9 +5,10 @@
 }
 
 .header {
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  column-gap: 52px;
   width: 860px;
-  display: flex;
-  justify-content: space-between;
   align-items: center;
   padding-left: 28px;
   padding-bottom: 12px;
@@ -20,6 +21,10 @@
 .headerGroup {
   display: flex;
   align-items: center;
+}
+
+.headerGroup:last-child {
+  justify-self: end;
 }
 
 .headerTitle {
@@ -53,7 +58,7 @@
 }
 
 .blastAgainstButton {
-  margin-left: 66px;
+  margin-left: 18px;
 }
 
 .inputBoxesContainer {

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.test.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.test.tsx
@@ -178,19 +178,5 @@ describe('<BlastInputSequences />', () => {
         });
       });
     });
-
-    it.todo('guesses the type of the first sequence');
-
-    /**
-     * QUESTIONS
-     *
-     * WHAT SHOULD HAPPEN IF USER ADDS AN UNEXPECTED SEQUECE?
-     * - a sequence different from the predicted
-     * - a sequence with invalid characters
-     * - a sequence with only a FASTA header
-     * - too short a sequence?
-     *
-     * WHAT SHOULD HAPPEN IF USER ADDS MORE SEQUENCES THAN WE ARE LIMITING THEM TO?
-     */
   });
 });

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.tsx
@@ -15,65 +15,21 @@
  */
 
 import React from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 
-import {
-  setSequences,
-  setSequenceType
-} from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
+import { getEmptyInputVisibility } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
 
-import {
-  getSequences,
-  getSelectedSequenceType,
-  getSequenceSelectionMode,
-  getEmptyInputVisibility
-} from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
+import useBlastInputSequences from './useBlastInputSequences';
 
 import { parseBlastInput } from 'src/content/app/tools/blast/utils/blastInputParser';
-import { guessSequenceType } from 'src/content/app/tools/shared/helpers/sequenceTypeGuesser';
 
 import BlastInputSequence from './BlastInputSequence';
 
-import untypedBlastSettingsConfig from 'src/content/app/tools/blast/components/blast-settings/blastSettingsConfig.json';
-
-import type { BlastSettingsConfig } from 'src/content/app/tools/blast/types/blastSettings';
-import type { ParsedInputSequence } from 'src/content/app/tools/blast/types/parsedInputSequence';
-
 import styles from './BlastInputSequences.scss';
 
-const blastSettingsConfig = untypedBlastSettingsConfig as BlastSettingsConfig;
-
 const BlastInputSequences = () => {
-  const sequences = useSelector(getSequences);
-  const sequenceType = useSelector(getSelectedSequenceType);
-  const sequenceSelectionMode = useSelector(getSequenceSelectionMode);
+  const { sequences, updateSequences } = useBlastInputSequences();
   const shouldAppendEmptyInput = useSelector(getEmptyInputVisibility);
-  const dispatch = useDispatch();
-
-  const updateSequences = (sequences: ParsedInputSequence[]) => {
-    dispatch(setSequences({ sequences }));
-    updateSequenceType(sequences);
-  };
-
-  const updateSequenceType = (sequences: ParsedInputSequence[]) => {
-    if (sequenceSelectionMode === 'manual') {
-      return;
-    }
-
-    const guessedSequenceType = sequences.length
-      ? guessSequenceType(sequences[0].value)
-      : 'dna';
-
-    if (guessedSequenceType !== sequenceType) {
-      dispatch(
-        setSequenceType({
-          sequenceType: guessedSequenceType,
-          isAutomatic: true,
-          config: blastSettingsConfig
-        })
-      );
-    }
-  };
 
   const onSequenceAdded = (input: string, index: number | null) => {
     const parsedSequences = parseBlastInput(input);

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.tsx
@@ -18,11 +18,13 @@ import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
 import {
+  getSelectedSequenceType,
   getSequences,
   getEmptyInputVisibility
 } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
 
 import {
+  setSequenceType,
   setSequences,
   updateEmptyInputDisplay,
   switchToSpeciesStep
@@ -30,6 +32,14 @@ import {
 
 import { SecondaryButton } from 'src/shared/components/button/Button';
 import PlusButton from 'src/shared/components/plus-button/PlusButton';
+import RadioGroup from 'src/shared/components/radio-group/RadioGroup';
+
+import untypedBlastSettingsConfig from 'src/content/app/tools/blast/components/blast-settings/blastSettingsConfig.json';
+
+import type {
+  SequenceType,
+  BlastSettingsConfig
+} from 'src/content/app/tools/blast/types/blastSettings';
 
 import styles from './BlastInputSequences.scss';
 
@@ -37,12 +47,24 @@ export type Props = {
   compact: boolean;
 };
 
+const blastSettingsConfig = untypedBlastSettingsConfig as BlastSettingsConfig;
+
 const BlastInputSequencesHeader = (props: Props) => {
   const { compact } = props;
+  const sequenceType = useSelector(getSelectedSequenceType);
   const sequences = useSelector(getSequences);
   const shouldAppendEmptyInput = useSelector(getEmptyInputVisibility);
 
   const dispatch = useDispatch();
+
+  const onSequenceTypeChange = (sequenceType: SequenceType) => {
+    dispatch(
+      setSequenceType({
+        sequenceType,
+        config: blastSettingsConfig
+      })
+    );
+  };
 
   const onClearAll = () => {
     dispatch(
@@ -67,6 +89,10 @@ const BlastInputSequencesHeader = (props: Props) => {
         <span className={styles.sequenceCounter}>{sequences.length}</span>
         <span className={styles.maxSequences}>of 30</span>
       </div>
+      <SequenceSwitcher
+        sequenceType={sequenceType}
+        onChange={onSequenceTypeChange}
+      />
       <div className={styles.headerGroup}>
         <span className={styles.clearAll} onClick={onClearAll}>
           Clear all
@@ -99,6 +125,30 @@ const AddAnotherSequence = (props: AddAnotherSequenceProps) => {
       <span className={styles.addSequenceLabel}>Add another sequence</span>
       <PlusButton onClick={props.onAdd} disabled={props.disabled} />
     </div>
+  );
+};
+
+const SequenceSwitcher = (props: {
+  sequenceType: string;
+  onChange: (sequenceType: SequenceType) => void;
+}) => {
+  const options: { label: string; value: SequenceType }[] = [
+    {
+      label: 'Nucleotide',
+      value: 'dna'
+    },
+    {
+      label: 'Protein',
+      value: 'protein'
+    }
+  ];
+  return (
+    <RadioGroup
+      options={options}
+      direction="row"
+      selectedOption={props.sequenceType}
+      onChange={(val) => props.onChange(val as unknown as SequenceType)}
+    />
   );
 };
 

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.tsx
@@ -120,7 +120,7 @@ const SequenceSwitcher = (props: {
       options={options}
       direction="row"
       selectedOption={props.sequenceType}
-      onChange={(val) => props.onChange(val as unknown as SequenceType)}
+      onChange={(val) => props.onChange(val as SequenceType)}
     />
   );
 };

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.tsx
@@ -17,29 +17,20 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
-import {
-  getSelectedSequenceType,
-  getSequences,
-  getEmptyInputVisibility
-} from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
+import { getEmptyInputVisibility } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
 
 import {
-  setSequenceType,
-  setSequences,
   updateEmptyInputDisplay,
   switchToSpeciesStep
 } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
+
+import useBlastInputSequences from './useBlastInputSequences';
 
 import { SecondaryButton } from 'src/shared/components/button/Button';
 import PlusButton from 'src/shared/components/plus-button/PlusButton';
 import RadioGroup from 'src/shared/components/radio-group/RadioGroup';
 
-import untypedBlastSettingsConfig from 'src/content/app/tools/blast/components/blast-settings/blastSettingsConfig.json';
-
-import type {
-  SequenceType,
-  BlastSettingsConfig
-} from 'src/content/app/tools/blast/types/blastSettings';
+import type { SequenceType } from 'src/content/app/tools/blast/types/blastSettings';
 
 import styles from './BlastInputSequences.scss';
 
@@ -47,32 +38,14 @@ export type Props = {
   compact: boolean;
 };
 
-const blastSettingsConfig = untypedBlastSettingsConfig as BlastSettingsConfig;
-
 const BlastInputSequencesHeader = (props: Props) => {
   const { compact } = props;
-  const sequenceType = useSelector(getSelectedSequenceType);
-  const sequences = useSelector(getSequences);
+  const { sequences, sequenceType, updateSequenceType, clearAllSequences } =
+    useBlastInputSequences();
+
   const shouldAppendEmptyInput = useSelector(getEmptyInputVisibility);
 
   const dispatch = useDispatch();
-
-  const onSequenceTypeChange = (sequenceType: SequenceType) => {
-    dispatch(
-      setSequenceType({
-        sequenceType,
-        config: blastSettingsConfig
-      })
-    );
-  };
-
-  const onClearAll = () => {
-    dispatch(
-      setSequences({
-        sequences: []
-      })
-    );
-  };
 
   const appendEmptyInput = () => {
     dispatch(updateEmptyInputDisplay(true));
@@ -91,10 +64,10 @@ const BlastInputSequencesHeader = (props: Props) => {
       </div>
       <SequenceSwitcher
         sequenceType={sequenceType}
-        onChange={onSequenceTypeChange}
+        onChange={updateSequenceType}
       />
       <div className={styles.headerGroup}>
-        <span className={styles.clearAll} onClick={onClearAll}>
+        <span className={styles.clearAll} onClick={clearAllSequences}>
           Clear all
         </span>
         <AddAnotherSequence

--- a/src/content/app/tools/blast/components/blast-input-sequences/useBlastInputSequences.test.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/useBlastInputSequences.test.tsx
@@ -30,15 +30,16 @@ import blastFormReducer, {
   type BlastFormState
 } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
 
+const rootReducer = combineReducers({
+  blast: combineReducers({
+    blastForm: blastFormReducer
+  })
+});
+
 const getWrapper = (
   { state }: { state?: Partial<BlastFormState> } = { state: {} }
 ) => {
   const blastFormState = Object.assign({}, initialBlastFormState, state);
-  const rootReducer = combineReducers({
-    blast: combineReducers({
-      blastForm: blastFormReducer
-    })
-  });
   const initialState = {
     blast: { blastForm: blastFormState }
   };
@@ -232,14 +233,6 @@ describe('useBlastInputSequences', () => {
       const { result } = renderHook(() => useBlastInputSequences(), {
         wrapper
       });
-
-      // initial values
-      expect(getSelectedSequenceType(store.getState() as any)).toEqual(
-        'protein'
-      );
-      expect(getSequenceSelectionMode(store.getState() as any)).toEqual(
-        'manual'
-      );
 
       const { clearAllSequences } = result.current;
       clearAllSequences();

--- a/src/content/app/tools/blast/components/blast-input-sequences/useBlastInputSequences.test.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/useBlastInputSequences.test.tsx
@@ -1,0 +1,254 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { type ReactNode } from 'react';
+import useBlastInputSequences from './useBlastInputSequences';
+import { Provider } from 'react-redux';
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
+import { renderHook } from '@testing-library/react-hooks';
+
+import {
+  getSequences,
+  getSelectedSequenceType,
+  getSequenceSelectionMode
+} from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
+import blastFormReducer, {
+  initialState as initialBlastFormState,
+  type BlastFormState
+} from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
+
+const getWrapper = (
+  { state }: { state?: Partial<BlastFormState> } = { state: {} }
+) => {
+  const blastFormState = Object.assign({}, initialBlastFormState, state);
+  const rootReducer = combineReducers({
+    blast: combineReducers({
+      blastForm: blastFormReducer
+    })
+  });
+  const initialState = {
+    blast: { blastForm: blastFormState }
+  };
+
+  const store = configureStore({
+    reducer: rootReducer,
+    preloadedState: initialState
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+
+  return {
+    wrapper,
+    store
+  };
+};
+
+describe('useBlastInputSequences', () => {
+  it('returns sequences from redux slice', () => {
+    const sequences = [{ header: 'foo', value: 'AAA' }];
+    const { wrapper } = getWrapper({
+      state: {
+        sequences
+      }
+    });
+    const { result } = renderHook(() => useBlastInputSequences(), { wrapper });
+    expect(result.current.sequences).toEqual(sequences);
+  });
+
+  it('returns sequence type from redux slice', () => {
+    const { wrapper } = getWrapper();
+    const { result } = renderHook(() => useBlastInputSequences(), { wrapper });
+    expect(result.current.sequenceType).toEqual('dna');
+  });
+
+  describe('updateSequences', () => {
+    it('replaces sequences in the redux store', () => {
+      const sequences = [{ header: 'foo', value: 'AAA' }];
+      const { wrapper, store } = getWrapper({
+        state: {
+          sequences
+        }
+      });
+      const { result } = renderHook(() => useBlastInputSequences(), {
+        wrapper
+      });
+      const { updateSequences } = result.current;
+
+      const newSequences = [
+        { header: 'bar', value: 'ACTG' },
+        { header: 'baz', value: 'GUAC' }
+      ];
+      updateSequences(newSequences);
+
+      expect(getSequences(store.getState() as any)).toEqual(newSequences);
+    });
+
+    it('updates sequence type while updating the sequences', () => {
+      const proteinSequence =
+        'MENLNMDLLYMAAAVMMGLAAIGAAIGIGILGGKFLEGAARQPDLIPLLRTQFFIVMGLVDAIPMIAVGL';
+      const nucleotideSequence =
+        'CGGACCAGACGGACACAGGGAGAAGCTAGTTTCTTTCATGTGATTGANATNATGACTCTACTCCTAAAAG';
+      const { wrapper, store } = getWrapper();
+      const { result } = renderHook(() => useBlastInputSequences(), {
+        wrapper
+      });
+      const { updateSequences } = result.current;
+
+      let newSequences = [
+        { value: proteinSequence },
+        { value: nucleotideSequence }
+      ];
+      updateSequences(newSequences);
+
+      expect(getSelectedSequenceType(store.getState() as any)).toEqual(
+        'protein'
+      );
+
+      newSequences = [
+        { value: nucleotideSequence },
+        { value: proteinSequence }
+      ];
+      updateSequences(newSequences);
+
+      expect(getSelectedSequenceType(store.getState() as any)).toEqual('dna');
+    });
+
+    it('resets sequence type to dna if sequences are deleted', () => {
+      const proteinSequence =
+        'MENLNMDLLYMAAAVMMGLAAIGAAIGIGILGGKFLEGAARQPDLIPLLRTQFFIVMGLVDAIPMIAVGL';
+      // PART 1. With automatically guessed sequence type
+      const { wrapper: wrapper1, store: store1 } = getWrapper();
+      const { result: result1 } = renderHook(() => useBlastInputSequences(), {
+        wrapper: wrapper1
+      });
+      let updateSequences = result1.current.updateSequences;
+
+      updateSequences([{ value: proteinSequence }]);
+
+      expect(getSelectedSequenceType(store1.getState() as any)).toEqual(
+        'protein'
+      );
+
+      updateSequences([]);
+
+      expect(getSelectedSequenceType(store1.getState() as any)).toEqual('dna');
+
+      // PART 2. With manually set sequence type
+      const { wrapper: wrapper2, store: store2 } = getWrapper({
+        state: {
+          sequences: [{ header: 'foo', value: 'MENLNMDL' }],
+          settings: {
+            ...initialBlastFormState.settings,
+            sequenceSelectionMode: 'manual',
+            sequenceType: 'protein'
+          }
+        }
+      });
+      const { result: result2 } = renderHook(() => useBlastInputSequences(), {
+        wrapper: wrapper2
+      });
+      updateSequences = result2.current.updateSequences;
+
+      updateSequences([]);
+
+      expect(getSelectedSequenceType(store2.getState() as any)).toEqual('dna'); // sequence type reset to initial
+    });
+
+    it('does not change sequence type if user has changed sequence type manually', () => {
+      const proteinSequence =
+        'MENLNMDLLYMAAAVMMGLAAIGAAIGIGILGGKFLEGAARQPDLIPLLRTQFFIVMGLVDAIPMIAVGL';
+      const { wrapper, store } = getWrapper({
+        state: {
+          settings: {
+            ...initialBlastFormState.settings,
+            sequenceSelectionMode: 'manual'
+          }
+        }
+      });
+      const { result } = renderHook(() => useBlastInputSequences(), {
+        wrapper
+      });
+      const { updateSequences } = result.current;
+      expect(getSelectedSequenceType(store.getState() as any)).toEqual('dna'); // initial value
+
+      updateSequences([{ value: proteinSequence }]);
+
+      expect(getSelectedSequenceType(store.getState() as any)).toEqual('dna'); // sequence type should not have changed
+    });
+  });
+
+  describe('updateSequenceType', () => {
+    it('changes sequence type and sets the change type to manual', () => {
+      const { wrapper, store } = getWrapper();
+      const { result } = renderHook(() => useBlastInputSequences(), {
+        wrapper
+      });
+
+      // initial values
+      expect(getSelectedSequenceType(store.getState() as any)).toEqual('dna');
+      expect(getSequenceSelectionMode(store.getState() as any)).toEqual(
+        'automatic'
+      );
+
+      const { updateSequenceType } = result.current;
+      updateSequenceType('protein');
+
+      expect(getSelectedSequenceType(store.getState() as any)).toEqual(
+        'protein'
+      );
+      expect(getSequenceSelectionMode(store.getState() as any)).toEqual(
+        'manual'
+      );
+    });
+  });
+
+  describe('clearAllSequences', () => {
+    it('clears sequences and sets the change type to automatic', () => {
+      const { wrapper, store } = getWrapper({
+        state: {
+          sequences: [{ header: 'foo', value: 'MENLNMDL' }],
+          settings: {
+            ...initialBlastFormState.settings,
+            sequenceSelectionMode: 'manual',
+            sequenceType: 'protein'
+          }
+        }
+      });
+      const { result } = renderHook(() => useBlastInputSequences(), {
+        wrapper
+      });
+
+      // initial values
+      expect(getSelectedSequenceType(store.getState() as any)).toEqual(
+        'protein'
+      );
+      expect(getSequenceSelectionMode(store.getState() as any)).toEqual(
+        'manual'
+      );
+
+      const { clearAllSequences } = result.current;
+      clearAllSequences();
+
+      expect(getSequences(store.getState() as any)).toEqual([]);
+      expect(getSelectedSequenceType(store.getState() as any)).toEqual('dna');
+      expect(getSequenceSelectionMode(store.getState() as any)).toEqual(
+        'automatic'
+      );
+    });
+  });
+});

--- a/src/content/app/tools/blast/components/blast-input-sequences/useBlastInputSequences.ts
+++ b/src/content/app/tools/blast/components/blast-input-sequences/useBlastInputSequences.ts
@@ -1,0 +1,119 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useRef, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
+import {
+  setSequences,
+  setSequenceType
+} from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
+
+import {
+  getSequences,
+  getSelectedSequenceType,
+  getSequenceSelectionMode
+} from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
+
+import { guessSequenceType } from 'src/content/app/tools/shared/helpers/sequenceTypeGuesser';
+
+import untypedBlastSettingsConfig from 'src/content/app/tools/blast/components/blast-settings/blastSettingsConfig.json';
+
+import type {
+  SequenceType,
+  BlastSettingsConfig
+} from 'src/content/app/tools/blast/types/blastSettings';
+import type { ParsedInputSequence } from 'src/content/app/tools/blast/types/parsedInputSequence';
+
+const blastSettingsConfig = untypedBlastSettingsConfig as BlastSettingsConfig;
+
+const useBlastInputSequences = () => {
+  const sequences = useSelector(getSequences);
+  const sequenceType = useSelector(getSelectedSequenceType);
+  const sequenceSelectionMode = useSelector(getSequenceSelectionMode);
+  const dispatch = useDispatch();
+
+  const ref = useRef({
+    sequenceType,
+    sequenceSelectionMode
+  });
+
+  // to avoid stale closures persisting in functions returned from the hook
+  useEffect(() => {
+    ref.current = { sequenceType, sequenceSelectionMode };
+  });
+
+  const updateSequences = (sequences: ParsedInputSequence[]) => {
+    dispatch(setSequences({ sequences }));
+    updateSequenceTypeAutomatically(sequences);
+  };
+
+  const updateSequenceTypeAutomatically = (
+    sequences: ParsedInputSequence[]
+  ) => {
+    if (sequences.length && ref.current.sequenceSelectionMode === 'manual') {
+      return;
+    }
+
+    const guessedSequenceType = sequences.length
+      ? guessSequenceType(sequences[0].value)
+      : 'dna';
+
+    if (guessedSequenceType !== ref.current.sequenceType) {
+      dispatch(
+        setSequenceType({
+          sequenceType: guessedSequenceType,
+          isAutomatic: true,
+          config: blastSettingsConfig
+        })
+      );
+    }
+  };
+
+  const updateSequenceType = (sequenceType: SequenceType) => {
+    dispatch(
+      setSequenceType({
+        sequenceType,
+        config: blastSettingsConfig
+      })
+    );
+  };
+
+  const clearAllSequences = () => {
+    dispatch(
+      setSequences({
+        sequences: []
+      })
+    );
+    dispatch(
+      setSequenceType({
+        sequenceType: 'dna',
+        isAutomatic: true,
+        config: blastSettingsConfig
+      })
+    );
+  };
+
+  return {
+    sequences,
+    sequenceType,
+    updateSequences,
+    clearAllSequences,
+    updateSequenceType
+  };
+};
+
+export default useBlastInputSequences;

--- a/src/content/app/tools/blast/components/blast-settings/BlastSettings.tsx
+++ b/src/content/app/tools/blast/components/blast-settings/BlastSettings.tsx
@@ -19,7 +19,6 @@ import { useSelector, useDispatch } from 'react-redux';
 
 import ShowHide from 'src/shared/components/show-hide/ShowHide';
 import Checkbox from 'src/shared/components/checkbox/Checkbox';
-import RadioGroup from 'src/shared/components/radio-group/RadioGroup';
 
 import untypedBlastSettingsConfig from './blastSettingsConfig.json';
 
@@ -30,7 +29,6 @@ import {
   getBlastSearchParameters
 } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
 import {
-  setSequenceType,
   setBlastDatabase,
   setBlastProgram,
   changeSensitivityPresets,
@@ -38,7 +36,6 @@ import {
 } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
 
 import type {
-  SequenceType,
   BlastProgram,
   BlastSelectSetting,
   BlastBooleanSetting,
@@ -96,15 +93,6 @@ const BlastSettings = () => {
       onDatabaseChange(defaultDatabase);
     }
   }, []);
-
-  const onSequenceTypeChange = (sequenceType: string) => {
-    dispatch(
-      setSequenceType({
-        sequenceType: sequenceType as SequenceType,
-        config: blastSettingsConfig
-      })
-    );
-  };
 
   const onDatabaseChange = (database: string) => {
     dispatch(
@@ -189,10 +177,6 @@ const BlastSettings = () => {
             onClick={onParametersToggle}
           />
         </div>
-        <SequenceSwitcher
-          sequenceType={sequenceType}
-          onChange={onSequenceTypeChange}
-        />
       </div>
       {parametersExpanded && (
         <div className={styles.bottomLevel}>
@@ -274,29 +258,6 @@ const BlastSettings = () => {
         </div>
       )}
     </>
-  );
-};
-
-const SequenceSwitcher = (props: {
-  sequenceType: string;
-  onChange: (sequenceType: string) => void;
-}) => {
-  const options = [
-    {
-      label: 'Nucleotide',
-      value: 'dna'
-    },
-    {
-      label: 'Protein',
-      value: 'protein'
-    }
-  ];
-  return (
-    <RadioGroup
-      options={options}
-      selectedOption={props.sequenceType}
-      onChange={(val) => props.onChange(val as string)}
-    />
   );
 };
 

--- a/src/content/app/tools/shared/helpers/sequenceTypeGuesser.test.ts
+++ b/src/content/app/tools/shared/helpers/sequenceTypeGuesser.test.ts
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 
-import { guessSequenceType } from './sequenceTypeGuesser';
+import {
+  guessSequenceType,
+  guessSequencesType,
+  aminoAcidOnlyCodes
+} from './sequenceTypeGuesser';
 
-describe('guessSequence', () => {
+describe('guessSequenceType', () => {
   it('guesses a protein sequence', () => {
     const sequence =
       'MENLNMDLLYMAAAVMMGLAAIGAAIGIGILGGKFLEGAARQPDLIPLLRTQFFIVMGLVDAIPMIAVGL';
@@ -29,10 +33,46 @@ describe('guessSequence', () => {
     expect(guessSequenceType(sequence)).toBe('dna');
   });
 
-  it.skip('guesses a nucleotide sequence with ambiguous codes', () => {
-    // This will be guessed as a protein although it's a nucleic acid
-    // should we remove the N's as Uniprot does? What about other ambiguous nucleotide codes?
+  it('interprets sequence as protein if it contains one or more unique characters', () => {
+    // amino acid alphabet contains the following letters not present in the nucleotide alphabet: EFILPQXZ
+    aminoAcidOnlyCodes.split('').forEach((character) => {
+      const sequence = `ACGTUACGTUACGTUACGTUACGTUACGTU${character}`;
+      expect(guessSequenceType(sequence)).toBe('protein');
+    });
+  });
+
+  it('ignores the ambiguous code N when guessing a nucleotide sequence', () => {
+    // The letter N exists in both amino acid and nucleotide alphabets.
+    // It is ignored while guessing a sequence type
     const sequence = 'CCCNTTAAAGGGGGNNCCCCTNCNNGGGGGAATAAAACAANTTNNTTTTTT';
     expect(guessSequenceType(sequence)).toBe('dna');
+  });
+});
+
+describe('guessSequencesType', () => {
+  const nucleotideSequence1 = 'ACACACTCACACACACTTGGTCAGAGATGCTGTGC';
+  const nucleotideSequence2 = 'TNAAGCNTGACAACACCAGGCAGGTATGAGAGGAAAG';
+  const proteinSequence1 =
+    'QIKDLLVSSSTDLDTTLVLVNAIYFKGMWKTAFNAEDTREMPFHVTKQESKPVQMMCMNNSFNVATLPAE';
+  const proteinSequence2 =
+    'KMKILELPFASGDLSMLVLLPDEVSDLERIEKTINFEKLTEWTNPNTMEKRRVKVYLPQMKIEEKYNLTS';
+
+  it('assumes all sequences to be DNA if none is guessed as protein', () => {
+    const nucleotideSequences = [nucleotideSequence1, nucleotideSequence2];
+    expect(guessSequencesType(nucleotideSequences)).toBe('dna');
+  });
+
+  it('assumes all sequences to be protein if none is guessed as DNA', () => {
+    const proteinSequences = [proteinSequence1, proteinSequence2];
+    expect(guessSequencesType(proteinSequences)).toBe('protein');
+  });
+
+  it('assumes all sequences to be protein if at least one is guessed as protein', () => {
+    const mixedSequences = [
+      nucleotideSequence1,
+      nucleotideSequence2,
+      proteinSequence1
+    ];
+    expect(guessSequencesType(mixedSequences)).toBe('protein');
   });
 });

--- a/src/content/app/tools/shared/helpers/sequenceTypeGuesser.test.ts
+++ b/src/content/app/tools/shared/helpers/sequenceTypeGuesser.test.ts
@@ -1,0 +1,38 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { guessSequenceType } from './sequenceTypeGuesser';
+
+describe('guessSequence', () => {
+  it('guesses a protein sequence', () => {
+    const sequence =
+      'MENLNMDLLYMAAAVMMGLAAIGAAIGIGILGGKFLEGAARQPDLIPLLRTQFFIVMGLVDAIPMIAVGL';
+    expect(guessSequenceType(sequence)).toBe('protein');
+  });
+
+  it('guesses a nucleotide sequence', () => {
+    const sequence =
+      'CGGACCAGACGGACACAGGGAGAAGCTAGTTTCTTTCATGTGATTGANATNATGACTCTACTCCTAAAAG';
+    expect(guessSequenceType(sequence)).toBe('dna');
+  });
+
+  it.skip('guesses a nucleotide sequence with ambiguous codes', () => {
+    // This will be guessed as a protein although it's a nucleic acid
+    // should we remove the N's as Uniprot does? What about other ambiguous nucleotide codes?
+    const sequence = 'CCCNTTAAAGGGGGNNCCCCTNCNNGGGGGAATAAAACAANTTNNTTTTTT';
+    expect(guessSequenceType(sequence)).toBe('dna');
+  });
+});

--- a/src/content/app/tools/shared/helpers/sequenceTypeGuesser.ts
+++ b/src/content/app/tools/shared/helpers/sequenceTypeGuesser.ts
@@ -1,0 +1,130 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import difference from 'lodash/difference';
+
+/**
+ * The nucleic acid codes are:
+
+    A --> adenine             M --> A C (amino)
+    C --> cytosine            S --> G C (strong)
+    G --> guanine             W --> A T (weak)
+    T --> thymine             B --> G T C
+    U --> uracil              D --> G A T
+    R --> G A (purine)        H --> A C T
+    Y --> T C (pyrimidine)    V --> G C A
+    K --> G T (keto)          N --> A G C T (any)
+                              -  gap of indeterminate length
+
+ * The amino acid codes allowed by BLASTP and TBLASTN programs are:
+
+		A  alanine               P  proline
+		B  aspartate/asparagine  Q  glutamine
+		C  cystine               R  arginine
+		D  aspartate             S  serine
+		E  glutamate             T  threonine
+		F  phenylalanine         U  selenocysteine
+		G  glycine               V  valine
+		H  histidine             W  tryptophan
+		I  isoleucine            Y  tyrosine
+		K  lysine                Z  glutamate/glutamine
+		L  leucine               X  any
+		M  methionine            *  translation stop
+		N  asparagine            -  gap of indeterminate length
+
+  (From NCBI Blast docs: https://blast.ncbi.nlm.nih.gov/Blast.cgi?CMD=Web&PAGE_TYPE=BlastDocs&DOC_TYPE=BlastHelp)
+ */
+
+/**
+ * QUESTIONS:
+ * Uniprot (see https://github.com/ebi-uniprot/franklin-sites/blob/main/src/sequence-utils/sequenceValidator.ts):
+ * - Doesn't allow U as an amino acid code (although NCBI blast allows it as selenocysteine)
+ * - Includes J (leucine or isoleucine) in the list of ambiguous amino acid codes, whereas NCBI doesn't list it among allowed amino acid codes
+ *
+ * Who is right?
+ *
+ *
+ * Also, see old Ensembl code:
+ * https://github.com/Ensembl/public-plugins/blob/release/105/tools/htdocs/components/20_BlastForm.js#L364
+ */
+
+const certainAminoAcids = 'ACDEFGHIKLMNPQRSTUVWY';
+const ambiguousAminoAcids = 'XBZ';
+const certainNucleotides = 'ACGTU';
+const ambiguousNucleotides = 'BDHKMNRSVWY';
+
+// TODO: three lines below are from Uniprot; check them
+// Characters unique only to their subset e.g. 'U' is not a valid AA.
+// const aminoAcidsOnly = /[EQILFPXJ]/gi;
+// const nucleicAcidsOnly = /U/gi;
+
+// FIXME: remove the eslint disable comment
+/* eslint-disable @typescript-eslint/no-unused-vars */
+const aminoAcidOnlyCodes = difference(
+  `${certainAminoAcids}${ambiguousAminoAcids}`.split(''),
+  `${certainNucleotides}${ambiguousNucleotides}`.split('')
+).join('');
+
+const nucleotideOnlyCodes = difference(
+  `${certainNucleotides}${ambiguousNucleotides}`.split(''),
+  `${certainAminoAcids}${ambiguousAminoAcids}`.split('')
+).join('');
+
+const certainNucleotidesSet = new Set(Array.from(certainNucleotides));
+
+// FIXME: use SeuenceType
+
+export const guessSequenceType = (sequence: string) => {
+  // QUESTION: should we include testing for amino-acid-only codes in this function?
+  sequence = cleanUpSequence(sequence);
+
+  // an arbitrary threshold saying that if 90% or more characters in a sequence
+  // match unambiguous nucleotide characters, then guess that it's a nucleic acid
+  const nucleotideThreshold = 0.9;
+
+  const nucleotideCandidateCount = sequence
+    .split('')
+    .reduce(
+      (count, character) =>
+        certainNucleotidesSet.has(character) ? count + 1 : count,
+      0
+    );
+  return nucleotideCandidateCount / sequence.length >= nucleotideThreshold
+    ? 'dna'
+    : 'protein';
+};
+
+const cleanUpSequence = (sequence: string) => {
+  const cleanupRegExp = /[^A-Z]/gi; // anything that isn't a valid letter
+  return sequence.replace(cleanupRegExp, '');
+};
+
+/*
+
+export const validAminoAcids = [
+  naturalAminoAcids,
+  ambiguousAminoAcids,
+  '*', // Stop
+  '.-', // Gaps
+].join('');
+
+export const validNucleicAcids = [
+  baseNucleicAcids,
+  ambiguousNucleicAcids,
+  // No gaps e.g. - and . are not allowed
+].join('');
+
+*/

--- a/src/content/app/tools/shared/helpers/sequenceTypeGuesser.ts
+++ b/src/content/app/tools/shared/helpers/sequenceTypeGuesser.ts
@@ -71,19 +71,14 @@ const ambiguousNucleotides = 'BDHKMNRSVWY';
 // const aminoAcidsOnly = /[EQILFPXJ]/gi;
 // const nucleicAcidsOnly = /U/gi;
 
-// FIXME: remove the eslint disable comment
-/* eslint-disable @typescript-eslint/no-unused-vars */
+// While the amino acid alphabet includes all characters from the nucleotide alphabet,
+// it also contains some characters that are unique to the amino acid alphabet
 export const aminoAcidOnlyCodes = difference(
   `${certainAminoAcids}${ambiguousAminoAcids}`.split(''),
   `${certainNucleotides}${ambiguousNucleotides}`.split('')
 ).join('');
 
 const aminoAcidOnlyRegex = new RegExp(`[${aminoAcidOnlyCodes}]`, 'i');
-
-// const nucleotideOnlyCodes = difference(
-//   `${certainNucleotides}${ambiguousNucleotides}`.split(''),
-//   `${certainAminoAcids}${ambiguousAminoAcids}`.split('')
-// ).join('');
 
 const certainNucleotidesSet = new Set(Array.from(certainNucleotides));
 

--- a/src/content/app/tools/shared/helpers/sequenceTypeGuesser.ts
+++ b/src/content/app/tools/shared/helpers/sequenceTypeGuesser.ts
@@ -48,28 +48,10 @@ import difference from 'lodash/difference';
   (From NCBI Blast docs: https://blast.ncbi.nlm.nih.gov/Blast.cgi?CMD=Web&PAGE_TYPE=BlastDocs&DOC_TYPE=BlastHelp)
  */
 
-/**
- * QUESTIONS:
- * Uniprot (see https://github.com/ebi-uniprot/franklin-sites/blob/main/src/sequence-utils/sequenceValidator.ts):
- * - Doesn't allow U as an amino acid code (although NCBI blast allows it as selenocysteine)
- * - Includes J (leucine or isoleucine) in the list of ambiguous amino acid codes, whereas NCBI doesn't list it among allowed amino acid codes
- *
- * Who is right?
- *
- *
- * Also, see old Ensembl code:
- * https://github.com/Ensembl/public-plugins/blob/release/105/tools/htdocs/components/20_BlastForm.js#L364
- */
-
 const certainAminoAcids = 'ACDEFGHIKLMNPQRSTUVWY';
 const ambiguousAminoAcids = 'XBZ';
 const certainNucleotides = 'ACGTU';
 const ambiguousNucleotides = 'BDHKMNRSVWY';
-
-// TODO: three lines below are from Uniprot; check them
-// Characters unique only to their subset e.g. 'U' is not a valid AA.
-// const aminoAcidsOnly = /[EQILFPXJ]/gi;
-// const nucleicAcidsOnly = /U/gi;
 
 // While the amino acid alphabet includes all characters from the nucleotide alphabet,
 // it also contains some characters that are unique to the amino acid alphabet
@@ -125,20 +107,3 @@ const cleanUpSequence = (sequence: string) => {
   const cleanupRegExp = /[^A-Z]|[NJ]/gi;
   return sequence.replace(cleanupRegExp, '');
 };
-
-/*
-
-export const validAminoAcids = [
-  naturalAminoAcids,
-  ambiguousAminoAcids,
-  '*', // Stop
-  '.-', // Gaps
-].join('');
-
-export const validNucleicAcids = [
-  baseNucleicAcids,
-  ambiguousNucleicAcids,
-  // No gaps e.g. - and . are not allowed
-].join('');
-
-*/

--- a/src/content/app/tools/shared/helpers/sequenceTypeGuesser.ts
+++ b/src/content/app/tools/shared/helpers/sequenceTypeGuesser.ts
@@ -17,7 +17,7 @@
 import difference from 'lodash/difference';
 
 /**
- * The nucleic acid codes are:
+  The nucleotide codes are:
 
     A --> adenine             M --> A C (amino)
     C --> cytosine            S --> G C (strong)
@@ -29,7 +29,7 @@ import difference from 'lodash/difference';
     K --> G T (keto)          N --> A G C T (any)
                               -  gap of indeterminate length
 
- * The amino acid codes allowed by BLASTP and TBLASTN programs are:
+  The amino acid codes allowed by BLASTP and TBLASTN programs are:
 
     A  alanine               P  proline
     B  aspartate/asparagine  Q  glutamine


### PR DESCRIPTION
## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1481

## Description
Guess sequence type when user commits a sequence, according to the following rules:
- The guess is only made on the basis of the first sequence for consistency
- The guessing algorithm checks if there are protein-specific characters in the input sequence; and if not, whether unambiguous nucleotide codes make up more than 90% of the sequence
- If the user deletes the first sequence such that the first input box now contains the sequence of a different type, we automatically change the sequence type
- If the user has chosen sequence type manually, we do not attempt to make any guesses about the sequence type
- However, if the user presses the "Clear all" button or clears the only input box on the page, we reset the sequence type to initial (i.e. nucleotide)

### Other changes
This PR adds `@testing-library/react-hooks` to our list of dependencies.

## Deployment URL
http://sequence-type-predictor.review.ensembl.org