### PR TITLE
Blast jobs polling and storage using React context

### DIFF
--- a/src/content/app/App.tsx
+++ b/src/content/app/App.tsx
@@ -19,6 +19,8 @@ import { useLocation, useRoutes } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import routesConfig from 'src/routes/routesConfig';
 
+import useToolsContext from 'src/content/app/tools/shared/context/useToolsContext';
+
 import analyticsTracking from 'src/services/analytics-service';
 
 import { changeCurrentApp } from 'src/global/globalSlice';
@@ -28,6 +30,7 @@ import Header from 'src/header/Header';
 const AppContainer = () => {
   const dispatch = useDispatch();
   const location = useLocation();
+  const { restoreBlastSubmissions } = useToolsContext();
 
   useEffect(() => {
     const appName: string = location.pathname.split('/').filter(Boolean)[0];
@@ -39,6 +42,10 @@ const AppContainer = () => {
       dispatch(changeCurrentApp(''));
     };
   }, [location.pathname]);
+
+  useEffect(() => {
+    restoreBlastSubmissions();
+  }, []);
 
   useLocationReporting();
 

--- a/src/content/app/tools/blast/components/blast-job-submit/BlastJobSubmit.test.tsx
+++ b/src/content/app/tools/blast/components/blast-job-submit/BlastJobSubmit.test.tsx
@@ -32,7 +32,21 @@ const sequences = [
   }
 ];
 
