### PR TITLE
Replace "all" chunks with "initial" in splitChunks optimisation for the vendors module

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -16,7 +16,7 @@ module.exports = (api) => {
         '@babel/env',
         {
           useBuiltIns: 'usage',
-          corejs: 3,
+          corejs: 3.26,
           modules: false,
           targets
         }
@@ -29,7 +29,7 @@ module.exports = (api) => {
             '@babel/env',
             {
               useBuiltIns: 'usage',
-              corejs: 3
+              corejs: 3.26
             }
           ]
         ]

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
   "browserslist": [
     "> 1% and last 2 versions",
     "not dead",
-    "not ie 11"
+    "not ie 11",
+    "not op_mini all"
   ]
 }

--- a/webpack/client/production.ts
+++ b/webpack/client/production.ts
@@ -120,7 +120,7 @@ export default (): Configuration => {
           commons: {
             test: /node_modules/,
             name: 'vendors',
-            chunks: 'all'
+            chunks: 'initial'
           }
         }
       },


### PR DESCRIPTION
## Description
By using the `all` chunks setting when we were combining all third-party libraries into a single `vendors` chunk, we were preventing code-splitting of the libraries that we could load asynchronously. 

### Example
If you inspect the [vendors file](https://beta.ensembl.org/static/vendors.52129dc0b6349798eaab.js) on the beta site, you will notice that it references jszip which is the library that we are [asynchronously importing](https://github.com/Ensembl/ensembl-client/blob/58d6d2cfbb342a411b68597c75bc62ee8a25ba5d/src/content/app/tools/blast/blast-download/submissionDownload.ts#L132) when the user wants to download a BLAST submission. Normally, webpack would split off dynamically loaded modules into separate chunks; but the `all` keyword was preventing this.

### Savings
The vendors chunk on beta.ensembl.org — 249kB minified gzipped:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/6834224/205402803-b58ef4e3-a3bb-4883-a5c9-8e1e236990e5.png">

vs the vendors chunk on the review deployment, which is 178kB minified gzipped:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/6834224/205402858-908dd5fe-f887-4c09-abcf-4890d69ce4a5.png">

That's almost 70kB of javascript saved.

### Also
I am explicitly removing Opera mini from the list of supported browsers, which was generated by `browserslist`:

<img width="450" src="https://user-images.githubusercontent.com/6834224/205405114-31f5849d-62d3-4119-a67f-b0eb1ee0f2ec.png" />

PageSpeedInsights was flagging that we were including a polyfill for Array.prototype.includes somewhere in our files:

<img width="984" alt="image" src="https://user-images.githubusercontent.com/6834224/205405197-c6a0ef19-564e-4ed4-aef6-cbc124e00935.png">

and although I could not confirm this by inspecting the files, this would be consistent with the [lack of support](https://caniuse.com/array-includes) of this feature by Opera mini.

While I am at it, I am also updating babel config to specify the minor version of corejs, as per [documentation](https://github.com/zloirock/core-js#babelpreset-env).

## Deployment URL(s)
http://webpack-vendors.review.ensembl.org/