### PR TITLE
Show sequences in genome browser drawer's sequence view

### DIFF
--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.scss
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.scss
@@ -5,7 +5,7 @@
   grid-template-areas:
     'main-top aside-top'
     'main-bottom aside-bottom';
-  grid-template-columns: auto 1fr;
+  grid-template-columns: 60ch 1fr;
   grid-template-rows: 20px minmax(200px, 400px);
   grid-column-gap: 24px;
   align-items: start;
@@ -30,7 +30,6 @@
 .sequence {
   grid-area: main-bottom;
   margin-top: 10px;
-  width: 60ch;
   height: 100%;
   font-family: $font-family-monospace;
   color: $dark-grey;

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.scss
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.scss
@@ -56,10 +56,9 @@
 }
 
 .copyLozenge {
-  display: inline-block;
+  display: flex;
   height: 18px;
   padding: 0 14px;
-  display: flex;
   align-items: center;
   justify-content: center;
 }

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.scss
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.scss
@@ -5,7 +5,7 @@
   grid-template-areas:
     'main-top aside-top'
     'main-bottom aside-bottom';
-  grid-template-columns: 60ch 1fr;
+  grid-template-columns: auto 1fr;
   grid-template-rows: 20px minmax(200px, 400px);
   grid-column-gap: 24px;
   align-items: start;

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.tsx
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.tsx
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
+
+import { getReverseComplement } from 'src/shared/helpers/sequenceHelpers';
 
 import RadioGroup from 'src/shared/components/radio-group/RadioGroup';
+import Checkbox from 'src/shared/components/checkbox/Checkbox';
 
 import type { SequenceType } from 'src/content/app/genome-browser/state/drawer/drawer-sequence/drawerSequenceSlice';
 
