### PR TITLE
Remove the extra button wrapper in BlastLaunchbarButton

### DIFF
--- a/src/header/launchbar/BlastLaunchbarButton.tsx
+++ b/src/header/launchbar/BlastLaunchbarButton.tsx
@@ -24,8 +24,6 @@ import { getUnviewedBlastSubmissions } from 'src/content/app/tools/blast/state/b
 import LaunchbarButtonWithNotification from './LaunchbarButtonWithNotification';
 import { BlastIcon } from 'src/shared/components/app-icon';
 
-import styles from './Launchbar.scss';
-
 const BLAST_APP_ROOT_PATH = '/blast';
 
 const BlastLaunchbarButton = () => {
@@ -53,14 +51,12 @@ const BlastLaunchbarButton = () => {
   };
 
   return (
-    <div className={styles.category}>
-      <LaunchbarButtonWithNotification
-        path={blastAppPath}
-        description="BLAST"
-        icon={BlastIcon}
-        notification={getNotification()}
-      />
-    </div>
+    <LaunchbarButtonWithNotification
+      path={blastAppPath}
+      description="BLAST"
+      icon={BlastIcon}
+      notification={getNotification()}
+    />
   );
 };
 


### PR DESCRIPTION
## Description
Regression introduced in https://github.com/Ensembl/ensembl-client/pull/750

The BLAST launchbar button is twice wrapped in a category class:

![image](https://user-images.githubusercontent.com/6834224/171061552-2d0bf051-07b7-473e-a2a3-88d98ef678d9.png)

This resulted in extra white space to the right of the button:

![image](https://user-images.githubusercontent.com/6834224/171061718-4c00934b-fc98-4c02-b10c-81998018b7db.png)

After the fix:

<img width="575" alt="image" src="https://user-images.githubusercontent.com/6834224/171061752-8ba86f9f-4c1f-4615-ab5d-ad68e437ab06.png">

## Deployment URL(s)
http://fix-launchbar-button.review.ensembl.org