### PR TITLE
Enable BLAST in production

### DIFF
--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.tsx
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.tsx
@@ -21,8 +21,6 @@ import useGenomeBrowserAnalytics from 'src/content/app/genome-browser/hooks/useG
 
 import { getReverseComplement } from 'src/shared/helpers/sequenceHelpers';
 
-import { Environment, isEnvironment } from 'src/shared/helpers/environment';
-
 import { getCommittedSpeciesById } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 
 import BlastSequenceButton from 'src/shared/components/blast-sequence-button/BlastSequenceButton';
@@ -126,16 +124,14 @@ const DrawerSequenceView = (props: Props) => {
           )}
           {isLoading && <Loading />}
           {isError && <LoadFailure refetch={refetch} />}
-          {!isEnvironment([Environment.PRODUCTION]) && (
-            <div className={styles.asideTop}>
-              <BlastSequenceButton
-                className={styles.blastSequenceButton}
-                sequence={sequence}
-                species={species}
-                sequenceType={sequenceTypeForBlast}
-              />
-            </div>
-          )}
+          <div className={styles.asideTop}>
+            <BlastSequenceButton
+              className={styles.blastSequenceButton}
+              sequence={sequence}
+              species={species}
+              sequenceType={sequenceTypeForBlast}
+            />
+          </div>
           <div className={styles.asideBottom}>
             <div className={styles.sequenceTypeSelection}>
               <RadioGroup

--- a/src/header/launchbar/Launchbar.tsx
+++ b/src/header/launchbar/Launchbar.tsx
@@ -79,11 +79,9 @@ const Launchbar = () => {
               enabled={true}
             />
           </div>
-          {isEnvironment([Environment.DEVELOPMENT, Environment.INTERNAL]) && (
-            <div className={styles.category}>
-              <BlastLaunchbarButton />
-            </div>
-          )}
+          <div className={styles.category}>
+            <BlastLaunchbarButton />
+          </div>
           {isEnvironment([Environment.DEVELOPMENT, Environment.INTERNAL]) && (
             <div className={styles.category}>
               <LaunchbarButton

--- a/src/root/rootEpic.ts
+++ b/src/root/rootEpic.ts
@@ -19,11 +19,7 @@ import { combineEpics } from 'redux-observable';
 import * as speciesSelectorEpics from 'src/content/app/species-selector/state/speciesSelectorEpics';
 import * as blastEpics from 'src/content/app/tools/blast/state/epics/blastEpics';
 
-import { isEnvironment, Environment } from 'src/shared/helpers/environment';
-
 export default combineEpics(
   ...Object.values(speciesSelectorEpics),
-
-  // IMPORTANT! remember to update the database version of indexed db when enabling the below in production
-  ...(isEnvironment([Environment.PRODUCTION]) ? [] : Object.values(blastEpics))
+  ...Object.values(blastEpics)
 );


### PR DESCRIPTION
## Description
Removing the checks that were hiding the BLAST-related UI in production.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1705

## Deployment URL(s)
You won't really be able to see any meaningful changes; but this branch should be deployed to
http://enable-blast-in-prod.review.ensembl.org

## Views affected
- Launchbar everywhere
- "BLAST this sequence" button in genome browser drawer

I checked the production build locally to verify that it works. 