### PR TITLE
Update svgr loader settings

### DIFF
--- a/.storybook/webpack.js
+++ b/.storybook/webpack.js
@@ -44,7 +44,15 @@ module.exports = (config) => {
   });
   config.module.rules.push({
     test: /\.svg$/,
-    use: ['@svgr/webpack', 'file-loader'],
+    oneOf: [
+      {
+        resourceQuery: /url/, // will match all imports that end in `.svg?url`
+        type: 'asset/resource',
+      },
+      {
+        use: ['@svgr/webpack']
+      }
+    ]
   });
 
   config.resolve.extensions.push('.ts', '.tsx');

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,6 @@
         "eslint-plugin-react": "7.29.2",
         "eslint-plugin-react-hooks": "4.3.0",
         "faker": "5.5.3",
-        "file-loader": "6.2.0",
         "fork-ts-checker-webpack-plugin": "7.2.1",
         "gh-pages": "3.2.3",
         "html-webpack-plugin": "5.5.0",
@@ -188,28 +187,6 @@
         "subscriptions-transport-ws": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@apollo/client/node_modules/@graphql-typed-document-node/core": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
-      "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@apollo/client/node_modules/graphql-tag": {
-      "version": "2.12.6",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
-      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2158,129 +2135,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@csstools/postcss-color-function": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-1.0.2.tgz",
-      "integrity": "sha512-uayvFqfa0hITPwVduxRYNL9YBD/anTqula0tu2llalaxblEd7QPuETSN3gB5PvTYxSfd0d8kS4Fypgo5JaUJ6A==",
-      "dev": true,
-      "dependencies": {
-        "@csstools/postcss-progressive-custom-properties": "^1.1.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4"
-      }
-    },
-    "node_modules/@csstools/postcss-font-format-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-font-format-keywords/-/postcss-font-format-keywords-1.0.0.tgz",
-      "integrity": "sha512-oO0cZt8do8FdVBX8INftvIA4lUrKUSCcWUf9IwH9IPWOgKT22oAZFXeHLoDK7nhB2SmkNycp5brxfNMRLIhd6Q==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.3"
-      }
-    },
-    "node_modules/@csstools/postcss-hwb-function": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-hwb-function/-/postcss-hwb-function-1.0.0.tgz",
-      "integrity": "sha512-VSTd7hGjmde4rTj1rR30sokY3ONJph1reCBTUXqeW1fKwETPy1x4t/XIeaaqbMbC5Xg4SM/lyXZ2S8NELT2TaA==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.3"
-      }
-    },
-    "node_modules/@csstools/postcss-ic-unit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-ic-unit/-/postcss-ic-unit-1.0.0.tgz",
-      "integrity": "sha512-i4yps1mBp2ijrx7E96RXrQXQQHm6F4ym1TOD0D69/sjDjZvQ22tqiEvaNw7pFZTUO5b9vWRHzbHzP9+UKuw+bA==",
-      "dev": true,
-      "dependencies": {
-        "@csstools/postcss-progressive-custom-properties": "^1.1.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.3"
-      }
-    },
-    "node_modules/@csstools/postcss-is-pseudo-class": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-2.0.0.tgz",
-      "integrity": "sha512-WnfZlyuh/CW4oS530HBbrKq0G8BKl/bsNr5NMFoubBFzJfvFRGJhplCgIJYWUidLuL3WJ/zhMtDIyNFTqhx63Q==",
-      "dev": true,
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.9"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4"
-      }
-    },
-    "node_modules/@csstools/postcss-normalize-display-values": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-1.0.0.tgz",
-      "integrity": "sha512-bX+nx5V8XTJEmGtpWTO6kywdS725t71YSLlxWt78XoHUbELWgoCXeOFymRJmL3SU1TLlKSIi7v52EWqe60vJTQ==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.3"
-      }
-    },
-    "node_modules/@csstools/postcss-oklab-function": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-oklab-function/-/postcss-oklab-function-1.0.1.tgz",
-      "integrity": "sha512-Bnly2FWWSTZX20hDJLYHpurhp1ot+ZGvojLOsrHa9frzOVruOv4oPYMZ6wQomi9KsbZZ+Af/CuRYaGReTyGtEg==",
-      "dev": true,
-      "dependencies": {
-        "@csstools/postcss-progressive-custom-properties": "^1.1.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4"
-      }
-    },
-    "node_modules/@csstools/postcss-progressive-custom-properties": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-progressive-custom-properties/-/postcss-progressive-custom-properties-1.2.0.tgz",
-      "integrity": "sha512-YLpFPK5OaLIRKZhUfnrZPT9s9cmtqltIOg7W6jPcxmiDpnZ4lk+odfufZttOAgcg6IHWvNLgcITSLpJxIQB/qQ==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.3"
-      }
-    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz",
@@ -2508,6 +2362,14 @@
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "dev": true
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
+      "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.9.5",
@@ -2769,6 +2631,49 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@jest/core/node_modules/jest-config": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.5.1.tgz",
+      "integrity": "sha512-5sAsjm6tGdsVbW9ahcChPAFCk4IlkQUknH5AvKjuLTSlcO/wCZKyFdn7Rg0EkC+OGgWODEy2hDpWB1PgzH0JNA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.8.0",
+        "@jest/test-sequencer": "^27.5.1",
+        "@jest/types": "^27.5.1",
+        "babel-jest": "^27.5.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^27.5.1",
+        "jest-environment-jsdom": "^27.5.1",
+        "jest-environment-node": "^27.5.1",
+        "jest-get-type": "^27.5.1",
+        "jest-jasmine2": "^27.5.1",
+        "jest-regex-util": "^27.5.1",
+        "jest-resolve": "^27.5.1",
+        "jest-runner": "^27.5.1",
+        "jest-util": "^27.5.1",
+        "jest-validate": "^27.5.1",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^27.5.1",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      },
+      "peerDependencies": {
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ts-node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jest/core/node_modules/supports-color": {
@@ -4150,6 +4055,76 @@
         }
       }
     },
+    "node_modules/@storybook/addon-essentials/node_modules/@storybook/addon-docs/node_modules/@storybook/core": {
+      "version": "6.4.19",
+      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-6.4.19.tgz",
+      "integrity": "sha512-55LOQ/h/kf1jMhjN85t/pIEdIwWEG9yV7bdwv3niVvmoypCxyyjn9/QNK0RKYAeDSUtdm6FVoJ6k5CpxWz2d8w==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-client": "6.4.19",
+        "@storybook/core-server": "6.4.19"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@storybook/builder-webpack5": "6.4.19",
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "@storybook/builder-webpack5": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/addon-essentials/node_modules/@storybook/addon-docs/node_modules/@storybook/core/node_modules/@storybook/core-client": {
+      "version": "6.4.19",
+      "resolved": "https://registry.npmjs.org/@storybook/core-client/-/core-client-6.4.19.tgz",
+      "integrity": "sha512-rQHRZjhArPleE7/S8ZUolgzwY+hC0smSKX/3PQxO2GcebDjnJj6+iSV3h+aSMHMmTdoCQvjYw9aBpT8scuRe+A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addons": "6.4.19",
+        "@storybook/channel-postmessage": "6.4.19",
+        "@storybook/channel-websocket": "6.4.19",
+        "@storybook/client-api": "6.4.19",
+        "@storybook/client-logger": "6.4.19",
+        "@storybook/core-events": "6.4.19",
+        "@storybook/csf": "0.0.2--canary.87bc651.0",
+        "@storybook/preview-web": "6.4.19",
+        "@storybook/store": "6.4.19",
+        "@storybook/ui": "6.4.19",
+        "airbnb-js-shims": "^2.2.1",
+        "ansi-to-html": "^0.6.11",
+        "core-js": "^3.8.2",
+        "global": "^4.4.0",
+        "lodash": "^4.17.21",
+        "qs": "^6.10.0",
+        "regenerator-runtime": "^0.13.7",
+        "ts-dedent": "^2.0.0",
+        "unfetch": "^4.2.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@storybook/addon-essentials/node_modules/@types/yargs": {
       "version": "15.0.14",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
@@ -4802,28 +4777,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@storybook/builder-webpack4/node_modules/autoprefixer": {
-      "version": "9.8.8",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
-      "integrity": "sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==",
-      "dev": true,
-      "dependencies": {
-        "browserslist": "^4.12.0",
-        "caniuse-lite": "^1.0.30001109",
-        "normalize-range": "^0.1.2",
-        "num2fraction": "^1.2.2",
-        "picocolors": "^0.2.1",
-        "postcss": "^7.0.32",
-        "postcss-value-parser": "^4.1.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "funding": {
-        "type": "tidelift",
-        "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-      }
-    },
     "node_modules/@storybook/builder-webpack4/node_modules/babel-plugin-macros": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
@@ -5013,6 +4966,58 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/@storybook/builder-webpack4/node_modules/file-loader": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
+      "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
+      "dev": true,
+      "dependencies": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/@storybook/builder-webpack4/node_modules/file-loader/node_modules/loader-utils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "dev": true,
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
+    "node_modules/@storybook/builder-webpack4/node_modules/file-loader/node_modules/schema-utils": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/@storybook/builder-webpack4/node_modules/fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -5159,18 +5164,6 @@
       },
       "peerDependencies": {
         "webpack": "^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/@storybook/builder-webpack4/node_modules/icss-utils": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
-      "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
-      "dev": true,
-      "dependencies": {
-        "postcss": "^7.0.14"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/@storybook/builder-webpack4/node_modules/is-buffer": {
@@ -5442,56 +5435,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@storybook/builder-webpack4/node_modules/postcss-modules-extract-imports": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
-      "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
-      "dev": true,
-      "dependencies": {
-        "postcss": "^7.0.5"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@storybook/builder-webpack4/node_modules/postcss-modules-local-by-default": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.3.tgz",
-      "integrity": "sha512-e3xDq+LotiGesympRlKNgaJ0PCzoUIdpH0dj47iWAui/kyTgh3CiAr1qP54uodmJhl6p9rN6BoNcdEDVJx9RDw==",
-      "dev": true,
-      "dependencies": {
-        "icss-utils": "^4.1.1",
-        "postcss": "^7.0.32",
-        "postcss-selector-parser": "^6.0.2",
-        "postcss-value-parser": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@storybook/builder-webpack4/node_modules/postcss-modules-scope": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz",
-      "integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
-      "dev": true,
-      "dependencies": {
-        "postcss": "^7.0.6",
-        "postcss-selector-parser": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@storybook/builder-webpack4/node_modules/postcss-modules-values": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
-      "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
-      "dev": true,
-      "dependencies": {
-        "icss-utils": "^4.0.0",
-        "postcss": "^7.0.6"
       }
     },
     "node_modules/@storybook/builder-webpack4/node_modules/pretty-error": {
@@ -6453,6 +6396,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/@storybook/builder-webpack5/node_modules/icss-utils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/@storybook/builder-webpack5/node_modules/loader-utils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
@@ -6465,6 +6420,65 @@
       },
       "engines": {
         "node": ">=8.9.0"
+      }
+    },
+    "node_modules/@storybook/builder-webpack5/node_modules/postcss-modules-extract-imports": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
+      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/@storybook/builder-webpack5/node_modules/postcss-modules-local-by-default": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
+      "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
+      "dev": true,
+      "dependencies": {
+        "icss-utils": "^5.0.0",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/@storybook/builder-webpack5/node_modules/postcss-modules-scope": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
+      "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.4"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/@storybook/builder-webpack5/node_modules/postcss-modules-values": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+      "dev": true,
+      "dependencies": {
+        "icss-utils": "^5.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
       }
     },
     "node_modules/@storybook/builder-webpack5/node_modules/schema-utils": {
@@ -6689,76 +6703,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0",
         "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@storybook/core": {
-      "version": "6.4.19",
-      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-6.4.19.tgz",
-      "integrity": "sha512-55LOQ/h/kf1jMhjN85t/pIEdIwWEG9yV7bdwv3niVvmoypCxyyjn9/QNK0RKYAeDSUtdm6FVoJ6k5CpxWz2d8w==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/core-client": "6.4.19",
-        "@storybook/core-server": "6.4.19"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "@storybook/builder-webpack5": "6.4.19",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0",
-        "webpack": "*"
-      },
-      "peerDependenciesMeta": {
-        "@storybook/builder-webpack5": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@storybook/core-client": {
-      "version": "6.4.19",
-      "resolved": "https://registry.npmjs.org/@storybook/core-client/-/core-client-6.4.19.tgz",
-      "integrity": "sha512-rQHRZjhArPleE7/S8ZUolgzwY+hC0smSKX/3PQxO2GcebDjnJj6+iSV3h+aSMHMmTdoCQvjYw9aBpT8scuRe+A==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/addons": "6.4.19",
-        "@storybook/channel-postmessage": "6.4.19",
-        "@storybook/channel-websocket": "6.4.19",
-        "@storybook/client-api": "6.4.19",
-        "@storybook/client-logger": "6.4.19",
-        "@storybook/core-events": "6.4.19",
-        "@storybook/csf": "0.0.2--canary.87bc651.0",
-        "@storybook/preview-web": "6.4.19",
-        "@storybook/store": "6.4.19",
-        "@storybook/ui": "6.4.19",
-        "airbnb-js-shims": "^2.2.1",
-        "ansi-to-html": "^0.6.11",
-        "core-js": "^3.8.2",
-        "global": "^4.4.0",
-        "lodash": "^4.17.21",
-        "qs": "^6.10.0",
-        "regenerator-runtime": "^0.13.7",
-        "ts-dedent": "^2.0.0",
-        "unfetch": "^4.2.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0",
-        "webpack": "*"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/@storybook/core-common": {
@@ -7083,6 +7027,15 @@
         "y18n": "^4.0.0"
       }
     },
+    "node_modules/@storybook/core-common/node_modules/cacache/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
     "node_modules/@storybook/core-common/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -7236,36 +7189,6 @@
         }
       }
     },
-    "node_modules/@storybook/core-common/node_modules/fork-ts-checker-webpack-plugin/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@storybook/core-common/node_modules/fork-ts-checker-webpack-plugin/node_modules/schema-utils": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-      "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.4",
-        "ajv": "^6.12.2",
-        "ajv-keywords": "^3.4.1"
-      },
-      "engines": {
-        "node": ">= 8.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
     "node_modules/@storybook/core-common/node_modules/fork-ts-checker-webpack-plugin/node_modules/semver": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -7280,12 +7203,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/@storybook/core-common/node_modules/fork-ts-checker-webpack-plugin/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/@storybook/core-common/node_modules/has-flag": {
       "version": "4.0.0",
@@ -7359,15 +7276,6 @@
         "node": ">=4.3.0 <5.0.0 || >=5.10"
       }
     },
-    "node_modules/@storybook/core-common/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
     "node_modules/@storybook/core-common/node_modules/micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -7420,17 +7328,21 @@
       }
     },
     "node_modules/@storybook/core-common/node_modules/schema-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
+      "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
       "dev": true,
       "dependencies": {
-        "ajv": "^6.1.0",
-        "ajv-errors": "^1.0.0",
-        "ajv-keywords": "^3.1.0"
+        "@types/json-schema": "^7.0.4",
+        "ajv": "^6.12.2",
+        "ajv-keywords": "^3.4.1"
       },
       "engines": {
-        "node": ">= 4"
+        "node": ">= 8.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/@storybook/core-common/node_modules/serialize-javascript": {
@@ -7530,6 +7442,20 @@
         "webpack": "^4.0.0"
       }
     },
+    "node_modules/@storybook/core-common/node_modules/terser-webpack-plugin/node_modules/schema-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.1.0",
+        "ajv-errors": "^1.0.0",
+        "ajv-keywords": "^3.1.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/@storybook/core-common/node_modules/to-regex-range": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
@@ -7614,6 +7540,20 @@
       "dependencies": {
         "source-list-map": "^2.0.0",
         "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/@storybook/core-common/node_modules/webpack/node_modules/schema-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.1.0",
+        "ajv-errors": "^1.0.0",
+        "ajv-keywords": "^3.1.0"
+      },
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/@storybook/core-common/node_modules/y18n": {
@@ -7707,6 +7647,48 @@
         "@storybook/manager-webpack5": {
           "optional": true
         },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/core-client": {
+      "version": "6.4.19",
+      "resolved": "https://registry.npmjs.org/@storybook/core-client/-/core-client-6.4.19.tgz",
+      "integrity": "sha512-rQHRZjhArPleE7/S8ZUolgzwY+hC0smSKX/3PQxO2GcebDjnJj6+iSV3h+aSMHMmTdoCQvjYw9aBpT8scuRe+A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addons": "6.4.19",
+        "@storybook/channel-postmessage": "6.4.19",
+        "@storybook/channel-websocket": "6.4.19",
+        "@storybook/client-api": "6.4.19",
+        "@storybook/client-logger": "6.4.19",
+        "@storybook/core-events": "6.4.19",
+        "@storybook/csf": "0.0.2--canary.87bc651.0",
+        "@storybook/preview-web": "6.4.19",
+        "@storybook/store": "6.4.19",
+        "@storybook/ui": "6.4.19",
+        "airbnb-js-shims": "^2.2.1",
+        "ansi-to-html": "^0.6.11",
+        "core-js": "^3.8.2",
+        "global": "^4.4.0",
+        "lodash": "^4.17.21",
+        "qs": "^6.10.0",
+        "regenerator-runtime": "^0.13.7",
+        "ts-dedent": "^2.0.0",
+        "unfetch": "^4.2.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
@@ -8514,6 +8496,48 @@
         }
       }
     },
+    "node_modules/@storybook/manager-webpack4/node_modules/@storybook/core-client": {
+      "version": "6.4.19",
+      "resolved": "https://registry.npmjs.org/@storybook/core-client/-/core-client-6.4.19.tgz",
+      "integrity": "sha512-rQHRZjhArPleE7/S8ZUolgzwY+hC0smSKX/3PQxO2GcebDjnJj6+iSV3h+aSMHMmTdoCQvjYw9aBpT8scuRe+A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addons": "6.4.19",
+        "@storybook/channel-postmessage": "6.4.19",
+        "@storybook/channel-websocket": "6.4.19",
+        "@storybook/client-api": "6.4.19",
+        "@storybook/client-logger": "6.4.19",
+        "@storybook/core-events": "6.4.19",
+        "@storybook/csf": "0.0.2--canary.87bc651.0",
+        "@storybook/preview-web": "6.4.19",
+        "@storybook/store": "6.4.19",
+        "@storybook/ui": "6.4.19",
+        "airbnb-js-shims": "^2.2.1",
+        "ansi-to-html": "^0.6.11",
+        "core-js": "^3.8.2",
+        "global": "^4.4.0",
+        "lodash": "^4.17.21",
+        "qs": "^6.10.0",
+        "regenerator-runtime": "^0.13.7",
+        "ts-dedent": "^2.0.0",
+        "unfetch": "^4.2.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@storybook/manager-webpack4/node_modules/@types/html-minifier-terser": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz",
@@ -8867,6 +8891,58 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/@storybook/manager-webpack4/node_modules/file-loader": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
+      "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
+      "dev": true,
+      "dependencies": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/@storybook/manager-webpack4/node_modules/file-loader/node_modules/loader-utils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "dev": true,
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
+    "node_modules/@storybook/manager-webpack4/node_modules/file-loader/node_modules/schema-utils": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/@storybook/manager-webpack4/node_modules/fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -8985,18 +9061,6 @@
       },
       "peerDependencies": {
         "webpack": "^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/@storybook/manager-webpack4/node_modules/icss-utils": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
-      "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
-      "dev": true,
-      "dependencies": {
-        "postcss": "^7.0.14"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/@storybook/manager-webpack4/node_modules/is-buffer": {
@@ -9206,56 +9270,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/@storybook/manager-webpack4/node_modules/postcss-modules-extract-imports": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
-      "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
-      "dev": true,
-      "dependencies": {
-        "postcss": "^7.0.5"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@storybook/manager-webpack4/node_modules/postcss-modules-local-by-default": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.3.tgz",
-      "integrity": "sha512-e3xDq+LotiGesympRlKNgaJ0PCzoUIdpH0dj47iWAui/kyTgh3CiAr1qP54uodmJhl6p9rN6BoNcdEDVJx9RDw==",
-      "dev": true,
-      "dependencies": {
-        "icss-utils": "^4.1.1",
-        "postcss": "^7.0.32",
-        "postcss-selector-parser": "^6.0.2",
-        "postcss-value-parser": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@storybook/manager-webpack4/node_modules/postcss-modules-scope": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz",
-      "integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
-      "dev": true,
-      "dependencies": {
-        "postcss": "^7.0.6",
-        "postcss-selector-parser": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@storybook/manager-webpack4/node_modules/postcss-modules-values": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
-      "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
-      "dev": true,
-      "dependencies": {
-        "icss-utils": "^4.0.0",
-        "postcss": "^7.0.6"
       }
     },
     "node_modules/@storybook/manager-webpack4/node_modules/pretty-error": {
@@ -9896,6 +9910,48 @@
         }
       }
     },
+    "node_modules/@storybook/manager-webpack5/node_modules/@storybook/core-client": {
+      "version": "6.4.19",
+      "resolved": "https://registry.npmjs.org/@storybook/core-client/-/core-client-6.4.19.tgz",
+      "integrity": "sha512-rQHRZjhArPleE7/S8ZUolgzwY+hC0smSKX/3PQxO2GcebDjnJj6+iSV3h+aSMHMmTdoCQvjYw9aBpT8scuRe+A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addons": "6.4.19",
+        "@storybook/channel-postmessage": "6.4.19",
+        "@storybook/channel-websocket": "6.4.19",
+        "@storybook/client-api": "6.4.19",
+        "@storybook/client-logger": "6.4.19",
+        "@storybook/core-events": "6.4.19",
+        "@storybook/csf": "0.0.2--canary.87bc651.0",
+        "@storybook/preview-web": "6.4.19",
+        "@storybook/store": "6.4.19",
+        "@storybook/ui": "6.4.19",
+        "airbnb-js-shims": "^2.2.1",
+        "ansi-to-html": "^0.6.11",
+        "core-js": "^3.8.2",
+        "global": "^4.4.0",
+        "lodash": "^4.17.21",
+        "qs": "^6.10.0",
+        "regenerator-runtime": "^0.13.7",
+        "ts-dedent": "^2.0.0",
+        "unfetch": "^4.2.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@storybook/manager-webpack5/node_modules/@types/node": {
       "version": "14.18.12",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz",
@@ -9976,6 +10032,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/@storybook/manager-webpack5/node_modules/icss-utils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/@storybook/manager-webpack5/node_modules/loader-utils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
@@ -9988,6 +10056,65 @@
       },
       "engines": {
         "node": ">=8.9.0"
+      }
+    },
+    "node_modules/@storybook/manager-webpack5/node_modules/postcss-modules-extract-imports": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
+      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/@storybook/manager-webpack5/node_modules/postcss-modules-local-by-default": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
+      "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
+      "dev": true,
+      "dependencies": {
+        "icss-utils": "^5.0.0",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/@storybook/manager-webpack5/node_modules/postcss-modules-scope": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
+      "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.4"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/@storybook/manager-webpack5/node_modules/postcss-modules-values": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+      "dev": true,
+      "dependencies": {
+        "icss-utils": "^5.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
       }
     },
     "node_modules/@storybook/manager-webpack5/node_modules/schema-utils": {
@@ -10312,6 +10439,76 @@
       },
       "engines": {
         "node": ">=8.9.0"
+      }
+    },
+    "node_modules/@storybook/react/node_modules/@storybook/core": {
+      "version": "6.4.19",
+      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-6.4.19.tgz",
+      "integrity": "sha512-55LOQ/h/kf1jMhjN85t/pIEdIwWEG9yV7bdwv3niVvmoypCxyyjn9/QNK0RKYAeDSUtdm6FVoJ6k5CpxWz2d8w==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-client": "6.4.19",
+        "@storybook/core-server": "6.4.19"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@storybook/builder-webpack5": "6.4.19",
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "@storybook/builder-webpack5": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react/node_modules/@storybook/core/node_modules/@storybook/core-client": {
+      "version": "6.4.19",
+      "resolved": "https://registry.npmjs.org/@storybook/core-client/-/core-client-6.4.19.tgz",
+      "integrity": "sha512-rQHRZjhArPleE7/S8ZUolgzwY+hC0smSKX/3PQxO2GcebDjnJj6+iSV3h+aSMHMmTdoCQvjYw9aBpT8scuRe+A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addons": "6.4.19",
+        "@storybook/channel-postmessage": "6.4.19",
+        "@storybook/channel-websocket": "6.4.19",
+        "@storybook/client-api": "6.4.19",
+        "@storybook/client-logger": "6.4.19",
+        "@storybook/core-events": "6.4.19",
+        "@storybook/csf": "0.0.2--canary.87bc651.0",
+        "@storybook/preview-web": "6.4.19",
+        "@storybook/store": "6.4.19",
+        "@storybook/ui": "6.4.19",
+        "airbnb-js-shims": "^2.2.1",
+        "ansi-to-html": "^0.6.11",
+        "core-js": "^3.8.2",
+        "global": "^4.4.0",
+        "lodash": "^4.17.21",
+        "qs": "^6.10.0",
+        "regenerator-runtime": "^0.13.7",
+        "ts-dedent": "^2.0.0",
+        "unfetch": "^4.2.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@storybook/react/node_modules/@storybook/react-docgen-typescript-plugin": {
@@ -12681,9 +12878,9 @@
       }
     },
     "node_modules/@types/react/node_modules/csstype": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
-      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
+      "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
     },
     "node_modules/@types/redux-mock-store": {
       "version": "1.0.3",
@@ -13369,42 +13566,6 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webpack-cli/configtest": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
-      "integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
-      "dev": true,
-      "peerDependencies": {
-        "webpack": "4.x.x || 5.x.x",
-        "webpack-cli": "4.x.x"
-      }
-    },
-    "node_modules/@webpack-cli/info": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.1.tgz",
-      "integrity": "sha512-PKVGmazEq3oAo46Q63tpMr4HipI3OPfP7LiNOEJg963RMgT0rqheag28NCML0o3GIzA3DmxP1ZIAv9oTX1CUIA==",
-      "dev": true,
-      "dependencies": {
-        "envinfo": "^7.7.3"
-      },
-      "peerDependencies": {
-        "webpack-cli": "4.x.x"
-      }
-    },
-    "node_modules/@webpack-cli/serve": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
-      "integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
-      "dev": true,
-      "peerDependencies": {
-        "webpack-cli": "4.x.x"
-      },
-      "peerDependenciesMeta": {
-        "webpack-dev-server": {
-          "optional": true
-        }
       }
     },
     "node_modules/@wry/context": {
@@ -14165,30 +14326,57 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.2.tgz",
-      "integrity": "sha512-9fOPpHKuDW1w/0EKfRmVnxTDt8166MAnLI3mgZ1JCnhNtYWxcJ6Ud5CO/AVOZi/AvFa8DY9RTy3h3+tFBlrrdQ==",
+      "version": "9.8.8",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
+      "integrity": "sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.19.1",
-        "caniuse-lite": "^1.0.30001297",
-        "fraction.js": "^4.1.2",
+        "browserslist": "^4.12.0",
+        "caniuse-lite": "^1.0.30001109",
         "normalize-range": "^0.1.2",
-        "picocolors": "^1.0.0",
-        "postcss-value-parser": "^4.2.0"
+        "num2fraction": "^1.2.2",
+        "picocolors": "^0.2.1",
+        "postcss": "^7.0.32",
+        "postcss-value-parser": "^4.1.0"
       },
       "bin": {
         "autoprefixer": "bin/autoprefixer"
       },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+      }
