### PR TITLE
Remove the focusable attribute from the svg

### DIFF
--- a/src/shared/components/select/SelectArrowhead.tsx
+++ b/src/shared/components/select/SelectArrowhead.tsx
@@ -32,7 +32,7 @@ const SelectArrowhead = (props: Props) => {
     props.direction === Direction.DOWN ? '0,0 8,0 4,8' : '0,8 8,8 4,0';
 
   return (
-    <svg className={styles.selectArrowhead} focusable="false" viewBox="0 0 8 8">
+    <svg className={styles.selectArrowhead} viewBox="0 0 8 8">
       <polygon points={points} />
     </svg>
   );


### PR DESCRIPTION
## Description
Just a one-line change — addressing a lint error about an invalid `focusable` attribute for svg that @imransl noticed in https://github.com/Ensembl/ensembl-client/pull/818.

The linter is correct; the `focusable` attribute has been removed from the current svg spec. The current recommendation is to use tabindex if you want to make sure the svg element isn't focusable; but I played with the Select in the Storybook, and I don't think it is focusable even without these attributes.

## Views affected
Might check the Select element in Storybook if you wish.