### PR TITLE
Fix a BLAST settings bug

### DIFF
--- a/src/content/app/tools/blast/components/blast-settings/BlastSettings.tsx
+++ b/src/content/app/tools/blast/components/blast-settings/BlastSettings.tsx
@@ -198,12 +198,12 @@ const BlastSettings = ({ config }: Props) => {
           })}
           {buildSelect({
             ...(config.parameters['hsps'] as BlastSelectSetting),
-            selectedOption: blastParameters.scores as string,
+            selectedOption: blastParameters.hsps as string,
             onChange: (value: string) => onBlastParameterChange('hsps', value)
           })}
           {buildSelect({
             ...(config.parameters['dropoff'] as BlastSelectSetting),
-            selectedOption: blastParameters.scores as string,
+            selectedOption: blastParameters.dropoff as string,
             onChange: (value: string) =>
               onBlastParameterChange('dropoff', value)
           })}


### PR DESCRIPTION
## Description
There were a couple of copy-paste errors in the BlastSettings components that were causing the reuse of a setting in two unrelated dropdowns. Here is what the problem looked like:


https://user-images.githubusercontent.com/6834224/166457266-6d395ea0-22ee-4ef1-81b7-77c4c79a60a4.mp4


## Deployment URL(s)
PLEASE REVIEW LOCALLY; the [deployment](http://fix-blast-settings.review.ensembl.org) is broken because requests sometimes get routed to a wrong tools api container.