### PR TITLE
Fix blast config fetching and blast form submission

### DIFF
--- a/src/content/app/tools/blast/components/blast-job-submit/BlastJobSubmit.tsx
+++ b/src/content/app/tools/blast/components/blast-job-submit/BlastJobSubmit.tsx
@@ -43,6 +43,14 @@ export type PayloadParams = {
   };
 };
 
+type BlastSubmissionResponse = {
+  submissionId: string;
+  jobs: Array<{
+    jobId?: string;
+    error?: string;
+  }>;
+};
+
 const BlastJobSubmit = () => {
   const { sequences } = useBlastInputSequences();
   const selectedSpecies = useSelector(getSelectedSpeciesIds);
@@ -56,9 +64,13 @@ const BlastJobSubmit = () => {
     return submitBlastForm(payload);
   };
 
-  const onSubmitSuccess = (response: { jobIds: string[] }) => {
+  const onSubmitSuccess = (response: BlastSubmissionResponse) => {
     // TODO: change the temporary implementation of this function with a more permanent one
-    const firstJobId = response.jobIds[0];
+    const firstJobId = response.jobs[0].jobId;
+    if (!firstJobId) {
+      return;
+    }
+
     const resultPageUrl = `https://wwwdev.ebi.ac.uk/Tools/services/web/toolresult.ebi?jobId=${firstJobId}`;
 
     const resultTab = window.open(resultPageUrl, '_blank');

--- a/src/shared/state/api-slices/restSlice.ts
+++ b/src/shared/state/api-slices/restSlice.ts
@@ -15,7 +15,28 @@
  */
 
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-import fetch from 'cross-fetch';
+import {
+  fetch as crossFetch,
+  Headers as crossFetchHeaders,
+  Request as crossFetchRequest,
+  Response as crossFetchResponse
+} from 'cross-fetch';
+
+/**
+ * TODO:
+ * Since version 17.5, Node has added its own native implementation of fetch (yay!)
+ * (https://github.com/nodejs/node/commit/6ec225392675c92b102d3caad02ee3a157c9d1b7)
+ * But it is still experimental, and requires the `--experimental-fetch` flag.
+ * Once this feature is stabilized and we update to the new version of Node (new LTS or earlier),
+ * the cross-fetch module will become unnecessary; and the code below, as well as the fetchFn parameter
+ * of the `fetchBaseQuery` function can be deleted.
+ * */
+if (!globalThis.fetch) {
+  globalThis.fetch = crossFetch;
+  globalThis.Headers = crossFetchHeaders;
+  globalThis.Request = crossFetchRequest;
+  globalThis.Response = crossFetchResponse;
+}
 
 export default createApi({
   reducerPath: 'restApi',


### PR DESCRIPTION
## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1530

## Description
This PR fixes two bugs:
1. The problem with `cross-fetch` that we used for rest-api-slice in https://github.com/Ensembl/ensembl-client/pull/710.
  Turns out, RTK-query passes the `Request` object to the `fetch` function. `cross-fetch`, which uses `whatwg-fetch` in the browser environment, gets confused by this if the browser has its own native `Request` (see this code, where it compares the argument passed to the `fetch` function to a `Request` polyfill). As a result of this confusion, it generates a broken url, which looks like this:

<img src="https://user-images.githubusercontent.com/6834224/158041438-9c84878b-b7cc-46d9-b31a-d3c95666dda4.png" width="450">

  This bug is currently already in the dev branch. The fix is inspired by this discussion in redux-toolkit repo: `https://github.com/reduxjs/redux-toolkit/issues/1271`

2. Backend has updated the response to the form submission. 

## Deployment URL(s)
http://blast-form-fixes.review.ensembl.org/

## Views affected
Blast form page