### PR TITLE
Focus location

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2428,7 +2428,7 @@
     "node_modules/@ensembl/ensembl-genome-browser": {
       "version": "0.5.2-focus-loc",
       "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.2-focus-loc.tgz",
-      "integrity": "sha1-MMzMdQyXkPHZWOUYM25UYVnipBs="
+      "integrity": "sha1-D3mJBmyIO1bPs42MlQttNpesKYI="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
@@ -43100,7 +43100,7 @@
     "@ensembl/ensembl-genome-browser": {
       "version": "0.5.2-focus-loc",
       "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.2-focus-loc.tgz",
-      "integrity": "sha1-MMzMdQyXkPHZWOUYM25UYVnipBs="
+      "integrity": "sha1-D3mJBmyIO1bPs42MlQttNpesKYI="
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ensembl/ensembl-genome-browser": "0.5.2",
+        "@ensembl/ensembl-genome-browser": "0.5.2-focus-loc",
         "@react-spring/web": "9.4.5-beta.1",
         "@reduxjs/toolkit": "1.9.0",
         "@sentry/browser": "7.21.1",
@@ -2426,9 +2426,9 @@
       }
     },
     "node_modules/@ensembl/ensembl-genome-browser": {
-      "version": "0.5.2",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.2.tgz",
-      "integrity": "sha1-brVfUffaomeDY5BLSOAr6dLNL+8="
+      "version": "0.5.2-focus-loc",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.2-focus-loc.tgz",
+      "integrity": "sha1-MMzMdQyXkPHZWOUYM25UYVnipBs="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
@@ -43098,9 +43098,9 @@
       "dev": true
     },
     "@ensembl/ensembl-genome-browser": {
-      "version": "0.5.2",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.2.tgz",
-      "integrity": "sha1-brVfUffaomeDY5BLSOAr6dLNL+8="
+      "version": "0.5.2-focus-loc",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.2-focus-loc.tgz",
+      "integrity": "sha1-MMzMdQyXkPHZWOUYM25UYVnipBs="
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "coverage": "jest --coverage"
   },
   "dependencies": {
-    "@ensembl/ensembl-genome-browser": "0.5.2",
+    "@ensembl/ensembl-genome-browser": "0.5.2-focus-loc",
     "@react-spring/web": "9.4.5-beta.1",
     "@reduxjs/toolkit": "1.9.0",
     "@sentry/browser": "7.21.1",

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.test.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.test.tsx
@@ -116,7 +116,7 @@ describe('<TrackPanelList />', () => {
       const { container } = renderComponent(
         set(
           `browser.focusObjects.${activeFocusObjectId}.data`,
-          createFocusObject('region'),
+          createFocusObject('location'),
           mockState
         )
       );

--- a/src/content/app/genome-browser/hooks/useFocusTrack.ts
+++ b/src/content/app/genome-browser/hooks/useFocusTrack.ts
@@ -34,10 +34,7 @@ import type {
   FocusGeneTrack,
   FocusGeneTrackSettings
 } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSlice';
-import type {
-  FocusGene,
-  FocusObjectIdConstituents
-} from 'src/shared/types/focus-object/focusObjectTypes';
+import type { FocusGene } from 'src/shared/types/focus-object/focusObjectTypes';
 
 /**
  * The purposes of this hook are:
@@ -59,8 +56,7 @@ const useFocusTrack = () => {
     genomeBrowserMethods,
     focusGene:
       parsedFocusObjectId?.type === 'gene' ? (focusObject as FocusGene) : null,
-    focusObjectId,
-    parsedFocusObjectId
+    focusObjectId
   });
 
   /**
@@ -70,25 +66,19 @@ const useFocusTrack = () => {
 
 type Params = {
   focusGene: FocusGene | null;
-  parsedFocusObjectId: FocusObjectIdConstituents | null;
   focusObjectId: string;
   genomeBrowserMethods: ReturnType<typeof useGenomeBrowser>;
 };
 
 const useFocusGene = (params: Params) => {
-  const {
-    focusGene,
-    genomeBrowserMethods,
-    parsedFocusObjectId,
-    focusObjectId
-  } = params;
+  const { focusGene, genomeBrowserMethods, focusObjectId } = params;
   const {
     genomeBrowser,
     updateFocusGeneTranscripts,
     setFocusGene,
     toggleTrack
   } = genomeBrowserMethods;
-  const geneStableId = parsedFocusObjectId?.objectId;
+  const geneStableId = focusGene?.stable_id;
   const focusObjectIdRef = useRef(focusObjectId);
   const geneIdRef = useRef(geneStableId);
   const visibleTranscriptIds = focusGene?.visibleTranscriptIds ?? null;
@@ -103,8 +93,8 @@ const useFocusGene = (params: Params) => {
 
   useEffect(() => {
     focusObjectIdRef.current = focusObjectId;
-    geneIdRef.current = parsedFocusObjectId?.objectId;
-  }, [focusObjectId, parsedFocusObjectId?.objectId]);
+    geneIdRef.current = focusGene?.stable_id;
+  }, [focusObjectId, focusGene?.stable_id]);
 
   useEffect(() => {
     const subscription = genomeBrowser?.subscribe(
@@ -121,7 +111,7 @@ const useFocusGene = (params: Params) => {
   }, [genomeBrowser]);
 
   useEffect(() => {
-    if (!focusObjectId) {
+    if (!focusGene?.stable_id) {
       return;
     }
 
@@ -135,7 +125,12 @@ const useFocusGene = (params: Params) => {
     } else {
       toggleTrack({ trackId: 'focus', isTurnedOn: false });
     }
-  }, [genomeBrowser, focusObjectId, stringifiedVisibleTranscriptIds]);
+  }, [
+    genomeBrowser,
+    focusObjectId,
+    stringifiedVisibleTranscriptIds,
+    focusGene?.stable_id
+  ]);
 
   useEffect(() => {
     // Even if the user has disabled all gene's transcripts, re-focusing on this gene should show at least one transcript

--- a/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
@@ -72,12 +72,13 @@ const useGenomeBrowser = () => {
       return;
     }
 
-    const { genomeId, objectId } = parseFocusObjectId(focusObjectId);
+    const { genomeId, objectId, type } = parseFocusObjectId(focusObjectId);
 
     const action: OutgoingAction = {
       type: OutgoingActionType.SET_FOCUS,
       payload: {
-        focus: objectId,
+        focusId: objectId,
+        focusType: type,
         genomeId
       }
     };
@@ -86,12 +87,13 @@ const useGenomeBrowser = () => {
   };
 
   const changeFocusObject = (focusObjectId: string) => {
-    const { genomeId, objectId } = parseFocusObjectId(focusObjectId);
+    const { genomeId, type, objectId } = parseFocusObjectId(focusObjectId);
 
     const action: OutgoingAction = {
       type: OutgoingActionType.SET_FOCUS,
       payload: {
-        focus: objectId,
+        focusId: objectId,
+        focusType: type,
         genomeId,
         bringIntoView: true
       }

--- a/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
@@ -95,10 +95,13 @@ const useGenomeBrowserTracks = () => {
     if (!trackSettingsForGenome || !visibleTrackIds.length) {
       return;
     }
+    const nonFocusVisibleTracks = visibleTrackIds.filter(
+      (id) => id !== 'focus'
+    );
     const trackIdsForCurrentGenome = new Set(
       Object.keys(trackSettingsForGenome)
     );
-    const trackIdsToHide = visibleTrackIds.filter(
+    const trackIdsToHide = nonFocusVisibleTracks.filter(
       (id) => !trackIdsForCurrentGenome.has(id)
     );
 

--- a/src/content/app/genome-browser/state/focus-object/focusObjectSlice.ts
+++ b/src/content/app/genome-browser/state/focus-object/focusObjectSlice.ts
@@ -43,7 +43,7 @@ import type {
   FocusObject,
   FocusGene,
   FocusObjectIdConstituents,
-  FocusRegion
+  FocusLocation
 } from 'src/shared/types/focus-object/focusObjectTypes';
 import type { RootState } from 'src/store';
 
@@ -61,7 +61,9 @@ type BuildGeneObjectParams = {
 };
 
 // FIXME: many fields here are unnecessary for an focusObject
-export const buildGeneObject = (params: BuildGeneObjectParams): FocusGene => {
+export const buildFocusGeneObject = (
+  params: BuildGeneObjectParams
+): FocusGene => {
   const {
     slice: {
       location: { start, end },
@@ -102,12 +104,14 @@ const buildLoadedObject = (payload: { id: string; data: FocusObject }) => ({
   }
 });
 
-const buildRegionObject = (payload: FocusObjectIdConstituents): FocusRegion => {
+const buildFocusLocationObject = (
+  payload: FocusObjectIdConstituents
+): FocusLocation => {
   const { genomeId, objectId: regionId } = payload;
   const [chromosome, start, end] = getChrLocationFromStr(regionId);
 
   return {
-    type: 'region',
+    type: 'location',
     genome_id: genomeId,
     object_id: buildFocusObjectId(payload),
     label: regionId,
@@ -160,11 +164,11 @@ export const fetchFocusObject = createAsyncThunk(
       return;
     }
 
-    if (payload.type === 'region') {
-      const regionObject = buildRegionObject(payload);
+    if (payload.type === 'location') {
+      const focusLocationObject = buildFocusLocationObject(payload);
       return buildLoadedObject({
         id: focusObjectId,
-        data: regionObject
+        data: focusLocationObject
       });
     }
 
@@ -181,7 +185,7 @@ export const fetchFocusObject = createAsyncThunk(
       const result = await dispatchedPromise;
       dispatchedPromise.unsubscribe();
 
-      const geneFocusObject = buildGeneObject({
+      const geneFocusObject = buildFocusGeneObject({
         objectId: focusObjectId,
         genomeId,
         gene: result.data?.gene as TrackPanelGene

--- a/src/shared/components/feature-summary-strip/FeatureSummaryStrip.test.tsx
+++ b/src/shared/components/feature-summary-strip/FeatureSummaryStrip.test.tsx
@@ -54,7 +54,9 @@ describe('<FeatureSummaryStrip />', () => {
 
     it('contains RegionSummaryStrip if focus object is region', () => {
       const { container } = render(
-        renderFeatureSummaryStrip({ focusObject: createFocusObject('region') })
+        renderFeatureSummaryStrip({
+          focusObject: createFocusObject('location')
+        })
       );
       expect(container.textContent).toBe('Region Summary Strip'); // text from the mocked module
     });

--- a/src/shared/components/feature-summary-strip/FeatureSummaryStrip.tsx
+++ b/src/shared/components/feature-summary-strip/FeatureSummaryStrip.tsx
@@ -16,7 +16,10 @@
 
 import React from 'react';
 
-import { GeneSummaryStrip, RegionSummaryStrip } from '../feature-summary-strip';
+import {
+  GeneSummaryStrip,
+  LocationSummaryStrip
+} from '../feature-summary-strip';
 
 import { FocusObject } from 'src/shared/types/focus-object/focusObjectTypes';
 
@@ -31,8 +34,10 @@ export const FeatureSummaryStrip = (props: FeatureSummaryStripProps) => {
   switch (focusObject.type) {
     case 'gene':
       return <GeneSummaryStrip gene={focusObject} isGhosted={isGhosted} />;
-    case 'region':
-      return <RegionSummaryStrip region={focusObject} isGhosted={isGhosted} />;
+    case 'location':
+      return (
+        <LocationSummaryStrip location={focusObject} isGhosted={isGhosted} />
+      );
     default:
       return null;
   }

--- a/src/shared/components/feature-summary-strip/LocationSummaryStrip.tsx
+++ b/src/shared/components/feature-summary-strip/LocationSummaryStrip.tsx
@@ -21,25 +21,25 @@ import { getFormattedLocation } from 'src/shared/helpers/formatters/regionFormat
 
 import styles from './FeatureSummaryStrip.scss';
 
-import { FocusObject } from 'src/shared/types/focus-object/focusObjectTypes';
+import { FocusLocation } from 'src/shared/types/focus-object/focusObjectTypes';
 
 type Props = {
-  region: FocusObject;
+  location: FocusLocation;
   isGhosted?: boolean;
 };
 
-const RegionSummaryStrip = ({ region, isGhosted }: Props) => {
+const LocationSummaryStrip = ({ location, isGhosted }: Props) => {
   const stripClasses = classNames(styles.featureSummaryStrip, {
     [styles.featureSummaryStripGhosted]: isGhosted
   });
   return (
     <div className={stripClasses}>
-      <span className={styles.featureSummaryStripLabel}>Region:</span>
+      <span className={styles.featureSummaryStripLabel}>Location:</span>
       <span className={styles.featureDisplayName}>
-        {getFormattedLocation(region.location)}
+        {getFormattedLocation(location.location)}
       </span>
     </div>
   );
 };
 
-export default RegionSummaryStrip;
+export default LocationSummaryStrip;

--- a/src/shared/components/feature-summary-strip/index.ts
+++ b/src/shared/components/feature-summary-strip/index.ts
@@ -15,4 +15,4 @@
  */
 
 export { default as GeneSummaryStrip } from './GeneSummaryStrip';
-export { default as RegionSummaryStrip } from './RegionSummaryStrip';
+export { default as LocationSummaryStrip } from './LocationSummaryStrip';

--- a/src/shared/types/focus-object/focusObjectTypes.ts
+++ b/src/shared/types/focus-object/focusObjectTypes.ts
@@ -22,7 +22,7 @@ export type FocusObjectLocation = {
   start: number;
 };
 
-export type FocusObjectType = 'gene' | 'region';
+export type FocusObjectType = 'gene' | 'location';
 
 type BasicFocusObject = {
   object_id: string;
@@ -41,11 +41,11 @@ export type FocusGene = BasicFocusObject & {
   visibleTranscriptIds: string[] | null; // null means that chrome doesn't have an opinion on which transcripts should be visible in the genome browser
 };
 
-export type FocusRegion = BasicFocusObject & {
-  type: 'region';
+export type FocusLocation = BasicFocusObject & {
+  type: 'location';
 };
 
-export type FocusObject = FocusGene | FocusRegion;
+export type FocusObject = FocusGene | FocusLocation;
 
 export type FocusObjectResponse = FocusGene;
 

--- a/tests/fixtures/focus-object.ts
+++ b/tests/fixtures/focus-object.ts
@@ -19,7 +19,7 @@ import { faker } from '@faker-js/faker';
 import {
   FocusObject,
   FocusGene,
-  FocusRegion,
+  FocusLocation,
   FocusObjectType
 } from 'src/shared/types/focus-object/focusObjectTypes';
 import { Strand } from 'src/shared/types/thoas/strand';
@@ -28,8 +28,8 @@ export const createFocusObject = (
   objectType?: FocusObjectType
 ): FocusObject => {
   switch (objectType) {
-    case 'region':
-      return createFocusRegion();
+    case 'location':
+      return createFocusLocation();
     default:
       return createFocusGene();
   }
@@ -47,13 +47,13 @@ const createFocusGene = (): FocusGene => {
   };
 };
 
-const createFocusRegion = (): FocusRegion => {
+const createFocusLocation = (): FocusLocation => {
   const genome_id = faker.lorem.word();
-  const object_id = `${genome_id}:gene:${faker.datatype.uuid()};`;
+  const object_id = `${genome_id}:location:${faker.datatype.uuid()};`;
 
   return {
     ...commonFocusObjectFields({ genome_id }),
-    type: 'region',
+    type: 'location',
     object_id
   };
 };


### PR DESCRIPTION
## Description
Enable locations as focus objects for the genome browser, even before the genome browser update to a version that properly supports this.

Related PR: https://github.com/Ensembl/ensembl-genome-browser/pull/18

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1789

## Deployment URL(s)
http://focus-location.review.ensembl.org