### PR TITLE
Add onSearchSubmit callback to InAppSearch

### DIFF
--- a/src/shared/components/in-app-search/InAppSearch.test.tsx
+++ b/src/shared/components/in-app-search/InAppSearch.test.tsx
@@ -113,10 +113,12 @@ describe('<InAppSearch />', () => {
       jest
         .spyOn(inAppSearchSlice, 'search')
         .mockImplementation(() => ({ type: 'action' } as any));
+      const onSearchSubmit = jest.fn();
+      const props = { ...defaultProps, onSearchSubmit };
 
       const { container, rerender } = render(
         <Provider store={getStore()}>
-          <InAppSearch {...defaultProps} />
+          <InAppSearch {...props} />
         </Provider>
       );
 
@@ -135,11 +137,12 @@ describe('<InAppSearch />', () => {
         page: 1,
         per_page: 50
       });
+      expect(onSearchSubmit).toHaveBeenCalledWith('BRCA2');
 
       // let's try passing a different app name and a different genome id in props
       rerender(
         <Provider store={getStore()}>
-          <InAppSearch {...defaultProps} app="entityViewer" genomeId="wheat" />
+          <InAppSearch {...props} app="entityViewer" genomeId="wheat" />
         </Provider>
       );
 
@@ -157,6 +160,8 @@ describe('<InAppSearch />', () => {
         page: 1,
         per_page: 50
       });
+      expect(onSearchSubmit).toHaveBeenCalledWith('Traes');
+
       (inAppSearchSlice.search as any).mockRestore();
     });
 

--- a/src/shared/components/in-app-search/InAppSearch.tsx
+++ b/src/shared/components/in-app-search/InAppSearch.tsx
@@ -57,6 +57,7 @@ export type Props = {
   genomeId: string;
   genomeIdForUrl: string; // this should be a temporary measure; it should be returned by search api
   mode: InAppSearchMode;
+  onSearchSubmit?: (query: string) => void;
 };
 
 const InAppSearch = (props: Props) => {
@@ -76,6 +77,7 @@ const InAppSearch = (props: Props) => {
 
   const onSearchSubmit = async () => {
     setIsLoading(true);
+    props.onSearchSubmit?.(query);
 
     const searchParams = {
       app,


### PR DESCRIPTION
## Description
Add optional `onSearchSubmit` callback to `InAppSearch` component to enable analytics tracking from the parent component.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1704

## Deployment URL(s)
Should be deployed to http://in-app-search-callback.review.ensembl.org, although there won't be any changes in functionality.
