### PR TITLE
Update tooltip text for the eye next to the gene in right-hand panel

### DIFF
--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelGene.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelGene.tsx
@@ -144,12 +144,21 @@ const TrackPanelGene = (props: TrackPanelGeneProps) => {
     );
   };
 
+  const getVisibilityIconHelpText = (status: Status) => {
+    if (status === Status.SELECTED) {
+      return 'Hide all transcripts';
+    }
+
+    return 'Show all transcripts';
+  };
+
   return (
     <>
       <GroupTrackPanelItemLayout
         isCollapsed={isCollapsed}
         visibilityStatus={geneVisibilityStatus}
         onChangeVisibility={onGeneVisibilityChange}
+        getVisibilityIconHelpText={getVisibilityIconHelpText}
         onShowMore={onShowMore}
         toggleExpand={toggleExpand}
       >

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/track-panel-item-layout/SimpleTrackPanelItemLayout.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/track-panel-item-layout/SimpleTrackPanelItemLayout.tsx
@@ -39,9 +39,15 @@ import styles from './TrackPanelItemLayout.scss';
 export type Props = {
   visibilityStatus?: TrackActivityStatus | Status.PARTIALLY_SELECTED;
   onChangeVisibility?: () => void;
+  getVisibilityIconHelpText?: (
+    status: TrackActivityStatus | Status.PARTIALLY_SELECTED
+  ) => string;
   onShowMore?: () => void;
   isHighlighted?: boolean;
   highlightOnHover?: boolean;
+  visibilityIconHelpText?: {
+    [Status.PARTIALLY_SELECTED]: '';
+  };
   children: ReactNode;
 };
 
@@ -77,7 +83,7 @@ const SimpleTrackPanelItemLayout = (props: Props) => {
         {visibilityStatus && onChangeVisibility && (
           <VisibilityIcon
             status={visibilityStatus}
-            description={getVisibilityIconHelpText(visibilityStatus)}
+            description={props.getVisibilityIconHelpText?.(visibilityStatus)}
             onClick={onChangeVisibility}
           />
         )}
@@ -86,10 +92,12 @@ const SimpleTrackPanelItemLayout = (props: Props) => {
   );
 };
 
-const getVisibilityIconHelpText = (
-  status: NonNullable<Props['visibilityStatus']>
-) => {
-  return status === Status.UNSELECTED ? 'Show this track' : 'Hide this track';
+SimpleTrackPanelItemLayout.defaultProps = {
+  getVisibilityIconHelpText: (
+    status: NonNullable<Props['visibilityStatus']>
+  ) => {
+    return status === Status.UNSELECTED ? 'Show this track' : 'Hide this track';
+  }
 };
 
 export default SimpleTrackPanelItemLayout;


### PR DESCRIPTION
## Description
- optionally passing `getVisibilityIconHelpText` as a prop to customise the help text. 

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1679

## Deployment URL(s)
http://eye-tooltip-update.review.ensembl.org