+    },
+    "node_modules/autoprefixer/node_modules/picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+      "dev": true
+    },
+    "node_modules/autoprefixer/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
       "engines": {
-        "node": "^10 || ^12 || >=14"
+        "node": ">=6.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/postcss/"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/autoprefixer/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/babel-core": {
@@ -15579,13 +15767,13 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.19.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.3.tgz",
-      "integrity": "sha512-XK3X4xtKJ+Txj8G5c30B4gsm71s69lqXlkYui4s6EkKxuv49qjYlY6oVd+IFJ73d4YymtM3+djvvt/R/iJwwDg==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.0.tgz",
+      "integrity": "sha512-bnpOoa+DownbciXj0jVGENf8VYQnE2LNWomhYuCsMmmx9Jd9lwq0WXODuwpSsp8AVdKM2/HorrzxAfbKvWTByQ==",
       "dev": true,
       "dependencies": {
-        "caniuse-lite": "^1.0.30001312",
-        "electron-to-chromium": "^1.4.71",
+        "caniuse-lite": "^1.0.30001313",
+        "electron-to-chromium": "^1.4.76",
         "escalade": "^3.1.1",
         "node-releases": "^2.0.2",
         "picocolors": "^1.0.0"
@@ -15827,83 +16015,10 @@
         "node": ">=4"
       }
     },
-    "node_modules/cacheable-request/node_modules/is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/cacheable-request/node_modules/lowercase-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
       "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cacheable-request/node_modules/normalize-url": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
-      "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "prepend-http": "^2.0.0",
-        "query-string": "^5.0.1",
-        "sort-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/cacheable-request/node_modules/prepend-http": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/cacheable-request/node_modules/query-string": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "decode-uri-component": "^0.2.0",
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cacheable-request/node_modules/sort-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "is-plain-obj": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/cacheable-request/node_modules/strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true,
       "optional": true,
       "engines": {
@@ -16008,9 +16123,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001312",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
+      "version": "1.0.30001313",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001313.tgz",
+      "integrity": "sha512-rI1UN0koZUiKINjysQDuRi2VeSCce3bYJNmDcj3PIKREiAmjakugBul1QSkg/fPrlULYl6oWfGg3PbgOSY9X4Q==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -17659,39 +17774,6 @@
         "source-map-resolve": "^0.6.0"
       }
     },
-    "node_modules/css-blank-pseudo": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-3.0.3.tgz",
-      "integrity": "sha512-VS90XWtsHGqoM0t4KpH053c4ehxZ2E6HtGI7x68YFV0pTo/QmkV/YFA+NnlvK8guxZVNWGQhVNJGC39Q8XF4OQ==",
-      "dev": true,
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.9"
-      },
-      "bin": {
-        "css-blank-pseudo": "dist/cli.cjs"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4"
-      }
-    },
-    "node_modules/css-declaration-sorter": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.1.4.tgz",
-      "integrity": "sha512-lpfkqS0fctcmZotJGhnxkIyJWvBXgpyi2wsFd4J8VB7wzyrT6Ch/3Q+FMNJpjK4gu1+GN5khOnpU2ZVKrLbhCw==",
-      "dev": true,
-      "dependencies": {
-        "timsort": "^0.3.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.9"
-      }
-    },
     "node_modules/css-functions-list": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.0.1.tgz",
@@ -17699,24 +17781,6 @@
       "dev": true,
       "engines": {
         "node": ">=12.22"
-      }
-    },
-    "node_modules/css-has-pseudo": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-3.0.4.tgz",
-      "integrity": "sha512-Vse0xpR1K9MNlp2j5w1pgWIJtm1a8qS0JwS9goFYcImjlHEmywP9VUF05aGBXzGpDJF86QXk4L0ypBmwPhGArw==",
-      "dev": true,
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.9"
-      },
-      "bin": {
-        "css-has-pseudo": "dist/cli.cjs"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4"
       }
     },
     "node_modules/css-loader": {
@@ -17743,6 +17807,77 @@
       },
       "peerDependencies": {
         "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/css-loader/node_modules/icss-utils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/css-loader/node_modules/postcss-modules-extract-imports": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
+      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/css-loader/node_modules/postcss-modules-local-by-default": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
+      "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
+      "dev": true,
+      "dependencies": {
+        "icss-utils": "^5.0.0",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/css-loader/node_modules/postcss-modules-scope": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
+      "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.4"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/css-loader/node_modules/postcss-modules-values": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+      "dev": true,
+      "dependencies": {
+        "icss-utils": "^5.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
       }
     },
     "node_modules/css-loader/node_modules/semver": {
@@ -17826,11 +17961,518 @@
         "ajv": "^8.8.2"
       }
     },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/css-declaration-sorter": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.1.4.tgz",
+      "integrity": "sha512-lpfkqS0fctcmZotJGhnxkIyJWvBXgpyi2wsFd4J8VB7wzyrT6Ch/3Q+FMNJpjK4gu1+GN5khOnpU2ZVKrLbhCw==",
+      "dev": true,
+      "dependencies": {
+        "timsort": "^0.3.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.9"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/cssnano": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.0.tgz",
+      "integrity": "sha512-wWxave1wMlThGg4ueK98jFKaNqXnQd1nVZpSkQ9XvR+YymlzP1ofWqES1JkHtI250LksP9z5JH+oDcrKDJezAg==",
+      "dev": true,
+      "dependencies": {
+        "cssnano-preset-default": "^5.2.0",
+        "lilconfig": "^2.0.3",
+        "yaml": "^1.10.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/cssnano"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/cssnano-preset-default": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.0.tgz",
+      "integrity": "sha512-3N5Vcptj2pqVKpHVqH6ezOJvqikR2PdLTbTrsrhF61FbLRQuujAqZ2sKN5rvcMsb7hFjrNnjZT8CGEkxoN/Pwg==",
+      "dev": true,
+      "dependencies": {
+        "css-declaration-sorter": "^6.0.3",
+        "cssnano-utils": "^3.1.0",
+        "postcss-calc": "^8.2.3",
+        "postcss-colormin": "^5.3.0",
+        "postcss-convert-values": "^5.1.0",
+        "postcss-discard-comments": "^5.1.0",
+        "postcss-discard-duplicates": "^5.1.0",
+        "postcss-discard-empty": "^5.1.0",
+        "postcss-discard-overridden": "^5.1.0",
+        "postcss-merge-longhand": "^5.1.0",
+        "postcss-merge-rules": "^5.1.0",
+        "postcss-minify-font-values": "^5.1.0",
+        "postcss-minify-gradients": "^5.1.0",
+        "postcss-minify-params": "^5.1.0",
+        "postcss-minify-selectors": "^5.2.0",
+        "postcss-normalize-charset": "^5.1.0",
+        "postcss-normalize-display-values": "^5.1.0",
+        "postcss-normalize-positions": "^5.1.0",
+        "postcss-normalize-repeat-style": "^5.1.0",
+        "postcss-normalize-string": "^5.1.0",
+        "postcss-normalize-timing-functions": "^5.1.0",
+        "postcss-normalize-unicode": "^5.1.0",
+        "postcss-normalize-url": "^5.1.0",
+        "postcss-normalize-whitespace": "^5.1.0",
+        "postcss-ordered-values": "^5.1.0",
+        "postcss-reduce-initial": "^5.1.0",
+        "postcss-reduce-transforms": "^5.1.0",
+        "postcss-svgo": "^5.1.0",
+        "postcss-unique-selectors": "^5.1.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/cssnano-utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
+      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
     "node_modules/css-minimizer-webpack-plugin/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-calc": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-8.2.4.tgz",
+      "integrity": "sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.9",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.2"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-colormin": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.3.0.tgz",
+      "integrity": "sha512-WdDO4gOFG2Z8n4P8TWBpshnL3JpmNmJwdnfP2gbk2qBA8PWwOYcmjmI/t3CmMeL72a7Hkd+x/Mg9O2/0rD54Pg==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.16.6",
+        "caniuse-api": "^3.0.0",
+        "colord": "^2.9.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-convert-values": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.0.tgz",
+      "integrity": "sha512-GkyPbZEYJiWtQB0KZ0X6qusqFHUepguBCNFi9t5JJc7I2OTXG7C0twbTLvCfaKOLl3rSXmpAwV7W5txd91V84g==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-discard-comments": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.0.tgz",
+      "integrity": "sha512-L0IKF4jAshRyn03SkEO6ar/Ipz2oLywVbg2THf2EqqdNkBwmVMxuTR/RoAltOw4piiaLt3gCAdrbAqmTBInmhg==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-discard-duplicates": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
+      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-discard-empty": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.0.tgz",
+      "integrity": "sha512-782T/buGgb3HOuHOJAHpdyKzAAKsv/BxWqsutnZ+QsiHEcDkY7v+6WWdturuBiSal6XMOO1p1aJvwXdqLD5vhA==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-discard-overridden": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
+      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-merge-longhand": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.0.tgz",
+      "integrity": "sha512-Gr46srN2tsLD8fudKYoHO56RG0BLQ2nsBRnSZGY04eNBPwTeWa9KeHrbL3tOLAHyB2aliikycPH2TMJG1U+W6g==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0",
+        "stylehacks": "^5.1.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-merge-rules": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.0.tgz",
+      "integrity": "sha512-NecukEJovQ0mG7h7xV8wbYAkXGTO3MPKnXvuiXzOKcxoOodfTTKYjeo8TMhAswlSkjcPIBlnKbSFcTuVSDaPyQ==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.16.6",
+        "caniuse-api": "^3.0.0",
+        "cssnano-utils": "^3.1.0",
+        "postcss-selector-parser": "^6.0.5"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-minify-font-values": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-5.1.0.tgz",
+      "integrity": "sha512-el3mYTgx13ZAPPirSVsHqFzl+BBBDrXvbySvPGFnQcTI4iNslrPaFq4muTkLZmKlGk4gyFAYUBMH30+HurREyA==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-minify-gradients": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.1.0.tgz",
+      "integrity": "sha512-J/TMLklkONn3LuL8wCwfwU8zKC1hpS6VcxFkNUNjmVt53uKqrrykR3ov11mdUYyqVMEx67slMce0tE14cE4DTg==",
+      "dev": true,
+      "dependencies": {
+        "colord": "^2.9.1",
+        "cssnano-utils": "^3.1.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-minify-params": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.0.tgz",
+      "integrity": "sha512-q67dcts4Hct6x8+JmhBgctHkbvUsqGIg2IItenjE63iZXMbhjr7AlVZkNnKtIGt/1Wsv7p/7YzeSII6Q+KPXRg==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.16.6",
+        "cssnano-utils": "^3.1.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-minify-selectors": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.2.0.tgz",
+      "integrity": "sha512-vYxvHkW+iULstA+ctVNx0VoRAR4THQQRkG77o0oa4/mBS0OzGvvzLIvHDv/nNEM0crzN2WIyFU5X7wZhaUK3RA==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.5"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-normalize-charset": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
+      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-normalize-display-values": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-5.1.0.tgz",
+      "integrity": "sha512-WP4KIM4o2dazQXWmFaqMmcvsKmhdINFblgSeRgn8BJ6vxaMyaJkwAzpPpuvSIoG/rmX3M+IrRZEz2H0glrQNEA==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-normalize-positions": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.1.0.tgz",
+      "integrity": "sha512-8gmItgA4H5xiUxgN/3TVvXRoJxkAWLW6f/KKhdsH03atg0cB8ilXnrB5PpSshwVu/dD2ZsRFQcR1OEmSBDAgcQ==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-normalize-repeat-style": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.1.0.tgz",
+      "integrity": "sha512-IR3uBjc+7mcWGL6CtniKNQ4Rr5fTxwkaDHwMBDGGs1x9IVRkYIT/M4NelZWkAOBdV6v3Z9S46zqaKGlyzHSchw==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-normalize-string": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-5.1.0.tgz",
+      "integrity": "sha512-oYiIJOf4T9T1N4i+abeIc7Vgm/xPCGih4bZz5Nm0/ARVJ7K6xrDlLwvwqOydvyL3RHNf8qZk6vo3aatiw/go3w==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-normalize-timing-functions": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.1.0.tgz",
+      "integrity": "sha512-DOEkzJ4SAXv5xkHl0Wa9cZLF3WCBhF3o1SKVxKQAa+0pYKlueTpCgvkFAHfk+Y64ezX9+nITGrDZeVGgITJXjg==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-normalize-unicode": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.0.tgz",
+      "integrity": "sha512-J6M3MizAAZ2dOdSjy2caayJLQT8E8K9XjLce8AUQMwOrCvjCHv24aLC/Lps1R1ylOfol5VIDMaM/Lo9NGlk1SQ==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.16.6",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-normalize-url": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.1.0.tgz",
+      "integrity": "sha512-5upGeDO+PVthOxSmds43ZeMeZfKH+/DKgGRD7TElkkyS46JXAUhMzIKiCa7BabPeIy3AQcTkXwVVN7DbqsiCew==",
+      "dev": true,
+      "dependencies": {
+        "normalize-url": "^6.0.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-normalize-whitespace": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.1.0.tgz",
+      "integrity": "sha512-7O1FanKaJkpWFyCghFzIkLhehujV/frGkdofGLwhg5upbLyGsSfiTcZAdSzoPsSUgyPCkBkNMeWR8yVgPdQybg==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-ordered-values": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.1.0.tgz",
+      "integrity": "sha512-wU4Z4D4uOIH+BUKkYid36gGDJNQtkVJT7Twv8qH6UyfttbbJWyw4/xIPuVEkkCtQLAJ0EdsNSh8dlvqkXb49TA==",
+      "dev": true,
+      "dependencies": {
+        "cssnano-utils": "^3.1.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-reduce-initial": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.0.tgz",
+      "integrity": "sha512-5OgTUviz0aeH6MtBjHfbr57tml13PuedK/Ecg8szzd4XRMbYxH4572JFG067z+FqBIf6Zp/d+0581glkvvWMFw==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.16.6",
+        "caniuse-api": "^3.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-reduce-transforms": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-5.1.0.tgz",
+      "integrity": "sha512-2fbdbmgir5AvpW9RLtdONx1QoYG2/EtqpNQbFASDlixBbAYuTcJ0dECwlqNqH7VbaUnEnh8SrxOe2sRIn24XyQ==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-svgo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.1.0.tgz",
+      "integrity": "sha512-D75KsH1zm5ZrHyxPakAxJWtkyXew5qwS70v56exwvw542d9CRtTo78K0WeFxZB4G7JXKKMbEZtZayTGdIky/eA==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0",
+        "svgo": "^2.7.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-unique-selectors": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.1.0.tgz",
+      "integrity": "sha512-LmUhgGobtpeVJJHuogzjLRwJlN7VH+BL5c9GKMVJSS/ejoyePZkXvNsYUtk//F6vKOGK86gfRS0xH7fXQSDtvA==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.5"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
     },
     "node_modules/css-minimizer-webpack-plugin/node_modules/schema-utils": {
       "version": "4.0.0",
@@ -17860,19 +18502,20 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/css-prefers-color-scheme": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.3.tgz",
-      "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==",
+    "node_modules/css-minimizer-webpack-plugin/node_modules/stylehacks": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.0.tgz",
+      "integrity": "sha512-SzLmvHQTrIWfSgljkQCw2++C9+Ne91d/6Sp92I8c5uHTcy/PgeHamwITIbBW9wnFTY/3ZfSXR9HIL6Ikqmcu6Q==",
       "dev": true,
-      "bin": {
-        "css-prefers-color-scheme": "dist/cli.cjs"
+      "dependencies": {
+        "browserslist": "^4.16.6",
+        "postcss-selector-parser": "^6.0.4"
       },
       "engines": {
-        "node": "^12 || ^14 || >=16"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/css-select": {
@@ -17941,9 +18584,9 @@
       }
     },
     "node_modules/cssdb": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-6.4.0.tgz",
-      "integrity": "sha512-8NMWrur/ewSNrRNZndbtOTXc2Xb2b+NCTPHj8VErFYvJUlgsMAiBGaFaxG6hjy9zbCjj2ZLwSQrMM+tormO8qA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-6.4.1.tgz",
+      "integrity": "sha512-R70R/Q1fPlM1D6Y+Kpat0QjiY+aMsY2/8lekdVoYcJ7ZQs9kw71W78FdOMf8DFq975KHQf1089PNg1dLsbAhoA==",
       "dev": true
     },
     "node_modules/cssesc": {
@@ -17956,82 +18599,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/cssnano": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.0.tgz",
-      "integrity": "sha512-wWxave1wMlThGg4ueK98jFKaNqXnQd1nVZpSkQ9XvR+YymlzP1ofWqES1JkHtI250LksP9z5JH+oDcrKDJezAg==",
-      "dev": true,
-      "dependencies": {
-        "cssnano-preset-default": "^5.2.0",
-        "lilconfig": "^2.0.3",
-        "yaml": "^1.10.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/cssnano"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/cssnano-preset-default": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.0.tgz",
-      "integrity": "sha512-3N5Vcptj2pqVKpHVqH6ezOJvqikR2PdLTbTrsrhF61FbLRQuujAqZ2sKN5rvcMsb7hFjrNnjZT8CGEkxoN/Pwg==",
-      "dev": true,
-      "dependencies": {
-        "css-declaration-sorter": "^6.0.3",
-        "cssnano-utils": "^3.1.0",
-        "postcss-calc": "^8.2.3",
-        "postcss-colormin": "^5.3.0",
-        "postcss-convert-values": "^5.1.0",
-        "postcss-discard-comments": "^5.1.0",
-        "postcss-discard-duplicates": "^5.1.0",
-        "postcss-discard-empty": "^5.1.0",
-        "postcss-discard-overridden": "^5.1.0",
-        "postcss-merge-longhand": "^5.1.0",
-        "postcss-merge-rules": "^5.1.0",
-        "postcss-minify-font-values": "^5.1.0",
-        "postcss-minify-gradients": "^5.1.0",
-        "postcss-minify-params": "^5.1.0",
-        "postcss-minify-selectors": "^5.2.0",
-        "postcss-normalize-charset": "^5.1.0",
-        "postcss-normalize-display-values": "^5.1.0",
-        "postcss-normalize-positions": "^5.1.0",
-        "postcss-normalize-repeat-style": "^5.1.0",
-        "postcss-normalize-string": "^5.1.0",
-        "postcss-normalize-timing-functions": "^5.1.0",
-        "postcss-normalize-unicode": "^5.1.0",
-        "postcss-normalize-url": "^5.1.0",
-        "postcss-normalize-whitespace": "^5.1.0",
-        "postcss-ordered-values": "^5.1.0",
-        "postcss-reduce-initial": "^5.1.0",
-        "postcss-reduce-transforms": "^5.1.0",
-        "postcss-svgo": "^5.1.0",
-        "postcss-unique-selectors": "^5.1.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/cssnano-utils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
-      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
-      "dev": true,
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
       }
     },
     "node_modules/csso": {
@@ -18071,9 +18638,9 @@
       "dev": true
     },
     "node_modules/csstype": {
-      "version": "2.6.19",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
-      "integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==",
+      "version": "2.6.20",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
+      "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==",
       "dev": true
     },
     "node_modules/cwebp-bin": {
@@ -19357,9 +19924,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.75",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.75.tgz",
-      "integrity": "sha512-LxgUNeu3BVU7sXaKjUDD9xivocQLxFtq6wgERrutdY/yIOps3ODOZExK1jg8DTEg4U8TUCb5MLGeWFOYuxjF3Q==",
+      "version": "1.4.76",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.76.tgz",
+      "integrity": "sha512-3Vftv7cenJtQb+k00McEBZ2vVmZ/x+HEF7pcZONZIkOsESqAqVuACmBxMv0JhzX7u0YltU0vSqRqgBSTAhFUjA==",
       "dev": true
     },
     "node_modules/element-resize-detector": {
@@ -19469,9 +20036,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.1.tgz",
-      "integrity": "sha512-jdyZMwCQ5Oj4c5+BTnkxPgDZO/BJzh/ADDmKebayyzNwjVX1AFCeGkOfxNx0mHi2+8BKC5VxUYiw3TIvoT7vhw==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.2.tgz",
+      "integrity": "sha512-GIm3fQfwLJ8YZx2smuHpBKkXC1yOk+OBEmKckVyL0i/ea8mqDEykK3ld5dgH1QYPNyT/lIllxV2LULnxCHaHkA==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -21000,58 +21567,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/file-loader": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
-      "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
-      "dev": true,
-      "dependencies": {
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/file-loader/node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-      "dev": true,
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=8.9.0"
-      }
-    },
-    "node_modules/file-loader/node_modules/schema-utils": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
     "node_modules/file-system-cache": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/file-system-cache/-/file-system-cache-1.0.5.tgz",
@@ -21647,9 +22162,9 @@
       }
     },
     "node_modules/fraction.js": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.3.tgz",
-      "integrity": "sha512-pUHWWt6vHzZZiQJcM6S/0PXfS+g6FM4BF5rj9wZyreivhQPdsh5PpE25VtSNxq80wHS5RfY51Ii+8Z0Zl/pmzg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
+      "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -22538,6 +23053,20 @@
         "graphql": "14 - 16"
       }
     },
+    "node_modules/graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
     "node_modules/gzip-size": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
@@ -23186,9 +23715,9 @@
       }
     },
     "node_modules/http-parser-js": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.5.tgz",
-      "integrity": "sha512-x+JVEkO2PoM8qqpbPbOL3cqHPwerep7OwzK7Ay+sMQjKzaKCqWvjoXm5tqMP9tXWWTnTzAjIhXg+J99XYuPhPA==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.6.tgz",
+      "integrity": "sha512-vDlkRPDJn93swjcjqMSaGSPABbIarsr1TLAui/gLDXzV5VsJNdXNzMYDyNBLQkjWQCJ1uizu8T2oDMhmGt0PRA==",
       "dev": true
     },
     "node_modules/http-proxy": {
@@ -23296,15 +23825,47 @@
       }
     },
     "node_modules/icss-utils": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
+      "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
+      "dev": true,
+      "dependencies": {
+        "postcss": "^7.0.14"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/icss-utils/node_modules/picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+      "dev": true
+    },
+    "node_modules/icss-utils/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/icss-utils/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/idb": {
@@ -25072,19 +25633,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-cli/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-config": {
+    "node_modules/jest-cli/node_modules/jest-config": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.5.1.tgz",
       "integrity": "sha512-5sAsjm6tGdsVbW9ahcChPAFCk4IlkQUknH5AvKjuLTSlcO/wCZKyFdn7Rg0EkC+OGgWODEy2hDpWB1PgzH0JNA==",
@@ -25127,47 +25676,7 @@
         }
       }
     },
-    "node_modules/jest-config/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-config/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-config/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-config/node_modules/supports-color": {
+    "node_modules/jest-cli/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
@@ -27325,12 +27834,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
       "dev": true,
       "dependencies": {
-        "sourcemap-codec": "^1.4.4"
+        "sourcemap-codec": "^1.4.8"
       }
     },
     "node_modules/make-dir": {
@@ -27425,9 +27934,9 @@
       }
     },
     "node_modules/markdown-to-jsx": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.6.tgz",
-      "integrity": "sha512-1wrIGZYwIG2gR3yfRmbr4FlQmhaAKoKTpRo4wur4fp9p0njU1Hi7vR8fj0AUKKIcPduiJmPprzmCB5B/GvlC7g==",
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.7.tgz",
+      "integrity": "sha512-VI3TyyHlGkO8uFle0IOibzpO1c1iJDcXcS/zBrQrXQQvJ2tpdwVzVZ7XdKsyRz1NdRmre4dqQkMZzUHaKIG/1w==",
       "dev": true,
       "engines": {
         "node": ">= 10"
@@ -28501,15 +29010,76 @@
       "dev": true
     },
     "node_modules/normalize-url": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+      "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
       "dev": true,
-      "engines": {
-        "node": ">=10"
+      "optional": true,
+      "dependencies": {
+        "prepend-http": "^2.0.0",
+        "query-string": "^5.0.1",
+        "sort-keys": "^2.0.0"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/normalize-url/node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url/node_modules/prepend-http": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/normalize-url/node_modules/query-string": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url/node_modules/sort-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "is-plain-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/normalize-url/node_modules/strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/npm-conf": {
@@ -29837,245 +30407,6 @@
         "url": "https://opencollective.com/postcss/"
       }
     },
-    "node_modules/postcss-attribute-case-insensitive": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-5.0.0.tgz",
-      "integrity": "sha512-b4g9eagFGq9T5SWX4+USfVyjIb3liPnjhHHRMP7FMB2kFVpYyfEscV0wP3eaXhKlcHKUut8lt5BGoeylWA/dBQ==",
-      "dev": true,
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.2"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.2"
-      }
-    },
-    "node_modules/postcss-calc": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-8.2.4.tgz",
-      "integrity": "sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==",
-      "dev": true,
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.9",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.2"
-      }
-    },
-    "node_modules/postcss-color-functional-notation": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-4.2.2.tgz",
-      "integrity": "sha512-DXVtwUhIk4f49KK5EGuEdgx4Gnyj6+t2jBSEmxvpIK9QI40tWrpS2Pua8Q7iIZWBrki2QOaeUdEaLPPa91K0RQ==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4"
-      }
-    },
-    "node_modules/postcss-color-hex-alpha": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-8.0.3.tgz",
-      "integrity": "sha512-fESawWJCrBV035DcbKRPAVmy21LpoyiXdPTuHUfWJ14ZRjY7Y7PA6P4g8z6LQGYhU1WAxkTxjIjurXzoe68Glw==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4"
-      }
-    },
-    "node_modules/postcss-color-rebeccapurple": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-7.0.2.tgz",
-      "integrity": "sha512-SFc3MaocHaQ6k3oZaFwH8io6MdypkUtEy/eXzXEB1vEQlO3S3oDc/FSZA8AsS04Z25RirQhlDlHLh3dn7XewWw==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.3"
-      }
-    },
-    "node_modules/postcss-colormin": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.3.0.tgz",
-      "integrity": "sha512-WdDO4gOFG2Z8n4P8TWBpshnL3JpmNmJwdnfP2gbk2qBA8PWwOYcmjmI/t3CmMeL72a7Hkd+x/Mg9O2/0rD54Pg==",
-      "dev": true,
-      "dependencies": {
-        "browserslist": "^4.16.6",
-        "caniuse-api": "^3.0.0",
-        "colord": "^2.9.1",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-convert-values": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.0.tgz",
-      "integrity": "sha512-GkyPbZEYJiWtQB0KZ0X6qusqFHUepguBCNFi9t5JJc7I2OTXG7C0twbTLvCfaKOLl3rSXmpAwV7W5txd91V84g==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-custom-media": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-8.0.0.tgz",
-      "integrity": "sha512-FvO2GzMUaTN0t1fBULDeIvxr5IvbDXcIatt6pnJghc736nqNgsGao5NT+5+WVLAQiTt6Cb3YUms0jiPaXhL//g==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/postcss-custom-properties": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-12.1.4.tgz",
-      "integrity": "sha512-i6AytuTCoDLJkWN/MtAIGriJz3j7UX6bV7Z5t+KgFz+dwZS15/mlTJY1S0kRizlk6ba0V8u8hN50Fz5Nm7tdZw==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4"
-      }
-    },
-    "node_modules/postcss-custom-selectors": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-6.0.0.tgz",
-      "integrity": "sha512-/1iyBhz/W8jUepjGyu7V1OPcGbc636snN1yXEQCinb6Bwt7KxsiU7/bLQlp8GwAXzCh7cobBU5odNn/2zQWR8Q==",
-      "dev": true,
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.4"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.2"
-      }
-    },
-    "node_modules/postcss-dir-pseudo-class": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-6.0.4.tgz",
-      "integrity": "sha512-I8epwGy5ftdzNWEYok9VjW9whC4xnelAtbajGv4adql4FIF09rnrxnA9Y8xSHN47y7gqFIv10C5+ImsLeJpKBw==",
-      "dev": true,
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.9"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4"
-      }
-    },
-    "node_modules/postcss-discard-comments": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.0.tgz",
-      "integrity": "sha512-L0IKF4jAshRyn03SkEO6ar/Ipz2oLywVbg2THf2EqqdNkBwmVMxuTR/RoAltOw4piiaLt3gCAdrbAqmTBInmhg==",
-      "dev": true,
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-discard-duplicates": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
-      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
-      "dev": true,
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-discard-empty": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.0.tgz",
-      "integrity": "sha512-782T/buGgb3HOuHOJAHpdyKzAAKsv/BxWqsutnZ+QsiHEcDkY7v+6WWdturuBiSal6XMOO1p1aJvwXdqLD5vhA==",
-      "dev": true,
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-discard-overridden": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
-      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
-      "dev": true,
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-double-position-gradients": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-3.1.0.tgz",
-      "integrity": "sha512-oz73I08yMN3oxjj0s8mED1rG+uOYoK3H8N9RjQofyg52KBRNmePJKg3fVwTpL2U5ZFbCzXoZBsUD/CvZdlqE4Q==",
-      "dev": true,
-      "dependencies": {
-        "@csstools/postcss-progressive-custom-properties": "^1.1.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4"
-      }
-    },
-    "node_modules/postcss-env-function": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-env-function/-/postcss-env-function-4.0.5.tgz",
-      "integrity": "sha512-gPUJc71ji9XKyl0WSzAalBeEA/89kU+XpffpPxSaaaZ1c48OL36r1Ep5R6+9XAPkIiDlSvVAwP4io12q/vTcvA==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4"
-      }
-    },
     "node_modules/postcss-flexbugs-fixes": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-4.2.1.tgz",
