### PR TITLE
Set min, max width for GB zmenu

### DIFF
--- a/src/content/app/genome-browser/components/zmenu/Zmenu.scss
+++ b/src/content/app/genome-browser/components/zmenu/Zmenu.scss
@@ -11,7 +11,6 @@
 
 .zmenuContentLine {
   display: block;
-  white-space: nowrap;
 }
 
 .zmenuContentBlock {
@@ -60,4 +59,9 @@
     flex-direction: column;
     align-items: center;
   }
+}
+
+.toolBoxWrapper {
+  max-width: 450px;
+  min-width: 250px;
 }

--- a/src/content/app/genome-browser/components/zmenu/Zmenu.scss
+++ b/src/content/app/genome-browser/components/zmenu/Zmenu.scss
@@ -61,7 +61,7 @@
   }
 }
 
-.toolBoxWrapper {
+.toolBox {
   max-width: 450px;
   min-width: 250px;
 }

--- a/src/content/app/genome-browser/components/zmenu/Zmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/Zmenu.tsx
@@ -145,6 +145,7 @@ const Zmenu = (props: ZmenuProps) => {
           <ToolboxExpandableContent
             mainContent={mainContent}
             footerContent={getToolboxFooterContent(transcriptId)}
+            className={styles.toolBoxWrapper}
           />
         </Toolbox>
       )}

--- a/src/content/app/genome-browser/components/zmenu/Zmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/Zmenu.tsx
@@ -145,7 +145,7 @@ const Zmenu = (props: ZmenuProps) => {
           <ToolboxExpandableContent
             mainContent={mainContent}
             footerContent={getToolboxFooterContent(transcriptId)}
-            className={styles.toolBoxWrapper}
+            className={styles.toolBox}
           />
         </Toolbox>
       )}

--- a/src/shared/components/toolbox/toolbox-expandable-content/ToolboxExpandableContent.scss
+++ b/src/shared/components/toolbox/toolbox-expandable-content/ToolboxExpandableContent.scss
@@ -1,5 +1,0 @@
-@import 'src/styles/common';
-
-.main {
-  position: relative;
-}

--- a/src/shared/components/toolbox/toolbox-expandable-content/ToolboxExpandableContent.tsx
+++ b/src/shared/components/toolbox/toolbox-expandable-content/ToolboxExpandableContent.tsx
@@ -16,11 +16,8 @@
 
 import React, { useState, useContext, ReactNode } from 'react';
 import noop from 'lodash/noop';
-import classNames from 'classnames';
 
 import ShowHide from 'src/shared/components/show-hide/ShowHide';
-
-import styles from './ToolboxExpandableContent.scss';
 
 export type ToolboxContext = {
   toggleExpanded: () => void;
@@ -49,14 +46,12 @@ const ToolboxExpandableContent = (props: ToolboxExpandableContentProps) => {
     setIsExpanded(updated);
   };
 
-  const wrapperClasses = classNames(styles.main, props.className);
-
   return (
     <ToolboxExpandableContentContext.Provider
       value={{ toggleExpanded, isExpanded }}
     >
-      <div>
-        <div className={wrapperClasses}>{props.mainContent}</div>
+      <div className={props.className}>
+        <div>{props.mainContent}</div>
         {isExpanded && <div>{props.footerContent}</div>}
       </div>
     </ToolboxExpandableContentContext.Provider>

--- a/src/shared/components/toolbox/toolbox-expandable-content/ToolboxExpandableContent.tsx
+++ b/src/shared/components/toolbox/toolbox-expandable-content/ToolboxExpandableContent.tsx
@@ -16,6 +16,7 @@
 
 import React, { useState, useContext, ReactNode } from 'react';
 import noop from 'lodash/noop';
+import classNames from 'classnames';
 
 import ShowHide from 'src/shared/components/show-hide/ShowHide';
 
@@ -29,6 +30,7 @@ export type ToolboxContext = {
 type ToolboxExpandableContentProps = {
   mainContent: ReactNode;
   footerContent: ReactNode;
+  className?: string;
 };
 
 type ToggleButtonProps = {
@@ -47,12 +49,14 @@ const ToolboxExpandableContent = (props: ToolboxExpandableContentProps) => {
     setIsExpanded(updated);
   };
 
+  const wrapperClasses = classNames(styles.main, props.className);
+
   return (
     <ToolboxExpandableContentContext.Provider
       value={{ toggleExpanded, isExpanded }}
     >
       <div>
-        <div className={styles.main}>{props.mainContent}</div>
+        <div className={wrapperClasses}>{props.mainContent}</div>
         {isExpanded && <div>{props.footerContent}</div>}
       </div>
     </ToolboxExpandableContentContext.Provider>


### PR DESCRIPTION
## Description
To format gene name line in the GB zmenu by setting a max and minimum width

•  zMenu without pointer: max width 450px
•  zMenu without pointer: min width 250px

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1233

## Deployment URL(s)
http://zmenu-css.review.ensembl.org/

## Views affected
GB Zmenu