### PR TITLE
Fix duplication of stable id in the list of previously viewed features in genome browser

### DIFF
--- a/src/content/app/genome-browser/state/browser-bookmarks/browserBookmarksSlice.ts
+++ b/src/content/app/genome-browser/state/browser-bookmarks/browserBookmarksSlice.ts
@@ -83,8 +83,7 @@ export const updatePreviouslyViewedObjectsAndSave =
         : null;
 
     const geneSymbol =
-      activeFocusObject.type === 'gene' &&
-      activeFocusObject.label !== activeFocusObject.stable_id
+      activeFocusObject.type === 'gene' && activeFocusObject.label !== stable_id
         ? activeFocusObject.label
         : null;
 


### PR DESCRIPTION
## Description
As per jira ticket, fix bug showing duplicate label where the symbol and the stable id are the same.

The issue was because we were using stable_id instead of versioned stable_id to compare with the gene symbol


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1592

## Deployment URL(s)
http://duplicate-stableid.review.ensembl.org


## Views affected
Previously viewed in Genome Browser (use this gene as example: [ENSG00000286286.1](http://duplicate-stableid.review.ensembl.org/genome-browser/homo_sapiens_GCA_000001405_28?focus=gene:ENSG00000286286)