### PR TITLE
Remove the disabled property from RadioGroup props

### DIFF
--- a/src/shared/components/radio-group/RadioGroup.test.tsx
+++ b/src/shared/components/radio-group/RadioGroup.test.tsx
@@ -73,16 +73,4 @@ describe('<RadioGroup />', () => {
 
     expect(onChange).toHaveBeenCalledWith(defaultProps.options[0].value);
   });
-
-  it('does not respond to interactions when disabled', () => {
-    const { container } = render(
-      <RadioGroup {...defaultProps} disabled={true} />
-    );
-
-    const firstRadioButton = container.querySelector('.radio');
-
-    userEvent.click(firstRadioButton as HTMLElement);
-
-    expect(onChange).not.toHaveBeenCalled();
-  });
 });

--- a/src/shared/components/radio-group/RadioGroup.tsx
+++ b/src/shared/components/radio-group/RadioGroup.tsx
@@ -33,7 +33,6 @@ export type RadioGroupProps = {
   onChange: (selectedOption: OptionValue) => void;
   options: RadioOptions;
   selectedOption: OptionValue;
-  disabled?: boolean;
   theme?: Theme;
   direction?: Direction;
   className?: string; // optional class name for the whole radio group element
@@ -44,7 +43,7 @@ const RadioGroup = (props: RadioGroupProps) => {
   const theme = props.theme ?? 'light';
 
   const handleChange = (value: OptionValue) => {
-    if (props.disabled || value === props.selectedOption) {
+    if (value === props.selectedOption) {
       return;
     }
     props.onChange(value);
@@ -77,7 +76,6 @@ const RadioGroup = (props: RadioGroupProps) => {
             type="radio"
             onChange={() => handleChange(option.value)}
             checked={option.value === props.selectedOption}
-            disabled={props.disabled}
           />
         </label>
       ))}


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement to existing feature

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1509

## Importance

## Description
We have a disabled property for radiogroup which shows a group of radio disabled. The real use case will be to have one of the radio button disabled in a group but we currently dont have any usecase of this on the site, hence removing this property. Can be added and implemented against once we have a use case of a disabled radio button.

## Deployment URL
http://radio-disabled.review.ensembl.org 

## Views affected


### Other effects

- [ ] I have checked any requirements for Google Analytics
- [ ] I have created any required tests
- [ ] The PR has as its final commit a WASM/JS update commit if any Rust files were updated.

## Possible complications
