### PR TITLE
create delete confirmation component and added to storybook

### DIFF
--- a/src/shared/components/deletion-confirmation/DeletionConfirmation.scss
+++ b/src/shared/components/deletion-confirmation/DeletionConfirmation.scss
@@ -3,15 +3,15 @@
 .deleteConfirmationContainer {
   display: flex;
   align-items: center;
-  justify-content: var(--container-justify-content, flex-end);
+  justify-content: flex-end;
   column-gap: 30px;
 }
 
 .warningText {
-  color: var(--warning-text-color, #{$red});
+  color: var(--deletion-confirmation-warning-color, #{$red});
 }
 
 .cancel {
-  color: var(--clickable-color, #{$blue});
+  color: var(--deletion-confirmation-cancel-color, #{$blue});
   cursor: pointer;
 }

--- a/src/shared/components/deletion-confirmation/DeletionConfirmation.scss
+++ b/src/shared/components/deletion-confirmation/DeletionConfirmation.scss
@@ -3,16 +3,16 @@
 .deleteConfirmationContainer {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  column-gap: 30px;
-  margin: 20px 0px;
+  justify-content: var(--container-justify-content, flex-end);
+  column-gap: var(--container-column-gap, 30px);
+  margin: var(--container-margin, 20px 0px);
 }
 
 .warningText {
-  color: $red;
+  color: var(--warning-text-color, #{$red});
 }
 
 .clickable {
-  color: $blue;
+  color: var(--clickable-color, #{$blue});
   cursor: pointer;
 }

--- a/src/shared/components/deletion-confirmation/DeletionConfirmation.scss
+++ b/src/shared/components/deletion-confirmation/DeletionConfirmation.scss
@@ -4,8 +4,12 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+  column-gap: 30px;
+  row-gap: 10px;
+}
+
+.contentAlignRight {
   justify-content: flex-end;
-  gap: 30px;
 }
 
 .warningText {
@@ -15,7 +19,6 @@
 .controlsContainer {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
   column-gap: 30px;
 }
 

--- a/src/shared/components/deletion-confirmation/DeletionConfirmation.scss
+++ b/src/shared/components/deletion-confirmation/DeletionConfirmation.scss
@@ -1,6 +1,6 @@
 @import 'src/styles/common';
 
-.deleteMessageContainer {
+.deleteConfirmationContainer {
   display: flex;
   align-items: center;
   justify-content: flex-end;
@@ -8,7 +8,7 @@
   margin: 20px 0px;
 }
 
-.deleteMessage {
+.warningText {
   color: $red;
 }
 

--- a/src/shared/components/deletion-confirmation/DeletionConfirmation.scss
+++ b/src/shared/components/deletion-confirmation/DeletionConfirmation.scss
@@ -1,0 +1,18 @@
+@import 'src/styles/common';
+
+.deleteMessageContainer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  column-gap: 30px;
+  margin: 20px 0px;
+}
+
+.deleteMessage {
+  color: $red;
+}
+
+.clickable {
+  color: $blue;
+  cursor: pointer;
+}

--- a/src/shared/components/deletion-confirmation/DeletionConfirmation.scss
+++ b/src/shared/components/deletion-confirmation/DeletionConfirmation.scss
@@ -2,13 +2,21 @@
 
 .deleteConfirmationContainer {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: flex-end;
-  column-gap: 30px;
+  gap: 30px;
 }
 
 .warningText {
   color: var(--deletion-confirmation-warning-color, #{$red});
+}
+
+.controlsContainer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  column-gap: 30px;
 }
 
 .cancel {

--- a/src/shared/components/deletion-confirmation/DeletionConfirmation.scss
+++ b/src/shared/components/deletion-confirmation/DeletionConfirmation.scss
@@ -4,15 +4,14 @@
   display: flex;
   align-items: center;
   justify-content: var(--container-justify-content, flex-end);
-  column-gap: var(--container-column-gap, 30px);
-  margin: var(--container-margin, 20px 0px);
+  column-gap: 30px;
 }
 
 .warningText {
   color: var(--warning-text-color, #{$red});
 }
 
-.clickable {
+.cancel {
   color: var(--clickable-color, #{$blue});
   cursor: pointer;
 }

--- a/src/shared/components/deletion-confirmation/DeletionConfirmation.test.tsx
+++ b/src/shared/components/deletion-confirmation/DeletionConfirmation.test.tsx
@@ -52,7 +52,7 @@ describe('DeletionConfirmation', () => {
     const deleteButton = container.querySelector('button') as HTMLButtonElement;
     expect(deleteButton?.textContent).toBe('Remove');
 
-    const cancelLink = container.querySelector('.clickable') as HTMLElement;
+    const cancelLink = container.querySelector('.cancel') as HTMLElement;
     expect(cancelLink?.textContent).toBe('Do not remove');
 
     const warningText = container.querySelector('.warningText') as HTMLElement;
@@ -65,9 +65,10 @@ describe('DeletionConfirmation', () => {
     );
 
     const deletionConfirmation = container.firstChild as HTMLElement;
-    expect(
-      deletionConfirmation.classList.contains('.componentClass')
-    ).toBeTruthy();
+
+    expect(deletionConfirmation.classList.contains('componentClass')).toBe(
+      true
+    );
   });
 
   it('it calls correct callback on confirmation', async () => {
@@ -81,7 +82,7 @@ describe('DeletionConfirmation', () => {
 
   it('it calls correct callback on cancellation', async () => {
     const { container } = render(<DeletionConfirmation {...props} />);
-    const cancelLabel = container.querySelector('.clickable') as HTMLElement;
+    const cancelLabel = container.querySelector('.cancel') as HTMLElement;
 
     await userEvent.click(cancelLabel);
 

--- a/src/shared/components/deletion-confirmation/DeletionConfirmation.test.tsx
+++ b/src/shared/components/deletion-confirmation/DeletionConfirmation.test.tsx
@@ -43,8 +43,8 @@ describe('DeletionConfirmation', () => {
     const { container } = render(
       <DeletionConfirmation
         {...props}
-        confirmationText="Remove"
-        cancellationText="Do not remove"
+        confirmText="Remove"
+        cancelText="Do not remove"
         warningText="Do you want to remove?"
       />
     );
@@ -64,7 +64,10 @@ describe('DeletionConfirmation', () => {
       <DeletionConfirmation {...props} className="componentClass" />
     );
 
-    expect(container.querySelector('.componentClass')).toBeTruthy();
+    const deletionConfirmation = container.firstChild as HTMLElement;
+    expect(
+      deletionConfirmation.classList.contains('.componentClass')
+    ).toBeTruthy();
   });
 
   it('it calls correct callback on confirmation', async () => {

--- a/src/shared/components/deletion-confirmation/DeletionConfirmation.test.tsx
+++ b/src/shared/components/deletion-confirmation/DeletionConfirmation.test.tsx
@@ -39,13 +39,13 @@ describe('DeletionConfirmation', () => {
     const { container } = render(<DeletionConfirmation {...props} />);
 
     const deleteButton = container.querySelector('button') as HTMLButtonElement;
-    expect(deleteButton?.textContent).toBe('Remove');
+    expect(deleteButton?.textContent).toBe(props.confirmText);
 
     const cancelLink = container.querySelector('.cancel') as HTMLElement;
-    expect(cancelLink?.textContent).toBe('Do not remove');
+    expect(cancelLink?.textContent).toBe(props.cancelText);
 
     const warningText = container.querySelector('.warningText') as HTMLElement;
-    expect(warningText?.textContent).toBe('Do you want to remove?');
+    expect(warningText?.textContent).toBe(props.warningText);
   });
 
   it('applies custom class name passed from the parent', () => {
@@ -62,7 +62,7 @@ describe('DeletionConfirmation', () => {
     );
   });
 
-  it('applies alignment class set from the parent', () => {
+  it('applies alignment set from the parent', () => {
     const { container, rerender } = render(<DeletionConfirmation {...props} />);
 
     const deletionConfirmation = container.firstChild as HTMLElement;

--- a/src/shared/components/deletion-confirmation/DeletionConfirmation.test.tsx
+++ b/src/shared/components/deletion-confirmation/DeletionConfirmation.test.tsx
@@ -62,6 +62,20 @@ describe('DeletionConfirmation', () => {
     );
   });
 
+  it('applies alignment class set from the parent', () => {
+    const { container, rerender } = render(<DeletionConfirmation {...props} />);
+
+    const deletionConfirmation = container.firstChild as HTMLElement;
+    expect(
+      deletionConfirmation.classList.contains('deleteConfirmationContainer')
+    ).toBe(true);
+
+    rerender(<DeletionConfirmation {...props} alignContent="right" />);
+    expect(deletionConfirmation.classList.contains('contentAlignRight')).toBe(
+      true
+    );
+  });
+
   it('it calls correct callback on confirmation', async () => {
     const { container } = render(<DeletionConfirmation {...props} />);
     const button = container.querySelector('button') as HTMLButtonElement;

--- a/src/shared/components/deletion-confirmation/DeletionConfirmation.test.tsx
+++ b/src/shared/components/deletion-confirmation/DeletionConfirmation.test.tsx
@@ -32,16 +32,42 @@ describe('DeletionConfirmation', () => {
     jest.resetAllMocks();
   });
 
-  it('renders a button with correct label', () => {
+  it('renders with default message', () => {
+    const { container } = render(<DeletionConfirmation {...props} />);
+
+    const deleteButton = container.querySelector('button') as HTMLButtonElement;
+    expect(deleteButton?.textContent).toBe('Delete');
+  });
+
+  it('applies custom messages provided by parent', () => {
     const { container } = render(
-      <DeletionConfirmation {...props} confirmButtonLabel="Remove" />
+      <DeletionConfirmation
+        {...props}
+        confirmationText="Remove"
+        cancellationText="Do not remove"
+        warningText="Do you want to remove?"
+      />
     );
 
     const deleteButton = container.querySelector('button') as HTMLButtonElement;
     expect(deleteButton?.textContent).toBe('Remove');
+
+    const cancelLink = container.querySelector('.clickable') as HTMLElement;
+    expect(cancelLink?.textContent).toBe('Do not remove');
+
+    const warningText = container.querySelector('.warningText') as HTMLElement;
+    expect(warningText?.textContent).toBe('Do you want to remove?');
   });
 
-  it('calls confirmDeletion onClick when clicked', async () => {
+  it('applies custom class name passed from the parent', () => {
+    const { container } = render(
+      <DeletionConfirmation {...props} className="componentClass" />
+    );
+
+    expect(container.querySelector('.componentClass')).toBeTruthy();
+  });
+
+  it('it calls correct callback on confirmation', async () => {
     const { container } = render(<DeletionConfirmation {...props} />);
     const button = container.querySelector('button') as HTMLButtonElement;
 
@@ -50,7 +76,7 @@ describe('DeletionConfirmation', () => {
     expect(props.onConfirm).toHaveBeenCalled();
   });
 
-  it('calls cancelDeletion onClick when clicked', async () => {
+  it('it calls correct callback on cancellation', async () => {
     const { container } = render(<DeletionConfirmation {...props} />);
     const cancelLabel = container.querySelector('.clickable') as HTMLElement;
 

--- a/src/shared/components/deletion-confirmation/DeletionConfirmation.test.tsx
+++ b/src/shared/components/deletion-confirmation/DeletionConfirmation.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import DeletionConfirmation, {
+  DeletionConfirmationProps
+} from './DeletionConfirmation';
+
+const props: DeletionConfirmationProps = {
+  onConfirm: jest.fn(),
+  onCancel: jest.fn()
+};
+
+describe('DeletionConfirmation', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('renders a button with correct label', () => {
+    const { container } = render(
+      <DeletionConfirmation {...props} confirmButtonLabel="Remove" />
+    );
+
+    const deleteButton = container.querySelector('button') as HTMLButtonElement;
+    expect(deleteButton?.textContent).toBe('Remove');
+  });
+
+  it('calls confirmDeletion onClick when clicked', async () => {
+    const { container } = render(<DeletionConfirmation {...props} />);
+    const button = container.querySelector('button') as HTMLButtonElement;
+
+    await userEvent.click(button);
+
+    expect(props.onConfirm).toHaveBeenCalled();
+  });
+
+  it('calls cancelDeletion onClick when clicked', async () => {
+    const { container } = render(<DeletionConfirmation {...props} />);
+    const cancelLabel = container.querySelector('.clickable') as HTMLElement;
+
+    await userEvent.click(cancelLabel);
+
+    expect(props.onCancel).toHaveBeenCalled();
+  });
+});

--- a/src/shared/components/deletion-confirmation/DeletionConfirmation.test.tsx
+++ b/src/shared/components/deletion-confirmation/DeletionConfirmation.test.tsx
@@ -23,6 +23,9 @@ import DeletionConfirmation, {
 } from './DeletionConfirmation';
 
 const props: DeletionConfirmationProps = {
+  confirmText: 'Remove',
+  cancelText: 'Do not remove',
+  warningText: 'Do you want to remove?',
   onConfirm: jest.fn(),
   onCancel: jest.fn()
 };
@@ -32,22 +35,8 @@ describe('DeletionConfirmation', () => {
     jest.resetAllMocks();
   });
 
-  it('renders with default message', () => {
-    const { container } = render(<DeletionConfirmation {...props} />);
-
-    const deleteButton = container.querySelector('button') as HTMLButtonElement;
-    expect(deleteButton?.textContent).toBe('Delete');
-  });
-
   it('applies custom messages provided by parent', () => {
-    const { container } = render(
-      <DeletionConfirmation
-        {...props}
-        confirmText="Remove"
-        cancelText="Do not remove"
-        warningText="Do you want to remove?"
-      />
-    );
+    const { container } = render(<DeletionConfirmation {...props} />);
 
     const deleteButton = container.querySelector('button') as HTMLButtonElement;
     expect(deleteButton?.textContent).toBe('Remove');
@@ -60,12 +49,14 @@ describe('DeletionConfirmation', () => {
   });
 
   it('applies custom class name passed from the parent', () => {
-    const { container } = render(
-      <DeletionConfirmation {...props} className="componentClass" />
-    );
+    const { container, rerender } = render(<DeletionConfirmation {...props} />);
 
     const deletionConfirmation = container.firstChild as HTMLElement;
+    expect(
+      deletionConfirmation.classList.contains('deleteConfirmationContainer')
+    ).toBe(true);
 
+    rerender(<DeletionConfirmation {...props} className="componentClass" />);
     expect(deletionConfirmation.classList.contains('componentClass')).toBe(
       true
     );

--- a/src/shared/components/deletion-confirmation/DeletionConfirmation.tsx
+++ b/src/shared/components/deletion-confirmation/DeletionConfirmation.tsx
@@ -25,6 +25,7 @@ export type DeletionConfirmationProps = {
   warningText: string;
   confirmText: string;
   cancelText: string;
+  contentAlignRight?: boolean;
   onConfirm: () => void;
   onCancel: () => void;
   className?: string;
@@ -33,6 +34,7 @@ export type DeletionConfirmationProps = {
 const DeletionConfirmation = (props: DeletionConfirmationProps) => {
   const containerClass = classNames(
     styles.deleteConfirmationContainer,
+    props.contentAlignRight && styles.contentAlignRight,
     props.className
   );
 

--- a/src/shared/components/deletion-confirmation/DeletionConfirmation.tsx
+++ b/src/shared/components/deletion-confirmation/DeletionConfirmation.tsx
@@ -25,7 +25,7 @@ export type DeletionConfirmationProps = {
   warningText: string;
   confirmText: string;
   cancelText: string;
-  contentAlignRight?: boolean;
+  alignContent?: 'left' | 'right';
   onConfirm: () => void;
   onCancel: () => void;
   className?: string;
@@ -34,7 +34,7 @@ export type DeletionConfirmationProps = {
 const DeletionConfirmation = (props: DeletionConfirmationProps) => {
   const containerClass = classNames(
     styles.deleteConfirmationContainer,
-    props.contentAlignRight && styles.contentAlignRight,
+    { [styles.contentAlignRight]: props.alignContent === 'right' },
     props.className
   );
 

--- a/src/shared/components/deletion-confirmation/DeletionConfirmation.tsx
+++ b/src/shared/components/deletion-confirmation/DeletionConfirmation.tsx
@@ -1,0 +1,58 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import classNames from 'classnames';
+
+import { PrimaryButton } from 'src/shared/components/button/Button';
+
+import styles from './DeletionConfirmation.scss';
+
+export type DeletionConfirmationProps = {
+  message?: string;
+  confirmButtonLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  className?: string;
+};
+
+const DeletionConfirmation = (props: DeletionConfirmationProps) => {
+  const containerClass = classNames(
+    styles.deleteMessageContainer,
+    props.className
+  );
+
+  return (
+    <div className={containerClass}>
+      <span className={styles.deleteMessage}>{props.message}</span>
+      <PrimaryButton onClick={props.onConfirm}>
+        {props.confirmButtonLabel}
+      </PrimaryButton>
+      <span className={styles.clickable} onClick={props.onCancel}>
+        {props.cancelLabel}
+      </span>
+    </div>
+  );
+};
+
+DeletionConfirmation.defaultProps = {
+  message: 'Are you sure you want to delete?',
+  confirmButtonLabel: 'Delete',
+  cancelLabel: 'Do not delete'
+};
+
+export default DeletionConfirmation;

--- a/src/shared/components/deletion-confirmation/DeletionConfirmation.tsx
+++ b/src/shared/components/deletion-confirmation/DeletionConfirmation.tsx
@@ -22,9 +22,9 @@ import { PrimaryButton } from 'src/shared/components/button/Button';
 import styles from './DeletionConfirmation.scss';
 
 export type DeletionConfirmationProps = {
-  message?: string;
-  confirmButtonLabel?: string;
-  cancelLabel?: string;
+  warningText?: string;
+  confirmationText?: string;
+  cancellationText?: string;
   onConfirm: () => void;
   onCancel: () => void;
   className?: string;
@@ -32,27 +32,27 @@ export type DeletionConfirmationProps = {
 
 const DeletionConfirmation = (props: DeletionConfirmationProps) => {
   const containerClass = classNames(
-    styles.deleteMessageContainer,
+    styles.deleteConfirmationContainer,
     props.className
   );
 
   return (
     <div className={containerClass}>
-      <span className={styles.deleteMessage}>{props.message}</span>
+      <span className={styles.warningText}>{props.warningText}</span>
       <PrimaryButton onClick={props.onConfirm}>
-        {props.confirmButtonLabel}
+        {props.confirmationText}
       </PrimaryButton>
       <span className={styles.clickable} onClick={props.onCancel}>
-        {props.cancelLabel}
+        {props.cancellationText}
       </span>
     </div>
   );
 };
 
 DeletionConfirmation.defaultProps = {
-  message: 'Are you sure you want to delete?',
-  confirmButtonLabel: 'Delete',
-  cancelLabel: 'Do not delete'
+  warningText: 'Are you sure you want to delete?',
+  confirmationText: 'Delete',
+  cancellationText: 'Do not delete'
 };
 
 export default DeletionConfirmation;

--- a/src/shared/components/deletion-confirmation/DeletionConfirmation.tsx
+++ b/src/shared/components/deletion-confirmation/DeletionConfirmation.tsx
@@ -23,8 +23,8 @@ import styles from './DeletionConfirmation.scss';
 
 export type DeletionConfirmationProps = {
   warningText?: string;
-  confirmationText?: string;
-  cancellationText?: string;
+  confirmText?: string;
+  cancelText?: string;
   onConfirm: () => void;
   onCancel: () => void;
   className?: string;
@@ -40,10 +40,10 @@ const DeletionConfirmation = (props: DeletionConfirmationProps) => {
     <div className={containerClass}>
       <span className={styles.warningText}>{props.warningText}</span>
       <PrimaryButton onClick={props.onConfirm}>
-        {props.confirmationText}
+        {props.confirmText}
       </PrimaryButton>
-      <span className={styles.clickable} onClick={props.onCancel}>
-        {props.cancellationText}
+      <span className={styles.cancel} onClick={props.onCancel}>
+        {props.cancelText}
       </span>
     </div>
   );
@@ -51,8 +51,8 @@ const DeletionConfirmation = (props: DeletionConfirmationProps) => {
 
 DeletionConfirmation.defaultProps = {
   warningText: 'Are you sure you want to delete?',
-  confirmationText: 'Delete',
-  cancellationText: 'Do not delete'
+  confirmText: 'Delete',
+  cancelText: 'Do not delete'
 };
 
 export default DeletionConfirmation;

--- a/src/shared/components/deletion-confirmation/DeletionConfirmation.tsx
+++ b/src/shared/components/deletion-confirmation/DeletionConfirmation.tsx
@@ -22,9 +22,9 @@ import { PrimaryButton } from 'src/shared/components/button/Button';
 import styles from './DeletionConfirmation.scss';
 
 export type DeletionConfirmationProps = {
-  warningText?: string;
-  confirmText?: string;
-  cancelText?: string;
+  warningText: string;
+  confirmText: string;
+  cancelText: string;
   onConfirm: () => void;
   onCancel: () => void;
   className?: string;
@@ -47,12 +47,6 @@ const DeletionConfirmation = (props: DeletionConfirmationProps) => {
       </span>
     </div>
   );
-};
-
-DeletionConfirmation.defaultProps = {
-  warningText: 'Are you sure you want to delete?',
-  confirmText: 'Delete',
-  cancelText: 'Do not delete'
 };
 
 export default DeletionConfirmation;

--- a/src/shared/components/deletion-confirmation/DeletionConfirmation.tsx
+++ b/src/shared/components/deletion-confirmation/DeletionConfirmation.tsx
@@ -38,13 +38,15 @@ const DeletionConfirmation = (props: DeletionConfirmationProps) => {
 
   return (
     <div className={containerClass}>
-      <span className={styles.warningText}>{props.warningText}</span>
-      <PrimaryButton onClick={props.onConfirm}>
-        {props.confirmText}
-      </PrimaryButton>
-      <span className={styles.cancel} onClick={props.onCancel}>
-        {props.cancelText}
-      </span>
+      <div className={styles.warningText}>{props.warningText}</div>
+      <div className={styles.controlsContainer}>
+        <PrimaryButton onClick={props.onConfirm}>
+          {props.confirmText}
+        </PrimaryButton>
+        <span className={styles.cancel} onClick={props.onCancel}>
+          {props.cancelText}
+        </span>
+      </div>
     </div>
   );
 };

--- a/stories/shared-components/deletion-confirmation/DeletionConfirmation.scss
+++ b/stories/shared-components/deletion-confirmation/DeletionConfirmation.scss
@@ -1,0 +1,4 @@
+.wrapper {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/stories/shared-components/deletion-confirmation/DeletionConfirmation.stories.tsx
+++ b/stories/shared-components/deletion-confirmation/DeletionConfirmation.stories.tsx
@@ -18,6 +18,8 @@ import React from 'react';
 
 import DeletionConfirmation from 'src/shared/components/deletion-confirmation/DeletionConfirmation';
 
+import styles from './DeletionConfirmation.scss';
+
 type DefaultArgs = {
   onClick: (...args: any) => void;
 };
@@ -36,17 +38,20 @@ export const DefaultDeletionConfirmation = (args: DefaultArgs) => (
 DefaultDeletionConfirmation.storyName = 'default';
 
 export const wrappedDeletionConfirmation = (args: DefaultArgs) => (
-  <DeletionConfirmation
-    warningText="This is a very long text which will wrap to the next line and we want the text to stay on the line and only the buttons to wrap to the next line. Are you sure you want to to remove this item?"
-    confirmText="Remove this item"
-    cancelText="Do not remove this item"
-    onConfirm={() => args.onClick('Confirmed')}
-    onCancel={() => args.onClick('Cancel')}
-    {...args}
-  />
+  <div className={styles.wrapper}>
+    <DeletionConfirmation
+      warningText="This is a very long text which will wrap to the next line and we want the text to stay on the line and only the buttons to wrap to the next line. Are you sure you want to to remove this item?"
+      confirmText="Remove this item"
+      cancelText="Do not remove this item"
+      contentAlignRight={true}
+      onConfirm={() => args.onClick('Confirmed')}
+      onCancel={() => args.onClick('Cancel')}
+      {...args}
+    />
+  </div>
 );
 
-wrappedDeletionConfirmation.storyName = 'Text wrapping';
+wrappedDeletionConfirmation.storyName = 'Text wrapping and align right';
 
 export default {
   title: 'Components/Shared Components/Deletion Confirmation',

--- a/stories/shared-components/deletion-confirmation/DeletionConfirmation.stories.tsx
+++ b/stories/shared-components/deletion-confirmation/DeletionConfirmation.stories.tsx
@@ -1,0 +1,38 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import DeletionConfirmation from 'src/shared/components/deletion-confirmation/DeletionConfirmation';
+
+type DefaultArgs = {
+  onClick: (...args: any) => void;
+};
+
+export const DefaultDeletionConfirmation = (args: DefaultArgs) => (
+  <DeletionConfirmation
+    onConfirm={() => args.onClick('Confirmed')}
+    onCancel={() => args.onClick('Cancel')}
+    {...args}
+  />
+);
+
+DefaultDeletionConfirmation.storyName = 'default';
+
+export default {
+  title: 'Components/Shared Components/Deletion Confirmation',
+  argTypes: { onClick: { action: 'click' } }
+};

--- a/stories/shared-components/deletion-confirmation/DeletionConfirmation.stories.tsx
+++ b/stories/shared-components/deletion-confirmation/DeletionConfirmation.stories.tsx
@@ -35,6 +35,19 @@ export const DefaultDeletionConfirmation = (args: DefaultArgs) => (
 
 DefaultDeletionConfirmation.storyName = 'default';
 
+export const wrappedDeletionConfirmation = (args: DefaultArgs) => (
+  <DeletionConfirmation
+    warningText="This is a very long text which will wrap to the next line and we want the text to stay on the line and only the buttons to wrap to the next line. Are you sure you want to to remove this item?"
+    confirmText="Remove this item"
+    cancelText="Do not remove this item"
+    onConfirm={() => args.onClick('Confirmed')}
+    onCancel={() => args.onClick('Cancel')}
+    {...args}
+  />
+);
+
+wrappedDeletionConfirmation.storyName = 'Text wrapping';
+
 export default {
   title: 'Components/Shared Components/Deletion Confirmation',
   argTypes: { onClick: { action: 'click' } }

--- a/stories/shared-components/deletion-confirmation/DeletionConfirmation.stories.tsx
+++ b/stories/shared-components/deletion-confirmation/DeletionConfirmation.stories.tsx
@@ -24,6 +24,9 @@ type DefaultArgs = {
 
 export const DefaultDeletionConfirmation = (args: DefaultArgs) => (
   <DeletionConfirmation
+    warningText="Are you sure you want to delete?"
+    confirmText="Delete"
+    cancelText="Do not delete"
     onConfirm={() => args.onClick('Confirmed')}
     onCancel={() => args.onClick('Cancel')}
     {...args}

--- a/stories/shared-components/deletion-confirmation/DeletionConfirmation.stories.tsx
+++ b/stories/shared-components/deletion-confirmation/DeletionConfirmation.stories.tsx
@@ -43,7 +43,7 @@ export const wrappedDeletionConfirmation = (args: DefaultArgs) => (
       warningText="This is a very long text which will wrap to the next line and we want the text to stay on the line and only the buttons to wrap to the next line. Are you sure you want to to remove this item?"
       confirmText="Remove this item"
       cancelText="Do not remove this item"
-      contentAlignRight={true}
+      alignContent="right"
       onConfirm={() => args.onClick('Confirmed')}
       onCancel={() => args.onClick('Cancel')}
       {...args}


### PR DESCRIPTION
## Description
we will have a common component for deleting or removing confirmation (example will be blast job deletion or removing species in species selector).

The component should show a message in red and have 1 button to confirm deletion and 1 link to cancel the deletion.


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1732

## Deployment URL(s)
Will need to deploy storybook locally to visualize it


## Views affected
storybook (shared component/DeletionConfirmation)