### PR TITLE
Update in-app search

### DIFF
--- a/src/content/app/entity-viewer/components/example-links/ExampleLinks.tsx
+++ b/src/content/app/entity-viewer/components/example-links/ExampleLinks.tsx
@@ -53,7 +53,7 @@ const ExampleLinks = () => {
       <div>
         <div className={styles.exampleLinks__emptyTopbar} />
         <div className={styles.exampleLinks}>
-          <CircleLoader />
+          <CircleLoader size="small" />
         </div>
       </div>
     );

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-modal/TrackPanelModal.scss
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-modal/TrackPanelModal.scss
@@ -1,6 +1,0 @@
-.trackPanelModal {
-  p {
-    font-size: 13px;
-    margin-bottom: 30px;
-  }
-}

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-modal/TrackPanelModal.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-modal/TrackPanelModal.tsx
@@ -30,8 +30,6 @@ import TrackPanelDownloads from './modal-views/TrackPanelDownloads';
 
 import SidebarModal from 'src/shared/components/layout/sidebar-modal/SidebarModal';
 
-import styles from './TrackPanelModal.scss';
-
 export const TrackPanelModal = () => {
   const trackPanelModalView = useSelector(getTrackPanelModalView);
   const dispatch = useDispatch();
@@ -65,11 +63,9 @@ export const TrackPanelModal = () => {
 
   const { title, content } = getModalViewData();
   return (
-    <section className={styles.trackPanelModal}>
-      <SidebarModal title={title} onClose={onClose}>
-        {content}
-      </SidebarModal>
-    </section>
+    <SidebarModal title={title} onClose={onClose}>
+      {content}
+    </SidebarModal>
   );
 };
 

--- a/src/shared/components/in-app-search/InAppSearch.scss
+++ b/src/shared/components/in-app-search/InAppSearch.scss
@@ -49,15 +49,9 @@
 }
 
 .spinner {
-  height: 30px;
-  width: 30px;
-  border-width: 2px;
+  --circle-loader-display: block;
   margin-top: 30px;
   margin-left: 20px;
-}
-
-.inAppSearchTopInterstitial + .spinner {
-  display: block;
 }
 
 .hitsCount {

--- a/src/shared/components/in-app-search/InAppSearch.scss
+++ b/src/shared/components/in-app-search/InAppSearch.scss
@@ -48,6 +48,18 @@
   padding: 6px 18px;
 }
 
