### PR TITLE
Add loading states to the DownloadButton

### DIFF
--- a/src/shared/components/download-button/DownloadButton.scss
+++ b/src/shared/components/download-button/DownloadButton.scss
@@ -1,15 +1,15 @@
 @import 'src/styles/common';
 
 .downloadButton {
+  --_download-button-size: var(--download-button-size, 18px);
   background-color: var(--download-button-background, #{$blue});
   border: none;
   outline: none;
-  height: var(--download-button-size, 18px);
-  width: var(--download-button-size, 18px);
+  height: var(--_download-button-size);
+  width: var(--_download-button-size);
 
   svg {
-    height: 10px;
-    width: 10px;
+    width: 56%; // about 10px for a 18px-wide button
     fill: $white;
   }
 }
@@ -17,4 +17,46 @@
 .downloadButtonDisabled {
   --download-button-background: #{$grey};
   cursor: default;
+}
+
+.downloadButtonLoading {
+  background-color: var(--download-button-loading-background, transparent);
+  --circle-loader-diameter: var(--_download-button-size);
+  transform: scale(1.2);
+}
+
+.downloadButtonLoading,
+.downloadButtonSuccess,
+.downloadButtonError {
+  cursor: default;
+}
+
+.downloadButtonSuccess,
+.downloadButtonError {
+  background-color: var(--download-button-success-background, transparent);
+  border: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  svg {
+    height: auto;
+  }
+}
+
+.downloadButtonSuccess {
+  svg {
+    width: 100%;
+    transform: scale(1.1);
+    fill: $green;
+  }
+}
+
+.downloadButtonError {
+  background-color: var(--download-button-success-background, transparent);
+
+  svg {
+    fill: $red;
+    width: 75%;
+  }
 }

--- a/src/shared/components/download-button/DownloadButton.scss
+++ b/src/shared/components/download-button/DownloadButton.scss
@@ -34,14 +34,9 @@
 .downloadButtonSuccess,
 .downloadButtonError {
   background-color: var(--download-button-success-background, transparent);
-  border: none;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-
-  svg {
-    height: auto;
-  }
 }
 
 .downloadButtonSuccess {
@@ -53,7 +48,7 @@
 }
 
 .downloadButtonError {
-  background-color: var(--download-button-success-background, transparent);
+  background-color: var(--download-button-error-background, transparent);
 
   svg {
     fill: $red;

--- a/src/shared/components/download-button/DownloadButton.tsx
+++ b/src/shared/components/download-button/DownloadButton.tsx
@@ -54,14 +54,6 @@ const DownloadButton = (props: Props, ref: ForwardedRef<HTMLButtonElement>) => {
     }
   };
 
-  // const { className, ...otherProps } = props;
-
-  // const elementClasses = classNames(
-  //   styles.downloadButton,
-  //   { [styles.downloadButtonDisabled]: props.disabled },
-  //   className
-  // );
-
   return (
     <ControlledDownloadButtonWithForwardedRef
       {...otherProps}


### PR DESCRIPTION
## Description
- DownloadButton will cycle through the following download states:
  - not_requested (regular button appearance)
  - loading (spinner)
  - success (green checkmark) or error (red cross)
- While the button is in the loading, success, or error state, it will not register additional clicks and thus won't start unnecessary downloads

**Note:** visual appearance of the button in different states is somewhat different from XD; but was discussed with and approved by Andrea.

### Questions to consider for subsequent PRs
- `DownloadButton` now is very similar to the `LoadingButton`; do they need to be merged together?
- `DownloadButton` can't avoid showing the spinner for near-instantaneous downloads; not does it know how to show the spinner for a minimal duration to avoid unpleasant flickering (can be addressed in a dedicated PR) 
- What should happen if the user starts the download, switches to a different screen before it finishes, and then comes back?

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1749

## Deployment URL(s)
http://submission-download-ui.review.ensembl.org

## Views affected
- BLAST submissions list view
- BLAST submission details view