### PR TITLE
Add find genes instructions to species selector

### DIFF
--- a/src/content/app/species-selector/components/find-gene-instructions/FindGeneInstructions.scss
+++ b/src/content/app/species-selector/components/find-gene-instructions/FindGeneInstructions.scss
@@ -1,0 +1,47 @@
+@import 'src/styles/common';
+
+$columnWidth: 230px;
+$columnGap: 60px;
+$rowGap: 60px;
+$leftMargin: 25px;
+
+.instructionsPanel {
+  margin-top: 15px;
+}
+
+.instructionsWrapper {
+  margin-left: $leftMargin;
+  display: grid;
+  grid-template-columns: repeat(4, #{$columnWidth});
+  grid-column-gap: $columnGap;
+  grid-row-gap: $rowGap;
+  max-width: calc(4 * #{$columnWidth} + 3 * #{$columnGap});
+}
+
+.description {
+  display: flex;
+  align-items: center;
+  --app-icon-bg-color: #{$dark-grey};
+
+  .iconLabel {
+    margin-left: 12px;
+  }
+}
+
+.searchIcon {
+  width: 30px;
+  height: 30px;
+  fill: $dark-grey;
+}
+
+.speciesLozenge {
+  background-color: $dark-grey;
+  border-color: $dark-grey;
+  color: $white;
+}
+
+@media ($leftMargin + 4 * $columnWidth + 3 * $columnGap) {
+  .instructionsWrapper {
+    grid-template-columns: repeat(2, #{$columnWidth});
+  }
+}

--- a/src/content/app/species-selector/components/find-gene-instructions/FindGeneInstructions.tsx
+++ b/src/content/app/species-selector/components/find-gene-instructions/FindGeneInstructions.tsx
@@ -1,0 +1,67 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import classNames from 'classnames';
+
+import { Step } from 'src/shared/components/step/Step';
+
+import SearchIcon from 'static/icons/icon_search.svg';
+
+import styles from './FindGeneInstructions.scss';
+import speciesLozengeStyles from 'src/shared/components/selected-species/SpeciesLozenge.scss';
+
+const FindGeneInstructions = () => {
+  return (
+    <section className={styles.instructionsPanel}>
+      <div className={styles.instructionsWrapper}>
+        <div className={styles.stepWrapper}>
+          <Step count={1} label="Find and add a species" />
+        </div>
+
+        <div className={styles.stepWrapper}>
+          <Step count={2} label="Select a species tab in any app">
+            <div className={styles.description}>
+              <div
+                className={classNames(
+                  speciesLozengeStyles.species,
+                  styles.speciesLozenge
+                )}
+              >
+                <div className={speciesLozengeStyles.inner}>
+                  <span className={speciesLozengeStyles.name}>Species</span>
+                  <span className={speciesLozengeStyles.assembly}>
+                    Assembly
+                  </span>
+                </div>
+              </div>
+            </div>
+          </Step>
+        </div>
+
+        <div className={styles.stepWrapper}>
+          <Step count={3} label="Use Search in that app to find a gene">
+            <div className={styles.description}>
+              <SearchIcon className={styles.searchIcon} />
+            </div>
+          </Step>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default FindGeneInstructions;

--- a/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.scss
+++ b/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.scss
@@ -2,6 +2,22 @@
 
 $rightCornerWidth: 40px;
 
+label,
+.showHide {
+  display: block;
+  font-size: 12px;
+  margin-left: 25px;
+}
+
+label {
+  color: $dark-grey;
+  margin-bottom: 10px;
+}
+
+.showHide {
+  margin-top: 10px;
+}
+
 .speciesSearchFieldWrapper {
   display: inline-flex;
   align-items: center;
@@ -15,12 +31,12 @@ $rightCornerWidth: 40px;
     background: $white;
     height: 36px;
     padding-left: 22px;
-  
+
     input {
       &::placeholder {
         color: $grey;
       }
-  
+
       &:focus {
         &::placeholder {
           color: white;

--- a/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx
+++ b/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx
@@ -38,6 +38,8 @@ import CloseButton from 'src/shared/components/close-button/CloseButton';
 import QuestionButton, {
   QuestionButtonOption
 } from 'src/shared/components/question-button/QuestionButton';
+import ShowHide from 'src/shared/components/show-hide/ShowHide';
+import FindGeneInstructions from '../find-gene-instructions/FindGeneInstructions';
 
 import type {
   SearchMatch,
@@ -63,6 +65,8 @@ type RightCornerProps = {
 
 export const SpeciesSearchField = () => {
   const [isFocused, setIsFocused] = useState(false);
+  const [shouldShowFindGeneInstructions, showFindGeneInstructions] =
+    useState(false);
   const searchText = useAppSelector(getSearchText);
   const matches = useAppSelector(getSearchResults);
   const selectedItemText = useAppSelector(getSelectedItemText);
@@ -105,21 +109,33 @@ export const SpeciesSearchField = () => {
   const isNotFound = Boolean(matches && matches.length === 0);
 
   return (
-    <AutosuggestSearchField
-      search={selectedItemText || searchText}
-      placeholder="Common or scientific name..."
-      className={styles.speciesSearchFieldWrapper}
-      onChange={onSearchChange}
-      onSelect={onMatchSelected}
-      matchGroups={matchGroups}
-      searchFieldClassName={styles.speciesSearchField}
-      canShowSuggestions={canShowSuggesions}
-      notFound={isNotFound}
-      notFoundText={NOT_FOUND_TEXT}
-      onFocus={() => setIsFocused(true)}
-      onBlur={() => setIsFocused(false)}
-      rightCorner={<RightCorner status={rightCornerStatus} clear={clear} />}
-    />
+    <>
+      <label>Find a species</label>
+      <AutosuggestSearchField
+        search={selectedItemText || searchText}
+        placeholder="Common or scientific name..."
+        className={styles.speciesSearchFieldWrapper}
+        onChange={onSearchChange}
+        onSelect={onMatchSelected}
+        matchGroups={matchGroups}
+        searchFieldClassName={styles.speciesSearchField}
+        canShowSuggestions={canShowSuggesions}
+        notFound={isNotFound}
+        notFoundText={NOT_FOUND_TEXT}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        rightCorner={<RightCorner status={rightCornerStatus} clear={clear} />}
+      />
+      <ShowHide
+        label="How to find genes"
+        isExpanded={shouldShowFindGeneInstructions}
+        onClick={() =>
+          showFindGeneInstructions(!shouldShowFindGeneInstructions)
+        }
+        className={styles.showHide}
+      />
+      {shouldShowFindGeneInstructions && <FindGeneInstructions />}
+    </>
   );
 };
 

--- a/src/content/app/species-selector/containers/species-search-panel/SpeciesSearchPanel.scss
+++ b/src/content/app/species-selector/containers/species-search-panel/SpeciesSearchPanel.scss
@@ -2,17 +2,14 @@
 
 .speciesSearchPanel {
   background-color: $light-grey;
-  height: 235px;
+  min-height: 235px;
   padding: 65px 40px;
   padding-left: $global-padding-left;
   box-shadow: 0 3px 5px $global-box-shadow;
 }
 
 .speciesSearchPanelRow {
-  display: flex;
-  align-items: center;
   margin-bottom: 0.5em;
-  margin-left: -22px;
   user-select: none;
 }
 


### PR DESCRIPTION
## Description
Add label for Species selector search field and instructions on how to find a gene in other apps.

TODO: Find out if we need a shared component instead of using separate ones for instructions in apps.

## Related JIRA Issue(s)
[ENSWBSITES-1774](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1774)

## Deployment URL(s)
http://species-selector-find-gene.review.ensembl.org

## Views affected
Species selector