@@ -44,7 +47,9 @@ const DrawerSequenceView = (props: Props) => {
     sequence,
     sequenceTypes,
     selectedSequenceType,
-    onSequenceTypeChange
+    onSequenceTypeChange,
+    isReverseComplement,
+    onReverseComplementChange
   } = props;
 
   const sequenceTypeOptions = sequenceTypes.map((sequenceType) => ({
@@ -52,19 +57,23 @@ const DrawerSequenceView = (props: Props) => {
     label: sequenceLabelsMap[sequenceType]
   }));
 
+  const displaySequence = useMemo(() => {
+    return isReverseComplement ? getReverseComplement(sequence) : sequence;
+  }, [sequence, isReverseComplement]);
+
   const sequenceLengthUnits = selectedSequenceType === 'protein' ? 'aa' : 'bp';
 
   return (
     <div className={styles.layout}>
       <div className={styles.mainTop}>
         <div>
-          <span>{sequence.length}</span>
+          <span>{displaySequence.length}</span>
           <span className={styles.sequenceLengthUnits}>
             {sequenceLengthUnits}
           </span>
         </div>
       </div>
-      <div className={styles.sequence}>{sequence}</div>
+      <div className={styles.sequence}>{displaySequence}</div>
       <div className={styles.asideTop}>
         <div>blast control</div>
       </div>
@@ -78,7 +87,11 @@ const DrawerSequenceView = (props: Props) => {
             selectedOption={selectedSequenceType}
           />
           <div className={styles.reverseComplement}>
-            Reverse complement checkbox
+            <Checkbox
+              label="Reverse complement"
+              checked={isReverseComplement}
+              onChange={onReverseComplementChange}
+            />
           </div>
         </div>
       </div>

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.tsx
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.tsx
@@ -144,7 +144,16 @@ const Sequence = (props: {
         </span>
         <Copy value={displaySequence} />
       </div>
-      <div className={styles.sequence}>{displaySequence}</div>
+
+      {/*
+        NOTE: the dangerouslySetInnerHTML on the line below shouldn't be necessary;
+        but for some reason, Chrome has problems wrapping the sequence
+        if it is just passed to the div as a child.
+      */}
+      <div
+        className={styles.sequence}
+        dangerouslySetInnerHTML={{ __html: displaySequence }}
+      />
     </>
   );
 };

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.tsx
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import React, { useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
+import classNames from 'classnames';
 
 import { getReverseComplement } from 'src/shared/helpers/sequenceHelpers';
 
@@ -128,13 +129,50 @@ const Sequence = (props: {
   return (
     <>
       <div className={styles.mainTop}>
-        <span>{displaySequence.length}</span>
-        <span className={styles.sequenceLengthUnits}>
-          {sequenceLengthUnits}
+        <span>
+          {displaySequence.length}
+          <span className={styles.sequenceLengthUnits}>
+            {sequenceLengthUnits}
+          </span>
         </span>
+        <Copy value={displaySequence} />
       </div>
       <div className={styles.sequence}>{displaySequence}</div>
     </>
+  );
+};
+
+// QUESTION: is this going to become a a standalone component?
+const Copy = (props: { value: string }) => {
+  const [copied, setCopied] = useState(false);
+
+  let timeout: ReturnType<typeof setTimeout>;
+
+  useEffect(() => {
+    return () => timeout && clearTimeout(timeout);
+  }, []);
+
+  const copy = () => {
+    setCopied(true);
+    navigator.clipboard.writeText(props.value);
+
+    timeout = setTimeout(() => setCopied(false), 1500);
+  };
+
+  const componentStyles = classNames(styles.copyLozenge, {
+    [styles.copyLozengeCopied]: copied
+  });
+
+  return (
+    <span className={componentStyles}>
+      {copied ? (
+        'Copied'
+      ) : (
+        <span className={styles.copy} onClick={copy}>
+          Copy
+        </span>
+      )}
+    </span>
   );
 };
 

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.tsx
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.tsx
@@ -52,12 +52,16 @@ const DrawerSequenceView = (props: Props) => {
     label: sequenceLabelsMap[sequenceType]
   }));
 
+  const sequenceLengthUnits = selectedSequenceType === 'protein' ? 'aa' : 'bp';
+
   return (
     <div className={styles.layout}>
       <div className={styles.mainTop}>
         <div>
           <span>{sequence.length}</span>
-          <span className={styles.basePairsLabel}>bp</span>
+          <span className={styles.sequenceLengthUnits}>
+            {sequenceLengthUnits}
+          </span>
         </div>
       </div>
       <div className={styles.sequence}>{sequence}</div>

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.tsx
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.tsx
@@ -63,6 +63,8 @@ const DrawerSequenceView = (props: Props) => {
     label: sequenceLabelsMap[sequenceType]
   }));
 
+  const canHaveReverseComplement = selectedSequenceType === 'genomic';
+
   const showHideStyleProps = isExpanded
     ? {
         classNames: { wrapper: styles.showHide }
@@ -86,9 +88,12 @@ const DrawerSequenceView = (props: Props) => {
               isReverseComplement={isReverseComplement}
             />
           )}
-          <div className={styles.asideTop}>
-            <div>blast control</div>
-          </div>
+          {/* The BLAST button will go here when ready
+
+              <div className={styles.asideTop}>
+                BLAST BUTTON HERE!
+              </div>
+          */}
           <div className={styles.asideBottom}>
             <div className={styles.sequenceTypeSelection}>
               <RadioGroup
@@ -98,13 +103,15 @@ const DrawerSequenceView = (props: Props) => {
                 }
                 selectedOption={selectedSequenceType}
               />
-              <div className={styles.reverseComplement}>
-                <Checkbox
-                  label="Reverse complement"
-                  checked={isReverseComplement}
-                  onChange={onReverseComplementChange}
-                />
-              </div>
+              {canHaveReverseComplement && (
+                <div className={styles.reverseComplement}>
+                  <Checkbox
+                    label="Reverse complement"
+                    checked={isReverseComplement}
+                    onChange={onReverseComplementChange}
+                  />
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.tsx
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.tsx
@@ -1,0 +1,85 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import RadioGroup from 'src/shared/components/radio-group/RadioGroup';
+
+import type { SequenceType } from 'src/content/app/genome-browser/state/drawer/drawer-sequence/drawerSequenceSlice';
+
+import styles from './SequenceView.scss';
+
+const sequenceLabelsMap: Record<SequenceType, string> = {
+  genomic: 'Genomic sequence',
+  cdna: 'cDNA',
+  cds: 'CDS',
+  protein: 'Protein sequence'
+};
+
+// TODO: we probably also want to pass a sequence header in order to be able to blast it
+type Props = {
+  sequence: string;
+  sequenceTypes: SequenceType[];
+  selectedSequenceType: SequenceType;
+  isReverseComplement: boolean;
+  onSequenceTypeChange: (sequenceType: SequenceType) => void;
+  onReverseComplementChange: (isReverseComplement: boolean) => void;
+};
+
+const DrawerSequenceView = (props: Props) => {
+  const {
+    sequence,
+    sequenceTypes,
+    selectedSequenceType,
+    onSequenceTypeChange
+  } = props;
+
+  const sequenceTypeOptions = sequenceTypes.map((sequenceType) => ({
+    value: sequenceType,
+    label: sequenceLabelsMap[sequenceType]
+  }));
+
+  return (
+    <div className={styles.layout}>
+      <div className={styles.mainTop}>
+        <div>
+          <span>{sequence.length}</span>
+          <span className={styles.basePairsLabel}>bp</span>
+        </div>
+      </div>
+      <div className={styles.sequence}>{sequence}</div>
+      <div className={styles.asideTop}>
+        <div>blast control</div>
+      </div>
+      <div className={styles.asideBottom}>
+        <div className={styles.sequenceTypeSelection}>
+          <RadioGroup
+            options={sequenceTypeOptions}
+            onChange={(sequenceType) =>
+              onSequenceTypeChange(sequenceType as SequenceType)
+            }
+            selectedOption={selectedSequenceType}
+          />
+          <div className={styles.reverseComplement}>
+            Reverse complement checkbox
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DrawerSequenceView;

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.tsx
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.tsx
@@ -25,7 +25,7 @@ import ShowHide from 'src/shared/components/show-hide/ShowHide';
 
 import type { SequenceType } from 'src/content/app/genome-browser/state/drawer/drawer-sequence/drawerSequenceSlice';
 
-import styles from './SequenceView.scss';
+import styles from './DrawerSequenceView.scss';
 
 const sequenceLabelsMap: Record<SequenceType, string> = {
   genomic: 'Genomic sequence',

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/GeneSequenceView.tsx
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/GeneSequenceView.tsx
@@ -40,14 +40,14 @@ export const GeneSequenceView = (props: Props) => {
   const { gene } = props;
 
   const genomeId = useAppSelector(getBrowserActiveGenomeId) as string;
-  const transcriptId = buildGeneId(genomeId, gene.stable_id);
+  const geneId = buildGeneId(genomeId, gene.stable_id);
 
   const {
     isExpanded,
     toggleSequenceVisibility,
     isReverseComplement,
     toggleReverseComplement
-  } = useDrawerSequenceSettings({ genomeId, featureId: transcriptId });
+  } = useDrawerSequenceSettings({ genomeId, featureId: geneId });
 
   const {
     region: {

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/GeneSequenceView.tsx
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/GeneSequenceView.tsx
@@ -57,12 +57,15 @@ export const GeneSequenceView = (props: Props) => {
     strand: { code: strand }
   } = gene.slice;
 
-  const { data: sequence } = useRefgetSequenceQuery({
-    checksum,
-    start,
-    end,
-    strand
-  });
+  const { data: sequence } = useRefgetSequenceQuery(
+    {
+      checksum,
+      start,
+      end,
+      strand
+    },
+    { skip: !isExpanded }
+  );
 
   return (
     <DrawerSequenceView

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/GeneSequenceView.tsx
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/GeneSequenceView.tsx
@@ -17,7 +17,14 @@
 import React from 'react';
 import noop from 'lodash/noop';
 
+import { useAppSelector } from 'src/store';
+
+import { buildFocusObjectId } from 'src/shared/helpers/focusObjectHelpers';
+
+import useDrawerSequenceSettings from './useDrawerSequenceSettings';
 import { useRefgetSequenceQuery } from 'src/shared/state/api-slices/refgetSlice';
+
+import { getBrowserActiveGenomeId } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
 
 import DrawerSequenceView from 'src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView';
 
@@ -31,6 +38,17 @@ type Props = {
 
 export const GeneSequenceView = (props: Props) => {
   const { gene } = props;
+
+  const genomeId = useAppSelector(getBrowserActiveGenomeId) as string;
+  const transcriptId = buildGeneId(genomeId, gene.stable_id);
+
+  const {
+    // isExpanded,
+    // toggleSequenceVisibility,
+    isReverseComplement,
+    toggleReverseComplement
+  } = useDrawerSequenceSettings({ genomeId, featureId: transcriptId });
+
   const {
     region: {
       sequence: { checksum }
@@ -51,11 +69,18 @@ export const GeneSequenceView = (props: Props) => {
       sequence={sequence}
       sequenceTypes={['genomic']}
       selectedSequenceType="genomic"
-      isReverseComplement={false}
+      isReverseComplement={isReverseComplement}
       onSequenceTypeChange={noop}
-      onReverseComplementChange={noop}
+      onReverseComplementChange={toggleReverseComplement}
     />
   ) : null;
 };
+
+const buildGeneId = (genomeId: string, geneStableId: string) =>
+  buildFocusObjectId({
+    genomeId,
+    type: 'gene',
+    objectId: geneStableId
+  });
 
 export default GeneSequenceView;

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/GeneSequenceView.tsx
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/GeneSequenceView.tsx
@@ -17,15 +17,11 @@
 import React from 'react';
 import noop from 'lodash/noop';
 
-import * as urlFor from 'src/shared/helpers/urlHelper';
+import { useRefgetSequenceQuery } from 'src/shared/state/api-slices/refgetSlice';
 
-import RadioGroup, {
-  RadioOptions
-} from 'src/shared/components/radio-group/RadioGroup';
+import DrawerSequenceView from 'src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView';
 
-import { GeneSummaryQueryResult } from 'src/content/app/genome-browser/state/api/queries/geneSummaryQuery';
-
-import styles from './SequenceView.scss';
+import type { GeneSummaryQueryResult } from 'src/content/app/genome-browser/state/api/queries/geneSummaryQuery';
 
 type Gene = {
   slice: GeneSummaryQueryResult['gene']['slice'];
@@ -36,41 +32,32 @@ type Props = {
 };
 
 export const GeneSequenceView = (props: Props) => {
-  const sequenceType = 'genomicSequence';
-  const { checksum } = props.gene.slice.region.sequence;
-  const { start, end } = props.gene.slice.location;
-  const sequenceURL = urlFor.refget({ checksum, start, end });
+  const { gene } = props;
+  const {
+    region: {
+      sequence: { checksum }
+    },
+    location: { start, end },
+    strand: { code: strand }
+  } = gene.slice;
 
-  const radioOptions: RadioOptions = [
-    {
-      value: 'genomicSequence',
-      label: 'Genomic sequence'
-    }
-  ];
+  const { data: sequence } = useRefgetSequenceQuery({
+    checksum,
+    start,
+    end,
+    strand
+  });
 
-  return (
-    <div className={styles.layout}>
-      <div>
-        <div>XXXX bp</div>
-        <div className={styles.sequenceWrapper}>
-          Fetching sequence for {sequenceType} : {sequenceURL}
-        </div>
-      </div>
-      <div>
-        <div>blast control</div>
-        <div className={styles.selectionWrapper}>
-          <RadioGroup
-            options={radioOptions}
-            onChange={noop}
-            selectedOption={sequenceType}
-          />
-          <div className={styles.reverseWrapper}>
-            Reverse complement checkbox
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+  return sequence ? (
+    <DrawerSequenceView
+      sequence={sequence}
+      sequenceTypes={['genomic']}
+      selectedSequenceType="genomic"
+      isReverseComplement={false}
+      onSequenceTypeChange={noop}
+      onReverseComplementChange={noop}
+    />
+  ) : null;
 };
 
 export default GeneSequenceView;

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/GeneSequenceView.tsx
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/GeneSequenceView.tsx
@@ -43,8 +43,8 @@ export const GeneSequenceView = (props: Props) => {
   const transcriptId = buildGeneId(genomeId, gene.stable_id);
 
   const {
-    // isExpanded,
-    // toggleSequenceVisibility,
+    isExpanded,
+    toggleSequenceVisibility,
     isReverseComplement,
     toggleReverseComplement
   } = useDrawerSequenceSettings({ genomeId, featureId: transcriptId });
@@ -64,8 +64,10 @@ export const GeneSequenceView = (props: Props) => {
     strand
   });
 
-  return sequence ? (
+  return (
     <DrawerSequenceView
+      isExpanded={isExpanded}
+      toggleSequenceVisibility={toggleSequenceVisibility}
       sequence={sequence}
       sequenceTypes={['genomic']}
       selectedSequenceType="genomic"
@@ -73,7 +75,7 @@ export const GeneSequenceView = (props: Props) => {
       onSequenceTypeChange={noop}
       onReverseComplementChange={toggleReverseComplement}
     />
-  ) : null;
+  );
 };
 
 const buildGeneId = (genomeId: string, geneStableId: string) =>

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/GeneSequenceView.tsx
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/GeneSequenceView.tsx
@@ -23,9 +23,7 @@ import DrawerSequenceView from 'src/content/app/genome-browser/components/drawer
 
 import type { GeneSummaryQueryResult } from 'src/content/app/genome-browser/state/api/queries/geneSummaryQuery';
 
-type Gene = {
-  slice: GeneSummaryQueryResult['gene']['slice'];
-};
+type Gene = Pick<GeneSummaryQueryResult['gene'], 'stable_id' | 'slice'>;
 
 type Props = {
   gene: Gene;

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/SequenceView.scss
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/SequenceView.scss
@@ -47,3 +47,7 @@
 .reverseComplement {
   margin-top: 43px;
 }
+
+.showHide {
+  margin-bottom: 16px;
+}

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/SequenceView.scss
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/SequenceView.scss
@@ -1,20 +1,49 @@
+@import 'src/styles/common';
+
 .layout {
   display: grid;
-  align-items: start;
-  grid-template-columns: 400px 1fr;
-  grid-column-gap: 24px;
+  grid-template-areas:
+    'main-top aside-top'
+    'main-bottom aside-bottom';
+  grid-template-columns: 60ch 1fr;
   grid-template-rows: 20px minmax(200px, 400px);
+  grid-column-gap: 24px;
+  align-items: start;
   grid-row-gap: 17px;
 }
 
-.selectionWrapper {
+.mainTop {
+  grid-area: main-top;
+}
+
+.basePairsLabel {
+  font-weight: $light;
+  margin-left: 0.5ch;
+}
+
+.asideTop {
+  grid-area: aside-top;
+}
+
+.sequence {
+  grid-area: main-bottom;
+  margin-top: 10px;
+  width: 60ch;
+  height: 100%;
+  font-family: $font-family-monospace;
+  color: $dark-grey;
+  word-break: break-all;
+  overflow: auto;
+}
+
+.asideBottom {
+  grid-area: aside-bottom;
+}
+
+.sequenceTypeSelection {
   margin-top: 50px;
 }
 
-.sequenceWrapper {
-  margin-top: 10px;
-}
-
-.reverseWrapper {
+.reverseComplement {
   margin-top: 43px;
 }

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/SequenceView.scss
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/SequenceView.scss
@@ -14,6 +14,8 @@
 
 .mainTop {
   grid-area: main-top;
+  display: flex;
+  justify-content: space-between;
 }
 
 .sequenceLengthUnits {
@@ -50,4 +52,24 @@
 
 .showHide {
   margin-bottom: 16px;
+}
+
+.copyLozenge {
+  display: inline-block;
+  height: 18px;
+  padding: 0 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.copy {
+  color: $blue;
+  cursor: pointer;
+}
+
+.copyLozengeCopied {
+  color: $white;
+  background-color: $black;
+  border-radius: 30px;
 }

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/SequenceView.scss
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/SequenceView.scss
@@ -16,7 +16,7 @@
   grid-area: main-top;
 }
 
-.basePairsLabel {
+.sequenceLengthUnits {
   font-weight: $light;
   margin-left: 0.5ch;
 }

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/SequenceView.scss
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/SequenceView.scss
@@ -34,8 +34,9 @@
   height: 100%;
   font-family: $font-family-monospace;
   color: $dark-grey;
-  word-break: break-all;
-  overflow: auto;
+  overflow-wrap: break-word;
+  overflow-y: auto;
+  overflow-x: hidden; // no idea why; but the browser creates a horizontal scrollbar otherwise
 }
 
 .asideBottom {

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/TranscriptSequenceView.test.tsx
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/TranscriptSequenceView.test.tsx
@@ -15,42 +15,215 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
+import { render, waitFor } from '@testing-library/react';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import userEvent from '@testing-library/user-event';
+
+import { getReverseComplement } from 'src/shared/helpers/sequenceHelpers';
+
+import createRootReducer from 'src/root/rootReducer';
+import restApiSlice from 'src/shared/state/api-slices/restSlice';
 
 import {
   createProteinCodingTranscript,
   createNonCodingTranscript
 } from 'tests/fixtures/entity-viewer/transcript';
 
-import TranscriptSequenceView from './TranscriptSequenceView';
+import TranscriptSequenceView, { type Props } from './TranscriptSequenceView';
 
-describe('<TranscriptSequenceView />', () => {
-  const proteinCodingTranscript = createProteinCodingTranscript();
-  it('displays correct list of sequence options for a protein-coding transcript', () => {
-    const { container } = render(
-      <TranscriptSequenceView transcript={proteinCodingTranscript} />
-    );
+jest.mock('config', () => ({
+  refgetBaseUrl: 'http://refget-api' // need to provide absolute urls to the fetch running in Node
+}));
 
-    const renderedLabels = [
-      ...container.querySelectorAll('.radioGroup .label')
-    ].map((el) => el.innerHTML);
-    expect(renderedLabels).toEqual([
-      'Genomic sequence',
-      'cDNA',
-      'CDS',
-      'Protein sequence'
-    ]);
+const renderTranscriptSequenceView = (props: Props) => {
+  const genomeId = 'human';
+  const initialState = {
+    browser: {
+      browserGeneral: {
+        activeGenomeId: genomeId
+      },
+      drawer: {
+        sequence: {
+          [genomeId]: {
+            isVisible: true,
+            features: {}
+          }
+        }
+      }
+    }
+  };
+
+  const store = configureStore({
+    reducer: createRootReducer(),
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware().concat([restApiSlice.middleware]),
+    preloadedState: initialState as any
   });
 
-  it('displays correct list of sequence options for a non-coding transcript', () => {
-    const nonCodingTranscript = createNonCodingTranscript();
-    const { container } = render(
-      <TranscriptSequenceView transcript={nonCodingTranscript} />
-    );
+  const renderResult = render(
+    <Provider store={store}>
+      <TranscriptSequenceView {...props} />
+    </Provider>
+  );
 
-    const renderedLabels = [
-      ...container.querySelectorAll('.radioGroup .label')
-    ].map((el) => el.innerHTML);
-    expect(renderedLabels).toEqual(['Genomic sequence', 'cDNA']);
+  return {
+    ...renderResult,
+    store
+  };
+};
+
+const mockGenomicSequence = 'ACTGACTGACTG';
+const mockCDNASequence = 'CTGACTGA';
+const mockCDSSequence = 'TGACTG';
+const mockProteinSequence = 'QS';
+
+const proteinCodingTranscript = createProteinCodingTranscript();
+const nonCodingTranscript = createNonCodingTranscript();
+
+const server = setupServer(
+  rest.get('http://refget-api/sequence/:checksum', (req, res, ctx) => {
+    const checksum = req.params.checksum as string;
+    if (
+      [
+        proteinCodingTranscript.slice.region.sequence.checksum,
+        nonCodingTranscript.slice.region.sequence.checksum
+      ].includes(checksum)
+    ) {
+      return res(ctx.text(mockGenomicSequence));
+    } else if (
+      [
+        proteinCodingTranscript.product_generating_contexts[0].cdna.sequence
+          .checksum,
+        nonCodingTranscript.product_generating_contexts[0].cdna.sequence
+          .checksum
+      ].includes(checksum)
+    ) {
+      return res(ctx.text(mockCDNASequence));
+    } else if (
+      [
+        proteinCodingTranscript.product_generating_contexts[0].cds.sequence
+          .checksum
+      ].includes(checksum)
+    ) {
+      return res(ctx.text(mockCDSSequence));
+    } else if (
+      [
+        proteinCodingTranscript.product_generating_contexts[0].product.sequence
+          .checksum
+      ].includes(checksum)
+    ) {
+      return res(ctx.text(mockProteinSequence));
+    }
+  })
+);
+
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest(req) {
+      const errorMessage = `Found an unhandled ${req.method} request to ${req.url.href}`;
+      throw new Error(errorMessage);
+    }
+  })
+);
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('<TranscriptSequenceView />', () => {
+  describe('sequence options', () => {
+    it('displays correct list of sequence options for a protein-coding transcript', () => {
+      const { container } = renderTranscriptSequenceView({
+        transcript: proteinCodingTranscript
+      });
+
+      const renderedLabels = [
+        ...container.querySelectorAll('.radioGroup .label')
+      ].map((el) => el.innerHTML);
+      expect(renderedLabels).toEqual([
+        'Genomic sequence',
+        'cDNA',
+        'CDS',
+        'Protein sequence'
+      ]);
+    });
+
+    it('displays correct list of sequence options for a non-coding transcript', () => {
+      const { container } = renderTranscriptSequenceView({
+        transcript: nonCodingTranscript
+      });
+
+      const renderedLabels = [
+        ...container.querySelectorAll('.radioGroup .label')
+      ].map((el) => el.innerHTML);
+      expect(renderedLabels).toEqual(['Genomic sequence', 'cDNA']);
+    });
+  });
+
+  describe('sequence fetching', () => {
+    it('fetches different sequences', () => {
+      const { container, getByLabelText } = renderTranscriptSequenceView({
+        transcript: proteinCodingTranscript
+      });
+
+      const sequenceContainer = container.querySelector(
+        '.sequence'
+      ) as HTMLElement;
+
+      waitFor(() =>
+        expect(sequenceContainer.textContent).toBe(mockGenomicSequence)
+      );
+
+      const cdsSequenceLabel = getByLabelText('CDS');
+
+      userEvent.click(cdsSequenceLabel);
+
+      waitFor(() =>
+        expect(sequenceContainer.textContent).toBe(mockCDSSequence)
+      );
+    });
+  });
+
+  describe('reverse complement', () => {
+    it('only shows the reverse complement checkbox for the genomic sequence', () => {
+      const { getByLabelText, queryByLabelText } = renderTranscriptSequenceView(
+        { transcript: proteinCodingTranscript }
+      );
+
+      const reverseComplementLabel = queryByLabelText('Reverse complement');
+
+      expect(reverseComplementLabel).not.toBe(null);
+
+      const otherLabels = ['cDNA', 'CDS', 'Protein sequence'];
+
+      for (const labelText of otherLabels) {
+        const label = getByLabelText(labelText);
+        userEvent.click(label);
+        expect(queryByLabelText('Reverse complement')).toBe(null);
+      }
+    });
+
+    it('produces a reverse complement of the sequence', () => {
+      const { container, getByLabelText } = renderTranscriptSequenceView({
+        transcript: proteinCodingTranscript
+      });
+
+      const sequenceContainer = container.querySelector(
+        '.sequence'
+      ) as HTMLElement;
+
+      waitFor(() =>
+        expect(sequenceContainer.textContent).toBe(mockGenomicSequence)
+      );
+
+      userEvent.click(getByLabelText('Reverse complement'));
+
+      waitFor(() =>
+        expect(sequenceContainer.textContent).toBe(
+          getReverseComplement(mockGenomicSequence)
+        )
+      );
+    });
   });
 });

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/TranscriptSequenceView.tsx
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/TranscriptSequenceView.tsx
@@ -71,7 +71,8 @@ const TranscriptSequenceView = (props: Props) => {
     : nonCodingTranscriptSequenceTypes;
 
   const { data: sequence } = useRefgetSequenceQuery(
-    getSequenceQueryParams(transcript, sequenceType)
+    getSequenceQueryParams(transcript, sequenceType),
+    { skip: !isExpanded }
   );
 
   return (
@@ -103,12 +104,12 @@ const getSequenceQueryParams = (
   const {
     strand: { code: strand }
   } = transcript.slice;
-  queryParams.strand = strand;
 
   if (sequenceType === 'genomic') {
     queryParams.checksum = transcript.slice.region.sequence.checksum;
     queryParams.start = transcript.slice.location.start;
     queryParams.end = transcript.slice.location.end;
+    queryParams.strand = strand;
   } else if (sequenceType === 'cdna') {
     queryParams.checksum = transcript.product_generating_contexts[0].cdna
       ?.sequence.checksum as string; // FIXME: is cdna really nullable?

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/TranscriptSequenceView.tsx
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/TranscriptSequenceView.tsx
@@ -58,8 +58,8 @@ const TranscriptSequenceView = (props: Props) => {
   const transcriptId = buildTranscriptId(genomeId, transcript.stable_id);
 
   const {
-    // isExpanded,
-    // toggleSequenceVisibility,
+    isExpanded,
+    toggleSequenceVisibility,
     sequenceType,
     onSequenceTypeChange,
     isReverseComplement,
@@ -76,6 +76,8 @@ const TranscriptSequenceView = (props: Props) => {
 
   return sequence ? (
     <DrawerSequenceView
+      isExpanded={isExpanded}
+      toggleSequenceVisibility={toggleSequenceVisibility}
       sequence={sequence}
       sequenceTypes={sequenceTypes}
       selectedSequenceType={sequenceType}

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/TranscriptSequenceView.tsx
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/TranscriptSequenceView.tsx
@@ -39,7 +39,7 @@ type Transcript = Pick<
   'stable_id' | 'slice' | 'product_generating_contexts'
 >;
 
-type Props = {
+export type Props = {
   transcript: Transcript;
 };
 
@@ -74,7 +74,7 @@ const TranscriptSequenceView = (props: Props) => {
     getSequenceQueryParams(transcript, sequenceType)
   );
 
-  return sequence ? (
+  return (
     <DrawerSequenceView
       isExpanded={isExpanded}
       toggleSequenceVisibility={toggleSequenceVisibility}
@@ -85,7 +85,7 @@ const TranscriptSequenceView = (props: Props) => {
       onSequenceTypeChange={onSequenceTypeChange}
       onReverseComplementChange={toggleReverseComplement}
     />
-  ) : null;
+  );
 };
 
 const buildTranscriptId = (genomeId: string, transcriptStableId: string) =>

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/useDrawerSequenceSettings.ts
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/useDrawerSequenceSettings.ts
@@ -1,0 +1,89 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useAppDispatch, useAppSelector } from 'src/store';
+
+import {
+  isDrawerSequenceVisible,
+  getDrawerSequenceType,
+  isDrawerSequenceReverseComplement
+} from 'src/content/app/genome-browser/state/drawer/drawer-sequence/drawerSequenceSelectors';
+
+import {
+  showSequence,
+  hideSequence,
+  changeSequenceType,
+  changeReverseComplement
+} from 'src/content/app/genome-browser/state/drawer/drawer-sequence/drawerSequenceSlice';
+
+import type { SequenceType } from 'src/content/app/genome-browser/state/drawer/drawer-sequence/drawerSequenceSlice';
+
+type Params = {
+  genomeId: string;
+  featureId: string;
+};
+
+const useDrawerSequenceSettings = (params: Params) => {
+  const { genomeId, featureId } = params;
+  const dispatch = useAppDispatch();
+
+  const isSequenceVisible = useAppSelector((state) =>
+    isDrawerSequenceVisible(state, genomeId)
+  );
+  const selectedSequenceType = useAppSelector((state) =>
+    getDrawerSequenceType(state, genomeId, featureId)
+  );
+  const isReverseComplement = useAppSelector((state) =>
+    isDrawerSequenceReverseComplement(state, genomeId, featureId)
+  );
+
+  const toggleSequenceVisibility = () => {
+    isSequenceVisible
+      ? dispatch(hideSequence({ genomeId }))
+      : dispatch(showSequence({ genomeId }));
+  };
+
+  const onSequenceTypeChange = (sequenceType: SequenceType) => {
+    dispatch(
+      changeSequenceType({
+        genomeId,
+        featureId,
+        sequenceType
+      })
+    );
+  };
+
+  const toggleReverseComplement = () => {
+    const actionParams = {
+      genomeId,
+      featureId,
+      isReverseComplement: !isReverseComplement
+    };
+
+    dispatch(changeReverseComplement(actionParams));
+  };
+
+  return {
+    isExpanded: isSequenceVisible,
+    toggleSequenceVisibility,
+    sequenceType: selectedSequenceType,
+    onSequenceTypeChange,
+    isReverseComplement,
+    toggleReverseComplement
+  };
+};
+
+export default useDrawerSequenceSettings;

--- a/src/content/app/genome-browser/components/drawer/drawer-views/gene-summary/GeneSummary.scss
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/gene-summary/GeneSummary.scss
@@ -86,10 +86,6 @@
   position: relative;
 }
 
-.sequenceWrapper {
-  margin-top: 20px;
-}
-
 .closeButton {
   position: absolute;
   right: 0;

--- a/src/content/app/genome-browser/components/drawer/drawer-views/gene-summary/GeneSummary.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/gene-summary/GeneSummary.tsx
@@ -50,7 +50,6 @@ import styles from './GeneSummary.scss';
 const GeneSummary = () => {
   const focusGene = useSelector(getBrowserActiveFocusObject) as FocusGene;
   const [shouldShowDownload, showDownload] = useState(false);
-  const [shouldShowSequence, showSequence] = useState(false);
 
   const geneQueryParams = {
     geneId: focusGene.stable_id,
@@ -119,18 +118,7 @@ const GeneSummary = () => {
       {isEnvironment([Environment.DEVELOPMENT, Environment.INTERNAL]) && (
         <div className={classNames(rowClasses, styles.downloadRow)}>
           <div className={styles.value}>
-            <ShowHide
-              label="Sequences"
-              isExpanded={shouldShowSequence}
-              onClick={() => showSequence(!shouldShowSequence)}
-            />
-          </div>
-          <div className={styles.value}>
-            {shouldShowSequence && (
-              <div className={styles.sequenceWrapper}>
-                <GeneSequenceView gene={gene} />
-              </div>
-            )}
+            <GeneSequenceView gene={gene} />
           </div>
         </div>
       )}

--- a/src/content/app/genome-browser/components/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
@@ -59,7 +59,6 @@ const TranscriptSummary = (props: Props) => {
   const { transcriptId } = props.drawerView;
   const activeGenomeId = useSelector(getBrowserActiveGenomeId);
   const [shouldShowDownload, showDownload] = useState(false);
-  const [shouldShowSequence, showSequence] = useState(false);
 
   const { currentData, isFetching } = useGbTranscriptSummaryQuery(
     {
@@ -165,18 +164,7 @@ const TranscriptSummary = (props: Props) => {
           )}
         >
           <div className={styles.value}>
-            <ShowHide
-              label="Sequences"
-              isExpanded={shouldShowSequence}
-              onClick={() => showSequence(!shouldShowSequence)}
-            />
-          </div>
-          <div className={styles.value}>
-            {shouldShowSequence && (
-              <div className={styles.sequenceWrapper}>
-                <TranscriptSequenceView transcript={transcript} />
-              </div>
-            )}
+            <TranscriptSequenceView transcript={transcript} />
           </div>
         </div>
       )}

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-bar/TrackPanelBar.test.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-bar/TrackPanelBar.test.tsx
@@ -40,9 +40,11 @@ const fakeGenomeId = 'human';
 const mockState = {
   browser: {
     drawer: {
-      [fakeGenomeId]: {
-        isDrawerOpened: false,
-        drawerView: { name: 'bookmarks' }
+      general: {
+        [fakeGenomeId]: {
+          isDrawerOpened: false,
+          drawerView: { name: 'bookmarks' }
+        }
       }
     },
     browserGeneral: {
@@ -175,7 +177,11 @@ describe('<TrackPanelBar />', () => {
     it('closes drawer view when the modal view changes', () => {
       jest.spyOn(drawerActions, 'closeDrawer');
       const { container } = renderComponent(
-        set(`browser.drawer.${fakeGenomeId}.isDrawerOpened`, true, mockState)
+        set(
+          `browser.drawer.general.${fakeGenomeId}.isDrawerOpened`,
+          true,
+          mockState
+        )
       );
       const bookmarksButton = [...container.querySelectorAll('button')].find(
         (button) => button.innerHTML === 'Previously viewed'

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-tabs/TrackPanelTabs.test.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-tabs/TrackPanelTabs.test.tsx
@@ -111,7 +111,7 @@ describe('<TrackPanelTabs />', () => {
 
         container = renderComponent(
           set(
-            `browser.drawer.${activeGenomeId}.isDrawerOpened`,
+            `browser.drawer.general.${activeGenomeId}.isDrawerOpened`,
             true,
             mockState
           )

--- a/src/content/app/genome-browser/state/drawer/drawer-sequence/drawerSequenceSelectors.ts
+++ b/src/content/app/genome-browser/state/drawer/drawer-sequence/drawerSequenceSelectors.ts
@@ -14,21 +14,30 @@
  * limitations under the License.
  */
 
-import { getBrowserActiveGenomeId } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
-import { defaultDrawerStateForGenome } from './drawerSlice';
-
 import type { RootState } from 'src/store';
 
-export const getActiveDrawer = (state: RootState) => {
-  const activeGenomeId = getBrowserActiveGenomeId(state);
-  const activeDrawer =
-    activeGenomeId && state.browser.drawer.general[activeGenomeId];
-
-  return activeDrawer || defaultDrawerStateForGenome;
+export const isDrawerSequenceVisible = (state: RootState, genomeId: string) => {
+  return state.browser.drawer.sequence[genomeId]?.isVisible ?? false;
 };
 
-export const getActiveDrawerView = (state: RootState) =>
-  getActiveDrawer(state).drawerView;
+export const getDrawerSequenceType = (
+  state: RootState,
+  genomeId: string,
+  featureId: string
+) => {
+  return (
+    state.browser.drawer.sequence[genomeId]?.features?.[featureId]
+      ?.sequenceType ?? 'genomic'
+  );
+};
 
-export const getIsDrawerOpened = (state: RootState) =>
-  getActiveDrawer(state).drawerView !== null;
+export const isDrawerSequenceReverseComplement = (
+  state: RootState,
+  genomeId: string,
+  featureId: string
+) => {
+  return (
+    state.browser.drawer.sequence[genomeId]?.features?.[featureId]
+      ?.isReverseComplement ?? false
+  );
+};

--- a/src/content/app/genome-browser/state/drawer/drawer-sequence/drawerSequenceSelectors.ts
+++ b/src/content/app/genome-browser/state/drawer/drawer-sequence/drawerSequenceSelectors.ts
@@ -36,8 +36,9 @@ export const isDrawerSequenceReverseComplement = (
   genomeId: string,
   featureId: string
 ) => {
-  return (
-    state.browser.drawer.sequence[genomeId]?.features?.[featureId]
-      ?.isReverseComplement ?? false
-  );
+  const { isReverseComplement = false, sequenceType = 'genomic' } =
+    state.browser.drawer.sequence[genomeId]?.features?.[featureId] ?? {};
+
+  // reverse complement option is only meaningful for genomic sequences
+  return sequenceType === 'genomic' && isReverseComplement;
 };

--- a/src/content/app/genome-browser/state/drawer/drawer-sequence/drawerSequenceSlice.ts
+++ b/src/content/app/genome-browser/state/drawer/drawer-sequence/drawerSequenceSlice.ts
@@ -80,7 +80,7 @@ const drawerSequenceSlice = createSlice({
     hideSequence(state, action: PayloadAction<{ genomeId: string }>) {
       const { genomeId } = action.payload;
       ensureGenomePresence(state, genomeId);
-      state[genomeId].isVisible = true;
+      state[genomeId].isVisible = false;
     },
     changeSequenceType(state, action: PayloadAction<SequenceTypeParams>) {
       const { genomeId, featureId, sequenceType } = action.payload;

--- a/src/content/app/genome-browser/state/drawer/drawer-sequence/drawerSequenceSlice.ts
+++ b/src/content/app/genome-browser/state/drawer/drawer-sequence/drawerSequenceSlice.ts
@@ -16,6 +16,8 @@
 
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
+import { changeDrawerViewForGenome } from 'src/content/app/genome-browser/state/drawer/drawerSlice';
+
 export type SequenceType = 'genomic' | 'cdna' | 'cds' | 'protein';
 
 type SequenceState = {
@@ -100,6 +102,15 @@ const drawerSequenceSlice = createSlice({
       const { genomeId } = action.payload;
       delete state[genomeId];
     }
+  },
+  extraReducers: (builder) => {
+    builder.addCase(changeDrawerViewForGenome, (state, action) => {
+      const { genomeId, drawerView } = action.payload;
+      if (!drawerView) {
+        // the drawer is closed; resetting the state for this genome
+        delete state[genomeId];
+      }
+    });
   }
 });
 

--- a/src/content/app/genome-browser/state/drawer/drawer-sequence/drawerSequenceSlice.ts
+++ b/src/content/app/genome-browser/state/drawer/drawer-sequence/drawerSequenceSlice.ts
@@ -1,0 +1,114 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export type SequenceType = 'genomic' | 'cdna' | 'cds' | 'protein';
+
+type SequenceState = {
+  sequenceType: SequenceType;
+  isReverseComplement: boolean;
+};
+
+// a map keyed by feature ids
+type SequenceStatePerFeature = Record<string, SequenceState>;
+
+type SequenceStatePerGenome = {
+  isVisible: boolean;
+  features: SequenceStatePerFeature;
+};
+
+// a map keyed by genome ids
+type DrawerSequenceState = Record<string, SequenceStatePerGenome>;
+
+type CommonParams = {
+  genomeId: string;
+  featureId: string;
+};
+
+type SequenceTypeParams = CommonParams & {
+  sequenceType: SequenceType;
+};
+
+type ReverseComplementParams = CommonParams & {
+  isReverseComplement: boolean;
+};
+
+const ensureGenomePresence = (state: DrawerSequenceState, genomeId: string) => {
+  if (!state[genomeId]) {
+    state[genomeId] = { isVisible: false, features: {} };
+  }
+};
+
+const ensureFeaturePresence = (
+  state: DrawerSequenceState,
+  genomeId: string,
+  featureId: string
+) => {
+  ensureGenomePresence(state, genomeId);
+
+  if (!state[genomeId].features[featureId]) {
+    state[genomeId].features[featureId] = {
+      sequenceType: 'genomic',
+      isReverseComplement: false
+    };
+  }
+};
+
+const drawerSequenceSlice = createSlice({
+  name: 'genome-browser-drawer-sequence',
+  initialState: {} as DrawerSequenceState,
+  reducers: {
+    showSequence(state, action: PayloadAction<{ genomeId: string }>) {
+      const { genomeId } = action.payload;
+      ensureGenomePresence(state, genomeId);
+      state[genomeId].isVisible = true;
+    },
+    hideSequence(state, action: PayloadAction<{ genomeId: string }>) {
+      const { genomeId } = action.payload;
+      ensureGenomePresence(state, genomeId);
+      state[genomeId].isVisible = true;
+    },
+    changeSequenceType(state, action: PayloadAction<SequenceTypeParams>) {
+      const { genomeId, featureId, sequenceType } = action.payload;
+      ensureFeaturePresence(state, genomeId, featureId);
+      state[genomeId].features[featureId].sequenceType = sequenceType;
+    },
+    changeReverseComplement(
+      state,
+      action: PayloadAction<ReverseComplementParams>
+    ) {
+      const { genomeId, featureId, isReverseComplement } = action.payload;
+      ensureFeaturePresence(state, genomeId, featureId);
+      state[genomeId].features[featureId].isReverseComplement =
+        isReverseComplement;
+    },
+    clearGenome(state, action: PayloadAction<{ genomeId: string }>) {
+      const { genomeId } = action.payload;
+      delete state[genomeId];
+    }
+  }
+});
+
+export const {
+  showSequence,
+  hideSequence,
+  changeSequenceType,
+  changeReverseComplement,
+  clearGenome
+} = drawerSequenceSlice.actions;
+
+export default drawerSequenceSlice.reducer;

--- a/src/content/app/genome-browser/state/drawer/drawerReducer.ts
+++ b/src/content/app/genome-browser/state/drawer/drawerReducer.ts
@@ -15,18 +15,11 @@
  */
 
 import { combineReducers } from '@reduxjs/toolkit';
-import drawer from 'src/content/app/genome-browser/state/drawer/drawerReducer';
-import browserGeneral from 'src/content/app/genome-browser/state/browser-general/browserGeneralSlice';
-import browserNav from 'src/content/app/genome-browser/state/browser-nav/browserNavSlice';
-import trackConfig from 'src/content/app/genome-browser/state/track-config/trackConfigSlice';
-import trackPanel from 'src/content/app/genome-browser/state/track-panel/trackPanelSlice';
-import focusObjects from 'src/content/app/genome-browser/state/focus-object/focusObjectSlice';
+
+import general from './drawerSlice';
+import sequence from './drawer-sequence/drawerSequenceSlice';
 
 export default combineReducers({
-  drawer,
-  browserGeneral,
-  browserNav,
-  trackConfig,
-  trackPanel,
-  focusObjects
+  general,
+  sequence
 });

--- a/src/shared/state/api-slices/refgetSlice.ts
+++ b/src/shared/state/api-slices/refgetSlice.ts
@@ -1,0 +1,68 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import config from 'config';
+
+import restApiSlice from 'src/shared/state/api-slices/restSlice';
+
+import { getReverseComplement } from 'src/shared/helpers/sequenceHelpers';
+
+import { Strand } from 'src/shared/types/thoas/strand';
+
+export type SequenceQueryParams = {
+  checksum: string;
+  start?: number;
+  end?: number;
+  strand?: Strand;
+};
+
+const refgetApiSlice = restApiSlice.injectEndpoints({
+  endpoints: (builder) => ({
+    refgetSequence: builder.query<string, SequenceQueryParams>({
+      query: (params) => {
+        const { checksum, start, end } = params;
+        const queryParameters = new URLSearchParams();
+        if (start) {
+          queryParameters.set('start', `${start}`);
+        }
+        if (end) {
+          queryParameters.set('end', `${end}`);
+        }
+
+        const queryString = [...queryParameters].length
+          ? `?${queryParameters.toString()}`
+          : '';
+
+        return {
+          url: `${config.refgetBaseUrl}/sequence/${checksum}${queryString}`,
+          // headers: {
+          //   'Accept': 'text/plain',
+          //   'Content-type': 'text/plain'
+          // },
+          responseHandler: 'text'
+        };
+      },
+      transformResponse: (sequence: string, _, params) => {
+        const { strand = Strand.FORWARD } = params;
+        return strand === Strand.REVERSE
+          ? getReverseComplement(sequence)
+          : sequence;
+      }
+    })
+  })
+});
+
+export const { useRefgetSequenceQuery } = refgetApiSlice;

--- a/src/shared/state/api-slices/refgetSlice.ts
+++ b/src/shared/state/api-slices/refgetSlice.ts
@@ -48,10 +48,6 @@ const refgetApiSlice = restApiSlice.injectEndpoints({
 
         return {
           url: `${config.refgetBaseUrl}/sequence/${checksum}${queryString}`,
-          // headers: {
-          //   'Accept': 'text/plain',
-          //   'Content-type': 'text/plain'
-          // },
           responseHandler: 'text'
         };
       },

--- a/tests/fixtures/browser.ts
+++ b/tests/fixtures/browser.ts
@@ -264,11 +264,9 @@ export const createMockBrowserState = () => {
         }
       },
       drawer: {
-        isDrawerOpened: {
-          fake_genome_id_1: false
-        },
-        drawerView: {},
-        activeDrawerTrackIds: {}
+        general: {
+          drawerView: {}
+        }
       },
       focusObjects: {
         'fake_genome_id_1:gene:fake_gene_stable_id_1': {

--- a/tests/fixtures/entity-viewer/transcript.ts
+++ b/tests/fixtures/entity-viewer/transcript.ts
@@ -22,15 +22,19 @@ import { createProduct } from './product';
 import { createExternalReference } from './external-reference';
 import { getFeatureCoordinates } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
 
-import { FullTranscript } from 'src/shared/types/thoas/transcript';
-import { Exon, SplicedExon, PhasedExon } from 'src/shared/types/thoas/exon';
-import { Slice } from 'src/shared/types/thoas/slice';
-import { FullCDS } from 'src/shared/types/thoas/cds';
-import { CDNA } from 'src/shared/types/thoas/cdna';
-import { FullProductGeneratingContext } from 'src/shared/types/thoas/productGeneratingContext';
-import { ProductType } from 'src/shared/types/thoas/product';
-import { ExternalReference } from 'src/shared/types/thoas/externalReference';
-import { TranscriptMetadata } from 'src/shared/types/thoas/metadata';
+import type { FullTranscript } from 'src/shared/types/thoas/transcript';
+import type {
+  Exon,
+  SplicedExon,
+  PhasedExon
+} from 'src/shared/types/thoas/exon';
+import type { Slice } from 'src/shared/types/thoas/slice';
+import type { FullCDS } from 'src/shared/types/thoas/cds';
+import type { CDNA } from 'src/shared/types/thoas/cdna';
+import type { FullProductGeneratingContext } from 'src/shared/types/thoas/productGeneratingContext';
+import { ProductType, type Product } from 'src/shared/types/thoas/product';
+import type { ExternalReference } from 'src/shared/types/thoas/externalReference';
+import type { TranscriptMetadata } from 'src/shared/types/thoas/metadata';
 
 type CommonTranscriptFields = Omit<
   FullTranscript,
@@ -39,8 +43,8 @@ type CommonTranscriptFields = Omit<
 
 type ProteinCodingProductGeneratingContext = Omit<
   FullProductGeneratingContext,
-  'cds'
-> & { cds: FullCDS };
+  'cds' | 'product'
+> & { cds: FullCDS; product: Product };
 
 export type ProteinCodingTranscript = Omit<
   Omit<FullTranscript, 'gene'>,


### PR DESCRIPTION
## Description
- Combine the common logic of the sequence view component in the `DrawerSequenceView` component and `useDrawerSequenceSettings` hook
- Move state-related logic to a redux sliice
- Add refget slice for fetching sequences
- Add the code for showing the reverse complement sequence 
- Add the Copy button to copy the sequence into the clipboard


## Related JIRA Issue(s)
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1547
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1574
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1568

## Deployment URL(s)
http://gb-sequence-view.review.ensembl.org

## Views affected
Genome browser drawer