### PR TITLE
Fix duplicate sequence deletion bug

### DIFF
--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence.tsx
@@ -120,12 +120,12 @@ const BlastInputSequence = (props: Props) => {
   };
 
   const onClear = () => {
-    if (props.sequence) {
-      props.onRemoveSequence?.(index);
-    } else {
+    if (!props.sequence) {
+      // clear textarea if its content has not yet been sent to the parent
       setInput('');
-      props.onInput?.('', index);
     }
+    props.onRemoveSequence?.(index);
+    props.onInput?.('', index);
   };
 
   const isInputValid = input

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence.tsx
@@ -120,9 +120,12 @@ const BlastInputSequence = (props: Props) => {
   };
 
   const onClear = () => {
-    setInput('');
-    props.onRemoveSequence?.(index);
-    props.onInput?.('', index);
+    if (props.sequence) {
+      props.onRemoveSequence?.(index);
+    } else {
+      setInput('');
+      props.onInput?.('', index);
+    }
   };
 
   const isInputValid = input


### PR DESCRIPTION
## Description
Bug reproduction steps:
- Enter three sequences, the first two of which are identical (the third may be the same or different)
- Delete the first input box

You will observe that out of the remaining input boxes, the first is empty, and the sequence that was second before you deleted the first one has disappeared:

https://user-images.githubusercontent.com/6834224/160947748-28af8d3a-1bb2-484a-86c7-898095a33196.mp4

### Cause of the bug
We are using a useEffect hook that updates the content of the textarea if the props contains a new sequence ([link](https://github.com/Ensembl/ensembl-client/blob/dev/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence.tsx#L78-L80)). However, in the above scenario, the new sequence for the first input box after the first sequence was deleted will be the second sequence that is identical to the first. Therefore, the useEffect hook will not fire. Without it firing though, the last thing that the component does when user clicks on the trashcan icon is clear the sequence from the textarea.

### Proposed solution
Only clear the sequence from the textarea if the input box has not been passed any sequence with the props. Otherwise, just tell the parent component to delete this sequence. 

**Behaviour after the fix:**

https://user-images.githubusercontent.com/6834224/160948419-b44ccaa1-4d61-45a5-ba70-2cde582906cd.mp4

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1526

## Deployment URL(s)
http://same-sequence-deleted.review.ensembl.org

## Views affected
Blast form page