### PR TITLE
increase sequence limit to 50

### DIFF
--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.scss
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.scss
@@ -44,6 +44,10 @@
   border-radius: 100%;
   font-size: 15px;
   margin: 0 0.6rem 0 0.6rem;
+
+  &Error {
+    background-color: $red;
+  }
 }
 
 .maxSequences {

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.tsx
@@ -17,7 +17,6 @@
 import React from 'react';
 import classNames from 'classnames';
 import { useSelector, useDispatch } from 'react-redux';
-import classNames from 'classnames';
 
 import {
   getEmptyInputVisibility,
@@ -78,7 +77,7 @@ const BlastInputSequencesHeader = (props: Props) => {
   const sequenceCounterClass = classNames(styles.sequenceCounter, {
     [styles.sequenceCounterError]: sequences.length > MAX_BLAST_SEQUENCE_COUNT
   });
-  
+
   const headerClass = classNames(styles.header, {
     [styles.smallScreenHeader]: compact
   });

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequencesHeader.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import classNames from 'classnames';
 
 import {
   getEmptyInputVisibility,
@@ -81,12 +82,18 @@ const BlastInputSequencesHeader = (props: Props) => {
     ? sequences.length + 1
     : sequences.length;
 
+  const sequenceCounterClass = classNames(styles.sequenceCounter, {
+    [styles.sequenceCounterError]: sequences.length > MAX_BLAST_SEQUENCE_COUNT
+  });
+
   return (
     <div className={styles.header}>
       <div className={styles.headerGroup}>
         <span className={styles.headerTitle}>Sequences</span>
-        <span className={styles.sequenceCounter}>{sequencesCount}</span>
-        <span className={styles.maxSequences}>of 30</span>
+        <span className={sequenceCounterClass}>{sequencesCount}</span>
+        <span className={styles.maxSequences}>
+          of {MAX_BLAST_SEQUENCE_COUNT}
+        </span>
       </div>
       <SequenceSwitcher
         sequenceType={sequenceType}

--- a/src/content/app/tools/blast/utils/blastFormValidator.ts
+++ b/src/content/app/tools/blast/utils/blastFormValidator.ts
@@ -17,7 +17,7 @@
 import { ParsedInputSequence } from 'src/content/app/tools/blast/types/parsedInputSequence';
 
 export const MAX_BLAST_SPECIES_COUNT = 25;
-export const MAX_BLAST_SEQUENCE_COUNT = 30;
+export const MAX_BLAST_SEQUENCE_COUNT = 50;
 
 export const isBlastFormValid = (
   species: string[],


### PR DESCRIPTION
## Description
Currently for blast we are limiting the maximum number of sequences that can be added to the form to 30; after user testing it was agreed to increase the limit to 50. This is updating the `MAX_BLAST_SEQUENCE_COUNT` from 30 to 50 and also changing the sequence counter background to red when this number is exceeded.


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1555

## Deployment URL(s)
http://sequence-limit.review.ensembl.org/blast


## Views affected
Blast