### PR TITLE
Remove the 'track:' prefix from track ids

### DIFF
--- a/src/content/app/genome-browser/components/browser-cog/useBrowserCogList.ts
+++ b/src/content/app/genome-browser/components/browser-cog/useBrowserCogList.ts
@@ -37,7 +37,7 @@ import {
 } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSlice';
 import { TrackId } from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
 
-import type { GenomeTrackCategory } from 'src/shared/state/genome/genomeTypes';
+import type { GenomeTrackCategory } from 'src/content/app/genome-browser/state/types/tracks';
 import type { FocusObject } from 'src/shared/types/focus-object/focusObjectTypes';
 
 const useBrowserCogList = () => {
@@ -93,13 +93,13 @@ const prepareTrackSettings = ({
 
   trackCategories.forEach((category) => {
     category.track_list.forEach((track) => {
-      const trackId = track.track_id.replace('track:', '');
-      const trackType = getTrackType(trackId);
+      const { track_id } = track;
+      const trackType = getTrackType(track_id);
 
       if (trackType === TrackType.GENE) {
-        defaultTrackSettings[trackId] = getDefaultGeneTrackSettings();
+        defaultTrackSettings[track_id] = getDefaultGeneTrackSettings();
       } else {
-        defaultTrackSettings[trackId] = getDefaultRegularTrackSettings();
+        defaultTrackSettings[track_id] = getDefaultRegularTrackSettings();
       }
     });
   });

--- a/src/content/app/genome-browser/components/drawer/sampleData.ts
+++ b/src/content/app/genome-browser/components/drawer/sampleData.ts
@@ -33,8 +33,8 @@ export type GenomeTrackDetails = {
 
 export const trackDetailsSampleData: GenomeTrackDetails = {
   homo_sapiens_GCA_000001405_28: {
-    'track:gene-pc-fwd': {
-      track_id: 'track:gene-pc-fwd',
+    'gene-pc-fwd': {
+      track_id: 'gene-pc-fwd',
       track_name: 'Protein coding genes',
       strand: 'forward',
       description:
@@ -45,7 +45,7 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:gene-other-fwd': {
+    'gene-other-fwd': {
       track_id: 'gene-other-fwd',
       track_name: 'Other genes',
       strand: 'forward',
@@ -57,7 +57,7 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:gene-pc-rev': {
+    'gene-pc-rev': {
       track_id: 'gene-pc-rev',
       track_name: 'Protein coding genes',
       strand: 'reverse',
@@ -69,7 +69,7 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:gene-other-rev': {
+    'gene-other-rev': {
       track_id: 'gene-other-rev',
       track_name: 'Other genes',
       strand: 'reverse',
@@ -81,19 +81,19 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:contig': {
+    contig: {
       track_id: 'contig',
       track_name: 'Reference assembly',
       strand: null,
       description: 'Shows the contigs underlying the reference assembly.'
     },
-    'track:gc': {
+    gc: {
       track_id: 'gc',
       track_name: '%GC',
       strand: null,
       description: 'Shows the percentage of Gs and Cs in a region'
     },
-    'track:variant': {
+    variant: {
       track_id: 'variant',
       track_name: '1000 Genomes all SNPs and indels',
       strand: null,
@@ -102,8 +102,8 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
     }
   },
   homo_sapiens_GCA_000001405_14: {
-    'track:gene-pc-fwd': {
-      track_id: 'track:gene-pc-fwd',
+    'gene-pc-fwd': {
+      track_id: 'gene-pc-fwd',
       track_name: 'Protein coding genes',
       strand: 'forward',
       description:
@@ -114,7 +114,7 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:gene-other-fwd': {
+    'gene-other-fwd': {
       track_id: 'gene-other-fwd',
       track_name: 'Other genes',
       strand: 'forward',
@@ -126,7 +126,7 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:gene-pc-rev': {
+    'gene-pc-rev': {
       track_id: 'gene-pc-rev',
       track_name: 'Protein coding genes',
       strand: 'reverse',
@@ -138,7 +138,7 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:gene-other-rev': {
+    'gene-other-rev': {
       track_id: 'gene-other-rev',
       track_name: 'Other genes',
       strand: 'reverse',
@@ -150,19 +150,19 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:contig': {
+    contig: {
       track_id: 'contig',
       track_name: 'Reference assembly',
       strand: null,
       description: 'Shows the contigs underlying the reference assembly.'
     },
-    'track:gc': {
+    gc: {
       track_id: 'gc',
       track_name: '%GC',
       strand: null,
       description: 'Shows the percentage of Gs and Cs in a region'
     },
-    'track:variant': {
+    variant: {
       track_id: 'variant',
       track_name: '1000 Genomes all SNPs and indels',
       strand: null,
@@ -171,8 +171,8 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
     }
   },
   triticum_aestivum_GCA_900519105_1: {
-    'track:gene-pc-fwd': {
-      track_id: 'track:gene-pc-fwd',
+    'gene-pc-fwd': {
+      track_id: 'gene-pc-fwd',
       track_name: 'Protein coding genes',
       strand: 'forward',
       description:
@@ -183,7 +183,7 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:gene-other-fwd': {
+    'gene-other-fwd': {
       track_id: 'gene-other-fwd',
       track_name: 'Other genes',
       strand: 'forward',
@@ -195,7 +195,7 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:gene-pc-rev': {
+    'gene-pc-rev': {
       track_id: 'gene-pc-rev',
       track_name: 'Protein coding genes',
       strand: 'reverse',
@@ -207,7 +207,7 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:gene-other-rev': {
+    'gene-other-rev': {
       track_id: 'gene-other-rev',
       track_name: 'Other genes',
       strand: 'reverse',
@@ -219,19 +219,19 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:contig': {
+    contig: {
       track_id: 'contig',
       track_name: 'Reference assembly',
       strand: null,
       description: 'Shows the contigs underlying the reference assembly.'
     },
-    'track:gc': {
+    gc: {
       track_id: 'gc',
       track_name: '%GC',
       strand: null,
       description: 'Shows the percentage of Gs and Cs in a region'
     },
-    'track:variant': {
+    variant: {
       track_id: 'variant',
       track_name: 'Sequence variants',
       strand: null,
@@ -239,8 +239,8 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
     }
   },
   escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845_2: {
-    'track:gene-pc-fwd': {
-      track_id: 'track:gene-pc-fwd',
+    'gene-pc-fwd': {
+      track_id: 'gene-pc-fwd',
       track_name: 'Protein coding genes',
       strand: 'forward',
       description:
@@ -251,7 +251,7 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:gene-other-fwd': {
+    'gene-other-fwd': {
       track_id: 'gene-other-fwd',
       track_name: 'Other genes',
       strand: 'forward',
@@ -263,7 +263,7 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:gene-pc-rev': {
+    'gene-pc-rev': {
       track_id: 'gene-pc-rev',
       track_name: 'Protein coding genes',
       strand: 'reverse',
@@ -275,7 +275,7 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:gene-other-rev': {
+    'gene-other-rev': {
       track_id: 'gene-other-rev',
       track_name: 'Other genes',
       strand: 'reverse',
@@ -287,13 +287,13 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:contig': {
+    contig: {
       track_id: 'contig',
       track_name: 'Reference assembly',
       strand: null,
       description: 'Shows the contigs underlying the reference assembly.'
     },
-    'track:gc': {
+    gc: {
       track_id: 'gc',
       track_name: '%GC',
       strand: null,
@@ -301,8 +301,8 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
     }
   },
   saccharomyces_cerevisiae_GCA_000146045_2: {
-    'track:gene-pc-fwd': {
-      track_id: 'track:gene-pc-fwd',
+    'gene-pc-fwd': {
+      track_id: 'gene-pc-fwd',
       track_name: 'Protein coding genes',
       strand: 'forward',
       description:
@@ -313,7 +313,7 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:gene-other-fwd': {
+    'gene-other-fwd': {
       track_id: 'gene-other-fwd',
       track_name: 'Other genes',
       strand: 'forward',
@@ -325,7 +325,7 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:gene-pc-rev': {
+    'gene-pc-rev': {
       track_id: 'gene-pc-rev',
       track_name: 'Protein coding genes',
       strand: 'reverse',
@@ -337,7 +337,7 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:gene-other-rev': {
+    'gene-other-rev': {
       track_id: 'gene-other-rev',
       track_name: 'Other genes',
       strand: 'reverse',
@@ -349,13 +349,13 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:contig': {
+    contig: {
       track_id: 'contig',
       track_name: 'Reference assembly',
       strand: null,
       description: 'Shows the contigs underlying the reference assembly.'
     },
-    'track:gc': {
+    gc: {
       track_id: 'gc',
       track_name: '%GC',
       strand: null,
@@ -363,8 +363,8 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
     }
   },
   plasmodium_falciparum_GCA_000002765_2: {
-    'track:gene-pc-fwd': {
-      track_id: 'track:gene-pc-fwd',
+    'gene-pc-fwd': {
+      track_id: 'gene-pc-fwd',
       track_name: 'Protein coding genes',
       strand: 'forward',
       description:
@@ -375,7 +375,7 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:gene-other-fwd': {
+    'gene-other-fwd': {
       track_id: 'gene-other-fwd',
       track_name: 'Other genes',
       strand: 'forward',
@@ -387,7 +387,7 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:gene-pc-rev': {
+    'gene-pc-rev': {
       track_id: 'gene-pc-rev',
       track_name: 'Protein coding genes',
       strand: 'reverse',
@@ -399,7 +399,7 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:gene-other-rev': {
+    'gene-other-rev': {
       track_id: 'gene-other-rev',
       track_name: 'Other genes',
       strand: 'reverse',
@@ -411,13 +411,13 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:contig': {
+    contig: {
       track_id: 'contig',
       track_name: 'Reference assembly',
       strand: null,
       description: 'Shows the contigs underlying the reference assembly.'
     },
-    'track:gc': {
+    gc: {
       track_id: 'gc',
       track_name: '%GC',
       strand: null,
@@ -425,8 +425,8 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
     }
   },
   caenorhabditis_elegans_GCA_000002985_3: {
-    'track:gene-pc-fwd': {
-      track_id: 'track:gene-pc-fwd',
+    'gene-pc-fwd': {
+      track_id: 'gene-pc-fwd',
       track_name: 'Protein coding genes',
       strand: 'forward',
       description:
@@ -437,7 +437,7 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:gene-other-fwd': {
+    'gene-other-fwd': {
       track_id: 'gene-other-fwd',
       track_name: 'Non coding RNA',
       strand: 'forward',
@@ -449,7 +449,7 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:gene-pc-rev': {
+    'gene-pc-rev': {
       track_id: 'gene-pc-rev',
       track_name: 'Protein coding genes',
       strand: 'reverse',
@@ -461,7 +461,7 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:gene-other-rev': {
+    'gene-other-rev': {
       track_id: 'gene-other-rev',
       track_name: 'Non coding RNA',
       strand: 'forward',
@@ -473,13 +473,13 @@ export const trackDetailsSampleData: GenomeTrackDetails = {
         id: ''
       }
     },
-    'track:contig': {
+    contig: {
       track_id: 'contig',
       track_name: 'Reference assembly',
       strand: null,
       description: 'Shows the contigs underlying the reference assembly.'
     },
-    'track:gc': {
+    gc: {
       track_id: 'gc',
       track_name: '%GC',
       strand: null,

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
@@ -41,8 +41,7 @@ import {
 } from 'src/shared/components/accordion';
 import SearchIcon from 'static/icons/icon_search.svg';
 
-import type { GenomeTrackCategory } from 'src/shared/state/genome/genomeTypes';
-import type { FocusObjectTrack } from 'src/shared/types/focus-object/focusObjectTypes';
+import type { GenomeTrackCategory } from 'src/content/app/genome-browser/state/types/tracks';
 
 import styles from './TrackPanelList.scss';
 
@@ -122,7 +121,7 @@ export const TrackPanelList = () => {
                   className={styles.trackPanelAccordionItemContent}
                 >
                   <dl>
-                    {category.track_list.map((track: FocusObjectTrack) => (
+                    {category.track_list.map((track) => (
                       <TrackPanelRegularItem
                         {...track}
                         genomeId={activeGenomeId}

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelRegularItem.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelRegularItem.tsx
@@ -28,7 +28,8 @@ import { changeDrawerViewForGenome } from 'src/content/app/genome-browser/state/
 import SimpleTrackPanelItemLayout from './track-panel-item-layout/SimpleTrackPanelItemLayout';
 
 import { Status } from 'src/shared/types/status';
-import { RootState } from 'src/store';
+import type { GenomicTrack } from 'src/content/app/genome-browser/state/types/tracks';
+import type { RootState } from 'src/store';
 
 import styles from './TrackPanelItem.scss';
 
@@ -37,11 +38,7 @@ import styles from './TrackPanelItem.scss';
  * by the tracks api.
  */
 
-type Props = {
-  additional_info?: string;
-  colour?: string;
-  label: string;
-  track_id: string;
+type Props = GenomicTrack & {
   genomeId: string;
   category: string;
 };

--- a/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
@@ -39,10 +39,7 @@ import {
   getBrowserActiveGenomeId
 } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
 import type { ChrLocation } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSlice';
-import {
-  TrackId,
-  TrackStates
-} from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
+import { TrackStates } from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
 import { TrackType } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSlice';
 import { Status } from 'src/shared/types/status';
 
@@ -52,7 +49,6 @@ const useGenomeBrowser = () => {
   const trackSettingsForGenome = useAppSelector(getAllTrackSettings);
   const genomeBrowserContext = useContext(GenomeBrowserContext);
   const trackSettings = trackSettingsForGenome?.tracks;
-  const GENE_TRACK_ID = TrackId.GENE;
 
   if (!genomeBrowserContext) {
     throw new Error(
@@ -124,15 +120,9 @@ const useGenomeBrowser = () => {
 
     Object.values(mergedTrackStates).forEach((trackStates) => {
       Object.keys(trackStates).forEach((trackId) => {
-        const trackIdWithoutPrefix = trackId.replace('track:', '');
-        const trackIdToSend =
-          trackIdWithoutPrefix === GENE_TRACK_ID
-            ? 'focus'
-            : trackIdWithoutPrefix;
-
         trackStates[trackId] === Status.SELECTED
-          ? tracksToTurnOn.push(trackIdToSend)
-          : tracksToTurnOff.push(trackIdToSend);
+          ? tracksToTurnOn.push(trackId)
+          : tracksToTurnOff.push(trackId);
       });
     });
 
@@ -286,16 +276,12 @@ const useGenomeBrowser = () => {
   }) => {
     const { trackId, shouldShowTrackName } = params;
 
-    const trackIdWithoutPrefix = trackId.replace('track:', '');
-    const trackIdToSend =
-      trackIdWithoutPrefix === GENE_TRACK_ID ? 'focus' : trackIdWithoutPrefix;
-
     genomeBrowser?.send({
       type: shouldShowTrackName
         ? OutgoingActionType.TURN_ON_NAMES
         : OutgoingActionType.TURN_OFF_NAMES,
       payload: {
-        track_ids: [trackIdToSend]
+        track_ids: [trackId]
       }
     });
   };
@@ -306,16 +292,12 @@ const useGenomeBrowser = () => {
   }) => {
     const { trackId, shouldShowFeatureLabels } = params;
 
-    const trackIdWithoutPrefix = trackId.replace('track:', '');
-    const trackIdToSend =
-      trackIdWithoutPrefix === GENE_TRACK_ID ? 'focus' : trackIdWithoutPrefix;
-
     genomeBrowser?.send({
       type: shouldShowFeatureLabels
         ? OutgoingActionType.TURN_ON_LABELS
         : OutgoingActionType.TURN_OFF_LABELS,
       payload: {
-        track_ids: [trackIdToSend]
+        track_ids: [trackId]
       }
     });
   };
@@ -325,16 +307,13 @@ const useGenomeBrowser = () => {
     shouldShowSeveralTranscripts: boolean;
   }) => {
     const { trackId, shouldShowSeveralTranscripts } = params;
-    const trackIdWithoutPrefix = trackId.replace('track:', '');
-    const trackIdToSend =
-      trackIdWithoutPrefix === GENE_TRACK_ID ? 'focus' : trackIdWithoutPrefix;
 
     genomeBrowser?.send({
       type: shouldShowSeveralTranscripts
         ? OutgoingActionType.TURN_ON_SEVERAL_TRANSCRIPTS
         : OutgoingActionType.TURN_OFF_SEVERAL_TRANSCRIPTS,
       payload: {
-        track_ids: [trackIdToSend]
+        track_ids: [trackId]
       }
     });
   };
@@ -344,16 +323,13 @@ const useGenomeBrowser = () => {
     shouldShowTranscriptIds: boolean;
   }) => {
     const { trackId, shouldShowTranscriptIds } = params;
-    const trackIdWithoutPrefix = trackId.replace('track:', '');
-    const trackIdToSend =
-      trackIdWithoutPrefix === GENE_TRACK_ID ? 'focus' : trackIdWithoutPrefix;
 
     genomeBrowser?.send({
       type: shouldShowTranscriptIds
         ? OutgoingActionType.TURN_ON_TRANSCRIPT_LABELS
         : OutgoingActionType.TURN_OFF_TRANSCRIPT_LABELS,
       payload: {
-        track_ids: [trackIdToSend]
+        track_ids: [trackId]
       }
     });
   };
@@ -362,16 +338,12 @@ const useGenomeBrowser = () => {
     const { trackId, status } = params;
     const isTurnedOn = status === Status.SELECTED;
 
-    const trackIdWithoutPrefix = trackId.replace('track:', '');
-    const trackIdToSend =
-      trackIdWithoutPrefix === GENE_TRACK_ID ? 'focus' : trackIdWithoutPrefix;
-
     genomeBrowser?.send({
       type: isTurnedOn
         ? OutgoingActionType.TURN_ON_TRACKS
         : OutgoingActionType.TURN_OFF_TRACKS,
       payload: {
-        track_ids: [trackIdToSend]
+        track_ids: [trackId]
       }
     });
 
@@ -383,7 +355,7 @@ const useGenomeBrowser = () => {
           ? OutgoingActionType.TURN_ON_LABELS
           : OutgoingActionType.TURN_OFF_LABELS,
         payload: {
-          track_ids: [trackIdToSend]
+          track_ids: [trackId]
         }
       });
     }
@@ -396,7 +368,7 @@ const useGenomeBrowser = () => {
           ? OutgoingActionType.TURN_ON_NAMES
           : OutgoingActionType.TURN_OFF_NAMES,
         payload: {
-          track_ids: [trackIdToSend]
+          track_ids: [trackId]
         }
       });
     }

--- a/src/content/app/genome-browser/state/api/genomeBrowserApiSlice.ts
+++ b/src/content/app/genome-browser/state/api/genomeBrowserApiSlice.ts
@@ -32,7 +32,7 @@ import {
   TranscriptZmenuQueryResult
 } from './queries/transcriptInZmenuQuery';
 
-import type { GenomeTrackCategory } from 'src/shared/state/genome/genomeTypes';
+import type { GenomeTrackCategory } from 'src/content/app/genome-browser/state/types/tracks';
 import type { TrackPanelGene } from '../types/track-panel-gene';
 
 type GeneQueryParams = { genomeId: string; geneId: string };

--- a/src/content/app/genome-browser/state/types/tracks.ts
+++ b/src/content/app/genome-browser/state/types/tracks.ts
@@ -14,32 +14,18 @@
  * limitations under the License.
  */
 
-export type ExampleFocusObject = {
-  id: string;
-  type: string;
+import { TrackSet } from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
+
+export type GenomicTrack = {
+  colour: string; // NOTE: the backend will want to get rid of this field
+  label: string;
+  track_id: string;
+  additional_info: string;
 };
 
-export type GenomeInfo = {
-  genome_id: string;
-  common_name: string;
-  assembly_name: string;
-  scientific_name: string;
-  example_objects: ExampleFocusObject[];
-  url_slug: string | null;
-};
-
-export type GenomeInfoResponse = {
-  genome_info: GenomeInfo[];
-};
-
-export enum GenomeKaryotypeItemType {
-  CHROMOSOME = 'chromosome'
-}
-
-export type GenomeKaryotypeItem = {
-  is_chromosome: boolean;
-  is_circular: boolean;
-  length: number;
-  name: string;
-  type: GenomeKaryotypeItemType;
+export type GenomeTrackCategory = {
+  label: string;
+  track_category_id: string;
+  track_list: GenomicTrack[];
+  types: TrackSet[]; // shows which groups of tracks this category belongs to
 };

--- a/src/server/middleware/proxyMiddleware.ts
+++ b/src/server/middleware/proxyMiddleware.ts
@@ -56,31 +56,13 @@ const staticAssetsMiddleware = createProxyMiddleware('/static', {
   target: 'http://localhost:8081'
 });
 
-// const apiProxyMiddleware = createProxyMiddleware('/api', {
-//   target: 'https://staging-2020.ensembl.org',
-//   changeOrigin: true,
-//   secure: false
-// });
-
-const apiProxyMiddleware = createProxyMiddleware(
-  ['/api/**', '!/api/tracks/**'],
-  {
-    target: 'https://staging-2020.ensembl.org',
-    changeOrigin: true,
-    secure: false
-  }
-);
-
-const tracksProxyMiddleware = createProxyMiddleware('/api/tracks/**', {
-  target: 'http://change-track-ids.review.ensembl.org',
-  // pathRewrite: {
-  //   '^/api/docs': '/api', // rewrite path
-  // },
+const apiProxyMiddleware = createProxyMiddleware('/api', {
+  target: 'https://staging-2020.ensembl.org',
   changeOrigin: true,
   secure: false
 });
 
-let proxyMiddleware = [apiProxyMiddleware, tracksProxyMiddleware];
+let proxyMiddleware = [apiProxyMiddleware];
 
 if (process.env.NODE_ENV === 'development') {
   proxyMiddleware = proxyMiddleware.concat([

--- a/src/server/middleware/proxyMiddleware.ts
+++ b/src/server/middleware/proxyMiddleware.ts
@@ -56,13 +56,31 @@ const staticAssetsMiddleware = createProxyMiddleware('/static', {
   target: 'http://localhost:8081'
 });
 
-const apiProxyMiddleware = createProxyMiddleware('/api', {
-  target: 'https://staging-2020.ensembl.org',
+// const apiProxyMiddleware = createProxyMiddleware('/api', {
+//   target: 'https://staging-2020.ensembl.org',
+//   changeOrigin: true,
+//   secure: false
+// });
+
+const apiProxyMiddleware = createProxyMiddleware(
+  ['/api/**', '!/api/tracks/**'],
+  {
+    target: 'https://staging-2020.ensembl.org',
+    changeOrigin: true,
+    secure: false
+  }
+);
+
+const tracksProxyMiddleware = createProxyMiddleware('/api/tracks/**', {
+  target: 'http://change-track-ids.review.ensembl.org',
+  // pathRewrite: {
+  //   '^/api/docs': '/api', // rewrite path
+  // },
   changeOrigin: true,
   secure: false
 });
 
-let proxyMiddleware = [apiProxyMiddleware];
+let proxyMiddleware = [apiProxyMiddleware, tracksProxyMiddleware];
 
 if (process.env.NODE_ENV === 'development') {
   proxyMiddleware = proxyMiddleware.concat([

--- a/src/shared/types/focus-object/focusObjectTypes.ts
+++ b/src/shared/types/focus-object/focusObjectTypes.ts
@@ -46,18 +46,6 @@ export type FocusRegion = BasicFocusObject & {
 
 export type FocusObject = FocusGene | FocusRegion;
 
-export type FocusObjectTrack = {
-  additional_info?: string;
-  child_tracks?: FocusObjectTrack[];
-  colour?: string;
-  label: string;
-  ensembl_object_id?: string;
-  support_level?: string | null;
-  track_id: string;
-  stable_id: string | null;
-  description: string | null;
-};
-
 export type FocusObjectResponse = FocusGene;
 
 export type FocusObjectIdConstituents = {

--- a/tests/fixtures/genomes.ts
+++ b/tests/fixtures/genomes.ts
@@ -17,11 +17,11 @@ import { faker } from '@faker-js/faker';
 import times from 'lodash/times';
 
 import { TrackSet } from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
-import {
+import { GenomeKaryotypeItemType } from 'src/shared/state/genome/genomeTypes';
+import type {
   GenomeTrackCategory,
-  GenomeKaryotypeItemType
-} from 'src/shared/state/genome/genomeTypes';
-import { FocusObjectTrack } from 'src/shared/types/focus-object/focusObjectTypes';
+  GenomicTrack
+} from 'src/content/app/genome-browser/state/types/tracks';
 
 export const createGenomeCategories = (): GenomeTrackCategory[] => [
   {
@@ -44,14 +44,12 @@ export const createGenomeCategories = (): GenomeTrackCategory[] => [
   }
 ];
 
-const createTrack = (): FocusObjectTrack => {
+const createTrack = (): GenomicTrack => {
   return {
     additional_info: faker.lorem.words(),
     colour: 'DARK_GREY',
     label: faker.lorem.words(),
-    track_id: 'track:gene-pc-fwd',
-    stable_id: faker.lorem.word(),
-    description: faker.lorem.words()
+    track_id: 'gene-pc-fwd'
   };
 };
 export const createGenomeKaryotype = () =>

--- a/tests/fixtures/track-panel.ts
+++ b/tests/fixtures/track-panel.ts
@@ -18,7 +18,7 @@ import { faker } from '@faker-js/faker';
 
 import { Status } from 'src/shared/types/status';
 import { BrowserTrackStates } from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
-import { FocusObjectTrack } from 'src/shared/types/focus-object/focusObjectTypes';
+import type { GenomicTrack } from 'src/content/app/genome-browser/state/types/tracks';
 
 export const createTrackStates = (): BrowserTrackStates => ({
   fake_genome_id_1: {
@@ -29,30 +29,9 @@ export const createTrackStates = (): BrowserTrackStates => ({
   }
 });
 
-export const createTrackInfo = (): FocusObjectTrack => ({
+export const createTrackInfo = (): GenomicTrack => ({
+  colour: 'GREY',
   additional_info: faker.lorem.words(),
-  description: faker.lorem.words(),
   label: faker.lorem.words(),
-  track_id: 'gene-pc-fwd',
-  stable_id: faker.lorem.words()
-});
-
-export const createMainTrackInfo = (): FocusObjectTrack => ({
-  additional_info: faker.lorem.words(),
-  child_tracks: [
-    {
-      additional_info: faker.lorem.words(),
-      colour: faker.lorem.words(),
-      description: faker.lorem.words(),
-      label: faker.lorem.words(),
-      support_level: faker.lorem.words(),
-      track_id: 'gene-feat-1',
-      stable_id: faker.lorem.words()
-    }
-  ],
-  description: faker.lorem.words(),
-  ensembl_object_id: faker.lorem.words(),
-  label: faker.lorem.words(),
-  track_id: 'gene-feat',
-  stable_id: faker.lorem.words()
+  track_id: 'gene-pc-fwd'
 });


### PR DESCRIPTION
## Description
After the track api has updated track ids to remove the prefix `track:` from them (see https://github.com/Ensembl/ensembl-track-api/pull/9), in this PR we are deleting the code that was responsible for the removal of this prefix before sending the track id to the genome browser.

Also, updated types to remove the outdated `FocusObjectTrack` type.

**NOTE:** release to be coordinated with Andres

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1623

## Deployment URL(s)
http://updated-track-ids.review.ensembl.org

## Views affected
Genome browser