### PR TITLE
Rename `5 transcripts` -> `First 5 transcripts`

### DIFF
--- a/src/content/app/genome-browser/components/track-settings-panel/track-settings-views/GeneTrackSettings.tsx
+++ b/src/content/app/genome-browser/components/track-settings-panel/track-settings-views/GeneTrackSettings.tsx
@@ -90,7 +90,7 @@ export const GeneTrackSettings = () => {
         <div className={styles.subLabel}>Show</div>
         <div>
           <div className={styles.toggleWrapper}>
-            <label>5 transcripts</label>
+            <label>First 5 transcripts</label>
             <SlideToggle
               isOn={shouldShowSeveralTranscripts}
               onChange={handleSeveralTranscriptsToggle}


### PR DESCRIPTION
## Description
- Changed the text in track settings panel from "5 transcripts" to "First 5 transcripts".

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1724

## Deployment URL(s)
http://first-5-transcripts.review.ensembl.org


## Views affected
Gene track settings panel