### PR TITLE
Add job name component and job submit component

### DIFF
--- a/src/content/app/tools/blast/components/blast-job-submit/BlastJobSubmit.tsx
+++ b/src/content/app/tools/blast/components/blast-job-submit/BlastJobSubmit.tsx
@@ -1,0 +1,34 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import noop from 'lodash/noop';
+
+import { PrimaryButton } from 'src/shared/components/button/Button';
+
+const BlastJobSubmit = () => {
+  // TODO:
+  // 1) validate the blast form before enabling the button
+  // 2) actually do the job submission
+
+  return (
+    <PrimaryButton onClick={noop} isDisabled={true}>
+      Run
+    </PrimaryButton>
+  );
+};
+
+export default BlastJobSubmit;

--- a/src/content/app/tools/blast/components/blast-settings/BlastSettings.scss
+++ b/src/content/app/tools/blast/components/blast-settings/BlastSettings.scss
@@ -32,3 +32,16 @@
   flex-basis: auto;
   white-space: nowrap;
 }
+
+.blastJobBlock {
+  display: inline-flex;
+  align-items: center;
+  column-gap: 32px;
+}
+
+.blastJobName {
+  display: inline-flex;
+  column-gap: 24px;
+  align-items: center;
+  white-space: nowrap;
+}

--- a/src/content/app/tools/blast/components/blast-settings/BlastSettings.tsx
+++ b/src/content/app/tools/blast/components/blast-settings/BlastSettings.tsx
@@ -19,6 +19,8 @@ import { useSelector, useDispatch } from 'react-redux';
 
 import ShowHide from 'src/shared/components/show-hide/ShowHide';
 import Checkbox from 'src/shared/components/checkbox/Checkbox';
+import ShadedInput from 'src/shared/components/input/ShadedInput';
+import BlastJobSubmit from 'src/content/app/tools/blast/components/blast-job-submit/BlastJobSubmit';
 
 import untypedBlastSettingsConfig from './blastSettingsConfig.json';
 
@@ -26,13 +28,15 @@ import {
   getSelectedSequenceType,
   getSelectedBlastProgram,
   getSelectedSearchSensitivity,
-  getBlastSearchParameters
+  getBlastSearchParameters,
+  getBlastJobName
 } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
 import {
   setBlastDatabase,
   setBlastProgram,
   changeSensitivityPresets,
-  setBlastParameter
+  setBlastParameter,
+  setBlastJobName
 } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
 
 import type {
@@ -177,6 +181,10 @@ const BlastSettings = () => {
             onClick={onParametersToggle}
           />
         </div>
+        <div className={styles.blastJobBlock}>
+          <BlastJobName />
+          <BlastJobSubmit />
+        </div>
       </div>
       {parametersExpanded && (
         <div className={styles.bottomLevel}>
@@ -258,6 +266,23 @@ const BlastSettings = () => {
         </div>
       )}
     </>
+  );
+};
+
+const BlastJobName = () => {
+  const jobName = useSelector(getBlastJobName);
+  const dispatch = useDispatch();
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const name = e.currentTarget.value;
+    dispatch(setBlastJobName(name));
+  };
+
+  return (
+    <div className={styles.blastJobName}>
+      <span>Name the job</span>
+      <ShadedInput value={jobName} onChange={onChange} placeholder="optional" />
+    </div>
   );
 };
 

--- a/src/content/app/tools/blast/state/blast-form/blastFormSelectors.ts
+++ b/src/content/app/tools/blast/state/blast-form/blastFormSelectors.ts
@@ -37,6 +37,9 @@ export const getSelectedSearchSensitivity = (state: RootState) =>
 export const getBlastSearchParameters = (state: RootState) =>
   state.blast.blastForm.settings.parameters;
 
+export const getBlastJobName = (state: RootState) =>
+  state.blast.blastForm.settings.jobName;
+
 export const getStep = (state: RootState) => state.blast.blastForm.step;
 
 export const getSelectedSpeciesIds = (state: RootState) =>

--- a/src/content/app/tools/blast/state/blast-form/blastFormSlice.ts
+++ b/src/content/app/tools/blast/state/blast-form/blastFormSlice.ts
@@ -26,6 +26,7 @@ import type {
 } from 'src/content/app/tools/blast/types/blastSettings';
 
 type BlastFormSettings = {
+  jobName: string;
   sequenceType: SequenceType;
   sequenceSelectionMode: 'automatic' | 'manual';
   program: BlastProgram;
@@ -42,6 +43,7 @@ export type BlastFormState = {
 };
 
 const initialBlastFormSettings: BlastFormSettings = {
+  jobName: '',
   sequenceType: 'dna',
   sequenceSelectionMode: 'automatic',
   program: 'blastn',
@@ -217,6 +219,9 @@ const blastFormSlice = createSlice({
       const { parameterName, parameterValue } = action.payload;
       state.settings.parameters[parameterName] = parameterValue;
     },
+    setBlastJobName(state, action: PayloadAction<string>) {
+      state.settings.jobName = action.payload;
+    },
     clearForm() {
       // TODO: apply default settings to the form
       return cloneDeep(initialState);
@@ -236,6 +241,7 @@ export const {
   setBlastDatabase,
   setBlastProgram,
   changeSensitivityPresets,
-  setBlastParameter
+  setBlastParameter,
+  setBlastJobName
 } = blastFormSlice.actions;
 export default blastFormSlice.reducer;


### PR DESCRIPTION
## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1491

## Description
The scope of this PR is only to add a job name field and a button for submitting the Blast job.
- The job name field is added as a part of BlastSettings component (it kind of feels like a Blast setting)
- The job submission button has been created as a separate component. At the moment, the button is always disabled.

## Deployment URL
http://job-name-submit.review.ensembl.org/blast