### PR TITLE
Add fallback sequence header in BLAST result

### DIFF
--- a/src/content/app/tools/blast/views/blast-submission-results/components/blast-results-per-sequence/BlastResultsPerSequence.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/blast-results-per-sequence/BlastResultsPerSequence.tsx
@@ -47,8 +47,10 @@ type BlastResultsPerSequenceProps = {
 const BlastResultsPerSequence = (props: BlastResultsPerSequenceProps) => {
   const { sequence, species, blastResults, parameters } = props;
   const parsedBlastSequence = parseBlastInput(sequence.value)[0];
-  const { header: sequenceHeader = '', value: sequenceValue } =
-    parsedBlastSequence;
+  const { header: sequenceHeader, value: sequenceValue } = parsedBlastSequence;
+  const sequenceHeaderLabel =
+    '>' + (sequenceHeader ?? `Sequence ${sequence.id}`);
+
   const rulerContainer = useRef<HTMLDivElement | null>(null);
   const { width: plotwidth } = useResizeObserver({ ref: rulerContainer });
   const [shouldShowJobResult, showJobResult] = useState(true);
@@ -61,7 +63,7 @@ const BlastResultsPerSequence = (props: BlastResultsPerSequenceProps) => {
         <div className={styles.sequenceHeader}>
           <div>
             <ShowHide
-              label={'>' + sequenceHeader}
+              label={sequenceHeaderLabel}
               isExpanded={shouldShowParamaters}
               onClick={() => showParamaters(!shouldShowParamaters)}
             ></ShowHide>


### PR DESCRIPTION
## Description
The clickable area of the sequence header for BLAST results with no hits is very small. This has been increased by adding `Sequence #id` as shown in: https://xd.adobe.com/view/bcfcabed-3d1d-44d9-996e-0a40d02f1143-e9af/screen/8b9588f3-aa1c-456f-95fc-281cd75974d9/?fullscreen.


## Related JIRA Issue(s)
[ENSWBSITES-1739](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1739)


## Deployment URL(s)
http://blast-fasta-header-clickable-area.review.ensembl.org


## Views affected
BLAST -> Unviewed Jobs -> Result