### PR TITLE
[FOR DISCUSSION]: another approach to table

### DIFF
--- a/src/shared/components/table/Table.scss
+++ b/src/shared/components/table/Table.scss
@@ -1,0 +1,43 @@
+@import 'src/styles/common';
+
+.table {
+  border-collapse: collapse;
+}
+
+.tableHeadCell {
+  font-size: 12px;
+  font-weight: $light;
+  border-bottom: 1px solid $blue;
+}
+
+.tableHeadCell,
+.tableCell {
+  padding: 6px 12px;
+}
+
+.tableCell {
+  vertical-align: top;
+}
+
+.tableHeadCellSortable {
+  position: relative;
+}
+
+.tableHeadCellSortableActive {
+  font-weight: $normal;
+}
+
+.tableHeadCellSortingControls {
+  position: absolute;
+  left: 0;
+}
+
+.tableHeadCellSortingArrow {
+  width: 8px;
+  fill: $grey;
+  cursor: pointer;
+}
+
+.tableHeadCellSortingArrowDown {
+  transform: rotate(180deg);
+}

--- a/src/shared/components/table/Table.scss
+++ b/src/shared/components/table/Table.scss
@@ -36,6 +36,7 @@
   width: 8px;
   fill: $grey;
   cursor: pointer;
+  user-select: none;
 }
 
 .tableHeadCellSortingArrowDown {

--- a/src/shared/components/table/Table.scss
+++ b/src/shared/components/table/Table.scss
@@ -4,10 +4,18 @@
   border-collapse: collapse;
 }
 
+// FIXME: sticky/non-sticky header should be configurable via props
+.table thead tr {
+  position: sticky;
+  top: 0;
+  background-color: white;
+}
+
 .tableHeadCell {
   font-size: 12px;
   font-weight: $light;
-  border-bottom: 1px solid $blue;
+  box-shadow: inset 0 -1px 0 $blue;
+  background-clip: padding-box;
 }
 
 .tableHeadCell,

--- a/src/shared/components/table/Table.tsx
+++ b/src/shared/components/table/Table.tsx
@@ -1,0 +1,44 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ReactNode } from 'react';
+
+import styles from './Table.scss';
+
+/**
+ * Responsibilities
+ * - render the table tag
+ * - width? (default: 100%)
+ * - background ?
+ */
+
+/**
+ * Questions:
+ * - what dictates the width of a column?
+ * - how can row selection work across table pages?
+ */
+
+type Props = {
+  children: ReactNode;
+};
+
+const Table = (props: Props) => {
+  const { children } = props;
+
+  return <table className={styles.table}>{children}</table>;
+};
+
+export default Table;

--- a/src/shared/components/table/TableBody.tsx
+++ b/src/shared/components/table/TableBody.tsx
@@ -1,0 +1,35 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ReactNode } from 'react';
+
+/**
+ * Responsibilities
+ * - render the table tag
+ * - width? (default: 100%)
+ */
+
+type Props = {
+  children: ReactNode;
+};
+
+const TableBody = (props: Props) => {
+  const { children } = props;
+
+  return <tbody>{children}</tbody>;
+};
+
+export default TableBody;

--- a/src/shared/components/table/TableBody.tsx
+++ b/src/shared/components/table/TableBody.tsx
@@ -18,8 +18,7 @@ import React, { ReactNode } from 'react';
 
 /**
  * Responsibilities
- * - render the table tag
- * - width? (default: 100%)
+ * - render the tbody tag
  */
 
 type Props = {

--- a/src/shared/components/table/TableCell.tsx
+++ b/src/shared/components/table/TableCell.tsx
@@ -1,0 +1,36 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ReactNode } from 'react';
+
+import styles from './Table.scss';
+
+/**
+ * Responsibilities
+ * - render the td tag
+ */
+
+type Props = {
+  children: ReactNode;
+};
+
+const TableHead = (props: Props) => {
+  const { children } = props;
+
+  return <td className={styles.tableCell}>{children}</td>;
+};
+
+export default TableHead;

