### PR TITLE
Refactor chevron to remove span wrapper

### DIFF
--- a/src/shared/components/app-bar/AppBar.tsx
+++ b/src/shared/components/app-bar/AppBar.tsx
@@ -17,7 +17,6 @@
 import React from 'react';
 
 import ConversationIcon from 'src/shared/components/communication-framework/ConversationIcon';
-import Chevron from 'src/shared/components/chevron/Chevron';
 
 import styles from './AppBar.scss';
 
@@ -39,17 +38,5 @@ export const AppBar = (props: AppBarProps) => (
     </div>
   </section>
 );
-
-// this is a temporary component; will need update/refactoring once we have help resources
-export const HelpAndDocumentation = () => {
-  return (
-    <div className={styles.helpLink}>
-      <span>
-        Help &amp; documentation
-        <Chevron direction="right" className={styles.chevron} />
-      </span>
-    </div>
-  );
-};
 
 export default AppBar;

--- a/src/shared/components/chevron/Chevron.scss
+++ b/src/shared/components/chevron/Chevron.scss
@@ -1,14 +1,11 @@
 @import 'src/styles/common';
 
-.wrapper {
-  display: inline-block;
-  font-size: 0; // to prevent line-height's impact on the height of the element
-}
-
 .chevron {
   fill: var(--chevron-fill, $blue);
   height: var(--chevron-height, 8px);
   user-select: none;
+  display: inline-block;
+  font-size: 0; // to prevent line-height's impact on the height of the element
 }
 
 .chevron_animated {

--- a/src/shared/components/chevron/Chevron.test.tsx
+++ b/src/shared/components/chevron/Chevron.test.tsx
@@ -25,11 +25,9 @@ describe('<Chevron />', () => {
       const { container, rerender } = render(
         <Chevron className="componentClass" direction="down" />
       );
-      const chevronWrapper = container.firstChild as HTMLElement;
       const chevronIcon = container.querySelector('svg') as SVGSVGElement;
 
-      expect(chevronWrapper.tagName.toLowerCase()).toBe('span');
-      expect(chevronWrapper.classList.contains('componentClass')).toBe(true);
+      expect(chevronIcon.classList.contains('componentClass')).toBe(true);
       expect(chevronIcon.classList.contains('chevron')).toBe(true);
 
       rerender(<Chevron direction="up" />);

--- a/src/shared/components/chevron/Chevron.tsx
+++ b/src/shared/components/chevron/Chevron.tsx
@@ -31,23 +31,14 @@ export type Props = {
 
 const Chevron = (props: Props) => {
   const isNonDefaultDirection = props.direction !== 'down';
+
   const chevronClasses = classNames(
     styles.chevron,
     { [styles[`chevron_${props.direction}`]]: isNonDefaultDirection },
-    { [styles.chevron_animated]: props.animate }
+    { [styles.chevron_animated]: props.animate },
+    props.className
   );
-
-  const wrapperClasses = classNames(styles.wrapper, props.className);
-
-  const wrapperProps = {
-    className: wrapperClasses
-  };
-
-  return (
-    <span {...wrapperProps}>
-      <ChevronDown className={chevronClasses} />
-    </span>
-  );
+  return <ChevronDown className={chevronClasses} />;
 };
 
 Chevron.defaultProps = {

--- a/stories/shared-components/chevron/Chevron.stories.tsx
+++ b/stories/shared-components/chevron/Chevron.stories.tsx
@@ -17,7 +17,7 @@
 import React, { useState } from 'react';
 
 import ChevronButton from 'src/shared/components/chevron-button/ChevronButton';
-import { Direction as ChevronDirection } from 'src/shared/components/chevron/Chevron';
+import { type Direction as ChevronDirection } from 'src/shared/components/chevron/Chevron';
 
 import RadioGroup from 'src/shared/components/radio-group/RadioGroup';
 

--- a/stories/shared-components/chevron/Chevron.stories.tsx
+++ b/stories/shared-components/chevron/Chevron.stories.tsx
@@ -17,9 +17,9 @@
 import React, { useState } from 'react';
 
 import ChevronButton from 'src/shared/components/chevron-button/ChevronButton';
-import { type Direction as ChevronDirection } from 'src/shared/components/chevron/Chevron';
-
 import RadioGroup from 'src/shared/components/radio-group/RadioGroup';
+
+import type { Direction as ChevronDirection } from 'src/shared/components/chevron/Chevron';
 
 import styles from './Chevron.stories.scss';
 


### PR DESCRIPTION
## Description
As per jira description, we dont need the extra span around the chevron since all the styling can be applied to the svg itself. So remove the span wrapper and applied the class thats being passed from the parents to the svg class.

Note: The second commit is a cleanup where i found the chevron being used in a component thats not used elsewhere.


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1722

## Deployment URL(s)
http://chevron-update.review.ensembl.org


## Views affected
All views that have chevron (species homepage, entity viewer, genome browser,...)