### PR TITLE
Skip request to track categories if genomeId is null

### DIFF
--- a/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
@@ -72,7 +72,10 @@ const useGenomeBrowserTracks = () => {
     // skip the effect if track categories have not yet been fetched
     // or if they have already been set
     if (
-      !(trackCategories && focusObject && trackSettingsForGenome && genomeId)
+      !trackCategories ||
+      !focusObject ||
+      trackSettingsForGenome ||
+      !genomeId
     ) {
       return;
     }

--- a/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
@@ -54,7 +54,9 @@ import type { FocusObject } from 'src/shared/types/focus-object/focusObjectTypes
 
 const useGenomeBrowserTracks = () => {
   const genomeId = useAppSelector(getBrowserActiveGenomeId) as string;
-  const { currentData: trackCategories } = useGenomeTracksQuery(genomeId);
+  const { currentData: trackCategories } = useGenomeTracksQuery(genomeId, {
+    skip: !genomeId
+  });
   const focusObject = useAppSelector(getBrowserActiveFocusObject); // should we think about what to do if there is no focus object
   const trackSettingsForGenome = useAppSelector(getAllTrackSettings)?.tracks;
   const visibleTrackIds = getVisibleTrackIds(useBrowserCogList().cogList); // get list of ids of tracks currently rendered in genome browser

--- a/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
@@ -53,10 +53,13 @@ import type { FocusObject } from 'src/shared/types/focus-object/focusObjectTypes
  */
 
 const useGenomeBrowserTracks = () => {
-  const genomeId = useAppSelector(getBrowserActiveGenomeId) as string;
-  const { currentData: trackCategories } = useGenomeTracksQuery(genomeId, {
-    skip: !genomeId
-  });
+  const genomeId = useAppSelector(getBrowserActiveGenomeId);
+  const { currentData: trackCategories } = useGenomeTracksQuery(
+    genomeId ?? '',
+    {
+      skip: !genomeId
+    }
+  );
   const focusObject = useAppSelector(getBrowserActiveFocusObject); // should we think about what to do if there is no focus object
   const trackSettingsForGenome = useAppSelector(getAllTrackSettings)?.tracks;
   const visibleTrackIds = getVisibleTrackIds(useBrowserCogList().cogList); // get list of ids of tracks currently rendered in genome browser
@@ -68,7 +71,9 @@ const useGenomeBrowserTracks = () => {
   useEffect(() => {
     // skip the effect if track categories have not yet been fetched
     // or if they have already been set
-    if (!trackCategories || !focusObject || trackSettingsForGenome) {
+    if (
+      !(trackCategories && !focusObject && trackSettingsForGenome && genomeId)
+    ) {
       return;
     }
 

--- a/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
@@ -72,7 +72,7 @@ const useGenomeBrowserTracks = () => {
     // skip the effect if track categories have not yet been fetched
     // or if they have already been set
     if (
-      !(trackCategories && !focusObject && trackSettingsForGenome && genomeId)
+      !(trackCategories && focusObject && trackSettingsForGenome && genomeId)
     ) {
       return;
     }


### PR DESCRIPTION
## Description
- this PR prevents the call to track categories endpoint when genomeId is null

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1729

## Deployment URL(s)
http://fix-null-track-categories.review.ensembl.org


## Views affected
- Genome browser interstitial 