### PR TITLE
blast single column layout for smaller screen

### DIFF
--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.scss
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.scss
@@ -8,7 +8,8 @@
   display: grid;
   grid-template-columns: auto auto 1fr;
   column-gap: 52px;
-  width: 860px;
+  width: 862px;
+  margin-left: -1px; //increasing the width by 2px and adding a left margin so that we dont see the borders shadows from the box below when scrolling
   align-items: center;
   padding-left: 28px;
   padding-bottom: 12px;
@@ -19,11 +20,7 @@
 }
 
 .smallScreenHeader {
-  top: 49px;
-}
-
-.mainContainerSmall .header {
-  top: 49px;
+  top: 48px;
 }
 
 .headerGroup {

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.scss
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.scss
@@ -18,6 +18,14 @@
   background-color: $white;
 }
 
+.smallScreenHeader {
+  top: 49px;
+}
+
+.mainContainerSmall .header {
+  top: 49px;
+}
+
 .headerGroup {
   display: flex;
   align-items: center;

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.scss
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.scss
@@ -11,8 +11,7 @@
   width: 862px;
   margin-left: -1px; //increasing the width by 2px and adding a left margin so that we dont see the borders shadows from the box below when scrolling
   align-items: center;
-  padding-left: 28px;
-  padding-bottom: 12px;
+  padding: 20px 0 12px 28px;
   position: sticky;
   top: 0px;
   z-index: 1;

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.scss
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.scss
@@ -19,7 +19,7 @@
 }
 
 .smallScreenHeader {
-  top: 48px;
+  top: 49px;
 }
 
 .headerGroup {

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.tsx
@@ -15,6 +15,7 @@
  */
 
 import React from 'react';
+import classNames from 'classnames';
 import { useSelector, useDispatch } from 'react-redux';
 
 import {
@@ -22,14 +23,10 @@ import {
   getUncommittedSequencePresence
 } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
 
-import {
-  updateEmptyInputDisplay,
-  switchToSpeciesStep
-} from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
+import { updateEmptyInputDisplay } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
 
 import useBlastInputSequences from './useBlastInputSequences';
 
-import { SecondaryButton } from 'src/shared/components/button/Button';
 import PlusButton from 'src/shared/components/plus-button/PlusButton';
 import RadioGroup from 'src/shared/components/radio-group/RadioGroup';
 
@@ -61,10 +58,6 @@ const BlastInputSequencesHeader = (props: Props) => {
     setTimeout(() => scrollToLastInputBox(), 0);
   };
 
-  const onSwitchToSpecies = () => {
-    dispatch(switchToSpeciesStep());
-  };
-
   const scrollToLastInputBox = () => {
     const lastInputBox = document.querySelector(
       `.${sequenceBoxStyles.inputSequenceBox}:last-child`
@@ -81,8 +74,12 @@ const BlastInputSequencesHeader = (props: Props) => {
     ? sequences.length + 1
     : sequences.length;
 
+  const headerClass = classNames(styles.header, {
+    [styles.smallScreenHeader]: compact
+  });
+
   return (
-    <div className={styles.header}>
+    <div className={headerClass}>
       <div className={styles.headerGroup}>
         <span className={styles.headerTitle}>Sequences</span>
         <span className={styles.sequenceCounter}>{sequencesCount}</span>
@@ -100,14 +97,6 @@ const BlastInputSequencesHeader = (props: Props) => {
           onAdd={appendEmptyInput}
           disabled={!shouldEnableAddButton}
         />
-        {compact && (
-          <SecondaryButton
-            className={styles.blastAgainstButton}
-            onClick={onSwitchToSpecies}
-          >
-            Blast against
-          </SecondaryButton>
-        )}
       </div>
     </div>
   );

--- a/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.scss
+++ b/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.scss
@@ -14,7 +14,7 @@
 }
 
 .smallScreenHeader {
-  top: 48px;
+  top: 49px;
 }
 
 .headerGroup {

--- a/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.scss
+++ b/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.scss
@@ -6,8 +6,7 @@
   justify-content: space-between;
   align-items: center;
   margin-left: -1px;
-  padding-left: 28px;
-  padding-bottom: 12px;
+  padding: 20px 0 12px 28px;
   position: sticky;
   top: 0px;
   z-index: 1;

--- a/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.scss
+++ b/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.scss
@@ -13,6 +13,10 @@
   background-color: $white;
 }
 
+.smallScreenHeader {
+  top: 49px;
+}
+
 .headerGroup {
   display: flex;
   align-items: center;

--- a/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.scss
+++ b/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.scss
@@ -2,9 +2,10 @@
 
 .header {
   display: flex;
-  width: 860px;
+  width: 862px;
   justify-content: space-between;
   align-items: center;
+  margin-left: -1px;
   padding-left: 28px;
   padding-bottom: 12px;
   position: sticky;
@@ -14,7 +15,7 @@
 }
 
 .smallScreenHeader {
-  top: 49px;
+  top: 48px;
 }
 
 .headerGroup {

--- a/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.scss
+++ b/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.scss
@@ -20,6 +20,7 @@
 .headerGroup {
   display: flex;
   align-items: center;
+  width: 100%;
 }
 
 .headerTitle {
@@ -34,6 +35,7 @@
 
 .clearAll {
   margin-right: 30px;
+  margin-left: auto;
   color: $blue;
   cursor: pointer;
   user-select: none;

--- a/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelectorHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelectorHeader.tsx
@@ -49,19 +49,10 @@ const BlastSpeciesSelectorHeader = (props: Props) => {
           {selectedSpeciesList.length}
         </span>
         <span className={styles.maxSpecies}>of 7 species</span>
-      </div>
-      {compact && (
         <span className={styles.clearAll} onClick={onClearAll}>
           Clear all
         </span>
-      )}
-      {!compact && (
-        <div className={styles.headerGroup}>
-          <span className={styles.clearAll} onClick={onClearAll}>
-            Clear all
-          </span>
-        </div>
-      )}
+      </div>
     </div>
   );
 };

--- a/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelectorHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelectorHeader.tsx
@@ -15,15 +15,11 @@
  */
 
 import React from 'react';
+import classNames from 'classnames';
 import { useSelector, useDispatch } from 'react-redux';
 
-import {
-  switchToSequencesStep,
-  clearSelectedSpecies
-} from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
+import { clearSelectedSpecies } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
 import { getSelectedSpeciesList } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
-
-import { SecondaryButton } from 'src/shared/components/button/Button';
 
 import styles from './BlastSpeciesSelector.scss';
 
@@ -37,43 +33,35 @@ const BlastSpeciesSelectorHeader = (props: Props) => {
 
   const selectedSpeciesList = useSelector(getSelectedSpeciesList);
 
-  const onSwitchToSequence = () => {
-    dispatch(switchToSequencesStep());
-  };
-
   const onClearAll = () => {
     dispatch(clearSelectedSpecies());
   };
 
+  const headerClass = classNames(styles.header, {
+    [styles.smallScreenHeader]: compact
+  });
+
   return (
-    <div className={styles.header}>
+    <div className={headerClass}>
       <div className={styles.headerGroup}>
         <span className={styles.headerTitle}>Blast against</span>
         <span className={styles.speciesCounter}>
           {selectedSpeciesList.length}
         </span>
         <span className={styles.maxSpecies}>of 7 species</span>
-        {compact && (
+      </div>
+      {compact && (
+        <span className={styles.clearAll} onClick={onClearAll}>
+          Clear all
+        </span>
+      )}
+      {!compact && (
+        <div className={styles.headerGroup}>
           <span className={styles.clearAll} onClick={onClearAll}>
             Clear all
           </span>
-        )}
-      </div>
-      <div className={styles.headerGroup}>
-        {!compact && (
-          <span className={styles.clearAll} onClick={onClearAll}>
-            Clear all
-          </span>
-        )}
-        {compact && (
-          <SecondaryButton
-            className={styles.sequencesButton}
-            onClick={onSwitchToSequence}
-          >
-            Sequences
-          </SecondaryButton>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/content/app/tools/blast/components/blast-submission-header-container/BlastSubmissionHeaderGrid.scss
+++ b/src/content/app/tools/blast/components/blast-submission-header-container/BlastSubmissionHeaderGrid.scss
@@ -4,6 +4,7 @@
   column-gap: 172px;
   align-items: center;
   padding-left: 26px; // TODO: seems to be a constant shared with sequence boxes (see ListedBlastSubmission.scss)
+  padding-top: 20px;
   margin-bottom: 14px;
   white-space: nowrap;
 }

--- a/src/content/app/tools/blast/views/blast-form/BlastForm.scss
+++ b/src/content/app/tools/blast/views/blast-form/BlastForm.scss
@@ -4,11 +4,13 @@
   display: grid;
   grid-template-rows: auto auto minmax(0, 1fr);
   height: 100%;
+  position: relative;
 }
 
 .mainContainer {
   height: 100%;
   padding-left: 65px;
+  padding-right: 10px;
 }
 
 .mainContainerSmall {
@@ -36,9 +38,9 @@
   display: flex;
   justify-content: flex-end;
   gap: 10px;
-  max-width: 1790px; //TODO: To replace with global variables for spaces on the blast form (see ENSWBSITES-1602)
+  max-width: 1770px; //TODO: To replace with global variables for spaces on the blast form (see ENSWBSITES-1602)
   margin-left: -2px;
-  padding: 2px 20px 20px 0;
+  padding: 20px 0 20px 0;
   background-color: white;
   position: sticky;
   top: 0px;

--- a/src/content/app/tools/blast/views/blast-form/BlastForm.scss
+++ b/src/content/app/tools/blast/views/blast-form/BlastForm.scss
@@ -31,3 +31,20 @@
   display: flex;
   flex-direction: column;
 }
+
+.sequenceSpeciesSelector {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  max-width: 1660px;
+  padding: 0 20px 20px 0;
+  background-color: white;
+  position: sticky;
+  top: 0px;
+  z-index: 1;
+}
+
+.selectedSequenceSpeciesButton {
+  background-color: $black;
+  border-color: $black;
+}

--- a/src/content/app/tools/blast/views/blast-form/BlastForm.scss
+++ b/src/content/app/tools/blast/views/blast-form/BlastForm.scss
@@ -10,6 +10,7 @@
 .mainContainer {
   height: 100%;
   padding: 0 20px 0 65px;
+  margin-top: 20px;
 }
 
 .mainContainerSmall {

--- a/src/content/app/tools/blast/views/blast-form/BlastForm.scss
+++ b/src/content/app/tools/blast/views/blast-form/BlastForm.scss
@@ -23,7 +23,6 @@
   grid-template-columns: repeat(2, min-content);
   column-gap: 45px;
   padding-bottom: 90px;
-  margin-top: 20px;
   overflow: auto;
   scroll-behavior: smooth;
   height: 100%;

--- a/src/content/app/tools/blast/views/blast-form/BlastForm.scss
+++ b/src/content/app/tools/blast/views/blast-form/BlastForm.scss
@@ -36,9 +36,9 @@
   display: flex;
   justify-content: flex-end;
   gap: 10px;
-  max-width: 1770px; //TODO: To replace with global variables for spaces on the blast form (see ENSWBSITES-1602)
+  max-width: 1790px; //TODO: To replace with global variables for spaces on the blast form (see ENSWBSITES-1602)
   margin-left: -2px;
-  padding: 2px 10px 20px 0;
+  padding: 2px 20px 20px 0;
   background-color: white;
   position: sticky;
   top: 0px;

--- a/src/content/app/tools/blast/views/blast-form/BlastForm.scss
+++ b/src/content/app/tools/blast/views/blast-form/BlastForm.scss
@@ -9,8 +9,7 @@
 
 .mainContainer {
   height: 100%;
-  padding: 0 20px 0 65px;
-  margin-top: 20px;
+  padding: 0 6px 0 65px;
 }
 
 .mainContainerSmall {
@@ -24,6 +23,7 @@
   grid-template-columns: repeat(2, min-content);
   column-gap: 45px;
   padding-bottom: 90px;
+  margin-top: 20px;
   overflow: auto;
   scroll-behavior: smooth;
   height: 100%;
@@ -40,7 +40,7 @@
   gap: 10px;
   max-width: 1770px; //TODO: To replace with global variables for spaces on the blast form (see ENSWBSITES-1602)
   margin-left: -2px;
-  padding-bottom: 20px;
+  padding-top: 20px;
   background-color: $white;
   position: sticky;
   top: 0px;

--- a/src/content/app/tools/blast/views/blast-form/BlastForm.scss
+++ b/src/content/app/tools/blast/views/blast-form/BlastForm.scss
@@ -32,7 +32,7 @@
   flex-direction: column;
 }
 
-.sequenceSpeciesSelector {
+.blastFormStepToggle {
   display: flex;
   justify-content: flex-end;
   gap: 10px;
@@ -44,7 +44,7 @@
   z-index: 1;
 }
 
-.selectedSequenceSpeciesButton {
+.buttonActive {
   background-color: $black;
   border-color: $black;
 }

--- a/src/content/app/tools/blast/views/blast-form/BlastForm.scss
+++ b/src/content/app/tools/blast/views/blast-form/BlastForm.scss
@@ -36,8 +36,9 @@
   display: flex;
   justify-content: flex-end;
   gap: 10px;
-  max-width: 1790px;
-  padding: 0 20px 20px 0;
+  max-width: 1770px; //TODO: To replace with global variables for spaces on the blast form (see ENSWBSITES-1602)
+  margin-left: -2px;
+  padding: 2px 10px 20px 0;
   background-color: white;
   position: sticky;
   top: 0px;

--- a/src/content/app/tools/blast/views/blast-form/BlastForm.scss
+++ b/src/content/app/tools/blast/views/blast-form/BlastForm.scss
@@ -36,7 +36,7 @@
   display: flex;
   justify-content: flex-end;
   gap: 10px;
-  max-width: 1660px;
+  max-width: 1790px;
   padding: 0 20px 20px 0;
   background-color: white;
   position: sticky;

--- a/src/content/app/tools/blast/views/blast-form/BlastForm.scss
+++ b/src/content/app/tools/blast/views/blast-form/BlastForm.scss
@@ -10,7 +10,7 @@
 .mainContainer {
   height: 100%;
   padding-left: 65px;
-  padding-right: 10px;
+  padding-right: 20px;
 }
 
 .mainContainerSmall {

--- a/src/content/app/tools/blast/views/blast-form/BlastForm.scss
+++ b/src/content/app/tools/blast/views/blast-form/BlastForm.scss
@@ -9,8 +9,7 @@
 
 .mainContainer {
   height: 100%;
-  padding-left: 65px;
-  padding-right: 20px;
+  padding: 0 20px 0 65px;
 }
 
 .mainContainerSmall {
@@ -40,8 +39,8 @@
   gap: 10px;
   max-width: 1770px; //TODO: To replace with global variables for spaces on the blast form (see ENSWBSITES-1602)
   margin-left: -2px;
-  padding: 20px 0 20px 0;
-  background-color: white;
+  padding-bottom: 20px;
+  background-color: $white;
   position: sticky;
   top: 0px;
   z-index: 1;

--- a/src/content/app/tools/blast/views/blast-form/BlastForm.tsx
+++ b/src/content/app/tools/blast/views/blast-form/BlastForm.tsx
@@ -21,8 +21,6 @@ import classNames from 'classnames';
 import { useBlastConfigQuery } from 'src/content/app/tools/blast/state/blast-api/blastApiSlice';
 import useMediaQuery from 'src/shared/hooks/useMediaQuery';
 
-import { SecondaryButton } from 'src/shared/components/button/Button';
-
 import { getStep } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
 import {
   switchToSequencesStep,
@@ -31,6 +29,7 @@ import {
 
 import ToolsAppBar from 'src/content/app/tools/shared/components/tools-app-bar/ToolsAppBar';
 import ToolsTopBar from 'src/content/app/tools/shared/components/tools-top-bar/ToolsTopBar';
+import { SecondaryButton } from 'src/shared/components/button/Button';
 
 import BlastInputSequencesHeader from 'src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader';
 import BlastInputSequences from 'src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences';
@@ -98,15 +97,14 @@ const MainSmall = () => {
 
   return (
     <div className={containerClasses} ref={containerRef}>
+      <BlastFormStepToggle />
       {step === 'sequences' ? (
         <>
-          <BlastFormStepToggle />
           <BlastInputSequencesHeader compact={true} />
           <BlastInputSequences />
         </>
       ) : (
         <>
-          <BlastFormStepToggle />
           <BlastSpeciesSelectorHeader compact={true} />
           <BlastSpeciesSelector />
         </>

--- a/src/content/app/tools/blast/views/blast-form/BlastForm.tsx
+++ b/src/content/app/tools/blast/views/blast-form/BlastForm.tsx
@@ -15,12 +15,19 @@
  */
 
 import React, { useEffect, useRef } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
+import classNames from 'classnames';
 
 import { useBlastConfigQuery } from 'src/content/app/tools/blast/state/blast-api/blastApiSlice';
 import useMediaQuery from 'src/shared/hooks/useMediaQuery';
 
+import { SecondaryButton } from 'src/shared/components/button/Button';
+
 import { getStep } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
+import {
+  switchToSequencesStep,
+  switchToSpeciesStep
+} from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
 
 import ToolsAppBar from 'src/content/app/tools/shared/components/tools-app-bar/ToolsAppBar';
 import ToolsTopBar from 'src/content/app/tools/shared/components/tools-top-bar/ToolsTopBar';
@@ -93,15 +100,54 @@ const MainSmall = () => {
     <div className={containerClasses} ref={containerRef}>
       {step === 'sequences' ? (
         <>
+          <BlastSequenceSpeciesSelector />
           <BlastInputSequencesHeader compact={true} />
           <BlastInputSequences />
         </>
       ) : (
         <>
+          <BlastSequenceSpeciesSelector />
           <BlastSpeciesSelectorHeader compact={true} />
           <BlastSpeciesSelector />
         </>
       )}
+    </div>
+  );
+};
+
+const BlastSequenceSpeciesSelector = () => {
+  const dispatch = useDispatch();
+  const step = useSelector(getStep);
+
+  const onSwitchToSpecies = () => {
+    dispatch(switchToSpeciesStep());
+  };
+
+  const onSwitchToSequence = () => {
+    dispatch(switchToSequencesStep());
+  };
+
+  const sequenceButtonClass = classNames(styles.blastAgainstButton, {
+    [styles.selectedSequenceSpeciesButton]: step === 'sequences'
+  });
+  const speciesButtonClass = classNames(styles.blastAgainstButton, {
+    [styles.selectedSequenceSpeciesButton]: step === 'species'
+  });
+
+  return (
+    <div className={styles.sequenceSpeciesSelector}>
+      <SecondaryButton
+        className={sequenceButtonClass}
+        onClick={onSwitchToSequence}
+      >
+        Add sequence(s)
+      </SecondaryButton>
+      <SecondaryButton
+        className={speciesButtonClass}
+        onClick={onSwitchToSpecies}
+      >
+        Select species
+      </SecondaryButton>
     </div>
   );
 };

--- a/src/content/app/tools/blast/views/blast-form/BlastForm.tsx
+++ b/src/content/app/tools/blast/views/blast-form/BlastForm.tsx
@@ -100,13 +100,13 @@ const MainSmall = () => {
     <div className={containerClasses} ref={containerRef}>
       {step === 'sequences' ? (
         <>
-          <BlastSequenceSpeciesSelector />
+          <BlastFormStepToggle />
           <BlastInputSequencesHeader compact={true} />
           <BlastInputSequences />
         </>
       ) : (
         <>
-          <BlastSequenceSpeciesSelector />
+          <BlastFormStepToggle />
           <BlastSpeciesSelectorHeader compact={true} />
           <BlastSpeciesSelector />
         </>
@@ -115,7 +115,7 @@ const MainSmall = () => {
   );
 };
 
-const BlastSequenceSpeciesSelector = () => {
+const BlastFormStepToggle = () => {
   const dispatch = useDispatch();
   const step = useSelector(getStep);
 
@@ -128,14 +128,14 @@ const BlastSequenceSpeciesSelector = () => {
   };
 
   const sequenceButtonClass = classNames(styles.blastAgainstButton, {
-    [styles.selectedSequenceSpeciesButton]: step === 'sequences'
+    [styles.buttonActive]: step === 'sequences'
   });
   const speciesButtonClass = classNames(styles.blastAgainstButton, {
-    [styles.selectedSequenceSpeciesButton]: step === 'species'
+    [styles.buttonActive]: step === 'species'
   });
 
   return (
-    <div className={styles.sequenceSpeciesSelector}>
+    <div className={styles.blastFormStepToggle}>
       <SecondaryButton
         className={sequenceButtonClass}
         onClick={onSwitchToSequence}

--- a/src/content/app/tools/shared/components/tools-top-bar/ToolsTopBar.scss
+++ b/src/content/app/tools/shared/components/tools-top-bar/ToolsTopBar.scss
@@ -5,5 +5,6 @@
   background-color: $light-grey;
   padding: 24px 20px 20px 30px;
   box-shadow: 0 3px 5px $global-box-shadow;
-  margin-bottom: 20px;
+  position: relative;
+  z-index: 2;
 }

--- a/src/content/app/tools/shared/components/tools-top-bar/ToolsTopBar.scss
+++ b/src/content/app/tools/shared/components/tools-top-bar/ToolsTopBar.scss
@@ -4,6 +4,7 @@
   min-height: 74px;
   background-color: $light-grey;
   padding: 24px 20px 20px 30px;
+  margin-bottom: 20px;
   box-shadow: 0 3px 5px $global-box-shadow;
   position: relative;
   z-index: 2;

--- a/src/content/app/tools/shared/components/tools-top-bar/ToolsTopBar.scss
+++ b/src/content/app/tools/shared/components/tools-top-bar/ToolsTopBar.scss
@@ -5,5 +5,5 @@
   background-color: $light-grey;
   padding: 24px 20px 20px 30px;
   box-shadow: 0 3px 5px $global-box-shadow;
-  margin-bottom: 21px;
+  margin-bottom: 20px;
 }

--- a/src/content/app/tools/shared/components/tools-top-bar/ToolsTopBar.scss
+++ b/src/content/app/tools/shared/components/tools-top-bar/ToolsTopBar.scss
@@ -4,7 +4,6 @@
   min-height: 74px;
   background-color: $light-grey;
   padding: 24px 20px 20px 30px;
-  margin-bottom: 20px;
   box-shadow: 0 3px 5px $global-box-shadow;
   position: relative;
   z-index: 2;


### PR DESCRIPTION
## Description
Improving the single column layout for blast when selecting between sequence and species for smaller screen. This is now split into two buttons instead of one button with different text.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1572

## Deployment URL(s)
http://blast-single-column.review.ensembl.org


## Views affected
blast: http://blast-single-column.review.ensembl.org/blast