### PR TITLE
Validate BLAST submission form

### DIFF
--- a/src/content/app/tools/blast/components/blast-job-submit/BlastJobSubmit.tsx
+++ b/src/content/app/tools/blast/components/blast-job-submit/BlastJobSubmit.tsx
@@ -16,16 +16,25 @@
 
 import React from 'react';
 import noop from 'lodash/noop';
+import { useSelector } from 'react-redux';
 
 import { PrimaryButton } from 'src/shared/components/button/Button';
 
+import useBlastInputSequences from 'src/content/app/tools/blast/components/blast-input-sequences/useBlastInputSequences';
+import { getSelectedSpeciesIds } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
+import { isBlastFormValid } from 'src/content/app/tools/blast/utils/blastFormValidator';
+
 const BlastJobSubmit = () => {
   // TODO:
-  // 1) validate the blast form before enabling the button
-  // 2) actually do the job submission
+  // 1) actually do the job submission
+
+  const { sequences } = useBlastInputSequences();
+  const selectedSpecies = useSelector(getSelectedSpeciesIds);
+
+  const isDisabled = !isBlastFormValid(selectedSpecies, sequences);
 
   return (
-    <PrimaryButton onClick={noop} isDisabled={true}>
+    <PrimaryButton onClick={noop} isDisabled={isDisabled}>
       Run
     </PrimaryButton>
   );

--- a/src/content/app/tools/blast/utils/blastFormValidator.ts
+++ b/src/content/app/tools/blast/utils/blastFormValidator.ts
@@ -1,0 +1,36 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ParsedInputSequence } from 'src/content/app/tools/blast/types/parsedInputSequence';
+
+const SPECIES_LIMIT = 25;
+const SEQUENCE_LIMIT = 30;
+
+export const isBlastFormValid = (
+  species: string[],
+  sequences: ParsedInputSequence[]
+) => {
+  if (
+    !species.length ||
+    species.length > SPECIES_LIMIT ||
+    !sequences.length ||
+    sequences.length > SEQUENCE_LIMIT
+  ) {
+    return false;
+  }
+
+  return true;
+};

--- a/src/content/app/tools/blast/utils/blastFormValidator.ts
+++ b/src/content/app/tools/blast/utils/blastFormValidator.ts
@@ -23,14 +23,10 @@ export const isBlastFormValid = (
   species: string[],
   sequences: ParsedInputSequence[]
 ) => {
-  if (
-    !species.length ||
-    species.length > BLAST_SPECIES_LIMIT ||
-    !sequences.length ||
-    sequences.length > BLAST_SEQUENCE_LIMIT
-  ) {
-    return false;
-  }
-
-  return true;
+  return (
+    species.length > 0 &&
+    species.length <= BLAST_SPECIES_LIMIT &&
+    sequences.length > 0 &&
+    sequences.length <= BLAST_SEQUENCE_LIMIT
+  );
 };

--- a/src/content/app/tools/blast/utils/blastFormValidator.ts
+++ b/src/content/app/tools/blast/utils/blastFormValidator.ts
@@ -16,8 +16,8 @@
 
 import { ParsedInputSequence } from 'src/content/app/tools/blast/types/parsedInputSequence';
 
