### PR TITLE
Old blast submissions

### DIFF
--- a/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.scss
+++ b/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.scss
@@ -52,7 +52,7 @@
 }
 
 .controlsSection {
-  grid-column: control-buttons;
+  grid-column: controls-section;
   display: flex;
   align-items: center;
   justify-content: flex-end;
@@ -86,7 +86,7 @@
 // Leave media queries at the bottom of the file to make sure they override CSS rules defined above
 @media screen and (max-width: 1439px) {
   .grid {
-    grid-template-columns: auto [submission-name] auto [submission-details] 1fr [control-buttons] auto;
+    grid-template-columns: auto [submission-name] auto [submission-details] 1fr [controls-section] auto;
   }
   .controlButtons {
     padding-left: 20px;
@@ -94,6 +94,10 @@
 }
 
 @media screen and (max-width: 1279px) {
+  .grid {
+    grid-template-columns: auto [submission-details] 1fr [controls-section] auto;
+  }
+
   .submissionName {
     display: none;
   }

--- a/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.scss
+++ b/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.scss
@@ -2,7 +2,7 @@
 
 .grid {
   display: grid;
-  grid-template-columns: 11ch [submission-name] auto [submission-details] 1fr [control-buttons] 20%;
+  grid-template-columns: 11ch [submission-name] auto [submission-details] 1fr [controls-section] 20%;
   column-gap: 20px;
   align-items: center;
   padding-left: 26px; // TODO: seems to be a constant shared with sequence boxes (see ListedBlastSubmission.scss)
@@ -51,7 +51,7 @@
   margin-left: 1ch;
 }
 
-.controlButtons {
+.controlsSection {
   grid-column: control-buttons;
   display: flex;
   align-items: center;
@@ -61,6 +61,13 @@
 
 .controlButtons > * {
   flex-shrink: 0;
+}
+
+.unavailableResultsMessage {
+  display: flex;
+  align-items: center;
+  column-gap: 0.6rem;
+  color: red;
 }
 
 .deleteMessageContainer {

--- a/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.tsx
@@ -174,7 +174,7 @@ const ControlsSection = (props: {
 }) => {
   const { submission, isAnyJobRunning, isInDeleteMode, onDelete, onDownload } =
     props;
-  const isExpiredSubmission = areSubmissionResultsAvailable(submission);
+  const isExpiredSubmission = !areSubmissionResultsAvailable(submission);
 
   return !isExpiredSubmission ? (
     <div className={styles.controlsSection}>

--- a/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.tsx
@@ -48,6 +48,8 @@ import type { BlastProgram } from 'src/content/app/tools/blast/types/blastSettin
 
 import styles from './BlastSubmissionHeader.scss';
 
+export const UNAVAILABLE_RESULTS_WARNING = 'Results no longer available';
+
 export type Props = {
   submission: BlastSubmission;
   isAnyJobRunning?: boolean;
@@ -194,7 +196,7 @@ const ControlsSection = (props: {
     <div className={styles.controlsSection}>
       <DeleteButton onClick={onDelete} disabled={isInDeleteMode} />
       <div className={styles.unavailableResultsMessage}>
-        <span>Results no longer available</span>
+        <span>{UNAVAILABLE_RESULTS_WARNING}</span>
         <QuestionButton helpText={<UnavailableResultsHelpText />} />
       </div>
     </div>

--- a/src/content/app/tools/blast/components/blast-views-navigation/BlastViewsNavigation.scss
+++ b/src/content/app/tools/blast/components/blast-views-navigation/BlastViewsNavigation.scss
@@ -1,6 +1,9 @@
+@import 'src/styles/common';
+
 .blastViewsNavigation {
   display: grid;
-  grid-template-columns: [left] auto [right] 1fr;
+  grid-template-columns: [left] auto [notice] 1fr [right] auto;
+  column-gap: 1.5rem;
   align-items: center;
   max-width: 1800px; // TODO: this is max width of the two-column blast form; set it to a constant
 }
@@ -19,6 +22,7 @@
 
 .wrapperRight {
   display: flex;
+  align-items: center;
   column-gap: 12px;
 }
 
@@ -29,4 +33,12 @@
 .rightColumn {
   grid-column: right;
   justify-self: end;
+}
+
+.resultsAvailabilityNotice {
+  grid-column: notice;
+  text-align: right;
+  line-height: 1;
+  color: $black;
+  font-weight: $light;
 }

--- a/src/content/app/tools/blast/components/blast-views-navigation/BlastViewsNavigation.tsx
+++ b/src/content/app/tools/blast/components/blast-views-navigation/BlastViewsNavigation.tsx
@@ -34,6 +34,10 @@ const BlastViewsNavigation = () => {
           </ButtonLink>
         </div>
       </div>
+      <div className={styles.resultsAvailabilityNotice}>
+        Results are only available for 7 days from submission. Submissions can
+        be rerun for 28 days.
+      </div>
       <div className={styles.rightColumn}>
         <div className={styles.wrapperRight}>
           <BlastJobListsNavigation />

--- a/src/content/app/tools/blast/components/listed-blast-submission/ListedBlastSubmission.test.tsx
+++ b/src/content/app/tools/blast/components/listed-blast-submission/ListedBlastSubmission.test.tsx
@@ -22,6 +22,8 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import * as blastStorageService from 'src/content/app/tools/blast/services/blastStorageService';
+import { BLAST_RESULTS_AVAILABILITY_DURATION } from 'src/content/app/tools/blast/services/blastStorageServiceConstants';
+import { UNAVAILABLE_RESULTS_WARNING } from 'src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader';
 
 import ListedBlastSubmission, {
   type Props as ListedBlastSubmissionProps
@@ -159,7 +161,7 @@ describe('BlastSubmissionHeader', () => {
         }
       });
 
-      it('shows disabled control buttons', () => {
+      it('disables control buttons, except for the delete button', () => {
         const { container } = renderComponent({
           props: { submission }
         });
@@ -170,7 +172,7 @@ describe('BlastSubmissionHeader', () => {
           '.downloadButton'
         ) as HTMLElement;
 
-        expect(deleteButton.hasAttribute('disabled')).toBe(true);
+        expect(deleteButton.hasAttribute('disabled')).toBe(false);
         expect(downloadButton.hasAttribute('disabled')).toBe(true);
       });
 
@@ -210,6 +212,27 @@ describe('BlastSubmissionHeader', () => {
         expect(buttonLink.getAttribute('href')).toBe(
           `/blast/submissions/${submission.id}`
         );
+      });
+    });
+
+    describe('when the submission is expected to no longer have accessible results', () => {
+      const submission = createBlastSubmission();
+      submission.submittedAt =
+        Date.now() - BLAST_RESULTS_AVAILABILITY_DURATION - 1000;
+
+      it('shows a warning text', () => {
+        const { container, getByText } = renderComponent({
+          props: { submission }
+        });
+        const deleteButton = container.querySelector('.deleteButton');
+        const downloadButton = container.querySelector('.downloadButton');
+        const buttonLink = container.querySelector('.buttonLink');
+
+        expect(buttonLink).toBeFalsy();
+        expect(downloadButton).toBeFalsy();
+        expect(deleteButton).toBeTruthy();
+
+        expect(getByText(UNAVAILABLE_RESULTS_WARNING)).toBeTruthy();
       });
     });
   });

--- a/src/content/app/tools/blast/services/blastStorageService.test.ts
+++ b/src/content/app/tools/blast/services/blastStorageService.test.ts
@@ -1,0 +1,86 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'fake-indexeddb/auto';
+import { openDB } from 'idb/with-async-ittr';
+import times from 'lodash/times';
+
+import IndexedDB from 'src/services/indexeddb-service';
+
+import {
+  BLAST_SUBMISSIONS_STORE_NAME,
+  BLAST_SUBMISSION_STORAGE_DURATION
+} from './blastStorageServiceConstants';
+
+import {
+  saveBlastSubmission,
+  deleteExpiredBlastSubmissions
+} from './blastStorageService';
+
+import { createBlastSubmission } from 'tests/fixtures/blast/blastSubmission';
+
+const getDatabase = async () => {
+  return await openDB('test-db', 1, {
+    upgrade(db) {
+      db.createObjectStore(BLAST_SUBMISSIONS_STORE_NAME);
+    }
+  });
+};
+
+jest.spyOn(IndexedDB, 'getDB').mockImplementation(() => getDatabase());
+
+describe('blastStorageService', () => {
+  afterEach(async () => {
+    await IndexedDB.clear(BLAST_SUBMISSIONS_STORE_NAME);
+  });
+
+  describe('deleteExpiredBlastSubmissions', () => {
+    it('deletes expired BLAST submissions', async () => {
+      const db = await IndexedDB.getDB();
+      const submissions = times(5, () => createBlastSubmission());
+      const nonExpiredSubmissionIds: string[] = [];
+
+      submissions.forEach((submission, index) => {
+        if (index < 3) {
+          submission.submittedAt =
+            Date.now() - BLAST_SUBMISSION_STORAGE_DURATION - 1000; // one second after the expiry date
+        } else {
+          submission.submittedAt =
+            Date.now() - BLAST_SUBMISSION_STORAGE_DURATION + 1000; // one second before the expiry date
+          nonExpiredSubmissionIds.push(submission.id);
+        }
+      });
+
+      // Prepare the database
+      for (const submission of submissions) {
+        await saveBlastSubmission(submission.id, submission);
+      }
+
+      await deleteExpiredBlastSubmissions();
+
+      const remainingSubmissions = await db.getAll(
+        BLAST_SUBMISSIONS_STORE_NAME
+      );
+      const remainingSubmissionIds = remainingSubmissions.map(
+        (submission) => submission.id
+      );
+
+      expect(remainingSubmissionIds.sort()).toEqual(
+        nonExpiredSubmissionIds.sort()
+      );
+    });
+  });
+});

--- a/src/content/app/tools/blast/services/blastStorageService.ts
+++ b/src/content/app/tools/blast/services/blastStorageService.ts
@@ -76,6 +76,9 @@ export const updateSavedBlastJob = async (params: {
 }) => {
   const { submissionId, jobId, fragment } = params;
   const submission = await getBlastSubmission(submissionId);
+  if (!submission) {
+    return;
+  }
   const job = submission.results.find((job) => job.jobId === jobId);
 
   if (!job) {

--- a/src/content/app/tools/blast/services/blastStorageServiceConstants.ts
+++ b/src/content/app/tools/blast/services/blastStorageServiceConstants.ts
@@ -1,0 +1,26 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ONE_HOUR_IN_MILLISECONDS,
+  ONE_DAY_IN_MILLISECONDS
+} from 'src/shared/constants/timeConstants';
+
+export const BLAST_SUBMISSIONS_STORE_NAME = 'blast-submissions';
+
+export const BLAST_RESULTS_AVAILABILITY_DURATION =
+  ONE_DAY_IN_MILLISECONDS * 7 - ONE_HOUR_IN_MILLISECONDS;
+export const BLAST_SUBMISSION_STORAGE_DURATION = ONE_DAY_IN_MILLISECONDS * 28;

--- a/src/content/app/tools/blast/state/blast-results/blastResultsSlice.ts
+++ b/src/content/app/tools/blast/state/blast-results/blastResultsSlice.ts
@@ -23,7 +23,8 @@ import {
 import {
   getAllBlastSubmissions,
   updateBlastSubmission as updateBlastSubmissionInStorage,
-  deleteBlastSubmission as deleteBlastSubmissionFromStorage
+  deleteBlastSubmission as deleteBlastSubmissionFromStorage,
+  deleteExpiredBlastSubmissions as deleteExpiredBlastSubmissionsFromStorage
 } from 'src/content/app/tools/blast/services/blastStorageService';
 
 import { submitBlast } from '../blast-api/blastApiSlice';
@@ -77,7 +78,7 @@ export type BlastSubmission = {
     parameters: BlastSubmissionParameters;
   };
   results: BlastJob[];
-  submittedAt: number; // timestamp
+  submittedAt: number; // timestamp, in milliseconds
   seen: boolean; // whether the user has viewed the results of this submission
 };
 
@@ -97,7 +98,10 @@ export type BlastResultsState = {
 
 export const restoreBlastSubmissions = createAsyncThunk(
   'blast-results/restore-blast-submissions',
-  () => getAllBlastSubmissions() || {}
+  async () => {
+    await deleteExpiredBlastSubmissionsFromStorage();
+    return (await getAllBlastSubmissions()) || {};
+  }
 );
 
 export const deleteBlastSubmission = createAsyncThunk(

--- a/src/content/app/tools/blast/state/blast-results/blastResultsSlice.ts
+++ b/src/content/app/tools/blast/state/blast-results/blastResultsSlice.ts
@@ -146,6 +146,11 @@ const blastResultsSlice = createSlice({
     ) {
       const { submissionId, jobId, fragment } = action.payload;
       const submission = state.submissions[submissionId];
+      if (!submission) {
+        // imagine an edge case when a submission has been deleted,
+        // but we still have some rogue async client-side logic running which tries to update it
+        return;
+      }
       const job = submission.results.find((job) => job.jobId === jobId);
       if (job) {
         Object.assign(job, fragment);

--- a/src/content/app/tools/blast/state/epics/blastEpics.ts
+++ b/src/content/app/tools/blast/state/epics/blastEpics.ts
@@ -78,7 +78,7 @@ export const blastFormSubmissionEpic: Epic<Action, Action, RootState> = (
       return results.map((job) => ({ submissionId, job }));
     }),
     poll(),
-    tap(databaseUpdaterSubject),
+    tap(databaseUpdaterSubject()),
     map((pollingResult) => {
       const {
         submissionId,
@@ -112,7 +112,7 @@ export const blastSubmissionsRestoreEpic: Epic<Action, Action, RootState> = (
       );
     }),
     poll(),
-    tap(databaseUpdaterSubject),
+    tap(databaseUpdaterSubject()),
     map((pollingResult) => {
       const {
         submissionId,
@@ -170,18 +170,19 @@ const checkJobStatuses = (input: { submissionId: string; job: BlastJob }[]) => {
 };
 
 // save polling results to database
-const databaseUpdaterSubject = new Subject<{
-  submissionId: string;
-  job: BlastJob;
-}>().pipe(
-  // make sure to wait until the async job of saving to indexedDb has been completed before starting a new one
-  concatMap((pollingResult) => {
-    const {
-      submissionId,
-      job: { jobId, status }
-    } = pollingResult;
-    return from(
-      updateSavedBlastJob({ submissionId, jobId, fragment: { status } })
-    );
-  })
-);
+const databaseUpdaterSubject = () =>
+  new Subject<{
+    submissionId: string;
+    job: BlastJob;
+  }>().pipe(
+    // make sure to wait until the async job of saving to indexedDb has been completed before starting a new one
+    concatMap((pollingResult) => {
+      const {
+        submissionId,
+        job: { jobId, status }
+      } = pollingResult;
+      return from(
+        updateSavedBlastJob({ submissionId, jobId, fragment: { status } })
+      );
+    })
+  );

--- a/src/content/app/tools/blast/state/epics/tests/blastEpics.test.ts
+++ b/src/content/app/tools/blast/state/epics/tests/blastEpics.test.ts
@@ -49,7 +49,8 @@ import {
 jest.mock('src/content/app/tools/blast/services/blastStorageService', () => ({
   saveBlastSubmission: jest.fn().mockImplementation(() => Promise.resolve()),
   updateSavedBlastJob: jest.fn().mockImplementation(() => Promise.resolve()),
-  getAllBlastSubmissions: jest.fn()
+  getAllBlastSubmissions: jest.fn(),
+  deleteExpiredBlastSubmissions: jest.fn()
 }));
 jest.mock('config', () => ({
   toolsApiBaseUrl: 'http://tools-api-url' // need to provide absolute urls to the fetch running in Node

--- a/src/content/app/tools/blast/utils/blastResultsAvailability.ts
+++ b/src/content/app/tools/blast/utils/blastResultsAvailability.ts
@@ -26,5 +26,5 @@ import type { BlastSubmission } from 'src/content/app/tools/blast/state/blast-re
 
 export const areSubmissionResultsAvailable = (submission: BlastSubmission) => {
   const { submittedAt } = submission;
-  return submittedAt < Date.now() - BLAST_RESULTS_AVAILABILITY_DURATION;
+  return submittedAt > Date.now() - BLAST_RESULTS_AVAILABILITY_DURATION;
 };

--- a/src/content/app/tools/blast/utils/blastResultsAvailability.ts
+++ b/src/content/app/tools/blast/utils/blastResultsAvailability.ts
@@ -1,0 +1,30 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BLAST_RESULTS_AVAILABILITY_DURATION } from 'src/content/app/tools/blast/services/blastStorageServiceConstants';
+
+import type { BlastSubmission } from 'src/content/app/tools/blast/state/blast-results/blastResultsSlice';
+
+/**
+ * We are currently using EBI BLAST infrastructure.
+ * As of now, results of BLAST jobs are kept for 7 calendar days starting from the submission date;
+ * although this time may be reduced in the future.
+ */
+
+export const areSubmissionResultsAvailable = (submission: BlastSubmission) => {
+  const { submittedAt } = submission;
+  return submittedAt < Date.now() - BLAST_RESULTS_AVAILABILITY_DURATION;
+};

--- a/src/content/app/tools/blast/views/blast-submission-results/BlastSubmissionResults.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/BlastSubmissionResults.tsx
@@ -87,7 +87,7 @@ const Main = () => {
 
   if (!blastSubmission) {
     return <MissingBlastSubmissionError hasSubmissionParameters={false} />;
-  } else if (areSubmissionResultsAvailable(blastSubmission)) {
+  } else if (!areSubmissionResultsAvailable(blastSubmission)) {
     return <MissingBlastSubmissionError hasSubmissionParameters={true} />;
   } else if (isLoading) {
     return <LoadingView submission={blastSubmission} />;

--- a/src/content/app/tools/blast/views/blast-submission-results/BlastSubmissionResults.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/BlastSubmissionResults.tsx
@@ -86,19 +86,9 @@ const Main = () => {
   }, [blastSubmission?.id]);
 
   if (!blastSubmission) {
-    return (
-      <MissingBlastSubmissionError
-        submissionId={submissionId}
-        hasSubmissionParameters={false}
-      />
-    );
-  } else if (!areSubmissionResultsAvailable(blastSubmission)) {
-    return (
-      <MissingBlastSubmissionError
-        submissionId={submissionId}
-        hasSubmissionParameters={true}
-      />
-    );
+    return <MissingBlastSubmissionError hasSubmissionParameters={false} />;
+  } else if (areSubmissionResultsAvailable(blastSubmission)) {
+    return <MissingBlastSubmissionError hasSubmissionParameters={true} />;
   } else if (isLoading) {
     return <LoadingView submission={blastSubmission} />;
   } else if (error) {

--- a/src/content/app/tools/blast/views/blast-submission-results/BlastSubmissionResults.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/BlastSubmissionResults.tsx
@@ -18,8 +18,12 @@ import React, { useEffect } from 'react';
 import { useParams } from 'react-router';
 
 import { useAppSelector, useAppDispatch } from 'src/store';
-import { useFetchAllBlastJobsQuery } from 'src/content/app/tools/blast/state/blast-api/blastApiSlice';
+
+import { areSubmissionResultsAvailable } from 'src/content/app/tools/blast/utils/blastResultsAvailability';
+
 import { getBlastSubmissionById } from 'src/content/app/tools/blast/state/blast-results/blastResultsSelectors';
+
+import { useFetchAllBlastJobsQuery } from 'src/content/app/tools/blast/state/blast-api/blastApiSlice';
 import {
   markBlastSubmissionAsSeen,
   type BlastSubmission,
@@ -32,6 +36,7 @@ import BlastAppBar from 'src/content/app/tools/blast/components/blast-app-bar/Bl
 import BlastViewsNavigation from 'src/content/app/tools/blast/components/blast-views-navigation/BlastViewsNavigation';
 import BlastSubmissionHeader from 'src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader';
 import BlastResultsPerSequence from './components/blast-results-per-sequence/BlastResultsPerSequence';
+import MissingBlastSubmissionError from './components/missing-blast-submission-error/MissingBlastSubmissionError';
 import { CircleLoader } from 'src/shared/components/loader';
 
 import type { BlastJobResultResponse } from 'src/content/app/tools/blast/types/blastJob';
@@ -81,7 +86,19 @@ const Main = () => {
   }, [blastSubmission?.id]);
 
   if (!blastSubmission) {
-    return null;
+    return (
+      <MissingBlastSubmissionError
+        submissionId={submissionId}
+        hasSubmissionParameters={false}
+      />
+    );
+  } else if (!areSubmissionResultsAvailable(blastSubmission)) {
+    return (
+      <MissingBlastSubmissionError
+        submissionId={submissionId}
+        hasSubmissionParameters={true}
+      />
+    );
   } else if (isLoading) {
     return <LoadingView submission={blastSubmission} />;
   } else if (error) {

--- a/src/content/app/tools/blast/views/blast-submission-results/components/missing-blast-submission-error/MissingBlastSubmissionError.scss
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/missing-blast-submission-error/MissingBlastSubmissionError.scss
@@ -1,0 +1,24 @@
+@import 'src/styles/common';
+
+.container {
+  --alert-icon-diameter: 30px; // TODO: do something to avoid repeating this?
+  --button-link-color: #{$green};
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 56px;
+  row-gap: 34px;
+}
+
+.container p {
+  margin: 0;
+  text-align: center;
+}
+
+.container p + p {
+  margin-top: 0.6rem;
+}
+
+.errorText {
+  color: $red;
+}

--- a/src/content/app/tools/blast/views/blast-submission-results/components/missing-blast-submission-error/MissingBlastSubmissionError.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/missing-blast-submission-error/MissingBlastSubmissionError.tsx
@@ -19,7 +19,10 @@ import React from 'react';
 import { useAppSelector } from 'src/store';
 import * as urlFor from 'src/shared/helpers/urlHelper';
 
-import { getUnviewedBlastSubmissions } from 'src/content/app/tools/blast/state/blast-results/blastResultsSelectors';
+import {
+  getViewedBlastSubmissions,
+  getUnviewedBlastSubmissions
+} from 'src/content/app/tools/blast/state/blast-results/blastResultsSelectors';
 
 import AlertButton from 'src/shared/components/alert-button/AlertButton';
 import ButtonLink from 'src/shared/components/button-link/ButtonLink';
@@ -27,34 +30,53 @@ import ButtonLink from 'src/shared/components/button-link/ButtonLink';
 import styles from './MissingBlastSubmissionError.scss';
 
 type Props = {
-  submissionId: string;
   hasSubmissionParameters: boolean;
 };
 
 const MissingBlastSubmissionError = (props: Props) => {
-  const { submissionId, hasSubmissionParameters } = props;
+  const viewedBlastSubmissions = useAppSelector(getViewedBlastSubmissions);
   const unviewedBlastSubmissions = useAppSelector(getUnviewedBlastSubmissions);
   const hasUnviewedBlastSubmissions = unviewedBlastSubmissions.length > 0;
+  const hasViewedBlastSubmissions = viewedBlastSubmissions.length > 0;
 
-  const buttonLink = hasUnviewedBlastSubmissions
-    ? urlFor.blastUnviewedSubmissions()
-    : urlFor.blastSubmissionsList();
+  let buttonLink: string;
 
-  const errorText = hasSubmissionParameters
-    ? 'The results for this submission are no longer available'
-    : `There are no results for the BLAST submission with an id ${submissionId}`;
+  if (hasUnviewedBlastSubmissions) {
+    buttonLink = urlFor.blastUnviewedSubmissions();
+  } else if (hasViewedBlastSubmissions) {
+    buttonLink = urlFor.blastSubmissionsList();
+  } else {
+    buttonLink = urlFor.blastForm();
+  }
 
   return (
     <div className={styles.container}>
       <AlertButton />
       <div>
-        <p className={styles.errorText}>{errorText}</p>
-        {hasSubmissionParameters && (
-          <p>It may be possible to rerun this submission from your Jobs list</p>
-        )}
+        <ErrorMessage {...props} />
       </div>
       <ButtonLink to={buttonLink}>Continue</ButtonLink>
     </div>
+  );
+};
+
+const ErrorMessage = (props: { hasSubmissionParameters: boolean }) => {
+  return props.hasSubmissionParameters ? (
+    <>
+      <p className={styles.errorText}>
+        The results for this submission are no longer available
+      </p>
+      <p>It may be possible to rerun this submission from your Jobs list</p>
+    </>
+  ) : (
+    <>
+      <p className={styles.errorText}>
+        There are no results for this BLAST submission
+      </p>
+      <p>
+        Any valid submissions can be found in your Unviewed jobs and Jobs lists
+      </p>
+    </>
   );
 };
 

--- a/src/content/app/tools/blast/views/blast-submission-results/components/missing-blast-submission-error/MissingBlastSubmissionError.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/missing-blast-submission-error/MissingBlastSubmissionError.tsx
@@ -1,0 +1,61 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { useAppSelector } from 'src/store';
+import * as urlFor from 'src/shared/helpers/urlHelper';
+
+import { getUnviewedBlastSubmissions } from 'src/content/app/tools/blast/state/blast-results/blastResultsSelectors';
+
+import AlertButton from 'src/shared/components/alert-button/AlertButton';
+import ButtonLink from 'src/shared/components/button-link/ButtonLink';
+
+import styles from './MissingBlastSubmissionError.scss';
+
+type Props = {
+  submissionId: string;
+  hasSubmissionParameters: boolean;
+};
+
+const MissingBlastSubmissionError = (props: Props) => {
+  const { submissionId, hasSubmissionParameters } = props;
+  const unviewedBlastSubmissions = useAppSelector(getUnviewedBlastSubmissions);
+  const hasUnviewedBlastSubmissions = unviewedBlastSubmissions.length > 0;
+
+  const buttonLink = hasUnviewedBlastSubmissions
+    ? urlFor.blastUnviewedSubmissions()
+    : urlFor.blastSubmissionsList();
+
+  const errorText = hasSubmissionParameters
+    ? 'The results for this submission are no longer available'
+    : `There are no results for the BLAST submission with an id ${submissionId}`;
+
+  return (
+    <div className={styles.container}>
+      <AlertButton />
+      <div>
+        <p className={styles.errorText}>{errorText}</p>
+        {hasSubmissionParameters && (
+          <p>It may be possible to rerun this submission from your Jobs list</p>
+        )}
+      </div>
+      <ButtonLink to={buttonLink}>Continue</ButtonLink>
+    </div>
+  );
+};
+
+export default MissingBlastSubmissionError;

--- a/src/services/indexeddb-service.ts
+++ b/src/services/indexeddb-service.ts
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import { openDB, IDBPDatabase } from 'idb';
+import { openDB, IDBPDatabase } from 'idb/with-async-ittr';
 
 import { GB_TRACK_SETTINGS_STORE_NAME } from 'src/content/app/genome-browser/services/track-settings/trackSettingsStorageConstants';
 import { GB_FOCUS_OBJECTS_STORE_NAME } from 'src/content/app/genome-browser/services/focus-objects/focusObjectStorageConstants';
+import { BLAST_SUBMISSIONS_STORE_NAME } from 'src/content/app/tools/blast/services/blastStorageServiceConstants';
 
 const DB_NAME = 'ensembl-website';
 const DB_VERSION = 2;
@@ -29,8 +30,8 @@ const getDbPromise = () => {
       if (!db.objectStoreNames.contains('contact-forms')) {
         db.createObjectStore('contact-forms');
       }
-      if (!db.objectStoreNames.contains('blast-submissions')) {
-        db.createObjectStore('blast-submissions');
+      if (!db.objectStoreNames.contains(BLAST_SUBMISSIONS_STORE_NAME)) {
+        db.createObjectStore(BLAST_SUBMISSIONS_STORE_NAME);
       }
       if (!db.objectStoreNames.contains(GB_TRACK_SETTINGS_STORE_NAME)) {
         const trackSettingsObjectStore = db.createObjectStore(

--- a/src/shared/components/alert-button/AlertButton.scss
+++ b/src/shared/components/alert-button/AlertButton.scss
@@ -2,6 +2,7 @@
 
 .alertButton {
   display: inline-block;
+  font-size: 0; // to prevent extra space in the bottom of the button element
   padding: 2px;
   user-select: none;
 

--- a/src/shared/constants/timeConstants.ts
+++ b/src/shared/constants/timeConstants.ts
@@ -1,0 +1,20 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const ONE_SECOND_IN_MILLISECONDS = 1 * 1000;
+export const ONE_MINUTE_IN_MILLISECONDS = 60 * ONE_SECOND_IN_MILLISECONDS;
+export const ONE_HOUR_IN_MILLISECONDS = 60 * ONE_MINUTE_IN_MILLISECONDS;
+export const ONE_DAY_IN_MILLISECONDS = 24 * ONE_HOUR_IN_MILLISECONDS;


### PR DESCRIPTION
## Description
The results of EBI BLAST jobs are stored only for 7 days; thus making it possible for the app to have BLAST submissions whose results are no longer accessible. This PR addresses this problem.

- Added a notice about how long BLAST submission results are available (and how long a submission is stored in the browser) to the grey bar in the top of BLAST pages
- After 7 days, will show a notice in the header of a BLAST submission informing user that results for this submission are no longer available
- Added error screens to the BLAST submission details page (for when user navigates to this page directly using the url)
- Added a check at every app startup that will delete submissions older than 28 days
- Added tests for the blast storage service method that deletes expired blast submissions

## Also
- Switched the the version of the `idb` library that uses async iterators (good for ergonomics)
- Fixed the bug when updated BLAST jobs status did not get written to IndexedDB after the polling

## Related JIRA Issue(s)
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1716
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1744

## Deployment URL(s)
http://old-blast-submissions.review.ensembl.org

## How to test
Ok, so you submitted your BLAST jobs; but you probably don't want to wait for 7 days until the jobs have properly expired. To artificially age your BLAST submission, you would need to modify the record in IndexedDB manually, by following the steps below:
- In browser's dev tools, find IndexedDB, then find the `blast-submissions` storage in it, and read an id of a BLAST submission that you want to make older
- Then, in your console, do something along the following lines:

```js
blastSubmissionId = the_id_that_you_see_in_indexed_db

dbRequest = window.indexedDB.open("ensembl-website");
dbRequest.onsuccess = (event) => {
  const db = event.target.result;
  const transaction = db.transaction("blast-submissions", 'readwrite')
  const objectStore = transaction.objectStore("blast-submissions")
  objectStore.get(blastSubmissionId).onsuccess = (event) => {
    updateSubmitTime(event.target.result, objectStore);
  };
};

updateSubmitTime = (data, objectStore) => {
  data.submittedAt = Date.now() - 1000 * 60 * 60 * 24 * 7 // you can set however many days you want here 
  const requestUpdate = objectStore.put(data, blastSubmissionId);
  requestUpdate.onsuccess = (event) => {
    console.log('blast submission date updated')
  };
}
```