### PR TITLE
Don't set zmenu if there is no transcript data

### DIFF
--- a/src/content/app/genome-browser/components/zmenu/ZmenuController.tsx
+++ b/src/content/app/genome-browser/components/zmenu/ZmenuController.tsx
@@ -19,9 +19,13 @@ import React, { useEffect, memo } from 'react';
 import useGenomeBrowser from 'src/content/app/genome-browser/hooks/useGenomeBrowser';
 
 import {
-  ZmenuCreateAction,
+  type ZmenuCreateAction,
+  type ZmenuCreatePayload,
+  type ZmenuContentGene,
+  type ZmenuContentTranscript,
+  type ZmenuPayloadVariety,
   IncomingActionType,
-  ZmenuCreatePayload
+  ZmenuPayloadVarietyType
 } from '@ensembl/ensembl-genome-browser';
 
 import Zmenu from './Zmenu';
@@ -55,6 +59,23 @@ const ZmenuController = (props: Props) => {
     if (!payload.variety.length) {
       return;
     }
+
+    const { content, variety } = action.payload;
+
+    const zmenuType = variety.find((variety: ZmenuPayloadVariety) =>
+      Boolean(variety.type)
+    )?.type;
+    if (zmenuType === ZmenuPayloadVarietyType.GENE_AND_ONE_TRANSCRIPT) {
+      const hasTranscript = content.some(
+        (feature: ZmenuContentTranscript | ZmenuContentGene) =>
+          feature.metadata.type === 'transcript'
+      );
+
+      if (!hasTranscript) {
+        return;
+      }
+    }
+
     const zmenuId = Object.keys(zmenus).length + 1;
 
     setZmenus &&


### PR DESCRIPTION
## Description
- Fixed the issue with zmenu not opening on the first click
- Currently it validates the data that comes from the GB to check if there is any data for transcript. If not, it simply doesn't try draw the zmenu.

**To reproduce**:
Click on the "-----" lines first and then click on a transcript.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1678

## Deployment URL(s)
http://fix-zmenu-ref.review.ensembl.org


## Views affected
Genome browser zmenu