### PR TITLE
Add visualisation for BLAST against genomic targets

### DIFF
--- a/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicHitsDiagram.scss
+++ b/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicHitsDiagram.scss
@@ -1,0 +1,20 @@
+@import 'src/styles/common';
+
+.regionName {
+  fill: $black;
+  font-size: 10px;
+}
+
+.backbone {
+  fill: $medium-dark-grey;
+}
+
+.hit {
+  fill: $black;
+  opacity: 0.3;
+}
+
+.topHit {
+  stroke: red;
+  fill: none;
+}

--- a/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicHitsDiagram.scss
+++ b/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicHitsDiagram.scss
@@ -18,3 +18,32 @@
   stroke: red;
   fill: none;
 }
+
+.diagramLegend {
+  display: grid;
+  grid-template-columns: repeat(2, auto);
+  column-gap: 14px;
+  align-items: center;
+}
+
+.diagramLegendLabel {
+  font-size: 12px;
+  font-weight: $light;
+}
+
+.diagramLegend > svg {
+  width: 13px;
+  overflow: visible;
+}
+
+.regionsExpandToggle {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.regionsExpandToggle > span {
+  font-size: 12px;
+  font-weight: $light;
+  margin-right: 10px;
+}

--- a/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicHitsDiagram.tsx
+++ b/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicHitsDiagram.tsx
@@ -20,6 +20,7 @@ import sortBy from 'lodash/sortBy';
 import { useGenomeKaryotypeQuery } from 'src/shared/state/genome/genomeApiSlice';
 
 import BlastGenomicRegionHeatmap from './BlastGenomicRegionHeatmap';
+import RegionWithoutMatches from './BlastGenomicRegionWithoutMatches';
 import PillButton from 'src/shared/components/pill-button/PillButton';
 import CloseButton from 'src/shared/components/close-button/CloseButton';
 
@@ -66,6 +67,10 @@ const BlastGenomicHitsDiagram = (props: Props) => {
   const regionNamesForDisplay = isExpanded
     ? sortedRegionNamesForExpandedView
     : sortedRegionNamesForCompactView;
+
+  if (!regionNamesForDisplay.length) {
+    return <RegionWithoutMatches width={width} />;
+  }
 
   return (
     <div>

--- a/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicHitsDiagram.tsx
+++ b/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicHitsDiagram.tsx
@@ -31,16 +31,7 @@ type Props = {
   genomeId: string;
   job: BlastJobResult;
   width: number;
-  // isExpanded: boolean;
 };
-
-// sort all matches by evalue
-// take the top five matches after sorting
-// if collapsed, only showing the regions that include the top five matches
-// if expanded, show all regions sorted by length (not necessarily having the top matches)
-// hack? exclude patches from human genomic hits?
-
-// NOTE: there may or may not be regions beyond the ones with the top five hits
 
 const BlastGenomicHitsDiagram = (props: Props) => {
   const { genomeId, job, width } = props;

--- a/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicHitsDiagram.tsx
+++ b/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicHitsDiagram.tsx
@@ -1,0 +1,93 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import sortBy from 'lodash/sortBy';
+
+import { useGenomeKaryotypeQuery } from 'src/shared/state/genome/genomeApiSlice';
+
+import BlastGenomicRegionHeatmap from './BlastGenomicRegionHeatmap';
+
+import type { BlastJobResult } from 'src/content/app/tools/blast/types/blastJob';
+
+type Props = {
+  genomeId: string;
+  job: BlastJobResult;
+  width: number;
+  // isExpanded: boolean;
+};
+
+// sort all matches by evalue
+// take the top five matches after sorting
+// if collapsed, only showing the regions that include the top five matches
+// if expanded, show all regions sorted by length (not necessarily having the top matches)
+// hack? exclude patches from human genomic hits?
+
+// NOTE: there may or may not be regions beyond the ones with the top five hits
+
+const BlastGenomicHitsDiagram = (props: Props) => {
+  const { genomeId, job, width } = props;
+  const { currentData: genomeKaryotype } = useGenomeKaryotypeQuery(genomeId); // the karyotype data has properly sorted top-level sequences
+
+  if (!genomeKaryotype) {
+    return null;
+  }
+
+  const topMatches = getTopMatchesWithRegionNames(job);
+
+  // For the compact view, select regions with top five matches, and deduplicate them
+  const regionNamesForCompactView = new Set(
+    topMatches.map(({ regionName }) => regionName)
+  );
+  const sortedRegionNamesForCompactView = genomeKaryotype
+    .map(({ name }) => name)
+    .filter((name) => regionNamesForCompactView.has(name));
+
+  return (
+    <div>
+      {sortedRegionNamesForCompactView.map((name) => (
+        <BlastGenomicRegionHeatmap
+          key={name}
+          job={job}
+          width={width}
+          regionName={name}
+          topHits={topMatches.filter((match) => match.regionName === name)}
+        />
+      ))}
+      <p></p>
+    </div>
+  );
+};
+
+// FIXME: will there be a problem with circular chromosomes?
+const getTopMatchesWithRegionNames = (job: BlastJobResult) => {
+  // order all hit_hsps by their e-value, and return regions containing the top five
+
+  const hitHspsWithRegionName = job.hits.flatMap((hit) => {
+    return hit.hit_hsps.map((hit_hsp) => ({
+      start: Math.min(hit_hsp.hsp_hit_from, hit_hsp.hsp_hit_to),
+      end: Math.max(hit_hsp.hsp_hit_from, hit_hsp.hsp_hit_to),
+      eValue: hit_hsp.hsp_expect,
+      regionName: hit.hit_acc
+    }));
+  });
+
+  const sortedHsps = sortBy(hitHspsWithRegionName, 'eValue');
+
+  return sortedHsps.slice(0, 5);
+};
+
+export default BlastGenomicHitsDiagram;

--- a/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicHitsDiagram.tsx
+++ b/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicHitsDiagram.tsx
@@ -93,6 +93,7 @@ const RegionsExpandToggle = (props: {
   isExpanded: boolean;
 }) => {
   const { count, onClick, isExpanded } = props;
+  const isCollapsed = !isExpanded;
 
   if (!count) {
     return null;
@@ -100,11 +101,13 @@ const RegionsExpandToggle = (props: {
 
   return (
     <div className={styles.regionsExpandToggle}>
-      <span>Other regions with hits</span>
-      {isExpanded ? (
-        <CloseButton onClick={onClick} />
+      {isCollapsed ? (
+        <>
+          <span>Other regions with hits</span>
+          <PillButton onClick={onClick}>+{count}</PillButton>
+        </>
       ) : (
-        <PillButton onClick={onClick}>+{count}</PillButton>
+        <CloseButton onClick={onClick} />
       )}
     </div>
   );

--- a/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicHitsDiagramLegend.tsx
+++ b/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicHitsDiagramLegend.tsx
@@ -16,10 +16,12 @@
 
 import React from 'react';
 
-import styles from './BlastGenomicHitsDiagram.scss';
+import {
+  TOP_HIT_MARK_RADIUS,
+  HIT_MARK_RADIUS
+} from './blastGenomicHitsDiagramConstants';
 
-const TOP_HIT_MARK_RADIUS = 6.5;
-const HIT_MARK_RADIUS = 3.5;
+import styles from './BlastGenomicHitsDiagram.scss';
 
 const BlastGenomicHitsDiagramLegend = () => {
   return (

--- a/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicHitsDiagramLegend.tsx
+++ b/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicHitsDiagramLegend.tsx
@@ -1,0 +1,50 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import styles from './BlastGenomicHitsDiagram.scss';
+
+const TOP_HIT_MARK_RADIUS = 6.5;
+const HIT_MARK_RADIUS = 3.5;
+
+const BlastGenomicHitsDiagramLegend = () => {
+  return (
+    <div className={styles.diagramLegend}>
+      <Image />
+      <span className={styles.diagramLegendLabel}>Top 5 hits by E-value</span>
+    </div>
+  );
+};
+
+const Image = () => (
+  <svg viewBox="0 0 13 13">
+    <circle
+      cx={TOP_HIT_MARK_RADIUS}
+      cy={TOP_HIT_MARK_RADIUS}
+      r={HIT_MARK_RADIUS}
+      className={styles.hit}
+    />
+    <circle
+      cx={TOP_HIT_MARK_RADIUS}
+      cy={TOP_HIT_MARK_RADIUS}
+      r={TOP_HIT_MARK_RADIUS}
+      className={styles.topHit}
+    />
+  </svg>
+);
+
+export default BlastGenomicHitsDiagramLegend;

--- a/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicRegionHeatmap.tsx
+++ b/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicRegionHeatmap.tsx
@@ -19,10 +19,11 @@ import { scaleLinear, interpolateRound, type ScaleLinear } from 'd3';
 
 import {
   LABEL_HEIGHT,
-  LABEL_TO_BACKBONE_DISTANCE,
   TOP_HIT_MARK_RADIUS,
   HIT_MARK_RADIUS,
-  BACKBONE_HEIGHT
+  BACKBONE_HEIGHT,
+  BACKBONE_Y,
+  ELEMENT_HEIGHT
 } from './blastGenomicHitsDiagramConstants';
 
 import type {
@@ -43,11 +44,6 @@ type Props = {
   regionName: string; // name of the genomic region (chromosome) that the heatmap is built for
   topHits?: HitLocation[];
 };
-
-const BACKBONE_Y = LABEL_HEIGHT + LABEL_TO_BACKBONE_DISTANCE;
-
-const ELEMENT_HEIGHT =
-  LABEL_HEIGHT + LABEL_TO_BACKBONE_DISTANCE + TOP_HIT_MARK_RADIUS;
 
 const BlastGenomicRegionHeatmap = (props: Props) => {
   const { width, job, regionName } = props;

--- a/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicRegionHeatmap.tsx
+++ b/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicRegionHeatmap.tsx
@@ -38,8 +38,8 @@ type Props = {
 
 // 12px font; 7 px small circle; 13px large circle => 25px height
 
-const LABEL_HEIGHT = 12;
-const LABEL_TO_BACKBONE_DISTANCE = 5;
+const LABEL_HEIGHT = 10;
+const LABEL_TO_BACKBONE_DISTANCE = 7;
 const TOP_HIT_MARK_RADIUS = 6.5;
 const HIT_MARK_RADIUS = 3.5;
 const BACKBONE_HEIGHT = 1;

--- a/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicRegionHeatmap.tsx
+++ b/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicRegionHeatmap.tsx
@@ -17,6 +17,14 @@
 import React from 'react';
 import { scaleLinear, interpolateRound, type ScaleLinear } from 'd3';
 
+import {
+  LABEL_HEIGHT,
+  LABEL_TO_BACKBONE_DISTANCE,
+  TOP_HIT_MARK_RADIUS,
+  HIT_MARK_RADIUS,
+  BACKBONE_HEIGHT
+} from './blastGenomicHitsDiagramConstants';
+
 import type {
   BlastHit,
   BlastJobResult
@@ -35,12 +43,6 @@ type Props = {
   regionName: string; // name of the genomic region (chromosome) that the heatmap is built for
   topHits?: HitLocation[];
 };
-
-const LABEL_HEIGHT = 10;
-const LABEL_TO_BACKBONE_DISTANCE = 7;
-const TOP_HIT_MARK_RADIUS = 6.5;
-const HIT_MARK_RADIUS = 3.5;
-const BACKBONE_HEIGHT = 1;
 
 const BACKBONE_Y = LABEL_HEIGHT + LABEL_TO_BACKBONE_DISTANCE;
 

--- a/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicRegionHeatmap.tsx
+++ b/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicRegionHeatmap.tsx
@@ -1,0 +1,159 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { scaleLinear, interpolateRound, type ScaleLinear } from 'd3';
+
+import type {
+  BlastHit,
+  BlastJobResult
+} from 'src/content/app/tools/blast/types/blastJob';
+
+import styles from './BlastGenomicHitsDiagram.scss';
+
+type HitLocation = {
+  start: number;
+  end: number;
+};
+
+type Props = {
+  job: BlastJobResult;
+  width: number;
+  regionName: string; // name of the genomic region (chromosome) that the heatmap is built for
+  topHits?: HitLocation[];
+};
+
+// 12px font; 7 px small circle; 13px large circle => 25px height
+
+const LABEL_HEIGHT = 12;
+const LABEL_TO_BACKBONE_DISTANCE = 5;
+const TOP_HIT_MARK_RADIUS = 6.5;
+const HIT_MARK_RADIUS = 3.5;
+const BACKBONE_HEIGHT = 1;
+
+const BACKBONE_Y = LABEL_HEIGHT + LABEL_TO_BACKBONE_DISTANCE;
+
+const ELEMENT_HEIGHT =
+  LABEL_HEIGHT + LABEL_TO_BACKBONE_DISTANCE + TOP_HIT_MARK_RADIUS;
+
+const BlastGenomicRegionHeatmap = (props: Props) => {
+  const { width, job, regionName } = props;
+  const region = job.hits.find((hit) => hit.hit_acc === regionName) as BlastHit;
+  const regionLength = region.hit_len;
+
+  const scale = scaleLinear()
+    .domain([1, regionLength])
+    .range([1, width])
+    .interpolate(interpolateRound)
+    .clamp(true);
+
+  // return JSON.stringify(props);
+  //  <rect x={0} y={0} width={width} height={ELEMENT_HEIGHT} />
+
+  return (
+    <svg
+      width={width}
+      viewBox={`0 0 ${width} ${ELEMENT_HEIGHT}`}
+      overflow="visible"
+    >
+      <RegionName name={regionName} />
+      <Backbone width={width} />
+      <Hits matches={region.hit_hsps} scale={scale} />
+      {props.topHits?.length && (
+        <TopHits locations={props.topHits} scale={scale} />
+      )}
+    </svg>
+  );
+};
+
+const RegionName = (props: { name: string }) => {
+  return (
+    <text x={0} y={LABEL_HEIGHT} className={styles.regionName}>
+      {props.name}
+    </text>
+  );
+};
+
+const Backbone = (props: { width: number }) => {
+  const { width } = props;
+  return (
+    <rect
+      x={0}
+      y={BACKBONE_Y}
+      className={styles.backbone}
+      width={width}
+      height={BACKBONE_HEIGHT}
+    />
+  );
+};
+
+const Hits = (props: {
+  matches: BlastHit['hit_hsps'];
+  scale: ScaleLinear<number, number>;
+}) => {
+  return (
+    <g>
+      {props.matches.map((match, index) => (
+        <circle
+          key={index}
+          cx={calculateCircleX({
+            matchStart: Math.min(match.hsp_hit_from, match.hsp_hit_to),
+            matchEnd: Math.max(match.hsp_hit_from, match.hsp_hit_to),
+            scale: props.scale
+          })}
+          cy={BACKBONE_Y + 0.5}
+          r={HIT_MARK_RADIUS}
+          className={styles.hit}
+        />
+      ))}
+    </g>
+  );
+};
+
+const TopHits = (props: {
+  locations: { start: number; end: number }[];
+  scale: ScaleLinear<number, number>;
+}) => {
+  return (
+    <g>
+      {props.locations.map((location, index) => (
+        <circle
+          key={index}
+          cx={calculateCircleX({
+            matchStart: location.start,
+            matchEnd: location.end,
+            scale: props.scale
+          })}
+          cy={BACKBONE_Y + 0.5}
+          r={TOP_HIT_MARK_RADIUS}
+          className={styles.topHit}
+        />
+      ))}
+    </g>
+  );
+};
+
+const calculateCircleX = (params: {
+  matchStart: number;
+  matchEnd: number;
+  scale: ScaleLinear<number, number>;
+}) => {
+  const { matchStart, matchEnd, scale } = params;
+  const matchMidpoint = matchStart + (matchEnd - matchStart) / 2;
+  return scale(matchMidpoint);
+};
+
+export default BlastGenomicRegionHeatmap;

--- a/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicRegionHeatmap.tsx
+++ b/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicRegionHeatmap.tsx
@@ -36,8 +36,6 @@ type Props = {
   topHits?: HitLocation[];
 };
 
-// 12px font; 7 px small circle; 13px large circle => 25px height
-
 const LABEL_HEIGHT = 10;
 const LABEL_TO_BACKBONE_DISTANCE = 7;
 const TOP_HIT_MARK_RADIUS = 6.5;
@@ -59,9 +57,6 @@ const BlastGenomicRegionHeatmap = (props: Props) => {
     .range([1, width])
     .interpolate(interpolateRound)
     .clamp(true);
-
-  // return JSON.stringify(props);
-  //  <rect x={0} y={0} width={width} height={ELEMENT_HEIGHT} />
 
   return (
     <svg

--- a/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicRegionWithoutMatches.tsx
+++ b/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicRegionWithoutMatches.tsx
@@ -14,13 +14,34 @@
  * limitations under the License.
  */
 
-export const LABEL_HEIGHT = 10;
-export const LABEL_TO_BACKBONE_DISTANCE = 7;
-export const TOP_HIT_MARK_RADIUS = 6.5;
-export const HIT_MARK_RADIUS = 3.5;
-export const BACKBONE_HEIGHT = 1;
+import React from 'react';
 
-export const BACKBONE_Y = LABEL_HEIGHT + LABEL_TO_BACKBONE_DISTANCE;
+import {
+  BACKBONE_HEIGHT,
+  BACKBONE_Y,
+  ELEMENT_HEIGHT
+} from './blastGenomicHitsDiagramConstants';
 
-export const ELEMENT_HEIGHT =
-  LABEL_HEIGHT + LABEL_TO_BACKBONE_DISTANCE + TOP_HIT_MARK_RADIUS;
+import styles from './BlastGenomicHitsDiagram.scss';
+
+type Props = {
+  width: number;
+};
+
+const RegionWithoutMatches = (props: Props) => {
+  const { width } = props;
+
+  return (
+    <svg viewBox={`0 0 ${width} ${ELEMENT_HEIGHT}`} width={width}>
+      <rect
+        x={0}
+        y={BACKBONE_Y}
+        className={styles.backbone}
+        width={width}
+        height={BACKBONE_HEIGHT}
+      />
+    </svg>
+  );
+};
+
+export default RegionWithoutMatches;

--- a/src/content/app/tools/blast/components/blast-genomic-hits-diagram/blastGenomicHitsDiagramConstants.ts
+++ b/src/content/app/tools/blast/components/blast-genomic-hits-diagram/blastGenomicHitsDiagramConstants.ts
@@ -1,0 +1,21 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const LABEL_HEIGHT = 10;
+export const LABEL_TO_BACKBONE_DISTANCE = 7;
+export const TOP_HIT_MARK_RADIUS = 6.5;
+export const HIT_MARK_RADIUS = 3.5;
+export const BACKBONE_HEIGHT = 1;

--- a/src/content/app/tools/blast/components/blast-genomic-hits-diagram/index.ts
+++ b/src/content/app/tools/blast/components/blast-genomic-hits-diagram/index.ts
@@ -1,0 +1,17 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default as BlastGenomicHitsDiagram } from './BlastGenomicHitsDiagram';

--- a/src/content/app/tools/blast/types/blastJob.ts
+++ b/src/content/app/tools/blast/types/blastJob.ts
@@ -29,8 +29,9 @@ export type BlastJobResult = {
 };
 
 export type BlastHit = {
-  hit_acc: string;
+  hit_acc: string; // name of the hit; a hit also contains a `hit_id` field that seems to be identical to `hit_acc`
   hit_def: string;
+  hit_len: number;
   hit_hsps: HSP[];
 };
 

--- a/src/content/app/tools/blast/views/blast-submission-results/components/blast-results-per-sequence/BlastResultsPerSequence.scss
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/blast-results-per-sequence/BlastResultsPerSequence.scss
@@ -20,7 +20,7 @@
   display: grid;
   grid-template-columns: 11ch [ruler] minmax(48%, 1050px) minmax(20%, 1fr);
   column-gap: 20px;
-  padding: 0 24px 10px 24px;
+  padding-bottom: 10px;
 }
 
 .rulerContainer {

--- a/src/content/app/tools/blast/views/blast-submission-results/components/blast-results-per-sequence/BlastResultsPerSequence.scss
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/blast-results-per-sequence/BlastResultsPerSequence.scss
@@ -9,6 +9,12 @@
   padding-bottom: 20px;
 }
 
+.headerWithLegend {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  column-gap: 1.5rem;
+}
+
 /* The distances in this grid are mostly repeating the distances of the grid for SingleBlastJobResult */
 .rulerPlacementGrid {
   display: grid;

--- a/src/content/app/tools/blast/views/blast-submission-results/components/blast-results-per-sequence/BlastResultsPerSequence.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/blast-results-per-sequence/BlastResultsPerSequence.tsx
@@ -22,6 +22,7 @@ import ShowHide from 'src/shared/components/show-hide/ShowHide';
 import FeatureLengthRuler from 'src/shared/components/feature-length-ruler/FeatureLengthRuler';
 import JobParameters from '../job-parameters/JobParameters';
 import SingleBlastJobResult from '../single-blast-job-result/SingleBlastJobResult';
+import { BlastGenomicHitsDiagramLegend } from 'src/content/app/tools/blast/components/blast-genomic-hits-diagram';
 
 import { parseBlastInput } from 'src/content/app/tools/blast/utils/blastInputParser';
 
@@ -61,19 +62,24 @@ const BlastResultsPerSequence = (props: BlastResultsPerSequenceProps) => {
   const { width: plotwidth } = useResizeObserver({ ref: rulerContainer });
   const [shouldShowJobResult, showJobResult] = useState(true);
   const [shouldShowParamaters, showParamaters] = useState(false);
-  const needsGenomicHitsDiagram = parameters.database === 'dna'; // NOTE: works for now; but likely to expand in the future
+  const usesGenomicHitsDiagram = parameters.database === 'dna'; // NOTE: works for now; but likely to expand in the future
+
+  const headerClasses = usesGenomicHitsDiagram
+    ? styles.headerWithLegend
+    : undefined;
 
   return (
     <div className={styles.wrapper}>
       <div className={styles.resultsSummaryRow}>
         <div>Sequence {sequence.id}</div>
         <div className={styles.sequenceHeader}>
-          <div>
+          <div className={headerClasses}>
             <ShowHide
               label={sequenceHeaderLabel}
               isExpanded={shouldShowParamaters}
               onClick={() => showParamaters(!shouldShowParamaters)}
             ></ShowHide>
+            {usesGenomicHitsDiagram && <BlastGenomicHitsDiagramLegend />}
           </div>
           {shouldShowParamaters && (
             <JobParameters
@@ -115,7 +121,7 @@ const BlastResultsPerSequence = (props: BlastResultsPerSequenceProps) => {
         })}
       <div className={styles.rulerPlacementGrid}>
         <div ref={rulerContainer} className={styles.rulerContainer}>
-          {shouldShowJobResult && !needsGenomicHitsDiagram && (
+          {shouldShowJobResult && !usesGenomicHitsDiagram && (
             <FeatureLengthRuler
               rulerLabel="Length"
               rulerLabelOffset={2.5}

--- a/src/content/app/tools/blast/views/blast-submission-results/components/blast-results-per-sequence/BlastResultsPerSequence.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/blast-results-per-sequence/BlastResultsPerSequence.tsx
@@ -62,9 +62,9 @@ const BlastResultsPerSequence = (props: BlastResultsPerSequenceProps) => {
   const { width: plotwidth } = useResizeObserver({ ref: rulerContainer });
   const [shouldShowJobResult, showJobResult] = useState(true);
   const [shouldShowParamaters, showParamaters] = useState(false);
-  const usesGenomicHitsDiagram = parameters.database === 'dna'; // NOTE: works for now; but likely to expand in the future
+  const needsGenomicHitsDiagram = parameters.database === 'dna'; // NOTE: works for now; but likely to expand in the future
 
-  const headerClasses = usesGenomicHitsDiagram
+  const headerClasses = needsGenomicHitsDiagram
     ? styles.headerWithLegend
     : undefined;
 
@@ -79,7 +79,7 @@ const BlastResultsPerSequence = (props: BlastResultsPerSequenceProps) => {
               isExpanded={shouldShowParamaters}
               onClick={() => showParamaters(!shouldShowParamaters)}
             ></ShowHide>
-            {usesGenomicHitsDiagram && <BlastGenomicHitsDiagramLegend />}
+            {needsGenomicHitsDiagram && <BlastGenomicHitsDiagramLegend />}
           </div>
           {shouldShowParamaters && (
             <JobParameters
@@ -121,7 +121,7 @@ const BlastResultsPerSequence = (props: BlastResultsPerSequenceProps) => {
         })}
       <div className={styles.rulerPlacementGrid}>
         <div ref={rulerContainer} className={styles.rulerContainer}>
-          {shouldShowJobResult && !usesGenomicHitsDiagram && (
+          {shouldShowJobResult && !needsGenomicHitsDiagram && (
             <FeatureLengthRuler
               rulerLabel="Length"
               rulerLabelOffset={2.5}

--- a/src/content/app/tools/blast/views/blast-submission-results/components/blast-results-per-sequence/BlastResultsPerSequence.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/blast-results-per-sequence/BlastResultsPerSequence.tsx
@@ -62,9 +62,9 @@ const BlastResultsPerSequence = (props: BlastResultsPerSequenceProps) => {
   const { width: plotwidth } = useResizeObserver({ ref: rulerContainer });
   const [shouldShowJobResult, showJobResult] = useState(true);
   const [shouldShowParamaters, showParamaters] = useState(false);
-  const needsGenomicHitsDiagram = parameters.database === 'dna'; // NOTE: works for now; but likely to expand in the future
+  const shouldUseGenomicHitsDiagram = parameters.database === 'dna'; // NOTE: works for now; but likely to expand in the future
 
-  const headerClasses = needsGenomicHitsDiagram
+  const headerClasses = shouldUseGenomicHitsDiagram
     ? styles.headerWithLegend
     : undefined;
 
@@ -79,7 +79,7 @@ const BlastResultsPerSequence = (props: BlastResultsPerSequenceProps) => {
               isExpanded={shouldShowParamaters}
               onClick={() => showParamaters(!shouldShowParamaters)}
             ></ShowHide>
-            {needsGenomicHitsDiagram && <BlastGenomicHitsDiagramLegend />}
+            {shouldUseGenomicHitsDiagram && <BlastGenomicHitsDiagramLegend />}
           </div>
           {shouldShowParamaters && (
             <JobParameters
@@ -121,7 +121,7 @@ const BlastResultsPerSequence = (props: BlastResultsPerSequenceProps) => {
         })}
       <div className={styles.rulerPlacementGrid}>
         <div ref={rulerContainer} className={styles.rulerContainer}>
-          {shouldShowJobResult && !needsGenomicHitsDiagram && (
+          {shouldShowJobResult && !shouldUseGenomicHitsDiagram && (
             <FeatureLengthRuler
               rulerLabel="Length"
               rulerLabelOffset={2.5}

--- a/src/content/app/tools/blast/views/blast-submission-results/components/blast-results-per-sequence/BlastResultsPerSequence.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/blast-results-per-sequence/BlastResultsPerSequence.tsx
@@ -61,6 +61,7 @@ const BlastResultsPerSequence = (props: BlastResultsPerSequenceProps) => {
   const { width: plotwidth } = useResizeObserver({ ref: rulerContainer });
   const [shouldShowJobResult, showJobResult] = useState(true);
   const [shouldShowParamaters, showParamaters] = useState(false);
+  const needsGenomicHitsDiagram = parameters.database === 'dna'; // NOTE: works for now; but likely to expand in the future
 
   return (
     <div className={styles.wrapper}>
@@ -114,7 +115,7 @@ const BlastResultsPerSequence = (props: BlastResultsPerSequenceProps) => {
         })}
       <div className={styles.rulerPlacementGrid}>
         <div ref={rulerContainer} className={styles.rulerContainer}>
-          {shouldShowJobResult && (
+          {shouldShowJobResult && !needsGenomicHitsDiagram && (
             <FeatureLengthRuler
               rulerLabel="Length"
               rulerLabelOffset={2.5}

--- a/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.scss
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.scss
@@ -2,10 +2,9 @@
 
 .resultsSummaryRow {
   display: grid;
-  grid-template-columns: [sequence-label] 11ch [hits-diagram] minmax(
-      48%,
-      1050px
-    ) [species] minmax(20%, 1fr);
+  grid-template-columns:
+    [sequence-label] 11ch [hits-diagram] minmax(48%, 1050px)
+    [species] minmax(20%, 1fr);
 
   grid-template-areas:
     'sequence-label hits-diagram species'
@@ -13,8 +12,6 @@
 
   gap: 20px;
   padding-bottom: 20px;
-  padding-left: 24px;
-  padding-right: 24px;
 
   &:first-of-type {
     padding-top: 24px;
@@ -26,8 +23,8 @@
 
   .tableWrapper {
     grid-area: table;
-    margin-left: -43px;
-    margin-right: -43px;
+    margin-left: -20px;
+    margin-right: -20px;
   }
 }
 

--- a/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
@@ -22,6 +22,7 @@ import DataTable from 'src/shared/components/data-table/DataTable';
 import ShowHide from 'src/shared/components/show-hide/ShowHide';
 
 import BlastHitsDiagram from 'src/content/app/tools/blast/components/blast-hits-diagram/BlastHitsDiagram';
+import { BlastGenomicHitsDiagram } from 'src/content/app/tools/blast/components/blast-genomic-hits-diagram';
 import BlastSequenceAlignment from 'src/content/app/tools/blast/components/blast-sequence-alignment/BlastSequenceAlignment';
 
 import {
@@ -169,7 +170,10 @@ const hitsTableColumns: DataTableColumns = [
 
 const SingleBlastJobResult = (props: SingleBlastJobResultProps) => {
   const { species: speciesInfo, jobResult, diagramWidth, submission } = props;
+  const blastDatabase = submission.submittedData.parameters.database;
   const [isExpanded, setExpanded] = useState(false);
+
+  const needsGenomicHitsDiagram = blastDatabase === 'dna'; // NOTE: works for now; but likely to expand in the future
 
   const alignmentsCount = countAlignments(jobResult.data);
 
@@ -180,7 +184,15 @@ const SingleBlastJobResult = (props: SingleBlastJobResultProps) => {
         <span>{pluralise('hit', alignmentsCount)}</span>
       </div>
       <div className={styles.summaryPlot}>
-        <BlastHitsDiagram job={jobResult.data} width={diagramWidth} />
+        {needsGenomicHitsDiagram ? (
+          <BlastGenomicHitsDiagram
+            genomeId={speciesInfo.genome_id}
+            job={jobResult.data}
+            width={diagramWidth}
+          />
+        ) : (
+          <BlastHitsDiagram job={jobResult.data} width={diagramWidth} />
+        )}
       </div>
       <div className={styles.speciesInfo}>
         {speciesInfo.common_name && <span>{speciesInfo.common_name}</span>}

--- a/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
@@ -173,7 +173,7 @@ const SingleBlastJobResult = (props: SingleBlastJobResultProps) => {
   const blastDatabase = submission.submittedData.parameters.database;
   const [isExpanded, setExpanded] = useState(false);
 
-  const needsGenomicHitsDiagram = blastDatabase === 'dna'; // NOTE: works for now; but likely to expand in the future
+  const shouldUseGenomicHitsDiagram = blastDatabase === 'dna'; // NOTE: works for now; but likely to expand in the future
 
   const alignmentsCount = countAlignments(jobResult.data);
 
@@ -184,7 +184,7 @@ const SingleBlastJobResult = (props: SingleBlastJobResultProps) => {
         <span>{pluralise('hit', alignmentsCount)}</span>
       </div>
       <div className={styles.summaryPlot}>
-        {needsGenomicHitsDiagram ? (
+        {shouldUseGenomicHitsDiagram ? (
           <BlastGenomicHitsDiagram
             genomeId={speciesInfo.genome_id}
             job={jobResult.data}

--- a/src/shared/components/pill-button/PillButton.scss
+++ b/src/shared/components/pill-button/PillButton.scss
@@ -1,0 +1,10 @@
+@import 'src/styles/common';
+
+.pillButton {
+  background: var(--pill-button-color, #{$blue});
+  color: var(--pill-button-text-color, #{$white});
+  font-size: var(--pill-button-font-size, 10px);
+  font-weight: var(--pill-button-font-weight, #{$bold});
+  padding: var(--pill-button-padding, 2px 8px);
+  border-radius: var(--pill-button-border-radius, 14px);
+}

--- a/src/shared/components/pill-button/PillButton.tsx
+++ b/src/shared/components/pill-button/PillButton.tsx
@@ -14,5 +14,23 @@
  * limitations under the License.
  */
 
-export { default as BlastGenomicHitsDiagram } from './BlastGenomicHitsDiagram';
-export { default as BlastGenomicHitsDiagramLegend } from './BlastGenomicHitsDiagramLegend';
+import React, {
+  forwardRef,
+  type ComponentProps,
+  type ForwardedRef
+} from 'react';
+import classNames from 'classnames';
+
+import styles from './PillButton.scss';
+
+type Props = ComponentProps<'button'>;
+
+const PillButton = (props: Props, ref: ForwardedRef<HTMLButtonElement>) => {
+  const { className, ...otherProps } = props;
+
+  const buttonClass = classNames(styles.pillButton, className);
+
+  return <button className={buttonClass} ref={ref} {...otherProps} />;
+};
+
+export default forwardRef(PillButton);

--- a/stories/shared-components/pill-button/PlusButton.stories.tsx
+++ b/stories/shared-components/pill-button/PlusButton.stories.tsx
@@ -1,0 +1,43 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import noop from 'lodash/noop';
+
+import PillButton from 'src/shared/components/pill-button/PillButton';
+
+export default {
+  title: 'Components/Shared Components/Pill button'
+};
+
+export const PlusButtonStory = () => (
+  <>
+    <div>
+      <PillButton onClick={noop}>+ 2</PillButton>
+    </div>
+    <div>
+      <PillButton onClick={noop}>+ 42</PillButton>
+    </div>
+    <div>
+      <PillButton onClick={noop}>+ 512</PillButton>
+    </div>
+    <div>
+      <PillButton onClick={noop}>+ 1234</PillButton>
+    </div>
+  </>
+);
+
+PlusButtonStory.storyName = 'default';


### PR DESCRIPTION
## Description
This PR introduces a new visualisation specifically for results of BLAST jobs against top-level genomic sequences (the DNA database). See the XD with the design [here](https://xd.adobe.com/view/3b27cc95-2a60-4407-855d-5a310e783e9e-6e74/?fullscreen)

The genomic visualisation makes an api call to fetch the species karyotype, which it then uses as a reference when drawing genomic regions. This allows us both to display top-level regions in the same order as they are typically represented in a karyotype, and to filter out the regions that are not part of karyotype (such as chromosome patches).

The rendering of the visualisation of BLAST results is now conditional on which database the input sequences were BLASTed against. For the DNA database, we will be showing the new visualisation; while for the transcripts and the proteins databases, we will be showing the one that we developed previously.

**Also:**
Removed extra horizontal padding from row elements in a BLAST results box:

![image](https://user-images.githubusercontent.com/6834224/197504499-a90e6db0-8ba9-4509-b56e-69c2016208c1.png)

notice the unnecessary inner padding (green):

![image](https://user-images.githubusercontent.com/6834224/197504517-a6238b19-95ee-44e6-b9a4-ed146a8b600c.png)

which resulted in this misalignment in the layout:

![image](https://user-images.githubusercontent.com/6834224/197504625-99dba20f-cd4e-49ae-a85b-a47b225bfdd8.png)


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1735

## Deployment URL(s)
http://genomic-blast-viz.review.ensembl.org