### PR TITLE
Fix GB in-app search bug selecting current feature

### DIFF
--- a/src/content/app/genome-browser/components/browser-bar/BrowserBar.tsx
+++ b/src/content/app/genome-browser/components/browser-bar/BrowserBar.tsx
@@ -25,28 +25,16 @@ import BrowserLocationIndicator from '../browser-location-indicator/BrowserLocat
 
 import { getIsDrawerOpened } from 'src/content/app/genome-browser/state/drawer/drawerSelectors';
 import { getBrowserActiveFocusObject } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
-import { getChrLocation } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
-
-import { FocusObject } from 'src/shared/types/focus-object/focusObjectTypes';
-import { ChrLocation } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSlice';
 
 import styles from './BrowserBar.scss';
 
-export type BrowserBarProps = {
-  chrLocation: ChrLocation | null;
-  defaultChrLocation: ChrLocation | null;
-  isDrawerOpened: boolean;
-  focusObject: FocusObject | null;
-};
-
 export const BrowserBar = () => {
-  const chrLocation = useSelector(getChrLocation);
   const focusObject = useSelector(getBrowserActiveFocusObject);
   const isDrawerOpened = useSelector(getIsDrawerOpened);
 
   // return empty div instead of null, so that the dedicated slot in the CSS grid of StandardAppLayout
   // always contains a child DOM element
-  if (!(chrLocation && focusObject)) {
+  if (!focusObject) {
     return <div />;
   }
 

--- a/src/content/app/genome-browser/state/browser-general/browserGeneralSlice.ts
+++ b/src/content/app/genome-browser/state/browser-general/browserGeneralSlice.ts
@@ -324,6 +324,8 @@ const browserGeneralSlice = createSlice({
 
       if (chrLocation) {
         state.chrLocations[activeGenomeId] = chrLocation;
+      } else {
+        delete state.chrLocations[activeGenomeId];
       }
     },
     updateBrowserActiveFocusObjectIds(

--- a/src/content/app/genome-browser/state/browser-general/browserGeneralSlice.ts
+++ b/src/content/app/genome-browser/state/browser-general/browserGeneralSlice.ts
@@ -324,8 +324,6 @@ const browserGeneralSlice = createSlice({
 
       if (chrLocation) {
         state.chrLocations[activeGenomeId] = chrLocation;
-      } else {
-        delete state.chrLocations[activeGenomeId];
       }
     },
     updateBrowserActiveFocusObjectIds(


### PR DESCRIPTION
## Description
This PR fixes the issue with the disappearing content in the horizontal bar above the genome browser when the user tries to navigate to a feature that is currently active (by searching for it and clicking on a search result). This fix however, does not prevent the location information in the URL from getting lost but this does not cause any problem.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1721

## Deployment URL(s)
http://fix-gb-in-app-search-bug.review.ensembl.org


## Views affected
- Genome browser bar