### PR TITLE
Add different track configs for different types of tracks

### DIFF
--- a/src/content/app/genome-browser/components/browser-track-config/BrowserTrackConfig.test.tsx
+++ b/src/content/app/genome-browser/components/browser-track-config/BrowserTrackConfig.test.tsx
@@ -126,14 +126,12 @@ describe('<BrowserTrackConfig />', () => {
         .find((element) => element.textContent === 'Track name')
         ?.parentElement?.querySelector('svg') as SVGElement;
 
-      jest.spyOn(trackConfigActions, 'updateTrackConfigNames');
+      jest.spyOn(trackConfigActions, 'updateTrackName');
 
       await userEvent.click(toggle);
       const updatedState = store.getState();
-      expect(trackConfigActions.updateTrackConfigNames).toHaveBeenCalledTimes(
-        1
-      );
-      expect(trackConfigActions.updateTrackConfigNames).toHaveBeenCalledWith({
+      expect(trackConfigActions.updateTrackName).toHaveBeenCalledTimes(1);
+      expect(trackConfigActions.updateTrackName).toHaveBeenCalledWith({
         genomeId,
         isTrackNameShown: true,
         selectedCog: updatedState.browser.trackConfig[genomeId].selectedCog
@@ -150,13 +148,11 @@ describe('<BrowserTrackConfig />', () => {
         .find((element) => element.textContent === 'Feature labels')
         ?.parentElement?.querySelector('svg') as SVGElement;
 
-      jest.spyOn(trackConfigActions, 'updateTrackConfigLabel');
+      jest.spyOn(trackConfigActions, 'updateFeatureLabel');
       await userEvent.click(toggle);
       const updatedState = store.getState();
-      expect(trackConfigActions.updateTrackConfigLabel).toHaveBeenCalledTimes(
-        1
-      );
-      expect(trackConfigActions.updateTrackConfigLabel).toHaveBeenCalledWith({
+      expect(trackConfigActions.updateFeatureLabel).toHaveBeenCalledTimes(1);
+      expect(trackConfigActions.updateFeatureLabel).toHaveBeenCalledWith({
         genomeId,
         isTrackLabelShown: true,
         selectedCog: updatedState.browser.trackConfig[genomeId].selectedCog

--- a/src/content/app/genome-browser/components/browser-track-config/track-config-views/GeneTrackConfig.tsx
+++ b/src/content/app/genome-browser/components/browser-track-config/track-config-views/GeneTrackConfig.tsx
@@ -20,7 +20,7 @@ import { useSelector } from 'react-redux';
 
 import SlideToggle from 'src/shared/components/slide-toggle/SlideToggle';
 
-import { TrackType } from 'src/content/app/genome-browser/state/track-config/trackConfigSlice';
+import { type GeneTrackConfig as GeneTrackConfigType } from 'src/content/app/genome-browser/state/track-config/trackConfigSlice';
 import {
   getBrowserSelectedCog,
   getTrackConfigForTrackId
@@ -32,20 +32,46 @@ import styles from '../BrowserTrackConfig.scss';
 
 export const GeneTrackConfig = () => {
   const selectedCog = useSelector(getBrowserSelectedCog) || '';
-  const selectedTrackConfigInfo = useSelector((state: RootState) =>
-    getTrackConfigForTrackId(state, selectedCog)
+  const selectedTrackConfig = useSelector(
+    (state: RootState) =>
+      getTrackConfigForTrackId(state, selectedCog) as GeneTrackConfigType
   );
-  const shouldShowTrackName = selectedTrackConfigInfo?.showTrackName ?? false;
-  const shouldShowTrackLabel =
-    selectedTrackConfigInfo?.trackType === TrackType.GENE &&
-    selectedTrackConfigInfo.showFeatureLabel;
 
-  const { updateTrackName, updateTrackLabel } = useBrowserTrackConfig();
+  const shouldShowTrackName = selectedTrackConfig.showTrackName;
+  const shouldShowTrackLabel = selectedTrackConfig.showFeatureLabel;
+  const shouldShowSeveralTranscripts =
+    selectedTrackConfig.showSeveralTranscripts;
+  const shouldShowTranscriptIDs = selectedTrackConfig.showTranscriptIds;
+
+  const {
+    updateTrackName,
+    updateTrackLabel,
+    updateShowSeveralTranscripts,
+    updateShowTranscriptIds
+  } = useBrowserTrackConfig();
 
   return (
     <div className={styles.section}>
       <div className={styles.subLabel}>Show</div>
       <div>
+        <div className={styles.toggleWrapper}>
+          <label>5 transcripts</label>
+          <SlideToggle
+            isOn={shouldShowSeveralTranscripts}
+            onChange={() =>
+              updateShowSeveralTranscripts(!shouldShowSeveralTranscripts)
+            }
+            className={styles.slideToggle}
+          />
+        </div>
+        <div className={styles.toggleWrapper}>
+          <label>Transcript IDs</label>
+          <SlideToggle
+            isOn={shouldShowTranscriptIDs}
+            onChange={() => updateShowTranscriptIds(!shouldShowTranscriptIDs)}
+            className={styles.slideToggle}
+          />
+        </div>
         <div className={styles.toggleWrapper}>
           <label>Track name</label>
           <SlideToggle

--- a/src/content/app/genome-browser/components/browser-track-config/useBrowserTrackConfig.ts
+++ b/src/content/app/genome-browser/components/browser-track-config/useBrowserTrackConfig.ts
@@ -28,8 +28,10 @@ import {
   getBrowserSelectedCog
 } from '../../state/track-config/trackConfigSelectors';
 import {
-  updateTrackConfigNames,
-  updateTrackConfigLabel,
+  updateTrackName as updateTrackConfigTrackName,
+  updateFeatureLabel as updateTrackConfigFeatureLabel,
+  updateShowSeveralTranscripts as updateTrackConfigShowSeveralTranscripts,
+  updateShowTranscriptIds as updateTrackConfigShowTranscriptIds,
   updateApplyToAll,
   TrackType
 } from '../../state/track-config/trackConfigSlice';
@@ -55,7 +57,12 @@ const useBrowserTrackConfig = () => {
 
   const dispatch = useDispatch();
 
-  const { toggleTrackName, toggleTrackLabel } = useGenomeBrowser();
+  const {
+    toggleTrackName,
+    toggleTrackLabel,
+    toggleSeveralTranscripts,
+    toggleTranscriptIds
+  } = useGenomeBrowser();
 
   const updateTrackName = (isTrackNameShown: boolean) => {
     if (!activeGenomeId) {
@@ -64,7 +71,7 @@ const useBrowserTrackConfig = () => {
     if (shouldApplyToAllRef.current) {
       Object.keys(browserCogList).forEach((trackId) => {
         dispatch(
-          updateTrackConfigNames({
+          updateTrackConfigTrackName({
             genomeId: activeGenomeId,
             selectedCog: trackId,
             isTrackNameShown
@@ -74,7 +81,7 @@ const useBrowserTrackConfig = () => {
       });
     } else {
       dispatch(
-        updateTrackConfigNames({
+        updateTrackConfigTrackName({
           genomeId: activeGenomeId,
           selectedCog,
           isTrackNameShown
@@ -101,7 +108,7 @@ const useBrowserTrackConfig = () => {
     if (shouldApplyToAllRef.current) {
       Object.keys(browserCogList).forEach((trackId) => {
         dispatch(
-          updateTrackConfigLabel({
+          updateTrackConfigFeatureLabel({
             genomeId: activeGenomeId,
             selectedCog: trackId,
             isTrackLabelShown
@@ -114,7 +121,7 @@ const useBrowserTrackConfig = () => {
       });
     } else {
       dispatch(
-        updateTrackConfigLabel({
+        updateTrackConfigFeatureLabel({
           genomeId: activeGenomeId,
           selectedCog,
           isTrackLabelShown
@@ -130,6 +137,85 @@ const useBrowserTrackConfig = () => {
       category: 'track_settings',
       label: selectedCog,
       action: 'feature_label_' + (isTrackLabelShown ? 'on' : 'off')
+    });
+  };
+
+  const updateShowSeveralTranscripts = (isSeveralTranscriptsShown: boolean) => {
+    if (!activeGenomeId) {
+      return;
+    }
+    if (shouldApplyToAllRef.current) {
+      Object.keys(browserCogList).forEach((trackId) => {
+        dispatch(
+          updateTrackConfigShowSeveralTranscripts({
+            genomeId: activeGenomeId,
+            selectedCog: trackId,
+            isSeveralTranscriptsShown
+          })
+        );
+        toggleSeveralTranscripts({
+          trackId,
+          shouldShowSeveralTranscripts: isSeveralTranscriptsShown
+        });
+      });
+    } else {
+      dispatch(
+        updateTrackConfigShowSeveralTranscripts({
+          genomeId: activeGenomeId,
+          selectedCog,
+          isSeveralTranscriptsShown
+        })
+      );
+      toggleSeveralTranscripts({
+        trackId: selectedCog,
+        shouldShowSeveralTranscripts: isSeveralTranscriptsShown
+      });
+    }
+
+    analyticsTracking.trackEvent({
+      category: 'track_settings',
+      label: selectedCog,
+      action:
+        'several_transcripts_' + (isSeveralTranscriptsShown ? 'on' : 'off')
+    });
+  };
+
+  const updateShowTranscriptIds = (isTranscriptIdsShown: boolean) => {
+    if (!activeGenomeId) {
+      return;
+    }
+    if (shouldApplyToAllRef.current) {
+      Object.keys(browserCogList).forEach((trackId) => {
+        dispatch(
+          updateTrackConfigShowTranscriptIds({
+            genomeId: activeGenomeId,
+            selectedCog: trackId,
+            isTranscriptIdsShown
+          })
+        );
+        toggleTranscriptIds({
+          trackId,
+          shouldShowTranscriptIds: isTranscriptIdsShown
+        });
+      });
+    } else {
+      dispatch(
+        updateTrackConfigShowTranscriptIds({
+          genomeId: activeGenomeId,
+          selectedCog,
+          isTranscriptIdsShown
+        })
+      );
+      toggleTranscriptIds({
+        trackId: selectedCog,
+        shouldShowTranscriptIds: isTranscriptIdsShown
+      });
+    }
+
+    analyticsTracking.trackEvent({
+      category: 'track_settings',
+      label: selectedCog,
+      action: 'several_transcripts_' + (isTranscriptIdsShown ? 'on' : 'off')
     });
   };
 
@@ -163,6 +249,8 @@ const useBrowserTrackConfig = () => {
   return {
     updateTrackName,
     updateTrackLabel,
+    updateShowSeveralTranscripts,
+    updateShowTranscriptIds,
     handleRadioChange
   };
 };

--- a/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
@@ -291,6 +291,44 @@ const useGenomeBrowser = () => {
     });
   };
 
+  const toggleSeveralTranscripts = (params: {
+    trackId: string;
+    shouldShowSeveralTranscripts: boolean;
+  }) => {
+    const { trackId, shouldShowSeveralTranscripts } = params;
+    const trackIdWithoutPrefix = trackId.replace('track:', '');
+    const trackIdToSend =
+      trackIdWithoutPrefix === 'gene-focus' ? 'focus' : trackIdWithoutPrefix;
+
+    genomeBrowser?.send({
+      type: shouldShowSeveralTranscripts
+        ? OutgoingActionType.TURN_ON_SEVERAL_TRANSCRIPTS
+        : OutgoingActionType.TURN_OFF_SEVERAL_TRANSCRIPTS,
+      payload: {
+        track_ids: [trackIdToSend]
+      }
+    });
+  };
+
+  const toggleTranscriptIds = (params: {
+    trackId: string;
+    shouldShowTranscriptIds: boolean;
+  }) => {
+    const { trackId, shouldShowTranscriptIds } = params;
+    const trackIdWithoutPrefix = trackId.replace('track:', '');
+    const trackIdToSend =
+      trackIdWithoutPrefix === 'gene-focus' ? 'focus' : trackIdWithoutPrefix;
+
+    genomeBrowser?.send({
+      type: shouldShowTranscriptIds
+        ? OutgoingActionType.TURN_ON_TRANSCRIPT_IDS
+        : OutgoingActionType.TURN_OFF_TRANSCRIPT_IDS,
+      payload: {
+        track_ids: [trackIdToSend]
+      }
+    });
+  };
+
   const toggleTrack = (params: { trackId: string; status: Status }) => {
     const { trackId, status } = params;
     const isTurnedOn = status === Status.SELECTED;
@@ -347,6 +385,8 @@ const useGenomeBrowser = () => {
     toggleTrack,
     toggleTrackName,
     toggleTrackLabel,
+    toggleSeveralTranscripts,
+    toggleTranscriptIds,
     genomeBrowser,
     zmenus
   };

--- a/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
@@ -291,6 +291,8 @@ const useGenomeBrowser = () => {
     });
   };
 
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+
   const toggleSeveralTranscripts = (params: {
     trackId: string;
     shouldShowSeveralTranscripts: boolean;
@@ -300,14 +302,14 @@ const useGenomeBrowser = () => {
     const trackIdToSend =
       trackIdWithoutPrefix === 'gene-focus' ? 'focus' : trackIdWithoutPrefix;
 
-    genomeBrowser?.send({
-      type: shouldShowSeveralTranscripts
-        ? OutgoingActionType.TURN_ON_SEVERAL_TRANSCRIPTS
-        : OutgoingActionType.TURN_OFF_SEVERAL_TRANSCRIPTS,
-      payload: {
-        track_ids: [trackIdToSend]
-      }
-    });
+    // genomeBrowser?.send({
+    //   type: shouldShowSeveralTranscripts
+    //     ? OutgoingActionType.TURN_ON_SEVERAL_TRANSCRIPTS
+    //     : OutgoingActionType.TURN_OFF_SEVERAL_TRANSCRIPTS,
+    //   payload: {
+    //     track_ids: [trackIdToSend]
+    //   }
+    // });
   };
 
   const toggleTranscriptIds = (params: {
@@ -319,15 +321,16 @@ const useGenomeBrowser = () => {
     const trackIdToSend =
       trackIdWithoutPrefix === 'gene-focus' ? 'focus' : trackIdWithoutPrefix;
 
-    genomeBrowser?.send({
-      type: shouldShowTranscriptIds
-        ? OutgoingActionType.TURN_ON_TRANSCRIPT_IDS
-        : OutgoingActionType.TURN_OFF_TRANSCRIPT_IDS,
-      payload: {
-        track_ids: [trackIdToSend]
-      }
-    });
+    // genomeBrowser?.send({
+    //   type: shouldShowTranscriptIds
+    //     ? OutgoingActionType.TURN_ON_TRANSCRIPT_IDS
+    //     : OutgoingActionType.TURN_OFF_TRANSCRIPT_IDS,
+    //   payload: {
+    //     track_ids: [trackIdToSend]
+    //   }
+    // });
   };
+  /* eslint-enable @typescript-eslint/no-unused-vars */
 
   const toggleTrack = (params: { trackId: string; status: Status }) => {
     const { trackId, status } = params;

--- a/src/content/app/genome-browser/state/track-config/trackConfigSlice.ts
+++ b/src/content/app/genome-browser/state/track-config/trackConfigSlice.ts
@@ -221,7 +221,7 @@ const browserTrackConfigSlice = createSlice({
         fragment: { applyToAllConfig: { isSelected } }
       });
     },
-    updateTrackConfigNames(
+    updateTrackName(
       state,
       action: PayloadAction<{
         genomeId: string;
@@ -244,7 +244,7 @@ const browserTrackConfigSlice = createSlice({
         fragment
       });
     },
-    updateTrackConfigLabel(
+    updateFeatureLabel(
       state,
       action: PayloadAction<{
         genomeId: string;
@@ -273,6 +273,67 @@ const browserTrackConfigSlice = createSlice({
         genomeId,
         fragment
       });
+    },
+    updateShowSeveralTranscripts(
+      state,
+      action: PayloadAction<{
+        genomeId: string;
+        selectedCog: string;
+        isSeveralTranscriptsShown: boolean;
+      }>
+    ) {
+      const { genomeId, selectedCog, isSeveralTranscriptsShown } =
+        action.payload;
+      const trackConfigState = state[genomeId].tracks[selectedCog];
+
+      if (trackConfigState.trackType !== TrackType.GENE) {
+        return;
+      }
+
+      // TODO: check if trackConfigState is a reference and the actual state is not getting updated
+      trackConfigState.showSeveralTranscripts = isSeveralTranscriptsShown;
+
+      const fragment = {
+        tracks: {
+          [selectedCog]: {
+            ...trackConfigState
+          }
+        }
+      };
+      browserTrackConfigStorageService.setTrackConfigState({
+        genomeId,
+        fragment
+      });
+    },
+    updateShowTranscriptIds(
+      state,
+      action: PayloadAction<{
+        genomeId: string;
+        selectedCog: string;
+        isTranscriptIdsShown: boolean;
+      }>
+    ) {
+      const { genomeId, selectedCog, isTranscriptIdsShown } = action.payload;
+      const trackConfigState = state[genomeId].tracks[selectedCog];
+
+      if (trackConfigState.trackType !== TrackType.GENE) {
+        return;
+      }
+
+      // TODO: check if trackConfigState is a reference and the actual state is not getting updated
+      trackConfigState.showTranscriptIds = isTranscriptIdsShown;
+
+      const fragment = {
+        tracks: {
+          [selectedCog]: {
+            ...trackConfigState
+          }
+        }
+      };
+      browserTrackConfigStorageService.setTrackConfigState({
+        genomeId,
+        fragment
+      });
     }
   }
 });
@@ -282,8 +343,10 @@ export const {
   updateCogList,
   updateSelectedCog,
   updateApplyToAll,
-  updateTrackConfigNames,
-  updateTrackConfigLabel
+  updateTrackName,
+  updateFeatureLabel,
+  updateShowSeveralTranscripts,
+  updateShowTranscriptIds
 } = browserTrackConfigSlice.actions;
 
 export default browserTrackConfigSlice.reducer;


### PR DESCRIPTION
## Description
Currently we only need 2 versions of the track panel (see spec)

Spec:  https://www.ebi.ac.uk/seqdb/confluence/display/ENSWEB/Genome+browser+settings+panels

(As Andrea is on leave, I decided to go with "Show 5 transcripts", which can be later discussed and changed.)

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1567

## Deployment URL(s)
http://more-track-settings.review.ensembl.org/

## Views affected
Track config in GB