### PR TITLE
Make sure ButtonLink component matches the url precisely

### DIFF
--- a/src/content/app/tools/blast/BlastPage.tsx
+++ b/src/content/app/tools/blast/BlastPage.tsx
@@ -53,11 +53,10 @@ const BrowserPage = () => {
             path="unviewed-submissions"
             element={<BlastUnviewedSubmissions />}
           />
-          <Route
-            path="submissions/:submissionId"
-            element={<BlastSubmissionResults />}
-          />
-          <Route path="submissions" element={<BlastJobs />} />
+          <Route path="submissions">
+            <Route index={true} element={<BlastJobs />} />
+            <Route path=":submissionId" element={<BlastSubmissionResults />} />
+          </Route>
         </Routes>
       )}
     </>

--- a/src/shared/components/button-link/ButtonLink.tsx
+++ b/src/shared/components/button-link/ButtonLink.tsx
@@ -27,11 +27,29 @@ import styles from './ButtonLink.scss';
 
 type Props = Omit<NavLinkProps, 'children'> & {
   isDisabled?: boolean;
+  matchDescendantPaths?: boolean; // see explanation below; this is something we are unlikely to want
   children: ReactNode;
 };
 
+/**
+ * The `matchDescendantPaths` in `ButtonLink`'s props determines
+ * whether the `end` prop will be added to NavLink.
+ *
+ * According to ReactRouter documentation, the `end` prop
+ * ensures that NavLink doesn't get marked as "active"
+ * when its descendant paths are matched. For example,
+ * <NavLink to="/" end>Home</NavLink> will only be active at the website root,
+ * and not at any other url that starts with "/".
+ */
+
 const ButtonLink = (props: Props) => {
-  const { className, isDisabled, children, ...otherProps } = props;
+  const {
+    className,
+    isDisabled,
+    matchDescendantPaths = false,
+    children,
+    ...otherProps
+  } = props;
 
   const inactiveLinkClasses = classNames(
     styles.buttonLink,
@@ -53,7 +71,7 @@ const ButtonLink = (props: Props) => {
       className={({ isActive }) =>
         isActive ? activeLinkClasses : inactiveLinkClasses
       }
-      end={true}
+      end={!matchDescendantPaths}
     >
       {children}
     </NavLink>

--- a/src/shared/components/button-link/ButtonLink.tsx
+++ b/src/shared/components/button-link/ButtonLink.tsx
@@ -53,6 +53,7 @@ const ButtonLink = (props: Props) => {
       className={({ isActive }) =>
         isActive ? activeLinkClasses : inactiveLinkClasses
       }
+      end={true}
     >
       {children}
     </NavLink>


### PR DESCRIPTION
## Description
Make sure the ButtonLink component is not interpreted as active on parent routes 

**Example:**

We have a `/blast/submissions` page, and a `/blast/submissions/:submissionId` page. The `NavLink` component  from react-router (which we use in the `ButtonLink` component) is reporting as "active" if it matches a parent route by default: 

![image](https://user-images.githubusercontent.com/6834224/180775174-7892b363-f466-466a-9d83-23754774af9f.png)

After the change:

![image](https://user-images.githubusercontent.com/6834224/180775866-5ce78157-5b39-4f57-816c-cfd064a376bb.png)

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1645

## Deployment URL(s)
http://fix-blast-jobs-list-button.review.ensembl.org