### PR TITLE
do not wrap white space

### DIFF
--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.scss
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.scss
@@ -48,6 +48,7 @@
 
 .reverseComplement {
   margin-top: 43px;
+  white-space: nowrap;
 }
 
 .showHide {


### PR DESCRIPTION
## Description
Simple css fix to not wrap white spaces in the label in sequence viewer

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1606

## Deployment URL(s)
http://white-space-wrap.review.ensembl.org/


## Views affected
Sequence viewer in GB drawer