### PR TITLE
Check REPORT_ERRORS environment variable when initialising Sentry

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -73,6 +73,11 @@ const shouldReportAnalytics = () =>
   isClient() &&
   (window as any)[CONFIG_FIELD_ON_WINDOW]?.environment.shouldReportAnalytics;
 
+// TODO: figure out what to do with errors that happen server-side
+const shouldReportErrors = () =>
+  isClient() &&
+  (window as any)[CONFIG_FIELD_ON_WINDOW]?.environment.shouldReportErrors;
+
 const buildEnvironment = readEnvironment().buildEnvironment;
 
 export default {
@@ -84,6 +89,7 @@ export default {
   isProduction: buildEnvironment !== 'development',
 
   shouldReportAnalytics: shouldReportAnalytics(),
+  shouldReportErrors: shouldReportErrors(),
 
   // TODO: remove this from the config in the future (will require refactoring of the apiService)
   // We will instead be passing base urls for differeent microservices individually

--- a/src/server/helpers/getConfigForClient.ts
+++ b/src/server/helpers/getConfigForClient.ts
@@ -34,7 +34,8 @@ const getEnvironment = () => {
   return {
     buildEnvironment: process.env.NODE_ENV ?? 'production',
     deploymentEnvironment: process.env.ENVIRONMENT ?? 'development',
-    shouldReportAnalytics: shouldReportAnalytics()
+    shouldReportAnalytics: shouldReportAnalytics(),
+    shouldReportErrors: shouldReportErrors()
   };
 };
 
@@ -46,6 +47,9 @@ const getKeys = () => {
 
 const shouldReportAnalytics = () =>
   `${process.env.REPORT_ANALYTICS}`.toLowerCase() === 'true';
+
+const shouldReportErrors = () =>
+  `${process.env.REPORT_ERRORS}`.toLowerCase() === 'true';
 
 export const getConfigForClient = () => {
   return {

--- a/src/services/error-service.ts
+++ b/src/services/error-service.ts
@@ -38,7 +38,7 @@ class ErrorService implements ErrorServiceInterface {
   }
 
   private initializeReportingService() {
-    if (config.isProduction) {
+    if (config.shouldReportErrors) {
       Sentry.init({
         dsn: 'https://ab4205dce9c047588d30ddfaafd0655a@sentry.io/1507303',
         ignoreErrors: [


### PR DESCRIPTION
## Description
The previous test for whether to report errors to Sentry was not precise enough. It was just checking for whether the build happened to be a development one, and if not, enabled error reporting. This led to two undesirable consequences: 1) if ensembl-client were running locally in a docker container after a production build, any errors will be reported to Sentry; and 2) our test of the error boundary component would occasionally send an error message to Sentry.
In this PR, we are checking for the presence of a dedicated environment variable `REPORT_ERRORS` to determine whether to send errors to Sentry.

### TODO in a different PR
The current PR only initialises sentry on the client side. In the future, we may also want to reporting to Sentry if something goes wrong during server-side rendering; but for that, we will need to think about how to read the environment variable on the server. 

## Deployment URL
http://env-var-report-errors.review.ensembl.org