### PR TITLE
Make the label of FeatureLengthRuler more customizable

### DIFF
--- a/src/content/app/entity-viewer/gene-view/components/gene-overview-image/GeneOverviewImage.scss
+++ b/src/content/app/entity-viewer/gene-view/components/gene-overview-image/GeneOverviewImage.scss
@@ -57,5 +57,6 @@
   grid-column: 3/4;
   grid-row: 3/4;
   padding-top: 15px;
+  --sequence-ruler-name-color: white;
   --sequence-ruler-label-color: white;
 }

--- a/src/content/app/entity-viewer/gene-view/components/gene-overview-image/GeneOverviewImage.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-overview-image/GeneOverviewImage.tsx
@@ -67,7 +67,7 @@ const GeneOverviewImage = (props: GeneOverviewImageProps) => {
         <FeatureLengthRuler
           length={length}
           width={gene_image_width}
-          unitsLabel="bp"
+          rulerLabel="bp"
           onTicksCalculated={props.onTicksCalculated}
           standalone={true}
         />

--- a/src/content/app/tools/blast/views/blast-submission-results/components/blast-results-per-sequence/BlastResultsPerSequence.scss
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/blast-results-per-sequence/BlastResultsPerSequence.scss
@@ -19,6 +19,7 @@
 
 .rulerContainer {
   grid-column: ruler;
+  --sequence-ruler-name-color: #{$dark-grey};
 }
 
 .wrapper {

--- a/src/content/app/tools/blast/views/blast-submission-results/components/blast-results-per-sequence/BlastResultsPerSequence.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/blast-results-per-sequence/BlastResultsPerSequence.tsx
@@ -111,6 +111,7 @@ const BlastResultsPerSequence = (props: BlastResultsPerSequenceProps) => {
         <div ref={rulerContainer} className={styles.rulerContainer}>
           {shouldShowJobResult && (
             <FeatureLengthRuler
+              unitsLabel="Label"
               width={plotwidth}
               length={sequenceValue.length}
               standalone={true}

--- a/src/content/app/tools/blast/views/blast-submission-results/components/blast-results-per-sequence/BlastResultsPerSequence.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/blast-results-per-sequence/BlastResultsPerSequence.tsx
@@ -112,6 +112,7 @@ const BlastResultsPerSequence = (props: BlastResultsPerSequenceProps) => {
           {shouldShowJobResult && (
             <FeatureLengthRuler
               rulerLabel="Length"
+              rulerLabelOffset={2.5}
               width={plotwidth}
               length={sequenceValue.length}
               standalone={true}

--- a/src/content/app/tools/blast/views/blast-submission-results/components/blast-results-per-sequence/BlastResultsPerSequence.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/blast-results-per-sequence/BlastResultsPerSequence.tsx
@@ -111,7 +111,7 @@ const BlastResultsPerSequence = (props: BlastResultsPerSequenceProps) => {
         <div ref={rulerContainer} className={styles.rulerContainer}>
           {shouldShowJobResult && (
             <FeatureLengthRuler
-              unitsLabel="Label"
+              rulerLabel="Length"
               width={plotwidth}
               length={sequenceValue.length}
               standalone={true}

--- a/src/shared/components/feature-length-ruler/FeatureLengthRuler.scss
+++ b/src/shared/components/feature-length-ruler/FeatureLengthRuler.scss
@@ -9,6 +9,10 @@
   fill: var(--sequence-ruler-color, #{$orange});
 }
 
+.rulerName {
+  fill: var(--sequence-ruler-name-color, black);
+}
+
 .label {
   fill: var(--sequence-ruler-label-color, black);
   font-size: 10px;

--- a/src/shared/components/feature-length-ruler/FeatureLengthRuler.tsx
+++ b/src/shared/components/feature-length-ruler/FeatureLengthRuler.tsx
@@ -50,7 +50,8 @@ export type TicksAndScale = Ticks & {
 type Props = {
   length: number; // number of biological building blocks (e.g. nucleotides) in the feature
   width: number; // number of pixels allotted to the axis on the screen
-  unitsLabel?: string; // optional label showing what the ruler is measuring; will be displayed at the start of the ruler if present
+  rulerLabel?: string; // optional label showing what the ruler is measuring; will be displayed at the start of the ruler if present
+  rulerLabelOffset?: number; // in ch units (roughly, one character width) — how much space to put between the ruler label and the first tick label, defaults to 2 ch
   onTicksCalculated?: (payload: TicksAndScale) => void; // way to pass the ticks to the parent if it is interested in them
   standalone?: boolean; // wrap the component in an svg element if true
 };
@@ -79,10 +80,15 @@ const FeatureLengthRuler = (props: Props) => {
       <g>
         <rect className={styles.tick} width={1} height={6} />
         <text className={styles.label} x={0} y={20} textAnchor="end">
-          {props.unitsLabel && (
-            <tspan className={styles.rulerName}>{props.unitsLabel}</tspan>
+          {props.rulerLabel && (
+            <tspan
+              className={styles.rulerName}
+              x={`-${props.rulerLabelOffset ?? 2}ch`}
+            >
+              {props.rulerLabel}
+            </tspan>
           )}
-          <tspan>1</tspan>
+          <tspan x={0}>1</tspan>
         </text>
       </g>
       {ticks.map((tick) => (

--- a/src/shared/components/feature-length-ruler/FeatureLengthRuler.tsx
+++ b/src/shared/components/feature-length-ruler/FeatureLengthRuler.tsx
@@ -79,7 +79,10 @@ const FeatureLengthRuler = (props: Props) => {
       <g>
         <rect className={styles.tick} width={1} height={6} />
         <text className={styles.label} x={0} y={20} textAnchor="end">
-          {props.unitsLabel ? `${props.unitsLabel} 1` : 1}
+          {props.unitsLabel && (
+            <tspan className={styles.rulerName}>{props.unitsLabel}</tspan>
+          )}
+          <tspan>1</tspan>
         </text>
       </g>
       {ticks.map((tick) => (

--- a/stories/shared-components/feature-length-ruler/FeatureLengthRuler.stories.tsx
+++ b/stories/shared-components/feature-length-ruler/FeatureLengthRuler.stories.tsx
@@ -57,7 +57,7 @@ export const FeatureLengthRulerStory = () => {
       <FeatureLengthRuler
         length={length}
         width={800}
-        unitsLabel="bp"
+        rulerLabel="bp"
         standalone={true}
       />
       <div>


### PR DESCRIPTION
## Description
- Add customisability for FeatureLengthRuler label
  - Enable colouring it differently from the labels of the ticks
  - Make the distance between the ruler label and the first tick label tweakable 
- Changed the `unitsLabel` property to `rulerLabel`
- Add the label `Length` to the ruler on the BLAST submission details page

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1738

## Deployment URL(s)
http://ruler-label.review.ensembl.org