### PR TITLE
Fix type definitions of SimpleSelect; and fix SimpleSelect in BlastSettings 

### DIFF
--- a/src/content/app/tools/blast/components/blast-settings/BlastSettings.tsx
+++ b/src/content/app/tools/blast/components/blast-settings/BlastSettings.tsx
@@ -304,7 +304,7 @@ const buildSelect = (setting: {
       <label>
         <span>{setting.label}</span>
         <SimpleSelect
-          defaultValue={setting.selectedOption}
+          value={setting.selectedOption}
           onInput={onChange}
           options={setting.options}
         />

--- a/src/shared/components/simple-select/SimpleSelect.tsx
+++ b/src/shared/components/simple-select/SimpleSelect.tsx
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import React, { type HTMLAttributes } from 'react';
+import React, { type SelectHTMLAttributes } from 'react';
 import classNames from 'classnames';
 import styles from './SimpleSelect.scss';
 
-type HTMLSelectProps = HTMLAttributes<HTMLSelectElement>;
+type HTMLSelectProps = SelectHTMLAttributes<HTMLSelectElement>;
 
 // This is just a simple wrapper for the native HTML select element.
 // The purpose of this React component is to style the select button,
@@ -67,11 +67,7 @@ const SimpleSelect = (props: SimpleSelectProps) => {
     const { optionGroups, ...selectProps } = rest;
     return (
       <div className={selectClassnames}>
-        <select
-          className={styles.selectResetDefaults}
-          defaultValue=""
-          {...selectProps}
-        >
+        <select className={styles.selectResetDefaults} {...selectProps}>
           {placeholder && (
             <option value="" hidden={true}>
               {placeholder}
@@ -96,11 +92,7 @@ const SimpleSelect = (props: SimpleSelectProps) => {
   const { options, ...selectProps } = rest;
   return (
     <div className={selectClassnames}>
-      <select
-        className={styles.selectResetDefaults}
-        defaultValue=""
-        {...selectProps}
-      >
+      <select className={styles.selectResetDefaults} {...selectProps}>
         {placeholder && (
           <option value="" hidden={true}>
             {placeholder}


### PR DESCRIPTION
## Description
**Bug:** the `SimpleSelect` component in `BlastSettings` was not updating when the selected value in its props was updated.

Example: when I switch from a nucleotide database to a protein database, I expect the word count setting to to change to 6 (default for protein databases). The screen recording below shows that although the property of the SimpleSelect component changed from 11 to 6, the visible selected value remained the same. 

https://user-images.githubusercontent.com/6834224/157559907-8a5bc78d-5b20-416f-a4f2-fc39eb26dc66.mp4

The bug was caused by the fact that the code passed the selected value with the `defaultValue` prop rather than the `value` prop for the `SimpleSelect` component. This, in turn, was due to the incorrect typescript type chosen to describe the properties of a native `select` component — the correct type is `SelectHTMLAttributes<HTMLSelectElement>`, which includes the `value` property, rather than `HTMLAttributes<HTMLSelectElement>`, which doesn't.

## Deployment url
http://fix-simple-select-props.review.ensembl.org/blast

## Views affected
Blast form page