### PR TITLE
Use real genome id instead of the id in the url for external references in Entity Viewer

### DIFF
--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.tsx
@@ -15,11 +15,11 @@
  */
 
 import React, { useState } from 'react';
-import { useParams } from 'react-router';
 import sortBy from 'lodash/sortBy';
 
-import { parseFocusObjectIdFromUrl } from 'src/shared/helpers/focusObjectHelpers';
 import { defaultSort } from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
+
+import useGeneViewIds from 'src/content/app/entity-viewer/gene-view/hooks/useGeneViewIds';
 
 import { useGeneExternalReferencesQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
 import useEntityViewerAnalytics from 'src/content/app/entity-viewer/hooks/useEntityViewerAnalytics';
@@ -41,8 +41,7 @@ type ExternalReferencesGroupType = {
 };
 
 const GeneExternalReferences = () => {
-  const { entityId, genomeId } = useParams<'genomeId' | 'entityId'>();
-  const geneId = entityId ? parseFocusObjectIdFromUrl(entityId).objectId : null;
+  const { genomeId, geneId } = useGeneViewIds();
 
   const { trackExternalReferenceLinkClick } = useEntityViewerAnalytics();
 


### PR DESCRIPTION
## Description
External References component in Entity Viewer is querying Thoas using the genome id it gets from the url instead of the "real" genome id:

![image](https://user-images.githubusercontent.com/6834224/182618064-43086bbe-669d-4ed6-a692-5607ad329cc0.png)

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1680

## Deployment URL(s)
http://fix-ev-external-references.review.ensembl.org