@@ -30117,97 +30448,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/postcss-focus-visible": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-focus-visible/-/postcss-focus-visible-6.0.4.tgz",
-      "integrity": "sha512-QcKuUU/dgNsstIK6HELFRT5Y3lbrMLEOwG+A4s5cA+fx3A3y/JTq3X9LaOj3OC3ALH0XqyrgQIgey/MIZ8Wczw==",
-      "dev": true,
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.9"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4"
-      }
-    },
-    "node_modules/postcss-focus-within": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-5.0.4.tgz",
-      "integrity": "sha512-vvjDN++C0mu8jz4af5d52CB184ogg/sSxAFS+oUJQq2SuCe7T5U2iIsVJtsCp2d6R4j0jr5+q3rPkBVZkXD9fQ==",
-      "dev": true,
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.9"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4"
-      }
-    },
-    "node_modules/postcss-font-variant": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
-      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
-      "dev": true,
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/postcss-gap-properties": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-3.0.3.tgz",
-      "integrity": "sha512-rPPZRLPmEKgLk/KlXMqRaNkYTUpE7YC+bOIQFN5xcu1Vp11Y4faIXv6/Jpft6FMnl6YRxZqDZG0qQOW80stzxQ==",
-      "dev": true,
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4"
-      }
-    },
-    "node_modules/postcss-image-set-function": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-4.0.6.tgz",
-      "integrity": "sha512-KfdC6vg53GC+vPd2+HYzsZ6obmPqOk6HY09kttU19+Gj1nC3S3XBVEXDHxkhxTohgZqzbUb94bKXvKDnYWBm/A==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4"
-      }
-    },
-    "node_modules/postcss-initial": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
-      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
-      "dev": true,
-      "peerDependencies": {
-        "postcss": "^8.0.0"
-      }
-    },
-    "node_modules/postcss-lab-function": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-4.1.1.tgz",
-      "integrity": "sha512-j3Z0WQCimY2tMle++YcmygnnVbt6XdnrCV1FO2IpzaCSmtTF2oO8h4ZYUA1Q+QHYroIiaWPvNHt9uBR4riCksQ==",
-      "dev": true,
-      "dependencies": {
-        "@csstools/postcss-progressive-custom-properties": "^1.1.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4"
-      }
-    },
     "node_modules/postcss-loader": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-6.2.1.tgz",
@@ -30245,340 +30485,188 @@
         "node": ">=10"
       }
     },
-    "node_modules/postcss-logical": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.4.tgz",
-      "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==",
-      "dev": true,
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4"
-      }
-    },
-    "node_modules/postcss-media-minmax": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
-      "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
     "node_modules/postcss-media-query-parser": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
       "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
       "dev": true
     },
-    "node_modules/postcss-merge-longhand": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.0.tgz",
-      "integrity": "sha512-Gr46srN2tsLD8fudKYoHO56RG0BLQ2nsBRnSZGY04eNBPwTeWa9KeHrbL3tOLAHyB2aliikycPH2TMJG1U+W6g==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0",
-        "stylehacks": "^5.1.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-merge-rules": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.0.tgz",
-      "integrity": "sha512-NecukEJovQ0mG7h7xV8wbYAkXGTO3MPKnXvuiXzOKcxoOodfTTKYjeo8TMhAswlSkjcPIBlnKbSFcTuVSDaPyQ==",
-      "dev": true,
-      "dependencies": {
-        "browserslist": "^4.16.6",
-        "caniuse-api": "^3.0.0",
-        "cssnano-utils": "^3.1.0",
-        "postcss-selector-parser": "^6.0.5"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-minify-font-values": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-5.1.0.tgz",
-      "integrity": "sha512-el3mYTgx13ZAPPirSVsHqFzl+BBBDrXvbySvPGFnQcTI4iNslrPaFq4muTkLZmKlGk4gyFAYUBMH30+HurREyA==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-minify-gradients": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.1.0.tgz",
-      "integrity": "sha512-J/TMLklkONn3LuL8wCwfwU8zKC1hpS6VcxFkNUNjmVt53uKqrrykR3ov11mdUYyqVMEx67slMce0tE14cE4DTg==",
-      "dev": true,
-      "dependencies": {
-        "colord": "^2.9.1",
-        "cssnano-utils": "^3.1.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-minify-params": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.0.tgz",
-      "integrity": "sha512-q67dcts4Hct6x8+JmhBgctHkbvUsqGIg2IItenjE63iZXMbhjr7AlVZkNnKtIGt/1Wsv7p/7YzeSII6Q+KPXRg==",
-      "dev": true,
-      "dependencies": {
-        "browserslist": "^4.16.6",
-        "cssnano-utils": "^3.1.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-minify-selectors": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.2.0.tgz",
-      "integrity": "sha512-vYxvHkW+iULstA+ctVNx0VoRAR4THQQRkG77o0oa4/mBS0OzGvvzLIvHDv/nNEM0crzN2WIyFU5X7wZhaUK3RA==",
-      "dev": true,
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.5"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
     "node_modules/postcss-modules-extract-imports": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
+      "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
+      "dev": true,
+      "dependencies": {
+        "postcss": "^7.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss-modules-extract-imports/node_modules/picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+      "dev": true
+    },
+    "node_modules/postcss-modules-extract-imports/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/postcss-modules-extract-imports/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/postcss-modules-local-by-default": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
-      "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.3.tgz",
+      "integrity": "sha512-e3xDq+LotiGesympRlKNgaJ0PCzoUIdpH0dj47iWAui/kyTgh3CiAr1qP54uodmJhl6p9rN6BoNcdEDVJx9RDw==",
       "dev": true,
       "dependencies": {
-        "icss-utils": "^5.0.0",
+        "icss-utils": "^4.1.1",
+        "postcss": "^7.0.32",
         "postcss-selector-parser": "^6.0.2",
         "postcss-value-parser": "^4.1.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >= 14"
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss-modules-local-by-default/node_modules/picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+      "dev": true
+    },
+    "node_modules/postcss-modules-local-by-default/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
       },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/postcss-modules-local-by-default/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/postcss-modules-scope": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
-      "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz",
+      "integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
       "dev": true,
       "dependencies": {
-        "postcss-selector-parser": "^6.0.4"
+        "postcss": "^7.0.6",
+        "postcss-selector-parser": "^6.0.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >= 14"
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss-modules-scope/node_modules/picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+      "dev": true
+    },
+    "node_modules/postcss-modules-scope/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
       },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/postcss-modules-scope/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/postcss-modules-values": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
-      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
+      "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
       "dev": true,
       "dependencies": {
-        "icss-utils": "^5.0.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
+        "icss-utils": "^4.0.0",
+        "postcss": "^7.0.6"
       }
     },
-    "node_modules/postcss-nesting": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-10.1.2.tgz",
-      "integrity": "sha512-dJGmgmsvpzKoVMtDMQQG/T6FSqs6kDtUDirIfl4KnjMCiY9/ETX8jdKyCd20swSRAbUYkaBKV20pxkzxoOXLqQ==",
+    "node_modules/postcss-modules-values/node_modules/picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+      "dev": true
+    },
+    "node_modules/postcss-modules-values/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
       "dev": true,
       "dependencies": {
-        "postcss-selector-parser": "^6.0.8"
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
       },
       "engines": {
-        "node": "^12 || ^14 || >=16"
+        "node": ">=6.0.0"
       },
-      "peerDependencies": {
-        "postcss": "^8.3"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
-    "node_modules/postcss-normalize-charset": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
-      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
+    "node_modules/postcss-modules-values/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-normalize-display-values": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-5.1.0.tgz",
-      "integrity": "sha512-WP4KIM4o2dazQXWmFaqMmcvsKmhdINFblgSeRgn8BJ6vxaMyaJkwAzpPpuvSIoG/rmX3M+IrRZEz2H0glrQNEA==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-normalize-positions": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.1.0.tgz",
-      "integrity": "sha512-8gmItgA4H5xiUxgN/3TVvXRoJxkAWLW6f/KKhdsH03atg0cB8ilXnrB5PpSshwVu/dD2ZsRFQcR1OEmSBDAgcQ==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-normalize-repeat-style": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.1.0.tgz",
-      "integrity": "sha512-IR3uBjc+7mcWGL6CtniKNQ4Rr5fTxwkaDHwMBDGGs1x9IVRkYIT/M4NelZWkAOBdV6v3Z9S46zqaKGlyzHSchw==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-normalize-string": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-5.1.0.tgz",
-      "integrity": "sha512-oYiIJOf4T9T1N4i+abeIc7Vgm/xPCGih4bZz5Nm0/ARVJ7K6xrDlLwvwqOydvyL3RHNf8qZk6vo3aatiw/go3w==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-normalize-timing-functions": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.1.0.tgz",
-      "integrity": "sha512-DOEkzJ4SAXv5xkHl0Wa9cZLF3WCBhF3o1SKVxKQAa+0pYKlueTpCgvkFAHfk+Y64ezX9+nITGrDZeVGgITJXjg==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-normalize-unicode": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.0.tgz",
-      "integrity": "sha512-J6M3MizAAZ2dOdSjy2caayJLQT8E8K9XjLce8AUQMwOrCvjCHv24aLC/Lps1R1ylOfol5VIDMaM/Lo9NGlk1SQ==",
-      "dev": true,
-      "dependencies": {
-        "browserslist": "^4.16.6",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-normalize-url": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.1.0.tgz",
-      "integrity": "sha512-5upGeDO+PVthOxSmds43ZeMeZfKH+/DKgGRD7TElkkyS46JXAUhMzIKiCa7BabPeIy3AQcTkXwVVN7DbqsiCew==",
-      "dev": true,
-      "dependencies": {
-        "normalize-url": "^6.0.1",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-normalize-whitespace": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.1.0.tgz",
-      "integrity": "sha512-7O1FanKaJkpWFyCghFzIkLhehujV/frGkdofGLwhg5upbLyGsSfiTcZAdSzoPsSUgyPCkBkNMeWR8yVgPdQybg==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/postcss-opacity-percentage": {
@@ -30598,58 +30686,6 @@
       ],
       "engines": {
         "node": "^12 || ^14 || >=16"
-      }
-    },
-    "node_modules/postcss-ordered-values": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.1.0.tgz",
-      "integrity": "sha512-wU4Z4D4uOIH+BUKkYid36gGDJNQtkVJT7Twv8qH6UyfttbbJWyw4/xIPuVEkkCtQLAJ0EdsNSh8dlvqkXb49TA==",
-      "dev": true,
-      "dependencies": {
-        "cssnano-utils": "^3.1.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-overflow-shorthand": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-3.0.3.tgz",
-      "integrity": "sha512-CxZwoWup9KXzQeeIxtgOciQ00tDtnylYIlJBBODqkgS/PU2jISuWOL/mYLHmZb9ZhZiCaNKsCRiLp22dZUtNsg==",
-      "dev": true,
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4"
-      }
-    },
-    "node_modules/postcss-page-break": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
-      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
-      "dev": true,
-      "peerDependencies": {
-        "postcss": "^8"
-      }
-    },
-    "node_modules/postcss-place": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-place/-/postcss-place-7.0.4.tgz",
-      "integrity": "sha512-MrgKeiiu5OC/TETQO45kV3npRjOFxEHthsqGtkh3I1rPbZSbXGD/lZVi9j13cYh+NA8PIAPyk6sGjT9QbRyvSg==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-preset-env": {
@@ -30708,7 +30744,519 @@
         "postcss": "^8.4"
       }
     },
-    "node_modules/postcss-pseudo-class-any-link": {
+    "node_modules/postcss-preset-env/node_modules/@csstools/postcss-color-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-1.0.2.tgz",
+      "integrity": "sha512-uayvFqfa0hITPwVduxRYNL9YBD/anTqula0tu2llalaxblEd7QPuETSN3gB5PvTYxSfd0d8kS4Fypgo5JaUJ6A==",
+      "dev": true,
+      "dependencies": {
+        "@csstools/postcss-progressive-custom-properties": "^1.1.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/@csstools/postcss-font-format-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-font-format-keywords/-/postcss-font-format-keywords-1.0.0.tgz",
+      "integrity": "sha512-oO0cZt8do8FdVBX8INftvIA4lUrKUSCcWUf9IwH9IPWOgKT22oAZFXeHLoDK7nhB2SmkNycp5brxfNMRLIhd6Q==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/@csstools/postcss-hwb-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-hwb-function/-/postcss-hwb-function-1.0.0.tgz",
+      "integrity": "sha512-VSTd7hGjmde4rTj1rR30sokY3ONJph1reCBTUXqeW1fKwETPy1x4t/XIeaaqbMbC5Xg4SM/lyXZ2S8NELT2TaA==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/@csstools/postcss-ic-unit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-ic-unit/-/postcss-ic-unit-1.0.0.tgz",
+      "integrity": "sha512-i4yps1mBp2ijrx7E96RXrQXQQHm6F4ym1TOD0D69/sjDjZvQ22tqiEvaNw7pFZTUO5b9vWRHzbHzP9+UKuw+bA==",
+      "dev": true,
+      "dependencies": {
+        "@csstools/postcss-progressive-custom-properties": "^1.1.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/@csstools/postcss-is-pseudo-class": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-2.0.1.tgz",
+      "integrity": "sha512-Og5RrTzwFhrKoA79c3MLkfrIBYmwuf/X83s+JQtz/Dkk/MpsaKtqHV1OOzYkogQ+tj3oYp5Mq39XotBXNqVc3Q==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.9"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/@csstools/postcss-normalize-display-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-1.0.0.tgz",
+      "integrity": "sha512-bX+nx5V8XTJEmGtpWTO6kywdS725t71YSLlxWt78XoHUbELWgoCXeOFymRJmL3SU1TLlKSIi7v52EWqe60vJTQ==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/@csstools/postcss-oklab-function": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-oklab-function/-/postcss-oklab-function-1.0.1.tgz",
+      "integrity": "sha512-Bnly2FWWSTZX20hDJLYHpurhp1ot+ZGvojLOsrHa9frzOVruOv4oPYMZ6wQomi9KsbZZ+Af/CuRYaGReTyGtEg==",
+      "dev": true,
+      "dependencies": {
+        "@csstools/postcss-progressive-custom-properties": "^1.1.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/@csstools/postcss-progressive-custom-properties": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-progressive-custom-properties/-/postcss-progressive-custom-properties-1.3.0.tgz",
+      "integrity": "sha512-ASA9W1aIy5ygskZYuWams4BzafD12ULvSypmaLJT2jvQ8G0M3I8PRQhC0h7mG0Z3LI05+agZjqSR9+K9yaQQjA==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/autoprefixer": {
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.2.tgz",
+      "integrity": "sha512-9fOPpHKuDW1w/0EKfRmVnxTDt8166MAnLI3mgZ1JCnhNtYWxcJ6Ud5CO/AVOZi/AvFa8DY9RTy3h3+tFBlrrdQ==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.19.1",
+        "caniuse-lite": "^1.0.30001297",
+        "fraction.js": "^4.1.2",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/css-blank-pseudo": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-3.0.3.tgz",
+      "integrity": "sha512-VS90XWtsHGqoM0t4KpH053c4ehxZ2E6HtGI7x68YFV0pTo/QmkV/YFA+NnlvK8guxZVNWGQhVNJGC39Q8XF4OQ==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.9"
+      },
+      "bin": {
+        "css-blank-pseudo": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/css-has-pseudo": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-3.0.4.tgz",
+      "integrity": "sha512-Vse0xpR1K9MNlp2j5w1pgWIJtm1a8qS0JwS9goFYcImjlHEmywP9VUF05aGBXzGpDJF86QXk4L0ypBmwPhGArw==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.9"
+      },
+      "bin": {
+        "css-has-pseudo": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/css-prefers-color-scheme": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.3.tgz",
+      "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==",
+      "dev": true,
+      "bin": {
+        "css-prefers-color-scheme": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/postcss-attribute-case-insensitive": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-5.0.0.tgz",
+      "integrity": "sha512-b4g9eagFGq9T5SWX4+USfVyjIb3liPnjhHHRMP7FMB2kFVpYyfEscV0wP3eaXhKlcHKUut8lt5BGoeylWA/dBQ==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.2"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.2"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/postcss-color-functional-notation": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-4.2.2.tgz",
+      "integrity": "sha512-DXVtwUhIk4f49KK5EGuEdgx4Gnyj6+t2jBSEmxvpIK9QI40tWrpS2Pua8Q7iIZWBrki2QOaeUdEaLPPa91K0RQ==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/postcss-color-hex-alpha": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-8.0.3.tgz",
+      "integrity": "sha512-fESawWJCrBV035DcbKRPAVmy21LpoyiXdPTuHUfWJ14ZRjY7Y7PA6P4g8z6LQGYhU1WAxkTxjIjurXzoe68Glw==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/postcss-color-rebeccapurple": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-7.0.2.tgz",
+      "integrity": "sha512-SFc3MaocHaQ6k3oZaFwH8io6MdypkUtEy/eXzXEB1vEQlO3S3oDc/FSZA8AsS04Z25RirQhlDlHLh3dn7XewWw==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/postcss-custom-media": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-8.0.0.tgz",
+      "integrity": "sha512-FvO2GzMUaTN0t1fBULDeIvxr5IvbDXcIatt6pnJghc736nqNgsGao5NT+5+WVLAQiTt6Cb3YUms0jiPaXhL//g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/postcss-custom-properties": {
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-12.1.4.tgz",
+      "integrity": "sha512-i6AytuTCoDLJkWN/MtAIGriJz3j7UX6bV7Z5t+KgFz+dwZS15/mlTJY1S0kRizlk6ba0V8u8hN50Fz5Nm7tdZw==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/postcss-custom-selectors": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-6.0.0.tgz",
+      "integrity": "sha512-/1iyBhz/W8jUepjGyu7V1OPcGbc636snN1yXEQCinb6Bwt7KxsiU7/bLQlp8GwAXzCh7cobBU5odNn/2zQWR8Q==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.2"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/postcss-dir-pseudo-class": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-6.0.4.tgz",
+      "integrity": "sha512-I8epwGy5ftdzNWEYok9VjW9whC4xnelAtbajGv4adql4FIF09rnrxnA9Y8xSHN47y7gqFIv10C5+ImsLeJpKBw==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.9"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/postcss-double-position-gradients": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-3.1.1.tgz",
+      "integrity": "sha512-jM+CGkTs4FcG53sMPjrrGE0rIvLDdCrqMzgDC5fLI7JHDO7o6QG8C5TQBtExb13hdBdoH9C2QVbG4jo2y9lErQ==",
+      "dev": true,
+      "dependencies": {
+        "@csstools/postcss-progressive-custom-properties": "^1.1.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/postcss-env-function": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-env-function/-/postcss-env-function-4.0.5.tgz",
+      "integrity": "sha512-gPUJc71ji9XKyl0WSzAalBeEA/89kU+XpffpPxSaaaZ1c48OL36r1Ep5R6+9XAPkIiDlSvVAwP4io12q/vTcvA==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/postcss-focus-visible": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-focus-visible/-/postcss-focus-visible-6.0.4.tgz",
+      "integrity": "sha512-QcKuUU/dgNsstIK6HELFRT5Y3lbrMLEOwG+A4s5cA+fx3A3y/JTq3X9LaOj3OC3ALH0XqyrgQIgey/MIZ8Wczw==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.9"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/postcss-focus-within": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-5.0.4.tgz",
+      "integrity": "sha512-vvjDN++C0mu8jz4af5d52CB184ogg/sSxAFS+oUJQq2SuCe7T5U2iIsVJtsCp2d6R4j0jr5+q3rPkBVZkXD9fQ==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.9"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/postcss-font-variant": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
+      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
+      "dev": true,
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/postcss-gap-properties": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-3.0.3.tgz",
+      "integrity": "sha512-rPPZRLPmEKgLk/KlXMqRaNkYTUpE7YC+bOIQFN5xcu1Vp11Y4faIXv6/Jpft6FMnl6YRxZqDZG0qQOW80stzxQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/postcss-image-set-function": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-4.0.6.tgz",
+      "integrity": "sha512-KfdC6vg53GC+vPd2+HYzsZ6obmPqOk6HY09kttU19+Gj1nC3S3XBVEXDHxkhxTohgZqzbUb94bKXvKDnYWBm/A==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/postcss-initial": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
+      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
+      "dev": true,
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/postcss-lab-function": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-4.1.1.tgz",
+      "integrity": "sha512-j3Z0WQCimY2tMle++YcmygnnVbt6XdnrCV1FO2IpzaCSmtTF2oO8h4ZYUA1Q+QHYroIiaWPvNHt9uBR4riCksQ==",
+      "dev": true,
+      "dependencies": {
+        "@csstools/postcss-progressive-custom-properties": "^1.1.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/postcss-logical": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.4.tgz",
+      "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==",
+      "dev": true,
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/postcss-media-minmax": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
+      "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/postcss-nesting": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-10.1.3.tgz",
+      "integrity": "sha512-wUC+/YCik4wH3StsbC5fBG1s2Z3ZV74vjGqBFYtmYKlVxoio5TYGM06AiaKkQPPlkXWn72HKfS7Cw5PYxnoXSw==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.9"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/postcss-overflow-shorthand": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-3.0.3.tgz",
+      "integrity": "sha512-CxZwoWup9KXzQeeIxtgOciQ00tDtnylYIlJBBODqkgS/PU2jISuWOL/mYLHmZb9ZhZiCaNKsCRiLp22dZUtNsg==",
+      "dev": true,
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/postcss-page-break": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
+      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
+      "dev": true,
+      "peerDependencies": {
+        "postcss": "^8"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/postcss-place": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-place/-/postcss-place-7.0.4.tgz",
+      "integrity": "sha512-MrgKeiiu5OC/TETQO45kV3npRjOFxEHthsqGtkh3I1rPbZSbXGD/lZVi9j13cYh+NA8PIAPyk6sGjT9QbRyvSg==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/postcss-preset-env/node_modules/postcss-pseudo-class-any-link": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-7.1.1.tgz",
       "integrity": "sha512-JRoLFvPEX/1YTPxRxp1JO4WxBVXJYrSY7NHeak5LImwJ+VobFMwYDQHvfTXEpcn+7fYIeGkC29zYFhFWIZD8fg==",
@@ -30723,38 +31271,7 @@
         "postcss": "^8.4"
       }
     },
-    "node_modules/postcss-reduce-initial": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.0.tgz",
-      "integrity": "sha512-5OgTUviz0aeH6MtBjHfbr57tml13PuedK/Ecg8szzd4XRMbYxH4572JFG067z+FqBIf6Zp/d+0581glkvvWMFw==",
-      "dev": true,
-      "dependencies": {
-        "browserslist": "^4.16.6",
-        "caniuse-api": "^3.0.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-reduce-transforms": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-5.1.0.tgz",
-      "integrity": "sha512-2fbdbmgir5AvpW9RLtdONx1QoYG2/EtqpNQbFASDlixBbAYuTcJ0dECwlqNqH7VbaUnEnh8SrxOe2sRIn24XyQ==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-replace-overflow-wrap": {
+    "node_modules/postcss-preset-env/node_modules/postcss-replace-overflow-wrap": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
       "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
@@ -30763,45 +31280,7 @@
         "postcss": "^8.0.3"
       }
     },
-    "node_modules/postcss-resolve-nested-selector": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
-      "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4=",
-      "dev": true
-    },
-    "node_modules/postcss-safe-parser": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
-      "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      },
-      "peerDependencies": {
-        "postcss": "^8.3.3"
-      }
-    },
-    "node_modules/postcss-scss": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.3.tgz",
-      "integrity": "sha512-j4KxzWovfdHsyxwl1BxkUal/O4uirvHgdzMKS1aWJBAV0qh2qj5qAZqpeBfVUYGWv+4iK9Az7SPyZ4fyNju1uA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      },
-      "peerDependencies": {
-        "postcss": "^8.3.3"
-      }
-    },
-    "node_modules/postcss-selector-not": {
+    "node_modules/postcss-preset-env/node_modules/postcss-selector-not": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-5.0.0.tgz",
       "integrity": "sha512-/2K3A4TCP9orP4TNS7u3tGdRFVKqz/E6pX3aGnriPG0jU78of8wsUcqE4QAhWEU0d+WnMSF93Ah3F//vUtK+iQ==",
@@ -30812,6 +31291,12 @@
       "peerDependencies": {
         "postcss": "^8.1.0"
       }
+    },
+    "node_modules/postcss-resolve-nested-selector": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
+      "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4=",
+      "dev": true
     },
     "node_modules/postcss-selector-parser": {
       "version": "6.0.9",
@@ -30824,37 +31309,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/postcss-svgo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.1.0.tgz",
-      "integrity": "sha512-D75KsH1zm5ZrHyxPakAxJWtkyXew5qwS70v56exwvw542d9CRtTo78K0WeFxZB4G7JXKKMbEZtZayTGdIky/eA==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0",
-        "svgo": "^2.7.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-unique-selectors": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.1.0.tgz",
-      "integrity": "sha512-LmUhgGobtpeVJJHuogzjLRwJlN7VH+BL5c9GKMVJSS/ejoyePZkXvNsYUtk//F6vKOGK86gfRS0xH7fXQSDtvA==",
-      "dev": true,
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.5"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-value-parser": {
@@ -32438,9 +32892,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.69.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.69.0.tgz",
-      "integrity": "sha512-kjER91tHyek8gAkuz7+558vSnTQ+pITEok1P0aNOS45ZXyngaqPsXJmSel4QPQnJo7EJMjXUU1/GErWkWiKORg==",
+      "version": "2.70.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.0.tgz",
+      "integrity": "sha512-iEzYw+syFxQ0X9RefVwhr8BA2TNJsTaX8L8dhyeyMECDbmiba+8UQzcu+xZdji0+JQ+s7kouQnw+9Oz5M19XKA==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -34379,22 +34833,6 @@
         "inline-style-parser": "0.1.1"
       }
     },
-    "node_modules/stylehacks": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.0.tgz",
-      "integrity": "sha512-SzLmvHQTrIWfSgljkQCw2++C9+Ne91d/6Sp92I8c5uHTcy/PgeHamwITIbBW9wnFTY/3ZfSXR9HIL6Ikqmcu6Q==",
-      "dev": true,
-      "dependencies": {
-        "browserslist": "^4.16.6",
-        "postcss-selector-parser": "^6.0.4"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
     "node_modules/stylelint": {
       "version": "14.5.3",
       "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.5.3.tgz",
@@ -34475,6 +34913,22 @@
       },
       "peerDependencies": {
         "stylelint": "^14.0.0"
+      }
+    },
+    "node_modules/stylelint-config-recommended-scss/node_modules/postcss-scss": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.3.tgz",
+      "integrity": "sha512-j4KxzWovfdHsyxwl1BxkUal/O4uirvHgdzMKS1aWJBAV0qh2qj5qAZqpeBfVUYGWv+4iK9Az7SPyZ4fyNju1uA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.3"
       }
     },
     "node_modules/stylelint-scss": {
@@ -34607,6 +35061,22 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/postcss-safe-parser": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
+      "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.3"
       }
     },
     "node_modules/stylelint/node_modules/string-width": {
@@ -37052,6 +37522,42 @@
         }
       }
     },
