### PR TITLE
Clear BLAST form upon submission

### DIFF
--- a/src/content/app/tools/blast/components/blast-job-submit/BlastJobSubmit.tsx
+++ b/src/content/app/tools/blast/components/blast-job-submit/BlastJobSubmit.tsx
@@ -19,7 +19,7 @@ import { useNavigate } from 'react-router-dom';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
 
-import { useAppSelector } from 'src/store';
+import { useAppSelector, useAppDispatch } from 'src/store';
 
 import { useSubmitBlastMutation } from 'src/content/app/tools/blast/state/blast-api/blastApiSlice';
 import useBlastForm from 'src/content/app/tools/blast/hooks/useBlastForm';
@@ -27,6 +27,8 @@ import { isBlastFormValid } from 'src/content/app/tools/blast/utils/blastFormVal
 
 import { getBlastFormData } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
 import { getSelectedSpeciesIds } from 'src/content/app/tools/blast/state/blast-form/blastFormSelectors';
+
+import { clearBlastForm } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
 
 import { toFasta } from 'src/shared/helpers/formatters/fastaFormatter';
 
@@ -60,6 +62,7 @@ const BlastJobSubmit = () => {
     // and the user must be fantastically fast; so it is most likely a non-issue
     fixedCacheKey: 'submit-blast-form'
   });
+  const dispatch = useAppDispatch();
   const navigate = useNavigate();
 
   const isDisabled = !isBlastFormValid(selectedSpeciesIds, sequences);
@@ -71,6 +74,14 @@ const BlastJobSubmit = () => {
     const submission = submitBlast(payload);
     submission.then(() => submission.reset());
     navigate(urlFor.blastUnviewedSubmissions());
+
+    // QUESTION: should the form be cleared immediately on submission,
+    // or after the successful response is received (in which case
+    // the line below should be run in a then clause of the submission promise)?
+    // Edge case with clearing the form immediately: if the submission fails the form data will be lost
+    // Edge case with clearing the form after submission request completes:
+    // it may take several seconds, and the user may return to the form
+    dispatch(clearBlastForm());
   };
 
   return (

--- a/src/content/app/tools/blast/components/blast-job-submit/BlastJobSubmit.tsx
+++ b/src/content/app/tools/blast/components/blast-job-submit/BlastJobSubmit.tsx
@@ -75,12 +75,6 @@ const BlastJobSubmit = () => {
     submission.then(() => submission.reset());
     navigate(urlFor.blastUnviewedSubmissions());
 
-    // QUESTION: should the form be cleared immediately on submission,
-    // or after the successful response is received (in which case
-    // the line below should be run in a then clause of the submission promise)?
-    // Edge case with clearing the form immediately: if the submission fails the form data will be lost
-    // Edge case with clearing the form after submission request completes:
-    // it may take several seconds, and the user may return to the form
     dispatch(clearBlastForm());
   };
 


### PR DESCRIPTION
## Description
Clearing the BLAST form immediately upon submission. This should fix most of the cases when the user clicks on the "New job" button and sees the old form data.

**QUESTION:** There are still scenarios when the user can press on the "New job" button and see the filled form. Some such scenarios are useful (e.g. user hasn't finished filling in the form, switches to BLAST results list, and wants to return and continue filling in the form). Other scenarios are less desirable (e.g. press Edit/rerun → Jobs list → New job (will show filled form). Should a click handler that clears the form also be attached to the "New job" button?

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1742

## Deployment URL(s)
http://clear-blast-form-new.review.ensembl.org