### PR TITLE
Use the latest package of ensembl-genome-browser (0.2.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -144,6 +144,7 @@
     "../ensembl-genome-browser": {
       "name": "@ensembl/ensembl-genome-browser",
       "version": "0.2.1-test.2",
+      "extraneous": true,
       "license": "ISC",
       "devDependencies": {
         "@rollup/plugin-typescript": "8.2.1",
@@ -2294,8 +2295,9 @@
       "dev": true
     },
     "node_modules/@ensembl/ensembl-genome-browser": {
-      "resolved": "../ensembl-genome-browser",
-      "link": true
+      "version": "0.2.1-test.2",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.2.1-test.2.tgz",
+      "integrity": "sha1-AJ8aiear1touhOgmcZ8BT+LJtqg="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.2.0",
@@ -40254,17 +40256,9 @@
       "dev": true
     },
     "@ensembl/ensembl-genome-browser": {
-      "version": "file:../ensembl-genome-browser",
-      "requires": {
-        "@rollup/plugin-typescript": "8.2.1",
-        "@typescript-eslint/eslint-plugin": "4.28.1",
-        "@typescript-eslint/parser": "4.28.1",
-        "eslint": "7.29.0",
-        "rollup": "2.52.6",
-        "rollup-plugin-copy": "3.4.0",
-        "tslib": "2.3.1",
-        "typescript": "4.3.4"
-      }
+      "version": "0.2.1-test.2",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.2.1-test.2.tgz",
+      "integrity": "sha1-AJ8aiear1touhOgmcZ8BT+LJtqg="
     },
     "@eslint/eslintrc": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "3.5.10",
-        "@ensembl/ensembl-genome-browser": "0.2.1-test.2",
+        "@ensembl/ensembl-genome-browser": "0.2.1",
         "@loadable/component": "5.15.2",
         "@loadable/server": "5.15.2",
         "@react-spring/web": "9.4.3",
@@ -2279,9 +2279,9 @@
       "dev": true
     },
     "node_modules/@ensembl/ensembl-genome-browser": {
-      "version": "0.2.1-test.2",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.2.1-test.2.tgz",
-      "integrity": "sha1-AJ8aiear1touhOgmcZ8BT+LJtqg="
+      "version": "0.2.1",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.2.1.tgz",
+      "integrity": "sha1-+uRBOqTZCoNXjDIPtTH/omHOrnM="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.2.0",
@@ -40240,9 +40240,9 @@
       "dev": true
     },
     "@ensembl/ensembl-genome-browser": {
-      "version": "0.2.1-test.2",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.2.1-test.2.tgz",
-      "integrity": "sha1-AJ8aiear1touhOgmcZ8BT+LJtqg="
+      "version": "0.2.1",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.2.1.tgz",
+      "integrity": "sha1-+uRBOqTZCoNXjDIPtTH/omHOrnM="
     },
     "@eslint/eslintrc": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -141,22 +141,6 @@
         "workbox-webpack-plugin": "6.5.0"
       }
     },
-    "../ensembl-genome-browser": {
-      "name": "@ensembl/ensembl-genome-browser",
-      "version": "0.2.1-test.2",
-      "extraneous": true,
-      "license": "ISC",
-      "devDependencies": {
-        "@rollup/plugin-typescript": "8.2.1",
-        "@typescript-eslint/eslint-plugin": "4.28.1",
-        "@typescript-eslint/parser": "4.28.1",
-        "eslint": "7.29.0",
-        "rollup": "2.52.6",
-        "rollup-plugin-copy": "3.4.0",
-        "tslib": "2.3.1",
-        "typescript": "4.3.4"
-      }
-    },
     "node_modules/@ampproject/remapping": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "3.5.10",
-        "@ensembl/ensembl-genome-browser": "0.2.0",
+        "@ensembl/ensembl-genome-browser": "0.2.1-test.2",
         "@loadable/component": "5.15.2",
         "@loadable/server": "5.15.2",
         "@react-spring/web": "9.4.3",
@@ -139,6 +139,21 @@
         "webpack-merge": "5.8.0",
         "webpack-node-externals": "3.0.0",
         "workbox-webpack-plugin": "6.5.0"
+      }
+    },
+    "../ensembl-genome-browser": {
+      "name": "@ensembl/ensembl-genome-browser",
+      "version": "0.2.1-test.2",
+      "license": "ISC",
+      "devDependencies": {
+        "@rollup/plugin-typescript": "8.2.1",
+        "@typescript-eslint/eslint-plugin": "4.28.1",
+        "@typescript-eslint/parser": "4.28.1",
+        "eslint": "7.29.0",
+        "rollup": "2.52.6",
+        "rollup-plugin-copy": "3.4.0",
+        "tslib": "2.3.1",
+        "typescript": "4.3.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2279,9 +2294,8 @@
       "dev": true
     },
     "node_modules/@ensembl/ensembl-genome-browser": {
-      "version": "0.2.0",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.2.0.tgz",
-      "integrity": "sha1-3A5mTUML2f+hAyXWc5+8F20XpOs="
+      "resolved": "../ensembl-genome-browser",
+      "link": true
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.2.0",
@@ -40240,9 +40254,17 @@
       "dev": true
     },
     "@ensembl/ensembl-genome-browser": {
-      "version": "0.2.0",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.2.0.tgz",
-      "integrity": "sha1-3A5mTUML2f+hAyXWc5+8F20XpOs="
+      "version": "file:../ensembl-genome-browser",
+      "requires": {
+        "@rollup/plugin-typescript": "8.2.1",
+        "@typescript-eslint/eslint-plugin": "4.28.1",
+        "@typescript-eslint/parser": "4.28.1",
+        "eslint": "7.29.0",
+        "rollup": "2.52.6",
+        "rollup-plugin-copy": "3.4.0",
+        "tslib": "2.3.1",
+        "typescript": "4.3.4"
+      }
     },
     "@eslint/eslintrc": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@apollo/client": "3.5.10",
-    "@ensembl/ensembl-genome-browser": "0.2.1-test.2",
+    "@ensembl/ensembl-genome-browser": "0.2.1",
     "@loadable/component": "5.15.2",
     "@loadable/server": "5.15.2",
     "@react-spring/web": "9.4.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@apollo/client": "3.5.10",
-    "@ensembl/ensembl-genome-browser": "0.2.0",
+    "@ensembl/ensembl-genome-browser": "0.2.1-test.2",
     "@loadable/component": "5.15.2",
     "@loadable/server": "5.15.2",
     "@react-spring/web": "9.4.3",


### PR DESCRIPTION
## Description
Use the latest ensembl-genome-browser test package, which will be changed to `0.2.1` before merging this branch. The latest package includes a fix to the genome browser initialisation and the latest wasm build from ensembl-dauphin-style-compiler.

The related ensembl-genome-browser PR is: https://github.com/Ensembl/ensembl-genome-browser/pull/7

## Related JIRA Issue(s)
[ENSWBSITES-1511](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1511)

## Deployment URL(s)
http://test-gb-package.review.ensembl.org/


## Views affected
Genome browser