### PR TITLE
Fail downloading all sequences by InstantDownload if even one fails

### DIFF
--- a/src/shared/components/instant-download/instant-download-gene/InstantDownloadGene.tsx
+++ b/src/shared/components/instant-download/instant-download-gene/InstantDownloadGene.tsx
@@ -133,8 +133,9 @@ const InstantDownloadGene = (props: Props) => {
     try {
       await fetchForGene(payload);
       props.onDownloadSuccess?.(payload);
-    } catch {
+    } catch (error) {
       props.onDownloadFailure?.(payload);
+      throw error;
     } finally {
       resetCheckboxes();
     }

--- a/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.tsx
+++ b/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.tsx
@@ -149,8 +149,9 @@ const InstantDownloadTranscript = (props: Props) => {
     try {
       await fetchForTranscript(payload);
       props.onDownloadSuccess?.(payload);
-    } catch {
+    } catch (error) {
       props.onDownloadFailure?.(payload);
+      throw error;
     } finally {
       resetCheckboxes();
     }

--- a/src/shared/workers/sequenceFetcher.worker.ts
+++ b/src/shared/workers/sequenceFetcher.worker.ts
@@ -30,7 +30,13 @@ export type SequenceFetcherParams = Array<SingleSequenceFetchParams>;
 const downloadSequences = async (params: SequenceFetcherParams) => {
   const sequencePromises = params.map(({ label, url, reverseComplement }) => {
     return fetch(url)
-      .then((response) => response.text())
+      .then((response) => {
+        if (response.ok) {
+          return response.text();
+        } else {
+          throw new Error();
+        }
+      })
       .then((sequence) => {
         if (reverseComplement) {
           sequence = getReverseComplement(sequence);


### PR DESCRIPTION
## Description
At the moment, our code is ignoring 400/500 status codes of responses during sequence download. This PR fixes that:
- add a check for `response.ok` field in each request for a sequence; if it's false, throw an error
- throw an error in the submit handler, which will make the download button show a red cross

## How to test
This isn't really testable in a review deployment. Please, check the updated behaviour in your local copy.

The easies way to test is to modify the proxyMiddleware file (see [docs](https://github.com/chimurai/http-proxy-middleware/blob/master/recipes/response-interceptor.md#readme)) so that it always responds with a 404 for cDNA of BRCA2's first transcript:
```
import { createProxyMiddleware, responseInterceptor } from 'http-proxy-middleware';

...

const apiProxyMiddleware = createProxyMiddleware('/api', {
  target: 'https://staging-2020.ensembl.org',
  selfHandleResponse: true,
  onProxyRes: responseInterceptor(async (responseBuffer, proxyRes, req, res) => {
    if (req.url?.includes('2f8c687a656debd4c8b1b4d47747ba35')) {
      res.statusCode = 404;
    }
    const response = responseBuffer.toString('utf8');
    return response.replace('Hello', 'Teapot');
  }),
  changeOrigin: true,
  secure: false
});
```
and then try to download all sequences of BRCA2's first transcript.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1541

## Views affected
- Genome browser page
- Entity viewer page