### PR TITLE
Add GH action script

### DIFF
--- a/.github/workflows/delete_gitlab_branch.yaml
+++ b/.github/workflows/delete_gitlab_branch.yaml
@@ -1,0 +1,21 @@
+name: Delete removed branch from GitLab mirror
+
+on:
+  delete:
+    branches-igore:
+      - master
+      - dev
+
+jobs:
+  branch-delete:
+    if: github.event.ref_type == 'branch'
+    runs-on: ubuntu-latest
+    env:
+      TOKEN: ${{ secrets.GITLAB_TOKEN }}
+      REPO: ensembl-web%2F${{ github.event.repository.name }}
+      BRANCH: ${{ github.event.ref }}
+    steps:
+      - name: Send branch delete request
+        run: |
+          BRANCH=${BRANCH//\//%2F}
+          curl --request DELETE --header "PRIVATE-TOKEN: $TOKEN" "https://gitlab.ebi.ac.uk/api/v4/projects/$REPO/repository/branches/$BRANCH"

--- a/.github/workflows/delete_gitlab_branch.yaml
+++ b/.github/workflows/delete_gitlab_branch.yaml
@@ -2,7 +2,7 @@ name: Delete removed branch from GitLab mirror
 
 on:
   delete:
-    branches-igore:
+    branches-ignore:
       - master
       - dev
 


### PR DESCRIPTION
## Description
This PR will test a Github action script for syncing deleted branches from `ensembl-client` Github repo to its Gitlab mirror.
After merging this PR to the default branch (`dev`), all feature branches will run the script when the branch is deleted, issuing an API call to `enesmbl-client` GitLab repo for deleting the same branch from the GitLab mirror. This in turn will trigger the `Stop_review` job in GitLab CI/CD config, cleaning up the associated review app resources from kubernetes.


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/EWB-237

## Deployment URL(s)
All review apps
