### PR TITLE
Refactor useGenomeBrowserIds hook

### DIFF
--- a/src/content/app/genome-browser/hooks/useGenomeBrowserIds.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowserIds.ts
@@ -14,22 +14,12 @@
  * limitations under the License.
  */
 
-import { useLocation } from 'react-router-dom';
+import { useContext } from 'react';
 
-import {
-  buildFocusIdForUrl,
-  parseFocusIdFromUrl,
-  buildFocusObjectId
-} from 'src/shared/helpers/focusObjectHelpers';
+import { GenomeBrowserContext } from 'src/content/app/genome-browser/Browser';
 
 import { useAppSelector } from 'src/store';
-import { useUrlParams } from 'src/shared/hooks/useUrlParams';
-import {
-  useGenomeInfoQuery,
-  isGenomeNotFoundError
-} from 'src/shared/state/genome/genomeApiSlice';
 
-import { getCommittedSpeciesById } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 import {
   getBrowserActiveGenomeId,
   getBrowserActiveFocusObjectId
@@ -41,57 +31,29 @@ import {
 const useGenomeBrowserIds = () => {
   const activeGenomeId = useAppSelector(getBrowserActiveGenomeId);
   const activeFocusObjectId = useAppSelector(getBrowserActiveFocusObjectId);
-  const committedSpecies = useAppSelector((state) =>
-    getCommittedSpeciesById(state, activeGenomeId ?? '')
-  );
-  const params = useUrlParams<'genomeId'>('/genome-browser/:genomeId');
-  const { search } = useLocation();
+  const genomeBrowserContext = useContext(GenomeBrowserContext);
 
-  const { genomeId: genomeIdInUrl } = params;
-  const urlSearchParams = new URLSearchParams(search);
-  const focusObjectIdInUrl = urlSearchParams.get('focus');
-
-  const {
-    currentData: genomeInfo,
-    isFetching,
-    isError,
-    error
-  } = useGenomeInfoQuery(genomeIdInUrl ?? '', {
-    skip: !genomeIdInUrl
-  });
-  const genomeId = genomeInfo?.genomeId;
-  const isMissingGenomeId = isError && isGenomeNotFoundError(error);
-
-  // TODO: check if the logic below is correct
-  const genomeIdForUrl =
-    genomeIdInUrl ??
-    committedSpecies?.genome_tag ??
-    committedSpecies?.genome_id;
-
-  let focusObjectId;
-  let focusObjectIdForUrl;
-  let parsedFocusObjectId;
-  let isMalformedFocusObjectId = false;
-
-  if (focusObjectIdInUrl) {
-    focusObjectIdForUrl = focusObjectIdInUrl;
-    if (genomeId) {
-      try {
-        parsedFocusObjectId = {
-          genomeId,
-          ...parseFocusIdFromUrl(focusObjectIdInUrl)
-        };
-        focusObjectId = buildFocusObjectId(parsedFocusObjectId);
-      } catch {
-        isMalformedFocusObjectId = true;
-      }
-    }
-  } else if (activeFocusObjectId) {
-    focusObjectIdForUrl = buildFocusIdForUrl(activeFocusObjectId);
+  if (!genomeBrowserContext) {
+    throw new Error(
+      'useGenomeBrowserIds must be used with GenomeBrowserContext Provider'
+    );
   }
 
+  const {
+    genomeIdInUrl,
+    genomeIdForUrl,
+    focusObjectIdInUrl,
+    isFetchingGenomeId,
+    isMissingGenomeId,
+    genomeId,
+    focusObjectId,
+    focusObjectIdForUrl,
+    parsedFocusObjectId,
+    isMalformedFocusObjectId
+  } = genomeBrowserContext;
+
   return {
-    isFetchingGenomeId: isFetching,
+    isFetchingGenomeId,
     isMissingGenomeId,
     genomeId,
     genomeIdInUrl,


### PR DESCRIPTION
## Description
`useGenomeBrowserIds` hook is used across many components in the Genome browser app. Each time it is called, these IDs get generated from scratch, even for objects that have already been viewed. Instead of doing this, these IDs need to be stored somewhere in the Genome browser context and then called by the `useGenomeBrowserIds` hook to reduce number of calculations and API calls.

TODO: Store the context properly and retrieve it from where it is stored.


## Related JIRA Issue(s)
[ENSWBSITES-1720](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1720)

## Deployment URL(s)
refactor-usegenomebrowserid-hook.review.ensembl.org


## Views affected
Genome browser