### PR TITLE
Correct handling of empty BLAST input boxes 

### DIFF
--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence.test.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence.test.tsx
@@ -78,7 +78,7 @@ describe('<BlastInputSequence />', () => {
       const { container } = render(<BlastInputSequence {...commonProps} />);
       const deleteButton = container.querySelector('.deleteButton');
 
-      expect(deleteButton).toBe(null);
+      expect(deleteButton).toBeTruthy();
     });
   });
 
@@ -153,11 +153,13 @@ describe('<BlastInputSequence />', () => {
   });
 
   describe('when filled', () => {
-    it('can clear the input locally if the input has not yet been passed to the parent', () => {
+    it('clears the input locally and reports to the parent', () => {
       const onRemoveSequence = jest.fn();
+      const inputIndex = Math.random() > 0.5 ? 1 : undefined; // an input box may receive an index property
       const { container } = render(
         <BlastInputSequence
           {...commonProps}
+          index={inputIndex}
           onRemoveSequence={onRemoveSequence}
         />
       );
@@ -170,7 +172,7 @@ describe('<BlastInputSequence />', () => {
       userEvent.click(deleteButton as HTMLElement);
 
       expect(textarea.value).toBe('');
-      expect(onRemoveSequence).not.toHaveBeenCalled();
+      expect(onRemoveSequence).toHaveBeenCalledWith(inputIndex ?? null);
     });
   });
 });

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence.test.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence.test.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 import { setTimeout } from 'timers/promises';
 import { render, fireEvent, createEvent, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import faker from 'faker';
 import random from 'lodash/random';
 
 import BlastInputSequence from './BlastInputSequence';
@@ -74,7 +75,7 @@ describe('<BlastInputSequence />', () => {
       expect(commonProps.onCommitted).toHaveBeenCalledWith(testFasta, null);
     });
 
-    it('does not contain a control for clearing the input', () => {
+    it('contains a control for clearing the input', () => {
       const { container } = render(<BlastInputSequence {...commonProps} />);
       const deleteButton = container.querySelector('.deleteButton');
 
@@ -155,7 +156,7 @@ describe('<BlastInputSequence />', () => {
   describe('when filled', () => {
     it('clears the input locally and reports to the parent', () => {
       const onRemoveSequence = jest.fn();
-      const inputIndex = Math.random() > 0.5 ? 1 : undefined; // an input box may receive an index property
+      const inputIndex = faker.datatype.boolean() ? 1 : undefined; // an input box may receive an index property
       const { container } = render(
         <BlastInputSequence
           {...commonProps}

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence.tsx
@@ -46,6 +46,7 @@ type Props = {
   sequenceType: SequenceType;
   title?: string;
   onCommitted: (input: string, index: number | null) => void;
+  onInput?: (input: string, index: number | null) => void;
   onRemoveSequence?: (index: number | null) => void;
 };
 
@@ -83,7 +84,9 @@ const BlastInputSequence = (props: Props) => {
   };
 
   const onChange = (event: FormEvent<HTMLTextAreaElement>) => {
-    setInput(event.currentTarget.value);
+    const { value } = event.currentTarget;
+    setInput(value);
+    props.onInput?.(value, index);
   };
 
   const onPaste = (event: ClipboardEvent<HTMLTextAreaElement>) => {

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence.tsx
@@ -117,12 +117,8 @@ const BlastInputSequence = (props: Props) => {
   };
 
   const onClear = () => {
-    if (typeof index === 'number') {
-      props.onRemoveSequence?.(index);
-      forceReadSequenceFromProps();
-    } else {
-      setInput('');
-    }
+    setInput('');
+    props.onRemoveSequence?.(index);
   };
 
   const isInputValid = input
@@ -141,11 +137,9 @@ const BlastInputSequence = (props: Props) => {
     <div className={inputBoxClassnames} ref={dropZoneRef}>
       <div className={styles.header}>
         <span>{title}</span>
-        {input && (
-          <span className={styles.deleteButtonWrapper}>
-            <DeleteButton ref={deleteButtonRef} onClick={onClear} />
-          </span>
-        )}
+        <span className={styles.deleteButtonWrapper}>
+          <DeleteButton ref={deleteButtonRef} onClick={onClear} />
+        </span>
       </div>
       <div className={styles.body}>
         <Textarea

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence.tsx
@@ -122,6 +122,7 @@ const BlastInputSequence = (props: Props) => {
   const onClear = () => {
     setInput('');
     props.onRemoveSequence?.(index);
+    props.onInput?.('', index);
   };
 
   const isInputValid = input

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.tsx
@@ -28,7 +28,8 @@ import BlastInputSequence from './BlastInputSequence';
 import styles from './BlastInputSequences.scss';
 
 const BlastInputSequences = () => {
-  const { sequences, sequenceType, updateSequences } = useBlastInputSequences();
+  const { sequences, sequenceType, updateSequences, appendEmptyInputBox } =
+    useBlastInputSequences();
   const shouldAppendEmptyInput = useSelector(getEmptyInputVisibility);
 
   const onSequenceAdded = (input: string, index: number | null) => {
@@ -44,7 +45,11 @@ const BlastInputSequences = () => {
   };
 
   const onRemoveSequence = (index: number | null) => {
-    if (typeof index === 'number') {
+    if (index === null && sequences.length) {
+      // User has called the function from an added empty input box.
+      // The box can now be removed
+      appendEmptyInputBox(false);
+    } else if (typeof index === 'number') {
       const newSequences = [...sequences].filter((_, i) => i !== index);
       updateSequences(newSequences);
     }

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.tsx
@@ -28,8 +28,13 @@ import BlastInputSequence from './BlastInputSequence';
 import styles from './BlastInputSequences.scss';
 
 const BlastInputSequences = () => {
-  const { sequences, sequenceType, updateSequences, appendEmptyInputBox } =
-    useBlastInputSequences();
+  const {
+    sequences,
+    sequenceType,
+    updateSequences,
+    appendEmptyInputBox,
+    setUncommittedSequencePresence
+  } = useBlastInputSequences();
   const shouldAppendEmptyInput = useSelector(getEmptyInputVisibility);
 
   const onSequenceAdded = (input: string, index: number | null) => {
@@ -55,6 +60,10 @@ const BlastInputSequences = () => {
     }
   };
 
+  const onUncommittedSequenceInput = (sequence: string) => {
+    setUncommittedSequencePresence(Boolean(sequence.length));
+  };
+
   return (
     <div className={styles.blastInputSequences}>
       <div className={styles.inputBoxesContainer}>
@@ -74,6 +83,7 @@ const BlastInputSequences = () => {
             title={`Sequence ${sequences.length + 1}`}
             sequenceType={sequenceType}
             onCommitted={onSequenceAdded}
+            onInput={onUncommittedSequenceInput}
             onRemoveSequence={onRemoveSequence}
           />
         )}

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.test.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.test.tsx
@@ -31,6 +31,8 @@ import BlastInputSequencesHeader, {
   type Props as BlastInputSequencesHeaderProps
 } from './BlastInputSequencesHeader';
 
+import { MAX_BLAST_SEQUENCE_COUNT } from 'src/content/app/tools/blast/utils/blastFormValidator';
+
 const defaultProps: BlastInputSequencesHeaderProps = {
   compact: false
 };
@@ -145,6 +147,23 @@ describe('BlastInputSequencesHeader', () => {
       ) as HTMLButtonElement;
 
       expect(addSequenceButton.hasAttribute('disabled')).toBe(false);
+    });
+
+    it('is disabled if the number of added sequences has reached the allowed maximum', () => {
+      const sequences = times(MAX_BLAST_SEQUENCE_COUNT, () => ({
+        value: 'ACTG'
+      }));
+      const { container } = renderComponent({
+        state: {
+          shouldAppendEmptyInput: false, // means that the button would be enabled if not for the sequence count
+          sequences
+        }
+      });
+      const addSequenceButton = container.querySelector(
+        '.addSequence .plusButton'
+      ) as HTMLButtonElement;
+
+      expect(addSequenceButton.hasAttribute('disabled')).toBe(true);
     });
 
     it('toggles the flag for displaying an empty input box', () => {

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.test.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.test.tsx
@@ -93,10 +93,27 @@ describe('BlastInputSequencesHeader', () => {
         `${numberOfSequences}`
       );
     });
+
+    it('adds 1 to the number of committed sequences if the user is typing in a new one', () => {
+      const numberOfSequences = random(1, 30);
+      const sequences = times(numberOfSequences, () => ({ value: 'ACTG' }));
+      const { container } = renderComponent({
+        state: {
+          sequences,
+          hasUncommittedSequence: true // flag that gets set when the user is typing a sequence but has not yet committed it
+        }
+      });
+      const sequenceCounter = container.querySelector(
+        '.header .sequenceCounter'
+      );
+      expect(getNodeText(sequenceCounter as HTMLElement)).toBe(
+        `${numberOfSequences + 1}`
+      );
+    });
   });
 
   describe('button for adding sequences', () => {
-    it('is disabled if a flag for appending an empty input box is set', () => {
+    it('is disabled if the list of sequence input boxes ends in an empty one', () => {
       const { container } = renderComponent(); // initial state has shouldAppendEmptyInput set to true
       const addSequenceButton = container.querySelector(
         '.addSequence .plusButton'
@@ -105,7 +122,32 @@ describe('BlastInputSequencesHeader', () => {
       expect(addSequenceButton.hasAttribute('disabled')).toBe(true);
     });
 
-    it('toggles a flag for displaying an empty input box', () => {
+    it('is enabled if there are no empty sequence input boxes in the list', () => {
+      const { container } = renderComponent({
+        state: { shouldAppendEmptyInput: false }
+      });
+      const addSequenceButton = container.querySelector(
+        '.addSequence .plusButton'
+      ) as HTMLButtonElement;
+
+      expect(addSequenceButton.hasAttribute('disabled')).toBe(false);
+    });
+
+    it('is enabled when the user starts typing in an empty sequence box', () => {
+      const { container } = renderComponent({
+        state: {
+          shouldAppendEmptyInput: false,
+          hasUncommittedSequence: true // flag that gets set when the user is typing a sequence but has not yet committed it
+        }
+      });
+      const addSequenceButton = container.querySelector(
+        '.addSequence .plusButton'
+      ) as HTMLButtonElement;
+
+      expect(addSequenceButton.hasAttribute('disabled')).toBe(false);
+    });
+
+    it('toggles the flag for displaying an empty input box', () => {
       const { container, store } = renderComponent({
         state: { shouldAppendEmptyInput: false }
       });

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.tsx
@@ -72,9 +72,10 @@ const BlastInputSequencesHeader = (props: Props) => {
     lastTextarea?.focus();
   };
 
-  const shouldDisableAddButton =
-    sequences.length >= MAX_BLAST_SEQUENCE_COUNT ||
-    (isEmptyInputAppended && !isUserTypingInEmptyInput);
+  const shouldEnableAddButton = isEmptyInputAppended
+    ? isUserTypingInEmptyInput &&
+      sequences.length < MAX_BLAST_SEQUENCE_COUNT - 1
+    : sequences.length < MAX_BLAST_SEQUENCE_COUNT;
 
   const sequencesCount = isUserTypingInEmptyInput
     ? sequences.length + 1
@@ -97,7 +98,7 @@ const BlastInputSequencesHeader = (props: Props) => {
         </span>
         <AddAnotherSequence
           onAdd={appendEmptyInput}
-          disabled={shouldDisableAddButton}
+          disabled={!shouldEnableAddButton}
         />
         {compact && (
           <SecondaryButton

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.tsx
@@ -17,7 +17,10 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
-import { getEmptyInputVisibility } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
+import {
+  getEmptyInputVisibility,
+  getUncommittedSequencePresence
+} from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
 
 import {
   updateEmptyInputDisplay,
@@ -44,7 +47,8 @@ const BlastInputSequencesHeader = (props: Props) => {
   const { sequences, sequenceType, updateSequenceType, clearAllSequences } =
     useBlastInputSequences();
 
-  const shouldAppendEmptyInput = useSelector(getEmptyInputVisibility);
+  const isEmptyInputAppended = useSelector(getEmptyInputVisibility);
+  const isUserTypingInEmptyInput = useSelector(getUncommittedSequencePresence);
 
   const dispatch = useDispatch();
 
@@ -66,6 +70,9 @@ const BlastInputSequencesHeader = (props: Props) => {
     lastTextarea?.focus();
   };
 
+  const shouldDisableAddButton =
+    isEmptyInputAppended && !isUserTypingInEmptyInput;
+
   return (
     <div className={styles.header}>
       <div className={styles.headerGroup}>
@@ -83,7 +90,7 @@ const BlastInputSequencesHeader = (props: Props) => {
         </span>
         <AddAnotherSequence
           onAdd={appendEmptyInput}
-          disabled={shouldAppendEmptyInput}
+          disabled={shouldDisableAddButton}
         />
         {compact && (
           <SecondaryButton

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.tsx
@@ -33,6 +33,8 @@ import { SecondaryButton } from 'src/shared/components/button/Button';
 import PlusButton from 'src/shared/components/plus-button/PlusButton';
 import RadioGroup from 'src/shared/components/radio-group/RadioGroup';
 
+import { MAX_BLAST_SEQUENCE_COUNT } from 'src/content/app/tools/blast/utils/blastFormValidator';
+
 import type { SequenceType } from 'src/content/app/tools/blast/types/blastSettings';
 
 import styles from './BlastInputSequences.scss';
@@ -71,7 +73,8 @@ const BlastInputSequencesHeader = (props: Props) => {
   };
 
   const shouldDisableAddButton =
-    isEmptyInputAppended && !isUserTypingInEmptyInput;
+    sequences.length >= MAX_BLAST_SEQUENCE_COUNT ||
+    (isEmptyInputAppended && !isUserTypingInEmptyInput);
 
   const sequencesCount = isUserTypingInEmptyInput
     ? sequences.length + 1

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.tsx
@@ -73,11 +73,15 @@ const BlastInputSequencesHeader = (props: Props) => {
   const shouldDisableAddButton =
     isEmptyInputAppended && !isUserTypingInEmptyInput;
 
+  const sequencesCount = isUserTypingInEmptyInput
+    ? sequences.length + 1
+    : sequences.length;
+
   return (
     <div className={styles.header}>
       <div className={styles.headerGroup}>
         <span className={styles.headerTitle}>Sequences</span>
-        <span className={styles.sequenceCounter}>{sequences.length}</span>
+        <span className={styles.sequenceCounter}>{sequencesCount}</span>
         <span className={styles.maxSequences}>of 30</span>
       </div>
       <SequenceSwitcher

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.tsx
@@ -66,10 +66,10 @@ const BlastInputSequencesHeader = (props: Props) => {
   };
 
   const scrollToLastInputBox = () => {
-    const lastTextarea = document.querySelector(
-      `.${sequenceBoxStyles.inputSequenceBox}:last-child textarea`
-    ) as HTMLTextAreaElement;
-    lastTextarea?.focus();
+    const lastInputBox = document.querySelector(
+      `.${sequenceBoxStyles.inputSequenceBox}:last-child`
+    ) as HTMLDivElement;
+    lastInputBox.scrollIntoView({ block: 'end', behavior: 'smooth' }); // Safari doesn't properly support this (see https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView); but other options scroll just as jerkily on Safari
   };
 
   const shouldEnableAddButton = isEmptyInputAppended

--- a/src/content/app/tools/blast/components/blast-input-sequences/useBlastInputSequences.ts
+++ b/src/content/app/tools/blast/components/blast-input-sequences/useBlastInputSequences.ts
@@ -19,7 +19,8 @@ import { useSelector, useDispatch } from 'react-redux';
 
 import {
   setSequences,
-  setSequenceType
+  setSequenceType,
+  updateEmptyInputDisplay
 } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
 
 import {
@@ -56,9 +57,14 @@ const useBlastInputSequences = () => {
     ref.current = { sequenceType, sequenceSelectionMode };
   });
 
-  const updateSequences = (sequences: ParsedInputSequence[]) => {
-    dispatch(setSequences({ sequences }));
-    updateSequenceTypeAutomatically(sequences);
+  const updateSequences = (newSequences: ParsedInputSequence[]) => {
+    dispatch(setSequences({ sequences: newSequences }));
+    if (newSequences.length > sequences.length) {
+      dispatch(updateEmptyInputDisplay(false));
+    } else if (!newSequences.length) {
+      dispatch(updateEmptyInputDisplay(true));
+    }
+    updateSequenceTypeAutomatically(newSequences);
   };
 
   const updateSequenceTypeAutomatically = (
@@ -107,12 +113,17 @@ const useBlastInputSequences = () => {
     );
   };
 
+  const appendEmptyInputBox = (shouldAppend: boolean) => {
+    dispatch(updateEmptyInputDisplay(shouldAppend));
+  };
+
   return {
     sequences,
     sequenceType,
     updateSequences,
     clearAllSequences,
-    updateSequenceType
+    updateSequenceType,
+    appendEmptyInputBox
   };
 };
 

--- a/src/content/app/tools/blast/components/blast-input-sequences/useBlastInputSequences.ts
+++ b/src/content/app/tools/blast/components/blast-input-sequences/useBlastInputSequences.ts
@@ -20,13 +20,15 @@ import { useSelector, useDispatch } from 'react-redux';
 import {
   setSequences,
   setSequenceType,
-  updateEmptyInputDisplay
+  updateEmptyInputDisplay,
+  setHasUncommittedSequence
 } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
 
 import {
   getSequences,
   getSelectedSequenceType,
-  getSequenceSelectionMode
+  getSequenceSelectionMode,
+  getUncommittedSequencePresence
 } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
 
 import { guessSequenceType } from 'src/content/app/tools/blast/utils/sequenceTypeGuesser';
@@ -45,6 +47,7 @@ const useBlastInputSequences = () => {
   const sequences = useSelector(getSequences);
   const sequenceType = useSelector(getSelectedSequenceType);
   const sequenceSelectionMode = useSelector(getSequenceSelectionMode);
+  const hasUncommittedSequence = useSelector(getUncommittedSequencePresence);
   const dispatch = useDispatch();
 
   const ref = useRef({
@@ -65,6 +68,7 @@ const useBlastInputSequences = () => {
       dispatch(updateEmptyInputDisplay(true));
     }
     updateSequenceTypeAutomatically(newSequences);
+    setUncommittedSequencePresence(false);
   };
 
   const updateSequenceTypeAutomatically = (
@@ -117,13 +121,20 @@ const useBlastInputSequences = () => {
     dispatch(updateEmptyInputDisplay(shouldAppend));
   };
 
+  const setUncommittedSequencePresence = (isPresent: boolean) => {
+    if (isPresent !== hasUncommittedSequence) {
+      dispatch(setHasUncommittedSequence(isPresent));
+    }
+  };
+
   return {
     sequences,
     sequenceType,
     updateSequences,
     clearAllSequences,
     updateSequenceType,
-    appendEmptyInputBox
+    appendEmptyInputBox,
+    setUncommittedSequencePresence
   };
 };
 

--- a/src/content/app/tools/blast/state/blast-form/blastFormSelectors.ts
+++ b/src/content/app/tools/blast/state/blast-form/blastFormSelectors.ts
@@ -22,6 +22,9 @@ export const getSequences = (state: RootState) =>
 export const getEmptyInputVisibility = (state: RootState) =>
   state.blast.blastForm.shouldAppendEmptyInput;
 
+export const getUncommittedSequencePresence = (state: RootState) =>
+  state.blast.blastForm.hasUncommittedSequence;
+
 export const getSelectedSequenceType = (state: RootState) =>
   state.blast.blastForm.settings.sequenceType;
 

--- a/src/content/app/tools/blast/state/blast-form/blastFormSlice.ts
+++ b/src/content/app/tools/blast/state/blast-form/blastFormSlice.ts
@@ -38,6 +38,7 @@ export type BlastFormState = {
   step: 'sequences' | 'species'; // will only be relevant on smaller screens
   sequences: ParsedInputSequence[];
   shouldAppendEmptyInput: boolean;
+  hasUncommittedSequence: boolean;
   selectedSpecies: string[];
   settings: BlastFormSettings;
 };
@@ -55,6 +56,7 @@ export const initialState: BlastFormState = {
   step: 'sequences',
   sequences: [],
   shouldAppendEmptyInput: true,
+  hasUncommittedSequence: false,
   selectedSpecies: [],
   settings: initialBlastFormSettings
 };
@@ -114,6 +116,9 @@ const blastFormSlice = createSlice({
     },
     updateEmptyInputDisplay(state, action: PayloadAction<boolean>) {
       state.shouldAppendEmptyInput = action.payload;
+    },
+    setHasUncommittedSequence(state, action: PayloadAction<boolean>) {
+      state.hasUncommittedSequence = action.payload;
     },
     switchToSequencesStep(state) {
       state.step = 'sequences';
@@ -231,6 +236,7 @@ const blastFormSlice = createSlice({
 export const {
   setSequences,
   updateEmptyInputDisplay,
+  setHasUncommittedSequence,
   switchToSpeciesStep,
   switchToSequencesStep,
   addSelectedSpecies,

--- a/src/content/app/tools/blast/state/blast-form/blastFormSlice.ts
+++ b/src/content/app/tools/blast/state/blast-form/blastFormSlice.ts
@@ -98,7 +98,6 @@ const blastFormSlice = createSlice({
     ) {
       const { sequences } = action.payload;
       state.sequences = sequences;
-      state.shouldAppendEmptyInput = Boolean(!sequences.length);
     },
     addSelectedSpecies(state, action: PayloadAction<{ genomeId: string }>) {
       const { genomeId } = action.payload;

--- a/src/content/app/tools/blast/utils/blastFormValidator.ts
+++ b/src/content/app/tools/blast/utils/blastFormValidator.ts
@@ -16,8 +16,8 @@
 
 import { ParsedInputSequence } from 'src/content/app/tools/blast/types/parsedInputSequence';
 
-export const BLAST_SPECIES_LIMIT = 25;
-export const BLAST_SEQUENCE_LIMIT = 30;
+export const MAX_BLAST_SPECIES_COUNT = 25;
+export const MAX_BLAST_SEQUENCE_COUNT = 30;
 
 export const isBlastFormValid = (
   species: string[],
@@ -25,8 +25,8 @@ export const isBlastFormValid = (
 ) => {
   return (
     species.length > 0 &&
-    species.length <= BLAST_SPECIES_LIMIT &&
+    species.length <= MAX_BLAST_SPECIES_COUNT &&
     sequences.length > 0 &&
-    sequences.length <= BLAST_SEQUENCE_LIMIT
+    sequences.length <= MAX_BLAST_SEQUENCE_COUNT
   );
 };

--- a/src/content/app/tools/blast/utils/tests/blastFormValidator.test.ts
+++ b/src/content/app/tools/blast/utils/tests/blastFormValidator.test.ts
@@ -16,8 +16,8 @@
 import faker from 'faker';
 import {
   isBlastFormValid,
-  BLAST_SPECIES_LIMIT,
-  BLAST_SEQUENCE_LIMIT
+  MAX_BLAST_SPECIES_COUNT,
+  MAX_BLAST_SEQUENCE_COUNT
 } from '../blastFormValidator';
 
 const createFakeSpecies = (times: number) => {
@@ -32,7 +32,7 @@ const createFakeSequences = (times: number) => {
 
 describe('isBlastFormValid', () => {
   it('fails validation if the number of species is more than the limit', () => {
-    const species = createFakeSpecies(BLAST_SPECIES_LIMIT + 1);
+    const species = createFakeSpecies(MAX_BLAST_SPECIES_COUNT + 1);
     const sequences = createFakeSequences(1);
 
     expect(isBlastFormValid(species, sequences)).toBe(false);
@@ -40,7 +40,7 @@ describe('isBlastFormValid', () => {
 
   it('fails validation if the number of sequences is more than the limit', () => {
     const species = createFakeSpecies(1);
-    const sequences = createFakeSequences(BLAST_SEQUENCE_LIMIT + 1);
+    const sequences = createFakeSequences(MAX_BLAST_SEQUENCE_COUNT + 1);
 
     expect(isBlastFormValid(species, sequences)).toBe(false);
   });


### PR DESCRIPTION
## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1485

## Description
1. For empty input box
  - Prevent disappearance of empty input box when user unfocuses from it
    - Note that the box will still disappear if it contained a sequence before the user has selected and deleted it, and then clicked outside the textarea
  - Enable deletion of empty input box by pressing the trashcan icon
    - Note that the trashcan icon is showing on the first input box even while it's empty and isn't, technically, doing anything
2. "Add another sequence" button
  - Activate the button as soon as the user starts typing in the empty input box
  - Inactivate the button when the maximum allowed number of sequences has been added
3. Sequence counter
  - Update counter as soon as the user starts typing in the empty sequence box

### Not done (agreed that it was unnecessary)
Input box will still disappear if the user deletes a sequence and unfocuses from the textarea. This may cause surprise for the user, but Andrea decided that this is better than allowing the user to create as many empty boxes on the screen as they want. Plus, this is an edge case that is expected to occur very rarely. Technically, it's certainly much easier to keep the current behaviour of the input boxes.

## Deployment URL
http://empty-blast-input-boxes.review.ensembl.org
