### PR TITLE
blast error fix - reset sequence validity flags on sequences change

### DIFF
--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence.tsx
@@ -73,12 +73,6 @@ const BlastInputSequence = (props: Props) => {
   const blastFormContext = useContext(BlastFormContext);
 
   useEffect(() => {
-    return () => {
-      blastFormContext?.removeSequenceValidityFlag(index);
-    };
-  }, []);
-
-  useEffect(() => {
     setInput(toFasta(sequence));
   }, [sequence.header, sequence.value, forceRenderCount]);
 
@@ -194,7 +188,7 @@ const BlastInputSequence = (props: Props) => {
   );
 };
 
-const checkSequenceValidity = (
+export const checkSequenceValidity = (
   sequence: string,
   sequenceType: SequenceType
 ) => {

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.tsx
@@ -73,7 +73,6 @@ const BlastInputSequences = () => {
     } else if (typeof index === 'number') {
       const newSequences = [...sequences].filter((_, i) => i !== index);
       updateSequences(newSequences);
-      blastFormContext?.removeSequenceValidityFlag(index);
     }
   };
 

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.tsx
@@ -17,8 +17,6 @@
 import React, { useEffect, useContext } from 'react';
 import { useAppSelector } from 'src/store';
 
-import usePrevious from 'src/shared/hooks/usePrevious';
-
 import BlastFormContext from 'src/content/app/tools/blast/views/blast-form/BlastFormContext';
 
 import { getEmptyInputVisibility } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
@@ -46,15 +44,11 @@ const BlastInputSequences = () => {
 
   const blastFormContext = useContext(BlastFormContext);
 
-  const previousSequences = usePrevious(sequences);
-
   useEffect(() => {
-    if (previousSequences?.length !== sequences.length) {
-      const sequenceFlags = sequences.map((sequence) => {
-        return checkSequenceValidity(sequence.value, sequenceType);
-      });
-      blastFormContext?.setSequenceValidityFlags(sequenceFlags);
-    }
+    const sequenceFlags = sequences.map((sequence) => {
+      return checkSequenceValidity(sequence.value, sequenceType);
+    });
+    blastFormContext?.setSequenceValidityFlags(sequenceFlags);
   }, [sequences]);
 
   const onSequenceAdded = (input: string, index: number | null) => {

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.tsx
@@ -50,8 +50,6 @@ const BlastInputSequences = () => {
 
   useEffect(() => {
     if (previousSequences?.length !== sequences.length) {
-      blastFormContext?.clearSequenceValidityFlags();
-
       const sequenceFlags = sequences.map((sequence) => {
         return checkSequenceValidity(sequence.value, sequenceType);
       });

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.tsx
@@ -17,6 +17,8 @@
 import React, { useEffect, useContext } from 'react';
 import { useAppSelector } from 'src/store';
 
+import usePrevious from 'src/shared/hooks/usePrevious';
+
 import BlastFormContext from 'src/content/app/tools/blast/views/blast-form/BlastFormContext';
 
 import { getEmptyInputVisibility } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
@@ -44,13 +46,17 @@ const BlastInputSequences = () => {
 
   const blastFormContext = useContext(BlastFormContext);
 
-  useEffect(() => {
-    blastFormContext?.clearSequenceValidityFlags();
+  const previousSequences = usePrevious(sequences);
 
-    const sequenceFlags = sequences.map((sequence) => {
-      return checkSequenceValidity(sequence.value, sequenceType);
-    });
-    blastFormContext?.setSequenceValidityFlags(sequenceFlags);
+  useEffect(() => {
+    if (previousSequences?.length !== sequences.length) {
+      blastFormContext?.clearSequenceValidityFlags();
+
+      const sequenceFlags = sequences.map((sequence) => {
+        return checkSequenceValidity(sequence.value, sequenceType);
+      });
+      blastFormContext?.setSequenceValidityFlags(sequenceFlags);
+    }
   }, [sequences]);
 
   const onSequenceAdded = (input: string, index: number | null) => {

--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.tsx
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequences.tsx
@@ -14,10 +14,14 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useEffect, useContext } from 'react';
 import { useAppSelector } from 'src/store';
 
+import BlastFormContext from 'src/content/app/tools/blast/views/blast-form/BlastFormContext';
+
 import { getEmptyInputVisibility } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
+
+import { checkSequenceValidity } from 'src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence';
 
 import useBlastForm from 'src/content/app/tools/blast/hooks/useBlastForm';
 
@@ -35,7 +39,19 @@ const BlastInputSequences = () => {
     appendEmptyInputBox,
     setUncommittedSequencePresence
   } = useBlastForm();
+
   const shouldAppendEmptyInput = useAppSelector(getEmptyInputVisibility);
+
+  const blastFormContext = useContext(BlastFormContext);
+
+  useEffect(() => {
+    blastFormContext?.clearSequenceValidityFlags();
+
+    const sequenceFlags = sequences.map((sequence) => {
+      return checkSequenceValidity(sequence.value, sequenceType);
+    });
+    blastFormContext?.setSequenceValidityFlags(sequenceFlags);
+  }, [sequences]);
 
   const onSequenceAdded = (input: string, index: number | null) => {
     const parsedSequences = parseBlastInput(input);
@@ -57,6 +73,7 @@ const BlastInputSequences = () => {
     } else if (typeof index === 'number') {
       const newSequences = [...sequences].filter((_, i) => i !== index);
       updateSequences(newSequences);
+      blastFormContext?.removeSequenceValidityFlag(index);
     }
   };
 

--- a/src/content/app/tools/blast/views/blast-form/BlastFormContext.tsx
+++ b/src/content/app/tools/blast/views/blast-form/BlastFormContext.tsx
@@ -21,6 +21,7 @@ import useBlastForm from 'src/content/app/tools/blast/hooks/useBlastForm';
 type BlastFormContextType = {
   updateSequenceValidityFlags: (index: number | null, status: boolean) => void;
   removeSequenceValidityFlag: (index: number | null) => void;
+  setSequenceValidityFlags: (flags: boolean[]) => void;
   clearSequenceValidityFlags: () => void;
   sequenceValidityFlags: boolean[];
 };
@@ -65,6 +66,7 @@ export const BlastFormContextContainer = (props: Props) => {
         updateSequenceValidityFlags,
         removeSequenceValidityFlag,
         clearSequenceValidityFlags,
+        setSequenceValidityFlags,
         sequenceValidityFlags
       }}
     >


### PR DESCRIPTION
## Description
See jira ticket on how to reproduce bug. The issue was that the sequenceValidityFlags array wasn't getting clear properly when sequence boxes was deleted. 2 ways we can delete a sequence box:
1. click on the delete icon
2. delete all sequences in a box and then click outside box

The previous approach was using `useEffect` on unmounting the component but it was getting confused with the index of which box was getting removed and there was no way to find out the index of the sequence box being removed.

The solution that i choose which might not be the perfect one (but still better than rewriting the whole thing) is to have the sequences object in redux (the committed sequences) within a useEffect and everytime the object change, we revalidate all the sequences.


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1654

## Deployment URL(s)
http://blast-error-fix.review.ensembl.org


## Views affected
blast - http://blast-error-fix.review.ensembl.org/blast