### PR TITLE
Fix useRefWithRerender hook

### DIFF
--- a/src/content/app/genome-browser/components/zmenu/Zmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/Zmenu.tsx
@@ -56,7 +56,7 @@ export type ZmenuProps = {
 };
 
 const Zmenu = (props: ZmenuProps) => {
-  const anchorRef = useRefWithRerender<HTMLDivElement>(null);
+  const [anchorRef, setAnchorRef] = useRefWithRerender<HTMLDivElement>(null);
   const { zmenus, setZmenus } = useGenomeBrowser();
   const chromosomeLocation = useAppSelector(getActualChrLocation);
   const previousChromosomeLocation = usePrevious(chromosomeLocation);
@@ -135,7 +135,7 @@ const Zmenu = (props: ZmenuProps) => {
   const anchorStyles = getAnchorInlineStyles(props);
 
   return (
-    <div ref={anchorRef} className={styles.zmenuAnchor} style={anchorStyles}>
+    <div ref={setAnchorRef} className={styles.zmenuAnchor} style={anchorStyles}>
       {anchorRef.current && (
         <Toolbox
           onOutsideClick={destroyZmenu}

--- a/src/shared/hooks/tests/useRefWithRerender.test.tsx
+++ b/src/shared/hooks/tests/useRefWithRerender.test.tsx
@@ -22,10 +22,11 @@ import useRefWithRerender from '../useRefWithRerender';
 describe('useRefWithRerender', () => {
   it('updates the component when ref.current value changes', async () => {
     const TestComponent = () => {
-      const elementRef = useRefWithRerender<HTMLDivElement>(null); // notice that we start with null
+      const [elementRef, setElementRef] =
+        useRefWithRerender<HTMLDivElement>(null); // notice that we start with null
 
       return (
-        <div ref={elementRef}>
+        <div ref={setElementRef}>
           {elementRef.current && (
             <div className="success">This should render</div>
           )}

--- a/src/shared/hooks/useRefWithRerender.ts
+++ b/src/shared/hooks/useRefWithRerender.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useState, useRef, MutableRefObject } from 'react';
+import { useState, useRef, useCallback, MutableRefObject } from 'react';
 
 /*
 Normally, mutating ref.current will not cause React component
@@ -25,17 +25,18 @@ of ref.current changes. This logic can be abstracted into a custom hook.
 
 const useRefWithRerender = <T>(
   initialValue: T | null
-): MutableRefObject<T | null> => {
-  const [currentRef, setCurrentRef] = useState<T | null>(null);
-  const ref = useRef<T>(initialValue);
+): [MutableRefObject<T | null>, (value: T | null) => void] => {
+  const [, setRenderCount] = useState(0); // for force rerendering
+  const ref = useRef<typeof initialValue>(initialValue);
 
-  useEffect(() => {
-    if (currentRef !== ref.current) {
-      setCurrentRef(ref.current);
+  const callbackRef = useCallback((value: typeof initialValue) => {
+    if (value !== ref.current) {
+      ref.current = value;
+      setRenderCount((prevCount) => prevCount + 1); // to force a re-render
     }
-  }, [ref.current]);
+  }, []);
 
-  return ref;
+  return [ref, callbackRef];
 };
 
 export default useRefWithRerender;

--- a/stories/shared-components/tooltip/Tooltip.stories.tsx
+++ b/stories/shared-components/tooltip/Tooltip.stories.tsx
@@ -61,7 +61,7 @@ const ContentSwitch = (props: {
 export const DefaultTooltipStory = () => {
   const [isMousedOver, setIsMousedOver] = useState(false);
   const [isLongContent, setIsLongContent] = useState(false);
-  const elementRef = useRefWithRerender<HTMLDivElement>(null);
+  const [elementRef, setElementRef] = useRefWithRerender<HTMLDivElement>(null);
 
   return (
     <div className={styles.container}>
@@ -75,7 +75,7 @@ export const DefaultTooltipStory = () => {
         <div
           onMouseEnter={() => setIsMousedOver(true)}
           onMouseLeave={() => setIsMousedOver(false)}
-          ref={elementRef}
+          ref={setElementRef}
           className={styles.tooltipAnchor}
         >
           Mouse over me
@@ -96,7 +96,7 @@ DefaultTooltipStory.storyName = 'default';
 
 export const OnScrollTooltipStory = () => {
   const [isMousedOver, setIsMousedOver] = useState(false);
-  const elementRef = useRefWithRerender<HTMLDivElement>(null);
+  const [elementRef, setElementRef] = useRefWithRerender<HTMLDivElement>(null);
 
   const hideTooltip = () => setIsMousedOver(false);
 
@@ -111,7 +111,7 @@ export const OnScrollTooltipStory = () => {
         <div
           onMouseEnter={() => setIsMousedOver(true)}
           onMouseLeave={() => setIsMousedOver(false)}
-          ref={elementRef}
+          ref={setElementRef}
           className={styles.tooltipAnchor}
         >
           Mouse over me
@@ -134,7 +134,7 @@ OnScrollTooltipStory.storyName = 'scrolling';
 
 export const OverflowHiddenStory = () => {
   const [isMousedOver, setIsMousedOver] = useState(false);
-  const elementRef = useRefWithRerender<HTMLDivElement>(null);
+  const [elementRef, setElementRef] = useRefWithRerender<HTMLDivElement>(null);
 
   return (
     <div className={classNames(styles.container, styles.containerOverflow)}>
@@ -146,7 +146,7 @@ export const OverflowHiddenStory = () => {
         <div
           onMouseEnter={() => setIsMousedOver(true)}
           onMouseLeave={() => setIsMousedOver(false)}
-          ref={elementRef}
+          ref={setElementRef}
           className={styles.tooltipAnchor}
         >
           Mouse over me


### PR DESCRIPTION
## Description
An accidental bug in genome browser (it sends an incorrect payload when you click on a dotted line on either side of the transcript, whereas it shouldn't send anything) revealed that we have a bug in our Zmenu. If it returns `null` during the first render, the next time it tries to render, it will also return null; and only the time after that it will render a DOM element.

Below is the demonstration of the problem: a click on a dashed line on either side of a transcript causes the genome browser to send a payload; but since this payload is not the one that our Zmenu understands, it returns `null`. Next time user clicks on a transcript, the payload from the genome browser is correct, but the Zmenu still is unable to render properly. Only the second time the user click on a transcript, the Zmenu shows up:

https://user-images.githubusercontent.com/6834224/183398510-55a5a792-c71a-49ef-bf77-41029cb756b5.mov

The problem was with the implementation of the `useRefWithRerender` hook, which was mistakenly relying on `useEffect`, which wouldn't fire if the parent component doesn't rerender. This PR changes the implementation of `useRefWithRerender` hook to use a callback prop. 

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1678

## Deployment URL(s)
http://fix-use-ref-with-rerender.review.ensembl.org