### PR TITLE
set min height for sequence view

### DIFF
--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.scss
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.scss
@@ -86,7 +86,6 @@
   grid-area: main-bottom;
   display: flex;
   justify-content: center;
-  padding-top: 110px;
 }
 
 .loadFailureContainer {


### PR DESCRIPTION
## Description
See description in Jira, we need to set a min height for the sequence view since there is a huge empty space for smaller sequence. 

Note regarding code change:
It looks like the `minmax(170px, 400px)` in the parent wasn't working as it was defaulting to 400px and thats because the parent of the parent is a flex container. So i have set the min-height and max-height in the sequence div instead.


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1604

## Deployment URL(s)
http://drawersequenceview-minheight.review.ensembl.org


## Views affected
Sequence view in Genome browser  drawer