### PR TITLE
Update genome browser to version 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2350,7 +2350,7 @@
     "node_modules/@ensembl/ensembl-genome-browser": {
       "version": "0.5.0",
       "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.0.tgz",
-      "integrity": "sha1-ms/4KYhrChCBn6qtuIhJI+HluKY="
+      "integrity": "sha1-+ZvY95islnmqyC0LjahiW4KDwh8="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.0",
@@ -42314,7 +42314,7 @@
     "@ensembl/ensembl-genome-browser": {
       "version": "0.5.0",
       "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.0.tgz",
-      "integrity": "sha1-ms/4KYhrChCBn6qtuIhJI+HluKY="
+      "integrity": "sha1-+ZvY95islnmqyC0LjahiW4KDwh8="
     },
     "@eslint/eslintrc": {
       "version": "1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ensembl/ensembl-genome-browser": "0.4.4",
+        "@ensembl/ensembl-genome-browser": "0.5.0",
         "@loadable/component": "5.15.2",
         "@loadable/server": "5.15.2",
         "@react-spring/web": "9.4.5-beta.1",
@@ -2348,9 +2348,9 @@
       }
     },
     "node_modules/@ensembl/ensembl-genome-browser": {
-      "version": "0.4.4",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.4.4.tgz",
-      "integrity": "sha1-i1AaV/KRbkbZMCauy6058v2n4nY="
+      "version": "0.5.0",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.0.tgz",
+      "integrity": "sha1-ms/4KYhrChCBn6qtuIhJI+HluKY="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.0",
@@ -42312,9 +42312,9 @@
       "dev": true
     },
     "@ensembl/ensembl-genome-browser": {
-      "version": "0.4.4",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.4.4.tgz",
-      "integrity": "sha1-i1AaV/KRbkbZMCauy6058v2n4nY="
+      "version": "0.5.0",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.0.tgz",
+      "integrity": "sha1-ms/4KYhrChCBn6qtuIhJI+HluKY="
     },
     "@eslint/eslintrc": {
       "version": "1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ensembl/ensembl-genome-browser": "0.4.3",
+        "@ensembl/ensembl-genome-browser": "0.4.4",
         "@loadable/component": "5.15.2",
         "@loadable/server": "5.15.2",
         "@react-spring/web": "9.4.5-beta.1",
@@ -2348,9 +2348,9 @@
       }
     },
     "node_modules/@ensembl/ensembl-genome-browser": {
-      "version": "0.4.3",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.4.3.tgz",
-      "integrity": "sha1-ipYFhuwR6NTwO934nkRH0e87CbI="
+      "version": "0.4.4",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.4.4.tgz",
+      "integrity": "sha1-i1AaV/KRbkbZMCauy6058v2n4nY="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.0",
@@ -42312,9 +42312,9 @@
       "dev": true
     },
     "@ensembl/ensembl-genome-browser": {
-      "version": "0.4.3",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.4.3.tgz",
-      "integrity": "sha1-ipYFhuwR6NTwO934nkRH0e87CbI="
+      "version": "0.4.4",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.4.4.tgz",
+      "integrity": "sha1-i1AaV/KRbkbZMCauy6058v2n4nY="
     },
     "@eslint/eslintrc": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "coverage": "jest --coverage"
   },
   "dependencies": {
-    "@ensembl/ensembl-genome-browser": "0.4.4",
+    "@ensembl/ensembl-genome-browser": "0.5.0",
     "@loadable/component": "5.15.2",
     "@loadable/server": "5.15.2",
     "@react-spring/web": "9.4.5-beta.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "coverage": "jest --coverage"
   },
   "dependencies": {
-    "@ensembl/ensembl-genome-browser": "0.4.3",
+    "@ensembl/ensembl-genome-browser": "0.4.4",
     "@loadable/component": "5.15.2",
     "@loadable/server": "5.15.2",
     "@react-spring/web": "9.4.5-beta.1",


### PR DESCRIPTION
## Description
Update genome browser to version ~0.4.4~ 0.5.0.

See the [changelog](https://github.com/Ensembl/ensembl-dauphin-style-compiler/blob/staging/CHANGELOG.md#044) for the list of features.

## Deployment URL(s)
http://update-genome-browser-044.review.ensembl.org