### PR TITLE
Fix warning: Detected incorrect braces with only single value

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -4,7 +4,7 @@
     "manage-licence-header add",
     "prettier --write"
   ],
-  "*.{scss}": [
+  "*.scss": [
     "stylelint",
     "prettier --write"
   ]


### PR DESCRIPTION
## Description
Fixes the following warning that appears when we try to commit some changes:
![Screenshot 2022-04-19 at 10 46 37](https://user-images.githubusercontent.com/3085815/163977291-c1f9016e-4a26-4e98-952b-17307a51dc17.png)
