### PR TITLE
show mane plus clinical

### DIFF
--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelTranscript.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelTranscript.tsx
@@ -67,7 +67,9 @@ const TrackPanelTranscript = (props: Props) => {
     </span>
   ) : (
     <span className={styles.labelTextSecondary}>
-      {transcript.metadata.biotype.label}
+      {getTranscriptSupportLevel(transcript)?.label
+        ? getTranscriptSupportLevel(transcript)?.label
+        : transcript.metadata.biotype.label}
     </span>
   );
 

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelTranscript.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelTranscript.tsx
@@ -67,9 +67,8 @@ const TrackPanelTranscript = (props: Props) => {
     </span>
   ) : (
     <span className={styles.labelTextSecondary}>
-      {getTranscriptSupportLevel(transcript)?.label
-        ? getTranscriptSupportLevel(transcript)?.label
-        : transcript.metadata.biotype.label}
+      {getTranscriptSupportLevel(transcript)?.label ||
+        transcript.metadata.biotype.label}
     </span>
   );
 


### PR DESCRIPTION
## Description
As per jira ticket, show mane plus clinical in track panel for transcript where available


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1711

## Deployment URL(s)
http://trackpanel-maneplus.review.ensembl.org


## Views affected
Track panel in genome browser
Example of gene with transcript mane plus clinical:
http://trackpanel-maneplus.review.ensembl.org/genome-browser/grch38?focus=gene:ENSG00000053747&location=18:23556067-24089607