### PR TITLE
Add missing app dimension to EV tracking events

### DIFF
--- a/src/content/app/entity-viewer/hooks/useEntityViewerAnalytics.ts
+++ b/src/content/app/entity-viewer/hooks/useEntityViewerAnalytics.ts
@@ -34,6 +34,7 @@ import {
 import { RootState } from 'src/store';
 import { SidebarTabName } from '../state/sidebar/entityViewerSidebarSlice';
 import { AnalyticsOptions } from 'src/analyticsHelper';
+import { AppName } from 'src/global/globalConfig';
 
 type TrackDownloadPayload = {
   category: string;
@@ -61,7 +62,8 @@ const useEntityViewerAnalytics = () => {
     analyticsTracking.trackEvent({
       ...ga,
       species: speciesNameForAnalytics,
-      feature: featureType
+      feature: featureType,
+      app: AppName.ENTITY_VIEWER
     });
   };
 


### PR DESCRIPTION
## Description
- This PR puts back the `app` dimension to the Entity viewer tracking events that got removed [here](https://github.com/Ensembl/ensembl-client/pull/622/files#diff-5f194e31e4a61ccfb8b3510b6c7adb864c5fad341b4c4bab8189e0461a9c603bL61)
