### PR TITLE
Fix genome browser canvas overflow

### DIFF
--- a/src/content/app/genome-browser/components/browser-image/BrowserImage.scss
+++ b/src/content/app/genome-browser/components/browser-image/BrowserImage.scss
@@ -1,6 +1,6 @@
 @import 'src/styles/common';
 
-.browserImagePlus {
+.browserImageWrapper {
   height: 100%;
   position: relative;
 }
@@ -8,7 +8,6 @@
 .browserStage {
   height: 100%;
   width: 100%;
-  overflow: hidden;
 }
 
 .loaderWrapper {

--- a/src/content/app/genome-browser/components/browser-image/BrowserImage.tsx
+++ b/src/content/app/genome-browser/components/browser-image/BrowserImage.tsx
@@ -66,7 +66,7 @@ export const BrowserImage = () => {
   });
 
   const browserImageContents = (
-    <div className={styles.browserImagePlus}>
+    <div className={styles.browserImageWrapper}>
       <div
         id={BROWSER_CONTAINER_ID}
         className={browserContainerClassNames}


### PR DESCRIPTION
## Description
The genome browser canvas, temporarily, is allowed to be taller than the container element
that we are passing to the genome browser to render into. This leads to the bottom of the canvas
being cropped out. The decision was to remove the "overflow: hidden" CSS rule
from that container element.

As a result of this PR, it should be possible to view all MAPK10 transcripts in the genome browser.

See [relevant discussion](https://genomes-ebi.slack.com/archives/C01QD9623KK/p1660140599275119) on Slack

## Deployment URL(s)
http://fix-canvas-overflow.review.ensembl.org