### PR TITLE
Add FASTA header to BLAST result in job list pages

### DIFF
--- a/src/content/app/tools/blast/components/listed-blast-submission/ListedBlastSubmission.scss
+++ b/src/content/app/tools/blast/components/listed-blast-submission/ListedBlastSubmission.scss
@@ -32,6 +32,10 @@ and also that it can be of variable width
   border-top: none;
 }
 
+.sequenceHeader {
+  font-weight: $light;
+}
+
 .speciesCount {
   grid-column: species-count;
 }

--- a/src/content/app/tools/blast/components/listed-blast-submission/ListedBlastSubmission.tsx
+++ b/src/content/app/tools/blast/components/listed-blast-submission/ListedBlastSubmission.tsx
@@ -22,6 +22,8 @@ import { useAppDispatch, useAppSelector } from 'src/store';
 import BlastSubmissionHeader from '../blast-submission-header/BlastSubmissionHeader';
 
 import { pluralise } from 'src/shared/helpers/formatters/pluralisationFormatter';
+import { parseBlastInput } from 'src/content/app/tools/blast/utils/blastInputParser';
+
 import {
   type BlastSubmission,
   type BlastJob,
@@ -123,10 +125,15 @@ type SequenceBoxProps = {
 
 const SequenceBox = (props: SequenceBoxProps) => {
   const { sequence, jobs } = props;
+  const parsedBlastSequence = parseBlastInput(sequence.value)[0];
+  const { header: sequenceHeader } = parsedBlastSequence;
+  const sequenceHeaderLabel =
+    '>' + (sequenceHeader ?? `Sequence ${sequence.id}`);
 
   return (
     <div className={styles.sequenceBox}>
       <div>Sequence {sequence.id}</div>
+      <div className={styles.sequenceHeader}>{sequenceHeaderLabel}</div>
       <div className={styles.speciesCount}>
         <span className={styles.againstText}>Against</span> {jobs.length}{' '}
         species


### PR DESCRIPTION
## Description
Add FASTA header to BLAST result pages (Unviewed jobs and Jobs list). This has already been added into running BLAST jobs to increase the clickable area (#843).


## Related JIRA Issue(s)
[ENSWBSITES-1760](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1760)


## Deployment URL(s)
http://add-fasta-header-blast-result.review.ensembl.org


## Views affected
Blast -> Unviewed jobs
Blast -> Jobs list