### PR TITLE
Enable blast form scrolling with fixed header position

### DIFF
--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.scss
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.scss
@@ -1,7 +1,6 @@
 @import 'src/styles/common';
 
 .blastInputSequences {
-  margin-bottom: 90px;
   width: 860px;
 }
 
@@ -14,6 +13,7 @@
   padding-bottom: 12px;
   position: sticky;
   top: 0px;
+  z-index: 1;
   background-color: $white;
 }
 

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.scss
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.scss
@@ -17,7 +17,6 @@
   padding-bottom: 12px;
   position: sticky;
   top: 0px;
-  z-index: 2;
   background-color: $white;
 }
 

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.scss
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.scss
@@ -11,6 +11,10 @@
   align-items: center;
   padding-left: 28px;
   padding-bottom: 12px;
+  position: sticky;
+  top: 0px;
+  z-index: 2;
+  background-color: $white;
 }
 
 .headerGroup {

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.scss
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.scss
@@ -7,9 +7,6 @@
 
 .header {
   width: 860px;
-}
-
-.header {
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.scss
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.scss
@@ -1,6 +1,10 @@
 @import 'src/styles/common';
 
-.blastInputSequences,
+.blastInputSequences {
+  margin-bottom: 90px;
+  width: 860px;
+}
+
 .header {
   width: 860px;
 }

--- a/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.scss
+++ b/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.scss
@@ -9,7 +9,6 @@
   padding-bottom: 12px;
   position: sticky;
   top: 0px;
-  z-index: 2;
   background-color: $white;
 }
 

--- a/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.scss
+++ b/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.scss
@@ -9,6 +9,7 @@
   padding-bottom: 12px;
   position: sticky;
   top: 0px;
+  z-index: 1;
   background-color: $white;
 }
 
@@ -54,7 +55,6 @@
   background-color: $light-grey;
   border: 1px solid $grey;
   padding: 10px;
-  margin-bottom: 90px;
 
   .checkboxUnchecked {
     margin-top: 0px;

--- a/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.scss
+++ b/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.scss
@@ -55,6 +55,7 @@
   background-color: $light-grey;
   border: 1px solid $grey;
   padding: 10px;
+  margin-bottom: 90px;
 
   .checkboxUnchecked {
     margin-top: 0px;

--- a/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.scss
+++ b/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.scss
@@ -7,6 +7,10 @@
   align-items: center;
   padding-left: 28px;
   padding-bottom: 12px;
+  position: sticky;
+  top: 0px;
+  z-index: 2;
+  background-color: $white;
 }
 
 .headerGroup {

--- a/src/content/app/tools/blast/views/blast-form/BlastForm.scss
+++ b/src/content/app/tools/blast/views/blast-form/BlastForm.scss
@@ -2,20 +2,26 @@
 
 .container {
   display: grid;
-  grid-template-rows: auto auto 1fr;
+  grid-template-rows: auto auto minmax(0, 1fr);
   height: 100%;
 }
 
 .mainContainer {
   height: 100%;
-  padding: 0px 65px;
+  padding-left: 65px;
+}
+
+.mainContainerSmall {
   overflow: auto;
+  padding-bottom: 90px;
 }
 
 .grid {
   display: grid;
   grid-template-columns: repeat(2, min-content);
   column-gap: 45px;
+  padding-bottom: 90px;
+  overflow: auto;
   height: 100%;
 }
 

--- a/src/content/app/tools/blast/views/blast-form/BlastForm.scss
+++ b/src/content/app/tools/blast/views/blast-form/BlastForm.scss
@@ -8,7 +8,8 @@
 
 .mainContainer {
   height: 100%;
-  padding: 21px 65px 90px;
+  padding: 0px 65px 90px;
+  overflow: auto;
 }
 
 .grid {

--- a/src/content/app/tools/blast/views/blast-form/BlastForm.scss
+++ b/src/content/app/tools/blast/views/blast-form/BlastForm.scss
@@ -8,7 +8,7 @@
 
 .mainContainer {
   height: 100%;
-  padding: 0px 65px 90px;
+  padding: 0px 65px;
   overflow: auto;
 }
 

--- a/src/content/app/tools/blast/views/blast-form/BlastForm.tsx
+++ b/src/content/app/tools/blast/views/blast-form/BlastForm.tsx
@@ -71,9 +71,10 @@ const MainLarge = () => {
 
 const MainSmall = () => {
   const step = useSelector(getStep);
+  const containerClasses = `${styles.mainContainer} ${styles.mainContainerSmall}`;
 
   return (
-    <div className={styles.mainContainer}>
+    <div className={containerClasses}>
       {step === 'sequences' ? (
         <>
           <BlastInputSequencesHeader compact={true} />

--- a/src/content/app/tools/shared/components/tools-top-bar/ToolsTopBar.scss
+++ b/src/content/app/tools/shared/components/tools-top-bar/ToolsTopBar.scss
@@ -5,4 +5,5 @@
   background-color: $light-grey;
   padding-left: 36px; // TODO: does this value repeat across Genome Browser, Entity Viewer, and Tools?
   box-shadow: 0 3px 5px $global-box-shadow;
+  margin-bottom: 21px;
 }


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [x] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1469

## Importance
N/A

## Description
As per the jira description, keeping the blast species selector header fixed when scrolling on the page.

## Deployment URL
http://blast-header.review.ensembl.org 

## Views affected
Blast only

### Other effects
N/A

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
N/A