+    "node_modules/webpack-cli/node_modules/@webpack-cli/configtest": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
+      "integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
+      "dev": true,
+      "peerDependencies": {
+        "webpack": "4.x.x || 5.x.x",
+        "webpack-cli": "4.x.x"
+      }
+    },
+    "node_modules/webpack-cli/node_modules/@webpack-cli/info": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.1.tgz",
+      "integrity": "sha512-PKVGmazEq3oAo46Q63tpMr4HipI3OPfP7LiNOEJg963RMgT0rqheag28NCML0o3GIzA3DmxP1ZIAv9oTX1CUIA==",
+      "dev": true,
+      "dependencies": {
+        "envinfo": "^7.7.3"
+      },
+      "peerDependencies": {
+        "webpack-cli": "4.x.x"
+      }
+    },
+    "node_modules/webpack-cli/node_modules/@webpack-cli/serve": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
+      "integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
+      "dev": true,
+      "peerDependencies": {
+        "webpack-cli": "4.x.x"
+      },
+      "peerDependenciesMeta": {
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webpack-cli/node_modules/commander": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -38261,22 +38767,6 @@
         "ts-invariant": "^0.9.4",
         "tslib": "^2.3.0",
         "zen-observable-ts": "^1.2.0"
-      },
-      "dependencies": {
-        "@graphql-typed-document-node/core": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
-          "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
-          "requires": {}
-        },
-        "graphql-tag": {
-          "version": "2.12.6",
-          "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
-          "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        }
       }
     },
     "@babel/code-frame": {
@@ -39620,81 +40110,6 @@
         "@cspotcode/source-map-consumer": "0.8.0"
       }
     },
-    "@csstools/postcss-color-function": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-1.0.2.tgz",
-      "integrity": "sha512-uayvFqfa0hITPwVduxRYNL9YBD/anTqula0tu2llalaxblEd7QPuETSN3gB5PvTYxSfd0d8kS4Fypgo5JaUJ6A==",
-      "dev": true,
-      "requires": {
-        "@csstools/postcss-progressive-custom-properties": "^1.1.0",
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "@csstools/postcss-font-format-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-font-format-keywords/-/postcss-font-format-keywords-1.0.0.tgz",
-      "integrity": "sha512-oO0cZt8do8FdVBX8INftvIA4lUrKUSCcWUf9IwH9IPWOgKT22oAZFXeHLoDK7nhB2SmkNycp5brxfNMRLIhd6Q==",
-      "dev": true,
-      "requires": {
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "@csstools/postcss-hwb-function": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-hwb-function/-/postcss-hwb-function-1.0.0.tgz",
-      "integrity": "sha512-VSTd7hGjmde4rTj1rR30sokY3ONJph1reCBTUXqeW1fKwETPy1x4t/XIeaaqbMbC5Xg4SM/lyXZ2S8NELT2TaA==",
-      "dev": true,
-      "requires": {
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "@csstools/postcss-ic-unit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-ic-unit/-/postcss-ic-unit-1.0.0.tgz",
-      "integrity": "sha512-i4yps1mBp2ijrx7E96RXrQXQQHm6F4ym1TOD0D69/sjDjZvQ22tqiEvaNw7pFZTUO5b9vWRHzbHzP9+UKuw+bA==",
-      "dev": true,
-      "requires": {
-        "@csstools/postcss-progressive-custom-properties": "^1.1.0",
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "@csstools/postcss-is-pseudo-class": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-2.0.0.tgz",
-      "integrity": "sha512-WnfZlyuh/CW4oS530HBbrKq0G8BKl/bsNr5NMFoubBFzJfvFRGJhplCgIJYWUidLuL3WJ/zhMtDIyNFTqhx63Q==",
-      "dev": true,
-      "requires": {
-        "postcss-selector-parser": "^6.0.9"
-      }
-    },
-    "@csstools/postcss-normalize-display-values": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-1.0.0.tgz",
-      "integrity": "sha512-bX+nx5V8XTJEmGtpWTO6kywdS725t71YSLlxWt78XoHUbELWgoCXeOFymRJmL3SU1TLlKSIi7v52EWqe60vJTQ==",
-      "dev": true,
-      "requires": {
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "@csstools/postcss-oklab-function": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-oklab-function/-/postcss-oklab-function-1.0.1.tgz",
-      "integrity": "sha512-Bnly2FWWSTZX20hDJLYHpurhp1ot+ZGvojLOsrHa9frzOVruOv4oPYMZ6wQomi9KsbZZ+Af/CuRYaGReTyGtEg==",
-      "dev": true,
-      "requires": {
-        "@csstools/postcss-progressive-custom-properties": "^1.1.0",
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "@csstools/postcss-progressive-custom-properties": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-progressive-custom-properties/-/postcss-progressive-custom-properties-1.2.0.tgz",
-      "integrity": "sha512-YLpFPK5OaLIRKZhUfnrZPT9s9cmtqltIOg7W6jPcxmiDpnZ4lk+odfufZttOAgcg6IHWvNLgcITSLpJxIQB/qQ==",
-      "dev": true,
-      "requires": {
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
     "@discoveryjs/json-ext": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz",
@@ -39890,6 +40305,12 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "dev": true
     },
+    "@graphql-typed-document-node/core": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
+      "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
+      "requires": {}
+    },
     "@humanwhocodes/config-array": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
@@ -40081,6 +40502,38 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
+        },
+        "jest-config": {
+          "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.5.1.tgz",
+          "integrity": "sha512-5sAsjm6tGdsVbW9ahcChPAFCk4IlkQUknH5AvKjuLTSlcO/wCZKyFdn7Rg0EkC+OGgWODEy2hDpWB1PgzH0JNA==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.8.0",
+            "@jest/test-sequencer": "^27.5.1",
+            "@jest/types": "^27.5.1",
+            "babel-jest": "^27.5.1",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "deepmerge": "^4.2.2",
+            "glob": "^7.1.1",
+            "graceful-fs": "^4.2.9",
+            "jest-circus": "^27.5.1",
+            "jest-environment-jsdom": "^27.5.1",
+            "jest-environment-node": "^27.5.1",
+            "jest-get-type": "^27.5.1",
+            "jest-jasmine2": "^27.5.1",
+            "jest-regex-util": "^27.5.1",
+            "jest-resolve": "^27.5.1",
+            "jest-runner": "^27.5.1",
+            "jest-util": "^27.5.1",
+            "jest-validate": "^27.5.1",
+            "micromatch": "^4.0.4",
+            "parse-json": "^5.2.0",
+            "pretty-format": "^27.5.1",
+            "slash": "^3.0.0",
+            "strip-json-comments": "^3.1.1"
+          }
         },
         "supports-color": {
           "version": "7.2.0",
@@ -41044,6 +41497,48 @@
             "remark-slug": "^6.0.0",
             "ts-dedent": "^2.0.0",
             "util-deprecate": "^1.0.2"
+          },
+          "dependencies": {
+            "@storybook/core": {
+              "version": "6.4.19",
+              "resolved": "https://registry.npmjs.org/@storybook/core/-/core-6.4.19.tgz",
+              "integrity": "sha512-55LOQ/h/kf1jMhjN85t/pIEdIwWEG9yV7bdwv3niVvmoypCxyyjn9/QNK0RKYAeDSUtdm6FVoJ6k5CpxWz2d8w==",
+              "dev": true,
+              "requires": {
+                "@storybook/core-client": "6.4.19",
+                "@storybook/core-server": "6.4.19"
+              },
+              "dependencies": {
+                "@storybook/core-client": {
+                  "version": "6.4.19",
+                  "resolved": "https://registry.npmjs.org/@storybook/core-client/-/core-client-6.4.19.tgz",
+                  "integrity": "sha512-rQHRZjhArPleE7/S8ZUolgzwY+hC0smSKX/3PQxO2GcebDjnJj6+iSV3h+aSMHMmTdoCQvjYw9aBpT8scuRe+A==",
+                  "dev": true,
+                  "requires": {
+                    "@storybook/addons": "6.4.19",
+                    "@storybook/channel-postmessage": "6.4.19",
+                    "@storybook/channel-websocket": "6.4.19",
+                    "@storybook/client-api": "6.4.19",
+                    "@storybook/client-logger": "6.4.19",
+                    "@storybook/core-events": "6.4.19",
+                    "@storybook/csf": "0.0.2--canary.87bc651.0",
+                    "@storybook/preview-web": "6.4.19",
+                    "@storybook/store": "6.4.19",
+                    "@storybook/ui": "6.4.19",
+                    "airbnb-js-shims": "^2.2.1",
+                    "ansi-to-html": "^0.6.11",
+                    "core-js": "^3.8.2",
+                    "global": "^4.4.0",
+                    "lodash": "^4.17.21",
+                    "qs": "^6.10.0",
+                    "regenerator-runtime": "^0.13.7",
+                    "ts-dedent": "^2.0.0",
+                    "unfetch": "^4.2.0",
+                    "util-deprecate": "^1.0.2"
+                  }
+                }
+              }
+            }
           }
         },
         "@types/yargs": {
@@ -41542,21 +42037,6 @@
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
-        "autoprefixer": {
-          "version": "9.8.8",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
-          "integrity": "sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==",
-          "dev": true,
-          "requires": {
-            "browserslist": "^4.12.0",
-            "caniuse-lite": "^1.0.30001109",
-            "normalize-range": "^0.1.2",
-            "num2fraction": "^1.2.2",
-            "picocolors": "^0.2.1",
-            "postcss": "^7.0.32",
-            "postcss-value-parser": "^4.1.0"
-          }
-        },
         "babel-plugin-macros": {
           "version": "2.8.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
@@ -41709,6 +42189,40 @@
           "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
           "dev": true
         },
+        "file-loader": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
+          "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
+          "dev": true,
+          "requires": {
+            "loader-utils": "^2.0.0",
+            "schema-utils": "^3.0.0"
+          },
+          "dependencies": {
+            "loader-utils": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+              "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+              "dev": true,
+              "requires": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^3.0.0",
+                "json5": "^2.1.2"
+              }
+            },
+            "schema-utils": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+              "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+              "dev": true,
+              "requires": {
+                "@types/json-schema": "^7.0.8",
+                "ajv": "^6.12.5",
+                "ajv-keywords": "^3.5.2"
+              }
+            }
+          }
+        },
         "fill-range": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -41823,15 +42337,6 @@
             "pretty-error": "^2.1.1",
             "tapable": "^1.1.3",
             "util.promisify": "1.0.0"
-          }
-        },
-        "icss-utils": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
-          "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
-          "dev": true,
-          "requires": {
-            "postcss": "^7.0.14"
           }
         },
         "is-buffer": {
@@ -42032,47 +42537,6 @@
                 "lru-cache": "^6.0.0"
               }
             }
-          }
-        },
-        "postcss-modules-extract-imports": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
-          "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
-          "dev": true,
-          "requires": {
-            "postcss": "^7.0.5"
-          }
-        },
-        "postcss-modules-local-by-default": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.3.tgz",
-          "integrity": "sha512-e3xDq+LotiGesympRlKNgaJ0PCzoUIdpH0dj47iWAui/kyTgh3CiAr1qP54uodmJhl6p9rN6BoNcdEDVJx9RDw==",
-          "dev": true,
-          "requires": {
-            "icss-utils": "^4.1.1",
-            "postcss": "^7.0.32",
-            "postcss-selector-parser": "^6.0.2",
-            "postcss-value-parser": "^4.1.0"
-          }
-        },
-        "postcss-modules-scope": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz",
-          "integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
-          "dev": true,
-          "requires": {
-            "postcss": "^7.0.6",
-            "postcss-selector-parser": "^6.0.0"
-          }
-        },
-        "postcss-modules-values": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
-          "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
-          "dev": true,
-          "requires": {
-            "icss-utils": "^4.0.0",
-            "postcss": "^7.0.6"
           }
         },
         "pretty-error": {
@@ -42798,6 +43262,13 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "icss-utils": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+          "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+          "dev": true,
+          "requires": {}
+        },
         "loader-utils": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
@@ -42807,6 +43278,42 @@
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
             "json5": "^2.1.2"
+          }
+        },
+        "postcss-modules-extract-imports": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
+          "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+          "dev": true,
+          "requires": {}
+        },
+        "postcss-modules-local-by-default": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
+          "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
+          "dev": true,
+          "requires": {
+            "icss-utils": "^5.0.0",
+            "postcss-selector-parser": "^6.0.2",
+            "postcss-value-parser": "^4.1.0"
+          }
+        },
+        "postcss-modules-scope": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
+          "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
+          "dev": true,
+          "requires": {
+            "postcss-selector-parser": "^6.0.4"
+          }
+        },
+        "postcss-modules-values": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+          "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+          "dev": true,
+          "requires": {
+            "icss-utils": "^5.0.0"
           }
         },
         "schema-utils": {
@@ -42967,44 +43474,6 @@
         "react-textarea-autosize": "^8.3.0",
         "regenerator-runtime": "^0.13.7",
         "ts-dedent": "^2.0.0",
-        "util-deprecate": "^1.0.2"
-      }
-    },
-    "@storybook/core": {
-      "version": "6.4.19",
-      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-6.4.19.tgz",
-      "integrity": "sha512-55LOQ/h/kf1jMhjN85t/pIEdIwWEG9yV7bdwv3niVvmoypCxyyjn9/QNK0RKYAeDSUtdm6FVoJ6k5CpxWz2d8w==",
-      "dev": true,
-      "requires": {
-        "@storybook/core-client": "6.4.19",
-        "@storybook/core-server": "6.4.19"
-      }
-    },
-    "@storybook/core-client": {
-      "version": "6.4.19",
-      "resolved": "https://registry.npmjs.org/@storybook/core-client/-/core-client-6.4.19.tgz",
-      "integrity": "sha512-rQHRZjhArPleE7/S8ZUolgzwY+hC0smSKX/3PQxO2GcebDjnJj6+iSV3h+aSMHMmTdoCQvjYw9aBpT8scuRe+A==",
-      "dev": true,
-      "requires": {
-        "@storybook/addons": "6.4.19",
-        "@storybook/channel-postmessage": "6.4.19",
-        "@storybook/channel-websocket": "6.4.19",
-        "@storybook/client-api": "6.4.19",
-        "@storybook/client-logger": "6.4.19",
-        "@storybook/core-events": "6.4.19",
-        "@storybook/csf": "0.0.2--canary.87bc651.0",
-        "@storybook/preview-web": "6.4.19",
-        "@storybook/store": "6.4.19",
-        "@storybook/ui": "6.4.19",
-        "airbnb-js-shims": "^2.2.1",
-        "ansi-to-html": "^0.6.11",
-        "core-js": "^3.8.2",
-        "global": "^4.4.0",
-        "lodash": "^4.17.21",
-        "qs": "^6.10.0",
-        "regenerator-runtime": "^0.13.7",
-        "ts-dedent": "^2.0.0",
-        "unfetch": "^4.2.0",
         "util-deprecate": "^1.0.2"
       }
     },
@@ -43293,6 +43762,17 @@
             "ssri": "^6.0.1",
             "unique-filename": "^1.1.1",
             "y18n": "^4.0.0"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "5.1.1",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+              "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+              "dev": true,
+              "requires": {
+                "yallist": "^3.0.2"
+              }
+            }
           }
         },
         "chalk": {
@@ -43407,26 +43887,6 @@
             "tapable": "^1.0.0"
           },
           "dependencies": {
-            "lru-cache": {
-              "version": "6.0.0",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-              "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-              "dev": true,
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            },
-            "schema-utils": {
-              "version": "2.7.0",
-              "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-              "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
-              "dev": true,
-              "requires": {
-                "@types/json-schema": "^7.0.4",
-                "ajv": "^6.12.2",
-                "ajv-keywords": "^3.4.1"
-              }
-            },
             "semver": {
               "version": "7.3.5",
               "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -43435,12 +43895,6 @@
               "requires": {
                 "lru-cache": "^6.0.0"
               }
-            },
-            "yallist": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-              "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-              "dev": true
             }
           }
         },
@@ -43500,15 +43954,6 @@
           "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==",
           "dev": true
         },
-        "lru-cache": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-          "dev": true,
-          "requires": {
-            "yallist": "^3.0.2"
-          }
-        },
         "micromatch": {
           "version": "3.1.10",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -43555,14 +44000,14 @@
           }
         },
         "schema-utils": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
+          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
           "dev": true,
           "requires": {
-            "ajv": "^6.1.0",
-            "ajv-errors": "^1.0.0",
-            "ajv-keywords": "^3.1.0"
+            "@types/json-schema": "^7.0.4",
+            "ajv": "^6.12.2",
+            "ajv-keywords": "^3.4.1"
           }
         },
         "serialize-javascript": {
@@ -43639,6 +44084,19 @@
             "terser": "^4.1.2",
             "webpack-sources": "^1.4.0",
             "worker-farm": "^1.7.0"
+          },
+          "dependencies": {
+            "schema-utils": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+              "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+              "dev": true,
+              "requires": {
+                "ajv": "^6.1.0",
+                "ajv-errors": "^1.0.0",
+                "ajv-keywords": "^3.1.0"
+              }
+            }
           }
         },
         "to-regex-range": {
@@ -43692,6 +44150,19 @@
             "terser-webpack-plugin": "^1.4.3",
             "watchpack": "^1.7.4",
             "webpack-sources": "^1.4.1"
+          },
+          "dependencies": {
+            "schema-utils": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+              "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+              "dev": true,
+              "requires": {
+                "ajv": "^6.1.0",
+                "ajv-errors": "^1.0.0",
+                "ajv-keywords": "^3.1.0"
+              }
+            }
           }
         },
         "webpack-sources": {
@@ -43777,6 +44248,34 @@
         "ws": "^8.2.3"
       },
       "dependencies": {
+        "@storybook/core-client": {
+          "version": "6.4.19",
+          "resolved": "https://registry.npmjs.org/@storybook/core-client/-/core-client-6.4.19.tgz",
+          "integrity": "sha512-rQHRZjhArPleE7/S8ZUolgzwY+hC0smSKX/3PQxO2GcebDjnJj6+iSV3h+aSMHMmTdoCQvjYw9aBpT8scuRe+A==",
+          "dev": true,
+          "requires": {
+            "@storybook/addons": "6.4.19",
+            "@storybook/channel-postmessage": "6.4.19",
+            "@storybook/channel-websocket": "6.4.19",
+            "@storybook/client-api": "6.4.19",
+            "@storybook/client-logger": "6.4.19",
+            "@storybook/core-events": "6.4.19",
+            "@storybook/csf": "0.0.2--canary.87bc651.0",
+            "@storybook/preview-web": "6.4.19",
+            "@storybook/store": "6.4.19",
+            "@storybook/ui": "6.4.19",
+            "airbnb-js-shims": "^2.2.1",
+            "ansi-to-html": "^0.6.11",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "lodash": "^4.17.21",
+            "qs": "^6.10.0",
+            "regenerator-runtime": "^0.13.7",
+            "ts-dedent": "^2.0.0",
+            "unfetch": "^4.2.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
         "@types/node": {
           "version": "14.18.12",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz",
@@ -44442,6 +44941,34 @@
         "webpack-virtual-modules": "^0.2.2"
       },
       "dependencies": {
+        "@storybook/core-client": {
+          "version": "6.4.19",
+          "resolved": "https://registry.npmjs.org/@storybook/core-client/-/core-client-6.4.19.tgz",
+          "integrity": "sha512-rQHRZjhArPleE7/S8ZUolgzwY+hC0smSKX/3PQxO2GcebDjnJj6+iSV3h+aSMHMmTdoCQvjYw9aBpT8scuRe+A==",
+          "dev": true,
+          "requires": {
+            "@storybook/addons": "6.4.19",
+            "@storybook/channel-postmessage": "6.4.19",
+            "@storybook/channel-websocket": "6.4.19",
+            "@storybook/client-api": "6.4.19",
+            "@storybook/client-logger": "6.4.19",
+            "@storybook/core-events": "6.4.19",
+            "@storybook/csf": "0.0.2--canary.87bc651.0",
+            "@storybook/preview-web": "6.4.19",
+            "@storybook/store": "6.4.19",
+            "@storybook/ui": "6.4.19",
+            "airbnb-js-shims": "^2.2.1",
+            "ansi-to-html": "^0.6.11",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "lodash": "^4.17.21",
+            "qs": "^6.10.0",
+            "regenerator-runtime": "^0.13.7",
+            "ts-dedent": "^2.0.0",
+            "unfetch": "^4.2.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
         "@types/html-minifier-terser": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz",
@@ -44741,6 +45268,40 @@
           "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
           "dev": true
         },
+        "file-loader": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
+          "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
+          "dev": true,
+          "requires": {
+            "loader-utils": "^2.0.0",
+            "schema-utils": "^3.0.0"
+          },
+          "dependencies": {
+            "loader-utils": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+              "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+              "dev": true,
+              "requires": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^3.0.0",
+                "json5": "^2.1.2"
+              }
+            },
+            "schema-utils": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+              "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+              "dev": true,
+              "requires": {
+                "@types/json-schema": "^7.0.8",
+                "ajv": "^6.12.5",
+                "ajv-keywords": "^3.5.2"
+              }
+            }
+          }
+        },
         "fill-range": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -44832,15 +45393,6 @@
             "pretty-error": "^2.1.1",
             "tapable": "^1.1.3",
             "util.promisify": "1.0.0"
-          }
-        },
-        "icss-utils": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
-          "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
-          "dev": true,
-          "requires": {
-            "postcss": "^7.0.14"
           }
         },
         "is-buffer": {
@@ -45004,47 +45556,6 @@
           "requires": {
             "picocolors": "^0.2.1",
             "source-map": "^0.6.1"
-          }
-        },
-        "postcss-modules-extract-imports": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
-          "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
-          "dev": true,
-          "requires": {
-            "postcss": "^7.0.5"
-          }
-        },
-        "postcss-modules-local-by-default": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.3.tgz",
-          "integrity": "sha512-e3xDq+LotiGesympRlKNgaJ0PCzoUIdpH0dj47iWAui/kyTgh3CiAr1qP54uodmJhl6p9rN6BoNcdEDVJx9RDw==",
-          "dev": true,
-          "requires": {
-            "icss-utils": "^4.1.1",
-            "postcss": "^7.0.32",
-            "postcss-selector-parser": "^6.0.2",
-            "postcss-value-parser": "^4.1.0"
-          }
-        },
-        "postcss-modules-scope": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz",
-          "integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
-          "dev": true,
-          "requires": {
-            "postcss": "^7.0.6",
-            "postcss-selector-parser": "^6.0.0"
-          }
-        },
-        "postcss-modules-values": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
-          "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
-          "dev": true,
-          "requires": {
-            "icss-utils": "^4.0.0",
-            "postcss": "^7.0.6"
           }
         },
         "pretty-error": {
@@ -45537,6 +46048,34 @@
         "webpack-virtual-modules": "^0.4.1"
       },
       "dependencies": {
+        "@storybook/core-client": {
+          "version": "6.4.19",
+          "resolved": "https://registry.npmjs.org/@storybook/core-client/-/core-client-6.4.19.tgz",
+          "integrity": "sha512-rQHRZjhArPleE7/S8ZUolgzwY+hC0smSKX/3PQxO2GcebDjnJj6+iSV3h+aSMHMmTdoCQvjYw9aBpT8scuRe+A==",
+          "dev": true,
+          "requires": {
+            "@storybook/addons": "6.4.19",
+            "@storybook/channel-postmessage": "6.4.19",
+            "@storybook/channel-websocket": "6.4.19",
+            "@storybook/client-api": "6.4.19",
+            "@storybook/client-logger": "6.4.19",
+            "@storybook/core-events": "6.4.19",
+            "@storybook/csf": "0.0.2--canary.87bc651.0",
+            "@storybook/preview-web": "6.4.19",
+            "@storybook/store": "6.4.19",
+            "@storybook/ui": "6.4.19",
+            "airbnb-js-shims": "^2.2.1",
+            "ansi-to-html": "^0.6.11",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "lodash": "^4.17.21",
+            "qs": "^6.10.0",
+            "regenerator-runtime": "^0.13.7",
+            "ts-dedent": "^2.0.0",
+            "unfetch": "^4.2.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
         "@types/node": {
           "version": "14.18.12",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz",
@@ -45592,6 +46131,13 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "icss-utils": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+          "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+          "dev": true,
+          "requires": {}
+        },
         "loader-utils": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
@@ -45601,6 +46147,42 @@
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
             "json5": "^2.1.2"
+          }
+        },
+        "postcss-modules-extract-imports": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
+          "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+          "dev": true,
+          "requires": {}
+        },
+        "postcss-modules-local-by-default": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
+          "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
+          "dev": true,
+          "requires": {
+            "icss-utils": "^5.0.0",
+            "postcss-selector-parser": "^6.0.2",
+            "postcss-value-parser": "^4.1.0"
+          }
+        },
+        "postcss-modules-scope": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
+          "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
+          "dev": true,
+          "requires": {
+            "postcss-selector-parser": "^6.0.4"
+          }
+        },
+        "postcss-modules-values": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+          "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+          "dev": true,
+          "requires": {
+            "icss-utils": "^5.0.0"
           }
         },
         "schema-utils": {
@@ -45798,6 +46380,46 @@
                 "big.js": "^5.2.2",
                 "emojis-list": "^3.0.0",
                 "json5": "^2.1.2"
+              }
+            }
+          }
+        },
+        "@storybook/core": {
+          "version": "6.4.19",
+          "resolved": "https://registry.npmjs.org/@storybook/core/-/core-6.4.19.tgz",
+          "integrity": "sha512-55LOQ/h/kf1jMhjN85t/pIEdIwWEG9yV7bdwv3niVvmoypCxyyjn9/QNK0RKYAeDSUtdm6FVoJ6k5CpxWz2d8w==",
+          "dev": true,
+          "requires": {
+            "@storybook/core-client": "6.4.19",
+            "@storybook/core-server": "6.4.19"
+          },
+          "dependencies": {
+            "@storybook/core-client": {
+              "version": "6.4.19",
+              "resolved": "https://registry.npmjs.org/@storybook/core-client/-/core-client-6.4.19.tgz",
+              "integrity": "sha512-rQHRZjhArPleE7/S8ZUolgzwY+hC0smSKX/3PQxO2GcebDjnJj6+iSV3h+aSMHMmTdoCQvjYw9aBpT8scuRe+A==",
+              "dev": true,
+              "requires": {
+                "@storybook/addons": "6.4.19",
+                "@storybook/channel-postmessage": "6.4.19",
+                "@storybook/channel-websocket": "6.4.19",
+                "@storybook/client-api": "6.4.19",
+                "@storybook/client-logger": "6.4.19",
+                "@storybook/core-events": "6.4.19",
+                "@storybook/csf": "0.0.2--canary.87bc651.0",
+                "@storybook/preview-web": "6.4.19",
+                "@storybook/store": "6.4.19",
+                "@storybook/ui": "6.4.19",
+                "airbnb-js-shims": "^2.2.1",
+                "ansi-to-html": "^0.6.11",
+                "core-js": "^3.8.2",
+                "global": "^4.4.0",
+                "lodash": "^4.17.21",
+                "qs": "^6.10.0",
+                "regenerator-runtime": "^0.13.7",
+                "ts-dedent": "^2.0.0",
+                "unfetch": "^4.2.0",
+                "util-deprecate": "^1.0.2"
               }
             }
           }
@@ -47688,9 +48310,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.10",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
-          "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+          "version": "3.0.11",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
+          "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
         }
       }
     },
@@ -48356,29 +48978,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "@webpack-cli/configtest": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
-      "integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
-      "dev": true,
-      "requires": {}
-    },
-    "@webpack-cli/info": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.1.tgz",
-      "integrity": "sha512-PKVGmazEq3oAo46Q63tpMr4HipI3OPfP7LiNOEJg963RMgT0rqheag28NCML0o3GIzA3DmxP1ZIAv9oTX1CUIA==",
-      "dev": true,
-      "requires": {
-        "envinfo": "^7.7.3"
-      }
-    },
-    "@webpack-cli/serve": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
-      "integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
-      "dev": true,
-      "requires": {}
-    },
     "@wry/context": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
@@ -48965,17 +49564,42 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.2.tgz",
-      "integrity": "sha512-9fOPpHKuDW1w/0EKfRmVnxTDt8166MAnLI3mgZ1JCnhNtYWxcJ6Ud5CO/AVOZi/AvFa8DY9RTy3h3+tFBlrrdQ==",
+      "version": "9.8.8",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
+      "integrity": "sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.19.1",
-        "caniuse-lite": "^1.0.30001297",
-        "fraction.js": "^4.1.2",
+        "browserslist": "^4.12.0",
+        "caniuse-lite": "^1.0.30001109",
         "normalize-range": "^0.1.2",
