### PR TITLE
Remove production check for multiple transcripts

### DIFF
--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelGene.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelGene.tsx
@@ -16,8 +16,6 @@
 
 import React, { useEffect, useState } from 'react';
 
-import { isEnvironment, Environment } from 'src/shared/helpers/environment';
-
 import { useAppSelector, useAppDispatch } from 'src/store';
 import useGenomeBrowser from 'src/content/app/genome-browser/hooks/useGenomeBrowser';
 import { useGetTrackPanelGeneQuery } from 'src/content/app/genome-browser/state/api/genomeBrowserApiSlice';
@@ -37,7 +35,6 @@ import GroupTrackPanelItemLayout from './track-panel-item-layout/GroupTrackPanel
 
 import { Status } from 'src/shared/types/status';
 import { TrackId } from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
-import type { TrackPanelTranscript as TrackPanelTranscriptType } from 'src/content/app/genome-browser/state/types/track-panel-gene';
 import type { RootState } from 'src/store';
 import {
   IncomingActionType,
@@ -56,8 +53,7 @@ type TrackPanelGeneProps = {
 const GENE_TRACK_ID = TrackId.GENE;
 const TrackPanelGene = (props: TrackPanelGeneProps) => {
   const { genomeId, geneId, focusObjectId } = props;
-  const startWithCollapsed = !isEnvironment([Environment.PRODUCTION]); // TODO: remove after multiple transcripts are available
-  const [isCollapsed, setIsCollapsed] = useState(startWithCollapsed);
+  const [isCollapsed, setIsCollapsed] = useState(true);
   const { currentData } = useGetTrackPanelGeneQuery({
     genomeId,
     geneId
@@ -78,7 +74,6 @@ const TrackPanelGene = (props: TrackPanelGeneProps) => {
   const dispatch = useAppDispatch();
 
   const allTranscriptsInGene = currentData?.gene.transcripts ?? [];
-  let sortedTranscripts: TrackPanelTranscriptType[] | undefined;
 
   useEffect(() => {
     const subscription = genomeBrowser?.subscribe(
@@ -138,14 +133,9 @@ const TrackPanelGene = (props: TrackPanelGeneProps) => {
 
   const { gene } = currentData;
 
-  if (isEnvironment([Environment.PRODUCTION])) {
-    // TODO: remove this branch when multiple transcripts become available
-    sortedTranscripts = isCollapsed ? [] : [defaultSort(gene.transcripts)[0]];
-  } else {
-    sortedTranscripts = isCollapsed
-      ? [defaultSort(gene.transcripts)[0]]
-      : defaultSort(gene.transcripts);
-  }
+  const sortedTranscripts = isCollapsed
+    ? [defaultSort(gene.transcripts)[0]]
+    : defaultSort(gene.transcripts);
 
   const toggleExpand = () => {
     setIsCollapsed(!isCollapsed);
@@ -189,14 +179,12 @@ const TrackPanelGene = (props: TrackPanelGeneProps) => {
           key={transcript.stable_id}
         />
       ))}
-      {!isEnvironment([Environment.PRODUCTION]) &&
-        isCollapsed &&
-        gene.transcripts.length > 1 && (
-          <TrackPanelItemsCount
-            itemName="transcript"
-            count={gene.transcripts.length - 1}
-          />
-        )}
+      {isCollapsed && gene.transcripts.length > 1 && (
+        <TrackPanelItemsCount
+          itemName="transcript"
+          count={gene.transcripts.length - 1}
+        />
+      )}
     </>
   );
 };


### PR DESCRIPTION
## Description
I forgot to remove the production check for multiple transcripts in `TrackPanelGene.tsx`. So have created this PR as a quick fix for it.

## Related JIRA Issue(s)
[ENSWBSITES-1594](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1594)

## Deployment URL(s)
http://remove-prod-check-multi-transcripts.review.ensembl.org

## Views affected
Genome browser -> Track panel