### PR TITLE
Displayed tracks redux

### DIFF
--- a/src/content/app/genome-browser/Browser.tsx
+++ b/src/content/app/genome-browser/Browser.tsx
@@ -162,15 +162,11 @@ const SidebarContent = () => {
   return isBrowserSidebarModalOpened ? <BrowserSidebarModal /> : <TrackPanel />;
 };
 
-export type CogList = Record<string, number>;
-
 type GenomeBrowserContextType = {
   genomeBrowser: EnsemblGenomeBrowser | null;
   setGenomeBrowser: (genomeBrowser: EnsemblGenomeBrowser | null) => void;
   zmenus: StateZmenu;
   setZmenus: (zmenus: StateZmenu) => void;
-  cogList: CogList | null;
-  setCogList: (cogList: CogList) => void;
 };
 
 export const GenomeBrowserContext = React.createContext<
@@ -182,7 +178,6 @@ const GenomeBrowserInitContainer = () => {
     useState<EnsemblGenomeBrowser | null>(null);
 
   const [zmenus, setZmenus] = useState<StateZmenu>({});
-  const [cogList, setCogList] = useState<CogList | null>(null);
 
   const browser = useMemo(() => {
     return <Browser />;
@@ -194,9 +189,7 @@ const GenomeBrowserInitContainer = () => {
         genomeBrowser,
         setGenomeBrowser,
         zmenus,
-        setZmenus,
-        cogList,
-        setCogList
+        setZmenus
       }}
     >
       {browser}

--- a/src/content/app/genome-browser/components/browser-cog/BrowserCogList.tsx
+++ b/src/content/app/genome-browser/components/browser-cog/BrowserCogList.tsx
@@ -15,27 +15,25 @@
  */
 
 import React, { useState, useEffect, memo } from 'react';
-
 import {
   IncomingActionType,
   type UpdateTrackSummaryAction,
-  type TrackSummaryList,
-  type TrackSummary
+  type TrackSummaryList
 } from '@ensembl/ensembl-genome-browser';
 
-import useGenomeBrowser from 'src/content/app/genome-browser/hooks/useGenomeBrowser';
+import { useAppDispatch, useAppSelector } from 'src/store';
 
-import BrowserCog from './BrowserCog';
-
-import { useAppSelector } from 'src/store';
-import useBrowserCogList from './useBrowserCogList';
-
+import { getDisplayedTracks } from 'src/content/app/genome-browser/state/displayed-tracks/displayedTracksSelectors';
 import {
   getBrowserActiveFocusObjectId,
   getBrowserActiveGenomeId
 } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
 
-import type { CogList } from 'src/content/app/genome-browser/Browser';
+import { setDisplayedTracks } from 'src/content/app/genome-browser/state/displayed-tracks/displayedTracksSlice';
+
+import useGenomeBrowser from 'src/content/app/genome-browser/hooks/useGenomeBrowser';
+
+import BrowserCog from './BrowserCog';
 
 import styles from './BrowserCogList.scss';
 
@@ -46,37 +44,27 @@ export const BrowserCogList = () => {
 
   const { genomeBrowser } = useGenomeBrowser();
 
-  const { cogList: browserCogList, setCogList } = useBrowserCogList();
+  const displayedTracks = useAppSelector(getDisplayedTracks);
+  const dispatch = useAppDispatch();
 
   useEffect(() => {
     const subscription = genomeBrowser?.subscribe(
       IncomingActionType.TRACK_SUMMARY,
       (action: UpdateTrackSummaryAction) => {
-        updateTrackSummary(action.payload);
+        updateDisplayedTracks(action.payload);
       }
     );
     return () => subscription?.unsubscribe();
   }, [genomeBrowser, genomeId, focusObjectId]);
 
-  const updateTrackSummary = (trackSummaryList: TrackSummaryList) => {
-    if (!focusObjectId) {
-      return;
-    }
+  const updateDisplayedTracks = (trackSummaryList: TrackSummaryList) => {
+    const payload = trackSummaryList.map((track) => ({
+      id: track['switch-id'],
+      height: track.height as unknown as number, // FIXME: fix genome browser types
+      offsetTop: track.offset as unknown as number // FIXME: fix genome browser types
+    }));
 
-    const cogList: CogList = {};
-
-    trackSummaryList.forEach((trackSummary: TrackSummary) => {
-      if (
-        trackSummary.offset &&
-        trackSummary['switch-id'] &&
-        !cogList[trackSummary['switch-id']]
-      ) {
-        const trackId = trackSummary['switch-id'];
-        cogList[trackId] = Number(trackSummary.offset);
-      }
-    });
-
-    setCogList(cogList);
+    dispatch(setDisplayedTracks(payload));
   };
 
   useEffect(() => {
@@ -88,21 +76,19 @@ export const BrowserCogList = () => {
     setSelectedCog(trackId);
   };
 
-  const cogs =
-    browserCogList &&
-    Object.entries(browserCogList).map(([name, pos]) => {
-      const posStyle = { top: `${pos}px` };
+  const cogs = displayedTracks.map((track) => {
+    const posStyle = { top: `${track.offsetTop}px` };
 
-      return (
-        <div key={name} className={styles.browserCogOuter} style={posStyle}>
-          <BrowserCog
-            cogActivated={selectedCog === name}
-            trackId={name}
-            updateSelectedCog={updateSelectedCog}
-          />
-        </div>
-      );
-    });
+    return (
+      <div key={track.id} className={styles.browserCogOuter} style={posStyle}>
+        <BrowserCog
+          cogActivated={selectedCog === track.id}
+          trackId={track.id}
+          updateSelectedCog={updateSelectedCog}
+        />
+      </div>
+    );
+  });
 
   return genomeBrowser ? (
     <div className={styles.browserTrackSettingsOuter}>

--- a/src/content/app/genome-browser/components/track-settings-panel/TrackSettingsPanel.test.tsx
+++ b/src/content/app/genome-browser/components/track-settings-panel/TrackSettingsPanel.test.tsx
@@ -15,11 +15,12 @@
  */
 
 import React from 'react';
-import { configureStore, combineReducers } from '@reduxjs/toolkit';
+import { configureStore } from '@reduxjs/toolkit';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 
+import createRootReducer from 'src/root/rootReducer';
 import MockGenomeBrowser from 'tests/mocks/mockGenomeBrowser';
 
 import * as trackSettingsSlice from 'src/content/app/genome-browser/state/track-settings/trackSettingsSlice';
@@ -31,14 +32,18 @@ import TrackSettingsPanel from './TrackSettingsPanel';
 const genomeId = 'fake_genome_id_1';
 const selectedTrackId = 'focus';
 
-const renderComponent = () => {
-  const rootReducer = combineReducers({
-    browser: combineReducers({
-      browserGeneral: browserGeneralSlice.default,
-      trackSettings: trackSettingsSlice.default
-    })
-  });
+jest.mock(
+  'src/content/app/genome-browser/hooks/useGenomeBrowserAnalytics',
+  () => () => ({
+    trackTrackNameToggle: jest.fn(),
+    trackFeatureLabelToggle: jest.fn(),
+    trackShowSeveralTranscriptsToggle: jest.fn(),
+    trackShowTranscriptsIdToggle: jest.fn(),
+    trackApplyToAllInTrackSettings: jest.fn()
+  })
+);
 
+const renderComponent = () => {
   const fragment = {
     [selectedTrackId]: {
       id: selectedTrackId,
@@ -59,6 +64,13 @@ const renderComponent = () => {
         ...browserGeneralSlice.defaultBrowserGeneralState,
         activeGenomeId: genomeId
       },
+      displayedTracks: [
+        {
+          id: selectedTrackId,
+          height: 100,
+          offsetTop: 0
+        }
+      ],
       trackSettings: {
         [genomeId]: {
           ...trackSettingsSlice.defaultTrackSettingsForGenome,
@@ -69,7 +81,7 @@ const renderComponent = () => {
   };
 
   const store = configureStore({
-    reducer: rootReducer,
+    reducer: createRootReducer(),
     preloadedState: initialState as any
   });
 
@@ -94,15 +106,6 @@ jest.mock(
     toggleFeatureLabels: jest.fn(),
     toggleTranscriptIds: jest.fn(),
     toggleSeveralTranscripts: jest.fn()
-  })
-);
-
-jest.mock(
-  'src/content/app/genome-browser/components/browser-cog/useBrowserCogList',
-  () => () => ({
-    cogList: {
-      [selectedTrackId]: 0
-    }
   })
 );
 

--- a/src/content/app/genome-browser/components/track-settings-panel/useTrackSettings.ts
+++ b/src/content/app/genome-browser/components/track-settings-panel/useTrackSettings.ts
@@ -16,14 +16,15 @@
 
 import { useEffect, useRef } from 'react';
 
-import { useAppSelector, useAppDispatch, type RootState } from 'src/store';
+import { useAppSelector, useAppDispatch } from 'src/store';
 
-import useBrowserCogList from '../browser-cog/useBrowserCogList';
 import { getBrowserActiveGenomeId } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
 import {
   getTrackSettingsForTrackId,
   getApplyToAllSettings
 } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSelectors';
+import { getDisplayedTracks } from 'src/content/app/genome-browser/state/displayed-tracks/displayedTracksSelectors';
+
 import {
   updateTrackName as updateTrackSettingsTrackName,
   updateFeatureLabelsVisibility as updateTrackSettingsFeatureLabelsVisibility,
@@ -45,9 +46,9 @@ type Params = {
 
 const useBrowserTrackSettings = (params: Params) => {
   const { selectedTrackId } = params;
-  const { cogList } = useBrowserCogList();
   const activeGenomeId = useAppSelector(getBrowserActiveGenomeId);
-  const selectedTrackSettings = useAppSelector((state: RootState) =>
+  const displayedTracks = useAppSelector(getDisplayedTracks);
+  const selectedTrackSettings = useAppSelector((state) =>
     getTrackSettingsForTrackId(state, selectedTrackId)
   );
   const shouldApplyToAll = useAppSelector(getApplyToAllSettings);
@@ -78,16 +79,19 @@ const useBrowserTrackSettings = (params: Params) => {
       return;
     }
 
-    if (shouldApplyToAllRef.current && cogList) {
-      Object.keys(cogList).forEach((trackId) => {
+    if (shouldApplyToAllRef.current) {
+      displayedTracks.forEach((track) => {
         dispatch(
           updateTrackSettingsTrackName({
             genomeId: activeGenomeId,
-            trackId,
+            trackId: track.id,
             isTrackNameShown
           })
         );
-        toggleTrackName({ trackId, shouldShowTrackName: isTrackNameShown });
+        toggleTrackName({
+          trackId: track.id,
+          shouldShowTrackName: isTrackNameShown
+        });
       });
     } else {
       dispatch(
@@ -113,17 +117,17 @@ const useBrowserTrackSettings = (params: Params) => {
       return;
     }
 
-    if (shouldApplyToAllRef.current && cogList) {
-      Object.keys(cogList).forEach((trackId) => {
+    if (shouldApplyToAllRef.current) {
+      displayedTracks.forEach((track) => {
         dispatch(
           updateTrackSettingsFeatureLabelsVisibility({
             genomeId: activeGenomeId,
-            trackId,
+            trackId: track.id,
             areFeatureLabelsShown
           })
         );
         toggleFeatureLabels({
-          trackId,
+          trackId: track.id,
           shouldShowFeatureLabels: areFeatureLabelsShown
         });
       });
@@ -152,17 +156,17 @@ const useBrowserTrackSettings = (params: Params) => {
     if (!activeGenomeId) {
       return;
     }
-    if (shouldApplyToAllRef.current && cogList) {
-      Object.keys(cogList).forEach((trackId) => {
+    if (shouldApplyToAllRef.current) {
+      displayedTracks.forEach((track) => {
         dispatch(
           updateTrackSettingsShowSeveralTranscripts({
             genomeId: activeGenomeId,
-            trackId,
+            trackId: track.id,
             areSeveralTranscriptsShown
           })
         );
         toggleSeveralTranscripts({
-          trackId,
+          trackId: track.id,
           shouldShowSeveralTranscripts: areSeveralTranscriptsShown
         });
       });
@@ -192,17 +196,17 @@ const useBrowserTrackSettings = (params: Params) => {
     if (!activeGenomeId) {
       return;
     }
-    if (shouldApplyToAllRef.current && cogList) {
-      Object.keys(cogList).forEach((trackId) => {
+    if (shouldApplyToAllRef.current) {
+      displayedTracks.forEach((track) => {
         dispatch(
           updateTrackSettingsShowTranscriptIds({
             genomeId: activeGenomeId,
-            trackId,
+            trackId: track.id,
             shouldShowTranscriptIds
           })
         );
         toggleTranscriptIds({
-          trackId,
+          trackId: track.id,
           shouldShowTranscriptIds
         });
       });

--- a/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
@@ -20,7 +20,6 @@ import { useAppDispatch, useAppSelector } from 'src/store';
 import { useGenomeTracksQuery } from 'src/content/app/genome-browser/state/api/genomeBrowserApiSlice';
 import useFocusTrack from './useFocusTrack';
 import useGenomicTracks from './useGenomicTracks';
-import useBrowserCogList from 'src/content/app/genome-browser/components/browser-cog/useBrowserCogList';
 import useGenomeBrowser from 'src/content/app/genome-browser/hooks/useGenomeBrowser';
 
 import { getTrackSettingsForGenome as restoreTrackSettingsForGenome } from 'src/content/app/genome-browser/services/track-settings/trackSettingsStorageService';
@@ -30,6 +29,7 @@ import {
   getBrowserActiveFocusObject
 } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
 import { getAllTrackSettings } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSelectors';
+import { getDisplayedTrackIds } from 'src/content/app/genome-browser/state/displayed-tracks/displayedTracksSelectors';
 
 import {
   setInitialTrackSettingsForGenome,
@@ -64,7 +64,7 @@ const useGenomeBrowserTracks = () => {
   const focusObject = useAppSelector(getBrowserActiveFocusObject); // should we think about what to do if there is no focus object
   const trackSettingsForGenome =
     useAppSelector(getAllTrackSettings)?.settingsForIndividualTracks;
-  const visibleTrackIds = getVisibleTrackIds(useBrowserCogList().cogList); // get list of ids of tracks currently rendered in genome browser
+  const visibleTrackIds = useAppSelector(getDisplayedTrackIds); // get list of ids of tracks currently rendered in genome browser
   const { toggleTrack } = useGenomeBrowser();
 
   const dispatch = useAppDispatch();
@@ -171,12 +171,6 @@ const prepareTrackSettings = ({
     });
   });
   return defaultTrackSettings;
-};
-
-const getVisibleTrackIds = (cogsList: Record<string, number> | null) => {
-  cogsList = cogsList ?? {};
-
-  return Object.keys(cogsList);
 };
 
 export default useGenomeBrowserTracks;

--- a/src/content/app/genome-browser/state/displayed-tracks/displayedTracksSelectors.ts
+++ b/src/content/app/genome-browser/state/displayed-tracks/displayedTracksSelectors.ts
@@ -1,0 +1,27 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createSelector } from '@reduxjs/toolkit';
+
+import type { RootState } from 'src/store';
+
+export const getDisplayedTracks = (state: RootState) =>
+  state.browser.displayedTracks;
+
+export const getDisplayedTrackIds = createSelector(
+  getDisplayedTracks,
+  (tracks) => tracks.map((track) => track.id)
+);

--- a/src/content/app/genome-browser/state/displayed-tracks/displayedTracksSlice.ts
+++ b/src/content/app/genome-browser/state/displayed-tracks/displayedTracksSlice.ts
@@ -14,25 +14,26 @@
  * limitations under the License.
  */
 
-import { useContext } from 'react';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
-import { GenomeBrowserContext } from '../../Browser';
-
-const useBrowserCogList = () => {
-  const genomeBrowserContext = useContext(GenomeBrowserContext);
-
-  if (!genomeBrowserContext) {
-    throw new Error(
-      'useGenomeBrowser must be used with GenomeBrowserContext Provider'
-    );
-  }
-
-  const { cogList, setCogList } = genomeBrowserContext;
-
-  return {
-    cogList,
-    setCogList
-  };
+type DisplayedTrack = {
+  id: string;
+  height: number;
+  offsetTop: number;
 };
 
-export default useBrowserCogList;
+type DisplayedTracksState = DisplayedTrack[];
+
+const displayedTracksSlice = createSlice({
+  name: 'genome-browser-displayed-tracks',
+  initialState: [] as DisplayedTracksState,
+  reducers: {
+    setDisplayedTracks(state, action: PayloadAction<DisplayedTrack[]>) {
+      return action.payload;
+    }
+  }
+});
+
+export const { setDisplayedTracks } = displayedTracksSlice.actions;
+
+export default displayedTracksSlice.reducer;

--- a/src/content/app/genome-browser/state/focus-object/focusObjectSlice.ts
+++ b/src/content/app/genome-browser/state/focus-object/focusObjectSlice.ts
@@ -15,10 +15,10 @@
  */
 
 import {
-  Action,
   createAsyncThunk,
   createSlice,
-  ThunkAction
+  type Action,
+  type ThunkAction
 } from '@reduxjs/toolkit';
 
 import isGeneFocusObject from './isGeneFocusObject';

--- a/src/content/app/genome-browser/state/genomeBrowserReducer.ts
+++ b/src/content/app/genome-browser/state/genomeBrowserReducer.ts
@@ -23,6 +23,7 @@ import trackPanel from 'src/content/app/genome-browser/state/track-panel/trackPa
 import browserSidebarModal from 'src/content/app/genome-browser/state/browser-sidebar-modal/browserSidebarModalSlice';
 import browserBookmarks from 'src/content/app/genome-browser/state/browser-bookmarks/browserBookmarksSlice';
 import focusObjects from 'src/content/app/genome-browser/state/focus-object/focusObjectSlice';
+import displayedTracks from 'src/content/app/genome-browser/state/displayed-tracks/displayedTracksSlice';
 
 export default combineReducers({
   drawer,
@@ -32,5 +33,6 @@ export default combineReducers({
   trackPanel,
   browserSidebarModal,
   browserBookmarks,
-  focusObjects
+  focusObjects,
+  displayedTracks
 });

--- a/tests/fixtures/browser.ts
+++ b/tests/fixtures/browser.ts
@@ -34,20 +34,12 @@ import {
   getDefaultRegularTrackSettings
 } from 'src/content/app/genome-browser/state/track-settings/trackSettingsConstants';
 
-import type { CogList } from 'src/content/app/genome-browser/Browser';
-
 import type { ChrLocation } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSlice';
 import type { RegionValidationResponse } from 'src/content/app/genome-browser/helpers/browserHelper';
 import { TrackSet } from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
 import { Strand } from 'src/shared/types/thoas/strand';
 import { LoadingState } from 'src/shared/types/loading-state';
 import { BreakpointWidth } from 'src/global/globalConfig';
-
-export const createCogTrackList = (): CogList => ({
-  'gene-focus': faker.datatype.number(),
-  contig: faker.datatype.number(),
-  gc: faker.datatype.number()
-});
 
 export const createTrackSettings = () => ({
   'gene-focus': getDefaultGeneTrackSettings(),


### PR DESCRIPTION
## Description
Refactoring, continued.

In this PR, information about tracks that are at any time displayed by the genome browser is stored in its own redux slice. The reason for doing so is that this data can be (and is) used in multiple places; not just in the component that is responsible for rendering track cogs.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1710

## Deployment URL(s)
http://displayed-tracks-redux.review.ensembl.org