### PR TITLE
Add refget proxy k8s manifests.

### DIFF
--- a/gitlab-ci-templates/.setup-review-template.yaml
+++ b/gitlab-ci-templates/.setup-review-template.yaml
@@ -14,7 +14,7 @@
 
   before_script:
     - git clone https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
-    - git -C ensembl-k8s-manifests/ checkout refget-proxy-manifests
+    - git -C ensembl-k8s-manifests/ checkout wp-k8s-review
     - cd ensembl-k8s-manifests/
     # ensembl-client
     - sed -i "s#<DEPLOYMENT_ENV>#${CI_COMMIT_REF_SLUG}#g" ensembl_client_nginx_service.yaml

--- a/gitlab-ci-templates/.setup-review-template.yaml
+++ b/gitlab-ci-templates/.setup-review-template.yaml
@@ -14,7 +14,7 @@
 
   before_script:
     - git clone https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
-    - git -C ensembl-k8s-manifests/ checkout wp-k8s-review
+    - git -C ensembl-k8s-manifests/ checkout refget-proxy-manifests
     - cd ensembl-k8s-manifests/
     # ensembl-client
     - sed -i "s#<DEPLOYMENT_ENV>#${CI_COMMIT_REF_SLUG}#g" ensembl_client_nginx_service.yaml
@@ -42,10 +42,10 @@
     - sed -i "s#<DEPLOYMENT_ENV>#${THOAS_SERVICE_SLUG}#g" ensembl_thoas_service.yaml
     - sed -i "s#<DEPLOYMENT_ENV>#${THOAS_SERVICE_SLUG}#g" ensembl_thoas_ingress.yaml
     - sed -i "s#<SUB_DOMAIN>#${CI_COMMIT_REF_SLUG}#g" ensembl_thoas_ingress.yaml 
-    # ensembl-refget
-    - sed -i "s#<DEPLOYMENT_ENV>#${REFGET_SERVICE_SLUG}#g" ensembl_refget_service.yaml
-    - sed -i "s#<DEPLOYMENT_ENV>#${REFGET_SERVICE_SLUG}#g" ensembl_refget_ingress.yaml
-    - sed -i "s#<SUB_DOMAIN>#${CI_COMMIT_REF_SLUG}#g" ensembl_refget_ingress.yaml 
+    # ensembl-refget-proxy
+    - sed -i "s#<DEPLOYMENT_ENV>#${REFGET_SERVICE_SLUG}#g" ensembl_refget_proxy_service.yaml
+    - sed -i "s#<DEPLOYMENT_ENV>#${REFGET_SERVICE_SLUG}#g" ensembl_refget_proxy_ingress.yaml
+    - sed -i "s#<SUB_DOMAIN>#${CI_COMMIT_REF_SLUG}#g" ensembl_refget_proxy_ingress.yaml 
     # ensembl-help-docs
     - sed -i "s#<DEPLOYMENT_ENV>#${HELP_DOCS_SERVICE_SLUG}#g" ensembl_help_docs_service.yaml
     - sed -i "s#<DEPLOYMENT_ENV>#${HELP_DOCS_SERVICE_SLUG}#g" ensembl_help_docs_ingress.yaml
@@ -68,9 +68,9 @@
     # ensembl-help-and-docs
     - kubectl apply -f ensembl_help_docs_service.yaml
     - kubectl apply -f ensembl_help_docs_ingress.yaml
-    # ensembl-refget
-    - kubectl apply -f ensembl_refget_service.yaml
-    - kubectl apply -f ensembl_refget_ingress.yaml
+    # ensembl-refget-proxy
+    - kubectl apply -f ensembl_refget_proxy_service.yaml
+    - kubectl apply -f ensembl_refget_proxy_ingress.yaml
     # ensembl-thoas
     - kubectl apply -f ensembl_thoas_service.yaml
     - kubectl apply -f ensembl_thoas_ingress.yaml


### PR DESCRIPTION
## Description
Replace GAA refget with refget proxy in review branches to be able to retrieve genomic sequences from ENA refget.


## Related JIRA Issue(s)
[JIRA
](https://www.ebi.ac.uk/panda/jira/browse/EWB-182)

## Deployment URL(s)
http://refget-proxy-review-template.review.ensembl.org


## Views affected
None
Affects only CI/CD pipeline 