### PR TITLE
Fix tests requiring mock product

### DIFF
--- a/tests/fixtures/entity-viewer/product.ts
+++ b/tests/fixtures/entity-viewer/product.ts
@@ -27,7 +27,7 @@ import {
 
 export const createProduct = (fragment: Partial<Product> = {}): Product => {
   const length =
-    fragment?.length || faker.datatype.number({ min: 10, max: 100 });
+    fragment?.length || faker.datatype.number({ min: 50, max: 100 });
   const unversionedStableId = faker.datatype.uuid();
   const version = 1;
   const stableId = `${unversionedStableId}.${version}`;
@@ -54,8 +54,9 @@ const createFamilyMatches = (proteinLength: number): FamilyMatch[] => {
   return times(numberOfDomains, (index: number) => {
     const minCoordinate = maxDomainLength * index + 1;
     const maxCoordinate = maxDomainLength * (index + 1);
-    const middleCoordinate =
-      maxCoordinate - (maxCoordinate - minCoordinate) / 2;
+    const middleCoordinate = Math.floor(
+      maxCoordinate - (maxCoordinate - minCoordinate) / 2
+    );
     const start = faker.datatype.number({
       min: minCoordinate,
       max: middleCoordinate


### PR DESCRIPTION
## Description
The new faker, quite reasonably, throws an error when it's asked to generate a random number for which the upper boundary is a smaller number than the lower boundary.

Our tests were failing, because when we were generating a product fixture, the protein length was allowed to be as small as 10 amino acids; while the number of domains was allowed to be as large as 10. Which meant that sometimes, an individual domain was calculated to be very small; and the upper and the lower boundaries for such domain became dangerously close to each other.

I updated the length of the generated protein, requiring it to be no smaller than 50 amino acids. This made the errors go away. I re-generated the protein product fixture a 100,000 times to be fairly sure that it won't fail randomly. It didn't. 