### PR TITLE
Update genome browser to 0.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2432,7 +2432,7 @@
     "node_modules/@ensembl/ensembl-genome-browser": {
       "version": "0.5.2",
       "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.2.tgz",
-      "integrity": "sha1-TtS/tnFeEp4fIY52aQmxg8JTdqI="
+      "integrity": "sha1-brVfUffaomeDY5BLSOAr6dLNL+8="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.1",
@@ -42184,7 +42184,7 @@
     "@ensembl/ensembl-genome-browser": {
       "version": "0.5.2",
       "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.2.tgz",
-      "integrity": "sha1-TtS/tnFeEp4fIY52aQmxg8JTdqI="
+      "integrity": "sha1-brVfUffaomeDY5BLSOAr6dLNL+8="
     },
     "@eslint/eslintrc": {
       "version": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2432,7 +2432,7 @@
     "node_modules/@ensembl/ensembl-genome-browser": {
       "version": "0.5.2",
       "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.2.tgz",
-      "integrity": "sha1-0m1O2Nhl2GvG5RhPwfi3txeoRUA="
+      "integrity": "sha1-TtS/tnFeEp4fIY52aQmxg8JTdqI="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.1",
@@ -42184,7 +42184,7 @@
     "@ensembl/ensembl-genome-browser": {
       "version": "0.5.2",
       "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.2.tgz",
-      "integrity": "sha1-0m1O2Nhl2GvG5RhPwfi3txeoRUA="
+      "integrity": "sha1-TtS/tnFeEp4fIY52aQmxg8JTdqI="
     },
     "@eslint/eslintrc": {
       "version": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ensembl/ensembl-genome-browser": "0.5.1",
+        "@ensembl/ensembl-genome-browser": "0.5.2",
         "@react-spring/web": "9.4.5-beta.1",
         "@reduxjs/toolkit": "1.8.5",
         "@sentry/browser": "7.12.1",
@@ -2430,9 +2430,9 @@
       }
     },
     "node_modules/@ensembl/ensembl-genome-browser": {
-      "version": "0.5.1",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.1.tgz",
-      "integrity": "sha1-wuUKH6VGIvFt9gJJ540XSCqcwiY="
+      "version": "0.5.2",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.2.tgz",
+      "integrity": "sha1-0m1O2Nhl2GvG5RhPwfi3txeoRUA="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.1",
@@ -42182,9 +42182,9 @@
       "dev": true
     },
     "@ensembl/ensembl-genome-browser": {
-      "version": "0.5.1",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.1.tgz",
-      "integrity": "sha1-wuUKH6VGIvFt9gJJ540XSCqcwiY="
+      "version": "0.5.2",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.2.tgz",
+      "integrity": "sha1-0m1O2Nhl2GvG5RhPwfi3txeoRUA="
     },
     "@eslint/eslintrc": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "coverage": "jest --coverage"
   },
   "dependencies": {
-    "@ensembl/ensembl-genome-browser": "0.5.1",
+    "@ensembl/ensembl-genome-browser": "0.5.2",
     "@react-spring/web": "9.4.5-beta.1",
     "@reduxjs/toolkit": "1.8.5",
     "@sentry/browser": "7.12.1",

--- a/src/content/app/genome-browser/components/genome-browser-error/GenomeBrowserError.scss
+++ b/src/content/app/genome-browser/components/genome-browser-error/GenomeBrowserError.scss
@@ -1,0 +1,23 @@
+@import 'src/styles/common';
+
+.container {
+  --alert-icon-diameter: 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 56px;
+  row-gap: 34px;
+}
+
+.container p {
+  margin: 0;
+  text-align: center;
+}
+
+.container p:not(:first-child) {
+  margin-top: 0.6rem;
+}
+
+.errorText {
+  color: $red;
+}

--- a/src/content/app/genome-browser/components/genome-browser-error/GenomeBrowserError.tsx
+++ b/src/content/app/genome-browser/components/genome-browser-error/GenomeBrowserError.tsx
@@ -1,0 +1,71 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import AlertButton from 'src/shared/components/alert-button/AlertButton';
+import { PrimaryButton } from 'src/shared/components/button/Button';
+
+import {
+  GenomeBrowserErrorType,
+  type GenomeBrowserError as GenomeBrowserErrorObj
+} from '@ensembl/ensembl-genome-browser';
+
+import styles from './GenomeBrowserError.scss';
+
+type Props = {
+  error: GenomeBrowserErrorObj;
+};
+
+const GenomeBrowserError = (props: Props) => {
+  const { error } = props;
+
+  if (error.type === GenomeBrowserErrorType.BAD_VERSION) {
+    return <GenomeBrowserVersionError />;
+  } else {
+    return <GenericGenomeBrowserError />;
+  }
+};
+
+const GenomeBrowserVersionError = () => {
+  return (
+    <div className={styles.container}>
+      <AlertButton />
+      <div>
+        <p className={styles.errorText}>We have updated the genome browser</p>
+        <p>Please reload this page to continue</p>
+      </div>
+      <PrimaryButton onClick={reloadPage}>Reload</PrimaryButton>
+    </div>
+  );
+};
+
+const GenericGenomeBrowserError = () => {
+  return (
+    <div className={styles.container}>
+      <AlertButton />
+      <div>
+        <p className={styles.errorText}>Genome browser has crashed</p>
+        <p>Please try reloading the page</p>
+      </div>
+      <PrimaryButton onClick={reloadPage}>Reload</PrimaryButton>
+    </div>
+  );
+};
+
+const reloadPage = () => window.location.reload();
+
+export default GenomeBrowserError;


### PR DESCRIPTION
## Description
[Related PR in the ensembl-genome-browser repo](https://github.com/Ensembl/ensembl-genome-browser)

Changes associated with this update

### Vertical scrolling

**Previous model**

Notice that:
- The canvas could be higher than the container element passed from chrome, into which the canvas was rendering. The height of the canvas dictated whether the scrollbar would appear.
- We used to render Zmenu and BrowserCogs as **siblings** of the element that we passed to the genome browser.

![image](https://user-images.githubusercontent.com/6834224/202660745-6112d6a1-ce9c-4d82-9b2a-0705b68b9d75.png)

**New model**

Notice that:
- The canvas is always as high as the container element passed to the genome browser from chrome
- Genome browser also renders an empty div which is as high as the full vertical content of genome browser. This empty div is what is responsible for the appearance of the scrollbar
- Zmenu and BrowserCogs are now rendered as **children** of the container element passed to the genome browser 

![image](https://user-images.githubusercontent.com/6834224/202660819-465d16f7-4644-4879-b6a5-1200ddcd8638.png)

### Error messaging
Genome browser now sends an error message when the client's version is out of date with the backend; and we respond to it by showing a screen that asks the user to refresh their browser.

Unfortunately, there was no time to properly refactor error messages at the Rust level; which is why it's a bit messy for this release, both in ensembl-genome-browser repo and here. Error messages are expected to be improved and made more standard in a future release of the genome browser.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1778

## Deployment URL(s)
http://gb-vertical-scrolling.review.ensembl.org