### PR TITLE
Add Tools API integration to review apps

### DIFF
--- a/gitlab-ci-templates/.setup-review-template.yaml
+++ b/gitlab-ci-templates/.setup-review-template.yaml
@@ -13,7 +13,7 @@
 
   before_script:
     - git clone https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
-    - git -C ensembl-k8s-manifests/ checkout wp-k8s-review
+    - git -C ensembl-k8s-manifests/ checkout tools-api-integration
     - cd ensembl-k8s-manifests/
     # ensembl-client
     - sed -i "s#<DEPLOYMENT_ENV>#${CI_COMMIT_REF_SLUG}#g" ensembl_client_nginx_service.yaml
@@ -52,7 +52,14 @@
     - sed -i "s#<DEPLOYMENT_ENV>#${TRACK_API_SERVICE_SLUG}#g" ensembl_track_api_service.yaml
     - sed -i "s#<DEPLOYMENT_ENV>#${TRACK_API_SERVICE_SLUG}#g" ensembl_track_api_ingress.yaml
     - sed -i "s#<SUB_DOMAIN>#${CI_COMMIT_REF_SLUG}#g" ensembl_track_api_ingress.yaml
+    # ensembl-tools-api
+    - sed -i "s#<DEPLOYMENT_ENV>#${TRACK_API_SERVICE_SLUG}#g" ensembl_tools_api_service.yaml
+    - sed -i "s#<DEPLOYMENT_ENV>#${TRACK_API_SERVICE_SLUG}#g" ensembl_tools_api_ingress.yaml
+    - sed -i "s#<SUB_DOMAIN>#${CI_COMMIT_REF_SLUG}#g" ensembl_tools_api_ingress.yaml
   script:
+    # ensembl-tools-api
+    - kubectl apply -f ensembl_tools_api_service.yaml
+    - kubectl apply -f ensembl_tools_api_ingress.yaml
     # ensembl-track-api
     - kubectl apply -f ensembl_track_api_service.yaml
     - kubectl apply -f ensembl_track_api_ingress.yaml

--- a/gitlab-ci-templates/.setup-review-template.yaml
+++ b/gitlab-ci-templates/.setup-review-template.yaml
@@ -13,7 +13,7 @@
 
   before_script:
     - git clone https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
-    - git -C ensembl-k8s-manifests/ checkout tools-api-integration
+    - git -C ensembl-k8s-manifests/ checkout wp-k8s-review
     - cd ensembl-k8s-manifests/
     # ensembl-client
     - sed -i "s#<DEPLOYMENT_ENV>#${CI_COMMIT_REF_SLUG}#g" ensembl_client_nginx_service.yaml

--- a/gitlab-ci-templates/.setup-review-template.yaml
+++ b/gitlab-ci-templates/.setup-review-template.yaml
@@ -10,6 +10,7 @@
     REFGET_SERVICE_SLUG: dev
     HELP_DOCS_SERVICE_SLUG: dev
     TRACK_API_SERVICE_SLUG: dev
+    TOOLS_API_SERVICE_SLUG: dev
 
   before_script:
     - git clone https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
@@ -53,8 +54,8 @@
     - sed -i "s#<DEPLOYMENT_ENV>#${TRACK_API_SERVICE_SLUG}#g" ensembl_track_api_ingress.yaml
     - sed -i "s#<SUB_DOMAIN>#${CI_COMMIT_REF_SLUG}#g" ensembl_track_api_ingress.yaml
     # ensembl-tools-api
-    - sed -i "s#<DEPLOYMENT_ENV>#${TRACK_API_SERVICE_SLUG}#g" ensembl_tools_api_service.yaml
-    - sed -i "s#<DEPLOYMENT_ENV>#${TRACK_API_SERVICE_SLUG}#g" ensembl_tools_api_ingress.yaml
+    - sed -i "s#<DEPLOYMENT_ENV>#${TOOLS_API_SERVICE_SLUG}#g" ensembl_tools_api_service.yaml
+    - sed -i "s#<DEPLOYMENT_ENV>#${TOOLS_API_SERVICE_SLUG}#g" ensembl_tools_api_ingress.yaml
     - sed -i "s#<SUB_DOMAIN>#${CI_COMMIT_REF_SLUG}#g" ensembl_tools_api_ingress.yaml
   script:
     # ensembl-tools-api


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/EWB-20
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1433

## Importance
Required for adding the BLAST tool functionality to Ensembl 2020.

## Description
This PR integrates the ingress/service configuration files in [ensembl-k8s-manifests](https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests) for deploying review apps.

## Deployment URL
Example review app Tools API endpoints:
http://test-toolsapi-1.review.ensembl.org/api/tools/blast/config
http://test-toolsapi-2.review.ensembl.org/api/tools/docs

## Views affected
BLAST tool interface (not yet integrated to FE)

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
Deploys additional BE service for review apps, should not affect current review apps. 