-        "picocolors": "^1.0.0",
-        "postcss-value-parser": "^4.2.0"
+        "num2fraction": "^1.2.2",
+        "picocolors": "^0.2.1",
+        "postcss": "^7.0.32",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "dependencies": {
+        "picocolors": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+          "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+          "dev": true
+        },
+        "postcss": {
+          "version": "7.0.39",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+          "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+          "dev": true,
+          "requires": {
+            "picocolors": "^0.2.1",
+            "source-map": "^0.6.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "babel-core": {
@@ -50117,13 +50741,13 @@
       }
     },
     "browserslist": {
-      "version": "4.19.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.3.tgz",
-      "integrity": "sha512-XK3X4xtKJ+Txj8G5c30B4gsm71s69lqXlkYui4s6EkKxuv49qjYlY6oVd+IFJ73d4YymtM3+djvvt/R/iJwwDg==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.0.tgz",
+      "integrity": "sha512-bnpOoa+DownbciXj0jVGENf8VYQnE2LNWomhYuCsMmmx9Jd9lwq0WXODuwpSsp8AVdKM2/HorrzxAfbKvWTByQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001312",
-        "electron-to-chromium": "^1.4.71",
+        "caniuse-lite": "^1.0.30001313",
+        "electron-to-chromium": "^1.4.76",
         "escalade": "^3.1.1",
         "node-releases": "^2.0.2",
         "picocolors": "^1.0.0"
@@ -50310,65 +50934,10 @@
           "dev": true,
           "optional": true
         },
-        "is-plain-obj": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-          "dev": true,
-          "optional": true
-        },
         "lowercase-keys": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
           "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
-          "dev": true,
-          "optional": true
-        },
-        "normalize-url": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
-          "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "prepend-http": "^2.0.0",
-            "query-string": "^5.0.1",
-            "sort-keys": "^2.0.0"
-          }
-        },
-        "prepend-http": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-          "dev": true,
-          "optional": true
-        },
-        "query-string": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-          "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "decode-uri-component": "^0.2.0",
-            "object-assign": "^4.1.0",
-            "strict-uri-encode": "^1.0.0"
-          }
-        },
-        "sort-keys": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-          "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "is-plain-obj": "^1.0.0"
-          }
-        },
-        "strict-uri-encode": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
           "dev": true,
           "optional": true
         }
@@ -50450,9 +51019,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001312",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
+      "version": "1.0.30001313",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001313.tgz",
+      "integrity": "sha512-rI1UN0koZUiKINjysQDuRi2VeSCce3bYJNmDcj3PIKREiAmjakugBul1QSkg/fPrlULYl6oWfGg3PbgOSY9X4Q==",
       "dev": true
     },
     "capture-exit": {
@@ -51768,38 +52337,11 @@
         }
       }
     },
-    "css-blank-pseudo": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-3.0.3.tgz",
-      "integrity": "sha512-VS90XWtsHGqoM0t4KpH053c4ehxZ2E6HtGI7x68YFV0pTo/QmkV/YFA+NnlvK8guxZVNWGQhVNJGC39Q8XF4OQ==",
-      "dev": true,
-      "requires": {
-        "postcss-selector-parser": "^6.0.9"
-      }
-    },
-    "css-declaration-sorter": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.1.4.tgz",
-      "integrity": "sha512-lpfkqS0fctcmZotJGhnxkIyJWvBXgpyi2wsFd4J8VB7wzyrT6Ch/3Q+FMNJpjK4gu1+GN5khOnpU2ZVKrLbhCw==",
-      "dev": true,
-      "requires": {
-        "timsort": "^0.3.0"
-      }
-    },
     "css-functions-list": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.0.1.tgz",
       "integrity": "sha512-PriDuifDt4u4rkDgnqRCLnjfMatufLmWNfQnGCq34xZwpY3oabwhB9SqRBmuvWUgndbemCFlKqg+nO7C2q0SBw==",
       "dev": true
-    },
-    "css-has-pseudo": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-3.0.4.tgz",
-      "integrity": "sha512-Vse0xpR1K9MNlp2j5w1pgWIJtm1a8qS0JwS9goFYcImjlHEmywP9VUF05aGBXzGpDJF86QXk4L0ypBmwPhGArw==",
-      "dev": true,
-      "requires": {
-        "postcss-selector-parser": "^6.0.9"
-      }
     },
     "css-loader": {
       "version": "6.6.0",
@@ -51817,6 +52359,49 @@
         "semver": "^7.3.5"
       },
       "dependencies": {
+        "icss-utils": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+          "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+          "dev": true,
+          "requires": {}
+        },
+        "postcss-modules-extract-imports": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
+          "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+          "dev": true,
+          "requires": {}
+        },
+        "postcss-modules-local-by-default": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
+          "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
+          "dev": true,
+          "requires": {
+            "icss-utils": "^5.0.0",
+            "postcss-selector-parser": "^6.0.2",
+            "postcss-value-parser": "^4.1.0"
+          }
+        },
+        "postcss-modules-scope": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
+          "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
+          "dev": true,
+          "requires": {
+            "postcss-selector-parser": "^6.0.4"
+          }
+        },
+        "postcss-modules-values": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+          "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+          "dev": true,
+          "requires": {
+            "icss-utils": "^5.0.0"
+          }
+        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -51863,11 +52448,331 @@
             "fast-deep-equal": "^3.1.3"
           }
         },
+        "css-declaration-sorter": {
+          "version": "6.1.4",
+          "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.1.4.tgz",
+          "integrity": "sha512-lpfkqS0fctcmZotJGhnxkIyJWvBXgpyi2wsFd4J8VB7wzyrT6Ch/3Q+FMNJpjK4gu1+GN5khOnpU2ZVKrLbhCw==",
+          "dev": true,
+          "requires": {
+            "timsort": "^0.3.0"
+          }
+        },
+        "cssnano": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.0.tgz",
+          "integrity": "sha512-wWxave1wMlThGg4ueK98jFKaNqXnQd1nVZpSkQ9XvR+YymlzP1ofWqES1JkHtI250LksP9z5JH+oDcrKDJezAg==",
+          "dev": true,
+          "requires": {
+            "cssnano-preset-default": "^5.2.0",
+            "lilconfig": "^2.0.3",
+            "yaml": "^1.10.2"
+          }
+        },
+        "cssnano-preset-default": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.0.tgz",
+          "integrity": "sha512-3N5Vcptj2pqVKpHVqH6ezOJvqikR2PdLTbTrsrhF61FbLRQuujAqZ2sKN5rvcMsb7hFjrNnjZT8CGEkxoN/Pwg==",
+          "dev": true,
+          "requires": {
+            "css-declaration-sorter": "^6.0.3",
+            "cssnano-utils": "^3.1.0",
+            "postcss-calc": "^8.2.3",
+            "postcss-colormin": "^5.3.0",
+            "postcss-convert-values": "^5.1.0",
+            "postcss-discard-comments": "^5.1.0",
+            "postcss-discard-duplicates": "^5.1.0",
+            "postcss-discard-empty": "^5.1.0",
+            "postcss-discard-overridden": "^5.1.0",
+            "postcss-merge-longhand": "^5.1.0",
+            "postcss-merge-rules": "^5.1.0",
+            "postcss-minify-font-values": "^5.1.0",
+            "postcss-minify-gradients": "^5.1.0",
+            "postcss-minify-params": "^5.1.0",
+            "postcss-minify-selectors": "^5.2.0",
+            "postcss-normalize-charset": "^5.1.0",
+            "postcss-normalize-display-values": "^5.1.0",
+            "postcss-normalize-positions": "^5.1.0",
+            "postcss-normalize-repeat-style": "^5.1.0",
+            "postcss-normalize-string": "^5.1.0",
+            "postcss-normalize-timing-functions": "^5.1.0",
+            "postcss-normalize-unicode": "^5.1.0",
+            "postcss-normalize-url": "^5.1.0",
+            "postcss-normalize-whitespace": "^5.1.0",
+            "postcss-ordered-values": "^5.1.0",
+            "postcss-reduce-initial": "^5.1.0",
+            "postcss-reduce-transforms": "^5.1.0",
+            "postcss-svgo": "^5.1.0",
+            "postcss-unique-selectors": "^5.1.0"
+          }
+        },
+        "cssnano-utils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
+          "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
+          "dev": true,
+          "requires": {}
+        },
         "json-schema-traverse": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
           "dev": true
+        },
+        "normalize-url": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+          "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+          "dev": true
+        },
+        "postcss-calc": {
+          "version": "8.2.4",
+          "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-8.2.4.tgz",
+          "integrity": "sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==",
+          "dev": true,
+          "requires": {
+            "postcss-selector-parser": "^6.0.9",
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-colormin": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.3.0.tgz",
+          "integrity": "sha512-WdDO4gOFG2Z8n4P8TWBpshnL3JpmNmJwdnfP2gbk2qBA8PWwOYcmjmI/t3CmMeL72a7Hkd+x/Mg9O2/0rD54Pg==",
+          "dev": true,
+          "requires": {
+            "browserslist": "^4.16.6",
+            "caniuse-api": "^3.0.0",
+            "colord": "^2.9.1",
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-convert-values": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.0.tgz",
+          "integrity": "sha512-GkyPbZEYJiWtQB0KZ0X6qusqFHUepguBCNFi9t5JJc7I2OTXG7C0twbTLvCfaKOLl3rSXmpAwV7W5txd91V84g==",
+          "dev": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-discard-comments": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.0.tgz",
+          "integrity": "sha512-L0IKF4jAshRyn03SkEO6ar/Ipz2oLywVbg2THf2EqqdNkBwmVMxuTR/RoAltOw4piiaLt3gCAdrbAqmTBInmhg==",
+          "dev": true,
+          "requires": {}
+        },
+        "postcss-discard-duplicates": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
+          "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
+          "dev": true,
+          "requires": {}
+        },
+        "postcss-discard-empty": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.0.tgz",
+          "integrity": "sha512-782T/buGgb3HOuHOJAHpdyKzAAKsv/BxWqsutnZ+QsiHEcDkY7v+6WWdturuBiSal6XMOO1p1aJvwXdqLD5vhA==",
+          "dev": true,
+          "requires": {}
+        },
+        "postcss-discard-overridden": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
+          "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
+          "dev": true,
+          "requires": {}
+        },
+        "postcss-merge-longhand": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.0.tgz",
+          "integrity": "sha512-Gr46srN2tsLD8fudKYoHO56RG0BLQ2nsBRnSZGY04eNBPwTeWa9KeHrbL3tOLAHyB2aliikycPH2TMJG1U+W6g==",
+          "dev": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0",
+            "stylehacks": "^5.1.0"
+          }
+        },
+        "postcss-merge-rules": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.0.tgz",
+          "integrity": "sha512-NecukEJovQ0mG7h7xV8wbYAkXGTO3MPKnXvuiXzOKcxoOodfTTKYjeo8TMhAswlSkjcPIBlnKbSFcTuVSDaPyQ==",
+          "dev": true,
+          "requires": {
+            "browserslist": "^4.16.6",
+            "caniuse-api": "^3.0.0",
+            "cssnano-utils": "^3.1.0",
+            "postcss-selector-parser": "^6.0.5"
+          }
+        },
+        "postcss-minify-font-values": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-5.1.0.tgz",
+          "integrity": "sha512-el3mYTgx13ZAPPirSVsHqFzl+BBBDrXvbySvPGFnQcTI4iNslrPaFq4muTkLZmKlGk4gyFAYUBMH30+HurREyA==",
+          "dev": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-minify-gradients": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.1.0.tgz",
+          "integrity": "sha512-J/TMLklkONn3LuL8wCwfwU8zKC1hpS6VcxFkNUNjmVt53uKqrrykR3ov11mdUYyqVMEx67slMce0tE14cE4DTg==",
+          "dev": true,
+          "requires": {
+            "colord": "^2.9.1",
+            "cssnano-utils": "^3.1.0",
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-minify-params": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.0.tgz",
+          "integrity": "sha512-q67dcts4Hct6x8+JmhBgctHkbvUsqGIg2IItenjE63iZXMbhjr7AlVZkNnKtIGt/1Wsv7p/7YzeSII6Q+KPXRg==",
+          "dev": true,
+          "requires": {
+            "browserslist": "^4.16.6",
+            "cssnano-utils": "^3.1.0",
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-minify-selectors": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.2.0.tgz",
+          "integrity": "sha512-vYxvHkW+iULstA+ctVNx0VoRAR4THQQRkG77o0oa4/mBS0OzGvvzLIvHDv/nNEM0crzN2WIyFU5X7wZhaUK3RA==",
+          "dev": true,
+          "requires": {
+            "postcss-selector-parser": "^6.0.5"
+          }
+        },
+        "postcss-normalize-charset": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
+          "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
+          "dev": true,
+          "requires": {}
+        },
+        "postcss-normalize-display-values": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-5.1.0.tgz",
+          "integrity": "sha512-WP4KIM4o2dazQXWmFaqMmcvsKmhdINFblgSeRgn8BJ6vxaMyaJkwAzpPpuvSIoG/rmX3M+IrRZEz2H0glrQNEA==",
+          "dev": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-normalize-positions": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.1.0.tgz",
+          "integrity": "sha512-8gmItgA4H5xiUxgN/3TVvXRoJxkAWLW6f/KKhdsH03atg0cB8ilXnrB5PpSshwVu/dD2ZsRFQcR1OEmSBDAgcQ==",
+          "dev": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-normalize-repeat-style": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.1.0.tgz",
+          "integrity": "sha512-IR3uBjc+7mcWGL6CtniKNQ4Rr5fTxwkaDHwMBDGGs1x9IVRkYIT/M4NelZWkAOBdV6v3Z9S46zqaKGlyzHSchw==",
+          "dev": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-normalize-string": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-5.1.0.tgz",
+          "integrity": "sha512-oYiIJOf4T9T1N4i+abeIc7Vgm/xPCGih4bZz5Nm0/ARVJ7K6xrDlLwvwqOydvyL3RHNf8qZk6vo3aatiw/go3w==",
+          "dev": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-normalize-timing-functions": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.1.0.tgz",
+          "integrity": "sha512-DOEkzJ4SAXv5xkHl0Wa9cZLF3WCBhF3o1SKVxKQAa+0pYKlueTpCgvkFAHfk+Y64ezX9+nITGrDZeVGgITJXjg==",
+          "dev": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-normalize-unicode": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.0.tgz",
+          "integrity": "sha512-J6M3MizAAZ2dOdSjy2caayJLQT8E8K9XjLce8AUQMwOrCvjCHv24aLC/Lps1R1ylOfol5VIDMaM/Lo9NGlk1SQ==",
+          "dev": true,
+          "requires": {
+            "browserslist": "^4.16.6",
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-normalize-url": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.1.0.tgz",
+          "integrity": "sha512-5upGeDO+PVthOxSmds43ZeMeZfKH+/DKgGRD7TElkkyS46JXAUhMzIKiCa7BabPeIy3AQcTkXwVVN7DbqsiCew==",
+          "dev": true,
+          "requires": {
+            "normalize-url": "^6.0.1",
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-normalize-whitespace": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.1.0.tgz",
+          "integrity": "sha512-7O1FanKaJkpWFyCghFzIkLhehujV/frGkdofGLwhg5upbLyGsSfiTcZAdSzoPsSUgyPCkBkNMeWR8yVgPdQybg==",
+          "dev": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-ordered-values": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.1.0.tgz",
+          "integrity": "sha512-wU4Z4D4uOIH+BUKkYid36gGDJNQtkVJT7Twv8qH6UyfttbbJWyw4/xIPuVEkkCtQLAJ0EdsNSh8dlvqkXb49TA==",
+          "dev": true,
+          "requires": {
+            "cssnano-utils": "^3.1.0",
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-reduce-initial": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.0.tgz",
+          "integrity": "sha512-5OgTUviz0aeH6MtBjHfbr57tml13PuedK/Ecg8szzd4XRMbYxH4572JFG067z+FqBIf6Zp/d+0581glkvvWMFw==",
+          "dev": true,
+          "requires": {
+            "browserslist": "^4.16.6",
+            "caniuse-api": "^3.0.0"
+          }
+        },
+        "postcss-reduce-transforms": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-5.1.0.tgz",
+          "integrity": "sha512-2fbdbmgir5AvpW9RLtdONx1QoYG2/EtqpNQbFASDlixBbAYuTcJ0dECwlqNqH7VbaUnEnh8SrxOe2sRIn24XyQ==",
+          "dev": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-svgo": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.1.0.tgz",
+          "integrity": "sha512-D75KsH1zm5ZrHyxPakAxJWtkyXew5qwS70v56exwvw542d9CRtTo78K0WeFxZB4G7JXKKMbEZtZayTGdIky/eA==",
+          "dev": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0",
+            "svgo": "^2.7.0"
+          }
+        },
+        "postcss-unique-selectors": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.1.0.tgz",
+          "integrity": "sha512-LmUhgGobtpeVJJHuogzjLRwJlN7VH+BL5c9GKMVJSS/ejoyePZkXvNsYUtk//F6vKOGK86gfRS0xH7fXQSDtvA==",
+          "dev": true,
+          "requires": {
+            "postcss-selector-parser": "^6.0.5"
+          }
         },
         "schema-utils": {
           "version": "4.0.0",
@@ -51886,15 +52791,18 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
+        },
+        "stylehacks": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.0.tgz",
+          "integrity": "sha512-SzLmvHQTrIWfSgljkQCw2++C9+Ne91d/6Sp92I8c5uHTcy/PgeHamwITIbBW9wnFTY/3ZfSXR9HIL6Ikqmcu6Q==",
+          "dev": true,
+          "requires": {
+            "browserslist": "^4.16.6",
+            "postcss-selector-parser": "^6.0.4"
+          }
         }
       }
-    },
-    "css-prefers-color-scheme": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.3.tgz",
-      "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==",
-      "dev": true,
-      "requires": {}
     },
     "css-select": {
       "version": "4.2.1",
@@ -51940,9 +52848,9 @@
       "dev": true
     },
     "cssdb": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-6.4.0.tgz",
-      "integrity": "sha512-8NMWrur/ewSNrRNZndbtOTXc2Xb2b+NCTPHj8VErFYvJUlgsMAiBGaFaxG6hjy9zbCjj2ZLwSQrMM+tormO8qA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-6.4.1.tgz",
+      "integrity": "sha512-R70R/Q1fPlM1D6Y+Kpat0QjiY+aMsY2/8lekdVoYcJ7ZQs9kw71W78FdOMf8DFq975KHQf1089PNg1dLsbAhoA==",
       "dev": true
     },
     "cssesc": {
@@ -51950,61 +52858,6 @@
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
-    },
-    "cssnano": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.0.tgz",
-      "integrity": "sha512-wWxave1wMlThGg4ueK98jFKaNqXnQd1nVZpSkQ9XvR+YymlzP1ofWqES1JkHtI250LksP9z5JH+oDcrKDJezAg==",
-      "dev": true,
-      "requires": {
-        "cssnano-preset-default": "^5.2.0",
-        "lilconfig": "^2.0.3",
-        "yaml": "^1.10.2"
-      }
-    },
-    "cssnano-preset-default": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.0.tgz",
-      "integrity": "sha512-3N5Vcptj2pqVKpHVqH6ezOJvqikR2PdLTbTrsrhF61FbLRQuujAqZ2sKN5rvcMsb7hFjrNnjZT8CGEkxoN/Pwg==",
-      "dev": true,
-      "requires": {
-        "css-declaration-sorter": "^6.0.3",
-        "cssnano-utils": "^3.1.0",
-        "postcss-calc": "^8.2.3",
-        "postcss-colormin": "^5.3.0",
-        "postcss-convert-values": "^5.1.0",
-        "postcss-discard-comments": "^5.1.0",
-        "postcss-discard-duplicates": "^5.1.0",
-        "postcss-discard-empty": "^5.1.0",
-        "postcss-discard-overridden": "^5.1.0",
-        "postcss-merge-longhand": "^5.1.0",
-        "postcss-merge-rules": "^5.1.0",
-        "postcss-minify-font-values": "^5.1.0",
-        "postcss-minify-gradients": "^5.1.0",
-        "postcss-minify-params": "^5.1.0",
-        "postcss-minify-selectors": "^5.2.0",
-        "postcss-normalize-charset": "^5.1.0",
-        "postcss-normalize-display-values": "^5.1.0",
-        "postcss-normalize-positions": "^5.1.0",
-        "postcss-normalize-repeat-style": "^5.1.0",
-        "postcss-normalize-string": "^5.1.0",
-        "postcss-normalize-timing-functions": "^5.1.0",
-        "postcss-normalize-unicode": "^5.1.0",
-        "postcss-normalize-url": "^5.1.0",
-        "postcss-normalize-whitespace": "^5.1.0",
-        "postcss-ordered-values": "^5.1.0",
-        "postcss-reduce-initial": "^5.1.0",
-        "postcss-reduce-transforms": "^5.1.0",
-        "postcss-svgo": "^5.1.0",
-        "postcss-unique-selectors": "^5.1.0"
-      }
-    },
-    "cssnano-utils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
-      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
-      "dev": true,
-      "requires": {}
     },
     "csso": {
       "version": "4.2.0",
@@ -52039,9 +52892,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.19",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
-      "integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==",
+      "version": "2.6.20",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
+      "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==",
       "dev": true
     },
     "cwebp-bin": {
@@ -53119,9 +53972,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.75",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.75.tgz",
-      "integrity": "sha512-LxgUNeu3BVU7sXaKjUDD9xivocQLxFtq6wgERrutdY/yIOps3ODOZExK1jg8DTEg4U8TUCb5MLGeWFOYuxjF3Q==",
+      "version": "1.4.76",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.76.tgz",
+      "integrity": "sha512-3Vftv7cenJtQb+k00McEBZ2vVmZ/x+HEF7pcZONZIkOsESqAqVuACmBxMv0JhzX7u0YltU0vSqRqgBSTAhFUjA==",
       "dev": true
     },
     "element-resize-detector": {
@@ -53217,9 +54070,9 @@
       }
     },
     "enhanced-resolve": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.1.tgz",
-      "integrity": "sha512-jdyZMwCQ5Oj4c5+BTnkxPgDZO/BJzh/ADDmKebayyzNwjVX1AFCeGkOfxNx0mHi2+8BKC5VxUYiw3TIvoT7vhw==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.2.tgz",
+      "integrity": "sha512-GIm3fQfwLJ8YZx2smuHpBKkXC1yOk+OBEmKckVyL0i/ea8mqDEykK3ld5dgH1QYPNyT/lIllxV2LULnxCHaHkA==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.4",
@@ -54392,40 +55245,6 @@
         "flat-cache": "^3.0.4"
       }
     },
-    "file-loader": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
-      "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0"
-      },
-      "dependencies": {
-        "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-          "dev": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        },
-        "schema-utils": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.8",
-            "ajv": "^6.12.5",
-            "ajv-keywords": "^3.5.2"
-          }
-        }
-      }
-    },
     "file-system-cache": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/file-system-cache/-/file-system-cache-1.0.5.tgz",
@@ -54878,9 +55697,9 @@
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
     },
     "fraction.js": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.3.tgz",
-      "integrity": "sha512-pUHWWt6vHzZZiQJcM6S/0PXfS+g6FM4BF5rj9wZyreivhQPdsh5PpE25VtSNxq80wHS5RfY51Ii+8Z0Zl/pmzg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
+      "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
       "dev": true
     },
     "fragment-cache": {
@@ -55565,6 +56384,14 @@
         "form-data": "^3.0.0"
       }
     },
+    "graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
     "gzip-size": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
@@ -56069,9 +56896,9 @@
       }
     },
     "http-parser-js": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.5.tgz",
-      "integrity": "sha512-x+JVEkO2PoM8qqpbPbOL3cqHPwerep7OwzK7Ay+sMQjKzaKCqWvjoXm5tqMP9tXWWTnTzAjIhXg+J99XYuPhPA==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.6.tgz",
+      "integrity": "sha512-vDlkRPDJn93swjcjqMSaGSPABbIarsr1TLAui/gLDXzV5VsJNdXNzMYDyNBLQkjWQCJ1uizu8T2oDMhmGt0PRA==",
       "dev": true
     },
     "http-proxy": {
@@ -56144,11 +56971,37 @@
       }
     },
     "icss-utils": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
+      "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
       "dev": true,
-      "requires": {}
+      "requires": {
+        "postcss": "^7.0.14"
+      },
+      "dependencies": {
+        "picocolors": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+          "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+          "dev": true
+        },
+        "postcss": {
+          "version": "7.0.39",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+          "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+          "dev": true,
+          "requires": {
+            "picocolors": "^0.2.1",
+            "source-map": "^0.6.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
     },
     "idb": {
       "version": "7.0.0",
@@ -57419,73 +58272,37 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+        "jest-config": {
+          "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.5.1.tgz",
+          "integrity": "sha512-5sAsjm6tGdsVbW9ahcChPAFCk4IlkQUknH5AvKjuLTSlcO/wCZKyFdn7Rg0EkC+OGgWODEy2hDpWB1PgzH0JNA==",
           "dev": true,
           "requires": {
-            "has-flag": "^4.0.0"
+            "@babel/core": "^7.8.0",
+            "@jest/test-sequencer": "^27.5.1",
+            "@jest/types": "^27.5.1",
+            "babel-jest": "^27.5.1",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "deepmerge": "^4.2.2",
+            "glob": "^7.1.1",
+            "graceful-fs": "^4.2.9",
+            "jest-circus": "^27.5.1",
+            "jest-environment-jsdom": "^27.5.1",
+            "jest-environment-node": "^27.5.1",
+            "jest-get-type": "^27.5.1",
+            "jest-jasmine2": "^27.5.1",
+            "jest-regex-util": "^27.5.1",
+            "jest-resolve": "^27.5.1",
+            "jest-runner": "^27.5.1",
+            "jest-util": "^27.5.1",
+            "jest-validate": "^27.5.1",
+            "micromatch": "^4.0.4",
+            "parse-json": "^5.2.0",
+            "pretty-format": "^27.5.1",
+            "slash": "^3.0.0",
+            "strip-json-comments": "^3.1.1"
           }
-        }
-      }
-    },
-    "jest-config": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.5.1.tgz",
-      "integrity": "sha512-5sAsjm6tGdsVbW9ahcChPAFCk4IlkQUknH5AvKjuLTSlcO/wCZKyFdn7Rg0EkC+OGgWODEy2hDpWB1PgzH0JNA==",
-      "dev": true,
-      "requires": {
-        "@babel/core": "^7.8.0",
-        "@jest/test-sequencer": "^27.5.1",
-        "@jest/types": "^27.5.1",
-        "babel-jest": "^27.5.1",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "deepmerge": "^4.2.2",
-        "glob": "^7.1.1",
-        "graceful-fs": "^4.2.9",
-        "jest-circus": "^27.5.1",
-        "jest-environment-jsdom": "^27.5.1",
-        "jest-environment-node": "^27.5.1",
-        "jest-get-type": "^27.5.1",
-        "jest-jasmine2": "^27.5.1",
-        "jest-regex-util": "^27.5.1",
-        "jest-resolve": "^27.5.1",
-        "jest-runner": "^27.5.1",
-        "jest-util": "^27.5.1",
-        "jest-validate": "^27.5.1",
-        "micromatch": "^4.0.4",
-        "parse-json": "^5.2.0",
-        "pretty-format": "^27.5.1",
-        "slash": "^3.0.0",
-        "strip-json-comments": "^3.1.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
@@ -59103,12 +59920,12 @@
       "dev": true
     },
     "magic-string": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
       "dev": true,
       "requires": {
-        "sourcemap-codec": "^1.4.4"
+        "sourcemap-codec": "^1.4.8"
       }
     },
     "make-dir": {
@@ -59178,9 +59995,9 @@
       "dev": true
     },
     "markdown-to-jsx": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.6.tgz",
