### PR TITLE
Fix blast input clearing and database switching

### DIFF
--- a/src/content/app/tools/blast/components/blast-input-sequences/useBlastInputSequences.ts
+++ b/src/content/app/tools/blast/components/blast-input-sequences/useBlastInputSequences.ts
@@ -103,18 +103,7 @@ const useBlastInputSequences = () => {
   };
 
   const clearAllSequences = () => {
-    dispatch(
-      setSequences({
-        sequences: []
-      })
-    );
-    dispatch(
-      setSequenceType({
-        sequenceType: 'dna',
-        isAutomatic: true,
-        config: blastSettingsConfig
-      })
-    );
+    updateSequences([]);
   };
 
   const appendEmptyInputBox = (shouldAppend: boolean) => {

--- a/src/content/app/tools/blast/components/blast-settings/BlastSettings.tsx
+++ b/src/content/app/tools/blast/components/blast-settings/BlastSettings.tsx
@@ -242,7 +242,7 @@ const BlastSettings = () => {
             })}
           {buildSelect({
             ...(getParameterData('wordsize') as BlastSelectSetting),
-            selectedOption: blastParameters.match_scores as string,
+            selectedOption: blastParameters.wordsize as string,
             onChange: (value: string) =>
               onBlastParameterChange('wordsize', value)
           })}
@@ -254,13 +254,13 @@ const BlastSettings = () => {
           })}
           {buildSelect({
             ...(getParameterData('gapext') as BlastSelectSetting),
-            selectedOption: blastParameters.gapopen as string,
+            selectedOption: blastParameters.gapext as string,
             onChange: (value: string) => onBlastParameterChange('gapext', value)
           })}
           {databaseSequenceType === 'protein' &&
             buildSelect({
               ...(getParameterData('matrix') as BlastSelectSetting),
-              selectedOption: blastParameters.gapopen as string,
+              selectedOption: blastParameters.matrix as string,
               onChange: (value: string) =>
                 onBlastParameterChange('matrix', value)
             })}

--- a/src/content/app/tools/blast/components/blast-settings/blastSettingsConfig.json
+++ b/src/content/app/tools/blast/components/blast-settings/blastSettingsConfig.json
@@ -685,7 +685,7 @@
           "exp": "1e-1",
           "gapopen": "11",
           "gapext": "1",
-          "wordsize": "11",
+          "wordsize": "6",
           "matrix": "BLOSUM62"
         },
         "near_match": {
@@ -699,7 +699,7 @@
           "exp": "1e-1",
           "gapopen": "11",
           "gapext": "1",
-          "wordsize": "11",
+          "wordsize": "6",
           "matrix": "BLOSUM90"
         },
         "distant_homologies": {
@@ -713,7 +713,7 @@
           "exp": "1e-1",
           "gapopen": "11",
           "gapext": "1",
-          "wordsize": "11",
+          "wordsize": "6",
           "matrix": "BLOSUM45"
         }
       },
@@ -729,7 +729,7 @@
           "exp": "1e-1",
           "gapopen": "11",
           "gapext": "1",
-          "wordsize": "11",
+          "wordsize": "6",
           "matrix": "BLOSUM62"
         },
         "near_match": {
@@ -743,7 +743,7 @@
           "exp": "1e-1",
           "gapopen": "11",
           "gapext": "1",
-          "wordsize": "11",
+          "wordsize": "6",
           "matrix": "BLOSUM90"
         },
         "distant_homologies": {
@@ -757,7 +757,7 @@
           "exp": "1e-1",
           "gapopen": "11",
           "gapext": "1",
-          "wordsize": "11",
+          "wordsize": "6",
           "matrix": "BLOSUM45"
         }
       },

--- a/src/content/app/tools/blast/components/blast-settings/blastSettingsConfig.json
+++ b/src/content/app/tools/blast/components/blast-settings/blastSettingsConfig.json
@@ -575,7 +575,7 @@
     },
     {
       "sequence_type": "dna",
-      "database_type": "pep",
+      "database_type": "protein",
       "programs": ["blastx"]
     },
     {
@@ -585,7 +585,7 @@
     },
     {
       "sequence_type": "protein",
-      "database_type": "pep",
+      "database_type": "protein",
       "programs": ["blastp"]
     }
   ],


### PR DESCRIPTION
## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1520
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1521

## Description
This PR fixes two bugs:
- Clicking on the "Clear all" element removes all input boxes from the screen instead of leaving an empty one
- Switching between databases does not correctly update the blast program (regression from https://github.com/Ensembl/ensembl-client/pull/709)

## Deployment URL
CI/CD failing