### PR TITLE
Prevent ShowHide line wrapping

### DIFF
--- a/src/shared/components/show-hide/ShowHide.scss
+++ b/src/shared/components/show-hide/ShowHide.scss
@@ -3,11 +3,11 @@
 .showHide {
   cursor: pointer;
   display: inline-block;
+  white-space: nowrap;
 }
 
 .label {
   color: var(--show-hide-label-color, $blue);
-  white-space: nowrap;
 }
 
 .chevron {


### PR DESCRIPTION
## Description
**Before,** the chevron could get detached from the label of a ShowHide:

https://user-images.githubusercontent.com/6834224/184887136-7fe94294-ff9c-4722-a3d0-2dfa99f5343c.mov

After, the chevron and the label always stay on the same line:

https://user-images.githubusercontent.com/6834224/184887503-52925571-10ee-4bcf-bbdf-7a7fe47050c7.mov

## Deployment URL(s)
http://prevent-showhide-wrapping.review.ensembl.org