+.spinner {
+  height: 30px;
+  width: 30px;
+  border-width: 2px;
+  margin-top: 30px;
+  margin-left: 20px;
+}
+
+.inAppSearchTopInterstitial + .spinner {
+  display: block;
+}
+
 .hitsCount {
   grid-area: hits-count;
   padding: 20px 0 0 20px;

--- a/src/shared/components/in-app-search/InAppSearch.scss
+++ b/src/shared/components/in-app-search/InAppSearch.scss
@@ -3,9 +3,9 @@
 .inAppSearchTopInterstitial {
   display: inline-grid;
   grid-template-areas:
-          'label label'
-          'search-field search-button'
-          'hits-count .';
+    'label label'
+    'search-field search-button'
+    'hits-count .';
   grid-template-columns: 485px auto;
   column-gap: 48px;
 }
@@ -13,11 +13,10 @@
 .inAppSearchTopSidebar {
   display: grid;
   grid-template-areas:
-          'label label'
-          'search-field search-field'
-          'hits-count search-button';
+    'label label'
+    'search-field search-field'
+    'hits-count search-button';
   grid-template-columns: 1fr min-content;
-  align-items: top;
 }
 
 .searchFieldWrapper {

--- a/src/shared/components/in-app-search/InAppSearch.tsx
+++ b/src/shared/components/in-app-search/InAppSearch.tsx
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-import React from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
 import classNames from 'classnames';
 import upperFirst from 'lodash/upperFirst';
+
+import { useAppDispatch } from 'src/store';
 
 import {
   search,
@@ -57,19 +59,22 @@ export type Props = {
 
 const InAppSearch = (props: Props) => {
   const { app, genomeId, mode } = props;
+  const [isLoading, setIsLoading] = useState(false);
   const query = useSelector((state: RootState) =>
     getSearchQuery(state, app, genomeId)
   );
   const searchResult = useSelector((state: RootState) =>
     getSearchResults(state, app, genomeId)
   );
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const onQueryChange = (query: string) => {
     dispatch(updateQuery({ app, genomeId, query }));
   };
 
-  const onSearchSubmit = () => {
+  const onSearchSubmit = async () => {
+    setIsLoading(true);
+
     const searchParams = {
       app,
       genome_id: genomeId,
@@ -77,14 +82,19 @@ const InAppSearch = (props: Props) => {
       page: 1,
       per_page: 50
     };
-    dispatch(search(searchParams));
 
-    if (app === 'entityViewer') {
-      analyticsTracking.trackEvent({
-        category: `${app}_${mode}_search`,
-        action: 'submit_search',
-        label: query
-      });
+    try {
+      await dispatch(search(searchParams));
+
+      if (app === 'entityViewer') {
+        analyticsTracking.trackEvent({
+          category: `${app}_${mode}_search`,
+          action: 'submit_search',
+          label: query
+        });
+      }
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -124,7 +134,7 @@ const InAppSearch = (props: Props) => {
         <PrimaryButton
           onClick={onSearchSubmit}
           className={styles.searchButton}
-          isDisabled={!query}
+          isDisabled={!query || isLoading}
         >
           Go
         </PrimaryButton>

--- a/src/shared/components/in-app-search/InAppSearch.tsx
+++ b/src/shared/components/in-app-search/InAppSearch.tsx
@@ -42,6 +42,7 @@ import QuestionButton, {
   QuestionButtonOption
 } from 'src/shared/components/question-button/QuestionButton';
 import CloseButton from 'src/shared/components/close-button/CloseButton';
+import { CircleLoader } from 'src/shared/components/loader';
 import InAppSearchMatches from './InAppSearchMatches';
 
 import type { RootState } from 'src/store';
@@ -138,7 +139,7 @@ const InAppSearch = (props: Props) => {
         >
           Go
         </PrimaryButton>
-        {searchResult && (
+        {!isLoading && searchResult && (
           <div className={styles.hitsCount}>
             <span className={styles.hitsNumber}>
               {getCommaSeparatedNumber(searchResult.meta.total_hits)}
@@ -147,8 +148,12 @@ const InAppSearch = (props: Props) => {
           </div>
         )}
       </div>
-      {searchResult && (
-        <InAppSearchMatches {...searchResult} app={app} mode={mode} />
+      {isLoading ? (
+        <CircleLoader className={styles.spinner} />
+      ) : (
+        searchResult && (
+          <InAppSearchMatches {...searchResult} app={app} mode={mode} />
+        )
       )}
     </div>
   );

--- a/src/shared/components/in-app-search/InAppSearch.tsx
+++ b/src/shared/components/in-app-search/InAppSearch.tsx
@@ -149,7 +149,7 @@ const InAppSearch = (props: Props) => {
         )}
       </div>
       {isLoading ? (
-        <CircleLoader className={styles.spinner} />
+        <CircleLoader className={styles.spinner} size="small" />
       ) : (
         searchResult && (
           <InAppSearchMatches {...searchResult} app={app} mode={mode} />

--- a/src/shared/components/input/Input.tsx
+++ b/src/shared/components/input/Input.tsx
@@ -25,7 +25,9 @@ const Input = (props: Props, ref: ForwardedRef<HTMLInputElement>) => {
   const { className: classNameFromProps, ...otherProps } = props;
   const className = classNames(styles.input, classNameFromProps);
 
-  return <input className={className} ref={ref} {...otherProps} />;
+  return (
+    <input className={className} ref={ref} spellCheck={false} {...otherProps} />
+  );
 };
 
 export default forwardRef(Input);

--- a/src/shared/components/layout/sidebar-modal/SidebarModal.scss
+++ b/src/shared/components/layout/sidebar-modal/SidebarModal.scss
@@ -2,10 +2,12 @@
 
 .wrapper {
   display: grid;
-  grid-template-areas: "title close"
-                       "content content";
+  grid-template-areas:
+    'title close'
+    'content content';
   grid-template-columns: 1fr 20px;
-  grid-template-rows: 38px auto;
+  grid-template-rows: 38px 1fr;
+  height: 100%;
 }
 
 .title {
@@ -14,7 +16,7 @@
   margin-top: 0;
 }
 
-.content { 
+.content {
   grid-area: content;
   overflow: auto;
 }

--- a/src/shared/components/loader/CircleLoader.scss
+++ b/src/shared/components/loader/CircleLoader.scss
@@ -1,13 +1,24 @@
 @import 'src/styles/common';
 
 .circleLoader {
-  display: inline-block;
-  border: 3px solid $grey;
-  border-top-color: $red;
-  width: 40px;
-  height: 40px;
+  display: var(--circle-loader-display, inline-block);
   border-radius: 100%;
   animation: loader-spin 1.3s linear infinite;
+  border-style: solid;
+  border-color: $grey;
+  border-top-color: $red;
+}
+
+.circleLoaderDefault {
+  width: var(--circle-loader-diameter, 40px);
+  height: var(--circle-loader-diameter, 40px);
+  border-width: var(--circle-loader-border-width, 3px);
+}
+
+.circleLoaderSmall {
+  width: var(--circle-loader-diameter, 30px);
+  height: var(--circle-loader-diameter, 30px);
+  border-width: var(--circle-loader-border-width, 2px);
 }
 
 @keyframes loader-spin {

--- a/src/shared/components/loader/CircleLoader.tsx
+++ b/src/shared/components/loader/CircleLoader.tsx
@@ -16,15 +16,24 @@
 
 import React from 'react';
 import classNames from 'classnames';
+import upperFirst from 'lodash/upperFirst';
 
 import styles from './CircleLoader.scss';
 
+type Size = 'default' | 'small';
+
 type Props = {
   className?: string;
+  size?: Size;
 };
 
 const CircleLoader = (props: Props) => {
-  const className = classNames(styles.circleLoader, props.className);
+  const loaderSize = props.size ?? 'default';
+  const className = classNames(
+    styles.circleLoader,
+    styles[`circleLoader${upperFirst(loaderSize)}`],
+    props.className
+  );
 
   return <div className={className} />;
 };

--- a/src/shared/state/in-app-search/inAppSearchSlice.ts
+++ b/src/shared/state/in-app-search/inAppSearchSlice.ts
@@ -16,8 +16,6 @@
 
 import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
 
-import apiService, { HTTPMethod } from 'src/services/api-service';
-
 import type { Strand } from 'src/shared/types/thoas/strand';
 
 export type AppName = 'genomeBrowser' | 'entityViewer';
@@ -85,14 +83,18 @@ export const search = createAsyncThunk(
     };
 
     const url = '/api/search';
-    const response: SearchResults = await apiService.fetch(url, {
+    const response: SearchResults = await fetch(url, {
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json'
       },
-      method: HTTPMethod.POST,
-      noCache: true,
+      method: 'POST',
       body: JSON.stringify(queryParams)
+    }).then((response) => {
+      if (!response.ok) {
+        throw new Error();
+      }
+      return response.json();
     });
 
     return {

--- a/src/store.ts
+++ b/src/store.ts
@@ -15,7 +15,7 @@
  */
 
 import { configureStore } from '@reduxjs/toolkit';
-import { StateType } from 'typesafe-actions';
+import { useDispatch } from 'react-redux';
 import { createEpicMiddleware } from 'redux-observable';
 
 import config from 'config';
@@ -29,8 +29,6 @@ import rootEpic from './root/rootEpic';
 const epicMiddleware = createEpicMiddleware();
 
 const rootReducer = createRootReducer();
-
-export type RootState = StateType<typeof rootReducer>;
 
 const middleware = [
   epicMiddleware,
@@ -53,3 +51,8 @@ export default function getReduxStore() {
 
   return store;
 }
+
+type AppStore = ReturnType<typeof getReduxStore>;
+export type RootState = ReturnType<typeof rootReducer>;
+export type AppDispatch = AppStore['dispatch'];
+export const useAppDispatch = () => useDispatch<AppDispatch>();


### PR DESCRIPTION
## Description
This PR adds some improvements around the behaviour of the InAppSearch component

1. Update the component's behaviour while the request is in flight, to both give some feedback to the user and to prevent excessive requests:
  - disable the "Go" button
  - show a spinner
  - these will still show up if the response comes back quickly; but Andrea doesn't mind
  - updated the CircleLoader component to enable two preset sizes: 40x40 and 30x30px; further customisations available via CSS variables

https://user-images.githubusercontent.com/6834224/158028223-9b7e717a-089f-4f73-bef0-ed06bcdf2630.mp4

2. CSS fixes to get rid of the unnecessary vertical scrollbar in the sidebar modal:

![image](https://user-images.githubusercontent.com/6834224/157783377-c78a7cab-8cfa-47ef-a0e5-84b36d3bcff7.png)

3. Disabled spellchecking in input fields by default (this can be overridden by parent if necessary) to avoid the annoying red underline (we trust that users will know what they type into the input fields)

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/6834224/158028596-e09afb2f-44f4-414f-8a44-63a239e3d544.png">


3. Added typed `useAppDispatch` and `useAppSelector` hooks, which correctly infer the types of the redux state and of return values of redux middleware, as suggested in the [docs](https://redux.js.org/usage/usage-with-typescript#define-typed-hooks).
  Specifically, writing `await dispatch(search(searchParams));` would be impossible without the typed `useAppDispatch`; because the regular `dispatch` does not know that an action creator created by the `createAsyncThunk` function returns a promise when it is `dispatch`ed
5. Using a simple `fetch` instead of the `apiService` for requests to search api.


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1495. This PR doesn't fix the problem described in ENSWBSITES-1495 — it's a backend problem — but it adds certain improvements to the behaviour of InAppSearch component, which were made while investigating the problem described in ENSWBSITES-1495.

## Deployment URL(s)
http://in-app-search-fixes.review.ensembl.org

## Views affected
- InAppSearch in the sidebar on the genome browser and entity viewer page
- InAppSearch in the interstitial view on the genome browser and entity viewer page