--- a/src/shared/components/table/TableCell.tsx
+++ b/src/shared/components/table/TableCell.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactNode } from 'react';
+import React, { type HTMLProps } from 'react';
 
 import styles from './Table.scss';
 
@@ -23,14 +23,10 @@ import styles from './Table.scss';
  * - render the td tag
  */
 
-type Props = {
-  children: ReactNode;
+type Props = HTMLProps<HTMLTableCellElement>;
+
+const TableCell = (props: Props) => {
+  return <td className={styles.tableCell} {...props} />;
 };
 
-const TableHead = (props: Props) => {
-  const { children } = props;
-
-  return <td className={styles.tableCell}>{children}</td>;
-};
-
-export default TableHead;
+export default TableCell;

--- a/src/shared/components/table/TableHead.tsx
+++ b/src/shared/components/table/TableHead.tsx
@@ -20,8 +20,7 @@ import styles from './Table.scss';
 
 /**
  * Responsibilities
- * - render the table tag
- * - width? (default: 100%)
+ * - render the thead tag
  */
 
 type Props = {

--- a/src/shared/components/table/TableHead.tsx
+++ b/src/shared/components/table/TableHead.tsx
@@ -1,0 +1,37 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ReactNode } from 'react';
+
+import styles from './Table.scss';
+
+/**
+ * Responsibilities
+ * - render the table tag
+ * - width? (default: 100%)
+ */
+
+type Props = {
+  children: ReactNode;
+};
+
+const TableHead = (props: Props) => {
+  const { children } = props;
+
+  return <thead className={styles.tableHead}>{children}</thead>;
+};
+
+export default TableHead;

--- a/src/shared/components/table/TableHeaderCell.tsx
+++ b/src/shared/components/table/TableHeaderCell.tsx
@@ -1,0 +1,90 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ReactNode } from 'react';
+import classNames from 'classnames';
+
+import IconArrow from 'static/icons/icon_arrow.svg';
+
+import styles from './Table.scss';
+
+/**
+ * Responsibilities
+ * - render the th tag
+ * - know about whether it is determining the sorting order in this column
+ * - know the direction of the sorting order
+ * - have a callback for sort
+ */
+
+type SortDirection = 'asc' | 'desc';
+
+type MinimalProps = {
+  children: ReactNode;
+};
+
+type SortableProps = MinimalProps & {
+  sortDirection: SortDirection;
+  onSortDirectionChange: (direction: SortDirection) => void;
+  isSortingActive: boolean;
+};
+
+type Props = MinimalProps | SortableProps;
+
+const TableHeadCell = (props: Props) => {
+  if ('sortDirection' in props) {
+    return <SortableTableHeadCell {...props} />;
+  }
+  const { children } = props;
+
+  return <th className={styles.tableHeadCell}>{children}</th>;
+};
+
+const SortableTableHeadCell = (props: SortableProps) => {
+  const { sortDirection, onSortDirectionChange, isSortingActive, children } =
+    props;
+
+  const onIconClick = () => {
+    const nextDirection = sortDirection === 'asc' ? 'desc' : 'asc';
+    onSortDirectionChange(nextDirection);
+  };
+
+  const cellClasses = classNames(
+    styles.tableHeadCell,
+    styles.tableHeadCellSortable,
+    {
+      [styles.tableHeadCellSortableActive]: isSortingActive
+    }
+  );
+
+  const arrowClasses = classNames(styles.tableHeadCellSortingArrow, {
+    [styles.tableHeadCellSortingArrowDown]: sortDirection === 'asc'
+  });
+
+  return (
+    <th className={cellClasses}>
+      <div className={styles.tableHeadCellSortingControls}>
+        <IconArrow className={arrowClasses} onClick={onIconClick} />
+      </div>
+      {children}
+    </th>
+  );
+};
+
+const SortDirection = () => {
+  return <div></div>;
+};
+
+export default TableHeadCell;

