### PR TITLE
Ignore outdated genome browser messages for location change

### DIFF
--- a/src/content/app/genome-browser/hooks/useGenomeBrowserPosition.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowserPosition.ts
@@ -99,7 +99,13 @@ const useGenomeBrowserPosition = () => {
     const { activeGenomeId, genomeIdForUrl, focusObjectIdForUrl } =
       idRef.current;
     const { stick, start, end } = action.payload;
-    const chromosome = stick.split(':')[1];
+    const [genomeId, chromosome] = stick.split(':');
+
+    if (genomeId !== activeGenomeId) {
+      // ignore the message, because it must be a delayed message for the previous species
+      // when the user has already switched to another one
+      return;
+    }
 
     if (action.type === IncomingActionType.CURRENT_POSITION) {
       dispatch(updateActualChrLocation([chromosome, start, end]));


### PR DESCRIPTION
## Description
When quickly switching between species, it is possible to pollute the url of one genome with the genomic location from another genome.

See example in the video below (observe the changes in the url):

https://user-images.githubusercontent.com/6834224/185955524-8780eb45-cfe4-4f03-ab0c-8c465453cfb5.mov


### Likely cause
Although I have not confirmed it positively, the most likely explanation is that sometimes, when the genome browser is too slow to update the location, it sends a message about the target location for a genome after the user has already switched to a different species. We did not have any safeguards in our code to prevent that.


### Solution
When receiving a message from the genome browser about updated location, check that it refers to the same genome id before updating it in browser chrome to avoid invalid combinations of genome id for one species and chromosome location from another species.

## Deployment URL(s)
http://ignore-old-gb-loc-messsages.review.ensembl.org