### PR TITLE
blast species lozenges onclick function

### DIFF
--- a/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.tsx
+++ b/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.tsx
@@ -17,7 +17,10 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
-import { updateSelectedSpecies } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
+import {
+  addSelectedSpecies,
+  removeSelectedSpecies
+} from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
 import { getSelectedSpeciesIds } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
 
 import Checkbox from 'src/shared/components/checkbox/Checkbox';
@@ -31,7 +34,11 @@ const BlastSpeciesSelector = () => {
   const selectedSpecies = useSelector(getSelectedSpeciesIds);
 
   const onSpeciesSelection = (isChecked: boolean, genomeId: string) => {
-    dispatch(updateSelectedSpecies({ isChecked, genomeId }));
+    if (isChecked) {
+      dispatch(addSelectedSpecies({ genomeId }));
+    } else {
+      dispatch(removeSelectedSpecies({ genomeId }));
+    }
   };
 
   return (

--- a/src/content/app/tools/blast/state/blast-form/blastFormSlice.ts
+++ b/src/content/app/tools/blast/state/blast-form/blastFormSlice.ts
@@ -45,19 +45,15 @@ const blastFormSlice = createSlice({
       state.sequences = sequences;
       state.shouldAppendEmptyInput = Boolean(!sequences.length);
     },
-    updateSelectedSpecies(
-      state,
-      action: PayloadAction<{ isChecked: boolean; genomeId: string }>
-    ) {
-      const { genomeId, isChecked } = action.payload;
-
-      if (isChecked) {
-        state.selectedSpecies.push(genomeId);
-      } else {
-        state.selectedSpecies = state.selectedSpecies.filter(
-          (item) => item !== genomeId
-        );
-      }
+    addSelectedSpecies(state, action: PayloadAction<{ genomeId: string }>) {
+      const { genomeId } = action.payload;
+      state.selectedSpecies.push(genomeId);
+    },
+    removeSelectedSpecies(state, action: PayloadAction<{ genomeId: string }>) {
+      const { genomeId } = action.payload;
+      state.selectedSpecies = state.selectedSpecies.filter(
+        (item) => item !== genomeId
+      );
     },
     clearSelectedSpecies(state) {
       state.selectedSpecies = [];
@@ -82,7 +78,8 @@ export const {
   updateEmptyInputDisplay,
   switchToSpeciesStep,
   switchToSequencesStep,
-  updateSelectedSpecies,
+  addSelectedSpecies,
+  removeSelectedSpecies,
   clearSelectedSpecies
 } = blastFormSlice.actions;
 export default blastFormSlice.reducer;

--- a/src/content/app/tools/blast/state/blast-form/blastFormSlice.ts
+++ b/src/content/app/tools/blast/state/blast-form/blastFormSlice.ts
@@ -231,7 +231,7 @@ export const {
   switchToSequencesStep,
   addSelectedSpecies,
   removeSelectedSpecies,
-  clearSelectedSpecies
+  clearSelectedSpecies,
   setSequenceType,
   setBlastDatabase,
   setBlastProgram,

--- a/src/content/app/tools/shared/components/tools-app-bar/ToolsAppBar.test.tsx
+++ b/src/content/app/tools/shared/components/tools-app-bar/ToolsAppBar.test.tsx
@@ -16,51 +16,61 @@
 
 import React from 'react';
 import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router';
 import { configureStore, combineReducers } from '@reduxjs/toolkit';
 import { render } from '@testing-library/react';
 
 import blastFormReducer, {
-  initialState as initialBlastFormState,
-  type BlastFormState
+  initialState as initialBlastFormState
 } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
+
+import speciesSelectorReducer, {
+  SpeciesSelectorState
+} from 'src/content/app/species-selector/state/speciesSelectorSlice';
 
 import ToolsAppBar from './ToolsAppBar';
 
-const renderComponent = (
-  { state }: { state?: Partial<BlastFormState> } = { state: {} }
-) => {
-  const blastFormState = Object.assign({}, initialBlastFormState, state);
+jest.mock(
+  'src/shared/components/communication-framework/ConversationIcon',
+  () => () => <div>ConversationIcon</div>
+);
 
-  const rootReducer = combineReducers({
-    blast: combineReducers({
-      blastForm: blastFormReducer
-    })
-  });
+const mockCommittedItems = [
+  {
+    genome_id: 'homo_sapiens_GCA_000001405_14',
+    reference_genome_id: null,
+    common_name: 'Human',
+    scientific_name: 'Homo sapiens',
+    assembly_name: 'GRCh37.p13',
+    isEnabled: true
+  }
+];
 
-  const mockCommittedItems = [
-    {
-      genome_id: 'homo_sapiens_GCA_000001405_14',
-      reference_genome_id: null,
-      common_name: 'Human',
-      scientific_name: 'Homo sapiens',
-      assembly_name: 'GRCh37.p13',
-      isEnabled: true
-    }
-  ];
+const initialState = {
+  blast: { blastForm: initialBlastFormState },
+  speciesSelector: {
+    committedItems: mockCommittedItems
+  } as SpeciesSelectorState
+};
 
-  const initialState = {
-    blast: { blastForm: blastFormState },
-    speciesSelector: { committedItems: mockCommittedItems }
-  };
+const rootReducer = combineReducers({
+  blast: combineReducers({
+    blastForm: blastFormReducer
+  }),
+  speciesSelector: speciesSelectorReducer
+});
 
-  const store = configureStore({
-    reducer: rootReducer,
-    preloadedState: initialState
-  });
+const store = configureStore({
+  reducer: rootReducer,
+  preloadedState: initialState
+});
 
+const renderComponent = () => {
   const renderResult = render(
     <Provider store={store}>
-      <ToolsAppBar />
+      <MemoryRouter>
+        <ToolsAppBar />
+      </MemoryRouter>
     </Provider>
   );
 

--- a/src/content/app/tools/shared/components/tools-app-bar/ToolsAppBar.test.tsx
+++ b/src/content/app/tools/shared/components/tools-app-bar/ToolsAppBar.test.tsx
@@ -19,6 +19,7 @@ import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router';
 import { configureStore, combineReducers } from '@reduxjs/toolkit';
 import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import blastFormReducer, {
   initialState as initialBlastFormState
@@ -83,9 +84,15 @@ const renderComponent = () => {
 describe('ToolsAppBar', () => {
   describe('Species Lozenge click', () => {
     it('updates the selectedSpecies state', () => {
-      const { container } = renderComponent();
+      const { container, store } = renderComponent();
 
-      container.querySelector('.selectedSpecies');
+      const speciesLozenge = container.querySelector('.inUseInactive');
+
+      userEvent.click(speciesLozenge as HTMLElement);
+
+      const updatedState = store.getState();
+
+      expect(updatedState.blast.blastForm.selectedSpecies.length).toBe(1);
     });
   });
 });

--- a/src/content/app/tools/shared/components/tools-app-bar/ToolsAppBar.test.tsx
+++ b/src/content/app/tools/shared/components/tools-app-bar/ToolsAppBar.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Provider } from 'react-redux';
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
+import { render } from '@testing-library/react';
+
+import blastFormReducer, {
+  initialState as initialBlastFormState,
+  type BlastFormState
+} from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
+
+import ToolsAppBar from './ToolsAppBar';
+
+const renderComponent = (
+  { state }: { state?: Partial<BlastFormState> } = { state: {} }
+) => {
+  const blastFormState = Object.assign({}, initialBlastFormState, state);
+
+  const rootReducer = combineReducers({
+    blast: combineReducers({
+      blastForm: blastFormReducer
+    })
+  });
+
+  const mockCommittedItems = [
+    {
+      genome_id: 'homo_sapiens_GCA_000001405_14',
+      reference_genome_id: null,
+      common_name: 'Human',
+      scientific_name: 'Homo sapiens',
+      assembly_name: 'GRCh37.p13',
+      isEnabled: true
+    }
+  ];
+
+  const initialState = {
+    blast: { blastForm: blastFormState },
+    speciesSelector: { committedItems: mockCommittedItems }
+  };
+
+  const store = configureStore({
+    reducer: rootReducer,
+    preloadedState: initialState
+  });
+
+  const renderResult = render(
+    <Provider store={store}>
+      <ToolsAppBar />
+    </Provider>
+  );
+
+  return {
+    ...renderResult,
+    store
+  };
+};
+
+describe('ToolsAppBar', () => {
+  describe('Species Lozenge click', () => {
+    it('updates the selectedSpecies state', () => {
+      const { container } = renderComponent();
+
+      container.querySelector('.selectedSpecies');
+    });
+  });
+});

--- a/src/content/app/tools/shared/components/tools-app-bar/ToolsAppBar.test.tsx
+++ b/src/content/app/tools/shared/components/tools-app-bar/ToolsAppBar.test.tsx
@@ -88,7 +88,7 @@ describe('ToolsAppBar', () => {
 
       const speciesLozenge = getByText(container as HTMLElement, 'Human');
 
-      userEvent.click(speciesLozenge as HTMLElement);
+      userEvent.click(speciesLozenge);
 
       const updatedState = store.getState();
 

--- a/src/content/app/tools/shared/components/tools-app-bar/ToolsAppBar.test.tsx
+++ b/src/content/app/tools/shared/components/tools-app-bar/ToolsAppBar.test.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router';
 import { configureStore, combineReducers } from '@reduxjs/toolkit';
-import { render } from '@testing-library/react';
+import { render, getByText } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import blastFormReducer, {
@@ -86,7 +86,7 @@ describe('ToolsAppBar', () => {
     it('updates the selectedSpecies state', () => {
       const { container, store } = renderComponent();
 
-      const speciesLozenge = container.querySelector('.inUseInactive');
+      const speciesLozenge = getByText(container as HTMLElement, 'Human');
 
       userEvent.click(speciesLozenge as HTMLElement);
 

--- a/src/content/app/tools/shared/components/tools-app-bar/ToolsAppBar.tsx
+++ b/src/content/app/tools/shared/components/tools-app-bar/ToolsAppBar.tsx
@@ -23,7 +23,7 @@ import { AppName } from 'src/global/globalConfig';
 
 import { getEnabledCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 
-import { updateSelectedSpecies } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
+import { addSelectedSpecies } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
 import { getSelectedSpeciesIds } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
 
 import AppBar from 'src/shared/components/app-bar/AppBar';
@@ -37,7 +37,7 @@ const ToolsAppBar = () => {
 
   const speciesLozengeClick = (genomeId: string) => {
     if (!speciesListIds.includes(genomeId)) {
-      dispatch(updateSelectedSpecies({ isChecked: true, genomeId }));
+      dispatch(addSelectedSpecies({ genomeId }));
     }
   };
 

--- a/src/content/app/tools/shared/components/tools-app-bar/ToolsAppBar.tsx
+++ b/src/content/app/tools/shared/components/tools-app-bar/ToolsAppBar.tsx
@@ -15,14 +15,16 @@
  */
 
 import React, { useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
-import noop from 'lodash/noop';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import { AppName } from 'src/global/globalConfig';
 
 import { getEnabledCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
+
+import { updateSelectedSpecies } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
+import { getSelectedSpeciesIds } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
 
 import AppBar from 'src/shared/components/app-bar/AppBar';
 import { SelectedSpecies } from 'src/shared/components/selected-species';
@@ -30,9 +32,21 @@ import SpeciesTabsWrapper from 'src/shared/components/species-tabs-wrapper/Speci
 
 const ToolsAppBar = () => {
   const speciesList = useSelector(getEnabledCommittedSpecies);
+  const speciesListIds = useSelector(getSelectedSpeciesIds);
+  const dispatch = useDispatch();
+
+  const speciesLozengeClick = (genomeId: string) => {
+    if (!speciesListIds.includes(genomeId)) {
+      dispatch(updateSelectedSpecies({ isChecked: true, genomeId }));
+    }
+  };
 
   const speciesTabs = speciesList.map((species, index) => (
-    <SelectedSpecies key={index} species={species} onClick={noop} />
+    <SelectedSpecies
+      key={index}
+      species={species}
+      onClick={() => speciesLozengeClick(species.genome_id)}
+    />
   ));
   const speciesSelectorLink = useMemo(() => {
     return <Link to={urlFor.speciesSelector()}>Change</Link>;


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [x] New feature
- [ ] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1481

## Importance
N/A

## Description
select species checkbox when clicking on the species lozenge in blast. Note that if the species checkbox is already selected/checked, nothing happen when clicking the species lozenge. Only action is select the species checkbox if it is not selected.

## Deployment URL
http://blast-specieslozenge.review.ensembl.org

## Views affected
Blast

### Other effects
N/A

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
N/A
