### PR TITLE
Add proper handling of BLAST submission errors

### DIFF
--- a/src/content/app/tools/blast/blast-download/submissionDownload.ts
+++ b/src/content/app/tools/blast/blast-download/submissionDownload.ts
@@ -29,7 +29,7 @@ import { downloadBlobAsFile } from 'src/shared/helpers/downloadAsFile';
 
 import type { AppDispatch } from 'src/store';
 import type {
-  BlastSubmission,
+  SuccessfulBlastSubmission,
   BlastJobWithResults
 } from 'src/content/app/tools/blast/state/blast-results/blastResultsSlice';
 
@@ -65,12 +65,12 @@ type EnrichedBlastJobWithResults = BlastJobWithResults & {
   raw: string;
 };
 
-type EnrichedBlastSubmission = BlastSubmission & {
+type EnrichedBlastSubmission = SuccessfulBlastSubmission & {
   results: EnrichedBlastJobWithResults[];
 };
 
 const downloadBlastSubmission = async (
-  submission: BlastSubmission,
+  submission: SuccessfulBlastSubmission,
   dispatch: AppDispatch
 ) => {
   const blastedAgainst = submission.submittedData.parameters.database; // 'cdna' | 'dna' | 'pep'
@@ -168,7 +168,7 @@ const createZipArchive = async (submission: EnrichedBlastSubmission) => {
   return zip;
 };
 
-const getNameForZipRoot = (submission: BlastSubmission) => {
+const getNameForZipRoot = (submission: SuccessfulBlastSubmission) => {
   const {
     id,
     submittedData: {

--- a/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.scss
+++ b/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.scss
@@ -64,11 +64,12 @@
   flex-shrink: 0;
 }
 
-.unavailableResultsMessage {
+.errorMessage {
   display: flex;
   align-items: center;
   column-gap: 0.6rem;
-  color: red;
+  color: $red;
+  margin-right: 16px;
 }
 
 .deleteMessageContainer {

--- a/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.tsx
@@ -129,8 +129,18 @@ export const BlastSubmissionHeader = (props: Props) => {
           </div>
         )}
         <div className={styles.submissionDetails}>
-          <span className={styles.submissionNameLabel}>Submission</span>
-          <span>{submissionId}</span>
+          {
+            /*  don't show submission id if it's entirely client-side-generated  */
+            !(
+              isFailedBlastSubmission(submission) &&
+              !submission.hasServerGeneratedId
+            ) && (
+              <>
+                <span className={styles.submissionNameLabel}>Submission</span>
+                <span>{submissionId}</span>
+              </>
+            )
+          }
           <span className={styles.editSubmission} onClick={editSubmission}>
             Edit/rerun
           </span>
@@ -184,7 +194,7 @@ const ControlsSection = (props: {
     return (
       <div className={styles.controlsSection}>
         <DeleteButton onClick={onDelete} disabled={isInDeleteMode} />
-        <div className={styles.unavailableResultsMessage}>
+        <div className={styles.errorMessage}>
           <span>{FAILED_SUBMISSION_WARNING}</span>
           <QuestionButton helpText={<FailedSubmissionHelpText />} />
         </div>
@@ -194,7 +204,7 @@ const ControlsSection = (props: {
     return (
       <div className={styles.controlsSection}>
         <DeleteButton onClick={onDelete} disabled={isInDeleteMode} />
-        <div className={styles.unavailableResultsMessage}>
+        <div className={styles.errorMessage}>
           <span>{UNAVAILABLE_RESULTS_WARNING}</span>
           <QuestionButton helpText={<UnavailableResultsHelpText />} />
         </div>

--- a/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.tsx
@@ -29,7 +29,7 @@ import downloadBlastSubmission from 'src/content/app/tools/blast/blast-download/
 import { fillBlastForm } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
 import {
   deleteBlastSubmission,
-  SuccessfulBlastSubmission,
+  type SuccessfulBlastSubmission,
   type BlastSubmission
 } from 'src/content/app/tools/blast/state/blast-results/blastResultsSlice';
 import {

--- a/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.tsx
@@ -23,11 +23,13 @@ import * as urlFor from 'src/shared/helpers/urlHelper';
 
 import { getFormattedDateTime } from 'src/shared/helpers/formatters/dateFormatter';
 import { areSubmissionResultsAvailable } from 'src/content/app/tools/blast/utils/blastResultsAvailability';
+import { isFailedBlastSubmission } from 'src/content/app/tools/blast/utils/blastSubmisionTypeNarrowing';
 import downloadBlastSubmission from 'src/content/app/tools/blast/blast-download/submissionDownload';
 
 import { fillBlastForm } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
 import {
   deleteBlastSubmission,
+  SuccessfulBlastSubmission,
   type BlastSubmission
 } from 'src/content/app/tools/blast/state/blast-results/blastResultsSlice';
 import {
@@ -48,6 +50,7 @@ import type { BlastProgram } from 'src/content/app/tools/blast/types/blastSettin
 import styles from './BlastSubmissionHeader.scss';
 
 export const UNAVAILABLE_RESULTS_WARNING = 'Results no longer available';
+export const FAILED_SUBMISSION_WARNING = 'Submission failed';
 
 export type Props = {
   submission: BlastSubmission;
@@ -109,7 +112,10 @@ export const BlastSubmissionHeader = (props: Props) => {
   };
 
   const handleDownload = async () => {
-    await downloadBlastSubmission(submission, dispatch);
+    await downloadBlastSubmission(
+      submission as SuccessfulBlastSubmission,
+      dispatch
+    );
   };
 
   return (
@@ -174,29 +180,43 @@ const ControlsSection = (props: {
     props;
   const isExpiredSubmission = !areSubmissionResultsAvailable(submission);
 
-  return !isExpiredSubmission ? (
-    <div className={styles.controlsSection}>
-      <DeleteButton onClick={onDelete} disabled={isInDeleteMode} />
-      <DownloadButton
-        onClick={onDownload}
-        disabled={isAnyJobRunning || isInDeleteMode}
-      />
-      <ButtonLink
-        to={urlFor.blastSubmission(submission.id)}
-        isDisabled={isAnyJobRunning || isInDeleteMode}
-      >
-        Results
-      </ButtonLink>
-    </div>
-  ) : (
-    <div className={styles.controlsSection}>
-      <DeleteButton onClick={onDelete} disabled={isInDeleteMode} />
-      <div className={styles.unavailableResultsMessage}>
-        <span>{UNAVAILABLE_RESULTS_WARNING}</span>
-        <QuestionButton helpText={<UnavailableResultsHelpText />} />
+  if (isFailedBlastSubmission(submission)) {
+    return (
+      <div className={styles.controlsSection}>
+        <DeleteButton onClick={onDelete} disabled={isInDeleteMode} />
+        <div className={styles.unavailableResultsMessage}>
+          <span>{FAILED_SUBMISSION_WARNING}</span>
+          <QuestionButton helpText={<FailedSubmissionHelpText />} />
+        </div>
       </div>
-    </div>
-  );
+    );
+  } else if (isExpiredSubmission) {
+    return (
+      <div className={styles.controlsSection}>
+        <DeleteButton onClick={onDelete} disabled={isInDeleteMode} />
+        <div className={styles.unavailableResultsMessage}>
+          <span>{UNAVAILABLE_RESULTS_WARNING}</span>
+          <QuestionButton helpText={<UnavailableResultsHelpText />} />
+        </div>
+      </div>
+    );
+  } else {
+    return (
+      <div className={styles.controlsSection}>
+        <DeleteButton onClick={onDelete} disabled={isInDeleteMode} />
+        <DownloadButton
+          onClick={onDownload}
+          disabled={isAnyJobRunning || isInDeleteMode}
+        />
+        <ButtonLink
+          to={urlFor.blastSubmission(submission.id)}
+          isDisabled={isAnyJobRunning || isInDeleteMode}
+        >
+          Results
+        </ButtonLink>
+      </div>
+    );
+  }
 };
 
 const UnavailableResultsHelpText = () => (
@@ -209,6 +229,15 @@ const UnavailableResultsHelpText = () => (
     <p>
       Configurations are stored for 28 days after submission, then removed from
       the jobs list
+    </p>
+  </>
+);
+
+const FailedSubmissionHelpText = () => (
+  <>
+    <p>Unable to run this submission</p>
+    <p>
+      Use 'Edit/rerun' to check the submission details, and try running again
     </p>
   </>
 );

--- a/src/content/app/tools/blast/services/blastStorageService.ts
+++ b/src/content/app/tools/blast/services/blastStorageService.ts
@@ -21,6 +21,8 @@ import {
   BLAST_SUBMISSION_STORAGE_DURATION
 } from './blastStorageServiceConstants';
 
+import { isSuccessfulBlastSubmission } from 'src/content/app/tools/blast/utils/blastSubmisionTypeNarrowing';
+
 import type {
   BlastSubmission,
   BlastJob
@@ -49,7 +51,7 @@ export const getAllBlastSubmissions = async (): Promise<
 
 export const getBlastSubmission = async (
   submissionId: string
-): Promise<BlastSubmission> => {
+): Promise<BlastSubmission | undefined> => {
   return await IndexedDB.get(STORE_NAME, submissionId);
 };
 
@@ -76,10 +78,10 @@ export const updateSavedBlastJob = async (params: {
 }) => {
   const { submissionId, jobId, fragment } = params;
   const submission = await getBlastSubmission(submissionId);
-  if (!submission) {
+  if (!isSuccessfulBlastSubmission(submission)) {
     return;
   }
-  const job = submission.results.find((job) => job.jobId === jobId);
+  const job = submission?.results?.find((job) => job.jobId === jobId);
 
   if (!job) {
     return;

--- a/src/content/app/tools/blast/state/blast-api/blastApiSlice.ts
+++ b/src/content/app/tools/blast/state/blast-api/blastApiSlice.ts
@@ -15,7 +15,7 @@
  */
 
 import { nanoid } from '@reduxjs/toolkit';
-import { type FetchBaseQueryError } from '@reduxjs/toolkit/query';
+import type { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 
 import config from 'config';
 import type { BaseQueryFn } from '@reduxjs/toolkit/dist/query/baseQueryTypes';
@@ -83,7 +83,6 @@ const blastApiSlice = restApiSlice.injectEndpoints({
         }));
 
         const body = {
-          // genome_ids: ['foo'],
           genome_ids: payload.species.map(({ genome_id }) => genome_id),
           query_sequences: querySequences,
           parameters: payload.parameters

--- a/src/content/app/tools/blast/state/blast-api/blastApiSlice.ts
+++ b/src/content/app/tools/blast/state/blast-api/blastApiSlice.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import { nanoid } from '@reduxjs/toolkit';
+import { type FetchBaseQueryError } from '@reduxjs/toolkit/query';
+
 import config from 'config';
 import type { BaseQueryFn } from '@reduxjs/toolkit/dist/query/baseQueryTypes';
 
@@ -23,7 +26,10 @@ import { toFasta } from 'src/shared/helpers/formatters/fastaFormatter';
 
 import type { BlastSettingsConfig } from 'src/content/app/tools/blast/types/blastSettings';
 import type { Species } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
-import type { BlastSubmission } from '../blast-results/blastResultsSlice';
+import type {
+  SuccessfulBlastSubmission,
+  FailedBlastSubmission
+} from '../blast-results/blastResultsSlice';
 import type { BlastJobResultResponse } from 'src/content/app/tools/blast/types/blastJob';
 import type { SubmittedSequence } from 'src/content/app/tools/blast/types/blastSequence';
 
@@ -38,6 +44,11 @@ export type BlastSubmissionPayload = {
 export type BlastSubmissionResponse = {
   submission_id: string;
   jobs: Array<SubmittedJob | RejectedJob>;
+};
+
+export type BlastSubmissionErrorResponse = {
+  submission_id?: string; // if the request has reached the backend, and if the backend hasn't errored while running code, there will be a submission id, even if the submission is rejected as invalid
+  error: string;
 };
 
 export type SubmittedJob = {
@@ -61,10 +72,10 @@ const blastApiSlice = restApiSlice.injectEndpoints({
       keepUnusedDataFor: 60 * 60 // one hour
     }),
     submitBlast: builder.mutation<
-      { submissionId: string; submission: BlastSubmission },
+      { submissionId: string; submission: SuccessfulBlastSubmission },
       BlastSubmissionPayload
     >({
-      query(payload) {
+      async queryFn(payload, queryApi, _, baseQuery) {
         // backend tools API accepts sequences as FASTA strings
         const querySequences = payload.sequences.map((item) => ({
           id: item.id,
@@ -72,45 +83,49 @@ const blastApiSlice = restApiSlice.injectEndpoints({
         }));
 
         const body = {
+          // genome_ids: ['foo'],
           genome_ids: payload.species.map(({ genome_id }) => genome_id),
           query_sequences: querySequences,
           parameters: payload.parameters
         };
-        return {
-          url: `${config.toolsApiBaseUrl}/blast/job`,
-          method: 'POST',
-          body
-        };
-      },
-      transformResponse(response: BlastSubmissionResponse, _, payload) {
-        const { submission_id: submissionId, jobs } = response;
-        // TODO: decide what to do when a submission returns error jobs
-        const results = jobs
-          .filter((job): job is SubmittedJob => 'job_id' in job)
-          .map((job) => ({
-            jobId: job.job_id,
-            genomeId: job.genome_id,
-            sequenceId: job.sequence_id,
-            status: 'RUNNING',
-            data: null
-          }));
 
-        return {
-          submissionId,
-          submission: {
-            id: submissionId,
-            submittedData: {
-              species: payload.species,
-              sequences: payload.sequences,
-              preset: payload.preset,
-              submissionName: payload.submissionName,
-              parameters: payload.parameters
-            },
-            results,
-            submittedAt: Date.now(),
-            seen: false
-          } as BlastSubmission
-        };
+        try {
+          const { data: responseData, error: responseError } = await baseQuery({
+            url: `${config.toolsApiBaseUrl}/blast/job`,
+            method: 'POST',
+            body
+          });
+          if (!responseData) {
+            throw responseError ?? { error: 'Blast submission failed' };
+          } else if (
+            onlyContainsRejectedJobs(responseData as BlastSubmissionResponse)
+          ) {
+            return {
+              error: {
+                status: 422,
+                data: prepareFailedSubmissionPayload(
+                  payload,
+                  responseData as BlastSubmissionResponse
+                )
+              }
+            };
+          } else {
+            return {
+              data: prepareSuccessfulSubmissionPayload(
+                payload,
+                responseData as BlastSubmissionResponse
+              )
+            };
+          }
+        } catch (error: unknown) {
+          // if tools api rejects the submission with a validation error, the json payload of that error will be part of error.data
+          const errorData = (error as FetchBaseQueryError)?.data ?? {};
+          const failedSubmission = prepareFailedSubmissionPayload(
+            payload,
+            errorData as BlastSubmissionErrorResponse
+          );
+          return { error: { status: 422, data: failedSubmission } };
+        }
       }
     }),
     fetchAllBlastJobs: builder.query<BlastJobResultResponse[], string[]>({
@@ -182,6 +197,80 @@ const commonFetchAllBlastJobs = <BaseQuery extends BaseQueryFn>(
     );
 
   return Promise.all(requestPromises);
+};
+
+const onlyContainsRejectedJobs = (response: BlastSubmissionResponse) => {
+  return response.jobs.every((job) => 'error' in job);
+};
+
+const prepareSuccessfulSubmissionPayload = (
+  payload: BlastSubmissionPayload,
+  responseData: BlastSubmissionResponse
+) => {
+  const { submission_id: submissionId, jobs } = responseData;
+  const results = jobs.map((job) => {
+    return {
+      jobId: 'job_id' in job ? job.job_id : nanoid(),
+      genomeId: job.genome_id,
+      sequenceId: job.sequence_id,
+      status: 'error' in job ? 'FAILURE' : 'RUNNING',
+      data: null
+    };
+  });
+
+  return {
+    submissionId,
+    submission: {
+      id: submissionId,
+      submittedData: {
+        species: payload.species,
+        sequences: payload.sequences,
+        preset: payload.preset,
+        submissionName: payload.submissionName,
+        parameters: payload.parameters
+      },
+      results,
+      submittedAt: Date.now(),
+      seen: false
+    } as SuccessfulBlastSubmission
+  };
+};
+
+const prepareFailedSubmissionPayload = (
+  payload: BlastSubmissionPayload,
+  responseData: BlastSubmissionResponse | BlastSubmissionErrorResponse
+) => {
+  let submissionId: string;
+  let hasServerGeneratedId = false;
+  let errorMessage = 'Blast submission failed';
+
+  if ('submission_id' in responseData && responseData.submission_id) {
+    submissionId = responseData.submission_id;
+    hasServerGeneratedId = true;
+  } else {
+    submissionId = nanoid();
+  }
+
+  if ('error' in responseData) {
+    errorMessage = responseData.error;
+  }
+
+  return {
+    submissionId,
+    submission: {
+      id: submissionId,
+      hasServerGeneratedId,
+      submittedData: {
+        species: payload.species,
+        sequences: payload.sequences,
+        preset: payload.preset,
+        submissionName: payload.submissionName,
+        parameters: payload.parameters
+      },
+      submittedAt: Date.now(),
+      error: errorMessage
+    } as FailedBlastSubmission
+  };
 };
 
 export const {

--- a/src/content/app/tools/blast/state/blast-results/blastResultsSelectors.ts
+++ b/src/content/app/tools/blast/state/blast-results/blastResultsSelectors.ts
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+import {
+  isSuccessfulBlastSubmission,
+  isFailedBlastSubmission
+} from 'src/content/app/tools/blast/utils/blastSubmisionTypeNarrowing';
+
 import type { RootState } from 'src/store';
 import type { BlastSubmission } from 'src/content/app/tools/blast/state/blast-results/blastResultsSlice';
 
@@ -25,13 +30,13 @@ export const getBlastSubmissionsUi = (state: RootState) =>
 
 export const getUnviewedBlastSubmissions = (state: RootState) => {
   return Object.values(getBlastSubmissions(state)).filter(
-    (submission) => !submission.seen
+    (submission) => isFailedBlastSubmission(submission) || !submission.seen
   );
 };
 
 export const getViewedBlastSubmissions = (state: RootState) => {
   return Object.values(getBlastSubmissions(state)).filter(
-    (submission) => submission.seen
+    (submission) => isSuccessfulBlastSubmission(submission) && submission.seen
   );
 };
 

--- a/src/content/app/tools/blast/utils/blastSubmisionTypeNarrowing.ts
+++ b/src/content/app/tools/blast/utils/blastSubmisionTypeNarrowing.ts
@@ -1,0 +1,41 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  BlastSubmission,
+  SuccessfulBlastSubmission,
+  FailedBlastSubmission
+} from 'src/content/app/tools/blast/state/blast-results/blastResultsSlice';
+
+export const isSuccessfulBlastSubmission = (
+  submission?: BlastSubmission
+): submission is SuccessfulBlastSubmission => {
+  if (!submission) {
+    return false;
+  } else {
+    return 'results' in submission;
+  }
+};
+
+export const isFailedBlastSubmission = (
+  submission?: BlastSubmission
+): submission is FailedBlastSubmission => {
+  if (!submission) {
+    return false;
+  } else {
+    return 'error' in submission;
+  }
+};

--- a/src/content/app/tools/blast/views/blast-submission-results/BlastSubmissionResults.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/BlastSubmissionResults.tsx
@@ -20,6 +20,10 @@ import { useParams } from 'react-router';
 import { useAppSelector, useAppDispatch } from 'src/store';
 
 import { areSubmissionResultsAvailable } from 'src/content/app/tools/blast/utils/blastResultsAvailability';
+import {
+  isSuccessfulBlastSubmission,
+  isFailedBlastSubmission
+} from 'src/content/app/tools/blast/utils/blastSubmisionTypeNarrowing';
 
 import { getBlastSubmissionById } from 'src/content/app/tools/blast/state/blast-results/blastResultsSelectors';
 
@@ -70,9 +74,11 @@ const Main = () => {
     getBlastSubmissionById(state, submissionId)
   );
   const dispatch = useAppDispatch();
+  const isSuccessfulSubmission = isSuccessfulBlastSubmission(blastSubmission);
 
-  const blastSubmissionJobIds =
-    blastSubmission?.results.map((job) => job.jobId) || [];
+  const blastSubmissionJobIds = isSuccessfulSubmission
+    ? blastSubmission.results.map((job) => job.jobId)
+    : [];
   const {
     currentData: allBlastJobResults,
     isLoading,
@@ -82,12 +88,12 @@ const Main = () => {
   });
 
   useEffect(() => {
-    if (blastSubmission && !blastSubmission.seen) {
+    if (blastSubmission && isSuccessfulSubmission && !blastSubmission.seen) {
       dispatch(markBlastSubmissionAsSeen(blastSubmission.id));
     }
   }, [blastSubmission?.id]);
 
-  if (!blastSubmission) {
+  if (!blastSubmission || isFailedBlastSubmission(blastSubmission)) {
     return <MissingBlastSubmissionError hasSubmissionParameters={false} />;
   } else if (!areSubmissionResultsAvailable(blastSubmission)) {
     return <MissingBlastSubmissionError hasSubmissionParameters={true} />;

--- a/src/header/launchbar/BlastLaunchbarButton.tsx
+++ b/src/header/launchbar/BlastLaunchbarButton.tsx
@@ -19,6 +19,8 @@ import { useLocation } from 'react-router-dom';
 
 import { useAppSelector } from 'src/store';
 
+import { isSuccessfulBlastSubmission } from 'src/content/app/tools/blast/utils/blastSubmisionTypeNarrowing';
+
 import { getUnviewedBlastSubmissions } from 'src/content/app/tools/blast/state/blast-results/blastResultsSelectors';
 
 import LaunchbarButtonWithNotification from './LaunchbarButtonWithNotification';
@@ -40,8 +42,10 @@ const BlastLaunchbarButton = () => {
   const getNotification = () => {
     if (unviewedSubmissions.length > 0) {
       const isAnyJobRunning =
-        unviewedSubmissions.filter((submission) =>
-          submission.results.some((job) => job.status === 'RUNNING')
+        unviewedSubmissions.filter(
+          (submission) =>
+            isSuccessfulBlastSubmission(submission) &&
+            submission.results.some((job) => job.status === 'RUNNING')
         ).length > 0;
 
       return isAnyJobRunning ? 'red' : 'green';

--- a/tests/fixtures/blast/blastSubmission.ts
+++ b/tests/fixtures/blast/blastSubmission.ts
@@ -23,6 +23,7 @@ import { createSelectedSpecies } from 'tests/fixtures/selected-species';
 
 import type {
   BlastSubmission,
+  SuccessfulBlastSubmission,
   BlastJob,
   JobStatus
 } from 'src/content/app/tools/blast/state/blast-results/blastResultsSlice';
@@ -33,7 +34,7 @@ export const createBlastSubmission = (params?: {
     sequencesCount?: number;
     speciesCount?: number;
   };
-}): BlastSubmission => {
+}): SuccessfulBlastSubmission => {
   const fragment = params?.fragment;
   const { sequencesCount = 2, speciesCount = 1 } = params?.options ?? {};
   const species = times(speciesCount, () => createSelectedSpecies());
@@ -75,7 +76,7 @@ export const createBlastJobs = ({
 }: {
   species: BlastSubmission['submittedData']['species'];
   sequences: BlastSubmission['submittedData']['sequences'];
-}): BlastSubmission['results'] => {
+}): SuccessfulBlastSubmission['results'] => {
   const jobs = [];
 
   for (const species of speciesList) {


### PR DESCRIPTION
## Description
There are different ways for a BLAST submission to fail, either as a whole, or in parts (when individual jobs fail). See [this gist](https://gist.github.com/azangru/75ce0f51e0fa45c436fa4919aa6808cf) for more detailed discussion.

**The scope of this PR is to:**
- Separate the `BlastSubmission` type into a successful BLAST submission, and a failed BLAST submission types; and to update the code to support both types
- Handle the failure of a whole submission. Currently, this is the most realistic cause of failure (when the user submits an invalid combination of BLAST parameters)

**Not addressed in this PR:**
Displaying failures of individual BLAST jobs (will be addressed in ENSWBSITES-1772)

### How to test
You can generate an invalid BLAST submission by choosing a gap opening penalty of 7 for a blastn program.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1753

## Deployment URL(s)
http://blast-submission-error.review.ensembl.org