-      "integrity": "sha512-1wrIGZYwIG2gR3yfRmbr4FlQmhaAKoKTpRo4wur4fp9p0njU1Hi7vR8fj0AUKKIcPduiJmPprzmCB5B/GvlC7g==",
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.7.tgz",
+      "integrity": "sha512-VI3TyyHlGkO8uFle0IOibzpO1c1iJDcXcS/zBrQrXQQvJ2tpdwVzVZ7XdKsyRz1NdRmre4dqQkMZzUHaKIG/1w==",
       "dev": true,
       "requires": {}
     },
@@ -60047,10 +60864,61 @@
       "dev": true
     },
     "normalize-url": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+      "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "prepend-http": "^2.0.0",
+        "query-string": "^5.0.1",
+        "sort-keys": "^2.0.0"
+      },
+      "dependencies": {
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+          "dev": true,
+          "optional": true
+        },
+        "prepend-http": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+          "dev": true,
+          "optional": true
+        },
+        "query-string": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+          "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "decode-uri-component": "^0.2.0",
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
+        },
+        "sort-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+          "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-plain-obj": "^1.0.0"
+          }
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "npm-conf": {
       "version": "1.1.3",
@@ -61064,154 +61932,6 @@
         "source-map-js": "^1.0.2"
       }
     },
-    "postcss-attribute-case-insensitive": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-5.0.0.tgz",
-      "integrity": "sha512-b4g9eagFGq9T5SWX4+USfVyjIb3liPnjhHHRMP7FMB2kFVpYyfEscV0wP3eaXhKlcHKUut8lt5BGoeylWA/dBQ==",
-      "dev": true,
-      "requires": {
-        "postcss-selector-parser": "^6.0.2"
-      }
-    },
-    "postcss-calc": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-8.2.4.tgz",
-      "integrity": "sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==",
-      "dev": true,
-      "requires": {
-        "postcss-selector-parser": "^6.0.9",
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "postcss-color-functional-notation": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-4.2.2.tgz",
-      "integrity": "sha512-DXVtwUhIk4f49KK5EGuEdgx4Gnyj6+t2jBSEmxvpIK9QI40tWrpS2Pua8Q7iIZWBrki2QOaeUdEaLPPa91K0RQ==",
-      "dev": true,
-      "requires": {
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "postcss-color-hex-alpha": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-8.0.3.tgz",
-      "integrity": "sha512-fESawWJCrBV035DcbKRPAVmy21LpoyiXdPTuHUfWJ14ZRjY7Y7PA6P4g8z6LQGYhU1WAxkTxjIjurXzoe68Glw==",
-      "dev": true,
-      "requires": {
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "postcss-color-rebeccapurple": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-7.0.2.tgz",
-      "integrity": "sha512-SFc3MaocHaQ6k3oZaFwH8io6MdypkUtEy/eXzXEB1vEQlO3S3oDc/FSZA8AsS04Z25RirQhlDlHLh3dn7XewWw==",
-      "dev": true,
-      "requires": {
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "postcss-colormin": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.3.0.tgz",
-      "integrity": "sha512-WdDO4gOFG2Z8n4P8TWBpshnL3JpmNmJwdnfP2gbk2qBA8PWwOYcmjmI/t3CmMeL72a7Hkd+x/Mg9O2/0rD54Pg==",
-      "dev": true,
-      "requires": {
-        "browserslist": "^4.16.6",
-        "caniuse-api": "^3.0.0",
-        "colord": "^2.9.1",
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "postcss-convert-values": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.0.tgz",
-      "integrity": "sha512-GkyPbZEYJiWtQB0KZ0X6qusqFHUepguBCNFi9t5JJc7I2OTXG7C0twbTLvCfaKOLl3rSXmpAwV7W5txd91V84g==",
-      "dev": true,
-      "requires": {
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "postcss-custom-media": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-8.0.0.tgz",
-      "integrity": "sha512-FvO2GzMUaTN0t1fBULDeIvxr5IvbDXcIatt6pnJghc736nqNgsGao5NT+5+WVLAQiTt6Cb3YUms0jiPaXhL//g==",
-      "dev": true,
-      "requires": {}
-    },
-    "postcss-custom-properties": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-12.1.4.tgz",
-      "integrity": "sha512-i6AytuTCoDLJkWN/MtAIGriJz3j7UX6bV7Z5t+KgFz+dwZS15/mlTJY1S0kRizlk6ba0V8u8hN50Fz5Nm7tdZw==",
-      "dev": true,
-      "requires": {
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "postcss-custom-selectors": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-6.0.0.tgz",
-      "integrity": "sha512-/1iyBhz/W8jUepjGyu7V1OPcGbc636snN1yXEQCinb6Bwt7KxsiU7/bLQlp8GwAXzCh7cobBU5odNn/2zQWR8Q==",
-      "dev": true,
-      "requires": {
-        "postcss-selector-parser": "^6.0.4"
-      }
-    },
-    "postcss-dir-pseudo-class": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-6.0.4.tgz",
-      "integrity": "sha512-I8epwGy5ftdzNWEYok9VjW9whC4xnelAtbajGv4adql4FIF09rnrxnA9Y8xSHN47y7gqFIv10C5+ImsLeJpKBw==",
-      "dev": true,
-      "requires": {
-        "postcss-selector-parser": "^6.0.9"
-      }
-    },
-    "postcss-discard-comments": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.0.tgz",
-      "integrity": "sha512-L0IKF4jAshRyn03SkEO6ar/Ipz2oLywVbg2THf2EqqdNkBwmVMxuTR/RoAltOw4piiaLt3gCAdrbAqmTBInmhg==",
-      "dev": true,
-      "requires": {}
-    },
-    "postcss-discard-duplicates": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
-      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
-      "dev": true,
-      "requires": {}
-    },
-    "postcss-discard-empty": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.0.tgz",
-      "integrity": "sha512-782T/buGgb3HOuHOJAHpdyKzAAKsv/BxWqsutnZ+QsiHEcDkY7v+6WWdturuBiSal6XMOO1p1aJvwXdqLD5vhA==",
-      "dev": true,
-      "requires": {}
-    },
-    "postcss-discard-overridden": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
-      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
-      "dev": true,
-      "requires": {}
-    },
-    "postcss-double-position-gradients": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-3.1.0.tgz",
-      "integrity": "sha512-oz73I08yMN3oxjj0s8mED1rG+uOYoK3H8N9RjQofyg52KBRNmePJKg3fVwTpL2U5ZFbCzXoZBsUD/CvZdlqE4Q==",
-      "dev": true,
-      "requires": {
-        "@csstools/postcss-progressive-custom-properties": "^1.1.0",
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "postcss-env-function": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-env-function/-/postcss-env-function-4.0.5.tgz",
-      "integrity": "sha512-gPUJc71ji9XKyl0WSzAalBeEA/89kU+XpffpPxSaaaZ1c48OL36r1Ep5R6+9XAPkIiDlSvVAwP4io12q/vTcvA==",
-      "dev": true,
-      "requires": {
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
     "postcss-flexbugs-fixes": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-4.2.1.tgz",
@@ -61245,64 +61965,6 @@
         }
       }
     },
-    "postcss-focus-visible": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-focus-visible/-/postcss-focus-visible-6.0.4.tgz",
-      "integrity": "sha512-QcKuUU/dgNsstIK6HELFRT5Y3lbrMLEOwG+A4s5cA+fx3A3y/JTq3X9LaOj3OC3ALH0XqyrgQIgey/MIZ8Wczw==",
-      "dev": true,
-      "requires": {
-        "postcss-selector-parser": "^6.0.9"
-      }
-    },
-    "postcss-focus-within": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-5.0.4.tgz",
-      "integrity": "sha512-vvjDN++C0mu8jz4af5d52CB184ogg/sSxAFS+oUJQq2SuCe7T5U2iIsVJtsCp2d6R4j0jr5+q3rPkBVZkXD9fQ==",
-      "dev": true,
-      "requires": {
-        "postcss-selector-parser": "^6.0.9"
-      }
-    },
-    "postcss-font-variant": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
-      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
-      "dev": true,
-      "requires": {}
-    },
-    "postcss-gap-properties": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-3.0.3.tgz",
-      "integrity": "sha512-rPPZRLPmEKgLk/KlXMqRaNkYTUpE7YC+bOIQFN5xcu1Vp11Y4faIXv6/Jpft6FMnl6YRxZqDZG0qQOW80stzxQ==",
-      "dev": true,
-      "requires": {}
-    },
-    "postcss-image-set-function": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-4.0.6.tgz",
-      "integrity": "sha512-KfdC6vg53GC+vPd2+HYzsZ6obmPqOk6HY09kttU19+Gj1nC3S3XBVEXDHxkhxTohgZqzbUb94bKXvKDnYWBm/A==",
-      "dev": true,
-      "requires": {
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "postcss-initial": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
-      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
-      "dev": true,
-      "requires": {}
-    },
-    "postcss-lab-function": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-4.1.1.tgz",
-      "integrity": "sha512-j3Z0WQCimY2tMle++YcmygnnVbt6XdnrCV1FO2IpzaCSmtTF2oO8h4ZYUA1Q+QHYroIiaWPvNHt9uBR4riCksQ==",
-      "dev": true,
-      "requires": {
-        "@csstools/postcss-progressive-custom-properties": "^1.1.0",
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
     "postcss-loader": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-6.2.1.tgz",
@@ -61325,212 +61987,147 @@
         }
       }
     },
-    "postcss-logical": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.4.tgz",
-      "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==",
-      "dev": true,
-      "requires": {}
-    },
-    "postcss-media-minmax": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
-      "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
-      "dev": true,
-      "requires": {}
-    },
     "postcss-media-query-parser": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
       "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
       "dev": true
     },
-    "postcss-merge-longhand": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.0.tgz",
-      "integrity": "sha512-Gr46srN2tsLD8fudKYoHO56RG0BLQ2nsBRnSZGY04eNBPwTeWa9KeHrbL3tOLAHyB2aliikycPH2TMJG1U+W6g==",
-      "dev": true,
-      "requires": {
-        "postcss-value-parser": "^4.2.0",
-        "stylehacks": "^5.1.0"
-      }
-    },
-    "postcss-merge-rules": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.0.tgz",
-      "integrity": "sha512-NecukEJovQ0mG7h7xV8wbYAkXGTO3MPKnXvuiXzOKcxoOodfTTKYjeo8TMhAswlSkjcPIBlnKbSFcTuVSDaPyQ==",
-      "dev": true,
-      "requires": {
-        "browserslist": "^4.16.6",
-        "caniuse-api": "^3.0.0",
-        "cssnano-utils": "^3.1.0",
-        "postcss-selector-parser": "^6.0.5"
-      }
-    },
-    "postcss-minify-font-values": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-5.1.0.tgz",
-      "integrity": "sha512-el3mYTgx13ZAPPirSVsHqFzl+BBBDrXvbySvPGFnQcTI4iNslrPaFq4muTkLZmKlGk4gyFAYUBMH30+HurREyA==",
-      "dev": true,
-      "requires": {
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "postcss-minify-gradients": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.1.0.tgz",
-      "integrity": "sha512-J/TMLklkONn3LuL8wCwfwU8zKC1hpS6VcxFkNUNjmVt53uKqrrykR3ov11mdUYyqVMEx67slMce0tE14cE4DTg==",
-      "dev": true,
-      "requires": {
-        "colord": "^2.9.1",
-        "cssnano-utils": "^3.1.0",
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "postcss-minify-params": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.0.tgz",
-      "integrity": "sha512-q67dcts4Hct6x8+JmhBgctHkbvUsqGIg2IItenjE63iZXMbhjr7AlVZkNnKtIGt/1Wsv7p/7YzeSII6Q+KPXRg==",
-      "dev": true,
-      "requires": {
-        "browserslist": "^4.16.6",
-        "cssnano-utils": "^3.1.0",
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "postcss-minify-selectors": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.2.0.tgz",
-      "integrity": "sha512-vYxvHkW+iULstA+ctVNx0VoRAR4THQQRkG77o0oa4/mBS0OzGvvzLIvHDv/nNEM0crzN2WIyFU5X7wZhaUK3RA==",
-      "dev": true,
-      "requires": {
-        "postcss-selector-parser": "^6.0.5"
-      }
-    },
     "postcss-modules-extract-imports": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
+      "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
       "dev": true,
-      "requires": {}
+      "requires": {
+        "postcss": "^7.0.5"
+      },
+      "dependencies": {
+        "picocolors": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+          "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+          "dev": true
+        },
+        "postcss": {
+          "version": "7.0.39",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+          "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+          "dev": true,
+          "requires": {
+            "picocolors": "^0.2.1",
+            "source-map": "^0.6.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
     },
     "postcss-modules-local-by-default": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
-      "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.3.tgz",
+      "integrity": "sha512-e3xDq+LotiGesympRlKNgaJ0PCzoUIdpH0dj47iWAui/kyTgh3CiAr1qP54uodmJhl6p9rN6BoNcdEDVJx9RDw==",
       "dev": true,
       "requires": {
-        "icss-utils": "^5.0.0",
+        "icss-utils": "^4.1.1",
+        "postcss": "^7.0.32",
         "postcss-selector-parser": "^6.0.2",
         "postcss-value-parser": "^4.1.0"
+      },
+      "dependencies": {
+        "picocolors": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+          "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+          "dev": true
+        },
+        "postcss": {
+          "version": "7.0.39",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+          "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+          "dev": true,
+          "requires": {
+            "picocolors": "^0.2.1",
+            "source-map": "^0.6.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "postcss-modules-scope": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
-      "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz",
+      "integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
       "dev": true,
       "requires": {
-        "postcss-selector-parser": "^6.0.4"
+        "postcss": "^7.0.6",
+        "postcss-selector-parser": "^6.0.0"
+      },
+      "dependencies": {
+        "picocolors": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+          "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+          "dev": true
+        },
+        "postcss": {
+          "version": "7.0.39",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+          "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+          "dev": true,
+          "requires": {
+            "picocolors": "^0.2.1",
+            "source-map": "^0.6.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "postcss-modules-values": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
-      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
+      "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
       "dev": true,
       "requires": {
-        "icss-utils": "^5.0.0"
-      }
-    },
-    "postcss-nesting": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-10.1.2.tgz",
-      "integrity": "sha512-dJGmgmsvpzKoVMtDMQQG/T6FSqs6kDtUDirIfl4KnjMCiY9/ETX8jdKyCd20swSRAbUYkaBKV20pxkzxoOXLqQ==",
-      "dev": true,
-      "requires": {
-        "postcss-selector-parser": "^6.0.8"
-      }
-    },
-    "postcss-normalize-charset": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
-      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
-      "dev": true,
-      "requires": {}
-    },
-    "postcss-normalize-display-values": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-5.1.0.tgz",
-      "integrity": "sha512-WP4KIM4o2dazQXWmFaqMmcvsKmhdINFblgSeRgn8BJ6vxaMyaJkwAzpPpuvSIoG/rmX3M+IrRZEz2H0glrQNEA==",
-      "dev": true,
-      "requires": {
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "postcss-normalize-positions": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.1.0.tgz",
-      "integrity": "sha512-8gmItgA4H5xiUxgN/3TVvXRoJxkAWLW6f/KKhdsH03atg0cB8ilXnrB5PpSshwVu/dD2ZsRFQcR1OEmSBDAgcQ==",
-      "dev": true,
-      "requires": {
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "postcss-normalize-repeat-style": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.1.0.tgz",
-      "integrity": "sha512-IR3uBjc+7mcWGL6CtniKNQ4Rr5fTxwkaDHwMBDGGs1x9IVRkYIT/M4NelZWkAOBdV6v3Z9S46zqaKGlyzHSchw==",
-      "dev": true,
-      "requires": {
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "postcss-normalize-string": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-5.1.0.tgz",
-      "integrity": "sha512-oYiIJOf4T9T1N4i+abeIc7Vgm/xPCGih4bZz5Nm0/ARVJ7K6xrDlLwvwqOydvyL3RHNf8qZk6vo3aatiw/go3w==",
-      "dev": true,
-      "requires": {
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "postcss-normalize-timing-functions": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.1.0.tgz",
-      "integrity": "sha512-DOEkzJ4SAXv5xkHl0Wa9cZLF3WCBhF3o1SKVxKQAa+0pYKlueTpCgvkFAHfk+Y64ezX9+nITGrDZeVGgITJXjg==",
-      "dev": true,
-      "requires": {
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "postcss-normalize-unicode": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.0.tgz",
-      "integrity": "sha512-J6M3MizAAZ2dOdSjy2caayJLQT8E8K9XjLce8AUQMwOrCvjCHv24aLC/Lps1R1ylOfol5VIDMaM/Lo9NGlk1SQ==",
-      "dev": true,
-      "requires": {
-        "browserslist": "^4.16.6",
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "postcss-normalize-url": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.1.0.tgz",
-      "integrity": "sha512-5upGeDO+PVthOxSmds43ZeMeZfKH+/DKgGRD7TElkkyS46JXAUhMzIKiCa7BabPeIy3AQcTkXwVVN7DbqsiCew==",
-      "dev": true,
-      "requires": {
-        "normalize-url": "^6.0.1",
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "postcss-normalize-whitespace": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.1.0.tgz",
-      "integrity": "sha512-7O1FanKaJkpWFyCghFzIkLhehujV/frGkdofGLwhg5upbLyGsSfiTcZAdSzoPsSUgyPCkBkNMeWR8yVgPdQybg==",
-      "dev": true,
-      "requires": {
-        "postcss-value-parser": "^4.2.0"
+        "icss-utils": "^4.0.0",
+        "postcss": "^7.0.6"
+      },
+      "dependencies": {
+        "picocolors": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+          "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+          "dev": true
+        },
+        "postcss": {
+          "version": "7.0.39",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+          "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+          "dev": true,
+          "requires": {
+            "picocolors": "^0.2.1",
+            "source-map": "^0.6.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "postcss-opacity-percentage": {
@@ -61538,39 +62135,6 @@
       "resolved": "https://registry.npmjs.org/postcss-opacity-percentage/-/postcss-opacity-percentage-1.1.2.tgz",
       "integrity": "sha512-lyUfF7miG+yewZ8EAk9XUBIlrHyUE6fijnesuz+Mj5zrIHIEw6KcIZSOk/elVMqzLvREmXB83Zi/5QpNRYd47w==",
       "dev": true
-    },
-    "postcss-ordered-values": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.1.0.tgz",
-      "integrity": "sha512-wU4Z4D4uOIH+BUKkYid36gGDJNQtkVJT7Twv8qH6UyfttbbJWyw4/xIPuVEkkCtQLAJ0EdsNSh8dlvqkXb49TA==",
-      "dev": true,
-      "requires": {
-        "cssnano-utils": "^3.1.0",
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "postcss-overflow-shorthand": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-3.0.3.tgz",
-      "integrity": "sha512-CxZwoWup9KXzQeeIxtgOciQ00tDtnylYIlJBBODqkgS/PU2jISuWOL/mYLHmZb9ZhZiCaNKsCRiLp22dZUtNsg==",
-      "dev": true,
-      "requires": {}
-    },
-    "postcss-page-break": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
-      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
-      "dev": true,
-      "requires": {}
-    },
-    "postcss-place": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-place/-/postcss-place-7.0.4.tgz",
-      "integrity": "sha512-MrgKeiiu5OC/TETQO45kV3npRjOFxEHthsqGtkh3I1rPbZSbXGD/lZVi9j13cYh+NA8PIAPyk6sGjT9QbRyvSg==",
-      "dev": true,
-      "requires": {
-        "postcss-value-parser": "^4.2.0"
-      }
     },
     "postcss-preset-env": {
       "version": "7.4.2",
@@ -61620,71 +62184,347 @@
         "postcss-replace-overflow-wrap": "^4.0.0",
         "postcss-selector-not": "^5.0.0",
         "postcss-value-parser": "^4.2.0"
+      },
+      "dependencies": {
+        "@csstools/postcss-color-function": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-1.0.2.tgz",
+          "integrity": "sha512-uayvFqfa0hITPwVduxRYNL9YBD/anTqula0tu2llalaxblEd7QPuETSN3gB5PvTYxSfd0d8kS4Fypgo5JaUJ6A==",
+          "dev": true,
+          "requires": {
+            "@csstools/postcss-progressive-custom-properties": "^1.1.0",
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "@csstools/postcss-font-format-keywords": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@csstools/postcss-font-format-keywords/-/postcss-font-format-keywords-1.0.0.tgz",
+          "integrity": "sha512-oO0cZt8do8FdVBX8INftvIA4lUrKUSCcWUf9IwH9IPWOgKT22oAZFXeHLoDK7nhB2SmkNycp5brxfNMRLIhd6Q==",
+          "dev": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "@csstools/postcss-hwb-function": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@csstools/postcss-hwb-function/-/postcss-hwb-function-1.0.0.tgz",
+          "integrity": "sha512-VSTd7hGjmde4rTj1rR30sokY3ONJph1reCBTUXqeW1fKwETPy1x4t/XIeaaqbMbC5Xg4SM/lyXZ2S8NELT2TaA==",
+          "dev": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "@csstools/postcss-ic-unit": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@csstools/postcss-ic-unit/-/postcss-ic-unit-1.0.0.tgz",
+          "integrity": "sha512-i4yps1mBp2ijrx7E96RXrQXQQHm6F4ym1TOD0D69/sjDjZvQ22tqiEvaNw7pFZTUO5b9vWRHzbHzP9+UKuw+bA==",
+          "dev": true,
+          "requires": {
+            "@csstools/postcss-progressive-custom-properties": "^1.1.0",
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "@csstools/postcss-is-pseudo-class": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-2.0.1.tgz",
+          "integrity": "sha512-Og5RrTzwFhrKoA79c3MLkfrIBYmwuf/X83s+JQtz/Dkk/MpsaKtqHV1OOzYkogQ+tj3oYp5Mq39XotBXNqVc3Q==",
+          "dev": true,
+          "requires": {
+            "postcss-selector-parser": "^6.0.9"
+          }
+        },
+        "@csstools/postcss-normalize-display-values": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-1.0.0.tgz",
+          "integrity": "sha512-bX+nx5V8XTJEmGtpWTO6kywdS725t71YSLlxWt78XoHUbELWgoCXeOFymRJmL3SU1TLlKSIi7v52EWqe60vJTQ==",
+          "dev": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "@csstools/postcss-oklab-function": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@csstools/postcss-oklab-function/-/postcss-oklab-function-1.0.1.tgz",
+          "integrity": "sha512-Bnly2FWWSTZX20hDJLYHpurhp1ot+ZGvojLOsrHa9frzOVruOv4oPYMZ6wQomi9KsbZZ+Af/CuRYaGReTyGtEg==",
+          "dev": true,
+          "requires": {
+            "@csstools/postcss-progressive-custom-properties": "^1.1.0",
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "@csstools/postcss-progressive-custom-properties": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@csstools/postcss-progressive-custom-properties/-/postcss-progressive-custom-properties-1.3.0.tgz",
+          "integrity": "sha512-ASA9W1aIy5ygskZYuWams4BzafD12ULvSypmaLJT2jvQ8G0M3I8PRQhC0h7mG0Z3LI05+agZjqSR9+K9yaQQjA==",
+          "dev": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "autoprefixer": {
+          "version": "10.4.2",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.2.tgz",
+          "integrity": "sha512-9fOPpHKuDW1w/0EKfRmVnxTDt8166MAnLI3mgZ1JCnhNtYWxcJ6Ud5CO/AVOZi/AvFa8DY9RTy3h3+tFBlrrdQ==",
+          "dev": true,
+          "requires": {
+            "browserslist": "^4.19.1",
+            "caniuse-lite": "^1.0.30001297",
+            "fraction.js": "^4.1.2",
+            "normalize-range": "^0.1.2",
+            "picocolors": "^1.0.0",
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "css-blank-pseudo": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-3.0.3.tgz",
+          "integrity": "sha512-VS90XWtsHGqoM0t4KpH053c4ehxZ2E6HtGI7x68YFV0pTo/QmkV/YFA+NnlvK8guxZVNWGQhVNJGC39Q8XF4OQ==",
+          "dev": true,
+          "requires": {
+            "postcss-selector-parser": "^6.0.9"
+          }
+        },
+        "css-has-pseudo": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-3.0.4.tgz",
+          "integrity": "sha512-Vse0xpR1K9MNlp2j5w1pgWIJtm1a8qS0JwS9goFYcImjlHEmywP9VUF05aGBXzGpDJF86QXk4L0ypBmwPhGArw==",
+          "dev": true,
+          "requires": {
+            "postcss-selector-parser": "^6.0.9"
+          }
+        },
+        "css-prefers-color-scheme": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.3.tgz",
+          "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==",
+          "dev": true,
+          "requires": {}
+        },
+        "postcss-attribute-case-insensitive": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-5.0.0.tgz",
+          "integrity": "sha512-b4g9eagFGq9T5SWX4+USfVyjIb3liPnjhHHRMP7FMB2kFVpYyfEscV0wP3eaXhKlcHKUut8lt5BGoeylWA/dBQ==",
+          "dev": true,
+          "requires": {
+            "postcss-selector-parser": "^6.0.2"
+          }
+        },
+        "postcss-color-functional-notation": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-4.2.2.tgz",
+          "integrity": "sha512-DXVtwUhIk4f49KK5EGuEdgx4Gnyj6+t2jBSEmxvpIK9QI40tWrpS2Pua8Q7iIZWBrki2QOaeUdEaLPPa91K0RQ==",
+          "dev": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-color-hex-alpha": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-8.0.3.tgz",
+          "integrity": "sha512-fESawWJCrBV035DcbKRPAVmy21LpoyiXdPTuHUfWJ14ZRjY7Y7PA6P4g8z6LQGYhU1WAxkTxjIjurXzoe68Glw==",
+          "dev": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-color-rebeccapurple": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-7.0.2.tgz",
+          "integrity": "sha512-SFc3MaocHaQ6k3oZaFwH8io6MdypkUtEy/eXzXEB1vEQlO3S3oDc/FSZA8AsS04Z25RirQhlDlHLh3dn7XewWw==",
+          "dev": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-custom-media": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-8.0.0.tgz",
+          "integrity": "sha512-FvO2GzMUaTN0t1fBULDeIvxr5IvbDXcIatt6pnJghc736nqNgsGao5NT+5+WVLAQiTt6Cb3YUms0jiPaXhL//g==",
+          "dev": true,
+          "requires": {}
+        },
+        "postcss-custom-properties": {
+          "version": "12.1.4",
+          "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-12.1.4.tgz",
+          "integrity": "sha512-i6AytuTCoDLJkWN/MtAIGriJz3j7UX6bV7Z5t+KgFz+dwZS15/mlTJY1S0kRizlk6ba0V8u8hN50Fz5Nm7tdZw==",
+          "dev": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-custom-selectors": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-6.0.0.tgz",
+          "integrity": "sha512-/1iyBhz/W8jUepjGyu7V1OPcGbc636snN1yXEQCinb6Bwt7KxsiU7/bLQlp8GwAXzCh7cobBU5odNn/2zQWR8Q==",
+          "dev": true,
+          "requires": {
+            "postcss-selector-parser": "^6.0.4"
+          }
+        },
+        "postcss-dir-pseudo-class": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-6.0.4.tgz",
+          "integrity": "sha512-I8epwGy5ftdzNWEYok9VjW9whC4xnelAtbajGv4adql4FIF09rnrxnA9Y8xSHN47y7gqFIv10C5+ImsLeJpKBw==",
+          "dev": true,
+          "requires": {
+            "postcss-selector-parser": "^6.0.9"
+          }
+        },
+        "postcss-double-position-gradients": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-3.1.1.tgz",
+          "integrity": "sha512-jM+CGkTs4FcG53sMPjrrGE0rIvLDdCrqMzgDC5fLI7JHDO7o6QG8C5TQBtExb13hdBdoH9C2QVbG4jo2y9lErQ==",
+          "dev": true,
+          "requires": {
+            "@csstools/postcss-progressive-custom-properties": "^1.1.0",
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-env-function": {
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/postcss-env-function/-/postcss-env-function-4.0.5.tgz",
+          "integrity": "sha512-gPUJc71ji9XKyl0WSzAalBeEA/89kU+XpffpPxSaaaZ1c48OL36r1Ep5R6+9XAPkIiDlSvVAwP4io12q/vTcvA==",
+          "dev": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-focus-visible": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/postcss-focus-visible/-/postcss-focus-visible-6.0.4.tgz",
+          "integrity": "sha512-QcKuUU/dgNsstIK6HELFRT5Y3lbrMLEOwG+A4s5cA+fx3A3y/JTq3X9LaOj3OC3ALH0XqyrgQIgey/MIZ8Wczw==",
+          "dev": true,
+          "requires": {
+            "postcss-selector-parser": "^6.0.9"
+          }
+        },
+        "postcss-focus-within": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-5.0.4.tgz",
+          "integrity": "sha512-vvjDN++C0mu8jz4af5d52CB184ogg/sSxAFS+oUJQq2SuCe7T5U2iIsVJtsCp2d6R4j0jr5+q3rPkBVZkXD9fQ==",
+          "dev": true,
+          "requires": {
+            "postcss-selector-parser": "^6.0.9"
+          }
+        },
+        "postcss-font-variant": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
+          "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
+          "dev": true,
+          "requires": {}
+        },
+        "postcss-gap-properties": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-3.0.3.tgz",
+          "integrity": "sha512-rPPZRLPmEKgLk/KlXMqRaNkYTUpE7YC+bOIQFN5xcu1Vp11Y4faIXv6/Jpft6FMnl6YRxZqDZG0qQOW80stzxQ==",
+          "dev": true,
+          "requires": {}
+        },
+        "postcss-image-set-function": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-4.0.6.tgz",
+          "integrity": "sha512-KfdC6vg53GC+vPd2+HYzsZ6obmPqOk6HY09kttU19+Gj1nC3S3XBVEXDHxkhxTohgZqzbUb94bKXvKDnYWBm/A==",
+          "dev": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-initial": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
+          "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
+          "dev": true,
+          "requires": {}
+        },
+        "postcss-lab-function": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-4.1.1.tgz",
+          "integrity": "sha512-j3Z0WQCimY2tMle++YcmygnnVbt6XdnrCV1FO2IpzaCSmtTF2oO8h4ZYUA1Q+QHYroIiaWPvNHt9uBR4riCksQ==",
+          "dev": true,
+          "requires": {
+            "@csstools/postcss-progressive-custom-properties": "^1.1.0",
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-logical": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.4.tgz",
+          "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==",
+          "dev": true,
+          "requires": {}
+        },
+        "postcss-media-minmax": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
+          "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
+          "dev": true,
+          "requires": {}
+        },
+        "postcss-nesting": {
+          "version": "10.1.3",
+          "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-10.1.3.tgz",
+          "integrity": "sha512-wUC+/YCik4wH3StsbC5fBG1s2Z3ZV74vjGqBFYtmYKlVxoio5TYGM06AiaKkQPPlkXWn72HKfS7Cw5PYxnoXSw==",
+          "dev": true,
+          "requires": {
+            "postcss-selector-parser": "^6.0.9"
+          }
+        },
+        "postcss-overflow-shorthand": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-3.0.3.tgz",
+          "integrity": "sha512-CxZwoWup9KXzQeeIxtgOciQ00tDtnylYIlJBBODqkgS/PU2jISuWOL/mYLHmZb9ZhZiCaNKsCRiLp22dZUtNsg==",
+          "dev": true,
+          "requires": {}
+        },
+        "postcss-page-break": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
+          "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
+          "dev": true,
+          "requires": {}
+        },
+        "postcss-place": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/postcss-place/-/postcss-place-7.0.4.tgz",
+          "integrity": "sha512-MrgKeiiu5OC/TETQO45kV3npRjOFxEHthsqGtkh3I1rPbZSbXGD/lZVi9j13cYh+NA8PIAPyk6sGjT9QbRyvSg==",
+          "dev": true,
+          "requires": {
+            "postcss-value-parser": "^4.2.0"
+          }
+        },
+        "postcss-pseudo-class-any-link": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-7.1.1.tgz",
+          "integrity": "sha512-JRoLFvPEX/1YTPxRxp1JO4WxBVXJYrSY7NHeak5LImwJ+VobFMwYDQHvfTXEpcn+7fYIeGkC29zYFhFWIZD8fg==",
+          "dev": true,
+          "requires": {
+            "postcss-selector-parser": "^6.0.9"
+          }
+        },
+        "postcss-replace-overflow-wrap": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
+          "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
+          "dev": true,
+          "requires": {}
+        },
+        "postcss-selector-not": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-5.0.0.tgz",
+          "integrity": "sha512-/2K3A4TCP9orP4TNS7u3tGdRFVKqz/E6pX3aGnriPG0jU78of8wsUcqE4QAhWEU0d+WnMSF93Ah3F//vUtK+iQ==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        }
       }