-const SPECIES_LIMIT = 25;
-const SEQUENCE_LIMIT = 30;
+export const BLAST_SPECIES_LIMIT = 25;
+export const BLAST_SEQUENCE_LIMIT = 30;
 
 export const isBlastFormValid = (
   species: string[],
@@ -25,9 +25,9 @@ export const isBlastFormValid = (
 ) => {
   if (
     !species.length ||
-    species.length > SPECIES_LIMIT ||
+    species.length > BLAST_SPECIES_LIMIT ||
     !sequences.length ||
-    sequences.length > SEQUENCE_LIMIT
+    sequences.length > BLAST_SEQUENCE_LIMIT
   ) {
     return false;
   }

--- a/src/content/app/tools/blast/utils/tests/blastFormValidator.test.ts
+++ b/src/content/app/tools/blast/utils/tests/blastFormValidator.test.ts
@@ -1,0 +1,62 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isBlastFormValid } from '../blastFormValidator';
+
+const createFakeSpecies = (times: number) => {
+  return Array(times).fill('');
+};
+
+const createFakeSequences = (times: number) => {
+  return Array(times).fill({
+    value: 'ACTG'
+  });
+};
+
+describe('isBlastFormValid', () => {
+  it('fails validation if we have more than 25 species', () => {
+    const species = createFakeSpecies(26);
+    const sequences = createFakeSequences(1);
+
+    expect(isBlastFormValid(species, sequences)).toBe(false);
+  });
+
+  it('fails validation if we have more than 30 sequences', () => {
+    const species = createFakeSpecies(1);
+    const sequences = createFakeSequences(31);
+
+    expect(isBlastFormValid(species, sequences)).toBe(false);
+  });
+
+  it('fails validation if we have do not have at least one species and one sequence', () => {
+    let species = createFakeSpecies(1);
+    let sequences = createFakeSequences(0);
+
+    expect(isBlastFormValid(species, sequences)).toBe(false);
+
+    species = createFakeSpecies(0);
+    sequences = createFakeSequences(1);
+
+    expect(isBlastFormValid(species, sequences)).toBe(false);
+  });
+
+  it('passes validation if we have correct number of species and sequence', () => {
+    const species = createFakeSpecies(1);
+    const sequences = createFakeSequences(1);
+
+    expect(isBlastFormValid(species, sequences)).toBe(true);
+  });
+});

--- a/src/content/app/tools/blast/utils/tests/blastFormValidator.test.ts
+++ b/src/content/app/tools/blast/utils/tests/blastFormValidator.test.ts
@@ -31,7 +31,7 @@ const createFakeSequences = (times: number) => {
 };
 
 describe('isBlastFormValid', () => {
-  it('fails validation if the number of species more than the limit', () => {
+  it('fails validation if the number of species is more than the limit', () => {
     const species = createFakeSpecies(BLAST_SPECIES_LIMIT + 1);
     const sequences = createFakeSequences(1);
 
@@ -45,7 +45,7 @@ describe('isBlastFormValid', () => {
     expect(isBlastFormValid(species, sequences)).toBe(false);
   });
 
-  it('fails validation if there is at least one species and one sequence', () => {
+  it('fails validation if there is not at least one species and one sequence', () => {
     let species = createFakeSpecies(1);
     let sequences = createFakeSequences(0);
 
@@ -57,7 +57,7 @@ describe('isBlastFormValid', () => {
     expect(isBlastFormValid(species, sequences)).toBe(false);
   });
 
-  it('passes validation if the correct number of species and sequence', () => {
+  it('passes validation if the number of sequences and species is acceptable', () => {
     const species = createFakeSpecies(1);
     const sequences = createFakeSequences(1);
 

--- a/src/content/app/tools/blast/utils/tests/blastFormValidator.test.ts
+++ b/src/content/app/tools/blast/utils/tests/blastFormValidator.test.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { isBlastFormValid } from '../blastFormValidator';
+import {
+  isBlastFormValid,
+  BLAST_SPECIES_LIMIT,
+  BLAST_SEQUENCE_LIMIT
+} from '../blastFormValidator';
 
 const createFakeSpecies = (times: number) => {
   return Array(times).fill('');
@@ -27,16 +31,16 @@ const createFakeSequences = (times: number) => {
 };
 
 describe('isBlastFormValid', () => {
-  it('fails validation if we have more than 25 species', () => {
-    const species = createFakeSpecies(26);
+  it('fails validation if we have number of species more than the limit', () => {
+    const species = createFakeSpecies(BLAST_SPECIES_LIMIT + 1);
     const sequences = createFakeSequences(1);
 
     expect(isBlastFormValid(species, sequences)).toBe(false);
   });
 
-  it('fails validation if we have more than 30 sequences', () => {
+  it('fails validation if we have number of sequences more than the limit', () => {
     const species = createFakeSpecies(1);
-    const sequences = createFakeSequences(31);
+    const sequences = createFakeSequences(BLAST_SEQUENCE_LIMIT + 1);
 
     expect(isBlastFormValid(species, sequences)).toBe(false);
   });

--- a/src/content/app/tools/blast/utils/tests/blastFormValidator.test.ts
+++ b/src/content/app/tools/blast/utils/tests/blastFormValidator.test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+import faker from 'faker';
 import {
   isBlastFormValid,
   BLAST_SPECIES_LIMIT,
@@ -21,7 +21,7 @@ import {
 } from '../blastFormValidator';
 
 const createFakeSpecies = (times: number) => {
-  return Array(times).fill('');
+  return Array(times).fill(faker.datatype.uuid());
 };
 
 const createFakeSequences = (times: number) => {
@@ -31,21 +31,21 @@ const createFakeSequences = (times: number) => {
 };
 
 describe('isBlastFormValid', () => {
-  it('fails validation if we have number of species more than the limit', () => {
+  it('fails validation if the number of species more than the limit', () => {
     const species = createFakeSpecies(BLAST_SPECIES_LIMIT + 1);
     const sequences = createFakeSequences(1);
 
     expect(isBlastFormValid(species, sequences)).toBe(false);
   });
 
-  it('fails validation if we have number of sequences more than the limit', () => {
+  it('fails validation if the number of sequences is more than the limit', () => {
     const species = createFakeSpecies(1);
     const sequences = createFakeSequences(BLAST_SEQUENCE_LIMIT + 1);
 
     expect(isBlastFormValid(species, sequences)).toBe(false);
   });
 
-  it('fails validation if we have do not have at least one species and one sequence', () => {
+  it('fails validation if there is at least one species and one sequence', () => {
     let species = createFakeSpecies(1);
     let sequences = createFakeSequences(0);
 
@@ -57,7 +57,7 @@ describe('isBlastFormValid', () => {
     expect(isBlastFormValid(species, sequences)).toBe(false);
   });
 
-  it('passes validation if we have correct number of species and sequence', () => {
+  it('passes validation if the correct number of species and sequence', () => {
     const species = createFakeSpecies(1);
     const sequences = createFakeSequences(1);
 


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1486

## Description
This PR add some validation to the blast form by checking the number of species and sequences added.
The `Run` button will be disabled when the form is invalid.

## Deployment URL
http://blast-form-validation.review.ensembl.org

## Views affected
BLAST form

### Other effects

- [ ] I have checked any requirements for Google Analytics
- [x] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.
