### PR TITLE
Update ensembl-genome-browser to 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ensembl/ensembl-genome-browser": "0.2.1",
+        "@ensembl/ensembl-genome-browser": "0.3.0-test",
         "@loadable/component": "5.15.2",
         "@loadable/server": "5.15.2",
         "@react-spring/web": "9.4.5-beta.1",
@@ -2271,9 +2271,9 @@
       }
     },
     "node_modules/@ensembl/ensembl-genome-browser": {
-      "version": "0.2.1",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.2.1.tgz",
-      "integrity": "sha1-+uRBOqTZCoNXjDIPtTH/omHOrnM="
+      "version": "0.3.0-test",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.3.0-test.tgz",
+      "integrity": "sha1-5eOY40+4K7cPAMWkdECK1sApYLM="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.2.2",
@@ -42457,9 +42457,9 @@
       "dev": true
     },
     "@ensembl/ensembl-genome-browser": {
-      "version": "0.2.1",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.2.1.tgz",
-      "integrity": "sha1-+uRBOqTZCoNXjDIPtTH/omHOrnM="
+      "version": "0.3.0-test",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.3.0-test.tgz",
+      "integrity": "sha1-5eOY40+4K7cPAMWkdECK1sApYLM="
     },
     "@eslint/eslintrc": {
       "version": "1.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ensembl/ensembl-genome-browser": "0.3.0-test",
+        "@ensembl/ensembl-genome-browser": "0.3.0",
         "@loadable/component": "5.15.2",
         "@loadable/server": "5.15.2",
         "@react-spring/web": "9.4.5-beta.1",
@@ -2271,9 +2271,9 @@
       }
     },
     "node_modules/@ensembl/ensembl-genome-browser": {
-      "version": "0.3.0-test",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.3.0-test.tgz",
-      "integrity": "sha1-5eOY40+4K7cPAMWkdECK1sApYLM="
+      "version": "0.3.0",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.3.0.tgz",
+      "integrity": "sha1-x6mdheO3NyM35eLwG6lRZSiuNOY="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.2.2",
@@ -42457,9 +42457,9 @@
       "dev": true
     },
     "@ensembl/ensembl-genome-browser": {
-      "version": "0.3.0-test",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.3.0-test.tgz",
-      "integrity": "sha1-5eOY40+4K7cPAMWkdECK1sApYLM="
+      "version": "0.3.0",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.3.0.tgz",
+      "integrity": "sha1-x6mdheO3NyM35eLwG6lRZSiuNOY="
     },
     "@eslint/eslintrc": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "coverage": "jest --coverage"
   },
   "dependencies": {
-    "@ensembl/ensembl-genome-browser": "0.3.0-test",
+    "@ensembl/ensembl-genome-browser": "0.3.0",
     "@loadable/component": "5.15.2",
     "@loadable/server": "5.15.2",
     "@react-spring/web": "9.4.5-beta.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "coverage": "jest --coverage"
   },
   "dependencies": {
-    "@ensembl/ensembl-genome-browser": "0.2.1",
+    "@ensembl/ensembl-genome-browser": "0.3.0-test",
     "@loadable/component": "5.15.2",
     "@loadable/server": "5.15.2",
     "@react-spring/web": "9.4.5-beta.1",


### PR DESCRIPTION
## Description

Use the latest ensembl-genome-browser test package, which will be changed to `0.3.0` before merging this branch. The latest package includes support for multiple transcripts and gene bumping.

The related PR is: https://github.com/Ensembl/ensembl-genome-browser/pull/8

## Related JIRA Issue(s)
[ENSWBSITES-1591](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1591)

## Deployment URL(s)
http://update-gb-package.review.ensembl.org


## Views affected
Genome browser