-    },
-    "postcss-pseudo-class-any-link": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-7.1.1.tgz",
-      "integrity": "sha512-JRoLFvPEX/1YTPxRxp1JO4WxBVXJYrSY7NHeak5LImwJ+VobFMwYDQHvfTXEpcn+7fYIeGkC29zYFhFWIZD8fg==",
-      "dev": true,
-      "requires": {
-        "postcss-selector-parser": "^6.0.9"
-      }
-    },
-    "postcss-reduce-initial": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.0.tgz",
-      "integrity": "sha512-5OgTUviz0aeH6MtBjHfbr57tml13PuedK/Ecg8szzd4XRMbYxH4572JFG067z+FqBIf6Zp/d+0581glkvvWMFw==",
-      "dev": true,
-      "requires": {
-        "browserslist": "^4.16.6",
-        "caniuse-api": "^3.0.0"
-      }
-    },
-    "postcss-reduce-transforms": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-5.1.0.tgz",
-      "integrity": "sha512-2fbdbmgir5AvpW9RLtdONx1QoYG2/EtqpNQbFASDlixBbAYuTcJ0dECwlqNqH7VbaUnEnh8SrxOe2sRIn24XyQ==",
-      "dev": true,
-      "requires": {
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "postcss-replace-overflow-wrap": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
-      "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
-      "dev": true,
-      "requires": {}
     },
     "postcss-resolve-nested-selector": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
       "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4=",
       "dev": true
-    },
-    "postcss-safe-parser": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
-      "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-      "dev": true,
-      "requires": {}
-    },
-    "postcss-scss": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.3.tgz",
-      "integrity": "sha512-j4KxzWovfdHsyxwl1BxkUal/O4uirvHgdzMKS1aWJBAV0qh2qj5qAZqpeBfVUYGWv+4iK9Az7SPyZ4fyNju1uA==",
-      "dev": true,
-      "requires": {}
-    },
-    "postcss-selector-not": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-5.0.0.tgz",
-      "integrity": "sha512-/2K3A4TCP9orP4TNS7u3tGdRFVKqz/E6pX3aGnriPG0jU78of8wsUcqE4QAhWEU0d+WnMSF93Ah3F//vUtK+iQ==",
-      "dev": true,
-      "requires": {
-        "balanced-match": "^1.0.0"
-      }
     },
     "postcss-selector-parser": {
       "version": "6.0.9",
@@ -61694,25 +62534,6 @@
       "requires": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
-      }
-    },
-    "postcss-svgo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.1.0.tgz",
-      "integrity": "sha512-D75KsH1zm5ZrHyxPakAxJWtkyXew5qwS70v56exwvw542d9CRtTo78K0WeFxZB4G7JXKKMbEZtZayTGdIky/eA==",
-      "dev": true,
-      "requires": {
-        "postcss-value-parser": "^4.2.0",
-        "svgo": "^2.7.0"
-      }
-    },
-    "postcss-unique-selectors": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.1.0.tgz",
-      "integrity": "sha512-LmUhgGobtpeVJJHuogzjLRwJlN7VH+BL5c9GKMVJSS/ejoyePZkXvNsYUtk//F6vKOGK86gfRS0xH7fXQSDtvA==",
-      "dev": true,
-      "requires": {
-        "postcss-selector-parser": "^6.0.5"
       }
     },
     "postcss-value-parser": {
@@ -62944,9 +63765,9 @@
       }
     },
     "rollup": {
-      "version": "2.69.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.69.0.tgz",
-      "integrity": "sha512-kjER91tHyek8gAkuz7+558vSnTQ+pITEok1P0aNOS45ZXyngaqPsXJmSel4QPQnJo7EJMjXUU1/GErWkWiKORg==",
+      "version": "2.70.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.0.tgz",
+      "integrity": "sha512-iEzYw+syFxQ0X9RefVwhr8BA2TNJsTaX8L8dhyeyMECDbmiba+8UQzcu+xZdji0+JQ+s7kouQnw+9Oz5M19XKA==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -64510,16 +65331,6 @@
         "inline-style-parser": "0.1.1"
       }
     },
-    "stylehacks": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.0.tgz",
-      "integrity": "sha512-SzLmvHQTrIWfSgljkQCw2++C9+Ne91d/6Sp92I8c5uHTcy/PgeHamwITIbBW9wnFTY/3ZfSXR9HIL6Ikqmcu6Q==",
-      "dev": true,
-      "requires": {
-        "browserslist": "^4.16.6",
-        "postcss-selector-parser": "^6.0.4"
-      }
-    },
     "stylelint": {
       "version": "14.5.3",
       "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.5.3.tgz",
@@ -64599,6 +65410,13 @@
           "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
           "dev": true
         },
+        "postcss-safe-parser": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
+          "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
+          "dev": true,
+          "requires": {}
+        },
         "string-width": {
           "version": "4.2.3",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -64638,6 +65456,15 @@
         "postcss-scss": "^4.0.2",
         "stylelint-config-recommended": "^6.0.0",
         "stylelint-scss": "^4.0.0"
+      },
+      "dependencies": {
+        "postcss-scss": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.3.tgz",
+          "integrity": "sha512-j4KxzWovfdHsyxwl1BxkUal/O4uirvHgdzMKS1aWJBAV0qh2qj5qAZqpeBfVUYGWv+4iK9Az7SPyZ4fyNju1uA==",
+          "dev": true,
+          "requires": {}
+        }
       }
     },
     "stylelint-scss": {
@@ -66583,6 +67410,29 @@
         "webpack-merge": "^5.7.3"
       },
       "dependencies": {
+        "@webpack-cli/configtest": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
+          "integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
+          "dev": true,
+          "requires": {}
+        },
+        "@webpack-cli/info": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.1.tgz",
+          "integrity": "sha512-PKVGmazEq3oAo46Q63tpMr4HipI3OPfP7LiNOEJg963RMgT0rqheag28NCML0o3GIzA3DmxP1ZIAv9oTX1CUIA==",
+          "dev": true,
+          "requires": {
+            "envinfo": "^7.7.3"
+          }
+        },
+        "@webpack-cli/serve": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
+          "integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
+          "dev": true,
+          "requires": {}
+        },
         "commander": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "eslint-plugin-react": "7.29.2",
     "eslint-plugin-react-hooks": "4.3.0",
     "faker": "5.5.3",
-    "file-loader": "6.2.0",
     "fork-ts-checker-webpack-plugin": "7.2.1",
     "gh-pages": "3.2.3",
     "html-webpack-plugin": "5.5.0",

--- a/src/content/app/custom-download/components/checkbox-with-selects/CheckboxWithSelects.tsx
+++ b/src/content/app/custom-download/components/checkbox-with-selects/CheckboxWithSelects.tsx
@@ -20,8 +20,8 @@ import Checkbox from 'src/shared/components/checkbox/Checkbox';
 import Select, { Option } from 'src/shared/components/select/Select';
 import ImageButton from 'src/shared/components/image-button/ImageButton';
 
-import { ReactComponent as AddIcon } from 'static/icons/icon_plus_circle.svg';
-import { ReactComponent as RemoveIcon } from 'static/icons/icon_close.svg';
+import AddIcon from 'static/icons/icon_plus_circle.svg';
+import RemoveIcon from 'static/icons/icon_close.svg';
 
 import styles from './CheckboxWithSelects.scss';
 

--- a/src/content/app/custom-download/components/checkbox-with-textfields/CheckboxWithTextfields.tsx
+++ b/src/content/app/custom-download/components/checkbox-with-textfields/CheckboxWithTextfields.tsx
@@ -21,7 +21,7 @@ import Textarea from 'src/shared/components/textarea/Textarea';
 import { Upload, FileTransformedToString } from 'src/shared/components/upload';
 import ImageButton from 'src/shared/components/image-button/ImageButton';
 
-import { ReactComponent as RemoveIcon } from 'static/icons/icon_close.svg';
+import RemoveIcon from 'static/icons/icon_close.svg';
 
 import styles from './CheckboxWithTextfields.scss';
 

