### PR TITLE
Fix GB refocus issue

### DIFF
--- a/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/BookmarksModal.test.tsx
+++ b/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/BookmarksModal.test.tsx
@@ -28,11 +28,14 @@ import merge from 'lodash/fp/merge';
 import { changeDrawerViewForGenome } from 'src/content/app/genome-browser/state/drawer/drawerSlice';
 
 import { createMockBrowserState } from 'tests/fixtures/browser';
+import MockGenomeBrowser from 'tests/mocks/mockGenomeBrowser';
 
 import { BookmarksModal } from './BookmarksModal';
 
 import { PreviouslyViewedObject } from 'src/content/app/genome-browser/state/browser-bookmarks/browserBookmarksSlice';
 import { BrowserSidebarModalView } from 'src/content/app/genome-browser/state/browser-sidebar-modal/browserSidebarModalSlice';
+
+const mockGenomeBrowser = jest.fn(() => new MockGenomeBrowser() as any);
 
 const mockGenomeId = 'grch38';
 
@@ -49,6 +52,11 @@ jest.mock(
   () => () => ({
     genomeIdForUrl: mockGenomeId
   })
+);
+
+jest.mock(
+  'src/content/app/genome-browser/hooks/useGenomeBrowser',
+  () => () => mockGenomeBrowser
 );
 
 const createRandomPreviouslyViewedObject = (): PreviouslyViewedObject => ({

--- a/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/BookmarksModal.tsx
+++ b/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/BookmarksModal.tsx
@@ -20,6 +20,7 @@ import { Link } from 'react-router-dom';
 
 import { useAppSelector, useAppDispatch } from 'src/store';
 import useGenomeBrowserIds from 'src/content/app/genome-browser/hooks/useGenomeBrowserIds';
+import useGenomeBrowser from 'src/content/app/genome-browser/hooks/useGenomeBrowser';
 
 import analyticsTracking from 'src/services/analytics-service';
 import * as urlFor from 'src/shared/helpers/urlHelper';
@@ -33,7 +34,8 @@ import TextLine from 'src/shared/components/text-line/TextLine';
 import styles from './BookmarksModal.scss';
 
 export const PreviouslyViewedLinks = () => {
-  const { genomeIdForUrl } = useGenomeBrowserIds();
+  const { genomeIdForUrl, focusObjectId } = useGenomeBrowserIds();
+  const { changeFocusObject } = useGenomeBrowser();
   const previouslyViewedObjects = useAppSelector(
     getPreviouslyViewedObjects
   ).slice(0, 20);
@@ -55,16 +57,22 @@ export const PreviouslyViewedLinks = () => {
           focus: buildFocusIdForUrl(previouslyViewedObject.object_id)
         });
 
+        const isFocusCurrentlyActive =
+          focusObjectId === previouslyViewedObject.object_id;
+
+        const onClick = isFocusCurrentlyActive
+          ? (event: React.MouseEvent<HTMLAnchorElement>) => {
+              changeFocusObject(focusObjectId);
+              event.preventDefault();
+            }
+          : () => onLinkClick(previouslyViewedObject.type, index);
+
         return (
           <div
             key={previouslyViewedObject.object_id}
             className={styles.linkHolder}
           >
-            <Link
-              replace
-              to={path}
-              onClick={() => onLinkClick(previouslyViewedObject.type, index)}
-            >
+            <Link replace to={path} onClick={onClick}>
               <TextLine
                 text={previouslyViewedObject.label}
                 className={styles.label}

--- a/src/content/app/genome-browser/components/zmenu/ZmenuAppLinks.tsx
+++ b/src/content/app/genome-browser/components/zmenu/ZmenuAppLinks.tsx
@@ -26,6 +26,7 @@ import { ToggleButton as ToolboxToggleButton } from 'src/shared/components/toolb
 import ViewInApp, { UrlObj } from 'src/shared/components/view-in-app/ViewInApp';
 
 import styles from './Zmenu.scss';
+import { useNavigate } from 'react-router';
 
 type Props = {
   featureId: string;
@@ -37,6 +38,7 @@ const ZmenuAppLinks = (props: Props) => {
   const { genomeIdForUrl, focusObjectIdForUrl, focusObjectId } =
     useGenomeBrowserIds();
   const { changeFocusObject } = useGenomeBrowser();
+  const navigate = useNavigate();
 
   const { type: featureType } = parseFocusIdFromUrl(featureId);
 
@@ -62,6 +64,13 @@ const ZmenuAppLinks = (props: Props) => {
 
     if (isFocusCurrentlyActive) {
       changeFocusObject(focusObjectId);
+    } else {
+      navigate(
+        urlFor.browser({
+          genomeId: genomeIdForUrl,
+          focus: featureId
+        })
+      );
     }
   };
 

--- a/src/content/app/genome-browser/components/zmenu/ZmenuAppLinks.tsx
+++ b/src/content/app/genome-browser/components/zmenu/ZmenuAppLinks.tsx
@@ -20,12 +20,12 @@ import * as urlFor from 'src/shared/helpers/urlHelper';
 import { parseFocusIdFromUrl } from 'src/shared/helpers/focusObjectHelpers';
 
 import useGenomeBrowserIds from 'src/content/app/genome-browser/hooks/useGenomeBrowserIds';
+import useGenomeBrowser from '../../hooks/useGenomeBrowser';
 
 import { ToggleButton as ToolboxToggleButton } from 'src/shared/components/toolbox';
 import ViewInApp, { UrlObj } from 'src/shared/components/view-in-app/ViewInApp';
 
 import styles from './Zmenu.scss';
-import useGenomeBrowser from '../../hooks/useGenomeBrowser';
 
 type Props = {
   featureId: string;

--- a/src/content/app/genome-browser/components/zmenu/ZmenuAppLinks.tsx
+++ b/src/content/app/genome-browser/components/zmenu/ZmenuAppLinks.tsx
@@ -25,6 +25,7 @@ import { ToggleButton as ToolboxToggleButton } from 'src/shared/components/toolb
 import ViewInApp, { UrlObj } from 'src/shared/components/view-in-app/ViewInApp';
 
 import styles from './Zmenu.scss';
+import useGenomeBrowser from '../../hooks/useGenomeBrowser';
 
 type Props = {
   featureId: string;
@@ -33,7 +34,8 @@ type Props = {
 
 const ZmenuAppLinks = (props: Props) => {
   const { featureId } = props; // feature id here is passed in the format suitable for urls
-  const { genomeIdForUrl } = useGenomeBrowserIds();
+  const { genomeIdForUrl, focusObjectId } = useGenomeBrowserIds();
+  const { changeFocusObject } = useGenomeBrowser();
 
   const { type: featureType } = parseFocusIdFromUrl(featureId);
 
@@ -56,13 +58,30 @@ const ZmenuAppLinks = (props: Props) => {
       })
     }
   };
+
+  const onGenomeBrowserAppClick = (
+    event?: React.MouseEvent<HTMLDivElement>
+  ) => {
+    const isFocusCurrentlyActive = featureId === focusObjectId;
+
+    if (isFocusCurrentlyActive && event) {
+      changeFocusObject(featureId);
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+
   return (
     <div className={styles.zmenuAppLinks}>
       <ToolboxToggleButton
         className={styles.zmenuToggleFooter}
         label="Download"
       />
-      <ViewInApp links={links} onAnyAppClick={props.destroyZmenu} />
+      <ViewInApp
+        links={links}
+        onAnyAppClick={props.destroyZmenu}
+        onAppClick={{ genomeBrowser: onGenomeBrowserAppClick }}
+      />
     </div>
   );
 };

--- a/src/content/app/genome-browser/components/zmenu/ZmenuAppLinks.tsx
+++ b/src/content/app/genome-browser/components/zmenu/ZmenuAppLinks.tsx
@@ -34,7 +34,8 @@ type Props = {
 
 const ZmenuAppLinks = (props: Props) => {
   const { featureId } = props; // feature id here is passed in the format suitable for urls
-  const { genomeIdForUrl, focusObjectId } = useGenomeBrowserIds();
+  const { genomeIdForUrl, focusObjectIdForUrl, focusObjectId } =
+    useGenomeBrowserIds();
   const { changeFocusObject } = useGenomeBrowser();
 
   const { type: featureType } = parseFocusIdFromUrl(featureId);
@@ -44,13 +45,6 @@ const ZmenuAppLinks = (props: Props) => {
   }
 
   const links: UrlObj = {
-    genomeBrowser: {
-      url: urlFor.browser({
-        genomeId: genomeIdForUrl,
-        focus: featureId
-      }),
-      replaceState: true
-    },
     entityViewer: {
       url: urlFor.entityViewer({
         genomeId: genomeIdForUrl,
@@ -59,15 +53,15 @@ const ZmenuAppLinks = (props: Props) => {
     }
   };
 
-  const onGenomeBrowserAppClick = (
-    event?: React.MouseEvent<HTMLDivElement>
-  ) => {
-    const isFocusCurrentlyActive = featureId === focusObjectId;
+  const onGenomeBrowserAppClick = () => {
+    if (!(focusObjectIdForUrl && focusObjectId)) {
+      return;
+    }
 
-    if (isFocusCurrentlyActive && event) {
-      changeFocusObject(featureId);
-      event.preventDefault();
-      event.stopPropagation();
+    const isFocusCurrentlyActive = featureId === focusObjectIdForUrl;
+
+    if (isFocusCurrentlyActive) {
+      changeFocusObject(focusObjectId);
     }
   };
 

--- a/src/header/launchbar/Launchbar.scss
+++ b/src/header/launchbar/Launchbar.scss
@@ -28,6 +28,17 @@
   flex: 0 0 auto;
 }
 
+.launchbarButton {
+  display: inline-block;
+  height: 32px;
+  width: 32px;
+
+  button {
+    width: 32px;
+    height: 32px;
+  }
+}
+
 .category {
   display: flex;
   column-gap: 20px;
@@ -45,17 +56,6 @@
 
   &:not(:last-child) {
     border-right: 1px solid $grey;
-  }
-}
-
-.launchbarButton {
-  display: inline-block;
-  height: 32px;
-  width: 32px;
-
-  button {
-    width: 32px;
-    height: 32px;
   }
 }
 
@@ -81,6 +81,7 @@
   svg {
     fill: $white;
   }
+
   button {
     cursor: default;
   }

--- a/src/shared/components/image-button/ImageButton.tsx
+++ b/src/shared/components/image-button/ImageButton.tsx
@@ -38,14 +38,14 @@ export type Props = {
   image: FunctionComponent | string;
   className?: string;
   statusClasses?: { [key in ImageButtonStatus]?: string };
-  onClick?: () => void;
+  onClick?: (event?: React.MouseEvent<HTMLDivElement>) => void;
 };
 
 export const ImageButton = (props: Props) => {
   const [hoverRef, isHovered] = useHover<HTMLDivElement>();
 
-  const handleClick = () => {
-    props.onClick && props.onClick();
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    props.onClick && props.onClick(event);
   };
 
   const buttonProps =

--- a/src/shared/components/view-in-app/ViewInApp.tsx
+++ b/src/shared/components/view-in-app/ViewInApp.tsx
@@ -46,7 +46,9 @@ export type LinkObj = { url: string; replaceState?: boolean };
 
 export type UrlObj = Partial<Record<AppName, LinkObj>>;
 
-type AppClickHandlers = Partial<Record<AppName, () => void>>;
+type AppClickHandlers = Partial<
+  Record<AppName, (event?: React.MouseEvent<HTMLDivElement>) => void>
+>;
 
 export type ViewInAppProps = {
   links: UrlObj;
@@ -79,7 +81,7 @@ export const ViewInApp = (props: ViewInAppProps) => {
       {enabledApps.map((appName, index) => {
         const currentLinkObj = props.links[appName] as LinkObj;
 
-        const handleClick = () => {
+        const handleClick = (event?: React.MouseEvent<HTMLDivElement>) => {
           const onAppClickFn = onAppClick?.[appName];
 
           if (onAnyAppClickFn) {
@@ -87,7 +89,7 @@ export const ViewInApp = (props: ViewInAppProps) => {
           }
 
           if (onAppClickFn) {
-            onAppClickFn();
+            onAppClickFn(event);
           }
           if (currentLinkObj) {
             navigate(currentLinkObj.url, {
@@ -106,7 +108,9 @@ export const ViewInApp = (props: ViewInAppProps) => {
               status={Status.DEFAULT}
               description={Apps[appName].tooltip}
               image={Apps[appName].icon}
-              onClick={handleClick}
+              onClick={(event?: React.MouseEvent<HTMLDivElement>) =>
+                handleClick(event)
+              }
             />
           </div>
         );

--- a/src/shared/components/view-in-app/ViewInApp.tsx
+++ b/src/shared/components/view-in-app/ViewInApp.tsx
@@ -46,9 +46,7 @@ export type LinkObj = { url: string; replaceState?: boolean };
 
 export type UrlObj = Partial<Record<AppName, LinkObj>>;
 
-type AppClickHandlers = Partial<
-  Record<AppName, (event?: React.MouseEvent<HTMLDivElement>) => void>
->;
+type AppClickHandlers = Partial<Record<AppName, () => void>>;
 
 export type ViewInAppProps = {
   links: UrlObj;
@@ -81,7 +79,7 @@ export const ViewInApp = (props: ViewInAppProps) => {
       {enabledApps.map((appName, index) => {
         const currentLinkObj = props.links[appName] as LinkObj;
 
-        const handleClick = (event?: React.MouseEvent<HTMLDivElement>) => {
+        const handleClick = () => {
           const onAppClickFn = onAppClick?.[appName];
 
           if (onAnyAppClickFn) {
@@ -89,7 +87,7 @@ export const ViewInApp = (props: ViewInAppProps) => {
           }
 
           if (onAppClickFn) {
-            onAppClickFn(event);
+            onAppClickFn();
           }
           if (currentLinkObj) {
             navigate(currentLinkObj.url, {
@@ -108,9 +106,7 @@ export const ViewInApp = (props: ViewInAppProps) => {
               status={Status.DEFAULT}
               description={Apps[appName].tooltip}
               image={Apps[appName].icon}
-              onClick={(event?: React.MouseEvent<HTMLDivElement>) =>
-                handleClick(event)
-              }
+              onClick={handleClick}
             />
           </div>
         );
@@ -118,34 +114,5 @@ export const ViewInApp = (props: ViewInAppProps) => {
     </div>
   );
 };
-
-// const createClickHandler = (params: ViewInAppProps & { appName: AppName }) => {
-//   const { onAppClick, onAnyAppClick: onAnyAppClickFn, appName } = params;
-//   const onAppClickFn = onAppClick?.[appName];
-//   const clickHandlers: Array<(params: { appName: AppName, event: React.MouseEvent<HTMLDivElement> }) => void> = [];
-
-//   if (onAnyAppClickFn) {
-//     clickHandlers.push(() => onAnyAppClickFn({ appName }));
-//   }
-
-//   if (onAppClickFn) {
-//     clickHandlers.push(() => onAppClickFn({ event }));
-//   }
-
-//   return clickHandlers.length
-//     ? (event?: React.MouseEvent<HTMLDivElement>) => clickHandlers.forEach((fn) => fn(event))
-//     : undefined;
-// };
-
-// type AppButtonProps = {
-//   appId: AppName;
-//   url: string;
-//   replaceState?: boolean;
-//   onClick?: (event?: React.MouseEvent<HTMLDivElement>) => void;
-// };
-
-// export const AppButton = (props: ViewInAppProps & { appName: AppName }) => {
-
-// };
 
 export default ViewInApp;

--- a/src/shared/components/view-in-app/ViewInApp.tsx
+++ b/src/shared/components/view-in-app/ViewInApp.tsx
@@ -46,7 +46,9 @@ export type LinkObj = { url: string; replaceState?: boolean };
 
 export type UrlObj = Partial<Record<AppName, LinkObj>>;
 
-type AppClickHandlers = Partial<Record<AppName, () => void>>;
+type AppClickHandlers = Partial<
+  Record<AppName, (event?: React.MouseEvent<HTMLDivElement>) => void>
+>;
 
 export type ViewInAppProps = {
   links: UrlObj;
@@ -58,80 +60,86 @@ export type ViewInAppProps = {
 };
 
 export const ViewInApp = (props: ViewInAppProps) => {
+  const { onAppClick, onAnyAppClick: onAnyAppClickFn } = props;
+
+  const labelClass = classNames(styles.label, props.classNames?.label);
+
+  const navigate = useNavigate();
   if (Object.keys(props.links).length === 0) {
     return null;
   }
-
-  const labelClass = classNames(styles.label, props.classNames?.label);
 
   return (
     <div className={styles.viewInAppLinkButtons}>
       <span className={labelClass}>View in</span>
 
-      {(Object.keys(props.links) as AppName[]).map((appId) => {
-        const currentLinkObj = props.links[appId] as LinkObj;
+      {(Object.keys(props.links) as AppName[]).map((appName, index) => {
+        const currentLinkObj = props.links[appName] as LinkObj;
+
+        const handleClick = (event?: React.MouseEvent<HTMLDivElement>) => {
+          const onAppClickFn = onAppClick?.[appName];
+
+          if (onAnyAppClickFn) {
+            onAnyAppClickFn(appName);
+          }
+
+          if (onAppClickFn) {
+            onAppClickFn(event);
+          }
+
+          navigate(currentLinkObj.url, {
+            replace: currentLinkObj.replaceState
+          });
+        };
 
         return (
-          <AppButton
-            key={appId}
-            appId={appId}
-            url={currentLinkObj.url}
-            replaceState={currentLinkObj.replaceState}
-            onClick={createClickHandler({ ...props, appName: appId })}
-          />
+          <div
+            className={styles.viewInAppLink}
+            data-test-id={appName}
+            key={index}
+          >
+            <ImageButton
+              status={Status.DEFAULT}
+              description={Apps[appName].tooltip}
+              image={Apps[appName].icon}
+              onClick={(event?: React.MouseEvent<HTMLDivElement>) =>
+                handleClick(event)
+              }
+            />
+          </div>
         );
       })}
     </div>
   );
 };
 
-const createClickHandler = (params: ViewInAppProps & { appName: AppName }) => {
-  const { onAppClick, onAnyAppClick: onAnyAppClickFn, appName } = params;
-  const onAppClickFn = onAppClick?.[appName];
-  const clickHandlers: Array<(appName?: AppName) => void> = [];
+// const createClickHandler = (params: ViewInAppProps & { appName: AppName }) => {
+//   const { onAppClick, onAnyAppClick: onAnyAppClickFn, appName } = params;
+//   const onAppClickFn = onAppClick?.[appName];
+//   const clickHandlers: Array<(params: { appName: AppName, event: React.MouseEvent<HTMLDivElement> }) => void> = [];
 
-  if (onAnyAppClickFn) {
-    clickHandlers.push(() => onAnyAppClickFn(params.appName));
-  }
+//   if (onAnyAppClickFn) {
+//     clickHandlers.push(() => onAnyAppClickFn({ appName }));
+//   }
 
-  if (onAppClickFn) {
-    clickHandlers.push(() => onAppClickFn());
-  }
+//   if (onAppClickFn) {
+//     clickHandlers.push(() => onAppClickFn({ event }));
+//   }
 
-  return clickHandlers.length
-    ? () => clickHandlers.forEach((fn) => fn())
-    : undefined;
-};
+//   return clickHandlers.length
+//     ? (event?: React.MouseEvent<HTMLDivElement>) => clickHandlers.forEach((fn) => fn(event))
+//     : undefined;
+// };
 
-type AppButtonProps = {
-  appId: AppName;
-  url: string;
-  replaceState?: boolean;
-  onClick?: () => void;
-};
+// type AppButtonProps = {
+//   appId: AppName;
+//   url: string;
+//   replaceState?: boolean;
+//   onClick?: (event?: React.MouseEvent<HTMLDivElement>) => void;
+// };
 
-export const AppButton = (props: AppButtonProps) => {
-  const navigate = useNavigate();
+// export const AppButton = (props: ViewInAppProps & { appName: AppName }) => {
 
-  const handleClick = () => {
-    if (props.replaceState) {
-      navigate(props.url, { replace: true });
-    } else {
-      navigate(props.url);
-    }
-    props.onClick?.();
-  };
-
-  return (
-    <div className={styles.viewInAppLink} data-test-id={props.appId}>
-      <ImageButton
-        status={Status.DEFAULT}
-        description={Apps[props.appId].tooltip}
-        image={Apps[props.appId].icon}
-        onClick={handleClick}
-      />
-    </div>
-  );
-};
+// };
 
 export default ViewInApp;

--- a/src/shared/components/view-in-app/ViewInApp.tsx
+++ b/src/shared/components/view-in-app/ViewInApp.tsx
@@ -69,11 +69,16 @@ export const ViewInApp = (props: ViewInAppProps) => {
     return null;
   }
 
+  const enabledApps = Object.keys({
+    ...(props.onAppClick || {}),
+    ...props.links
+  }) as AppName[];
+
   return (
     <div className={styles.viewInAppLinkButtons}>
       <span className={labelClass}>View in</span>
 
-      {(Object.keys(props.links) as AppName[]).map((appName, index) => {
+      {enabledApps.map((appName, index) => {
         const currentLinkObj = props.links[appName] as LinkObj;
 
         const handleClick = (event?: React.MouseEvent<HTMLDivElement>) => {
@@ -86,10 +91,11 @@ export const ViewInApp = (props: ViewInAppProps) => {
           if (onAppClickFn) {
             onAppClickFn(event);
           }
-
-          navigate(currentLinkObj.url, {
-            replace: currentLinkObj.replaceState
-          });
+          if (currentLinkObj) {
+            navigate(currentLinkObj.url, {
+              replace: currentLinkObj.replaceState
+            });
+          }
         };
 
         return (


### PR DESCRIPTION
## Description
- Fixes the issue that breaks the nav bar when the bookmark link is clicked twice.

Also fixes the following `stylelint` warning that appears on save:
```
WARNING in [stylelint] 
src/header/launchbar/Launchbar.scss
 51:1  ⚠  Expected selector ".launchbarButton" to come      no-descending-specificity
          before selector ".category:first-child                                     
          .launchbarButton"                                                          
 51:1  ⚠  Expected selector ".launchbarButton" to come      no-descending-specificity
          before selector ".category:first-child                                     
          .launchbarButton:first-child"

```

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1681

## Deployment URL(s)
http://fix-gb-gene-refocus.review.ensembl.org


## Views affected
Genome browser -> bookmarks