### PR TITLE
Update default transcript sorting algorithm

### DIFF
--- a/src/content/app/entity-viewer/state/api/queries/geneExternalReferencesQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/geneExternalReferencesQuery.ts
@@ -58,6 +58,7 @@ export const geneExternalReferencesQuery = gql`
         product_generating_contexts {
           product_type
           product {
+            length
             external_references {
               accession_id
               name
@@ -75,6 +76,9 @@ export const geneExternalReferencesQuery = gql`
             value
           }
           mane {
+            value
+          }
+          biotype {
             value
           }
         }
@@ -97,6 +101,7 @@ export type QueriedTranscript = Pick<FullTranscript, 'stable_id'> &
         'label' | 'value' | 'definition'
       > | null;
       mane: Pick<NonNullable<TranscriptMetadata['mane']>, 'value'> | null;
+      biotype: Pick<TranscriptMetadata['biotype'], 'value'>;
     };
     external_references: QueriedExternalReference[];
     product_generating_contexts: QueriedProductGeneratingContext[];
@@ -111,6 +116,7 @@ type QueriedProductGeneratingContext = Pick<
 
 type QueriedProduct = {
   external_references: QueriedExternalReference[];
+  length: number;
 };
 
 type QueriedGene = Pick<FullGene, 'stable_id' | 'symbol'> & {

--- a/src/content/app/genome-browser/hooks/useGenomeBrowserIds.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowserIds.ts
@@ -52,7 +52,7 @@ const useGenomeBrowserIds = () => {
   const focusObjectIdInUrl = urlSearchParams.get('focus');
 
   const {
-    data: genomeInfo,
+    currentData: genomeInfo,
     isFetching,
     isError,
     error

--- a/src/content/app/genome-browser/state/api/queries/trackPanelGeneQuery.ts
+++ b/src/content/app/genome-browser/state/api/queries/trackPanelGeneQuery.ts
@@ -53,10 +53,14 @@ const trackPanelGeneQuery = (params: Params) => gql`
         }
         product_generating_contexts {
           product_type
+          product {
+            length
+          }
         }
         metadata {
           biotype {
             label
+            value
           }
           canonical {
             value

--- a/src/content/app/genome-browser/state/types/track-panel-gene.ts
+++ b/src/content/app/genome-browser/state/types/track-panel-gene.ts
@@ -18,7 +18,8 @@ import { Pick2, Pick3 } from 'ts-multipick';
 
 import type { FullGene } from 'src/shared/types/thoas/gene';
 import type { FullTranscript } from 'src/shared/types/thoas/transcript';
-import { FullProductGeneratingContext } from 'src/shared/types/thoas/productGeneratingContext';
+import type { FullProductGeneratingContext } from 'src/shared/types/thoas/productGeneratingContext';
+import type { Product } from 'src/shared/types/thoas/product';
 
 type GeneFields = Pick<
   FullGene,
@@ -31,16 +32,18 @@ type GeneSlice = Pick3<FullGene, 'slice', 'region', 'name'> &
 type TranscriptFields = Pick<FullTranscript, 'stable_id'>;
 type TranscriptSlice = Pick3<FullTranscript, 'slice', 'location', 'length'>;
 type TranscriptPGCs = {
-  product_generating_contexts: Pick<
+  product_generating_contexts: (Pick<
     FullProductGeneratingContext,
     'product_type'
-  >[];
+  > & {
+    product: Pick<Product, 'length'> | null;
+  })[];
 };
 type TranscriptMetadata = Pick3<
   FullTranscript,
   'metadata',
   'biotype',
-  'label'
+  'label' | 'value'
 > &
   Pick2<FullTranscript, 'metadata', 'canonical'> & // FIXME: this is not quite right
   Pick2<FullTranscript, 'metadata', 'mane'>; // FIXME: this is not quite right


### PR DESCRIPTION
## Description
Changing the default transcript sorting algorithm such that the resulting order is as follows:

```
1. MANE Select / Ensembl Canonical
2. MANE Plus Clinical
3. Protein coding biotype, ordered by translation length and transcript length
4. NMD biotype, ordered by translation length and transcript length
5. NSD biotype, ordered by translation length and transcript length
6. IG biotypes, ordered by translation length and transcript length
7. Polymorphic pseudogenes, ordered by translation length and transcript length
8. All non-coding biotypes, ordered by transcript length
```


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1695

## Deployment URL(s)
http://update-transcript-sorting-algorithm.review.ensembl.org


## Views affected
- Genome browser track panel
- Entity viewer transcripts list
- Entity viewer external references panel