--- a/src/content/app/custom-download/containers/content/attributes-accordion/AttributesAccordion.tsx
+++ b/src/content/app/custom-download/containers/content/attributes-accordion/AttributesAccordion.tsx
@@ -37,7 +37,7 @@ import {
 import BadgedButton from 'src/shared/components/badged-button/BadgedButton';
 import ImageButton from 'src/shared/components/image-button/ImageButton';
 
-import { ReactComponent as ResetIcon } from 'static/icons/icon_delete.svg';
+import ResetIcon from 'static/icons/icon_delete.svg';
 
 import AttributesAccordionSection from 'src/content/app/custom-download/containers/content/attributes-accordion/sections/AttributesAccordionSection';
 import {

--- a/src/content/app/custom-download/containers/content/filter-accordion/FiltersAccordion.tsx
+++ b/src/content/app/custom-download/containers/content/filter-accordion/FiltersAccordion.tsx
@@ -29,8 +29,6 @@ import {
 import ImageButton from 'src/shared/components/image-button/ImageButton';
 import BadgedButton from 'src/shared/components/badged-button/BadgedButton';
 
-import { ReactComponent as ResetIcon } from 'static/icons/icon_delete.svg';
-
 import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
 
 import FiltersAccordionSection from 'src/content/app/custom-download/containers/content/filter-accordion/sections/FiltersAccordionSection';
@@ -45,7 +43,9 @@ import {
 } from 'src/content/app/custom-download/state/filters/filtersSelector';
 import { getPreviewResult } from 'src/content/app/custom-download/state/customDownloadSelectors';
 
-import JSONValue from 'src/shared/types/JSON';
+import ResetIcon from 'static/icons/icon_delete.svg';
+
+import type JSONValue from 'src/shared/types/JSON';
 import { Status } from 'src/shared/types/status';
 
 import styles from './FiltersAccordion.scss';

--- a/src/content/app/entity-viewer/gene-view/components/protein-features-count/ProteinFeaturesCount.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/protein-features-count/ProteinFeaturesCount.tsx
@@ -18,11 +18,11 @@ import React from 'react';
 
 import { ProteinStats } from 'src/content/app/entity-viewer/shared/rest/rest-data-fetchers/proteinData';
 
-import structuresUrl from 'static/icons/icon_protein_structures.svg';
-import ligandsUrl from 'static/icons/icon_protein_ligands.svg';
-import interactionsUrl from 'static/icons/icon_protein_interactions.svg';
-import annotationsUrl from 'static/icons/icon_protein_annotations.svg';
-import similarProteinsUrl from 'static/icons/icon_protein_similar.svg';
+import structuresUrl from 'static/icons/icon_protein_structures.svg?url';
+import ligandsUrl from 'static/icons/icon_protein_ligands.svg?url';
+import interactionsUrl from 'static/icons/icon_protein_interactions.svg?url';
+import annotationsUrl from 'static/icons/icon_protein_annotations.svg?url';
+import similarProteinsUrl from 'static/icons/icon_protein_similar.svg?url';
 
 import styles from './ProteinFeaturesCount.scss';
 

--- a/src/content/app/entity-viewer/interstitial/entity-viewer-interstitial-instructions/EntityViewerInterstitialInstructions.tsx
+++ b/src/content/app/entity-viewer/interstitial/entity-viewer-interstitial-instructions/EntityViewerInterstitialInstructions.tsx
@@ -26,7 +26,7 @@ import {
   EntityViewerIcon
 } from 'src/shared/components/app-icon';
 
-import { ReactComponent as SearchIcon } from 'static/icons/icon_search.svg';
+import SearchIcon from 'static/icons/icon_search.svg';
 
 import styles from './EntityViewerInterstitialInstructions.scss';
 

--- a/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-toolstrip/EntityViewerSidebarToolstrip.tsx
+++ b/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-toolstrip/EntityViewerSidebarToolstrip.tsx
@@ -34,10 +34,10 @@ import { SidebarModalView } from 'src/content/app/entity-viewer/state/sidebar/en
 
 import ImageButton from 'src/shared/components/image-button/ImageButton';
 
-import { ReactComponent as searchIcon } from 'static/icons/icon_search.svg';
-import { ReactComponent as bookmarkIcon } from 'static/icons/icon_bookmark.svg';
-import { ReactComponent as shareIcon } from 'static/icons/icon_share.svg';
-import { ReactComponent as downloadIcon } from 'static/icons/icon_download.svg';
+import SearchIcon from 'static/icons/icon_search.svg';
+import BookmarkIcon from 'static/icons/icon_bookmark.svg';
+import ShareIcon from 'static/icons/icon_share.svg';
+import DownloadIcon from 'static/icons/icon_download.svg';
 
 import { Status } from 'src/shared/types/status';
 
@@ -78,7 +78,7 @@ export const EntityViewerSidebarToolstrip = () => {
         description="Search"
         className={styles.sidebarIcon}
         onClick={() => toggleModalView(SidebarModalView.SEARCH)}
-        image={searchIcon}
+        image={SearchIcon}
       />
       <ImageButton
         status={getViewIconStatus(SidebarModalView.BOOKMARKS)}
@@ -86,7 +86,7 @@ export const EntityViewerSidebarToolstrip = () => {
         className={styles.sidebarIcon}
         key={SidebarModalView.BOOKMARKS}
         onClick={() => toggleModalView(SidebarModalView.BOOKMARKS)}
-        image={bookmarkIcon}
+        image={BookmarkIcon}
       />
       <ImageButton
         status={Status.DISABLED}
@@ -94,14 +94,14 @@ export const EntityViewerSidebarToolstrip = () => {
         className={styles.sidebarIcon}
         key="share"
         onClick={noop}
-        image={shareIcon}
+        image={ShareIcon}
       />
       <ImageButton
         status={getViewIconStatus(SidebarModalView.DOWNLOADS)}
         description="Download"
         className={styles.sidebarIcon}
         onClick={() => toggleModalView(SidebarModalView.DOWNLOADS)}
-        image={downloadIcon}
+        image={DownloadIcon}
       />
     </>
   );

--- a/src/content/app/genome-browser/components/browser-cog/BrowserCog.tsx
+++ b/src/content/app/genome-browser/components/browser-cog/BrowserCog.tsx
@@ -23,7 +23,7 @@ import BrowserTrackConfig from '../browser-track-config/BrowserTrackConfig';
 import CloseButton from 'src/shared/components/close-button/CloseButton';
 import ImageButton from 'src/shared/components/image-button/ImageButton';
 
-import { ReactComponent as cogIcon } from 'static/icons/icon_settings.svg';
+import CogIcon from 'static/icons/icon_settings.svg';
 
 import styles from './BrowserCogList.scss';
 
@@ -62,7 +62,7 @@ const BrowserCog = (props: BrowserCogProps) => {
 
   const cogIconConfig = {
     description: 'Configure Track',
-    icon: cogIcon
+    icon: CogIcon
   };
 
   const [showTrackConfig, setTrackConfigAnimation] = useState(cogActivated);

--- a/src/content/app/genome-browser/components/browser-nav/browserNavConfig.ts
+++ b/src/content/app/genome-browser/components/browser-nav/browserNavConfig.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { ReactComponent as zoomInIcon } from 'static/icons/icon_plus_circle.svg';
-import { ReactComponent as zoomOutIcon } from 'static/icons/icon_minus_circle.svg';
-import { ReactComponent as navigateUpIcon } from 'static/icons/navigate-up.svg';
-import { ReactComponent as navigateDownIcon } from 'static/icons/navigate-down.svg';
-import { ReactComponent as navigateLeftIcon } from 'static/icons/navigate-left.svg';
-import { ReactComponent as navigateRightIcon } from 'static/icons/navigate-right.svg';
+import ZoomInIcon from 'static/icons/icon_plus_circle.svg';
+import ZoomOutIcon from 'static/icons/icon_minus_circle.svg';
+import NavigateUpIcon from 'static/icons/navigate-up.svg';
+import NavigateDownIcon from 'static/icons/navigate-down.svg';
+import NavigateLeftIcon from 'static/icons/navigate-left.svg';
+import NavigateRightIcon from 'static/icons/navigate-right.svg';
 
 import { BrowserNavAction } from 'src/content/app/genome-browser/state/browser-nav/browserNavSlice';
 
@@ -38,7 +38,7 @@ export const browserNavConfig: BrowserNavItem[] = [
     detail: {
       move_up_px: 50
     },
-    icon: navigateUpIcon,
+    icon: NavigateUpIcon,
     name: BrowserNavAction.MOVE_UP
   },
   {
@@ -46,7 +46,7 @@ export const browserNavConfig: BrowserNavItem[] = [
     detail: {
       move_down_px: 50
     },
-    icon: navigateDownIcon,
+    icon: NavigateDownIcon,
     name: BrowserNavAction.MOVE_DOWN
   },
   {
@@ -54,7 +54,7 @@ export const browserNavConfig: BrowserNavItem[] = [
     detail: {
       zoom_by: -0.3
     },
-    icon: zoomOutIcon,
+    icon: ZoomOutIcon,
     name: BrowserNavAction.ZOOM_OUT
   },
   {
@@ -62,7 +62,7 @@ export const browserNavConfig: BrowserNavItem[] = [
     detail: {
       zoom_by: 0.3
     },
-    icon: zoomInIcon,
+    icon: ZoomInIcon,
     name: BrowserNavAction.ZOOM_IN
   },
   {
@@ -70,7 +70,7 @@ export const browserNavConfig: BrowserNavItem[] = [
     detail: {
       move_left_px: 50
     },
-    icon: navigateLeftIcon,
+    icon: NavigateLeftIcon,
     name: BrowserNavAction.MOVE_LEFT
   },
   {
@@ -78,7 +78,7 @@ export const browserNavConfig: BrowserNavItem[] = [
     detail: {
       move_right_px: 50
     },
-    icon: navigateRightIcon,
+    icon: NavigateRightIcon,
     name: BrowserNavAction.MOVE_RIGHT
   }
 ];

--- a/src/content/app/genome-browser/components/browser-region-editor/BrowserRegionEditor.tsx
+++ b/src/content/app/genome-browser/components/browser-region-editor/BrowserRegionEditor.tsx
@@ -53,7 +53,7 @@ import analyticsTracking from 'src/services/analytics-service';
 import { GenomeKaryotypeItem } from 'src/shared/state/genome/genomeTypes';
 import { Position } from 'src/shared/components/pointer-box/PointerBox';
 
-import applyUrl from 'static/img/shared/apply.svg';
+import applyUrl from 'static/img/shared/apply.svg?url';
 
 import styles from './BrowserRegionEditor.scss';
 import browserNavBarStyles from '../browser-nav/BrowserNavBar.scss';

--- a/src/content/app/genome-browser/components/browser-region-field/BrowserRegionField.tsx
+++ b/src/content/app/genome-browser/components/browser-region-field/BrowserRegionField.tsx
@@ -43,7 +43,7 @@ import analyticsTracking from 'src/services/analytics-service';
 import Input from 'src/shared/components/input/Input';
 import Tooltip from 'src/shared/components/tooltip/Tooltip';
 
-import applyUrl from 'static/img/shared/apply.svg';
+import applyUrl from 'static/img/shared/apply.svg?url';
 
 import styles from './BrowserRegionField.scss';
 import browserNavBarStyles from '../browser-nav/BrowserNavBar.scss';

--- a/src/content/app/genome-browser/components/browser-reset/BrowserReset.tsx
+++ b/src/content/app/genome-browser/components/browser-reset/BrowserReset.tsx
@@ -24,7 +24,7 @@ import { getIsDrawerOpened } from 'src/content/app/genome-browser/state/drawer/d
 
 import ImageButton from 'src/shared/components/image-button/ImageButton';
 
-import { ReactComponent as resetIcon } from 'static/icons/icon_reset.svg';
+import ResetIcon from 'static/icons/icon_reset.svg';
 
 import { Status } from 'src/shared/types/status';
 
@@ -53,7 +53,7 @@ export const BrowserReset = () => {
     <ImageButton
       status={getResetIconStatus()}
       description={'Reset browser image'}
-      image={resetIcon}
+      image={ResetIcon}
       onClick={handleClick}
       className={styles.resetButton}
       statusClasses={{ disabled: styles.imageButtonDisabled }}

--- a/src/content/app/genome-browser/components/interstitial/browser-interstitial-instructions/BrowserInterstitialInstructions.tsx
+++ b/src/content/app/genome-browser/components/interstitial/browser-interstitial-instructions/BrowserInterstitialInstructions.tsx
@@ -26,7 +26,7 @@ import {
   GenomeBrowserIcon
 } from 'src/shared/components/app-icon';
 
-import { ReactComponent as SearchIcon } from 'static/icons/icon_search.svg';
+import SearchIcon from 'static/icons/icon_search.svg';
 
 import styles from './BrowserInterstitialInstructions.scss';
 

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-bar/TrackPanelBar.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-bar/TrackPanelBar.tsx
@@ -34,12 +34,12 @@ import { clearSearch } from 'src/shared/state/in-app-search/inAppSearchSlice';
 
 import ImageButton from 'src/shared/components/image-button/ImageButton';
 
-import { ReactComponent as SearchIcon } from 'static/icons/icon_search.svg';
-import { ReactComponent as TracksManagerIcon } from 'static/icons/icon_sliders.svg';
-import { ReactComponent as BookmarkIcon } from 'static/icons/icon_bookmark.svg';
-import { ReactComponent as PersonalDataIcon } from 'static/icons/icon_plus_circle.svg';
-import { ReactComponent as ShareIcon } from 'static/icons/icon_share.svg';
-import { ReactComponent as DownloadIcon } from 'static/icons/icon_download.svg';
+import SearchIcon from 'static/icons/icon_search.svg';
+import TracksManagerIcon from 'static/icons/icon_sliders.svg';
+import BookmarkIcon from 'static/icons/icon_bookmark.svg';
+import PersonalDataIcon from 'static/icons/icon_plus_circle.svg';
+import ShareIcon from 'static/icons/icon_share.svg';
+import DownloadIcon from 'static/icons/icon_download.svg';
 
 import { Status } from 'src/shared/types/status';
 

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/track-panel-item-layout/SimpleTrackPanelItemLayout.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/track-panel-item-layout/SimpleTrackPanelItemLayout.tsx
@@ -29,7 +29,7 @@ import classNames from 'classnames';
 import ImageButton from 'src/shared/components/image-button/ImageButton';
 import VisibilityIcon from 'src/shared/components/visibility-icon/VisibilityIcon';
 
-import { ReactComponent as Ellipsis } from 'static/icons/icon_ellipsis.svg';
+import Ellipsis from 'static/icons/icon_ellipsis.svg';
 
 import { TrackActivityStatus } from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
 import { Status } from 'src/shared/types/status';

--- a/src/content/app/help/components/help-landing/HelpLanding.tsx
+++ b/src/content/app/help/components/help-landing/HelpLanding.tsx
@@ -22,7 +22,7 @@ import LabelledAppIcon from '../labelled-app-icon/LabelledAppIcon';
 import { Step } from 'src/shared/components/step/Step';
 import ShowHide from 'src/shared/components/show-hide/ShowHide';
 
-import { ReactComponent as SearchIcon } from 'static/icons/icon_search.svg';
+import SearchIcon from 'static/icons/icon_search.svg';
 
 import styles from './HelpLanding.scss';
 

--- a/src/content/home/Home.tsx
+++ b/src/content/home/Home.tsx
@@ -27,14 +27,14 @@ import {
   EntityViewerIcon
 } from 'src/shared/components/app-icon';
 
-import { ReactComponent as Logotype } from 'static/img/brand/logotype.svg';
+import Logotype from 'static/img/brand/logotype.svg';
 
-import speciesStripUrl from 'static/img/home/species-strip.svg';
-import ebiLogoUrl from 'static/img/home/EMBLEBI-logo.svg';
-import elixirLogoUrl from 'static/img/home/elixir-logo.svg';
-import facebookIconUrl from 'static/icons/icon_facebook.svg';
-import twitterIconUrl from 'static/icons/icon_twitter.svg';
-import blogIconUrl from 'static/icons/icon_blog.svg';
+import speciesStripUrl from 'static/img/home/species-strip.svg?url';
+import ebiLogoUrl from 'static/img/home/EMBLEBI-logo.svg?url';
+import elixirLogoUrl from 'static/img/home/elixir-logo.svg?url';
+import facebookIconUrl from 'static/icons/icon_facebook.svg?url';
+import twitterIconUrl from 'static/icons/icon_twitter.svg?url';
+import blogIconUrl from 'static/icons/icon_blog.svg?url';
 
 import styles from './Home.scss';
 

--- a/src/content/unsupported-browser/UnsupportedBrowser.tsx
+++ b/src/content/unsupported-browser/UnsupportedBrowser.tsx
@@ -19,7 +19,7 @@ import React from 'react';
 import Topbar from './components/topbar/Topbar';
 import SupportedWebBrowser from './components/supported-web-browser/SupportedWebBrowser';
 
-import unsupportedBrowsersDiagramPath from 'src/content/unsupported-browser/images/unsupported_browsers_diagram.svg';
+import unsupportedBrowsersDiagramPath from 'src/content/unsupported-browser/images/unsupported_browsers_diagram.svg?url';
 
 import styles from './UnsupportedBrowser.scss';
 

--- a/src/content/unsupported-browser/components/supported-web-browser/SupportedWebBrowser.tsx
+++ b/src/content/unsupported-browser/components/supported-web-browser/SupportedWebBrowser.tsx
@@ -16,10 +16,10 @@
 
 import React from 'react';
 
-import chromeIconPath from './icons/chrome.svg';
-import edgeIconPath from './icons/edge.svg';
-import firefoxIconPath from './icons/firefox.svg';
-import safariIconPath from './icons/safari.svg';
+import chromeIconPath from './icons/chrome.svg?url';
+import edgeIconPath from './icons/edge.svg?url';
+import firefoxIconPath from './icons/firefox.svg?url';
+import safariIconPath from './icons/safari.svg?url';
 
 import styles from './SupportedWebBrowser.scss';
 

--- a/src/content/unsupported-browser/components/topbar/Topbar.tsx
+++ b/src/content/unsupported-browser/components/topbar/Topbar.tsx
@@ -16,8 +16,8 @@
 
 import React from 'react';
 
-import { ReactComponent as Logotype } from 'static/img/brand/logotype.svg';
-import { ReactComponent as HomeIcon } from 'static/icons/icon_home.svg';
+import Logotype from 'static/img/brand/logotype.svg';
+import HomeIcon from 'static/icons/icon_home.svg';
 
 import styles from './Topbar.scss';
 

--- a/src/header/Header.tsx
+++ b/src/header/Header.tsx
@@ -21,8 +21,8 @@ import useHasMounted from 'src/shared/hooks/useHasMounted';
 
 import Launchbar from './launchbar/Launchbar';
 
-import { ReactComponent as Logotype } from 'static/img/brand/logotype.svg';
-import { ReactComponent as HomeIcon } from 'static/icons/icon_home.svg';
+import Logotype from 'static/img/brand/logotype.svg';
+import HomeIcon from 'static/icons/icon_home.svg';
 
 import styles from './Header.scss';
 

--- a/src/header/launchbar/Launchbar.tsx
+++ b/src/header/launchbar/Launchbar.tsx
@@ -18,6 +18,8 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 
+import { isEnvironment, Environment } from 'src/shared/helpers/environment';
+
 import { getEnabledCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 
 import {
@@ -31,8 +33,7 @@ import {
 } from 'src/shared/components/app-icon';
 import LaunchbarButton from './LaunchbarButton';
 
-import { ReactComponent as Logotype } from 'static/img/brand/logotype.svg';
-import { isEnvironment, Environment } from 'src/shared/helpers/environment';
+import Logotype from 'static/img/brand/logotype.svg';
 
 import styles from './Launchbar.scss';
 

--- a/src/shared/components/app-icon/BlastIcon.tsx
+++ b/src/shared/components/app-icon/BlastIcon.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { ReactComponent as SVGIcon } from 'static/icons/icon_launchbar_blast.svg';
+import SVGIcon from 'static/icons/icon_launchbar_blast.svg';
 
 import styles from './AppIcon.scss';
 

--- a/src/shared/components/app-icon/CustomDownloadIcon.tsx
+++ b/src/shared/components/app-icon/CustomDownloadIcon.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { ReactComponent as SVGIcon } from 'static/icons/icon_download.svg';
+import SVGIcon from 'static/icons/icon_download.svg';
 
 import styles from './AppIcon.scss';
 

--- a/src/shared/components/app-icon/EntityViewerIcon.tsx
+++ b/src/shared/components/app-icon/EntityViewerIcon.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { ReactComponent as SVGIcon } from 'static/icons/icon_launchbar_entity_viewer.svg';
+import SVGIcon from 'static/icons/icon_launchbar_entity_viewer.svg';
 
 import styles from './AppIcon.scss';
 

--- a/src/shared/components/app-icon/GenomeBrowserIcon.tsx
+++ b/src/shared/components/app-icon/GenomeBrowserIcon.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { ReactComponent as SVGIcon } from 'static/icons/icon_launchbar_browser.svg';
+import SVGIcon from 'static/icons/icon_launchbar_browser.svg';
 
 import styles from './AppIcon.scss';
 

--- a/src/shared/components/app-icon/GlobalSearchIcon.tsx
+++ b/src/shared/components/app-icon/GlobalSearchIcon.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { ReactComponent as SVGIcon } from 'static/icons/icon_search.svg';
+import SVGIcon from 'static/icons/icon_search.svg';
 
 import styles from './AppIcon.scss';
 

--- a/src/shared/components/app-icon/HelpIcon.tsx
+++ b/src/shared/components/app-icon/HelpIcon.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { ReactComponent as SVGIcon } from 'static/icons/icon_question.svg';
+import SVGIcon from 'static/icons/icon_question.svg';
 
 import styles from './AppIcon.scss';
 

--- a/src/shared/components/app-icon/SpeciesSelectorIcon.tsx
+++ b/src/shared/components/app-icon/SpeciesSelectorIcon.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { ReactComponent as SVGIcon } from 'static/icons/icon_launchbar_species_selector.svg';
+import SVGIcon from 'static/icons/icon_launchbar_species_selector.svg';
 
 import styles from './AppIcon.scss';
 

--- a/src/shared/components/chevron/Chevron.tsx
+++ b/src/shared/components/chevron/Chevron.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { ReactComponent as ChevronDown } from 'static/icons/icon_chevron.svg';
+import ChevronDown from 'static/icons/icon_chevron.svg';
 
 import styles from './Chevron.scss';
 

--- a/src/shared/components/close-button/CloseButton.tsx
+++ b/src/shared/components/close-button/CloseButton.tsx
@@ -17,10 +17,7 @@
 import React from 'react';
 import classNames from 'classnames';
 
-// NOTE: Remove this comment before merging
-// the shared close.svg file in static/img/shared folder has inline style with fill
-// TODO: consider moving the close.svg imported below back to shared folder when all our components use the CloseButton consistently
-import { ReactComponent as CloseIcon } from 'static/icons/icon_close.svg';
+import CloseIcon from 'static/icons/icon_close.svg';
 
 import styles from './CloseButton.scss';
 

--- a/src/shared/components/communication-framework/CommunicationPanel.tsx
+++ b/src/shared/components/communication-framework/CommunicationPanel.tsx
@@ -22,7 +22,7 @@ import Overlay from 'src/shared/components/overlay/Overlay';
 import CloseButton from 'src/shared/components/close-button/CloseButton';
 import ContactUs from './contact-us/ContactUs';
 
-import { ReactComponent as ConversationIcon } from 'static/icons/icon_conversation.svg';
+import ConversationIcon from 'static/icons/icon_conversation.svg';
 
 import { toggleCommunicationPanel } from 'src/shared/state/communication/communicationSlice';
 import { isCommunicationPanelOpen } from 'src/shared/state/communication/communicationSelector';

--- a/src/shared/components/communication-framework/ConversationIcon.tsx
+++ b/src/shared/components/communication-framework/ConversationIcon.tsx
@@ -23,7 +23,7 @@ import { toggleCommunicationPanel } from 'src/shared/state/communication/communi
 
 import CommunicationPanel from 'src/shared/components/communication-framework/CommunicationPanel';
 
-import { ReactComponent as ConversationImageIcon } from 'static/icons/icon_conversation.svg';
+import ConversationImageIcon from 'static/icons/icon_conversation.svg';
 
 import styles from './ConversationIcon.scss';
 

--- a/src/shared/components/communication-framework/contact-us/ContactUs.tsx
+++ b/src/shared/components/communication-framework/contact-us/ContactUs.tsx
@@ -21,9 +21,9 @@ import { Invitation, Header } from './preform-header/PreformHeader';
 import { SecondaryButton } from 'src/shared/components/button/Button';
 import ExternalLink from 'src/shared/components/external-link/ExternalLink';
 
-import { ReactComponent as BlogIcon } from 'static/icons/icon_blog.svg';
-import { ReactComponent as FacebookIcon } from 'static/icons/icon_facebook.svg';
-import { ReactComponent as TwitterIcon } from 'static/icons/icon_twitter.svg';
+import BlogIcon from 'static/icons/icon_blog.svg';
+import FacebookIcon from 'static/icons/icon_facebook.svg';
+import TwitterIcon from 'static/icons/icon_twitter.svg';
 
 import styles from './ContactUs.scss';
 

--- a/src/shared/components/delete-button/DeleteButton.tsx
+++ b/src/shared/components/delete-button/DeleteButton.tsx
@@ -19,7 +19,7 @@ import React, {
   type HTMLAttributes,
   type ForwardedRef
 } from 'react';
-import { ReactComponent as TrashcanIcon } from 'static/icons/icon_delete.svg';
+import TrashcanIcon from 'static/icons/icon_delete.svg';
 
 import styles from './DeleteButton.scss';
 

--- a/src/shared/components/error-screen/GeneralErrorScreen.tsx
+++ b/src/shared/components/error-screen/GeneralErrorScreen.tsx
@@ -25,7 +25,7 @@ import { Topbar } from 'src/header/Header';
 import ShowHide from '../show-hide/ShowHide';
 import { PrimaryButton } from '../button/Button';
 
-import { ReactComponent as InfoIcon } from 'static/icons/icon_alert_circle.svg';
+import InfoIcon from 'static/icons/icon_alert_circle.svg';
 
 import styles from './ErrorScreen.scss';
 

--- a/src/shared/components/external-link/ExternalLink.tsx
+++ b/src/shared/components/external-link/ExternalLink.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { ReactComponent as LinkIcon } from 'static/icons/icon_xlink.svg';
+import LinkIcon from 'static/icons/icon_xlink.svg';
 
 import styles from './ExternalLink.scss';
 

--- a/src/shared/components/help-article/RelatedArticles.tsx
+++ b/src/shared/components/help-article/RelatedArticles.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import classNames from 'classnames';
 
-import { ReactComponent as VideoIcon } from 'static/icons/icon_video.svg';
+import VideoIcon from 'static/icons/icon_video.svg';
 
 import { RelatedArticleData } from 'src/shared/types/help-and-docs/article';
 

--- a/src/shared/components/help-popup/HelpPopupButton.tsx
+++ b/src/shared/components/help-popup/HelpPopupButton.tsx
@@ -20,7 +20,7 @@ import classNames from 'classnames';
 import Modal from 'src/shared/components/modal/Modal';
 import HelpPopupBody from './HelpPopupBody';
 
-import { ReactComponent as HelpIcon } from 'static/icons/icon_question.svg';
+import HelpIcon from 'static/icons/icon_question.svg';
 
 import styles from './HelpPopupButton.scss';
 

--- a/src/shared/components/help-popup/HistoryButtons.tsx
+++ b/src/shared/components/help-popup/HistoryButtons.tsx
@@ -17,8 +17,8 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { ReactComponent as BackIcon } from 'static/icons/navigate-left.svg';
-import { ReactComponent as ForwardIcon } from 'static/icons/navigate-right.svg';
+import BackIcon from 'static/icons/navigate-left.svg';
+import ForwardIcon from 'static/icons/navigate-right.svg';
 
 import styles from '../help-popup/HelpPopupBody.scss';
 

--- a/src/shared/components/loading-button/ControlledLoadingButton.tsx
+++ b/src/shared/components/loading-button/ControlledLoadingButton.tsx
@@ -20,8 +20,8 @@ import classNames from 'classnames';
 import { PrimaryButton } from 'src/shared/components/button/Button';
 import { CircleLoader } from 'src/shared/components/loader';
 
-import { ReactComponent as Checkmark } from 'static/icons/icon_tick.svg';
-import { ReactComponent as Cross } from 'static/icons/icon_cross.svg';
+import Checkmark from 'static/icons/icon_tick.svg';
+import Cross from 'static/icons/icon_cross.svg';
 
 import { LoadingState } from 'src/shared/types/loading-state';
 

--- a/src/shared/components/plus-button/PlusButton.tsx
+++ b/src/shared/components/plus-button/PlusButton.tsx
@@ -16,7 +16,7 @@
 
 import React, { type ButtonHTMLAttributes } from 'react';
 
-import { ReactComponent as PlusIcon } from 'static/icons/icon_plus_circle.svg';
+import PlusIcon from 'static/icons/icon_plus_circle.svg';
 
 import styles from './PlusButton.scss';
 

--- a/src/shared/components/question-button/QuestionButton.tsx
+++ b/src/shared/components/question-button/QuestionButton.tsx
@@ -21,7 +21,7 @@ import { useQuestionButtonBehaviour } from './useQuestionButtonBehaviour';
 
 import Tooltip from 'src/shared/components/tooltip/Tooltip';
 
-import { ReactComponent as QuestionIcon } from 'static/icons/icon_question_circle.svg';
+import QuestionIcon from 'static/icons/icon_question_circle.svg';
 
 import defaultStyles from './QuestionButton.scss';
 

--- a/src/shared/components/upload/Upload.tsx
+++ b/src/shared/components/upload/Upload.tsx
@@ -20,7 +20,7 @@ import classNames from 'classnames';
 import useFileDrop from './hooks/useFileDrop';
 import { transformFiles, transformFile } from './helpers/uploadHelpers';
 
-import { ReactComponent as UploadIcon } from 'static/icons/icon_upload.svg';
+import UploadIcon from 'static/icons/icon_upload.svg';
 
 import type { FileUploadParams, Options, Result } from './types';
 

--- a/src/shared/components/visibility-icon/VisibilityIcon.tsx
+++ b/src/shared/components/visibility-icon/VisibilityIcon.tsx
@@ -20,8 +20,8 @@ import ImageButton, {
   ImageButtonStatus
 } from 'src/shared/components/image-button/ImageButton';
 
-import { ReactComponent as Eye } from 'static/icons/icon_eye.svg';
-import { ReactComponent as EyePartial } from 'static/icons/icon_eye_slashed.svg';
+import Eye from 'static/icons/icon_eye.svg';
+import EyePartial from 'static/icons/icon_eye_slashed.svg';
 
 import { Status } from 'src/shared/types/status';
 

--- a/stories/shared-components/badged-button/BadgedButton.stories.tsx
+++ b/stories/shared-components/badged-button/BadgedButton.stories.tsx
@@ -22,7 +22,7 @@ import BadgedButton from 'src/shared/components/badged-button/BadgedButton';
 import { SecondaryButton } from 'src/shared/components/button/Button';
 import ImageButton from 'src/shared/components/image-button/ImageButton';
 
-import { ReactComponent as DownloadIcon } from 'static/icons/icon_download.svg';
+import DownloadIcon from 'static/icons/icon_download.svg';
 
 import { Status } from 'src/shared/types/status';
 

--- a/stories/shared-components/image-button/ImageButton.stories.tsx
+++ b/stories/shared-components/image-button/ImageButton.stories.tsx
@@ -21,7 +21,7 @@ import ImageButton, {
   ImageButtonStatus
 } from 'src/shared/components/image-button/ImageButton';
 
-import { ReactComponent as DownloadIcon } from 'static/icons/icon_download.svg';
+import DownloadIcon from 'static/icons/icon_download.svg';
 
 import { Status } from 'src/shared/types/status';
 

--- a/stories/static-assets/Icons.stories.tsx
+++ b/stories/static-assets/Icons.stories.tsx
@@ -22,14 +22,12 @@ import storyStyles from '../common.scss';
 
 function importAllIcons() {
   const iconsContextModule: any = require.context(
-    'static/icons',
+    'static/icons?url',
     true,
     /\.(svg)$/
   );
   const iconFileNames: string[] = iconsContextModule.keys();
-  const iconPaths = iconFileNames
-    .map(iconsContextModule)
-    .map((module) => (module as any).default as string); // svg modules are imported as file paths
+  const iconPaths = iconFileNames.map(iconsContextModule) as string[]; //svg modules are imported as file paths
 
   return iconPaths.map((iconPath, index) => {
     const fileName = iconFileNames[index].split('/').pop() as string;

--- a/tests/svgrMock.js
+++ b/tests/svgrMock.js
@@ -2,7 +2,4 @@
 // with modifications discussed here:
 // https://github.com/facebook/jest/issues/5258#issuecomment-356251559
 
-module.exports = {
-  default: 'svg',
-  ReactComponent: 'svg'
-};
+module.exports = 'svg';

--- a/typings/assets.d.ts
+++ b/typings/assets.d.ts
@@ -31,9 +31,11 @@ declare module '*.jpg' {
 
 declare module '*.svg' {
   import React = require('react');
-  export const ReactComponent: React.FunctionComponent<
-    React.SVGProps<SVGSVGElement>
-  >;
+  const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  export default ReactComponent;
+}
+
+declare module '*.svg?url' {
   const src: string;
   export default src;
 }

--- a/webpack/client/common.ts
+++ b/webpack/client/common.ts
@@ -76,20 +76,49 @@ export default (env: Record<string, unknown>): Configuration => {
 
         {
           test: /\.svg$/i,
-          issuer: /\.scss$/,
-          type: 'asset/resource',
-          generator: {
-            filename: 'images/[name].[hash][ext]'
-          }
-        },
+          oneOf: [
+            {
+              issuer: /\.scss$/,
+              type: 'asset/resource',
+              generator: {
+                filename: 'images/[name].[hash][ext]'
+              }
+            },
+            {
+              resourceQuery: /url/, // will match all imports that end in `.svg?url`
+              type: 'asset',
+              generator: {
+                filename: 'images/[name].[hash][ext]'
+              }
+            },
+            {
+              issuer: /\.[jt]sx?$/,
+              use: ['@svgr/webpack']
+            }
+          ]
+        }
+
+        // {
+        //   test: /\.svg$/i,
+        //   issuer: /\.scss$/,
+        //   type: 'asset/resource',
+        //   generator: {
+        //     filename: 'images/[name].[hash][ext]'
+        //   }
+        // },
+
+        // {
+        //   resourceQuery: /url/, // *.svg?url
+        //   type: 'asset',
+        // },
 
         // use file-loader on svg's (to be able to require them as a path to the image),
         // but also use @svgr/webpack to be able to require svg's directly as React components
-        {
-          test: /\.svg$/,
-          issuer: { not: [/\.scss$/s] },
-          use: ['@svgr/webpack', 'file-loader']
-        }
+        // {
+        //   test: /\.svg$/,
+        //   issuer: { not: [/\.scss$/s] },
+        //   use: ['@svgr/webpack', 'file-loader']
+        // }
       ]
     },
 

--- a/webpack/client/common.ts
+++ b/webpack/client/common.ts
@@ -86,7 +86,7 @@ export default (env: Record<string, unknown>): Configuration => {
             },
             {
               resourceQuery: /url/, // will match all imports that end in `.svg?url`
-              type: 'asset',
+              type: 'asset/resource',
               generator: {
                 filename: 'images/[name].[hash][ext]'
               }

--- a/webpack/client/common.ts
+++ b/webpack/client/common.ts
@@ -97,28 +97,6 @@ export default (env: Record<string, unknown>): Configuration => {
             }
           ]
         }
-
-        // {
-        //   test: /\.svg$/i,
-        //   issuer: /\.scss$/,
-        //   type: 'asset/resource',
-        //   generator: {
-        //     filename: 'images/[name].[hash][ext]'
-        //   }
-        // },
-
-        // {
-        //   resourceQuery: /url/, // *.svg?url
-        //   type: 'asset',
-        // },
-
-        // use file-loader on svg's (to be able to require them as a path to the image),
-        // but also use @svgr/webpack to be able to require svg's directly as React components
-        // {
-        //   test: /\.svg$/,
-        //   issuer: { not: [/\.scss$/s] },
-        //   use: ['@svgr/webpack', 'file-loader']
-        // }
       ]
     },
 

--- a/webpack/server/common.ts
+++ b/webpack/server/common.ts
@@ -49,11 +49,16 @@ export default (): Configuration => {
         {
           test: /.scss$/,
           use: [
-            MiniCssExtractPlugin.loader,
+            {
+              loader: MiniCssExtractPlugin.loader,
+              options: {
+                emit: false
+              }
+            },
             {
               loader: 'css-loader',
               options: {
-                sourceMap: true,
+                url: false,
                 modules: {
                   localIdentName: '[local]__[name]__[hash:base64:5]'
                 }

--- a/webpack/server/common.ts
+++ b/webpack/server/common.ts
@@ -71,21 +71,45 @@ export default (): Configuration => {
           ]
         },
 
-        // use file-loader on svg's (to be able to require them as a path to the image),
-        // but also use @svgr/webpack to be able to require svg's directly as React components
         {
-          test: /\.svg$/,
-          use: [
-            '@svgr/webpack',
+          test: /\.svg$/i,
+          oneOf: [
             {
-              loader: 'file-loader',
-              options: {
-                outputPath: paths.buildStaticPath,
-                publicPath: '/static/'
+              issuer: /\.scss$/,
+              type: 'asset/resource',
+              generator: {
+                filename: '../static/[hash][ext]'
               }
+            },
+            {
+              resourceQuery: /url/, // will match all imports that end in `.svg?url`
+              type: 'asset',
+              generator: {
+                filename: '../static/[hash][ext]'
+              }
+            },
+            {
+              issuer: /\.[jt]sx?$/,
+              use: ['@svgr/webpack']
             }
           ]
         }
+
+        // use file-loader on svg's (to be able to require them as a path to the image),
+        // but also use @svgr/webpack to be able to require svg's directly as React components
+        // {
+        //   test: /\.svg$/,
+        //   use: [
+        //     '@svgr/webpack',
+        //     {
+        //       loader: 'file-loader',
+        //       options: {
+        //         outputPath: paths.buildStaticPath,
+        //         publicPath: '/static/'
+        //       }
+        //     }
+        //   ]
+        // }
       ]
     },
 

--- a/webpack/server/common.ts
+++ b/webpack/server/common.ts
@@ -78,14 +78,18 @@ export default (): Configuration => {
               issuer: /\.scss$/,
               type: 'asset/resource',
               generator: {
-                filename: '../static/[hash][ext]'
+                filename: 'images/[name].[hash][ext]',
+                publicPath: '/static/',
+                emit: false
               }
             },
             {
               resourceQuery: /url/, // will match all imports that end in `.svg?url`
               type: 'asset/resource',
               generator: {
-                filename: '../static/[hash][ext]'
+                filename: 'images/[name].[hash][ext]',
+                publicPath: '/static/',
+                emit: false
               }
             },
             {
@@ -94,22 +98,6 @@ export default (): Configuration => {
             }
           ]
         }
-
-        // use file-loader on svg's (to be able to require them as a path to the image),
-        // but also use @svgr/webpack to be able to require svg's directly as React components
-        // {
-        //   test: /\.svg$/,
-        //   use: [
-        //     '@svgr/webpack',
-        //     {
-        //       loader: 'file-loader',
-        //       options: {
-        //         outputPath: paths.buildStaticPath,
-        //         publicPath: '/static/'
-        //       }
-        //     }
-        //   ]
-        // }
       ]
     },
 

--- a/webpack/server/common.ts
+++ b/webpack/server/common.ts
@@ -83,7 +83,7 @@ export default (): Configuration => {
             },
             {
               resourceQuery: /url/, // will match all imports that end in `.svg?url`
-              type: 'asset',
+              type: 'asset/resource',
               generator: {
                 filename: '../static/[hash][ext]'
               }

--- a/webpack/server/development.ts
+++ b/webpack/server/development.ts
@@ -25,10 +25,10 @@ export default (): Configuration => ({
       // this is the loader that will make webpack load file formats that are not supported by other loaders
       {
         test: /\.(woff|woff2|eot|ttf|otf|gif|png|jpe?g)$/,
-        loader: 'file-loader',
-        options: {
-          // the file path and name that webpack will use to store these files
-          name: `[path][name].[ext]`
+        type: 'asset/resource',
+        generator: {
+          publicPath: '/static/',
+          emit: false
         }
       }
     ]

--- a/webpack/server/production.ts
+++ b/webpack/server/production.ts
@@ -31,7 +31,7 @@ export default (): Configuration => {
           test: /.*\.(gif|png|jpe?g)$/i,
           type: 'asset/resource',
           generator: {
-            filename: '/images/[name].[hash][ext]',
+            filename: 'images/[name].[hash][ext]',
             publicPath: '/static/',
             emit: false
           }
@@ -42,7 +42,7 @@ export default (): Configuration => {
           test: /static\/fonts\/.*\.(woff2?|eot|ttf|otf|svg)$/i,
           type: 'asset/resource',
           generator: {
-            filename: '/fonts/[name].[hash][ext]',
+            filename: 'fonts/[name].[hash][ext]',
             publicPath: '/static/',
             emit: false
           }

--- a/webpack/server/production.ts
+++ b/webpack/server/production.ts
@@ -29,26 +29,22 @@ export default (): Configuration => {
         // then file loader takes over to copy the images into the dist folder
         {
           test: /.*\.(gif|png|jpe?g)$/i,
-          use: [
-            {
-              loader: 'file-loader',
-              options: {
-                emitFile: true,
-                name: '[name].[hash].[ext]',
-                outputPath: 'images'
-              }
-            },
-            'image-webpack-loader'
-          ]
+          type: 'asset/resource',
+          generator: {
+            filename: '/images/[name].[hash][ext]',
+            publicPath: '/static/',
+            emit: false
+          }
         },
 
         // loader for fonts that copies the fonts into the dist folder
         {
           test: /static\/fonts\/.*\.(woff2?|eot|ttf|otf|svg)$/i,
-          loader: 'file-loader',
-          options: {
-            emitFile: true,
-            name: '[path][name].[hash].[ext]'
+          type: 'asset/resource',
+          generator: {
+            filename: '/fonts/[name].[hash][ext]',
+            publicPath: '/static/',
+            emit: false
           }
         }
       ]


### PR DESCRIPTION
## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1460

## Description
This PR updates the configuration of svgr loader that we use for handling the svg images.

Previously, we used svgr-loader together with `file-loader`, such that a default import of an svg file produced path to the file (to be used in the `img` tag), whereas a `ReactComponent` named import transformed the svg image into a React component.

However, since webpack 5, `file-loader` has been deprecated, and the recommendations have changed. The documentation now recommends using webpack's assets modules, and to mark svgs that you want to import as url paths with a special query in the import.

As a result, after this PR:
- Default import of an svg file will import a React component
- Default import of an svg file marked with `?url` in the end will import a string that is the path to the svg file to be used in the img tag.

## Other changes
- Removed `file-loader` as no longer necessary; regenerated package-lock.json because of a conflict with dev
- Updated server-side webpack config to avoid emitting the assets files, since they aren't going to be used anyway

## Documentation
- SVGR docs https://react-svgr.com/docs/webpack/
- Webpack: Generating assets paths without emitting the assets: https://webpack.js.org/configuration/module/#rulegeneratoremit
- Webpack: using resource queries with require.context: `https://github.com/webpack/webpack/issues/9364#issuecomment-508513772`

## Deployment URL
http://update-svgr-loader.review.ensembl.org

## Checked locally
- unit tests — ✅ 
- typescript types — ✅ 
- development build — ✅ 
- production build — ✅ 
- storybook — ✅ 