### PR TITLE
blast parameter layout for different screen size

### DIFF
--- a/src/content/app/tools/blast/components/blast-settings/BlastSettings.scss
+++ b/src/content/app/tools/blast/components/blast-settings/BlastSettings.scss
@@ -1,27 +1,50 @@
 @import 'src/styles/common';
+.topLevelContainer {
+  display: grid;
+  grid-template-columns: minmax(100px, 1660px) 140px;
+}
 
 .topLevel {
   display: flex;
-  gap: 1rem;
+  flex-wrap: wrap;
+  row-gap: 20px;
+}
+
+.header {
+  font-weight: $bold;
+  margin-right: 45px;
+  font-size: 17px;
+}
+
+.subHeader {
+  font-weight: $bold;
+  margin-right: 55px;
+  margin-top: 5px;
+}
+
+.previousJobs {
+  height: 30px;
+  width: 120px;
+  margin-left: 20px;
 }
 
 .mainSettings {
-  display: flex;
-  gap: 1rem;
-}
-
-.mainSettings > * {
-  flex: 0 0 auto;
-}
-
-.mainSettings select {
-  flex: 0 0 auto;
+  margin-left: 20px;
 }
 
 .select label {
   display: grid;
   grid-template-columns: repeat(2, auto);
   column-gap: 10px;
+}
+
+.parametersColumn .select label {
+  grid-template-columns: 140px 70px;
+  text-align: right;
+}
+
+.parametersColumn .matrixSetting .select label {
+  grid-template-columns: 140px 110px;
 }
 
 .select label span {
@@ -32,8 +55,12 @@
 .bottomLevel {
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem;
-  padding-top: 0.6rem;
+  gap: 15px;
+  padding-top: 20px;
+  margin-left: 104px;
+  @media (max-width: 1610px) {
+    margin-left: -10px;
+  }
 }
 
 .bottomLevel > * {
@@ -41,15 +68,32 @@
   white-space: nowrap;
 }
 
+.parametersColumn {
+  display: grid;
+  grid-template-rows: 40px 40px;
+}
+
 .blastJobBlock {
   display: inline-flex;
   align-items: center;
-  column-gap: 32px;
+  column-gap: 30px;
+  margin-left: 30px;
 }
 
 .blastJobName {
   display: inline-flex;
-  column-gap: 24px;
+  column-gap: 11px;
   align-items: center;
   white-space: nowrap;
+}
+
+.parametersLabel {
+  margin: 5px 20px 0px 15px;
+}
+
+.checkboxLeftMargin {
+  margin-left: 60px;
+  @media (min-width: 1190px) and (max-width: 1490px) {
+    margin-left: 150px;
+  }
 }

--- a/src/content/app/tools/blast/components/blast-settings/BlastSettings.tsx
+++ b/src/content/app/tools/blast/components/blast-settings/BlastSettings.tsx
@@ -15,12 +15,15 @@
  */
 
 import React, { FormEvent, useEffect, useState } from 'react';
+import classNames from 'classnames';
 import { useSelector, useDispatch } from 'react-redux';
+import noop from 'lodash/noop';
 
 import ShowHide from 'src/shared/components/show-hide/ShowHide';
 import Checkbox from 'src/shared/components/checkbox/Checkbox';
 import SimpleSelect from 'src/shared/components/simple-select/SimpleSelect';
 import ShadedInput from 'src/shared/components/input/ShadedInput';
+import { SecondaryButton } from 'src/shared/components/button/Button';
 import BlastJobSubmit from 'src/content/app/tools/blast/components/blast-job-submit/BlastJobSubmit';
 
 import {
@@ -152,118 +155,154 @@ const BlastSettings = ({ config }: Props) => {
 
   return (
     <>
-      <div className={styles.topLevel}>
-        Settings
-        <div className={styles.mainSettings}>
-          {buildSelect({
-            ...(config.parameters['database'] as BlastSelectSetting),
-            selectedOption: blastParameters.database as string,
-            onChange: onDatabaseChange
-          })}
-          {buildSelect({
-            ...(availableBlastPrograms as BlastSelectSetting),
-            selectedOption: blastProgram,
-            onChange: onBlastProgramChange
-          })}
-          {buildSelect({
-            ...(getPresetsList(config) as BlastSelectSetting),
-            selectedOption: searchSensitivity,
-            onChange: onSearchSensitivityChange
-          })}
+      <div className={styles.topLevelContainer}>
+        <div className={styles.topLevel}>
+          <div className={styles.header}>Blast</div>
+          <div className={styles.subHeader}>Run a job</div>
+          <div>
+            {buildSelect({
+              ...(config.parameters['database'] as BlastSelectSetting),
+              selectedOption: blastParameters.database as string,
+              onChange: onDatabaseChange
+            })}
+          </div>
+          <div className={styles.mainSettings}>
+            {buildSelect({
+              ...(availableBlastPrograms as BlastSelectSetting),
+              selectedOption: blastProgram,
+              onChange: onBlastProgramChange
+            })}
+          </div>
+          <div className={styles.mainSettings}>
+            {buildSelect({
+              ...(getPresetsList(config) as BlastSelectSetting),
+              selectedOption: searchSensitivity,
+              onChange: onSearchSensitivityChange
+            })}
+          </div>
+          <div className={styles.parametersLabel}>
+            <ShowHide
+              label="Parameters"
+              isExpanded={parametersExpanded}
+              onClick={onParametersToggle}
+            />
+          </div>
+          <div className={styles.blastJobBlock}>
+            <BlastJobName />
+            <BlastJobSubmit />
+          </div>
         </div>
-        <div>
-          <ShowHide
-            label="Parameters"
-            isExpanded={parametersExpanded}
-            onClick={onParametersToggle}
-          />
-        </div>
-        <div className={styles.blastJobBlock}>
-          <BlastJobName />
-          <BlastJobSubmit />
-        </div>
+        <SecondaryButton className={styles.previousJobs} onClick={noop}>
+          Previous jobs
+        </SecondaryButton>
       </div>
       {parametersExpanded && (
         <div className={styles.bottomLevel}>
-          {buildSelect({
-            ...(config.parameters['alignments'] as BlastSelectSetting),
-            selectedOption: blastParameters.alignments as string,
-            onChange: (value: string) =>
-              onBlastParameterChange('alignments', value)
-          })}
-          {buildSelect({
-            ...(config.parameters['scores'] as BlastSelectSetting),
-            selectedOption: blastParameters.scores as string,
-            onChange: (value: string) => onBlastParameterChange('scores', value)
-          })}
-          {buildSelect({
-            ...(config.parameters['hsps'] as BlastSelectSetting),
-            selectedOption: blastParameters.scores as string,
-            onChange: (value: string) => onBlastParameterChange('hsps', value)
-          })}
-          {buildSelect({
-            ...(config.parameters['dropoff'] as BlastSelectSetting),
-            selectedOption: blastParameters.scores as string,
-            onChange: (value: string) =>
-              onBlastParameterChange('dropoff', value)
-          })}
-          {buildCheckbox({
-            ...(config.parameters['gapalign'] as BlastBooleanSetting),
-            selectedOption: blastParameters.gapalign as string,
-            onChange: (value: string) =>
-              onBlastParameterChange('gapalign', value)
-          })}
-          {buildCheckbox({
-            ...(config.parameters['filter'] as BlastBooleanSetting),
-            selectedOption: blastParameters.filter as string,
-            onChange: (value: string) => onBlastParameterChange('filter', value)
-          })}
-          {buildSelect({
-            ...(config.parameters['compstats'] as BlastSelectSetting),
-            selectedOption: blastParameters.compstats as string,
-            onChange: (value: string) =>
-              onBlastParameterChange('compstats', value)
-          })}
-          {buildSelect({
-            ...(config.parameters['exp'] as BlastSelectSetting),
-            selectedOption: blastParameters.exp as string,
-            onChange: (value: string) => onBlastParameterChange('exp', value)
-          })}
-          {databaseSequenceType === 'dna' &&
-            buildSelect({
-              ...(config.parameters['match_scores'] as BlastSelectSetting),
-              selectedOption: blastParameters.match_scores as string,
+          <div className={styles.parametersColumn}>
+            {buildSelect({
+              ...(config.parameters['alignments'] as BlastSelectSetting),
+              selectedOption: blastParameters.alignments as string,
               onChange: (value: string) =>
-                onBlastParameterChange('match_scores', value)
+                onBlastParameterChange('alignments', value)
             })}
-          {buildSelect({
-            options: config.programs_parameters_override.wordsize[blastProgram]
-              ? config.programs_parameters_override.wordsize[blastProgram]
-                  .options
-              : (config.parameters.wordsize.options as Option[]),
-            label: config.parameters.wordsize.label,
-            selectedOption: blastParameters.wordsize as string,
-            onChange: (value: string) =>
-              onBlastParameterChange('wordsize', value)
-          })}
-          {buildSelect({
-            ...(config.parameters['gapopen'] as BlastSelectSetting),
-            selectedOption: blastParameters.gapopen as string,
-            onChange: (value: string) =>
-              onBlastParameterChange('gapopen', value)
-          })}
-          {buildSelect({
-            ...(config.parameters['gapext'] as BlastSelectSetting),
-            selectedOption: blastParameters.gapext as string,
-            onChange: (value: string) => onBlastParameterChange('gapext', value)
-          })}
-          {databaseSequenceType === 'protein' &&
-            buildSelect({
-              ...(config.parameters['matrix'] as BlastSelectSetting),
-              selectedOption: blastParameters.matrix as string,
+            {buildSelect({
+              ...(config.parameters['scores'] as BlastSelectSetting),
+              selectedOption: blastParameters.scores as string,
               onChange: (value: string) =>
-                onBlastParameterChange('matrix', value)
+                onBlastParameterChange('scores', value)
             })}
+          </div>
+          <div className={styles.parametersColumn}>
+            {buildSelect({
+              ...(config.parameters['exp'] as BlastSelectSetting),
+              selectedOption: blastParameters.exp as string,
+              onChange: (value: string) => onBlastParameterChange('exp', value)
+            })}
+            {buildSelect({
+              ...(config.parameters['compstats'] as BlastSelectSetting),
+              selectedOption: blastParameters.compstats as string,
+              onChange: (value: string) =>
+                onBlastParameterChange('compstats', value)
+            })}
+          </div>
+          <div className={styles.parametersColumn}>
+            {buildSelect({
+              ...(config.parameters['hsps'] as BlastSelectSetting),
+              selectedOption: blastParameters.scores as string,
+              onChange: (value: string) => onBlastParameterChange('hsps', value)
+            })}
+            {buildSelect({
+              ...(config.parameters['dropoff'] as BlastSelectSetting),
+              selectedOption: blastParameters.scores as string,
+              onChange: (value: string) =>
+                onBlastParameterChange('dropoff', value)
+            })}
+          </div>
+          <div className={styles.parametersColumn}>
+            {buildSelect({
+              ...(config.parameters['gapopen'] as BlastSelectSetting),
+              selectedOption: blastParameters.gapopen as string,
+              onChange: (value: string) =>
+                onBlastParameterChange('gapopen', value)
+            })}
+            {buildSelect({
+              ...(config.parameters['gapext'] as BlastSelectSetting),
+              selectedOption: blastParameters.gapext as string,
+              onChange: (value: string) =>
+                onBlastParameterChange('gapext', value)
+            })}
+          </div>
+
+          <div className={styles.parametersColumn}>
+            {buildSelect({
+              options: config.programs_parameters_override.wordsize[
+                blastProgram
+              ]
+                ? config.programs_parameters_override.wordsize[blastProgram]
+                    .options
+                : (config.parameters.wordsize.options as Option[]),
+              label: config.parameters.wordsize.label,
+              selectedOption: blastParameters.wordsize as string,
+              onChange: (value: string) =>
+                onBlastParameterChange('wordsize', value)
+            })}
+            {databaseSequenceType === 'dna' &&
+              buildSelect({
+                ...(config.parameters['match_scores'] as BlastSelectSetting),
+                selectedOption: blastParameters.match_scores as string,
+                onChange: (value: string) =>
+                  onBlastParameterChange('match_scores', value)
+              })}
+            <div className={styles.matrixSetting}>
+              {databaseSequenceType === 'protein' &&
+                buildSelect({
+                  ...(config.parameters['matrix'] as BlastSelectSetting),
+                  selectedOption: blastParameters.matrix as string,
+                  onChange: (value: string) =>
+                    onBlastParameterChange('matrix', value)
+                })}
+            </div>
+          </div>
+
+          <div
+            className={classNames(
+              styles.parametersColumn,
+              styles.checkboxLeftMargin
+            )}
+          >
+            {buildCheckbox({
+              ...(config.parameters['gapalign'] as BlastBooleanSetting),
+              selectedOption: blastParameters.gapalign as string,
+              onChange: (value: string) =>
+                onBlastParameterChange('gapalign', value)
+            })}
+            {buildCheckbox({
+              ...(config.parameters['filter'] as BlastBooleanSetting),
+              selectedOption: blastParameters.filter as string,
+              onChange: (value: string) =>
+                onBlastParameterChange('filter', value)
+            })}
+          </div>
         </div>
       )}
     </>
@@ -281,7 +320,7 @@ const BlastJobName = () => {
 
   return (
     <div className={styles.blastJobName}>
-      <span>Name the job</span>
+      <span>Name this job</span>
       <ShadedInput value={jobName} onChange={onChange} placeholder="optional" />
     </div>
   );

--- a/src/content/app/tools/shared/components/tools-top-bar/ToolsTopBar.scss
+++ b/src/content/app/tools/shared/components/tools-top-bar/ToolsTopBar.scss
@@ -3,7 +3,7 @@
 .topBar {
   min-height: 74px;
   background-color: $light-grey;
-  padding-left: 36px; // TODO: does this value repeat across Genome Browser, Entity Viewer, and Tools?
+  padding: 24px 10px 20px 30px; // TODO: does this value repeat across Genome Browser, Entity Viewer, and Tools?
   box-shadow: 0 3px 5px $global-box-shadow;
   margin-bottom: 21px;
 }

--- a/tests/fixtures/blast/blastSettingsConfig.json
+++ b/tests/fixtures/blast/blastSettingsConfig.json
@@ -211,7 +211,7 @@
       ]
     },
     "gapalign": {
-      "label": "Gapalign",
+      "label": "Gap align",
       "description": "This is a true/false setting that tells the program the perform optimised alignments within regions involving gaps. If set to true, the program will perform an alignment using gaps. Otherwise, if it is set to false, it will report only individual HSP where two sequence match each other, and thus will not produce alignments with gaps.",
       "type": "boolean",
       "options": {
@@ -220,7 +220,7 @@
       }
     },
     "filter": {
-      "label": "Filter",
+      "label": "Filter low complexity regions",
       "description": "Filter regions of low sequence complexity. This can avoid issues with low complexity sequences where matches are found due to composition rather than meaningful sequence similarity. However in some cases filtering also masks regions of interest and so should be used with caution.",
       "type": "boolean",
       "options": {
@@ -708,7 +708,7 @@
     "database": "dna"
   },
   "presets": {
-    "label": "Search sensitivity",
+    "label": "Sensitivity",
     "defaultPreset": "normal",
     "options": [
       {


### PR DESCRIPTION
## Description
Styling the blast settings and parameters (the dropdowns and the checkbox), also renaming job list button as well as some labels.

I had to reorganise some of the elements to fit the new layout and mostly css changes.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1498

## Deployment URL(s)
http://blastparameters-layout.review.ensembl.org


## Views affected
Blast