### PR TITLE
Blast input validation

### DIFF
--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence.scss
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence.scss
@@ -37,11 +37,20 @@ $border: 1px solid $grey;
 }
 
 .textarea {
-  border: $border;
   font-family: $font-family-monospace;
   font-size: 12px;
   letter-spacing: 0.1rem;
   white-space: nowrap;
+}
+
+.textarea:not(.textareaInvalid) {
+  &:focus {
+    --textarea-border-color: #{$blue};
+  }
+}
+
+.textareaInvalid {
+  --textarea-border-color: #{$red};
 }
 
 .deleteButtonWrapper {

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence.test.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence.test.tsx
@@ -25,7 +25,8 @@ import BlastInputSequence from './BlastInputSequence';
 const testInput = 'AGCT'; // it shouldn't even matter for testing purposes
 
 const commonProps = {
-  onCommitted: jest.fn()
+  onCommitted: jest.fn(),
+  sequenceType: 'dna' as const
 };
 
 describe('<BlastInputSequence />', () => {

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence.tsx
@@ -25,10 +25,7 @@ import React, {
 import classNames from 'classnames';
 
 import { toFasta } from 'src/shared/helpers/formatters/fastaFormatter';
-import {
-  hasSufficientLength,
-  hasValidSequenceCharacters
-} from 'src/content/app/tools/blast/utils/sequenceValidators';
+import { isValidSequence } from 'src/content/app/tools/blast/utils/sequenceValidators';
 
 import Textarea from 'src/shared/components/textarea/Textarea';
 import {
@@ -174,11 +171,9 @@ const checkSequenceValidity = (
   sequence: string,
   sequenceType: SequenceType
 ) => {
+  // cleanup the sequence entered into the input box before validating it
   sequence = sequence.replace(/>.*/, '').replaceAll(/\s/g, '');
-  return (
-    hasSufficientLength(sequence) &&
-    hasValidSequenceCharacters(sequence, sequenceType)
-  );
+  return isValidSequence(sequence, sequenceType);
 };
 
 export default BlastInputSequence;

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.tsx
@@ -28,7 +28,7 @@ import BlastInputSequence from './BlastInputSequence';
 import styles from './BlastInputSequences.scss';
 
 const BlastInputSequences = () => {
-  const { sequences, updateSequences } = useBlastInputSequences();
+  const { sequences, sequenceType, updateSequences } = useBlastInputSequences();
   const shouldAppendEmptyInput = useSelector(getEmptyInputVisibility);
 
   const onSequenceAdded = (input: string, index: number | null) => {
@@ -58,6 +58,7 @@ const BlastInputSequences = () => {
             key={index}
             index={index}
             sequence={sequence}
+            sequenceType={sequenceType}
             title={`Sequence ${index + 1}`}
             onCommitted={onSequenceAdded}
             onRemoveSequence={onRemoveSequence}
@@ -66,6 +67,7 @@ const BlastInputSequences = () => {
         {shouldAppendEmptyInput && (
           <BlastInputSequence
             title={`Sequence ${sequences.length + 1}`}
+            sequenceType={sequenceType}
             onCommitted={onSequenceAdded}
             onRemoveSequence={onRemoveSequence}
           />

--- a/src/content/app/tools/blast/components/blast-input-sequences/useBlastInputSequences.ts
+++ b/src/content/app/tools/blast/components/blast-input-sequences/useBlastInputSequences.ts
@@ -28,7 +28,7 @@ import {
   getSequenceSelectionMode
 } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
 
-import { guessSequenceType } from 'src/content/app/tools/shared/helpers/sequenceTypeGuesser';
+import { guessSequenceType } from 'src/content/app/tools/blast/utils/sequenceTypeGuesser';
 
 import untypedBlastSettingsConfig from 'src/content/app/tools/blast/components/blast-settings/blastSettingsConfig.json';
 

--- a/src/content/app/tools/blast/utils/sequenceTypeGuesser.ts
+++ b/src/content/app/tools/blast/utils/sequenceTypeGuesser.ts
@@ -1,0 +1,65 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { certainNucleotides, aminoAcidOnlyCodes } from './sequenceAlphabets';
+
+const aminoAcidOnlyRegex = new RegExp(`[${aminoAcidOnlyCodes}]`, 'i');
+
+const certainNucleotidesSet = new Set(Array.from(certainNucleotides));
+
+// guess the type of a single sequence
+export const guessSequenceType = (sequence: string) => {
+  sequence = cleanUpSequence(sequence);
+
+  if (hasUniqueAminoAcidCharacters(sequence)) {
+    return 'protein';
+  }
+
+  // an arbitrary threshold meaning that if 90% or more characters in a sequence
+  // match unambiguous nucleotide characters, then guess that it's a nucleic acid
+  const nucleotideThreshold = 0.9;
+
+  const nucleotideCandidateCount = sequence
+    .split('')
+    .reduce(
+      (count, character) =>
+        certainNucleotidesSet.has(character) ? count + 1 : count,
+      0
+    );
+  return nucleotideCandidateCount / sequence.length >= nucleotideThreshold
+    ? 'dna'
+    : 'protein';
+};
+
+// guess the type of multiple sequences assuming that they are of the same type
+export const guessSequencesType = (sequences: string[]) => {
+  return sequences.some((sequence) => guessSequenceType(sequence) === 'protein')
+    ? 'protein'
+    : 'dna';
+};
+
+const hasUniqueAminoAcidCharacters = (sequence: string) => {
+  return aminoAcidOnlyRegex.test(sequence);
+};
+
+const cleanUpSequence = (sequence: string) => {
+  // Remove the following from the sequence:
+  // - any non-letter characters
+  // - the letter N (could be an amino acid or a common ambiguous nucleotide code; will impact the threshold)
+  // - the letter J (according to NCBI, not included in either the nucleotide or the amino acid alphabet)
+  const cleanupRegExp = /[^A-Z]|[NJ]/gi;
+  return sequence.replace(cleanupRegExp, '');
+};

--- a/src/content/app/tools/blast/utils/sequenceValidators.ts
+++ b/src/content/app/tools/blast/utils/sequenceValidators.ts
@@ -1,0 +1,47 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { aminoAcidAlphabet, nucleotideAlphabet } from './sequenceAlphabets';
+
+import type { SequenceType } from 'src/content/app/tools/blast/types/blastSettings';
+
+const MINIMUM_SEQUENCE_LENGTH = 5;
+
+const notNucleotideRegex = new RegExp(`[^${nucleotideAlphabet}]`, 'i');
+const notAminoAcidRegex = new RegExp(`[^${aminoAcidAlphabet}]`, 'i');
+
+export const hasSufficientLength = (sequence: string) => {
+  return sequence.length >= MINIMUM_SEQUENCE_LENGTH;
+};
+
+export const hasValidSequenceCharacters = (
+  sequence: string,
+  sequenceType: SequenceType
+) => {
+  return sequenceType === 'protein'
+    ? isValidProteinSequence(sequence)
+    : isValidNucleotideSequence(sequence);
+};
+
+export const isValidNucleotideSequence = (sequence: string) => {
+  // check if sequence contains anything outside the nucleotide alphabet
+  return !notNucleotideRegex.test(sequence);
+};
+
+export const isValidProteinSequence = (sequence: string) => {
+  // check if sequence contains anything outside the amino acid alphabet
+  return !notAminoAcidRegex.test(sequence);
+};

--- a/src/content/app/tools/blast/utils/sequenceValidators.ts
+++ b/src/content/app/tools/blast/utils/sequenceValidators.ts
@@ -45,3 +45,13 @@ export const isValidProteinSequence = (sequence: string) => {
   // check if sequence contains anything outside the amino acid alphabet
   return !notAminoAcidRegex.test(sequence);
 };
+
+export const isValidSequence = (
+  sequence: string,
+  sequenceType: SequenceType
+) => {
+  return (
+    hasSufficientLength(sequence) &&
+    hasValidSequenceCharacters(sequence, sequenceType)
+  );
+};

--- a/src/content/app/tools/blast/utils/tests/sequenceTypeGuesser.test.ts
+++ b/src/content/app/tools/blast/utils/tests/sequenceTypeGuesser.test.ts
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-import {
-  guessSequenceType,
-  guessSequencesType,
-  aminoAcidOnlyCodes
-} from './sequenceTypeGuesser';
+import { guessSequenceType, guessSequencesType } from '../sequenceTypeGuesser';
+import { aminoAcidOnlyCodes } from '../sequenceAlphabets';
 
 describe('guessSequenceType', () => {
   it('guesses a protein sequence', () => {

--- a/src/content/app/tools/blast/utils/tests/sequenceValidators.test.ts
+++ b/src/content/app/tools/blast/utils/tests/sequenceValidators.test.ts
@@ -1,0 +1,76 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  isValidNucleotideSequence,
+  isValidProteinSequence,
+  hasValidSequenceCharacters
+} from '../sequenceValidators';
+
+const nucleotideSequence =
+  'CGGACCAGACGGACACAGGGAGAAGCTAGTTTCTTTCATGTGATTGANATNATGACTCTACTCCTAAAAG';
+const proteinSequence =
+  'MENLNMDLLYMAAAVMMGLAAIGAAIGIGILGGKFLEGAARQPDLIPLLRTQFFIVMGLVDAIPMIAVGL';
+
+describe('isValidNucleotideSequence', () => {
+  it('reports a nucleotide sequence as valid', () => {
+    expect(isValidNucleotideSequence(nucleotideSequence)).toBe(true);
+  });
+
+  it('reports a non-nucleotide sequence as invalid', () => {
+    expect(isValidNucleotideSequence(proteinSequence)).toBe(false);
+  });
+});
+
+describe('isValidProteinSequence', () => {
+  it('reports a protein sequence as valid', () => {
+    expect(isValidProteinSequence(proteinSequence)).toBe(true);
+  });
+
+  it('reports a nucleotide sequence as valid', () => {
+    // nucleotide alphabet is a subset of amino acid alphabet
+    expect(isValidProteinSequence(nucleotideSequence)).toBe(true);
+  });
+
+  it('reports a sequence containing out-of-alphabet characters as invalid', () => {
+    expect(isValidProteinSequence(`${proteinSequence}J`)).toBe(false);
+  });
+});
+
+describe('hasValidSequenceCharacters', () => {
+  it('correctly reports valid sequences', () => {
+    // for DNA
+    expect(hasValidSequenceCharacters(nucleotideSequence, 'dna')).toBe(true);
+
+    // for RNA (we aren't making a difference in the sequence type passed to the function)
+    expect(
+      hasValidSequenceCharacters(nucleotideSequence.replaceAll('T', 'U'), 'dna')
+    ).toBe(true);
+
+    // for RNA (we aren't making a difference in the sequence type passed to the function)
+    expect(hasValidSequenceCharacters(proteinSequence, 'protein')).toBe(true);
+  });
+
+  it('correctly reports invalid sequences', () => {
+    // for DNA
+    expect(hasValidSequenceCharacters(proteinSequence, 'dna')).toBe(false);
+
+    // for RNA (we aren't making a difference in the sequence type passed to the function)
+    expect(hasValidSequenceCharacters(`${proteinSequence}J`, 'protein')).toBe(
+      false
+    );
+  });
+});

--- a/src/shared/components/textarea/Textarea.scss
+++ b/src/shared/components/textarea/Textarea.scss
@@ -1,10 +1,13 @@
 @import 'src/styles/common';
 
 .textarea {
-  border: none;
+  border-color: var(--textarea-border-color, $grey);
+  border-width: var(--textarea-border-width, 1px);
+  border-style: var(--textarea-border-style, solid);
   padding: 7px;
   width: 100%;
   height: var(--textarea-height, 85px); /* To display 5 lines of text */
+
   &:focus,
   &:active {
     outline: none;
@@ -21,6 +24,7 @@
 }
 
 .shadedTextarea {
+  --textarea-border-style: none;
   box-shadow: $form-field-shadow;
   padding: 7px 15px;
   border: none;


### PR DESCRIPTION
**NOTE:** this PR contains code from https://github.com/Ensembl/ensembl-client/pull/689 and should be merged after 689 is approved and merged.

## Related JIRA Issue(s)
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1482
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1501

## Description
This PR adds the following functionality:
- Focusing on a blast sequence input:
  - changes the colour of the textarea border to blue
  - hides the upload file component
- Added validation of sequence length (sadly, as per spec, the input box shows invalid input while the user is still typing)
- Added validation of sequence alphabet for given sequence type

## Deployment URL
http://blast-input-validation.review.ensembl.org/blast