### PR TITLE
check for abortController for browser support

### DIFF
--- a/src/shared/helpers/browserSupport.ts
+++ b/src/shared/helpers/browserSupport.ts
@@ -26,11 +26,11 @@ const hasOutdatedMediaQueryList = () => {
   );
 };
 
-const abortControllerSupport = () => {
+const hasNoAbortController = () => {
   return !('AbortController' in window);
 };
 
-const browserChecks = [hasOutdatedMediaQueryList, abortControllerSupport];
+const browserChecks = [hasOutdatedMediaQueryList, hasNoAbortController];
 
 const ensureBrowserSupport = () => {
   if (browserChecks.some((check) => check())) {

--- a/src/shared/helpers/browserSupport.ts
+++ b/src/shared/helpers/browserSupport.ts
@@ -26,7 +26,11 @@ const hasOutdatedMediaQueryList = () => {
   );
 };
 
-const browserChecks = [hasOutdatedMediaQueryList];
+const abortControllerSupport = () => {
+  return !('AbortController' in window);
+};
+
+const browserChecks = [hasOutdatedMediaQueryList, abortControllerSupport];
 
 const ensureBrowserSupport = () => {
   if (browserChecks.some((check) => check())) {


### PR DESCRIPTION
## Description
Adding one more check for browser support. AbortController isn't supported on new browser (chrome 65 and older). See linked Jira ticket for more details.

This can be tested  on browserstack.


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1510

## Deployment URL(s)
http://abortapi-check.review.ensembl.org


## Views affected
All