### PR TITLE
disable species lozenge on blast small screens

### DIFF
--- a/src/content/app/tools/blast/components/blast-app-bar/BlastAppBar.scss
+++ b/src/content/app/tools/blast/components/blast-app-bar/BlastAppBar.scss
@@ -1,0 +1,7 @@
+@import 'src/styles/common';
+
+.speciesLozenge {
+  @media (max-width: 1900px) {
+    --species-lozenge-bg-color: #{$grey};
+  }
+}

--- a/src/content/app/tools/blast/components/blast-app-bar/BlastAppBar.scss
+++ b/src/content/app/tools/blast/components/blast-app-bar/BlastAppBar.scss
@@ -3,5 +3,6 @@
 .speciesLozenge {
   @media (max-width: 1900px) {
     --species-lozenge-bg-color: #{$grey};
+    pointer-events: none;
   }
 }

--- a/src/content/app/tools/blast/components/blast-app-bar/BlastAppBar.scss
+++ b/src/content/app/tools/blast/components/blast-app-bar/BlastAppBar.scss
@@ -1,8 +1,0 @@
-@import 'src/styles/common';
-
-.speciesLozenge {
-  @media (max-width: 1900px) {
-    --species-lozenge-bg-color: #{$grey};
-    pointer-events: none;
-  }
-}

--- a/src/content/app/tools/blast/components/blast-app-bar/BlastAppBar.test.tsx
+++ b/src/content/app/tools/blast/components/blast-app-bar/BlastAppBar.test.tsx
@@ -37,6 +37,11 @@ jest.mock(
   () => () => <div>ConversationIcon</div>
 );
 
+jest.mock(
+  'src/shared/hooks/useMediaQuery',
+  () => () => false // no match
+);
+
 const mockCommittedItems = [
   {
     genome_id: 'homo_sapiens_GCA_000001405_14',

--- a/src/content/app/tools/blast/components/blast-app-bar/BlastAppBar.tsx
+++ b/src/content/app/tools/blast/components/blast-app-bar/BlastAppBar.tsx
@@ -34,6 +34,8 @@ import SpeciesTabsWrapper from 'src/shared/components/species-tabs-wrapper/Speci
 
 import type { CommittedItem } from 'src/content/app/species-selector/types/species-search';
 
+import styles from './BlastAppBar.scss';
+
 const BlastAppBar = () => {
   const speciesList = useSelector(getEnabledCommittedSpecies);
   const speciesListIds = useSelector(getSelectedSpeciesIds);
@@ -66,13 +68,19 @@ const BlastAppBar = () => {
     <SpeciesLozenge
       key={index}
       theme="blue"
+      className={styles.speciesLozenge}
       species={species}
       onClick={() => speciesLozengeClick(species)}
     />
   ));
 
   const disabledSpecies = speciesList.map((species, index) => (
-    <SpeciesLozenge key={index} theme="grey" species={species} />
+    <SpeciesLozenge
+      key={index}
+      theme="grey"
+      className={styles.speciesLozenge}
+      species={species}
+    />
   ));
 
   const speciesTabs =

--- a/src/content/app/tools/blast/views/blast-form/BlastForm.scss
+++ b/src/content/app/tools/blast/views/blast-form/BlastForm.scss
@@ -9,7 +9,7 @@
 
 .mainContainer {
   height: 100%;
-  padding: 0 6px 0 65px;
+  padding: 0 30px 0 65px;
 }
 
 .mainContainerSmall {

--- a/src/content/app/tools/blast/views/blast-form/BlastForm.tsx
+++ b/src/content/app/tools/blast/views/blast-form/BlastForm.tsx
@@ -23,6 +23,8 @@ import { BlastFormContextContainer } from './BlastFormContext';
 import { useBlastConfigQuery } from 'src/content/app/tools/blast/state/blast-api/blastApiSlice';
 import useMediaQuery from 'src/shared/hooks/useMediaQuery';
 
+import { smallViewportMediaQuery } from './blastFormConstants';
+
 import { getStep } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
 import {
   switchToSequencesStep,
@@ -68,7 +70,7 @@ const BlastForm = () => {
 };
 
 const Main = () => {
-  const isSmallViewport = useMediaQuery('(max-width: 1900px)');
+  const isSmallViewport = useMediaQuery(smallViewportMediaQuery);
 
   if (isSmallViewport === null) {
     return null;

--- a/src/content/app/tools/blast/views/blast-form/blastFormConstants.ts
+++ b/src/content/app/tools/blast/views/blast-form/blastFormConstants.ts
@@ -1,0 +1,26 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const columnWidth = 860;
+const columnGap = 45;
+const leftPagePadding = 60;
+const rightPagePadding = 30;
+const smallViewportBreakpoint =
+  columnWidth * 2 + columnGap + leftPagePadding + rightPagePadding;
+
+export const smallViewportMediaQuery = `(max-width: ${
+  smallViewportBreakpoint - 1
+}px)`; // subtract 1 because we are matching the max width


### PR DESCRIPTION
## Description
For blast, on small screen, we need to disable all lozenge (when the Add sequence/ Select species buttons appear)


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1685

## Deployment URL(s)
http://disable-species-blast.review.ensembl.org/


## Views affected
Blast