### PR TITLE
Remove cogs position from redux

### DIFF
--- a/src/content/app/genome-browser/Browser.tsx
+++ b/src/content/app/genome-browser/Browser.tsx
@@ -52,7 +52,8 @@ import BrowserInterstitial from './components/interstitial/BrowserInterstitial';
 import MissingGenomeError from 'src/shared/components/error-screen/url-errors/MissingGenomeError';
 import MissingFeatureError from 'src/shared/components/error-screen/url-errors/MissingFeatureError';
 
-import { StateZmenu } from 'src/content/app/genome-browser/components/zmenu/ZmenuController';
+import type { StateZmenu } from 'src/content/app/genome-browser/components/zmenu/ZmenuController';
+import type { CogList } from './state/track-settings/trackSettingsSlice';
 
 import styles from './Browser.scss';
 
@@ -167,6 +168,8 @@ type GenomeBrowserContextType = {
   setGenomeBrowser: (genomeBrowser: EnsemblGenomeBrowser | null) => void;
   zmenus: StateZmenu;
   setZmenus: (zmenus: StateZmenu) => void;
+  cogList: CogList | null;
+  setCogList: (cogList: CogList) => void;
 };
 
 export const GenomeBrowserContext = React.createContext<
@@ -178,6 +181,7 @@ const GenomeBrowserInitContainer = () => {
     useState<EnsemblGenomeBrowser | null>(null);
 
   const [zmenus, setZmenus] = useState<StateZmenu>({});
+  const [cogList, setCogList] = useState<CogList | null>(null);
 
   const browser = useMemo(() => {
     return <Browser />;
@@ -189,7 +193,9 @@ const GenomeBrowserInitContainer = () => {
         genomeBrowser,
         setGenomeBrowser,
         zmenus,
-        setZmenus
+        setZmenus,
+        cogList,
+        setCogList
       }}
     >
       {browser}

--- a/src/content/app/genome-browser/components/browser-cog/BrowserCogList.test.tsx
+++ b/src/content/app/genome-browser/components/browser-cog/BrowserCogList.test.tsx
@@ -27,8 +27,6 @@ import { BrowserCogList } from './BrowserCogList';
 
 import { createMockBrowserState } from 'tests/fixtures/browser';
 
-import { updateCogList } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSlice';
-
 const mockGenomeBrowser = jest.fn(() => new MockGenomeBrowser() as any);
 
 jest.mock(
@@ -44,6 +42,20 @@ jest.mock(
   'src/content/app/genome-browser/hooks/useGenomeBrowser',
   () => () => ({
     genomeBrowser: mockGenomeBrowser()
+  })
+);
+
+const mockSetCogList = jest.fn();
+
+jest.mock(
+  'src/content/app/genome-browser/components/browser-cog/useBrowserCogList',
+  () => () => ({
+    setCogList: mockSetCogList,
+    cogList: {
+      'gene-focus': 0,
+      contig: 192,
+      gc: 384
+    }
   })
 );
 
@@ -101,13 +113,7 @@ describe('<BrowserCogList />', () => {
         ]
       });
 
-      const dispatchedActions = store.getActions();
-
-      const updateCogListAction = dispatchedActions.find(
-        (action) => action.type === updateCogList.type
-      );
-
-      expect(updateCogListAction.payload).toEqual({
+      expect(mockSetCogList).toBeCalledWith({
         focus: 100,
         contig: 200
       });

--- a/src/content/app/genome-browser/components/browser-cog/BrowserCogList.tsx
+++ b/src/content/app/genome-browser/components/browser-cog/BrowserCogList.tsx
@@ -30,13 +30,9 @@ import BrowserCog from './BrowserCog';
 import { useAppDispatch, useAppSelector } from 'src/store';
 import useBrowserCogList from './useBrowserCogList';
 
-import {
-  getBrowserCogList,
-  getBrowserSelectedCog
-} from 'src/content/app/genome-browser/state/track-settings/trackSettingsSelectors';
+import { getBrowserSelectedCog } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSelectors';
 import {
   type CogList,
-  updateCogList,
   updateSelectedCog
 } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSlice';
 import {
@@ -48,7 +44,6 @@ import { TrackId } from 'src/content/app/genome-browser/components/track-panel/t
 import styles from './BrowserCogList.scss';
 
 export const BrowserCogList = () => {
-  const browserCogList = useAppSelector(getBrowserCogList);
   const selectedCog = useAppSelector(getBrowserSelectedCog);
   const genomeId = useAppSelector(getBrowserActiveGenomeId) as string;
   const objectId = useAppSelector(getBrowserActiveFocusObjectId);
@@ -56,7 +51,7 @@ export const BrowserCogList = () => {
 
   const { genomeBrowser } = useGenomeBrowser();
 
-  useBrowserCogList();
+  const { cogList: browserCogList, setCogList } = useBrowserCogList();
 
   useEffect(() => {
     const subscription = genomeBrowser?.subscribe(
@@ -89,7 +84,7 @@ export const BrowserCogList = () => {
       }
     });
 
-    dispatch(updateCogList(cogList));
+    setCogList(cogList);
   };
 
   useEffect(() => {

--- a/src/content/app/genome-browser/components/browser-cog/useBrowserCogList.ts
+++ b/src/content/app/genome-browser/components/browser-cog/useBrowserCogList.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
+import { useContext, useEffect } from 'react';
 
 import { useAppDispatch, useAppSelector } from 'src/store';
 import { useGenomeTracksQuery } from 'src/content/app/genome-browser/state/api/genomeBrowserApiSlice';
@@ -26,6 +26,8 @@ import {
   getBrowserActiveFocusObject
 } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
 
+import { GenomeBrowserContext } from '../../Browser';
+
 import {
   setInitialTrackSettingsForGenome,
   getDefaultGeneTrackSettings,
@@ -33,8 +35,7 @@ import {
   getTrackType,
   TrackType,
   type TrackSettings,
-  type TrackSettingsForGenome,
-  type CogList
+  type TrackSettingsForGenome
 } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSlice';
 import { TrackId } from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
 
@@ -46,7 +47,15 @@ const useBrowserCogList = () => {
   const { data: trackCategories } = useGenomeTracksQuery(genomeId);
   const focusObject = useAppSelector(getBrowserActiveFocusObject); // should we think about what to do if there is no focus object
 
-  const [cogList, setCogList] = useState<CogList | null>(null);
+  const genomeBrowserContext = useContext(GenomeBrowserContext);
+
+  if (!genomeBrowserContext) {
+    throw new Error(
+      'useGenomeBrowser must be used with GenomeBrowserContext Provider'
+    );
+  }
+
+  const { cogList, setCogList } = genomeBrowserContext;
 
   const dispatch = useAppDispatch();
 

--- a/src/content/app/genome-browser/components/browser-cog/useBrowserCogList.ts
+++ b/src/content/app/genome-browser/components/browser-cog/useBrowserCogList.ts
@@ -34,7 +34,7 @@ import {
   TrackType,
   type TrackSettings,
   type TrackSettingsForGenome,
-  CogList
+  type CogList
 } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSlice';
 import { TrackId } from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
 

--- a/src/content/app/genome-browser/components/browser-cog/useBrowserCogList.ts
+++ b/src/content/app/genome-browser/components/browser-cog/useBrowserCogList.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useAppDispatch, useAppSelector } from 'src/store';
 import { useGenomeTracksQuery } from 'src/content/app/genome-browser/state/api/genomeBrowserApiSlice';
@@ -33,7 +33,8 @@ import {
   getTrackType,
   TrackType,
   type TrackSettings,
-  type TrackSettingsForGenome
+  type TrackSettingsForGenome,
+  CogList
 } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSlice';
 import { TrackId } from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
 
@@ -44,6 +45,8 @@ const useBrowserCogList = () => {
   const genomeId = useAppSelector(getBrowserActiveGenomeId) as string;
   const { data: trackCategories } = useGenomeTracksQuery(genomeId);
   const focusObject = useAppSelector(getBrowserActiveFocusObject); // should we think about what to do if there is no focus object
+
+  const [cogList, setCogList] = useState<CogList | null>(null);
 
   const dispatch = useAppDispatch();
 
@@ -69,6 +72,11 @@ const useBrowserCogList = () => {
 
     dispatch(setInitialTrackSettingsForGenome({ genomeId, trackSettings }));
   }, [trackCategories, focusObject, genomeId]);
+
+  return {
+    cogList,
+    setCogList
+  };
 };
 
 export const getPersistentTrackSettingsForGenome = (

--- a/src/content/app/genome-browser/components/track-settings-panel/TrackSettingsPanel.test.tsx
+++ b/src/content/app/genome-browser/components/track-settings-panel/TrackSettingsPanel.test.tsx
@@ -57,10 +57,7 @@ const renderComponent = () => {
         { activeGenomeId: genomeId }
       ),
       trackSettings: {
-        browserTrackCogs: {
-          cogList: {},
-          selectedCog: selectedTrackId
-        },
+        selectedCog: selectedTrackId,
         settings: {
           [genomeId]: Object.assign(
             {},
@@ -95,7 +92,18 @@ jest.mock(
   () => () => ({
     genomeBrowser: mockGenomeBrowser,
     toggleTrackName: jest.fn(),
-    toggleFeatureLabels: jest.fn()
+    toggleFeatureLabels: jest.fn(),
+    toggleTranscriptIds: jest.fn(),
+    toggleSeveralTranscripts: jest.fn()
+  })
+);
+
+jest.mock(
+  'src/content/app/genome-browser/components/browser-cog/useBrowserCogList',
+  () => () => ({
+    cogList: {
+      [selectedTrackId]: 0
+    }
   })
 );
 
@@ -139,7 +147,7 @@ describe('<TrackSettingsPanel />', () => {
       expect(trackSettingsSlice.updateTrackName).toHaveBeenCalledWith({
         genomeId,
         isTrackNameShown: true,
-        trackId: updatedState.browser.trackSettings.browserTrackCogs.selectedCog
+        trackId: updatedState.browser.trackSettings.selectedCog
       });
       expect(
         updatedState.browser.trackSettings.settings[genomeId].tracks[
@@ -162,7 +170,7 @@ describe('<TrackSettingsPanel />', () => {
       ).toHaveBeenCalledWith({
         genomeId,
         areFeatureLabelsShown: true,
-        trackId: updatedState.browser.trackSettings.browserTrackCogs.selectedCog
+        trackId: updatedState.browser.trackSettings.selectedCog
       });
       const trackInfo =
         updatedState.browser.trackSettings.settings[genomeId].tracks[

--- a/src/content/app/genome-browser/components/track-settings-panel/useTrackSettings.ts
+++ b/src/content/app/genome-browser/components/track-settings-panel/useTrackSettings.ts
@@ -17,11 +17,12 @@
 import { useEffect, useRef } from 'react';
 
 import { useAppSelector, useAppDispatch, type RootState } from 'src/store';
+
+import useBrowserCogList from '../browser-cog/useBrowserCogList';
 import { getBrowserActiveGenomeId } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
 import {
   getTrackSettingsForTrackId,
   getApplyToAllSettings,
-  getBrowserCogList,
   getBrowserSelectedCog
 } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSelectors';
 import {
@@ -41,7 +42,7 @@ import useGenomeBrowser from 'src/content/app/genome-browser/hooks/useGenomeBrow
 import { type OptionValue } from 'src/shared/components/radio-group/RadioGroup';
 
 const useBrowserTrackSettings = () => {
-  const browserCogList = useAppSelector(getBrowserCogList);
+  const { cogList } = useBrowserCogList();
   const selectedCog = useAppSelector(getBrowserSelectedCog) || '';
   const activeGenomeId = useAppSelector(getBrowserActiveGenomeId);
   const selectedTrackSettings = useAppSelector((state: RootState) =>
@@ -67,8 +68,8 @@ const useBrowserTrackSettings = () => {
       return;
     }
 
-    if (shouldApplyToAllRef.current) {
-      Object.keys(browserCogList).forEach((trackId) => {
+    if (shouldApplyToAllRef.current && cogList) {
+      Object.keys(cogList).forEach((trackId) => {
         dispatch(
           updateTrackSettingsTrackName({
             genomeId: activeGenomeId,
@@ -106,8 +107,8 @@ const useBrowserTrackSettings = () => {
       return;
     }
 
-    if (shouldApplyToAllRef.current) {
-      Object.keys(browserCogList).forEach((trackId) => {
+    if (shouldApplyToAllRef.current && cogList) {
+      Object.keys(cogList).forEach((trackId) => {
         dispatch(
           updateTrackSettingsFeatureLabelsVisibility({
             genomeId: activeGenomeId,
@@ -147,8 +148,8 @@ const useBrowserTrackSettings = () => {
     if (!activeGenomeId) {
       return;
     }
-    if (shouldApplyToAllRef.current) {
-      Object.keys(browserCogList).forEach((trackId) => {
+    if (shouldApplyToAllRef.current && cogList) {
+      Object.keys(cogList).forEach((trackId) => {
         dispatch(
           updateTrackSettingsShowSeveralTranscripts({
             genomeId: activeGenomeId,
@@ -189,8 +190,8 @@ const useBrowserTrackSettings = () => {
     if (!activeGenomeId) {
       return;
     }
-    if (shouldApplyToAllRef.current) {
-      Object.keys(browserCogList).forEach((trackId) => {
+    if (shouldApplyToAllRef.current && cogList) {
+      Object.keys(cogList).forEach((trackId) => {
         dispatch(
           updateTrackSettingsShowTranscriptIds({
             genomeId: activeGenomeId,

--- a/src/content/app/genome-browser/state/track-settings/trackSettingsSelectors.ts
+++ b/src/content/app/genome-browser/state/track-settings/trackSettingsSelectors.ts
@@ -19,12 +19,8 @@ import { defaultTrackSettingsForGenome } from './trackSettingsSlice';
 
 import type { RootState } from 'src/store';
 
-export const getBrowserCogList = (state: RootState) => {
-  return state.browser.trackSettings.browserTrackCogs.cogList;
-};
-
 export const getBrowserSelectedCog = (state: RootState) => {
-  return state.browser.trackSettings.browserTrackCogs.selectedCog;
+  return state.browser.trackSettings.selectedCog;
 };
 
 export const getTrackSettingsForTrackId = (

--- a/src/content/app/genome-browser/state/track-settings/trackSettingsSlice.ts
+++ b/src/content/app/genome-browser/state/track-settings/trackSettingsSlice.ts
@@ -73,10 +73,7 @@ export type GenomeTrackSettings = {
  * Hopefully, we’ll be able to to remove the cogs from the redux state altogether
  */
 type TrackSettingsState = {
-  browserTrackCogs: {
-    cogList: CogList;
-    selectedCog: string | null;
-  };
+  selectedCog: string | null;
   settings: GenomeTrackSettings;
 };
 
@@ -128,10 +125,7 @@ export const getTrackType = (trackId: string) => {
 };
 
 const initialState: TrackSettingsState = {
-  browserTrackCogs: {
-    cogList: {},
-    selectedCog: null
-  },
+  selectedCog: null,
   settings: {}
 };
 
@@ -152,13 +146,9 @@ const trackSettingsSlice = createSlice({
         ...trackSettings
       };
     },
-    updateCogList(state, action: PayloadAction<CogList>) {
-      const browserCogList = action.payload;
-      state.browserTrackCogs.cogList = browserCogList;
-    },
     updateSelectedCog(state, action: PayloadAction<string | null>) {
       const selectedCog = action.payload;
-      state.browserTrackCogs.selectedCog = selectedCog;
+      state.selectedCog = selectedCog;
     },
     updateApplyToAll(
       state,
@@ -242,7 +232,6 @@ const trackSettingsSlice = createSlice({
 
 export const {
   setInitialTrackSettingsForGenome,
-  updateCogList,
   updateSelectedCog,
   updateApplyToAll,
   updateTrackName,

--- a/tests/fixtures/browser.ts
+++ b/tests/fixtures/browser.ts
@@ -215,11 +215,6 @@ export const createMockBrowserState = () => {
       },
       trackSettings: {
         browserTrackCogs: {
-          cogList: {
-            'gene-focus': 0,
-            contig: 192,
-            gc: 384
-          },
           selectedCog: 'gene-focus'
         },
         [fakeGenomeId]: {

--- a/tests/fixtures/browser.ts
+++ b/tests/fixtures/browser.ts
@@ -214,15 +214,7 @@ export const createMockBrowserState = () => {
         }
       },
       trackSettings: {
-        browserTrackCogs: {
-          selectedCog: 'gene-focus'
-        },
-        [fakeGenomeId]: {
-          applyToAllConfig: {
-            isSelected: true
-          },
-          tracks: createTrackSettings()
-        }
+        selectedCog: 'gene-focus'
       },
       trackPanel: {
         [fakeGenomeId]: {


### PR DESCRIPTION
## Description
- Removed the cogs position from redux and moved it to `useBrowserCogList`
-  Moved `selectedCog` one level up in redux
- Updated the tests


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1616

## Deployment URL(s)
http://cogs-out-of-redux.review.ensembl.org


## Views affected
Cogs