### PR TITLE
show - when description is null for protein family

### DIFF
--- a/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.test.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.test.tsx
@@ -59,6 +59,6 @@ describe('<ProteinDomainImage />', () => {
 
     expect(
       container.querySelector('svg')?.querySelectorAll('.domain').length
-    ).toBe(firstDomainsGroup.length);
+    ).toBe(firstDomainsGroup.locations.length);
   });
 });


### PR DESCRIPTION
## Description
As per jira description to show "-" when there is no description (or its null) for protein domain. It turns out to be a more complicated fix than a simple check for null. Thoas is returning the correct value as null but we are using the description field as a key in an object which is causing the null to appeared since the key is treated as a string. 

Its not a good idea to have description as a key to an object since it can be empty or null. so had to refactor the code to take name as a key and having description in the field.


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1776

## Deployment URL(s)
http://empty-protein-description.review.ensembl.org


## Views affected
Gene function under entity viewer (click on the first protein)

Example of gene with null description:
http://empty-protein-description.review.ensembl.org/entity-viewer/grch37/gene:ENSG00000139618?view=protein