### PR TITLE
GB version update - 0.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ensembl/ensembl-genome-browser": "0.3.0",
+        "@ensembl/ensembl-genome-browser": "0.3.1-test",
         "@loadable/component": "5.15.2",
         "@loadable/server": "5.15.2",
         "@react-spring/web": "9.4.5-beta.1",
@@ -2348,9 +2348,9 @@
       }
     },
     "node_modules/@ensembl/ensembl-genome-browser": {
-      "version": "0.3.0",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.3.0.tgz",
-      "integrity": "sha1-x6mdheO3NyM35eLwG6lRZSiuNOY="
+      "version": "0.3.1-test",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.3.1-test.tgz",
+      "integrity": "sha1-1+Z2cOqXRG3QX6ru/vwpiJyM+4k="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.0",
@@ -42312,9 +42312,9 @@
       "dev": true
     },
     "@ensembl/ensembl-genome-browser": {
-      "version": "0.3.0",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.3.0.tgz",
-      "integrity": "sha1-x6mdheO3NyM35eLwG6lRZSiuNOY="
+      "version": "0.3.1-test",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.3.1-test.tgz",
+      "integrity": "sha1-1+Z2cOqXRG3QX6ru/vwpiJyM+4k="
     },
     "@eslint/eslintrc": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "coverage": "jest --coverage"
   },
   "dependencies": {
-    "@ensembl/ensembl-genome-browser": "0.3.0",
+    "@ensembl/ensembl-genome-browser": "0.3.1-test",
     "@loadable/component": "5.15.2",
     "@loadable/server": "5.15.2",
     "@react-spring/web": "9.4.5-beta.1",

--- a/src/content/app/genome-browser/components/browser-track-config/BrowserTrackConfig.test.tsx
+++ b/src/content/app/genome-browser/components/browser-track-config/BrowserTrackConfig.test.tsx
@@ -41,7 +41,7 @@ const renderComponent = () => {
     tracks: {
       [selectedTrackId]: {
         showSeveralTranscripts: false,
-        showTranscriptIds: false,
+        showTranscriptLabels: false,
         showTrackName: false,
         showFeatureLabel: false,
         trackType: trackConfigSlice.TrackType.GENE

--- a/src/content/app/genome-browser/components/browser-track-config/track-config-views/GeneTrackConfig.tsx
+++ b/src/content/app/genome-browser/components/browser-track-config/track-config-views/GeneTrackConfig.tsx
@@ -43,7 +43,7 @@ export const GeneTrackConfig = () => {
     updateTrackName,
     updateTrackLabel,
     updateShowSeveralTranscripts,
-    updateShowTranscriptIds
+    updateShowTranscriptLabels
   } = useBrowserTrackConfig();
 
   if (!selectedTrackConfig) {
@@ -54,7 +54,7 @@ export const GeneTrackConfig = () => {
   const shouldShowTrackLabel = selectedTrackConfig.showFeatureLabel;
   const shouldShowSeveralTranscripts =
     selectedTrackConfig.showSeveralTranscripts;
-  const shouldShowTranscriptIDs = selectedTrackConfig.showTranscriptIds;
+  const shouldShowTranscriptLabels = selectedTrackConfig.showTranscriptLabels;
 
   return (
     <div className={styles.section}>
@@ -73,8 +73,10 @@ export const GeneTrackConfig = () => {
         <div className={styles.toggleWrapper}>
           <label>Transcript IDs</label>
           <SlideToggle
-            isOn={shouldShowTranscriptIDs}
-            onChange={() => updateShowTranscriptIds(!shouldShowTranscriptIDs)}
+            isOn={shouldShowTranscriptLabels}
+            onChange={() =>
+              updateShowTranscriptLabels(!shouldShowTranscriptLabels)
+            }
             className={styles.slideToggle}
           />
         </div>

--- a/src/content/app/genome-browser/components/browser-track-config/useBrowserTrackConfig.ts
+++ b/src/content/app/genome-browser/components/browser-track-config/useBrowserTrackConfig.ts
@@ -28,7 +28,7 @@ import {
   updateTrackName as updateTrackConfigTrackName,
   updateFeatureLabel as updateTrackConfigFeatureLabel,
   updateShowSeveralTranscripts as updateTrackConfigShowSeveralTranscripts,
-  updateShowTranscriptIds as updateTrackConfigShowTranscriptIds,
+  updateShowTranscriptLabels as updateTrackConfigShowTranscriptLabels,
   updateApplyToAll,
   saveTrackConfigsForGenome,
   TrackType
@@ -59,7 +59,7 @@ const useBrowserTrackConfig = () => {
     toggleTrackName,
     toggleTrackLabel,
     toggleSeveralTranscripts,
-    toggleTranscriptIds
+    toggleTranscriptLabels
   } = useGenomeBrowser();
 
   const updateTrackName = (isTrackNameShown: boolean) => {
@@ -185,35 +185,35 @@ const useBrowserTrackConfig = () => {
     });
   };
 
-  const updateShowTranscriptIds = (isTranscriptIdsShown: boolean) => {
+  const updateShowTranscriptLabels = (isTranscripLabelsShown: boolean) => {
     if (!activeGenomeId) {
       return;
     }
     if (shouldApplyToAllRef.current) {
       Object.keys(browserCogList).forEach((trackId) => {
         dispatch(
-          updateTrackConfigShowTranscriptIds({
+          updateTrackConfigShowTranscriptLabels({
             genomeId: activeGenomeId,
             trackId,
-            isTranscriptIdsShown
+            isTranscripLabelsShown
           })
         );
-        toggleTranscriptIds({
+        toggleTranscriptLabels({
           trackId,
-          shouldShowTranscriptIds: isTranscriptIdsShown
+          shouldShowTranscriptLabels: isTranscripLabelsShown
         });
       });
     } else {
       dispatch(
-        updateTrackConfigShowTranscriptIds({
+        updateTrackConfigShowTranscriptLabels({
           genomeId: activeGenomeId,
           trackId: selectedCog,
-          isTranscriptIdsShown
+          isTranscripLabelsShown
         })
       );
-      toggleTranscriptIds({
+      toggleTranscriptLabels({
         trackId: selectedCog,
-        shouldShowTranscriptIds: isTranscriptIdsShown
+        shouldShowTranscriptLabels: isTranscripLabelsShown
       });
     }
 
@@ -222,7 +222,7 @@ const useBrowserTrackConfig = () => {
     analyticsTracking.trackEvent({
       category: 'track_settings',
       label: selectedCog,
-      action: 'several_transcripts_' + (isTranscriptIdsShown ? 'on' : 'off')
+      action: 'several_transcripts_' + (isTranscripLabelsShown ? 'on' : 'off')
     });
   };
 
@@ -242,6 +242,11 @@ const useBrowserTrackConfig = () => {
         ? selectedTrackConfigs.showSeveralTranscripts
         : false;
 
+    const shouldShowTranscriptLabels =
+      selectedTrackConfigs.trackType === TrackType.GENE
+        ? selectedTrackConfigs.showTranscriptLabels
+        : false;
+
     dispatch(
       updateApplyToAll({
         genomeId: activeGenomeId,
@@ -254,6 +259,7 @@ const useBrowserTrackConfig = () => {
     updateTrackName(shouldShowTrackName);
     updateTrackLabel(shouldShowFeatureLabel);
     updateShowSeveralTranscripts(shouldShowSeveralTranscripts);
+    updateShowTranscriptLabels(shouldShowTranscriptLabels);
 
     analyticsTracking.trackEvent({
       category: 'track_settings',
@@ -266,7 +272,7 @@ const useBrowserTrackConfig = () => {
     updateTrackName,
     updateTrackLabel,
     updateShowSeveralTranscripts,
-    updateShowTranscriptIds,
+    updateShowTranscriptLabels,
     toggleApplyToAll
   };
 };

--- a/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
@@ -169,6 +169,7 @@ const useGenomeBrowser = () => {
     };
 
     const trackStateForSeveralTranscripts = cloneDeep(emptyOnOffLists);
+    const trackStateForTranscriptLabels = cloneDeep(emptyOnOffLists);
     const trackStateForNames = cloneDeep(emptyOnOffLists);
     const trackStateForLabels = cloneDeep(emptyOnOffLists);
 
@@ -193,6 +194,10 @@ const useGenomeBrowser = () => {
           config.showSeveralTranscripts
             ? trackStateForSeveralTranscripts.on.push(trackId)
             : trackStateForSeveralTranscripts.off.push(trackId);
+
+          config.showTranscriptLabels
+            ? trackStateForTranscriptLabels.on.push(trackId)
+            : trackStateForTranscriptLabels.off.push(trackId);
         }
       });
 
@@ -235,6 +240,20 @@ const useGenomeBrowser = () => {
       type: OutgoingActionType.TURN_OFF_SEVERAL_TRANSCRIPTS,
       payload: {
         track_ids: trackStateForSeveralTranscripts.off
+      }
+    });
+
+    genomeBrowser.send({
+      type: OutgoingActionType.TURN_ON_TRANSCRIPT_LABELS,
+      payload: {
+        track_ids: trackStateForTranscriptLabels.on
+      }
+    });
+
+    genomeBrowser.send({
+      type: OutgoingActionType.TURN_OFF_TRANSCRIPT_LABELS,
+      payload: {
+        track_ids: trackStateForTranscriptLabels.off
       }
     });
   };
@@ -325,27 +344,24 @@ const useGenomeBrowser = () => {
     });
   };
 
-  /* eslint-disable @typescript-eslint/no-unused-vars */
-  const toggleTranscriptIds = (params: {
+  const toggleTranscriptLabels = (params: {
     trackId: string;
-    shouldShowTranscriptIds: boolean;
+    shouldShowTranscriptLabels: boolean;
   }) => {
-    const { trackId, shouldShowTranscriptIds } = params;
+    const { trackId, shouldShowTranscriptLabels } = params;
     const trackIdWithoutPrefix = trackId.replace('track:', '');
     const trackIdToSend =
       trackIdWithoutPrefix === GENE_TRACK_ID ? 'focus' : trackIdWithoutPrefix;
 
-    // Below lines will be enabled when we have the relevant functionality in genome browser.
-    // genomeBrowser?.send({
-    //   type: shouldShowTranscriptIds
-    //     ? OutgoingActionType.TURN_ON_TRANSCRIPT_IDS
-    //     : OutgoingActionType.TURN_OFF_TRANSCRIPT_IDS,
-    //   payload: {
-    //     track_ids: [trackIdToSend]
-    //   }
-    // });
+    genomeBrowser?.send({
+      type: shouldShowTranscriptLabels
+        ? OutgoingActionType.TURN_ON_TRANSCRIPT_LABELS
+        : OutgoingActionType.TURN_OFF_TRANSCRIPT_LABELS,
+      payload: {
+        track_ids: [trackIdToSend]
+      }
+    });
   };
-  /* eslint-enable @typescript-eslint/no-unused-vars */
 
   const toggleTrack = (params: { trackId: string; status: Status }) => {
     const { trackId, status } = params;
@@ -404,7 +420,7 @@ const useGenomeBrowser = () => {
     toggleTrackName,
     toggleTrackLabel,
     toggleSeveralTranscripts,
-    toggleTranscriptIds,
+    toggleTranscriptLabels,
     genomeBrowser,
     zmenus
   };

--- a/src/content/app/genome-browser/state/track-config/trackConfigSlice.ts
+++ b/src/content/app/genome-browser/state/track-config/trackConfigSlice.ts
@@ -43,7 +43,7 @@ export enum TrackType {
 
 export type GeneTrackConfig = {
   showSeveralTranscripts: boolean;
-  showTranscriptIds: boolean;
+  showTranscriptLabels: boolean;
   showTrackName: boolean;
   showFeatureLabel: boolean;
   trackType: TrackType.GENE;
@@ -93,7 +93,7 @@ export const defaultTrackConfigsForGenome: TrackConfigsForGenome = {
 
 export const getDefaultGeneTrackConfig = (): GeneTrackConfig => ({
   showSeveralTranscripts: false,
-  showTranscriptIds: false,
+  showTranscriptLabels: false,
   showTrackName: false,
   showFeatureLabel: true,
   trackType: TrackType.GENE
@@ -226,22 +226,22 @@ const browserTrackConfigSlice = createSlice({
 
       trackConfigState.showSeveralTranscripts = isSeveralTranscriptsShown;
     },
-    updateShowTranscriptIds(
+    updateShowTranscriptLabels(
       state,
       action: PayloadAction<{
         genomeId: string;
         trackId: string;
-        isTranscriptIdsShown: boolean;
+        isTranscripLabelsShown: boolean;
       }>
     ) {
-      const { genomeId, trackId, isTranscriptIdsShown } = action.payload;
+      const { genomeId, trackId, isTranscripLabelsShown } = action.payload;
       const trackConfigState = state.configs[genomeId].tracks[trackId];
 
       if (trackConfigState.trackType !== TrackType.GENE) {
         return;
       }
 
-      trackConfigState.showTranscriptIds = isTranscriptIdsShown;
+      trackConfigState.showTranscriptLabels = isTranscripLabelsShown;
     },
     deleteTrackConfigsForGenome(state, action: PayloadAction<string>) {
       const genomeId = action.payload;
@@ -258,7 +258,7 @@ export const {
   updateTrackName,
   updateFeatureLabel,
   updateShowSeveralTranscripts,
-  updateShowTranscriptIds,
+  updateShowTranscriptLabels,
   deleteTrackConfigsForGenome
 } = browserTrackConfigSlice.actions;
 


### PR DESCRIPTION
## Description
Genome browser upgrade to 0.3.1-test
Once approved, we can change the version to 0.3.1

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1627

## Deployment URL(s)
http://version-update-0.3.1.review.ensembl.org/

## Views affected
Genome Browser