### PR TITLE
Update GB version to 0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ensembl/ensembl-genome-browser": "0.3.1",
+        "@ensembl/ensembl-genome-browser": "0.3.2",
         "@loadable/component": "5.15.2",
         "@loadable/server": "5.15.2",
         "@react-spring/web": "9.4.5-beta.1",
@@ -2348,9 +2348,9 @@
       }
     },
     "node_modules/@ensembl/ensembl-genome-browser": {
-      "version": "0.3.1",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.3.1.tgz",
-      "integrity": "sha1-6MOEXESmj5TSPtC1ugkaLkuGgCQ="
+      "version": "0.3.2",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.3.2.tgz",
+      "integrity": "sha1-nbFx573pRlzl0CPQrs6TpfsQThA="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.0",
@@ -42312,9 +42312,9 @@
       "dev": true
     },
     "@ensembl/ensembl-genome-browser": {
-      "version": "0.3.1",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.3.1.tgz",
-      "integrity": "sha1-6MOEXESmj5TSPtC1ugkaLkuGgCQ="
+      "version": "0.3.2",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.3.2.tgz",
+      "integrity": "sha1-nbFx573pRlzl0CPQrs6TpfsQThA="
     },
     "@eslint/eslintrc": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "coverage": "jest --coverage"
   },
   "dependencies": {
-    "@ensembl/ensembl-genome-browser": "0.3.1",
+    "@ensembl/ensembl-genome-browser": "0.3.2",
     "@loadable/component": "5.15.2",
     "@loadable/server": "5.15.2",
     "@react-spring/web": "9.4.5-beta.1",


### PR DESCRIPTION
## Description
- Updated the GB package version to 0.3.2 (Failed unload bugfix)

## Deployment URL(s)
http://gb-0-3-2.review.ensembl.org


## Views affected
Genome browser