### PR TITLE
Fix undefined transcript in TrackPanelGene

### DIFF
--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelGene.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelGene.tsx
@@ -75,7 +75,9 @@ const TrackPanelGene = (props: TrackPanelGeneProps) => {
 
   const sortedTranscripts = defaultSort(gene.transcripts);
   const visibleSortedTranscripts = isCollapsed
-    ? [sortedTranscripts[0]]
+    ? sortedTranscripts.length
+      ? [sortedTranscripts[0]]
+      : []
     : sortedTranscripts;
 
   const geneVisibilityStatus = !visibleTranscriptIds?.length


### PR DESCRIPTION
## Description
### Bug
Genome browser page crashes with the following error in Sentry:

![image](https://user-images.githubusercontent.com/6834224/185928220-fb1b673d-2d19-4298-bf26-88b995b62d20.png)

### Cause
The `sortedTranscripts` array in TrackPanelGene may be empty;
in which case accessing its first element will return `undefined`;
and typescript won’t alert us of this possibility.

I couldn't capture specific steps that will reliably result in an error. It occasionally occurs when switching between the species on the genome browser page. I've verified locally that the error is preceded by the appearance of the `sortedTranscripts` array that consists of the single `undefined` value:

![image](https://user-images.githubusercontent.com/6834224/185928595-c64d926b-1d99-4f1d-a5f1-b8291cba3ec6.png)

## Deployment URL(s)
http://fix-undefined-transcript.review.ensembl.org