### PR TITLE
Remove "data for this species" text from Species page

### DIFF
--- a/src/content/app/species/SpeciesPageContent.tsx
+++ b/src/content/app/species/SpeciesPageContent.tsx
@@ -123,7 +123,9 @@ const TopBar = () => {
         <Chevron direction="left" animate={false} />
         <span className={styles.pageTitle}>Find a Species</span>
       </div>
-      <div className={styles.dataForSpecies}>Data for this species</div>
+      <div className={styles.dataForSpecies}>
+        {/* placeholder for future species data */}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Description
As per jira ticket but leaving it comment out since there will be some text to be shown here.


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1689

## Deployment URL(s)
http://specieshomepage-cleanup.review.ensembl.org


## Views affected
species homepage. Any species top bar