### PR TITLE
Add analytics tracking to unsupported browser page

### DIFF
--- a/src/content/unsupported-browser/UnsupportedBrowser.tsx
+++ b/src/content/unsupported-browser/UnsupportedBrowser.tsx
@@ -16,6 +16,8 @@
 
 import React from 'react';
 
+import analyticsTracking from 'src/services/analytics-service';
+
 import Topbar from './components/topbar/Topbar';
 import SupportedWebBrowser from './components/supported-web-browser/SupportedWebBrowser';
 
@@ -24,6 +26,8 @@ import unsupportedBrowsersDiagramPath from 'src/content/unsupported-browser/imag
 import styles from './UnsupportedBrowser.scss';
 
 const UnsupportedBrowser = () => {
+  analyticsTracking.trackPageView('/unsupported-browser');
+
   return (
     <>
       <Topbar />

--- a/src/content/unsupported-browser/UnsupportedBrowser.tsx
+++ b/src/content/unsupported-browser/UnsupportedBrowser.tsx
@@ -16,8 +16,6 @@
 
 import React from 'react';
 
-import analyticsTracking from 'src/services/analytics-service';
-
 import Topbar from './components/topbar/Topbar';
 import SupportedWebBrowser from './components/supported-web-browser/SupportedWebBrowser';
 
@@ -26,8 +24,6 @@ import unsupportedBrowsersDiagramPath from 'src/content/unsupported-browser/imag
 import styles from './UnsupportedBrowser.scss';
 
 const UnsupportedBrowser = () => {
-  analyticsTracking.trackPageView('/unsupported-browser');
-
   return (
     <>
       <Topbar />

--- a/src/server/routes/unsupportedBrowserRouter.tsx
+++ b/src/server/routes/unsupportedBrowserRouter.tsx
@@ -39,6 +39,20 @@ const unsupportedBrowserRouter = (_: Request, res: Response) => {
 
   const jsx = extractor.collectChunks(ReactApp);
   const markup = renderToString(jsx);
+  const analyticsMarkup =
+    `'${process.env.REPORT_ANALYTICS}'`.toLowerCase() !== 'true'
+      ? ''
+      : `<script>
+    if('${process.env.REPORT_ANALYTICS}'.toLowerCase() === 'true'){
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+      ga('create', '${process.env.GOOGLE_ANALYTICS_KEY}', 'auto');
+      ga('send', 'pageview');
+    }
+    </script>`;
 
   const responseString = `
     <!DOCTYPE html>
@@ -49,17 +63,7 @@ const unsupportedBrowserRouter = (_: Request, res: Response) => {
       <title>Unsupported browser</title>
       <meta name="description" content="Your browser is not supported"></meta>
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <script>
-      if('${process.env.REPORT_ANALYTICS}'.toLowerCase() === 'true'){
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', '${process.env.GOOGLE_ANALYTICS_KEY}', 'auto');
-        ga('send', 'pageview');
-      }
-      </script>
+      ${analyticsMarkup}
       ${extractor.getLinkTags()}
       ${extractor.getStyleTags()}
     </head>

--- a/src/server/routes/unsupportedBrowserRouter.tsx
+++ b/src/server/routes/unsupportedBrowserRouter.tsx
@@ -24,8 +24,6 @@ import { getPaths } from 'webpackDir/paths';
 
 import UnsupportedBrowser from 'src/content/unsupported-browser/UnsupportedBrowser';
 
-import config from 'config';
-
 // const pathToHtml = path.resolve(__dirname, 'views/unsupported-browser.html'); // <-- notice that this will be the path in the dist directory
 
 const paths = getPaths();
@@ -52,13 +50,15 @@ const unsupportedBrowserRouter = (_: Request, res: Response) => {
       <meta name="description" content="Your browser is not supported"></meta>
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <script>
+      if('${process.env.REPORT_ANALYTICS}'.toLowerCase() === 'true'){
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-        ga('create', '${config.googleAnalyticsKey}', 'auto');
+        ga('create', '${process.env.GOOGLE_ANALYTICS_KEY}', 'auto');
         ga('send', 'pageview');
+      }
       </script>
       ${extractor.getLinkTags()}
       ${extractor.getStyleTags()}

--- a/src/server/routes/unsupportedBrowserRouter.tsx
+++ b/src/server/routes/unsupportedBrowserRouter.tsx
@@ -24,6 +24,8 @@ import { getPaths } from 'webpackDir/paths';
 
 import UnsupportedBrowser from 'src/content/unsupported-browser/UnsupportedBrowser';
 
+import config from 'config';
+
 // const pathToHtml = path.resolve(__dirname, 'views/unsupported-browser.html'); // <-- notice that this will be the path in the dist directory
 
 const paths = getPaths();
@@ -49,6 +51,15 @@ const unsupportedBrowserRouter = (_: Request, res: Response) => {
       <title>Unsupported browser</title>
       <meta name="description" content="Your browser is not supported"></meta>
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+        ga('create', '${config.googleAnalyticsKey}', 'auto');
+        ga('send', 'pageview');
+      </script>
       ${extractor.getLinkTags()}
       ${extractor.getStyleTags()}
     </head>

--- a/src/server/routes/unsupportedBrowserRouter.tsx
+++ b/src/server/routes/unsupportedBrowserRouter.tsx
@@ -49,10 +49,7 @@ const unsupportedBrowserRouter = (_: Request, res: Response) => {
       <title>Unsupported browser</title>
       <meta name="description" content="Your browser is not supported"></meta>
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      ${
-        '${process.env.REPORT_ANALYTICS}'.toLowerCase() === 'true' &&
-        getAnalyticsScript()
-      }
+      ${getAnalyticsScript()}
       ${extractor.getLinkTags()}
       ${extractor.getStyleTags()}
     </head>
@@ -68,13 +65,16 @@ const unsupportedBrowserRouter = (_: Request, res: Response) => {
 };
 
 const getAnalyticsScript = () =>
-  `<script>
+  process.env.REPORT_ANALYTICS?.toLowerCase() === 'true' &&
+  process.env.GOOGLE_ANALYTICS_KEY
+    ? `<script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
     ga('create', '${process.env.GOOGLE_ANALYTICS_KEY}', 'auto');
     ga('send', 'pageview');
-  </script>`;
+  </script>`
+    : '';
 
 export default unsupportedBrowserRouter;

--- a/src/server/routes/unsupportedBrowserRouter.tsx
+++ b/src/server/routes/unsupportedBrowserRouter.tsx
@@ -39,20 +39,6 @@ const unsupportedBrowserRouter = (_: Request, res: Response) => {
 
   const jsx = extractor.collectChunks(ReactApp);
   const markup = renderToString(jsx);
-  const analyticsMarkup =
-    `'${process.env.REPORT_ANALYTICS}'`.toLowerCase() !== 'true'
-      ? ''
-      : `<script>
-    if('${process.env.REPORT_ANALYTICS}'.toLowerCase() === 'true'){
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-      ga('create', '${process.env.GOOGLE_ANALYTICS_KEY}', 'auto');
-      ga('send', 'pageview');
-    }
-    </script>`;
 
   const responseString = `
     <!DOCTYPE html>
@@ -63,7 +49,10 @@ const unsupportedBrowserRouter = (_: Request, res: Response) => {
       <title>Unsupported browser</title>
       <meta name="description" content="Your browser is not supported"></meta>
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      ${analyticsMarkup}
+      ${
+        '${process.env.REPORT_ANALYTICS}'.toLowerCase() === 'true' &&
+        getAnalyticsScript()
+      }
       ${extractor.getLinkTags()}
       ${extractor.getStyleTags()}
     </head>
@@ -77,5 +66,15 @@ const unsupportedBrowserRouter = (_: Request, res: Response) => {
 
   res.send(responseString);
 };
+
+const getAnalyticsScript = () =>
+  `<script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    ga('create', '${process.env.GOOGLE_ANALYTICS_KEY}', 'auto');
+    ga('send', 'pageview');
+  </script>`;
 
 export default unsupportedBrowserRouter;


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1464

## Description
- added a call to the `trackPageView` method provided by analytics-service in the unsupported browser page

## Deployment URL
http://unsupported-browser-tracking.review.ensembl.org/unsupported-browser

## Views affected
Unsupported browser page
