### PR TITLE
Update the types and code of the ViewInApp component

### DIFF
--- a/src/content/app/genome-browser/components/zmenu/ZmenuAppLinks.tsx
+++ b/src/content/app/genome-browser/components/zmenu/ZmenuAppLinks.tsx
@@ -23,7 +23,9 @@ import useGenomeBrowserIds from 'src/content/app/genome-browser/hooks/useGenomeB
 import useGenomeBrowser from '../../hooks/useGenomeBrowser';
 
 import { ToggleButton as ToolboxToggleButton } from 'src/shared/components/toolbox';
-import ViewInApp, { UrlObj } from 'src/shared/components/view-in-app/ViewInApp';
+import ViewInApp, {
+  LinksConfig
+} from 'src/shared/components/view-in-app/ViewInApp';
 
 import styles from './Zmenu.scss';
 import { useNavigate } from 'react-router';
@@ -46,15 +48,6 @@ const ZmenuAppLinks = (props: Props) => {
     return null;
   }
 
-  const links: UrlObj = {
-    entityViewer: {
-      url: urlFor.entityViewer({
-        genomeId: genomeIdForUrl,
-        entityId: featureId
-      })
-    }
-  };
-
   const onGenomeBrowserAppClick = () => {
     if (!(focusObjectIdForUrl && focusObjectId)) {
       return;
@@ -74,17 +67,23 @@ const ZmenuAppLinks = (props: Props) => {
     }
   };
 
+  const links: LinksConfig = {
+    genomeBrowser: onGenomeBrowserAppClick,
+    entityViewer: {
+      url: urlFor.entityViewer({
+        genomeId: genomeIdForUrl,
+        entityId: featureId
+      })
+    }
+  };
+
   return (
     <div className={styles.zmenuAppLinks}>
       <ToolboxToggleButton
         className={styles.zmenuToggleFooter}
         label="Download"
       />
-      <ViewInApp
-        links={links}
-        onAnyAppClick={props.destroyZmenu}
-        onAppClick={{ genomeBrowser: onGenomeBrowserAppClick }}
-      />
+      <ViewInApp links={links} onAnyAppClick={props.destroyZmenu} />
     </div>
   );
 };

