### PR TITLE
Update launchbar button for Entity Viewer to avoid the flickering interstitial

### DIFF
--- a/src/content/app/entity-viewer/state/gene-view/view/geneViewViewSelectors.ts
+++ b/src/content/app/entity-viewer/state/gene-view/view/geneViewViewSelectors.ts
@@ -41,6 +41,9 @@ export const getCurrentView = (state: RootState) => {
   return getSliceForGene(state)?.current;
 };
 
+export const getAllGeneViews = (state: RootState) =>
+  state.entityViewer.geneView.view;
+
 export const getSelectedGeneViewTabs = (state: RootState): GeneViewTabData => {
   const view = getCurrentView(state);
   return view

--- a/src/header/launchbar/EntityViewerLaunchbarButton.tsx
+++ b/src/header/launchbar/EntityViewerLaunchbarButton.tsx
@@ -54,8 +54,8 @@ const EntityViewerLaunchbarButton = () => {
 
   const genomeIdForUrl =
     entityViewerActiveSpecies?.genome_id ?? entityViewerActiveGenomeId;
-  const entityIdForUrl = entityViewerActiveEntityId
-    ? buildFocusIdForUrl(parseFocusObjectId(entityViewerActiveEntityId))
+  const entityIdForUrl = parsedEntityId
+    ? buildFocusIdForUrl(parsedEntityId)
     : null;
 
   const entityViewerPath = urlFor.entityViewer({

--- a/src/header/launchbar/EntityViewerLaunchbarButton.tsx
+++ b/src/header/launchbar/EntityViewerLaunchbarButton.tsx
@@ -15,6 +15,7 @@
  */
 
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 
 import { useAppSelector } from 'src/store';
 
@@ -46,6 +47,7 @@ const EntityViewerLaunchbarButton = () => {
     getCommittedSpeciesById(state, entityViewerActiveGenomeId)
   );
   const geneView = useAppSelector(getCurrentGeneView) ?? null;
+  const location = useLocation();
 
   const parsedEntityId = entityViewerActiveEntityId
     ? parseFocusObjectId(entityViewerActiveEntityId)
@@ -53,7 +55,7 @@ const EntityViewerLaunchbarButton = () => {
   const entityType = parsedEntityId?.type;
 
   const genomeIdForUrl =
-    entityViewerActiveSpecies?.genome_id ?? entityViewerActiveGenomeId;
+    entityViewerActiveSpecies?.genome_tag ?? entityViewerActiveGenomeId;
   const entityIdForUrl = parsedEntityId
     ? buildFocusIdForUrl(parsedEntityId)
     : null;
@@ -70,6 +72,7 @@ const EntityViewerLaunchbarButton = () => {
       description="Entity Viewer"
       icon={EntityViewerIcon}
       enabled={true}
+      isActive={location.pathname.startsWith('/entity-viewer')}
     />
   );
 };

--- a/src/header/launchbar/EntityViewerLaunchbarButton.tsx
+++ b/src/header/launchbar/EntityViewerLaunchbarButton.tsx
@@ -1,0 +1,77 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { useAppSelector } from 'src/store';
+
+import * as urlFor from 'src/shared/helpers/urlHelper';
+
+import {
+  parseFocusObjectId,
+  buildFocusIdForUrl
+} from 'src/shared/helpers/focusObjectHelpers';
+
+import {
+  getEntityViewerActiveGenomeId,
+  getEntityViewerActiveEntityId
+} from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors';
+import { getCommittedSpeciesById } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
+import { getCurrentView as getCurrentGeneView } from 'src/content/app/entity-viewer/state/gene-view/view/geneViewViewSelectors';
+
+import LaunchbarButton from './LaunchbarButton';
+import { EntityViewerIcon } from 'src/shared/components/app-icon';
+
+const EntityViewerLaunchbarButton = () => {
+  const entityViewerActiveGenomeId = useAppSelector(
+    getEntityViewerActiveGenomeId
+  );
+  const entityViewerActiveEntityId = useAppSelector(
+    getEntityViewerActiveEntityId
+  );
+  const entityViewerActiveSpecies = useAppSelector((state) =>
+    getCommittedSpeciesById(state, entityViewerActiveGenomeId)
+  );
+  const geneView = useAppSelector(getCurrentGeneView) ?? null;
+
+  const parsedEntityId = entityViewerActiveEntityId
+    ? parseFocusObjectId(entityViewerActiveEntityId)
+    : null;
+  const entityType = parsedEntityId?.type;
+
+  const genomeIdForUrl =
+    entityViewerActiveSpecies?.genome_id ?? entityViewerActiveGenomeId;
+  const entityIdForUrl = entityViewerActiveEntityId
+    ? buildFocusIdForUrl(parseFocusObjectId(entityViewerActiveEntityId))
+    : null;
+
+  const entityViewerPath = urlFor.entityViewer({
+    genomeId: genomeIdForUrl ?? null,
+    entityId: entityIdForUrl,
+    view: entityType === 'gene' ? geneView : null
+  });
+
+  return (
+    <LaunchbarButton
+      path={entityViewerPath}
+      description="Entity Viewer"
+      icon={EntityViewerIcon}
+      enabled={true}
+    />
+  );
+};
+
+export default EntityViewerLaunchbarButton;

--- a/src/header/launchbar/Launchbar.tsx
+++ b/src/header/launchbar/Launchbar.tsx
@@ -21,10 +21,10 @@ import {
   GenomeBrowserIcon,
   SpeciesSelectorIcon,
   GlobalSearchIcon,
-  EntityViewerIcon,
   HelpIcon
 } from 'src/shared/components/app-icon';
 import LaunchbarButton from './LaunchbarButton';
+import EntityViewerLaunchbarButton from './EntityViewerLaunchbarButton';
 import BlastLaunchbarButton from './BlastLaunchbarButton';
 
 import Logotype from 'static/img/brand/logotype.svg';
@@ -64,12 +64,7 @@ const Launchbar = () => {
             />
           </div>
           <div className={styles.category}>
-            <LaunchbarButton
-              path="/entity-viewer"
-              description="Entity Viewer"
-              icon={EntityViewerIcon}
-              enabled={true}
-            />
+            <EntityViewerLaunchbarButton />
           </div>
           <div className={styles.category}>
             <BlastLaunchbarButton />

--- a/src/header/launchbar/LaunchbarButton.tsx
+++ b/src/header/launchbar/LaunchbarButton.tsx
@@ -33,6 +33,7 @@ export type LaunchbarButtonProps = {
   description: string;
   icon: FunctionComponent<unknown> | string;
   enabled: boolean;
+  isActive?: boolean;
 };
 
 const LaunchbarButton: FunctionComponent<LaunchbarButtonProps> = (
@@ -41,7 +42,10 @@ const LaunchbarButton: FunctionComponent<LaunchbarButtonProps> = (
   const location = useLocation();
 
   const { trackLaunchbarAppChange } = useHeaderAnalytics();
-  const isActive = new RegExp(`^${props.path}`).test(location.pathname);
+  const isActive =
+    'isActive' in props
+      ? (props.isActive as boolean)
+      : new RegExp(`^${props.path}`).test(location.pathname);
   const imageButtonStatus = getImageButtonStatus({
     isDisabled: !props.enabled,
     isActive


### PR DESCRIPTION
## Description
We were generating rather imprecise links to EntityViewer:
- In the launchbar, the link associated with the EntityViewer button was just `/entity-viewer`
- Within EntityViewer, the links generated by clicks on species lozenges were `/entity-viewer/:genomeId`

We were relying on EntityViewer to figure our on its own what it wants to display. Which it eventually did, but in the process, it could cycle through the interstitial screen, while figuring out whether it had an active genome id and gene id.

This PR updates links generated by the launchbar button and species lozenges, such that they open the exact EntityViewer screen based on which genome is active, which entity is active, and which view the user was in last.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1588

## Deployment URL(s)
http://update-link-to-entity-viewer.review.ensembl.org