--- a/src/shared/components/table/TableHeaderCell.tsx
+++ b/src/shared/components/table/TableHeaderCell.tsx
@@ -24,8 +24,9 @@ import styles from './Table.scss';
 /**
  * Responsibilities
  * - render the th tag
- * - know about whether it is determining the sorting order in this column
- * - know the direction of the sorting order
+ * - know about whether it can sort the data in its column
+ * - know whether the sorting rule associated with this column has actually been applied
+ * - for sorted columns, know the sorting order (ascending vs descending)
  * - have a callback for sort
  */
 

--- a/src/shared/components/table/TableHeaderCell.tsx
+++ b/src/shared/components/table/TableHeaderCell.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactNode } from 'react';
+import React, { HTMLProps } from 'react';
 import classNames from 'classnames';
 
 import IconArrow from 'static/icons/icon_arrow.svg';
@@ -31,9 +31,7 @@ import styles from './Table.scss';
 
 type SortDirection = 'asc' | 'desc';
 
-type MinimalProps = {
-  children: ReactNode;
-};
+type MinimalProps = HTMLProps<HTMLTableCellElement>;
 
 type SortableProps = MinimalProps & {
   sortDirection: SortDirection;

--- a/src/shared/components/table/TableRow.tsx
+++ b/src/shared/components/table/TableRow.tsx
@@ -18,8 +18,7 @@ import React, { ReactNode } from 'react';
 
 /**
  * Responsibilities
- * - render the table tag
- * - width? (default: 100%)
+ * - render the tr tag
  */
 
 type Props = {

--- a/src/shared/components/table/TableRow.tsx
+++ b/src/shared/components/table/TableRow.tsx
@@ -1,0 +1,35 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ReactNode } from 'react';
+
+/**
+ * Responsibilities
+ * - render the table tag
+ * - width? (default: 100%)
+ */
+
+type Props = {
+  children: ReactNode;
+};
+
+const TableHead = (props: Props) => {
+  const { children } = props;
+
+  return <tr>{children}</tr>;
+};
+
+export default TableHead;

--- a/src/shared/components/table/TableRowSelectorCell.tsx
+++ b/src/shared/components/table/TableRowSelectorCell.tsx
@@ -14,10 +14,31 @@
  * limitations under the License.
  */
 
-export { default as Table } from './Table';
-export { default as TableHead } from './TableHead';
-export { default as TableBody } from './TableBody';
-export { default as TableRow } from './TableRow';
-export { default as TableHeadCell } from './TableHeaderCell';
-export { default as TableCell } from './TableCell';
-export { default as TableRowSelectorCell } from './TableRowSelectorCell';
+import React from 'react';
+
+import Checkbox from 'src/shared/components/checkbox/Checkbox';
+
+import styles from './Table.scss';
+
+/**
+ * Responsibilities
+ * - render a td tag containing either a checkbox or an eye icon, to act as a way to select a row
+ */
+
+type Props = {
+  isSelected: boolean;
+  mode: 'default' | 'selecting';
+  onChange: () => void;
+};
+
+const TableRowSelectorCell = (props: Props) => {
+  const { isSelected, onChange } = props;
+
+  return (
+    <td className={styles.tableCell}>
+      <Checkbox checked={isSelected} onChange={onChange} />
+    </td>
+  );
+};
+
+export default TableRowSelectorCell;

--- a/src/shared/components/table/TableRowSelectorCell.tsx
+++ b/src/shared/components/table/TableRowSelectorCell.tsx
@@ -34,6 +34,7 @@ type Props = {
 const TableRowSelectorCell = (props: Props) => {
   const { isSelected, onChange } = props;
 
+  // NOTE: eye icon currently not implemented
   return (
     <td className={styles.tableCell}>
       <Checkbox checked={isSelected} onChange={onChange} />

--- a/src/shared/components/table/index.ts
+++ b/src/shared/components/table/index.ts
@@ -1,0 +1,22 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default as Table } from './Table';
+export { default as TableHead } from './TableHead';
+export { default as TableBody } from './TableBody';
+export { default as TableRow } from './TableRow';
+export { default as TableHeadCell } from './TableHeaderCell';
+export { default as TableCell } from './TableCell';

--- a/src/shared/components/table/useSelectableRows.ts
+++ b/src/shared/components/table/useSelectableRows.ts
@@ -13,11 +13,3 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-export { default as Table } from './Table';
-export { default as TableHead } from './TableHead';
-export { default as TableBody } from './TableBody';
-export { default as TableRow } from './TableRow';
-export { default as TableHeadCell } from './TableHeaderCell';
-export { default as TableCell } from './TableCell';
-export { default as TableRowSelectorCell } from './TableRowSelectorCell';

--- a/static/icons/icon_arrow.svg
+++ b/static/icons/icon_arrow.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.4.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="arrow" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 32 32" style="enable-background:new 0 0 32 32;" xml:space="preserve">
+<path id="_x3C_Path_arrow_up_x3E__1_" d="M17.2999992,6.0999999C17,5.5999999,16.5,5.2999997,15.999999,5.2999997
+	c-0.5,0-1.1000004,0.3000002-1.3000002,0.8000002L1.3,24C1,24.2999992,1,24.6000004,1,25.1000004
+	c0,0.7999992,0.8,1.6000004,1.5999999,1.6000004h26.7999992C30.1999989,26.7000008,31,25.9000015,31,25.1000004
+	C31,24.8000011,31,24.3000011,30.7000008,24L17.2999992,6.0999999z"/>
+</svg>

--- a/stories/shared-components/table/Table.stories.scss
+++ b/stories/shared-components/table/Table.stories.scss
@@ -1,0 +1,3 @@
+.widthLimitedContainer {
+  max-width: 20ch;
+}

--- a/stories/shared-components/table/Table.stories.scss
+++ b/stories/shared-components/table/Table.stories.scss
@@ -1,3 +1,9 @@
+.tableContainer {
+  height: 600px;
+  width: 400px;
+  overflow: auto;
+}
+
 .widthLimitedContainer {
   max-width: 20ch;
 }

--- a/stories/shared-components/table/Table.stories.tsx
+++ b/stories/shared-components/table/Table.stories.tsx
@@ -1,0 +1,87 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from 'react';
+
+import { fakeData } from './fakeData';
+
+import {
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableHeadCell,
+  TableCell
+} from 'src/shared/components/table';
+
+import styles from './Table.stories.scss';
+
+export const TableStory = () => {
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc' | null>(
+    null
+  );
+  const sortedFakeData = [...fakeData].sort((a, b) => {
+    if (sortDirection === 'asc') {
+      return b.second - a.second;
+    } else if (sortDirection === 'desc') {
+      return a.second - b.second;
+    } else {
+      return 0;
+    }
+  });
+
+  // if (sortDirection === 'asc') {
+  //   sortedFakeData.sort((a, b) => ) = sortBy(fakeData, ['second']);
+  // } else if (sortDirection === 'desc') {
+
+  // }
+  // const sortedFakeData = sortDirection ?
+
+  return (
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableHeadCell>Words</TableHeadCell>
+          <TableHeadCell
+            sortDirection={sortDirection ?? 'desc'}
+            onSortDirectionChange={setSortDirection}
+            isSortingActive={!!sortDirection}
+          >
+            Numerical
+          </TableHeadCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {sortedFakeData.map((rowData, index) => (
+          <TableRow key={index}>
+            <TableCell>
+              <div className={styles.widthLimitedContainer}>
+                {rowData.first}
+              </div>
+            </TableCell>
+            <TableCell>{rowData.second}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+};
+
+TableStory.storyName = 'default';
+
+export default {
+  title: 'Components/Shared Components/Table'
+};

--- a/stories/shared-components/table/Table.stories.tsx
+++ b/stories/shared-components/table/Table.stories.tsx
@@ -15,8 +15,9 @@
  */
 
 import React, { useState } from 'react';
+import times from 'lodash/times';
 
-import { fakeData } from './fakeData';
+import { fakeData as fakeDataShort } from './fakeData';
 
 import {
   Table,
@@ -30,6 +31,8 @@ import {
 import ShowHide from 'src/shared/components/show-hide/ShowHide';
 
 import styles from './Table.stories.scss';
+
+const fakeData = times(20, () => fakeDataShort).flat();
 
 export const TableStory = () => {
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc' | null>(
@@ -63,7 +66,7 @@ export const TableStory = () => {
     setExpandedRowIndex(nextExpandedIndex);
   };
 
-  return (
+  const table = (
     <Table>
       <TableHead>
         <TableRow>
@@ -78,7 +81,10 @@ export const TableStory = () => {
           >
             Numerical
           </TableHeadCell>
-          <TableHeadCell>Empty</TableHeadCell>
+          <TableHeadCell />
+          <TableHeadCell>Genomic location</TableHeadCell>
+          <TableHeadCell>Orientation</TableHeadCell>
+          <TableHeadCell>Overlapping Gene(s)</TableHeadCell>
         </TableRow>
       </TableHead>
       <TableBody>
@@ -102,6 +108,13 @@ export const TableStory = () => {
                   onChange={() => onExpandRow(index)}
                 />
               </TableCell>
+              <TableCell>{rowData.third}</TableCell>
+              <TableCell>{rowData.fourth}</TableCell>
+              <TableCell>
+                <div className={styles.widthLimitedContainer}>
+                  {rowData.fifth}
+                </div>
+              </TableCell>
             </TableRow>
             {index === expandedRowIndex && (
               <TableRow key={`${index}-expanded`}>
@@ -113,6 +126,8 @@ export const TableStory = () => {
       </TableBody>
     </Table>
   );
+
+  return <div className={styles.tableContainer}>{table}</div>;
 };
 
 const ExpandCell = (props: { isExpanded: boolean; onChange: () => void }) => {

--- a/stories/shared-components/table/Table.stories.tsx
+++ b/stories/shared-components/table/Table.stories.tsx
@@ -24,8 +24,10 @@ import {
   TableBody,
   TableRow,
   TableHeadCell,
-  TableCell
+  TableCell,
+  TableRowSelectorCell
 } from 'src/shared/components/table';
+import ShowHide from 'src/shared/components/show-hide/ShowHide';
 
 import styles from './Table.stories.scss';
 
@@ -33,6 +35,9 @@ export const TableStory = () => {
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc' | null>(
     null
   );
+  const [selectedRows, setSelectedRows] = useState<Set<number>>(new Set());
+  const [expandedRowIndex, setExpandedRowIndex] = useState<number | null>(null);
+
   const sortedFakeData = [...fakeData].sort((a, b) => {
     if (sortDirection === 'asc') {
       return b.second - a.second;
@@ -43,17 +48,28 @@ export const TableStory = () => {
     }
   });
 
-  // if (sortDirection === 'asc') {
-  //   sortedFakeData.sort((a, b) => ) = sortBy(fakeData, ['second']);
-  // } else if (sortDirection === 'desc') {
+  const onSelectedRowChanged = (index: number) => {
+    if (selectedRows.has(index)) {
+      setSelectedRows(
+        new Set([...selectedRows].filter((item) => item !== index))
+      );
+    } else {
+      setSelectedRows(new Set([...selectedRows, index]));
+    }
+  };
 
-  // }
-  // const sortedFakeData = sortDirection ?
+  const onExpandRow = (index: number) => {
+    const nextExpandedIndex = expandedRowIndex === index ? null : index;
+    setExpandedRowIndex(nextExpandedIndex);
+  };
 
   return (
     <Table>
       <TableHead>
         <TableRow>
+          <TableHeadCell>
+            {fakeData.length} / {fakeData.length}
+          </TableHeadCell>
           <TableHeadCell>Words</TableHeadCell>
           <TableHeadCell
             sortDirection={sortDirection ?? 'desc'}
@@ -62,22 +78,47 @@ export const TableStory = () => {
           >
             Numerical
           </TableHeadCell>
+          <TableHeadCell>Empty</TableHeadCell>
         </TableRow>
       </TableHead>
       <TableBody>
         {sortedFakeData.map((rowData, index) => (
-          <TableRow key={index}>
-            <TableCell>
-              <div className={styles.widthLimitedContainer}>
-                {rowData.first}
-              </div>
-            </TableCell>
-            <TableCell>{rowData.second}</TableCell>
-          </TableRow>
+          <>
+            <TableRow key={index}>
+              <TableRowSelectorCell
+                isSelected={selectedRows.has(index)}
+                onChange={() => onSelectedRowChanged(index)}
+                mode="default"
+              />
+              <TableCell>
+                <div className={styles.widthLimitedContainer}>
+                  {rowData.first}
+                </div>
+              </TableCell>
+              <TableCell>{rowData.second}</TableCell>
+              <TableCell>
+                <ExpandCell
+                  isExpanded={index === expandedRowIndex}
+                  onChange={() => onExpandRow(index)}
+                />
+              </TableCell>
+            </TableRow>
+            {index === expandedRowIndex && (
+              <TableRow key={`${index}-expanded`}>
+                <TableCell colSpan={4}>More content for row {index}</TableCell>
+              </TableRow>
+            )}
+          </>
         ))}
       </TableBody>
     </Table>
   );
+};
+
+const ExpandCell = (props: { isExpanded: boolean; onChange: () => void }) => {
+  const { isExpanded, onChange } = props;
+
+  return <ShowHide label="more" isExpanded={isExpanded} onClick={onChange} />;
 };
 
 TableStory.storyName = 'default';

--- a/stories/shared-components/table/fakeData.ts
+++ b/stories/shared-components/table/fakeData.ts
@@ -17,10 +17,16 @@
 export const fakeData = [
   {
     first: 'Hello',
-    second: 6
+    second: 6,
+    third: '1:19168307-19168349',
+    fourth: 'Forward',
+    fifth: 'CYCB1;5'
   },
   {
     first: 'This cell will contain more words',
-    second: 21
+    second: 21,
+    third: '4:7068331-7068350',
+    fourth: 'Reverse',
+    fifth: 'AT1G52790, AT4G13160, AT4G13170'
   }
 ];

--- a/stories/shared-components/table/fakeData.ts
+++ b/stories/shared-components/table/fakeData.ts
@@ -1,0 +1,26 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const fakeData = [
+  {
+    first: 'Hello',
+    second: 6
+  },
+  {
+    first: 'This cell will contain more words',
+    second: 21
+  }
+];


### PR DESCRIPTION
## Description
This PR presents an approach to building a table that is diametrically opposite to the one used in https://github.com/Ensembl/ensembl-client/pull/776 In this PR, the table, as well as its parts, is a dumb presentational component that does not have any logic of its own, and Instead delegates all logic to its parent component.

A clear disadvantage of this approach is that the logic present in the parent would have to be replicated across different instances of the table.

The advantages, on the other hand, are:
- flexibility
- keeping table state in one place (i.e. in the parent)

**Questions:**
- is anything else required for the validation of the approach to the building of the table?
- which approach do we prefer?
- is there any benefit in having both tables?
- if https://github.com/Ensembl/ensembl-client/pull/776 is preferred, can the smart table in https://github.com/Ensembl/ensembl-client/pull/776 be built utilising the components of the dumb table presented here?