-const selectedSpecies = ['human', 'wheat'];
+const selectedHuman = {
+  genome_id: 'human-genome-id',
+  common_name: 'Human',
+  scientific_name: 'Homo sapiens',
+  assembly_name: 'GRCh38'
+};
+
+const selectedMouse = {
+  genome_id: 'mouse-genome-id',
+  common_name: 'Mouse',
+  scientific_name: 'Mus musculus',
+  assembly_name: 'GRCm39'
+};
+
+const selectedSpecies = [selectedHuman, selectedMouse];
 const jobName = faker.lorem.words();
 const database = faker.lorem.word();
 const blastParameters = {
@@ -65,7 +79,7 @@ const mockState = merge({}, initialState, {
 });
 
 const expectedPayload = {
-  genomeIds: selectedSpecies,
+  species: selectedSpecies,
   querySequences: sequences.map((seq) => toFasta(seq)),
   parameters: {
     title: jobName,

--- a/src/content/app/tools/blast/components/blast-job-submit/BlastJobSubmit.tsx
+++ b/src/content/app/tools/blast/components/blast-job-submit/BlastJobSubmit.tsx
@@ -15,27 +15,33 @@
  */
 
 import React from 'react';
-import { useSelector } from 'react-redux';
 
-import config from 'config';
+import { useAppSelector } from 'src/store';
+
+import useToolsContext from 'src/content/app/tools/shared/context/useToolsContext';
 
 import LoadingButton from 'src/shared/components/loading-button/LoadingButton';
 
 import useBlastInputSequences from 'src/content/app/tools/blast/components/blast-input-sequences/useBlastInputSequences';
-import { getSelectedSpeciesIds } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
 import { isBlastFormValid } from 'src/content/app/tools/blast/utils/blastFormValidator';
-import { getBlastFormData } from '../../state/blast-form/blastFormSelectors';
+
+import { getBlastFormData } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
+import { getSelectedSpeciesIds } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
 
 import { toFasta } from 'src/shared/helpers/formatters/fastaFormatter';
 
-import { BlastFormState } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
-import {
+import type {
+  Species,
+  BlastFormState
+} from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
+import type {
   BlastParameterName,
   SequenceType
 } from 'src/content/app/tools/blast/types/blastSettings';
+import type { BlastSubmission } from 'src/content/app/tools/blast/state/blast-results/blastResultsSlice';
 
 export type PayloadParams = {
-  genomeIds: string[];
+  species: Species[];
   querySequences: string[];
   parameters: Partial<Record<BlastParameterName, string>> & {
     title: string;
@@ -45,28 +51,32 @@ export type PayloadParams = {
 
 type BlastSubmissionResponse = {
   submissionId: string;
-  jobs: Array<{
-    jobId?: string;
-    error?: string;
-  }>;
+  submission: BlastSubmission;
 };
 
 const BlastJobSubmit = () => {
   const { sequences } = useBlastInputSequences();
-  const selectedSpecies = useSelector(getSelectedSpeciesIds);
+  const selectedSpeciesIds = useAppSelector(getSelectedSpeciesIds);
 
-  const isDisabled = !isBlastFormValid(selectedSpecies, sequences);
+  const { submitBlastForm } = useToolsContext();
 
-  const blastFormData = useSelector(getBlastFormData);
+  const isDisabled = !isBlastFormValid(selectedSpeciesIds, sequences);
 
-  const onBlastSubmit = () => {
+  const blastFormData = useAppSelector(getBlastFormData);
+
+  const onBlastSubmit = async () => {
     const payload = createBlastSubmissionData(blastFormData);
-    return submitBlastForm(payload);
+
+    const response = await submitBlastForm(payload);
+
+    if (response) {
+      onSubmitSuccess(response);
+    }
   };
 
   const onSubmitSuccess = (response: BlastSubmissionResponse) => {
     // TODO: change the temporary implementation of this function with a more permanent one
-    const firstJobId = response.jobs[0].jobId;
+    const firstJobId = response.submission.results[0].jobId;
     if (!firstJobId) {
       return;
     }
@@ -80,11 +90,7 @@ const BlastJobSubmit = () => {
   };
 
   return (
-    <LoadingButton
-      onClick={onBlastSubmit}
-      onSuccess={onSubmitSuccess as any}
-      isDisabled={isDisabled}
-    >
+    <LoadingButton onClick={onBlastSubmit} isDisabled={isDisabled}>
       Run
     </LoadingButton>
   );
@@ -98,7 +104,7 @@ export const createBlastSubmissionData = (
   );
 
   return {
-    genomeIds: blastFormData.selectedSpecies,
+    species: blastFormData.selectedSpecies,
     querySequences: sequences,
     parameters: {
       title: blastFormData.settings.jobName,
@@ -108,26 +114,6 @@ export const createBlastSubmissionData = (
       ...blastFormData.settings.parameters
     }
   };
-};
-
-const submitBlastForm = async (
-  payload: ReturnType<typeof createBlastSubmissionData>
-) => {
-  const endpointURL = `${config.toolsApiBaseUrl}/blast/job`;
-
-  const response = await fetch(endpointURL, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify(payload)
-  });
-
-  if (response.ok) {
-    return response.json();
-  } else {
-    throw new Error();
-  }
 };
 
 export default BlastJobSubmit;

--- a/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.test.tsx
+++ b/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.test.tsx
@@ -25,7 +25,9 @@ import blastFormReducer, {
   type BlastFormState
 } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
 
-import SpeciesSelector from './BlastSpeciesSelector';
+import BlastSpeciesSelector from './BlastSpeciesSelector';
+
+import speciesList from './speciesList';
 
 const renderComponent = (
   {
@@ -51,7 +53,7 @@ const renderComponent = (
 
   const renderResult = render(
     <Provider store={store}>
-      <SpeciesSelector />
+      <BlastSpeciesSelector />
     </Provider>
   );
 
@@ -62,22 +64,20 @@ const renderComponent = (
 };
 
 describe('SpeciesSelector', () => {
-  describe('species selection', () => {
-    it('updates the selectedSpecies state', () => {
-      const { container, store } = renderComponent();
+  it('updates the selectedSpecies state', () => {
+    const { container, store } = renderComponent();
 
-      const speciesCheckbox = container.querySelector(
-        'tbody tr [data-test-id="checkbox"]'
-      ) as HTMLElement;
+    const speciesCheckbox = container.querySelector(
+      'tbody tr [data-test-id="checkbox"]'
+    ) as HTMLElement;
 
-      userEvent.click(speciesCheckbox);
+    userEvent.click(speciesCheckbox);
 
-      const updatedState = store.getState();
+    const updatedState = store.getState();
 
-      expect(updatedState.blast.blastForm.selectedSpecies.length).toBe(1);
-      expect(updatedState.blast.blastForm.selectedSpecies[0]).toEqual(
-        'homo_sapiens_GCA_000001405_14'
-      );
-    });
+    expect(updatedState.blast.blastForm.selectedSpecies.length).toBe(1);
+    expect(updatedState.blast.blastForm.selectedSpecies[0]).toEqual(
+      speciesList[0]
+    );
   });
 });

--- a/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.tsx
+++ b/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.tsx
@@ -21,23 +21,28 @@ import {
   addSelectedSpecies,
   removeSelectedSpecies
 } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
-import { getSelectedSpeciesIds } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
+import { getSelectedSpeciesList } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
 
 import Checkbox from 'src/shared/components/checkbox/Checkbox';
 
-import SpeciesList from './SpeciesList';
+import speciesList from './speciesList';
+
+import type { Species } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
 
 import styles from './BlastSpeciesSelector.scss';
 
 const BlastSpeciesSelector = () => {
   const dispatch = useDispatch();
-  const selectedSpecies = useSelector(getSelectedSpeciesIds);
+  const selectedSpeciesList = useSelector(getSelectedSpeciesList);
+  const selectedGenomeIds = selectedSpeciesList.map(
+    ({ genome_id }) => genome_id
+  );
 
-  const onSpeciesSelection = (isChecked: boolean, genomeId: string) => {
+  const onSpeciesSelection = (isChecked: boolean, species: Species) => {
     if (isChecked) {
-      dispatch(addSelectedSpecies({ genomeId }));
+      dispatch(addSelectedSpecies(species));
     } else {
-      dispatch(removeSelectedSpecies({ genomeId }));
+      dispatch(removeSelectedSpecies(species.genome_id));
     }
   };
 
@@ -53,19 +58,19 @@ const BlastSpeciesSelector = () => {
           </tr>
         </thead>
         <tbody>
-          {SpeciesList.map((item, index) => {
+          {speciesList.map((species, index) => {
             return (
               <tr key={index}>
-                <td>{item.common_name ? item.common_name : '-'}</td>
+                <td>{species.common_name ?? '-'}</td>
                 <td className={styles.scientificNameCol}>
-                  {item.scientific_name}
+                  {species.scientific_name}
                 </td>
-                <td className={styles.assemblyCol}>{item.assembly_name}</td>
+                <td className={styles.assemblyCol}>{species.assembly_name}</td>
                 <td className={styles.selectCol}>
                   <Checkbox
-                    checked={selectedSpecies.includes(item.genome_id)}
+                    checked={selectedGenomeIds.includes(species.genome_id)}
                     onChange={(isChecked) =>
-                      onSpeciesSelection(isChecked, item.genome_id)
+                      onSpeciesSelection(isChecked, species)
                     }
                   />
                 </td>

--- a/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelectorHeader.test.tsx
+++ b/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelectorHeader.test.tsx
@@ -70,6 +70,20 @@ const renderComponent = (
   };
 };
 
+const selectedHuman = {
+  genome_id: 'human-genome-id',
+  common_name: 'Human',
+  scientific_name: 'Homo sapiens',
+  assembly_name: 'GRCh38'
+};
+
+const selectedMouse = {
+  genome_id: 'mouse-genome-id',
+  common_name: 'Mouse',
+  scientific_name: 'Mus musculus',
+  assembly_name: 'GRCm39'
+};
+
 describe('SpeciesSelectorHeader', () => {
   describe('species counter', () => {
     it('starts with 0', () => {
@@ -79,7 +93,7 @@ describe('SpeciesSelectorHeader', () => {
     });
 
     it('displays the number of added species', () => {
-      const selectedSpecies = ['human', 'mouse'];
+      const selectedSpecies = [selectedHuman, selectedMouse];
       const { container } = renderComponent({ state: { selectedSpecies } });
       const speciesCounter = container.querySelector('.header .speciesCounter');
       expect(getNodeText(speciesCounter as HTMLElement)).toBe(
@@ -90,7 +104,7 @@ describe('SpeciesSelectorHeader', () => {
 
   describe('clear all control', () => {
     it('clears all selected species', () => {
-      const selectedSpecies = ['human', 'mouse'];
+      const selectedSpecies = [selectedHuman, selectedMouse];
       const { container, store } = renderComponent({
         state: { selectedSpecies }
       });

--- a/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelectorHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelectorHeader.tsx
@@ -21,7 +21,7 @@ import {
   switchToSequencesStep,
   clearSelectedSpecies
 } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
-import { getSelectedSpeciesIds } from 'src/content/app/tools/blast//state/blast-form/blastFormSelectors';
+import { getSelectedSpeciesList } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
 
 import { SecondaryButton } from 'src/shared/components/button/Button';
 
@@ -35,7 +35,7 @@ const BlastSpeciesSelectorHeader = (props: Props) => {
   const { compact } = props;
   const dispatch = useDispatch();
 
-  const selectedSpecies = useSelector(getSelectedSpeciesIds);
+  const selectedSpeciesList = useSelector(getSelectedSpeciesList);
 
   const onSwitchToSequence = () => {
     dispatch(switchToSequencesStep());
@@ -49,7 +49,9 @@ const BlastSpeciesSelectorHeader = (props: Props) => {
     <div className={styles.header}>
       <div className={styles.headerGroup}>
         <span className={styles.headerTitle}>Blast against</span>
-        <span className={styles.speciesCounter}>{selectedSpecies.length}</span>
+        <span className={styles.speciesCounter}>
+          {selectedSpeciesList.length}
+        </span>
         <span className={styles.maxSpecies}>of 7 species</span>
         {compact && (
           <span className={styles.clearAll} onClick={onClearAll}>

--- a/src/content/app/tools/blast/components/blast-species-selector/speciesList.ts
+++ b/src/content/app/tools/blast/components/blast-species-selector/speciesList.ts
@@ -16,7 +16,7 @@
 
 //TODO: hardcoding species list in this file, Once we get it from the API (when we implement search or add more species), this file can be deleted
 // Check if we need the sorting and which field we need to submit a job
-const SpeciesList = [
+const speciesList = [
   {
     assembly_name: 'GRCh38.p13',
     common_name: 'Human',
@@ -63,7 +63,7 @@ const SpeciesList = [
 ];
 // species with common name first and sort alphabetically by common name
 // If no common name, then sort by scientific name alphabetically
-SpeciesList.sort((a, b) => {
+speciesList.sort((a, b) => {
   if (a.common_name) {
     if (a.common_name && b.common_name) {
       return a.common_name > b.common_name ? 1 : -1;
@@ -77,4 +77,4 @@ SpeciesList.sort((a, b) => {
   }
 });
 
-export default SpeciesList;
+export default speciesList;

--- a/src/content/app/tools/blast/services/blastStorageService.ts
+++ b/src/content/app/tools/blast/services/blastStorageService.ts
@@ -30,11 +30,19 @@ export const saveBlastSubmission = async (
   await IndexedDB.set(STORE_NAME, submissionId, submission);
 };
 
-export const getAllBlastSubmissions = async (): Promise<BlastSubmission[]> => {
-  const submissionIds = await IndexedDB.keys(STORE_NAME);
-  return Promise.all(
-    submissionIds.map((id) => getBlastSubmission(id as string))
+export const getAllBlastSubmissions = async (): Promise<
+  Record<string, BlastSubmission>
+> => {
+  const submissionIds = (await IndexedDB.keys(STORE_NAME)) as string[];
+  const submissions = await Promise.all(
+    submissionIds.map((id) => getBlastSubmission(id))
   );
+  return submissionIds.reduce((obj, id, index) => {
+    return {
+      ...obj,
+      [id]: submissions[index]
+    };
+  }, {} as Record<string, BlastSubmission>);
 };
 
 export const getBlastSubmission = async (

--- a/src/content/app/tools/blast/services/blastStorageService.ts
+++ b/src/content/app/tools/blast/services/blastStorageService.ts
@@ -1,0 +1,60 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import IndexedDB from 'src/services/indexeddb-service';
+
+import type {
+  BlastSubmission,
+  BlastJob
+} from '../state/blast-results/blastResultsSlice';
+
+const STORE_NAME = 'blast-submissions';
+
+export const saveBlastSubmission = async (
+  submissionId: string,
+  submission: BlastSubmission
+) => {
+  await IndexedDB.set(STORE_NAME, submissionId, submission);
+};
+
+export const getAllBlastSubmissions = async (): Promise<BlastSubmission[]> => {
+  const submissionIds = await IndexedDB.keys(STORE_NAME);
+  return Promise.all(
+    submissionIds.map((id) => getBlastSubmission(id as string))
+  );
+};
+
+export const getBlastSubmission = async (
+  submissionId: string
+): Promise<BlastSubmission> => {
+  return await IndexedDB.get(STORE_NAME, submissionId);
+};
+
+export const updateSavedBlastJob = async (params: {
+  submissionId: string;
+  jobId: string;
+  fragment: Partial<BlastJob>;
+}) => {
+  const { submissionId, jobId, fragment } = params;
+  const submission = await getBlastSubmission(submissionId);
+  const job = submission.results.find((job) => job.jobId === jobId);
+  Object.assign(job, fragment); // this will mutate the object
+  await saveBlastSubmission(submissionId, submission);
+};
+
+export const deleteBlastSubmission = async (submissionId: string) => {
+  await IndexedDB.delete(STORE_NAME, submissionId);
+};

--- a/src/content/app/tools/blast/state/blast-api/blastApiSlice.ts
+++ b/src/content/app/tools/blast/state/blast-api/blastApiSlice.ts
@@ -19,6 +19,22 @@ import config from 'config';
 import restApiSlice from 'src/shared/state/api-slices/restSlice';
 
 import type { BlastSettingsConfig } from 'src/content/app/tools/blast/types/blastSettings';
+import type { Species } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
+import type { BlastSubmission } from '../blast-results/blastResultsSlice';
+
+export type BlastSubmissionPayload = {
+  species: Species[];
+  querySequences: string[];
+  parameters: Record<string, string>;
+};
+
+type BlastSubmissionResponse = {
+  submissionId: string;
+  jobs: Array<{
+    jobId?: string;
+    error?: string;
+  }>;
+};
 
 const blastApiSlice = restApiSlice.injectEndpoints({
   endpoints: (builder) => ({
@@ -27,8 +43,44 @@ const blastApiSlice = restApiSlice.injectEndpoints({
         url: `${config.toolsApiBaseUrl}/blast/config`
       }),
       keepUnusedDataFor: 60 * 60 // one hour
+    }),
+    submitBlast: builder.mutation<
+      { submissionId: string; submission: BlastSubmission },
+      BlastSubmissionPayload
+    >({
+      query(payload) {
+        const body = {
+          genomeIds: payload.species.map(({ genome_id }) => genome_id),
+          querySequences: payload.querySequences,
+          parameters: payload.parameters
+        };
+        return {
+          url: `${config.toolsApiBaseUrl}/blast/job`,
+          method: 'POST',
+          body
+        };
+      },
+      transformResponse(response: BlastSubmissionResponse, _, payload) {
+        const { submissionId, jobs } = response;
+        // TODO: decide what to do when a submission returns error jobs
+        const results = jobs.map((job) => ({
+          jobId: job.jobId as string,
+          status: 'RUNNING',
+          seen: false,
+          data: null
+        }));
+        return {
+          submissionId,
+          submission: {
+            submission: payload,
+            results,
+            submittedAt: Date.now()
+          } as unknown as BlastSubmission
+        };
+      }
     })
   })
 });
 
 export const { useBlastConfigQuery } = blastApiSlice;
+export const { submitBlast } = blastApiSlice.endpoints;

--- a/src/content/app/tools/blast/state/blast-form/blastFormSelectors.ts
+++ b/src/content/app/tools/blast/state/blast-form/blastFormSelectors.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { createSelector } from 'reselect';
+
 import { RootState } from 'src/store';
 
 export const getSequences = (state: RootState) =>
@@ -45,7 +47,12 @@ export const getBlastJobName = (state: RootState) =>
 
 export const getStep = (state: RootState) => state.blast.blastForm.step;
 
-export const getSelectedSpeciesIds = (state: RootState) =>
+export const getSelectedSpeciesList = (state: RootState) =>
   state.blast.blastForm.selectedSpecies;
+
+export const getSelectedSpeciesIds = createSelector(
+  getSelectedSpeciesList,
+  (speciesList) => speciesList.map(({ genome_id }) => genome_id)
+);
 
 export const getBlastFormData = (state: RootState) => state.blast.blastForm;

--- a/src/content/app/tools/blast/state/blast-form/blastFormSlice.ts
+++ b/src/content/app/tools/blast/state/blast-form/blastFormSlice.ts
@@ -34,12 +34,19 @@ type BlastFormSettings = {
   parameters: Partial<Record<BlastParameterName, string>>;
 };
 
+export type Species = {
+  genome_id: string;
+  common_name: string | null;
+  scientific_name: string;
+  assembly_name: string;
+};
+
 export type BlastFormState = {
   step: 'sequences' | 'species'; // will only be relevant on smaller screens
   sequences: ParsedInputSequence[];
   shouldAppendEmptyInput: boolean;
   hasUncommittedSequence: boolean;
-  selectedSpecies: string[];
+  selectedSpecies: Species[];
   settings: BlastFormSettings;
 };
 
@@ -101,14 +108,14 @@ const blastFormSlice = createSlice({
       const { sequences } = action.payload;
       state.sequences = sequences;
     },
-    addSelectedSpecies(state, action: PayloadAction<{ genomeId: string }>) {
-      const { genomeId } = action.payload;
-      state.selectedSpecies.push(genomeId);
+    addSelectedSpecies(state, action: PayloadAction<Species>) {
+      const species = action.payload;
+      state.selectedSpecies.push(species);
     },
-    removeSelectedSpecies(state, action: PayloadAction<{ genomeId: string }>) {
-      const { genomeId } = action.payload;
+    removeSelectedSpecies(state, action: PayloadAction<string>) {
+      const genomeId = action.payload;
       state.selectedSpecies = state.selectedSpecies.filter(
-        (item) => item !== genomeId
+        (species) => species.genome_id !== genomeId
       );
     },
     clearSelectedSpecies(state) {

--- a/src/content/app/tools/blast/state/blast-results/blastResultsSelectors.ts
+++ b/src/content/app/tools/blast/state/blast-results/blastResultsSelectors.ts
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-import { combineReducers } from 'redux';
+import { RootState } from 'src/store';
 
-import blastFormReducer from './blast-form/blastFormSlice';
-import blastResultsReducer from './blast-results/blastResultsSlice';
-
-export default combineReducers({
-  blastForm: blastFormReducer,
-  blastResults: blastResultsReducer
-});
+export const getBlastSubmissions = (state: RootState) =>
+  state.blast.blastResults;

--- a/src/content/app/tools/blast/state/blast-results/blastResultsSlice.ts
+++ b/src/content/app/tools/blast/state/blast-results/blastResultsSlice.ts
@@ -53,6 +53,12 @@ const blastResultsSlice = createSlice({
   name: 'blast-results',
   initialState: {} as BlastResultsState,
   reducers: {
+    restoreSubmissions(
+      state,
+      action: PayloadAction<Record<string, BlastSubmission>>
+    ) {
+      return action.payload;
+    },
     updateJob(
       state,
       action: PayloadAction<{
@@ -75,6 +81,6 @@ const blastResultsSlice = createSlice({
   }
 });
 
-export const { updateJob } = blastResultsSlice.actions;
+export const { restoreSubmissions, updateJob } = blastResultsSlice.actions;
 
 export default blastResultsSlice.reducer;

--- a/src/content/app/tools/blast/state/blast-results/blastResultsSlice.ts
+++ b/src/content/app/tools/blast/state/blast-results/blastResultsSlice.ts
@@ -1,0 +1,80 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { submitBlast } from '../blast-api/blastApiSlice';
+
+import type { BlastParameterName } from 'src/content/app/tools/blast/types/blastSettings';
+import type { Species } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
+
+export type JobStatus =
+  | 'RUNNING' // the job is currently being processed
+  | 'FINISHED' // job has finished, and the results can then be retrieved
+  | 'FAILURE' // the job failed
+  | 'ERROR' // an error occurred attempting to get the job status — TODO: ask backend to represent this as a 500 error?
+  | 'NOT_FOUND'; // TODO: ask backend to represent this as a 404 error?
+
+export type BlastSubmission = {
+  submission: {
+    species: Species[];
+    sequences: string[]; // Or perhaps parsed sequences?
+    parameters: Partial<Record<BlastParameterName, string>>;
+  };
+  results: Array<{
+    jobId: string;
+    status: JobStatus;
+    seen: boolean;
+    data: null; // TODO: add data type
+  }>;
+  submittedAt: number; // timestamp
+};
+
+export type BlastJob = BlastSubmission['results'][number];
+
+type BlastResultsState = {
+  [submissionId: string]: BlastSubmission;
+};
+
+const blastResultsSlice = createSlice({
+  name: 'blast-results',
+  initialState: {} as BlastResultsState,
+  reducers: {
+    updateJob(
+      state,
+      action: PayloadAction<{
+        submissionId: string;
+        jobId: string;
+        fragment: Partial<BlastJob>;
+      }>
+    ) {
+      const { submissionId, jobId, fragment } = action.payload;
+      const submission = state[submissionId];
+      const job = submission.results.find((job) => job.jobId === jobId);
+      Object.assign(job, fragment);
+    }
+  },
+  extraReducers: (builder) => {
+    builder.addMatcher(submitBlast.matchFulfilled, (state, { payload }) => {
+      const { submissionId, submission } = payload;
+      state[submissionId] = submission;
+    });
+  }
+});
+
+export const { updateJob } = blastResultsSlice.actions;
+
+export default blastResultsSlice.reducer;

--- a/src/content/app/tools/shared/components/tools-app-bar/ToolsAppBar.tsx
+++ b/src/content/app/tools/shared/components/tools-app-bar/ToolsAppBar.tsx
@@ -30,14 +30,23 @@ import AppBar from 'src/shared/components/app-bar/AppBar';
 import { SelectedSpecies } from 'src/shared/components/selected-species';
 import SpeciesTabsWrapper from 'src/shared/components/species-tabs-wrapper/SpeciesTabsWrapper';
 
+import type { CommittedItem } from 'src/content/app/species-selector/types/species-search';
+
 const ToolsAppBar = () => {
   const speciesList = useSelector(getEnabledCommittedSpecies);
   const speciesListIds = useSelector(getSelectedSpeciesIds);
   const dispatch = useDispatch();
 
-  const speciesLozengeClick = (genomeId: string) => {
-    if (!speciesListIds.includes(genomeId)) {
-      dispatch(addSelectedSpecies({ genomeId }));
+  const speciesLozengeClick = (species: CommittedItem) => {
+    if (!speciesListIds.includes(species.genome_id)) {
+      dispatch(
+        addSelectedSpecies({
+          genome_id: species.genome_id,
+          common_name: species.common_name,
+          scientific_name: species.scientific_name,
+          assembly_name: species.assembly_name
+        })
+      );
     }
   };
 
@@ -45,7 +54,7 @@ const ToolsAppBar = () => {
     <SelectedSpecies
       key={index}
       species={species}
-      onClick={() => speciesLozengeClick(species.genome_id)}
+      onClick={() => speciesLozengeClick(species)}
     />
   ));
   const speciesSelectorLink = useMemo(() => {

--- a/src/content/app/tools/shared/context/ToolsContextContainer.tsx
+++ b/src/content/app/tools/shared/context/ToolsContextContainer.tsx
@@ -1,0 +1,140 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { type ReactNode, createContext } from 'react';
+
+import config from 'config';
+
+import { useAppDispatch } from 'src/store';
+
+import { submitBlast } from 'src/content/app/tools/blast/state/blast-api/blastApiSlice';
+import { updateJob } from 'src/content/app/tools/blast/state/blast-results/blastResultsSlice';
+import {
+  saveBlastSubmission,
+  updateSavedBlastJob
+} from 'src/content/app/tools/blast/services/blastStorageService';
+
+import type { BlastSubmissionPayload } from 'src/content/app/tools/blast/state/blast-api/blastApiSlice';
+import type { BlastSubmission } from 'src/content/app/tools/blast/state/blast-results/blastResultsSlice';
+
+type Props = {
+  children: ReactNode;
+};
+
+type ToolsContextType = {
+  submitBlastForm: (
+    payload: BlastSubmissionPayload
+  ) => Promise<
+    { submissionId: string; submission: BlastSubmission } | undefined
+  >;
+};
+
+const ToolsContext = createContext<ToolsContextType | undefined>(undefined);
+
+const ToolContextContainer = (props: Props) => {
+  const dispatch = useAppDispatch();
+
+  // is blast form submitting
+
+  const submitBlastForm = async (payload: BlastSubmissionPayload) => {
+    const dispatched = dispatch(submitBlast.initiate(payload));
+    const response = await dispatched;
+    dispatched.reset(); // prevent indefinite caching of subscription result
+
+    if (!('data' in response)) {
+      return;
+    }
+
+    const {
+      data: { submissionId, submission }
+    } = response;
+    await saveBlastSubmission(submissionId, submission);
+
+    onBlastSubmissionSuccess(response.data);
+
+    return response.data;
+  };
+
+  const onBlastSubmissionSuccess = async ({
+    submissionId,
+    submission
+  }: {
+    submissionId: string;
+    submission: BlastSubmission;
+  }) => {
+    const jobIds = submission.results.map(({ jobId }) => ({
+      submissionId,
+      jobId
+    }));
+
+    for await (const job of getFinishedJobs({ jobs: jobIds })) {
+      const updatePayload = {
+        submissionId,
+        jobId: job.jobId,
+        fragment: { status: job.status }
+      };
+      dispatch(updateJob(updatePayload));
+      await updateSavedBlastJob(updatePayload);
+    }
+  };
+
+  return (
+    <ToolsContext.Provider value={{ submitBlastForm }}>
+      {props.children}
+    </ToolsContext.Provider>
+  );
+};
+
+type CheckStatusesParams = {
+  jobs: Array<{ submissionId: string; jobId: string }>;
+};
+
+async function* getFinishedJobs({ jobs }: CheckStatusesParams) {
+  while (jobs.length) {
+    for (const job of [...jobs]) {
+      const { status } = await fetchJobStatus(job.jobId);
+
+      if (['FINISHED', 'FAILURE'].includes(status)) {
+        jobs = jobs.filter(({ jobId }) => jobId !== job.jobId);
+        yield { ...job, status };
+      }
+    }
+
+    await timer(5000);
+  }
+}
+
+const timer = (time: number) =>
+  new Promise((resolve) => setTimeout(resolve, time));
+
+const fetchJobStatus = async (jobId: string) => {
+  const endpointURL = `${config.toolsApiBaseUrl}/blast/jobs/status/${jobId}`;
+
+  const response = await fetch(endpointURL, {
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  });
+
+  if (response.ok) {
+    return response.json();
+  } else {
+    throw new Error();
+  }
+};
+
+export { ToolsContext };
+export default ToolContextContainer;

--- a/src/content/app/tools/shared/context/useToolsContext.ts
+++ b/src/content/app/tools/shared/context/useToolsContext.ts
@@ -14,12 +14,19 @@
  * limitations under the License.
  */
 
-import { combineReducers } from 'redux';
+import { useContext } from 'react';
 
-import blastFormReducer from './blast-form/blastFormSlice';
-import blastResultsReducer from './blast-results/blastResultsSlice';
+import { ToolsContext } from './ToolsContextContainer';
 
-export default combineReducers({
-  blastForm: blastFormReducer,
-  blastResults: blastResultsReducer
-});
+const useToolsContext = () => {
+  const toolsContext = useContext(ToolsContext);
+  if (!toolsContext) {
+    throw new Error(
+      'useToolsContext must be used within ToolsContext provider'
+    );
+  }
+
+  return toolsContext;
+};
+
+export default useToolsContext;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,6 +24,8 @@ import { BrowserRouter } from 'react-router-dom';
 import ensureBrowserSupport from 'src/shared/helpers/browserSupport';
 
 import { Provider as IndexedDBProvider } from 'src/shared/contexts/IndexedDBContext';
+import ToolsContextContainer from 'src/content/app/tools/shared/context/ToolsContextContainer';
+
 import configureStore from './store';
 import Root from './root/Root';
 
@@ -41,9 +43,11 @@ hydrate(
       <IndexedDBProvider>
         <Provider store={store}>
           <BrowserRouter>
-            <HelmetProvider>
-              <Root />
-            </HelmetProvider>
+            <ToolsContextContainer>
+              <HelmetProvider>
+                <Root />
+              </HelmetProvider>
+            </ToolsContextContainer>
           </BrowserRouter>
         </Provider>
       </IndexedDBProvider>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,7 +24,6 @@ import { BrowserRouter } from 'react-router-dom';
 import ensureBrowserSupport from 'src/shared/helpers/browserSupport';
 
 import { Provider as IndexedDBProvider } from 'src/shared/contexts/IndexedDBContext';
-import ToolsContextContainer from 'src/content/app/tools/shared/context/ToolsContextContainer';
 
 import configureStore from './store';
 import Root from './root/Root';
@@ -43,11 +42,9 @@ hydrate(
       <IndexedDBProvider>
         <Provider store={store}>
           <BrowserRouter>
-            <ToolsContextContainer>
-              <HelmetProvider>
-                <Root />
-              </HelmetProvider>
-            </ToolsContextContainer>
+            <HelmetProvider>
+              <Root />
+            </HelmetProvider>
           </BrowserRouter>
         </Provider>
       </IndexedDBProvider>

--- a/src/root/Root.tsx
+++ b/src/root/Root.tsx
@@ -29,6 +29,7 @@ import App from '../content/app/App';
 import RootMeta from './RootMeta';
 import PrivacyBanner from '../shared/components/privacy-banner/PrivacyBanner';
 import ErrorBoundary from 'src/shared/components/error-boundary/ErrorBoundary';
+import ToolsContextContainer from 'src/content/app/tools/shared/context/ToolsContextContainer';
 import { GeneralErrorScreen } from 'src/shared/components/error-screen';
 
 import styles from './Root.scss';
@@ -63,9 +64,11 @@ export const Root = () => {
   return (
     <div className={styles.root}>
       <ErrorBoundary fallbackComponent={GeneralErrorScreen}>
-        <RootMeta />
-        <App />
-        {showPrivacyBanner && <PrivacyBanner closeBanner={closeBanner} />}
+        <ToolsContextContainer>
+          <RootMeta />
+          <App />
+          {showPrivacyBanner && <PrivacyBanner closeBanner={closeBanner} />}
+        </ToolsContextContainer>
       </ErrorBoundary>
     </div>
   );

--- a/src/root/rootReducer.ts
+++ b/src/root/rootReducer.ts
@@ -49,7 +49,8 @@ const createRootReducer = () =>
 export const createServerSideRootReducer = () =>
   combineReducers({
     speciesSelector,
-    entityViewer
+    entityViewer,
+    blast
   });
 
 export default createRootReducer;

--- a/src/services/indexeddb-service.ts
+++ b/src/services/indexeddb-service.ts
@@ -22,8 +22,12 @@ const DB_VERSION = 1;
 const getDbPromise = () => {
   return openDB(DB_NAME, DB_VERSION, {
     upgrade(db) {
+      // FIXME use constants for object store names
       if (!db.objectStoreNames.contains('contact-forms')) {
         db.createObjectStore('contact-forms');
+      }
+      if (!db.objectStoreNames.contains('blast-submissions')) {
+        db.createObjectStore('blast-submissions');
       }
     }
   });
@@ -39,17 +43,17 @@ class IndexedDB {
     return this.db;
   }
 
-  static async get(store: string, key: string) {
+  static async get(store: string, key: IDBValidKey) {
     const db = await this.getDB();
     return db.get(store, key);
   }
 
-  static async set(store: string, key: string, value: any) {
+  static async set(store: string, key: IDBValidKey, value: any) {
     const db = await this.getDB();
     return db.put(store, value, key);
   }
 
-  static async delete(store: string, key: string) {
+  static async delete(store: string, key: IDBValidKey) {
     const db = await this.getDB();
     return db.delete(store, key);
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -15,7 +15,11 @@
  */
 
 import { configureStore } from '@reduxjs/toolkit';
-import { useDispatch } from 'react-redux';
+import {
+  useDispatch,
+  useSelector,
+  type TypedUseSelectorHook
+} from 'react-redux';
 import { createEpicMiddleware } from 'redux-observable';
 
 import config from 'config';
@@ -36,7 +40,7 @@ const middleware = [
   restApiSlice.middleware
 ];
 
-const preloadedState = (window as any).__PRELOADED_STATE__ || {};
+const preloadedState = (globalThis as any).__PRELOADED_STATE__ || {};
 
 export default function getReduxStore() {
   const store = configureStore({
@@ -56,3 +60,4 @@ type AppStore = ReturnType<typeof getReduxStore>;
 export type RootState = ReturnType<typeof rootReducer>;
 export type AppDispatch = AppStore['dispatch'];
 export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;


### PR DESCRIPTION
## Description
This is one of several alternative PRs (see also https://github.com/Ensembl/ensembl-client/pull/718) to enable the following scenario:

1. Submit the blast from
2. Store the result of the submission
  (the response will be of shape `{submissionId: "some_id", jobs: [ { jobId: "ncbi-blah-blah" }, { error: "error message" }, { jobId: "ncbi-blah-blah" } ]})
    - in redux
    - in indexedDB
3. Poll the jobs while their status is `RUNNING`
4. When the status of a job is reported as `FINISHED` or `FAILURE`:
     - update redux state
     - update indexedDB data
     - stop polling

The solution proposed in this PR has extracted the logic for job status polling and for saving and updating blast submissions in indexedDB into a dedicated tools context. To be compared with https://github.com/Ensembl/ensembl-client/pull/718.

### Advantages and disadvantages of the proposed solution

| Advantages  | Disadvantages  |
|---|---|
| No extra dependencies required | The solution required creating a dedicated context component, and therefore is tied to the structure of the React component tree |
| The polling logic can be represented with an async iterator in a rather simple way |  |

### How to read this PR
The specific functions that run when a Blast form is submitted have been extracted into a dedicated React context (see `ToolsContextContainer`). When the user presses the button in the `BlastJobSubmit` component, the `submitBlastForm` function gets called. It submits the form through the `submitBlast` action creator in `blastApiSlice`, waits for the response (of shape `{ submissionId: string; submission: BlastSubmission }`), saves this to indexedDB, and stats polling for the status of individual jobs within the blast submission.

The polling logic (see the `getFinishedJobs` function) is written as an async iterator.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1527
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1529

## Deployment URL(s)
http://save-blast-submission.review.ensembl.org