### PR TITLE
Fix tooltip randomly appearing over the Blast launchbar button

### DIFF
--- a/src/header/launchbar/LaunchbarButton.tsx
+++ b/src/header/launchbar/LaunchbarButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FunctionComponent } from 'react';
+import React, { useMemo, type FunctionComponent } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
 import classNames from 'classnames';
 
@@ -47,13 +47,16 @@ const LaunchbarButton: FunctionComponent<LaunchbarButtonProps> = (
     isActive
   });
 
-  const imageButton = (
-    <ImageButton
-      className={styles.launchbarButton}
-      status={imageButtonStatus}
-      description={props.description}
-      image={props.icon}
-    />
+  const imageButton = useMemo(
+    () => (
+      <ImageButton
+        className={styles.launchbarButton}
+        status={imageButtonStatus}
+        description={props.description}
+        image={props.icon}
+      />
+    ),
+    [props.icon, props.description, imageButtonStatus]
   );
 
   const activeButtonClass = classNames(

--- a/src/header/launchbar/LaunchbarButtonWithNotification.tsx
+++ b/src/header/launchbar/LaunchbarButtonWithNotification.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import classNames from 'classnames';
 
 import LaunchbarButton, { LaunchbarButtonProps } from './LaunchbarButton';
@@ -30,22 +30,24 @@ type LaunchbarButtonWithNotificationProps = LaunchbarButtonProps & {
 const LaunchbarButtonWithNotification = (
   props: LaunchbarButtonWithNotificationProps
 ) => {
-  const getNotificationClasses = () =>
-    classNames(styles.notification, {
-      [styles.notificationRed]: props.notification === 'red',
-      [styles.notificationGreen]: props.notification === 'green'
-    });
+  const notificationClasses = classNames(styles.notification, {
+    [styles.notificationRed]: props.notification === 'red',
+    [styles.notificationGreen]: props.notification === 'green'
+  });
 
-  const WrappedIcon = () => {
-    const { icon: Icon } = props;
+  const WrappedIcon = useMemo(
+    () => () => {
+      const { icon: Icon } = props;
 
-    return (
-      <div className={styles.toolsIconWrapper}>
-        <Icon />
-        {props.notification && <div className={getNotificationClasses()}></div>}
-      </div>
-    );
-  };
+      return (
+        <div className={styles.toolsIconWrapper}>
+          <Icon />
+          {props.notification && <div className={notificationClasses}></div>}
+        </div>
+      );
+    },
+    [notificationClasses]
+  );
 
   return <LaunchbarButton {...props} icon={WrappedIcon} />;
 };

--- a/src/shared/components/app-icon/BlastIcon.tsx
+++ b/src/shared/components/app-icon/BlastIcon.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { memo } from 'react';
 import classNames from 'classnames';
 
 import SVGIcon from 'static/icons/icon_launchbar_blast.svg';
@@ -31,4 +31,4 @@ const BlastIcon = () => {
   );
 };
 
-export default BlastIcon;
+export default memo(BlastIcon);

--- a/src/shared/hooks/useHover.tsx
+++ b/src/shared/hooks/useHover.tsx
@@ -26,7 +26,7 @@ export default function useHover<T extends HTMLElement>(): UseHoverType<T> {
 
   const handleMouseEnter = () => {
     if (!isTouched) {
-      setIsHovering(true);
+      !isHovering && setIsHovering(true);
     }
     isTouched = false;
   };
@@ -40,24 +40,23 @@ export default function useHover<T extends HTMLElement>(): UseHoverType<T> {
 
   useEffect(() => {
     const element = ref.current;
-    if (element) {
-      element.addEventListener('mouseenter', handleMouseEnter);
-      element.addEventListener('mouseleave', handleMouseLeave);
-      element.addEventListener('click', handleMouseLeave);
-      element.addEventListener('touchstart', handleTouch, { passive: true });
 
-      // cancel hover state if user switches to a different tab
-      document.addEventListener('visibilitychange', handleMouseLeave);
+    element?.addEventListener('mouseenter', handleMouseEnter);
+    element?.addEventListener('mouseleave', handleMouseLeave);
+    element?.addEventListener('click', handleMouseLeave);
+    element?.addEventListener('touchstart', handleTouch, { passive: true });
 
-      return () => {
-        element.removeEventListener('mouseenter', handleMouseEnter);
-        element.removeEventListener('mouseleave', handleMouseLeave);
-        element.removeEventListener('click', handleMouseLeave);
-        element.removeEventListener('touchstart', handleTouch);
+    // cancel hover state if user switches to a different tab
+    document.addEventListener('visibilitychange', handleMouseLeave);
 
-        document.removeEventListener('visibilitychange', handleMouseLeave);
-      };
-    }
+    return () => {
+      element?.removeEventListener('mouseenter', handleMouseEnter);
+      element?.removeEventListener('mouseleave', handleMouseLeave);
+      element?.removeEventListener('click', handleMouseLeave);
+      element?.removeEventListener('touchstart', handleTouch);
+
+      document.removeEventListener('visibilitychange', handleMouseLeave);
+    };
   }, [ref.current]);
 
   return [ref, isHovering];

--- a/src/shared/hooks/useHover.tsx
+++ b/src/shared/hooks/useHover.tsx
@@ -26,7 +26,7 @@ export default function useHover<T extends HTMLElement>(): UseHoverType<T> {
 
   const handleMouseEnter = () => {
     if (!isTouched) {
-      !isHovering && setIsHovering(true);
+      setIsHovering(true);
     }
     isTouched = false;
   };


### PR DESCRIPTION
## Description
We've been occasionally seeing a weird bug when after a switch to the BLAST app, the tooltip will appear under the BLAST launchbar icon, like so:

https://user-images.githubusercontent.com/6834224/201969246-f748b4db-f5ad-4253-b8a9-33c79de29a45.mov

I've tried to hunt down and squash this bug. Can't be 100% certain; but I believe **the real issue** was  in the `LaunchbarButtonWithNotification` component, which was creating a new `WrappedIcon` component every time it rerendered. This means that at every rerender, the DOM element wrapping the icon and the notification was different. Which might explain why the BLAST button would register the mouseenter, but not register the mouseleave event.

The rest of the changes are minor improvements:
- Update to the syntax of `useHover` hook, using optional chaining syntax
- A couple of added memoizations

## Deployment URL(s)
http://fix-blast-launchbar-tooltip.review.ensembl.org