### PR TITLE
Download table data

### DIFF
--- a/src/content/app/tools/blast/blast-download/submissionDownload.ts
+++ b/src/content/app/tools/blast/blast-download/submissionDownload.ts
@@ -168,7 +168,7 @@ const createZipArchive = async (submission: EnrichedBlastSubmission) => {
   return zip;
 };
 
-const getNameForZipRoot = (submission: BlastSubmission) => {
+export const getNameForZipRoot = (submission: BlastSubmission) => {
   const {
     id,
     submittedData: {

--- a/src/content/app/tools/blast/blast-download/submissionDownload.ts
+++ b/src/content/app/tools/blast/blast-download/submissionDownload.ts
@@ -100,7 +100,7 @@ const downloadBlastSubmission = async (
       csv = createCSVForGenomicBlast(job.data);
     } else if (blastedAgainst === 'cdna') {
       csv = createCSVForTranscriptBlast(job.data);
-    } else if (blastedAgainst === 'protein') {
+    } else if (blastedAgainst === 'pep') {
       csv = createCSVForProteinBlast(job.data);
     }
 

--- a/src/content/app/tools/blast/blast-download/submissionDownload.ts
+++ b/src/content/app/tools/blast/blast-download/submissionDownload.ts
@@ -168,7 +168,7 @@ const createZipArchive = async (submission: EnrichedBlastSubmission) => {
   return zip;
 };
 
-export const getNameForZipRoot = (submission: BlastSubmission) => {
+const getNameForZipRoot = (submission: BlastSubmission) => {
   const {
     id,
     submittedData: {

--- a/src/content/app/tools/blast/views/blast-submission-results/BlastSubmissionResults.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/BlastSubmissionResults.tsx
@@ -124,9 +124,8 @@ const Main = () => {
         key={data.sequence.id}
         species={data.species}
         sequence={data.sequence}
-        preset={blastSubmission.submittedData.preset}
+        submission={blastSubmission}
         blastResults={data.blastResults}
-        parameters={blastSubmission.submittedData.parameters}
       />
     )
   );

--- a/src/content/app/tools/blast/views/blast-submission-results/components/blast-results-per-sequence/BlastResultsPerSequence.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/blast-results-per-sequence/BlastResultsPerSequence.tsx
@@ -26,11 +26,10 @@ import SingleBlastJobResult from '../single-blast-job-result/SingleBlastJobResul
 import { parseBlastInput } from 'src/content/app/tools/blast/utils/blastInputParser';
 
 import type {
-  BlastSubmissionParameters,
-  BlastJobWithResults
+  BlastJobWithResults,
+  BlastSubmission
 } from 'src/content/app/tools/blast/state/blast-results/blastResultsSlice';
 import type { Species } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
-import type { DatabaseType } from 'src/content/app/tools/blast/types/blastSettings';
 
 import styles from './BlastResultsPerSequence.scss';
 
@@ -40,13 +39,19 @@ type BlastResultsPerSequenceProps = {
     value: string;
   };
   species: Species[];
-  preset: string;
   blastResults: BlastJobWithResults[];
-  parameters: BlastSubmissionParameters;
+  submission: BlastSubmission;
 };
 
 const BlastResultsPerSequence = (props: BlastResultsPerSequenceProps) => {
-  const { sequence, species, blastResults, parameters } = props;
+  const {
+    sequence,
+    species,
+    blastResults,
+    submission: {
+      submittedData: { parameters, preset }
+    }
+  } = props;
   const parsedBlastSequence = parseBlastInput(sequence.value)[0];
   const { header: sequenceHeader, value: sequenceValue } = parsedBlastSequence;
   const sequenceHeaderLabel =
@@ -73,7 +78,7 @@ const BlastResultsPerSequence = (props: BlastResultsPerSequenceProps) => {
             <JobParameters
               sequenceValue={sequence.value}
               parameters={parameters}
-              preset={props.preset}
+              preset={preset}
             />
           )}
         </div>
@@ -103,7 +108,7 @@ const BlastResultsPerSequence = (props: BlastResultsPerSequenceProps) => {
               species={speciesInfo}
               jobResult={result}
               diagramWidth={plotwidth}
-              blastDatabase={parameters.database as DatabaseType}
+              submission={props.submission}
             />
           );
         })}

--- a/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
@@ -25,8 +25,7 @@ import BlastHitsDiagram from 'src/content/app/tools/blast/components/blast-hits-
 import BlastSequenceAlignment from 'src/content/app/tools/blast/components/blast-sequence-alignment/BlastSequenceAlignment';
 
 import { createCSVForGenomicBlast } from 'src/content/app/tools/blast/blast-download/createBlastCSVTable';
-import { getNameForZipRoot } from 'src/content/app/tools/blast/blast-download/submissionDownload';
-import { downloadBlobAsFile } from 'src/shared/helpers/downloadAsFile';
+import { downloadTextAsFile } from 'src/shared/helpers/downloadAsFile';
 
 import type {
   BlastHit,
@@ -193,11 +192,7 @@ const SingleBlastJobResult = (props: SingleBlastJobResultProps) => {
       </div>
 
       {isExpanded && (
-        <HitsTable
-          jobResult={jobResult}
-          submission={submission}
-          species={speciesInfo}
-        />
+        <HitsTable jobResult={jobResult} submission={submission} />
       )}
     </div>
   );
@@ -206,15 +201,12 @@ const SingleBlastJobResult = (props: SingleBlastJobResultProps) => {
 type HitsTableProps = {
   jobResult: SingleBlastJobResultProps['jobResult'];
   submission: BlastSubmission;
-  species: Species;
 };
 const HitsTable = (props: HitsTableProps) => {
-  const { jobResult, submission, species } = props;
+  const { jobResult, submission } = props;
 
   const blastDatabase = submission.submittedData.parameters
     .database as DatabaseType;
-
-  const zipFileName = getNameForZipRoot(submission) + '.zip';
 
   const [tableState, setTableState] = useState<Partial<DataTableState>>({
     rowsPerPage: 100,
@@ -347,26 +339,9 @@ const HitsTable = (props: HitsTableProps) => {
   };
 
   const downloadHandler = async () => {
-    const JSZip = await import('jszip').then((module) => module.default); // use a dynamic import to split this library off in a separate chunk
     const csv = createCSVForGenomicBlast(jobResult.data);
 
-    const zip = new JSZip();
-    const rootFolder = zip.folder(getNameForZipRoot(submission));
-
-    const { sequenceId } = jobResult;
-
-    const speciesFolderName = `${species.scientific_name}-${species.genome_id}`;
-    const sequenceFolderName = `Query sequence ${sequenceId}`; // NOTE: this name will probably change as well
-    const csvFileName = 'table';
-
-    rootFolder?.file(
-      `${speciesFolderName}/${sequenceFolderName}/${csvFileName}.csv`,
-      csv
-    );
-
-    const blob = await zip.generateAsync({ type: 'blob' });
-
-    await downloadBlobAsFile(blob, zipFileName);
+    await downloadTextAsFile(csv, 'table.csv');
   };
 
   return (
@@ -384,7 +359,6 @@ const HitsTable = (props: HitsTableProps) => {
           TableAction.DOWNLOAD_SHOWN_DATA
         ]}
         downloadHandler={downloadHandler}
-        downloadFileName={zipFileName}
       />
     </div>
   );

--- a/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
@@ -241,7 +241,7 @@ const HitsTable = (props: HitsTableProps) => {
           hitHsp.hsp_align_len,
           '', // view_alignment
           hitHsp.hsp_identity,
-          hitHsp.hsp_score,
+          hitHsp.hsp_bit_score,
           getDynamicColumnContent({
             hit,
             blastDatabase,

--- a/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
@@ -24,7 +24,11 @@ import ShowHide from 'src/shared/components/show-hide/ShowHide';
 import BlastHitsDiagram from 'src/content/app/tools/blast/components/blast-hits-diagram/BlastHitsDiagram';
 import BlastSequenceAlignment from 'src/content/app/tools/blast/components/blast-sequence-alignment/BlastSequenceAlignment';
 
-import { createCSVForGenomicBlast } from 'src/content/app/tools/blast/blast-download/createBlastCSVTable';
+import {
+  createCSVForGenomicBlast,
+  createCSVForProteinBlast,
+  createCSVForTranscriptBlast
+} from 'src/content/app/tools/blast/blast-download/createBlastCSVTable';
 import { downloadTextAsFile } from 'src/shared/helpers/downloadAsFile';
 
 import type {
@@ -339,7 +343,14 @@ const HitsTable = (props: HitsTableProps) => {
   };
 
   const downloadHandler = async () => {
-    const csv = createCSVForGenomicBlast(jobResult.data);
+    let csv = '';
+    if (blastDatabase === 'dna') {
+      csv = createCSVForGenomicBlast(jobResult.data);
+    } else if (blastDatabase === 'cdna') {
+      csv = createCSVForTranscriptBlast(jobResult.data);
+    } else if (blastDatabase === 'pep') {
+      csv = createCSVForProteinBlast(jobResult.data);
+    }
 
     await downloadTextAsFile(csv, 'table.csv');
   };
@@ -397,6 +408,7 @@ const getDynamicColumnContent = (props: DynamicColumnContentProps) => {
 
   return (
     <span className={styles.nowrap}>
+      <span>hello</span>
       {`${hit.hit_acc}:${[hitHsp.hsp_hit_from, hitHsp.hsp_hit_to]
         .sort()
         .join('-')}`}

--- a/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
@@ -408,7 +408,6 @@ const getDynamicColumnContent = (props: DynamicColumnContentProps) => {
 
   return (
     <span className={styles.nowrap}>
-      <span>hello</span>
       {`${hit.hit_acc}:${[hitHsp.hsp_hit_from, hitHsp.hsp_hit_to]
         .sort()
         .join('-')}`}

--- a/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
@@ -70,7 +70,12 @@ const hitsTableColumns: DataTableColumns = [
     title: 'Length',
     isSortable: true
   },
-  { width: '200px', columnId: 'view_alignment', isHideable: false },
+  {
+    width: '200px',
+    columnId: 'view_alignment',
+    isHideable: false,
+    isExportable: false
+  },
   {
     width: '100px',
     columnId: 'percentage_id',
@@ -199,6 +204,8 @@ type HitsTableProps = {
 const HitsTable = (props: HitsTableProps) => {
   const { jobResult, blastDatabase } = props;
 
+  const { jobId } = jobResult;
+
   const [tableState, setTableState] = useState<Partial<DataTableState>>({
     rowsPerPage: 100,
     sortedColumn: {
@@ -229,12 +236,11 @@ const HitsTable = (props: HitsTableProps) => {
           '', // view_alignment
           hitHsp.hsp_identity,
           hitHsp.hsp_score,
-          <DynamicColumnContent
-            key={counter}
-            hit={hit}
-            blastDatabase={blastDatabase}
-            hitHsp={hitHsp}
-          />,
+          getDynamicColumnContent({
+            hit,
+            blastDatabase,
+            hitHsp
+          }),
           <span key={counter} className={styles.hitOrientation}>
             {hitHsp.hsp_hit_frame === '1' ? 'Forward' : 'Reverse'}
           </span>,
@@ -339,11 +345,8 @@ const HitsTable = (props: HitsTableProps) => {
         theme="dark"
         className={styles.hitsTable}
         expandedContent={expandedContent}
-        disabledActions={[
-          TableAction.FILTERS,
-          TableAction.DOWNLOAD_ALL_DATA,
-          TableAction.DOWNLOAD_SHOWN_DATA
-        ]}
+        disabledActions={[TableAction.FILTERS]}
+        exportFileName={`ensembl-blast_${jobId}.csv`}
       />
     </div>
   );
@@ -373,7 +376,7 @@ type DynamicColumnContentProps = {
   blastDatabase: DatabaseType;
 };
 
-const DynamicColumnContent = (props: DynamicColumnContentProps) => {
+const getDynamicColumnContent = (props: DynamicColumnContentProps) => {
   const { hit, blastDatabase, hitHsp } = props;
 
   if (blastDatabase !== 'dna') {

--- a/src/shared/components/data-table/DataTable.tsx
+++ b/src/shared/components/data-table/DataTable.tsx
@@ -40,6 +40,7 @@ type TableContextType = DataTableState & {
   selectableColumnIndex: number;
   expandedContent: { [rowId: string]: ReactNode };
   disabledActions?: TableAction[];
+  exportFileName?: string;
   rows: TableRows;
 };
 
@@ -48,14 +49,15 @@ export const TableContext = React.createContext(
 );
 
 export type TableProps = {
-  onStateChange?: (newState: DataTableState) => void;
+  state: Partial<DataTableState>;
   columns: DataTableColumns;
-  state?: Partial<DataTableState>;
   theme: TableTheme;
   selectableColumnIndex: number;
-  className?: string;
   expandedContent: { [rowId: string]: ReactNode };
   disabledActions?: TableAction[];
+  className?: string;
+  exportFileName?: string;
+  onStateChange?: (newState: DataTableState) => void;
 };
 const DataTable = (props: TableProps) => {
   const initialDataTableState = {
@@ -96,7 +98,8 @@ const DataTable = (props: TableProps) => {
         theme: props.theme,
         selectableColumnIndex: props.selectableColumnIndex,
         expandedContent: props.expandedContent,
-        disabledActions: props.disabledActions
+        disabledActions: props.disabledActions,
+        exportFileName: props.exportFileName
       }}
     >
       <div className={wrapperClasses}>

--- a/src/shared/components/data-table/DataTable.tsx
+++ b/src/shared/components/data-table/DataTable.tsx
@@ -40,7 +40,8 @@ type TableContextType = DataTableState & {
   selectableColumnIndex: number;
   expandedContent: { [rowId: string]: ReactNode };
   disabledActions?: TableAction[];
-  exportFileName?: string;
+  downloadFileName?: string;
+  downloadHandler?: () => void;
   rows: TableRows;
 };
 
@@ -56,7 +57,8 @@ export type TableProps = {
   expandedContent: { [rowId: string]: ReactNode };
   disabledActions?: TableAction[];
   className?: string;
-  exportFileName?: string;
+  downloadFileName?: string;
+  downloadHandler?: () => void;
   onStateChange?: (newState: DataTableState) => void;
 };
 const DataTable = (props: TableProps) => {
@@ -99,7 +101,8 @@ const DataTable = (props: TableProps) => {
         selectableColumnIndex: props.selectableColumnIndex,
         expandedContent: props.expandedContent,
         disabledActions: props.disabledActions,
-        exportFileName: props.exportFileName
+        downloadFileName: props.downloadFileName,
+        downloadHandler: props.downloadHandler
       }}
     >
       <div className={wrapperClasses}>

--- a/src/shared/components/data-table/DataTable.tsx
+++ b/src/shared/components/data-table/DataTable.tsx
@@ -41,7 +41,7 @@ type TableContextType = DataTableState & {
   expandedContent: { [rowId: string]: ReactNode };
   disabledActions?: TableAction[];
   downloadFileName?: string;
-  downloadHandler?: () => void;
+  downloadHandler?: () => Promise<void>;
   rows: TableRows;
 };
 
@@ -58,7 +58,7 @@ export type TableProps = {
   disabledActions?: TableAction[];
   className?: string;
   downloadFileName?: string;
-  downloadHandler?: () => void;
+  downloadHandler?: () => Promise<void>;
   onStateChange?: (newState: DataTableState) => void;
 };
 const DataTable = (props: TableProps) => {

--- a/src/shared/components/data-table/components/table-controls/components/table-actions/TableActions.tsx
+++ b/src/shared/components/data-table/components/table-controls/components/table-actions/TableActions.tsx
@@ -55,7 +55,7 @@ const actionOptions = [
   },
   {
     value: TableAction.DOWNLOAD_ALL_DATA,
-    label: 'Download all data'
+    label: 'Download this table'
   },
   {
     value: TableAction.RESTORE_DEFAULTS,

--- a/src/shared/components/data-table/components/table-controls/components/table-actions/TableActions.tsx
+++ b/src/shared/components/data-table/components/table-controls/components/table-actions/TableActions.tsx
@@ -21,6 +21,7 @@ import { TableContext } from 'src/shared/components/data-table/DataTable';
 import RowVisibilityController from 'src/shared/components/data-table/components/main/components/table-row/components/row-visibility-controller/RowVisibilityController';
 import FindInTable from './components/find-in-table/FindInTable';
 import ShowHideColumns from './components/show-hide-columns/ShowHideColumns';
+import DownloadData from './components/download-data/DownloadData';
 
 import {
   type DataTableState,
@@ -144,6 +145,10 @@ const getActionComponent = (selectedAction: TableAction) => {
       return <ShowHideColumns />;
     case TableAction.SHOW_HIDE_ROWS:
       return <RowVisibilityController />;
+    case TableAction.DOWNLOAD_ALL_DATA:
+      return <DownloadData />;
+    case TableAction.DOWNLOAD_SHOWN_DATA:
+      return <DownloadData />;
     default:
       return null;
   }

--- a/src/shared/components/data-table/components/table-controls/components/table-actions/components/download-data/DownloadData.scss
+++ b/src/shared/components/data-table/components/table-controls/components/table-actions/components/download-data/DownloadData.scss
@@ -1,0 +1,14 @@
+@import 'src/styles/common';
+
+.downloadData {
+  display: flex;
+  column-gap: 10px;
+  margin-left: 10px;
+  align-items: center;
+}
+
+.cancel {
+  color: $blue;
+  cursor: pointer;
+  margin-left: 10px;
+}

--- a/src/shared/components/data-table/components/table-controls/components/table-actions/components/download-data/DownloadData.tsx
+++ b/src/shared/components/data-table/components/table-controls/components/table-actions/components/download-data/DownloadData.tsx
@@ -84,7 +84,11 @@ const DownloadData = () => {
         setTimeout(restoreDefaults, 1000);
       } catch {
         setDownloadState(LoadingState.ERROR);
-        setTimeout(() => setDownloadState(LoadingState.NOT_REQUESTED), 2000);
+        setTimeout(() => {
+          if (allowComponentResetRef.current) {
+            setDownloadState(LoadingState.NOT_REQUESTED);
+          }
+        }, 2000);
       }
 
       return;

--- a/src/shared/components/data-table/components/table-controls/components/table-actions/components/download-data/DownloadData.tsx
+++ b/src/shared/components/data-table/components/table-controls/components/table-actions/components/download-data/DownloadData.tsx
@@ -97,7 +97,7 @@ const DownloadData = () => {
 
   return (
     <div className={styles.downloadData}>
-      <span>{downloadFileName ?? 'Table export.csv'}</span>
+      <span>{downloadFileName ?? 'table.csv'}</span>
       <PrimaryButton onClick={handleDownload}>Download</PrimaryButton>
       <span className={styles.cancel} onClick={onCancel}>
         cancel

--- a/src/shared/components/data-table/components/table-controls/components/table-actions/components/download-data/DownloadData.tsx
+++ b/src/shared/components/data-table/components/table-controls/components/table-actions/components/download-data/DownloadData.tsx
@@ -1,0 +1,107 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { ReactNode } from 'react';
+
+import { TableAction } from 'src/shared/components/data-table/dataTableTypes';
+import useDataTable from 'src/shared/components/data-table/hooks/useDataTable';
+
+import { PrimaryButton } from 'src/shared/components/button/Button';
+
+import styles from './DownloadData.scss';
+import { downloadTextAsFile } from 'src/shared/helpers/downloadAsFile';
+
+const getReactNodeText = (node: ReactNode): string => {
+  if (['string', 'number'].includes(typeof node)) {
+    return node?.toString() || '';
+  }
+
+  if (typeof node === 'object' && node && 'props' in node) {
+    return getReactNodeText(node.props.children);
+  }
+
+  return '';
+};
+
+const DownloadData = () => {
+  const {
+    dispatch,
+    rows,
+    exportFileName,
+    columns,
+    selectedAction,
+    hiddenRowIds
+  } = useDataTable();
+
+  const onCancel = () => {
+    dispatch({
+      type: 'set_selected_action',
+      payload: TableAction.DEFAULT
+    });
+  };
+
+  const handleDownload = () => {
+    const dataForExport: string[][] = [];
+    dataForExport[0] = [
+      ...columns
+        .filter((column) => column.isExportable !== false)
+        .map((column) => column.title ?? '')
+    ];
+
+    const rowsToDownload =
+      selectedAction === TableAction.DOWNLOAD_ALL_DATA
+        ? rows
+        : rows.filter((row) => !hiddenRowIds[row.rowId]);
+
+    rowsToDownload.forEach((row, rowIndex) => {
+      dataForExport[rowIndex + 1] = [];
+      row.cells.forEach((cell, cellIndex) => {
+        const { renderer, isExportable } = columns[cellIndex];
+
+        if (isExportable !== false) {
+          const cellExportData = renderer
+            ? renderer({
+                rowData: row.cells,
+                rowId: String(row.rowId),
+                cellData: cell
+              })
+            : cell;
+
+          dataForExport[rowIndex + 1].push(getReactNodeText(cellExportData));
+        }
+      });
+    });
+
+    const csv = formatCSV(dataForExport);
+
+    downloadTextAsFile(csv, exportFileName ?? 'Table export.csv');
+  };
+
+  return (
+    <div className={styles.downloadData}>
+      <span>{exportFileName ?? 'Table export.csv'}</span>
+      <PrimaryButton onClick={handleDownload}>Download</PrimaryButton>
+      <span className={styles.cancel} onClick={onCancel}>
+        cancel
+      </span>
+    </div>
+  );
+};
+
+const formatCSV = (table: (string | number)[][]) => {
+  return table.map((row) => row.join(',')).join('\n');
+};
+
+export default DownloadData;

--- a/src/shared/components/data-table/components/table-controls/components/table-actions/components/download-data/DownloadData.tsx
+++ b/src/shared/components/data-table/components/table-controls/components/table-actions/components/download-data/DownloadData.tsx
@@ -15,13 +15,14 @@
  */
 import React, { ReactNode } from 'react';
 
-import { TableAction } from 'src/shared/components/data-table/dataTableTypes';
 import useDataTable from 'src/shared/components/data-table/hooks/useDataTable';
+import { downloadTextAsFile } from 'src/shared/helpers/downloadAsFile';
 
 import { PrimaryButton } from 'src/shared/components/button/Button';
 
+import { TableAction } from 'src/shared/components/data-table/dataTableTypes';
+
 import styles from './DownloadData.scss';
-import { downloadTextAsFile } from 'src/shared/helpers/downloadAsFile';
 
 const getReactNodeText = (node: ReactNode): string => {
   if (['string', 'number'].includes(typeof node)) {

--- a/src/shared/components/data-table/components/table-controls/components/table-actions/components/download-data/DownloadData.tsx
+++ b/src/shared/components/data-table/components/table-controls/components/table-actions/components/download-data/DownloadData.tsx
@@ -15,7 +15,7 @@
  */
 import React, { ReactNode } from 'react';
 import ReactDOM from 'react-dom/client';
-import { memoize } from 'lodash';
+import memoize from 'lodash/memoize';
 
 import useDataTable from 'src/shared/components/data-table/hooks/useDataTable';
 import { downloadTextAsFile } from 'src/shared/helpers/downloadAsFile';
@@ -53,7 +53,7 @@ const DownloadData = () => {
     downloadHandler
   } = useDataTable();
 
-  const onCancel = () => {
+  const restoreDefaults = () => {
     dispatch({
       type: 'set_selected_action',
       payload: TableAction.DEFAULT
@@ -62,7 +62,8 @@ const DownloadData = () => {
 
   const handleDownload = async () => {
     if (downloadHandler) {
-      downloadHandler();
+      await downloadHandler();
+      setTimeout(restoreDefaults, 1000);
       return;
     }
     const dataForExport: string[][] = [];
@@ -99,20 +100,15 @@ const DownloadData = () => {
     const csv = formatCSV(dataForExport);
 
     downloadTextAsFile(csv, downloadFileName ?? 'Table export.csv');
-  };
 
-  const onSuccess = () => {
-    // show the green tick momentarily before we close it
-    setTimeout(onCancel, 1000);
+    setTimeout(restoreDefaults, 1000);
   };
 
   return (
     <div className={styles.downloadData}>
       <span>{downloadFileName ?? 'table.csv'}</span>
-      <LoadingButton onClick={handleDownload} onSuccess={onSuccess}>
-        Download
-      </LoadingButton>
-      <span className={styles.cancel} onClick={onCancel}>
+      <LoadingButton onClick={handleDownload}>Download</LoadingButton>
+      <span className={styles.cancel} onClick={restoreDefaults}>
         cancel
       </span>
     </div>

--- a/src/shared/components/data-table/components/table-controls/components/table-actions/components/download-data/DownloadData.tsx
+++ b/src/shared/components/data-table/components/table-controls/components/table-actions/components/download-data/DownloadData.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom/client';
 import memoize from 'lodash/memoize';
 
@@ -53,11 +53,23 @@ const DownloadData = () => {
     downloadHandler
   } = useDataTable();
 
+  const allowComponentResetRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      allowComponentResetRef.current = false;
+    };
+  }, []);
+
   const restoreDefaults = () => {
-    dispatch({
-      type: 'set_selected_action',
-      payload: TableAction.DEFAULT
-    });
+    setTimeout(() => {
+      if (allowComponentResetRef.current) {
+        dispatch({
+          type: 'set_selected_action',
+          payload: TableAction.DEFAULT
+        });
+      }
+    }, 1000);
   };
 
   const handleDownload = async () => {
@@ -101,7 +113,7 @@ const DownloadData = () => {
 
     downloadTextAsFile(csv, downloadFileName ?? 'Table export.csv');
 
-    setTimeout(restoreDefaults, 1000);
+    restoreDefaults();
   };
 
   return (

--- a/src/shared/components/data-table/components/table-controls/components/table-actions/components/download-data/DownloadData.tsx
+++ b/src/shared/components/data-table/components/table-controls/components/table-actions/components/download-data/DownloadData.tsx
@@ -39,10 +39,11 @@ const DownloadData = () => {
   const {
     dispatch,
     rows,
-    exportFileName,
+    downloadFileName,
     columns,
     selectedAction,
-    hiddenRowIds
+    hiddenRowIds,
+    downloadHandler
   } = useDataTable();
 
   const onCancel = () => {
@@ -53,6 +54,10 @@ const DownloadData = () => {
   };
 
   const handleDownload = () => {
+    if (downloadHandler) {
+      downloadHandler();
+      return;
+    }
     const dataForExport: string[][] = [];
     dataForExport[0] = [
       ...columns
@@ -86,12 +91,12 @@ const DownloadData = () => {
 
     const csv = formatCSV(dataForExport);
 
-    downloadTextAsFile(csv, exportFileName ?? 'Table export.csv');
+    downloadTextAsFile(csv, downloadFileName ?? 'Table export.csv');
   };
 
   return (
     <div className={styles.downloadData}>
-      <span>{exportFileName ?? 'Table export.csv'}</span>
+      <span>{downloadFileName ?? 'Table export.csv'}</span>
       <PrimaryButton onClick={handleDownload}>Download</PrimaryButton>
       <span className={styles.cancel} onClick={onCancel}>
         cancel

--- a/src/shared/components/data-table/dataTableTypes.ts
+++ b/src/shared/components/data-table/dataTableTypes.ts
@@ -62,6 +62,7 @@ export type IndividualColumn = {
   isSearchable?: boolean;
   isFilterable?: boolean;
   isHideable?: boolean;
+  isExportable?: boolean;
   headerCellClassName?: string;
   bodyCellClassName?: string;
   helpText?: ReactNode;


### PR DESCRIPTION
## Description
- Implemented "Download this table" option on DataTable and enable it on Blast result table

The DataTable can either handle the download by itself by generating a csv or it can give the control over to the parent component using the `downloadHandler` prop.


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1736

## Deployment URL(s)
http://datatable-export.review.ensembl.org
