### PR TITLE
Replace gene-focus to focus

### DIFF
--- a/src/content/app/genome-browser/components/browser-cog/BrowserCogList.test.tsx
+++ b/src/content/app/genome-browser/components/browser-cog/BrowserCogList.test.tsx
@@ -82,7 +82,7 @@ describe('<BrowserCogList />', () => {
         type: IncomingActionType.TRACK_SUMMARY,
         payload: [
           {
-            'switch-id': 'gene-focus',
+            'switch-id': 'focus',
             offset: 100
           },
           {
@@ -99,7 +99,7 @@ describe('<BrowserCogList />', () => {
       );
 
       expect(updateCogListAction.payload).toEqual({
-        'gene-focus': 100,
+        focus: 100,
         contig: 200
       });
     });

--- a/src/content/app/genome-browser/components/browser-track-config/BrowserTrackConfig.test.tsx
+++ b/src/content/app/genome-browser/components/browser-track-config/BrowserTrackConfig.test.tsx
@@ -28,7 +28,7 @@ import * as browserGeneralSlice from 'src/content/app/genome-browser/state/brows
 import BrowserTrackConfig from './BrowserTrackConfig';
 
 const genomeId = 'fake_genome_id_1';
-const selectedTrackId = 'gene-focus';
+const selectedTrackId = 'focus';
 const renderComponent = () => {
   const rootReducer = combineReducers({
     browser: combineReducers({

--- a/src/content/app/genome-browser/components/track-panel/trackPanelConfig.ts
+++ b/src/content/app/genome-browser/components/track-panel/trackPanelConfig.ts
@@ -62,5 +62,5 @@ export type BrowserTrackStates = {
 };
 
 export enum TrackId {
-  GENE = 'gene-focus'
+  GENE = 'focus'
 }

--- a/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
@@ -174,10 +174,8 @@ const useGenomeBrowser = () => {
     const trackStateForLabels = cloneDeep(emptyOnOffLists);
 
     trackConfigs &&
-      Object.keys(trackConfigs).forEach((key) => {
-        const trackId = key;
-
-        const config = trackConfigs[key];
+      Object.keys(trackConfigs).forEach((trackId) => {
+        const config = trackConfigs[trackId];
 
         config.showTrackName
           ? trackStateForNames.on.push(trackId)

--- a/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
@@ -175,10 +175,7 @@ const useGenomeBrowser = () => {
 
     trackConfigs &&
       Object.keys(trackConfigs).forEach((key) => {
-        let trackId = key;
-        if (trackId.match('focus')) {
-          trackId = 'focus';
-        }
+        const trackId = key;
 
         const config = trackConfigs[key];
 

--- a/src/content/app/genome-browser/services/browserStorageService.test.ts
+++ b/src/content/app/genome-browser/services/browserStorageService.test.ts
@@ -29,7 +29,7 @@ const mockStorageService = {
 
 const trackStates = {
   main: {
-    'gene-focus': 'active'
+    focus: 'active'
   },
   Assembly: {
     gc: 'inactive'

--- a/src/content/app/genome-browser/state/track-config/trackConfigSlice.ts
+++ b/src/content/app/genome-browser/state/track-config/trackConfigSlice.ts
@@ -134,7 +134,7 @@ export const getTrackType = (trackId: string) => {
     return null;
   }
 
-  if (trackId.startsWith('gene')) {
+  if (trackId.startsWith('gene') || trackId.startsWith('focus')) {
     return TrackType.GENE;
   } else {
     return TrackType.REGULAR;

--- a/src/content/app/genome-browser/state/track-config/trackConfigSlice.ts
+++ b/src/content/app/genome-browser/state/track-config/trackConfigSlice.ts
@@ -134,7 +134,7 @@ export const getTrackType = (trackId: string) => {
     return null;
   }
 
-  if (trackId.startsWith('gene') || trackId.startsWith('focus')) {
+  if (trackId.startsWith('gene') || trackId === 'focus') {
     return TrackType.GENE;
   } else {
     return TrackType.REGULAR;


### PR DESCRIPTION
## Description
Currently, our code first assigns a "gene-focus" id to the focus track and then renames it to "focus" before sending the data to the genome browser. This indirection is clearly unnecessary.
The task is to just use the string "focus" as the identifier of the focus track.

I see a problem here and would like to know your suggestions.
On this [line](https://github.com/Ensembl/ensembl-client/pull/769/files#diff-285d5a75f69c1ff6ef15d53d6aaea4e49ed4ccd2c3ab789adf58f4f12b39188dR133) I have added a condition to consider focus track as a GENE type config. When we have variant or other tracks as focus in the future, this is not going to work properly


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1626

## Deployment URL(s)
http://use-focus.review.ensembl.org


## Views affected
Genome browser