### PR TITLE
Zmenu bugfixes

### DIFF
--- a/src/content/app/genome-browser/components/zmenu/Zmenu.test.tsx
+++ b/src/content/app/genome-browser/components/zmenu/Zmenu.test.tsx
@@ -110,13 +110,14 @@ const defaultProps: ZmenuProps = {
 
 describe('<Zmenu />', () => {
   describe('rendering', () => {
-    test('renders zmenu content', () => {
+    it('renders zmenu content', () => {
       const { queryByTestId } = renderComponent();
       expect(queryByTestId('zmenuContent')).toBeTruthy();
     });
   });
-  describe('destroying ZMenu', () => {
-    it('closes zmenu when location change', () => {
+
+  describe('behaviour', () => {
+    it('sends a signal to be closed when genome browser’s location changes', () => {
       const { store } = renderComponent();
       expect(mockSetZmenus).not.toHaveBeenCalled();
       act(() => {
@@ -128,7 +129,7 @@ describe('<Zmenu />', () => {
           ])
         );
       });
-      expect(mockSetZmenus).toHaveBeenCalledWith({});
+      expect(mockSetZmenus).toHaveBeenCalledWith({}); // the new zmenu object will not have the id of the current zmenu
     });
   });
 });

--- a/src/content/app/genome-browser/components/zmenu/Zmenu.test.tsx
+++ b/src/content/app/genome-browser/components/zmenu/Zmenu.test.tsx
@@ -15,6 +15,7 @@
  */
 
 import React from 'react';
+import { faker } from '@faker-js/faker';
 import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
@@ -25,6 +26,8 @@ import Zmenu, { ZmenuProps } from './Zmenu';
 import MockGenomeBrowser from 'tests/mocks/mockGenomeBrowser';
 
 import { createZmenuPayload } from 'tests/fixtures/browser';
+
+import type { ChrLocation } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSlice';
 
 const mockGenomeBrowser = new MockGenomeBrowser();
 jest.mock(
@@ -50,6 +53,21 @@ jest.mock('./ZmenuInstantDownload', () => () => (
   <div>ZmenuInstantDownload</div>
 ));
 
+const chrName = faker.lorem.word();
+const startPosition = faker.datatype.number({ min: 1, max: 1000000 });
+const endPosition =
+  startPosition + faker.datatype.number({ min: 1000, max: 1000000 });
+
+const mockState = {
+  browser: {
+    browserGeneral: {
+      actualChrLocations: {
+        human: [chrName, startPosition, endPosition] as ChrLocation
+      }
+    }
+  }
+};
+
 const defaultProps: ZmenuProps = {
   browserRef: {
     current: document.createElement('div')
@@ -60,8 +78,8 @@ const defaultProps: ZmenuProps = {
 
 const mockStore = configureMockStore([thunk]);
 let store: ReturnType<typeof mockStore>;
-const renderComponent = () => {
-  store = mockStore();
+const renderComponent = (state: typeof mockState = mockState) => {
+  store = mockStore(state);
   return render(
     <Provider store={store}>
       <Zmenu {...defaultProps} />

--- a/src/content/app/genome-browser/components/zmenu/Zmenu.test.tsx
+++ b/src/content/app/genome-browser/components/zmenu/Zmenu.test.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import { faker } from '@faker-js/faker';
 import { configureStore, combineReducers } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
-import { render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 
 import Zmenu, { ZmenuProps } from './Zmenu';
 
@@ -61,6 +61,7 @@ const endPosition =
 const initialState = {
   browser: {
     browserGeneral: {
+      activeGenomeId: 'human',
       chrLocations: {
         ['human']: [chrName, startPosition, endPosition] as ChrLocation
       },
@@ -114,11 +115,18 @@ describe('<Zmenu />', () => {
     it('closes zmenu when location change', () => {
       const { container, store } = renderComponent();
       expect(container.querySelectorAll('.pointerBox')).toBeTruthy();
+      //console.log(store.getState().browser.browserGeneral.actualChrLocations);
+      act(() => {
+        store.dispatch(
+          browserGeneralSlice.updateActualChrLocation([
+            chrName,
+            startPosition + 10,
+            endPosition
+          ])
+        );
+      });
 
-      const payload = {
-        ['human']: [chrName, startPosition, endPosition] as ChrLocation
-      };
-      store.dispatch(browserGeneralSlice.updateChrLocation(payload));
+      //console.log(store.getState().browser.browserGeneral.actualChrLocations);
       //console.log(container.innerHTML);
       expect(container.querySelectorAll('.pointerBox')).toBeFalsy();
     });

--- a/src/content/app/genome-browser/components/zmenu/Zmenu.test.tsx
+++ b/src/content/app/genome-browser/components/zmenu/Zmenu.test.tsx
@@ -19,7 +19,6 @@ import { faker } from '@faker-js/faker';
 import { configureStore, combineReducers } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
-import set from 'lodash/fp/set';
 
 import Zmenu, { ZmenuProps } from './Zmenu';
 
@@ -62,6 +61,9 @@ const endPosition =
 const initialState = {
   browser: {
     browserGeneral: {
+      chrLocations: {
+        ['human']: [chrName, startPosition, endPosition] as ChrLocation
+      },
       actualChrLocations: {
         human: [chrName, startPosition, endPosition] as ChrLocation
       }
@@ -81,11 +83,16 @@ const renderComponent = (state: typeof initialState = initialState) => {
     preloadedState: state as any
   });
 
-  return render(
+  const renderResult = render(
     <Provider store={store}>
       <Zmenu {...defaultProps} />
     </Provider>
   );
+
+  return {
+    ...renderResult,
+    store
+  };
 };
 
 const defaultProps: ZmenuProps = {
@@ -105,16 +112,15 @@ describe('<Zmenu />', () => {
   });
   describe('destroying ZMenu', () => {
     it('closes zmenu when location change', () => {
-      let { container } = renderComponent();
-      expect(container.querySelectorAll('pointerBox')).toBeTruthy();
-      const updatedState = set(
-        'browser.browserGeneral.browserGeneral.actualChrLocations.human',
-        [chrName, startPosition + 10, endPosition],
-        initialState
-      );
-      container = renderComponent(updatedState).container;
+      const { container, store } = renderComponent();
+      expect(container.querySelectorAll('.pointerBox')).toBeTruthy();
+
+      const payload = {
+        ['human']: [chrName, startPosition, endPosition] as ChrLocation
+      };
+      store.dispatch(browserGeneralSlice.updateChrLocation(payload));
       //console.log(container.innerHTML);
-      expect(container.querySelectorAll('pointerBox')).toBeFalsy();
+      expect(container.querySelectorAll('.pointerBox')).toBeFalsy();
     });
   });
 });

--- a/src/content/app/genome-browser/components/zmenu/Zmenu.test.tsx
+++ b/src/content/app/genome-browser/components/zmenu/Zmenu.test.tsx
@@ -29,11 +29,15 @@ import { createZmenuPayload } from 'tests/fixtures/browser';
 import type { ChrLocation } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSlice';
 import * as browserGeneralSlice from 'src/content/app/genome-browser/state/browser-general/browserGeneralSlice';
 
+const mockSetZmenus = jest.fn();
+
 const mockGenomeBrowser = new MockGenomeBrowser();
 jest.mock(
   'src/content/app/genome-browser/hooks/useGenomeBrowser',
   () => () => ({
-    genomeBrowser: mockGenomeBrowser
+    genomeBrowser: mockGenomeBrowser,
+    zmenus: { 1: {} },
+    setZmenus: mockSetZmenus
   })
 );
 
@@ -113,9 +117,8 @@ describe('<Zmenu />', () => {
   });
   describe('destroying ZMenu', () => {
     it('closes zmenu when location change', () => {
-      const { container, store } = renderComponent();
-      expect(container.querySelectorAll('.pointerBox')).toBeTruthy();
-      //console.log(store.getState().browser.browserGeneral.actualChrLocations);
+      const { store } = renderComponent();
+      expect(mockSetZmenus).not.toHaveBeenCalled();
       act(() => {
         store.dispatch(
           browserGeneralSlice.updateActualChrLocation([
@@ -125,10 +128,7 @@ describe('<Zmenu />', () => {
           ])
         );
       });
-
-      //console.log(store.getState().browser.browserGeneral.actualChrLocations);
-      //console.log(container.innerHTML);
-      expect(container.querySelectorAll('.pointerBox')).toBeFalsy();
+      expect(mockSetZmenus).toHaveBeenCalledWith({});
     });
   });
 });

--- a/src/content/app/genome-browser/components/zmenu/Zmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/Zmenu.tsx
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import pickBy from 'lodash/pickBy';
+import usePrevious from 'src/shared/hooks/usePrevious';
+
 import {
   ZmenuContentTranscript,
   ZmenuContentGene,
@@ -56,18 +58,19 @@ export type ZmenuProps = {
 const Zmenu = (props: ZmenuProps) => {
   const anchorRef = useRefWithRerender<HTMLDivElement>(null);
   const { zmenus, setZmenus } = useGenomeBrowser();
-  const actualChrLocation = useAppSelector(getActualChrLocation);
-  const [renderCount, setRenderCount] = useState(0);
+  const chromosomeLocation = useAppSelector(getActualChrLocation);
+  const previousChromosomeLocation = usePrevious(chromosomeLocation);
 
   const dispatch = useAppDispatch();
-
   useEffect(() => {
-    setRenderCount(renderCount + 1);
-    // Do not try to close the Zmenu on first render
-    if (renderCount) {
+    if (
+      chromosomeLocation &&
+      previousChromosomeLocation &&
+      chromosomeLocation.toString() !== previousChromosomeLocation.toString()
+    ) {
       destroyZmenu();
     }
-  }, [actualChrLocation]);
+  }, [chromosomeLocation]);
 
   const destroyZmenu = () => {
     dispatch(changeHighlightedTrackId(''));

--- a/src/content/app/genome-browser/components/zmenu/Zmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/Zmenu.tsx
@@ -61,10 +61,8 @@ const Zmenu = (props: ZmenuProps) => {
 
   const dispatch = useAppDispatch();
 
-  //useEffect on location change to close zmenu
   useEffect(() => {
     setRenderCount(renderCount + 1);
-
     // Do not try to close the Zmenu on first render
     if (renderCount) {
       destroyZmenu();

--- a/src/content/app/genome-browser/components/zmenu/Zmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/Zmenu.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import pickBy from 'lodash/pickBy';
 import {
   ZmenuContentTranscript,
@@ -57,17 +57,21 @@ const Zmenu = (props: ZmenuProps) => {
   const anchorRef = useRefWithRerender<HTMLDivElement>(null);
   const { zmenus, setZmenus } = useGenomeBrowser();
   const actualChrLocation = useAppSelector(getActualChrLocation);
+  const [renderCount, setRenderCount] = useState(0);
+
   const dispatch = useAppDispatch();
 
-  //console.log(actualChrLocation);
-  //useeffect on location change to close zmenu
+  //useEffect on location change to close zmenu
   useEffect(() => {
-    //console.log(zmenus);
-    Object.keys(zmenus).length && destroyZmenu();
+    setRenderCount(renderCount + 1);
+
+    // Do not try to close the Zmenu on first render
+    if (renderCount) {
+      destroyZmenu();
+    }
   }, [actualChrLocation]);
 
   const destroyZmenu = () => {
-    //console.log("DESTROYING ZMENU....")
     dispatch(changeHighlightedTrackId(''));
     setZmenus &&
       setZmenus(pickBy(zmenus, (value, key) => key !== props.zmenuId));

--- a/src/content/app/genome-browser/components/zmenu/Zmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/Zmenu.tsx
@@ -24,11 +24,13 @@ import {
   ZmenuCreatePayload
 } from '@ensembl/ensembl-genome-browser';
 
-import { useAppDispatch } from 'src/store';
+import { useAppSelector, useAppDispatch } from 'src/store';
 import useGenomeBrowser from 'src/content/app/genome-browser/hooks/useGenomeBrowser';
 import useRefWithRerender from 'src/shared/hooks/useRefWithRerender';
 
 import { changeHighlightedTrackId } from 'src/content/app/genome-browser/state/track-panel/trackPanelSlice';
+
+import { getActualChrLocation } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
 
 import {
   Toolbox,
@@ -54,9 +56,18 @@ export type ZmenuProps = {
 const Zmenu = (props: ZmenuProps) => {
   const anchorRef = useRefWithRerender<HTMLDivElement>(null);
   const { zmenus, setZmenus } = useGenomeBrowser();
+  const actualChrLocation = useAppSelector(getActualChrLocation);
   const dispatch = useAppDispatch();
 
+  //console.log(actualChrLocation);
+  //useeffect on location change to close zmenu
+  useEffect(() => {
+    //console.log(zmenus);
+    Object.keys(zmenus).length && destroyZmenu();
+  }, [actualChrLocation]);
+
   const destroyZmenu = () => {
+    //console.log("DESTROYING ZMENU....")
     dispatch(changeHighlightedTrackId(''));
     setZmenus &&
       setZmenus(pickBy(zmenus, (value, key) => key !== props.zmenuId));


### PR DESCRIPTION
## Description
Two bug fix related to ZMenu
1639 - Move dispatch into useEffect but had to rearrange code so that useEffect is before any return
1640 - Close Zmenu when dragging genome browser...Use a different approach as suggested in the jira as after speaking to dan there is a possibility that the genome browser can be moved by keyboard or some other actions and the best way to capture this is to check if the location is changing (meaning the genome browser is moving) then close the zmenu.


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1639
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1640

## Deployment URL(s)
http://zmenu-bugfix.review.ensembl.org


## Views affected
Genome browser