### PR TITLE
Fix tracks disappearing when drawer opened

### DIFF
--- a/src/content/app/genome-browser/hooks/useGenomicTracks.ts
+++ b/src/content/app/genome-browser/hooks/useGenomicTracks.ts
@@ -55,6 +55,7 @@ const useGenomicTracks = () => {
     if (
       !genomeBrowser ||
       !trackSettingsForGenome ||
+      !genomeTrackCategories ||
       genomeIdInitialisedRef.current === activeGenomeId
     ) {
       return;


### PR DESCRIPTION
## Description
The tracks apart from the the focus track disappears when the drawer has been opened for a while. This however happens only when you leave the genome browser app and return to it.

Steps to reproduce:

1. Open the drawer by clicking on the ellipsis (three dots) button of any track
2. Click on another app or home
3. Wait for a minute and then click on genome browser
4. You will see the drawer is still opened. Close it and notice only the focus track being displayed in the genome browser.

## Related JIRA Issue(s)
[ENSWBSITES-1782](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1782)

## Deployment URL(s)
http://fix-disappearing-tracks.review.ensembl.org


## Views affected
Genome browser