--- a/src/content/app/genome-browser/hooks/useBrowserRouting.ts
+++ b/src/content/app/genome-browser/hooks/useBrowserRouting.ts
@@ -132,6 +132,22 @@ const useBrowserRouting = () => {
         replace: true
       });
     } else if (focusObjectId && !chrLocation) {
+      if (
+        focusObjectId === activeFocusObjectId &&
+        allChrLocations[activeFocusObjectId]
+      ) {
+        navigate(
+          urlFor.browser({
+            genomeId: genomeIdForUrl,
+            focus: focusObjectIdInUrl,
+            location: getChrLocationStr(allChrLocations[activeFocusObjectId])
+          }),
+          {
+            replace: true
+          }
+        );
+        return;
+      }
       /*
        changeFocusObject needs to be called before setDataFromUrlAndSave
        because it will also try to bookmark the Ensembl object that is stored in redux state

--- a/src/content/app/genome-browser/hooks/useBrowserRouting.ts
+++ b/src/content/app/genome-browser/hooks/useBrowserRouting.ts
@@ -132,22 +132,6 @@ const useBrowserRouting = () => {
         replace: true
       });
     } else if (focusObjectId && !chrLocation) {
-      if (
-        focusObjectId === activeFocusObjectId &&
-        allChrLocations[activeFocusObjectId]
-      ) {
-        navigate(
-          urlFor.browser({
-            genomeId: genomeIdForUrl,
-            focus: focusObjectIdInUrl,
-            location: getChrLocationStr(allChrLocations[activeFocusObjectId])
-          }),
-          {
-            replace: true
-          }
-        );
-        return;
-      }
       /*
        changeFocusObject needs to be called before setDataFromUrlAndSave
        because it will also try to bookmark the Ensembl object that is stored in redux state

--- a/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
+++ b/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
@@ -38,7 +38,7 @@ import {
 } from 'src/content/app/species/state/general/speciesGeneralSlice';
 
 import { RootState } from 'src/store';
-import { UrlObj } from 'src/shared/components/view-in-app/ViewInApp';
+import { LinksConfig } from 'src/shared/components/view-in-app/ViewInApp';
 import { CommittedItem } from 'src/content/app/species-selector/types/species-search';
 import {
   StatsSection,
@@ -49,7 +49,7 @@ import {
 import styles from './SpeciesMainView.scss';
 
 type ExampleLinkPopupProps = {
-  links: UrlObj;
+  links: LinksConfig;
   children: ReactNode;
 };
 

--- a/src/content/app/species/state/general/speciesGeneralHelper.ts
+++ b/src/content/app/species/state/general/speciesGeneralHelper.ts
@@ -22,7 +22,7 @@ import { ExampleFocusObject } from 'src/shared/state/genome/genomeTypes';
 
 import { sampleData } from '../../sample-data';
 import { buildFocusIdForUrl } from 'src/shared/helpers/focusObjectHelpers';
-import { UrlObj } from 'src/shared/components/view-in-app/ViewInApp';
+import { LinksConfig } from 'src/shared/components/view-in-app/ViewInApp';
 
 export enum SpeciesStatsSection {
   CODING_STATS = 'coding_stats',
@@ -570,7 +570,7 @@ type StatsGroup = {
 
 export type StatsSection = {
   section: SpeciesStatsSection;
-  exampleLinks?: UrlObj;
+  exampleLinks?: LinksConfig;
   summaryStats?: IndividualStat[];
   groups: StatsGroup[];
 };
@@ -648,7 +648,7 @@ const getExampleLinks = (props: {
 }) => {
   const { section, genomeIdForUrl, exampleFocusObjects } = props;
 
-  let exampleLinks: UrlObj = {};
+  let exampleLinks: LinksConfig = {};
 
   if (section === SpeciesStatsSection.CODING_STATS) {
     const geneExample = exampleFocusObjects.find(

--- a/src/shared/components/view-in-app-popup/ViewInAppPopup.tsx
+++ b/src/shared/components/view-in-app-popup/ViewInAppPopup.tsx
@@ -18,12 +18,14 @@ import React, { useState, useRef, ReactNode } from 'react';
 import PointerBox, {
   Position
 } from 'src/shared/components/pointer-box/PointerBox';
-import ViewInApp, { UrlObj } from 'src/shared/components/view-in-app/ViewInApp';
+import ViewInApp, {
+  LinksConfig
+} from 'src/shared/components/view-in-app/ViewInApp';
 
 import styles from './ViewInAppPopup.scss';
 
 export type ViewInAppPopupProps = {
-  links: UrlObj;
+  links: LinksConfig;
   children: ReactNode;
   position: Position;
 };

--- a/src/shared/components/view-in-app/ViewInApp.test.tsx
+++ b/src/shared/components/view-in-app/ViewInApp.test.tsx
@@ -26,7 +26,7 @@ import {
   Apps,
   type AppName,
   type ViewInAppProps,
-  type UrlObj
+  type LinksConfig
 } from './ViewInApp';
 import RouteChecker from 'tests/router/RouteChecker';
 
@@ -74,7 +74,7 @@ const links = tuplesSample.reduce((result, tuple) => {
     ...result,
     [appName]: { url: link }
   };
-}, {}) as UrlObj;
+}, {}) as LinksConfig;
 
 describe('<ViewInApp />', () => {
   beforeEach(() => {
@@ -130,6 +130,23 @@ describe('<ViewInApp />', () => {
 
     expect(routerInfo.location?.pathname).toBe(links.genomeBrowser.url);
     expect(routerInfo.navigationType).toBe('REPLACE');
+  });
+
+  it('correctly handles links as functions', async () => {
+    const genomeBrowserLinkFn = jest.fn();
+    const links = {
+      genomeBrowser: genomeBrowserLinkFn
+    };
+
+    renderComponent({ links });
+
+    const appButtonContainer = screen.getByTestId('genomeBrowser');
+
+    await userEvent.click(
+      appButtonContainer.querySelector('button') as HTMLButtonElement
+    );
+
+    expect(genomeBrowserLinkFn).toHaveBeenCalled();
   });
 
   describe('onClick behaviour', () => {

--- a/src/shared/components/view-in-app/ViewInApp.tsx
+++ b/src/shared/components/view-in-app/ViewInApp.tsx
@@ -54,7 +54,7 @@ type AppClickHandlers = Partial<Record<AppName, () => void>>;
  * The fields of ViewInAppProps have the following semantics:
  * - the buttons rendered by the ViewInApp component,
  *   as well as the default behaviour upon a click on a given button
- *   are determined by the mandatory `links` property
+ *   are determined by the keys of the `links` object passed as a mandatory property
  * - the optional `onAppClick` property describes additional behaviour
  *   upon a click on a given button
  * - the optional `onAnyAppClick` property describes additional behaviour
@@ -62,12 +62,12 @@ type AppClickHandlers = Partial<Record<AppName, () => void>>;
  *
  * QUESTION: why not make the `links` property only ever contain url strings,
  * and pass functions describing more complex on-click behaviour
- * only via the `onAppClick` property?
+ * via the `onAppClick` property?
  *
  * ANSWER: because the `links` property is mandatory. Consider an edge case
  * in which the on-click behaviour on any button has to be described in a function.
- * That would require the consumer of the component to pass an empty `links` opject
- * into the component, which looks like a strange api.
+ * That would require the consumer of the component to pass an empty `links` object
+ * into the component, which makes for an awkward api.
  */
 
 export type ViewInAppProps = {

--- a/src/shared/components/view-in-app/ViewInApp.tsx
+++ b/src/shared/components/view-in-app/ViewInApp.tsx
@@ -42,16 +42,36 @@ export const Apps = {
 
 export type AppName = keyof typeof Apps;
 
-export type LinkObj = { url: string; replaceState?: boolean };
+export type LinkObject = { url: string; replaceState?: boolean };
 
-export type UrlObj = Partial<Record<AppName, LinkObj>>;
+export type LinkFunction = () => void;
 
-type AppClickHandlers = Partial<
-  Record<AppName, (event?: React.MouseEvent<HTMLDivElement>) => void>
->;
+export type LinksConfig = Partial<Record<AppName, LinkObject | LinkFunction>>;
+
+type AppClickHandlers = Partial<Record<AppName, () => void>>;
+
+/**
+ * The fields of ViewInAppProps have the following semantics:
+ * - the buttons rendered by the ViewInApp component,
+ *   as well as the default behaviour upon a click on a given button
+ *   are determined by the mandatory `links` property
+ * - the optional `onAppClick` property describes additional behaviour
+ *   upon a click on a given button
+ * - the optional `onAnyAppClick` property describes additional behaviour
+ *   upon a click on any button.
+ *
+ * QUESTION: why not make the `links` property only ever contain url strings,
+ * and pass functions describing more complex on-click behaviour
+ * only via the `onAppClick` property?
+ *
+ * ANSWER: because the `links` property is mandatory. Consider an edge case
+ * in which the on-click behaviour on any button has to be described in a function.
+ * That would require the consumer of the component to pass an empty `links` opject
+ * into the component, which looks like a strange api.
+ */
 
 export type ViewInAppProps = {
-  links: UrlObj;
+  links: LinksConfig;
   onAppClick?: AppClickHandlers;
   onAnyAppClick?: (appName?: AppName) => void;
   classNames?: {
@@ -60,8 +80,6 @@ export type ViewInAppProps = {
 };
 
 export const ViewInApp = (props: ViewInAppProps) => {
-  const { onAppClick, onAnyAppClick: onAnyAppClickFn } = props;
-
   const labelClass = classNames(styles.label, props.classNames?.label);
 
   const navigate = useNavigate();
@@ -69,8 +87,27 @@ export const ViewInApp = (props: ViewInAppProps) => {
     return null;
   }
 
+  const handleClick = (app: AppName) => {
+    const linkConfig = props.links[app];
+    if (!linkConfig) {
+      return; // shouldn't happen; but keeps the types sound
+    }
+
+    props.onAnyAppClick?.(app);
+    props.onAppClick?.[app]?.();
+
+    if (typeof linkConfig === 'function') {
+      // the parent knows better how to handle a click on a link; delegate decision to the parent
+      const linkClickHandler = linkConfig; // creating a new variable because writing `linkConfig()` looks awkward
+      linkClickHandler();
+    } else {
+      navigate(linkConfig.url, {
+        replace: linkConfig.replaceState
+      });
+    }
+  };
+
   const enabledApps = Object.keys({
-    ...(props.onAppClick || {}),
     ...props.links
   }) as AppName[];
 
@@ -79,25 +116,6 @@ export const ViewInApp = (props: ViewInAppProps) => {
       <span className={labelClass}>View in</span>
 
       {enabledApps.map((appName, index) => {
-        const currentLinkObj = props.links[appName] as LinkObj;
-
-        const handleClick = (event?: React.MouseEvent<HTMLDivElement>) => {
-          const onAppClickFn = onAppClick?.[appName];
-
-          if (onAnyAppClickFn) {
-            onAnyAppClickFn(appName);
-          }
-
-          if (onAppClickFn) {
-            onAppClickFn(event);
-          }
-          if (currentLinkObj) {
-            navigate(currentLinkObj.url, {
-              replace: currentLinkObj.replaceState
-            });
-          }
-        };
-
         return (
           <div
             className={styles.viewInAppLink}
@@ -108,9 +126,7 @@ export const ViewInApp = (props: ViewInAppProps) => {
               status={Status.DEFAULT}
               description={Apps[appName].tooltip}
               image={Apps[appName].icon}
-              onClick={(event?: React.MouseEvent<HTMLDivElement>) =>
-                handleClick(event)
-              }
+              onClick={() => handleClick(appName)}
             />
           </div>
         );


### PR DESCRIPTION
## Description
This is a refactoring PR that does not add any extra functionality or fix any bugs. It updates the api of the `ViewInApp` component, such that:
- the buttons shown in the `ViewInApp` component are determined only by the keys of the `links` property
- a member of the `links` property can be either an object describing a link, or a function that will perform the navigation task

### Rationale
The fields of ViewInAppProps have the following semantics:
- the buttons rendered by the ViewInApp component,  as well as the default behaviour upon a click on a given button, are determined by the keys of the `links` object passed as a mandatory property
- the optional `onAppClick` property describes additional behaviour upon a click on a given button
- the optional `onAnyAppClick` property describes additional behaviour upon a click on any button.

**QUESTION**: why not make the `links` property only ever contain url strings, and pass functions describing more complex on-click behaviour only via the `onAppClick` property?

**ANSWER**: because the `links` property is mandatory. Consider an edge case in which the on-click behaviour on any button has to be described in a function. That would require the consumer of the component to pass an empty `links` object into the component, which makes for an awkward api.

## Deployment URL(s)
http://update-view-in-app.review.ensembl.org