### PR TITLE
Track API service/ingress for review apps

### DIFF
--- a/gitlab-ci-templates/.setup-review-template.yaml
+++ b/gitlab-ci-templates/.setup-review-template.yaml
@@ -48,7 +48,7 @@
     - sed -i "s#<DEPLOYMENT_ENV>#${HELP_DOCS_SERVICE_SLUG}#g" ensembl_help_docs_service.yaml
     - sed -i "s#<DEPLOYMENT_ENV>#${HELP_DOCS_SERVICE_SLUG}#g" ensembl_help_docs_ingress.yaml
     - sed -i "s#<SUB_DOMAIN>#${CI_COMMIT_REF_SLUG}#g" ensembl_help_docs_ingress.yaml
-    # ensembl-help-docs
+    # ensembl-track-api
     - sed -i "s#<DEPLOYMENT_ENV>#${TRACK_API_SERVICE_SLUG}#g" ensembl_track_api_service.yaml
     - sed -i "s#<DEPLOYMENT_ENV>#${TRACK_API_SERVICE_SLUG}#g" ensembl_track_api_ingress.yaml
     - sed -i "s#<SUB_DOMAIN>#${CI_COMMIT_REF_SLUG}#g" ensembl_track_api_ingress.yaml

--- a/gitlab-ci-templates/.setup-review-template.yaml
+++ b/gitlab-ci-templates/.setup-review-template.yaml
@@ -9,10 +9,11 @@
     THOAS_SERVICE_SLUG: dev
     REFGET_SERVICE_SLUG: dev
     HELP_DOCS_SERVICE_SLUG: dev
+    TRACK_API_SERVICE_SLUG: dev
 
   before_script:
     - git clone https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
-    - git -C ensembl-k8s-manifests/ checkout wp-k8s-review
+    - git -C ensembl-k8s-manifests/ checkout track-api-integration
     - cd ensembl-k8s-manifests/
     # ensembl-client
     - sed -i "s#<DEPLOYMENT_ENV>#${CI_COMMIT_REF_SLUG}#g" ensembl_client_nginx_service.yaml
@@ -47,7 +48,14 @@
     - sed -i "s#<DEPLOYMENT_ENV>#${HELP_DOCS_SERVICE_SLUG}#g" ensembl_help_docs_service.yaml
     - sed -i "s#<DEPLOYMENT_ENV>#${HELP_DOCS_SERVICE_SLUG}#g" ensembl_help_docs_ingress.yaml
     - sed -i "s#<SUB_DOMAIN>#${CI_COMMIT_REF_SLUG}#g" ensembl_help_docs_ingress.yaml
+    # ensembl-help-docs
+    - sed -i "s#<DEPLOYMENT_ENV>#${TRACK_API_SERVICE_SLUG}#g" ensembl_track_api_service.yaml
+    - sed -i "s#<DEPLOYMENT_ENV>#${TRACK_API_SERVICE_SLUG}#g" ensembl_track_api_ingress.yaml
+    - sed -i "s#<SUB_DOMAIN>#${CI_COMMIT_REF_SLUG}#g" ensembl_track_api_ingress.yaml
   script:
+    # ensembl-track-api
+    - kubectl apply -f ensembl_track_api_service.yaml
+    - kubectl apply -f ensembl_track_api_ingress.yaml
     # ensembl-help-and-docs
     - kubectl apply -f ensembl_help_docs_service.yaml
     - kubectl apply -f ensembl_help_docs_ingress.yaml

--- a/gitlab-ci-templates/.setup-review-template.yaml
+++ b/gitlab-ci-templates/.setup-review-template.yaml
@@ -13,7 +13,7 @@
 
   before_script:
     - git clone https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
-    - git -C ensembl-k8s-manifests/ checkout track-api-integration
+    - git -C ensembl-k8s-manifests/ checkout wp-k8s-review
     - cd ensembl-k8s-manifests/
     # ensembl-client
     - sed -i "s#<DEPLOYMENT_ENV>#${CI_COMMIT_REF_SLUG}#g" ensembl_client_nginx_service.yaml


### PR DESCRIPTION
<!--
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This will normally be the development branch, so please ask your reviewer if you think it needs to go somewhere else. 
-->

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement to existing feature
- [x] Pipeline

## Related JIRA Issue(s)
<!--_Please provide the URL(s) for any JIRA issues related to this PR._-->

## Importance
Track API integration for review apps.

## Description
Track is not integrated for review apps. All the routes to /api/tracks should go to track API but for review apps its currently being served by the Track API Deployed at the staging-2020 accessible at staging-2020.ensembl.org/api/tracks

## Deployment URL
http://tai-test-1.review.ensembl.org
http://tai-test-2.review.ensembl.org

## Views affected
<!--
_List the website view(s) that you know are affected by this change._
_If possible please provide a relative or localhost URL that can be used to view the change._
-->

### Other effects
<!--
_List any other functionality that may be affected or which requires additional changes, such as saved configurations. Please add an explanation if, for example, no test is needed._
-->

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
<!--
_We appreciate this can be difficult but please highlight any views that you think might possibly be adversely affected by this change. For example a change to the services or app-level changes have potential for widespread consequences._
-->
