### PR TITLE
Bring back the 404 http status code for missing routes

### DIFF
--- a/src/server/routes/viewsRouter.tsx
+++ b/src/server/routes/viewsRouter.tsx
@@ -61,6 +61,8 @@ const viewRouter = async (req: Request, res: Response) => {
       // TODO: this would be a good place to log out the error when we set up loggers
       statusCode = 500;
     }
+  } else if (matchedPageConfig.path === '*') {
+    statusCode = 404;
   }
 
   const ReactApp = (


### PR DESCRIPTION
## Description
Restore the 404 http status code for:
- Non-existing routes (e.g. `beta.ensembl.org/foo`) — the regression occurred in https://github.com/Ensembl/ensembl-client/pull/878, where the relevant code block [got deleted](https://github.com/Ensembl/ensembl-client/pull/878/files#diff-0ce5023f4aabe0db1b762ff1fddc6465de9e737fef3e031e20eb44caef5dc350L120-L125)
- Non-existing genomes (e.g. `beta.ensembl.org/entity-viewer/grch3`)
- Non-existing genes in Entity Viewer (e.g. `beta.ensembl.org/entity-viewer/grch38/gene:ENSG0000013961`)

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1804

## Deployment URL(s)
http://fix-404.review.ensembl.org

Examples:
- [Entity Viewer, non-existing gene](https://fix-404.review.ensembl.org/entity-viewer/grch38/gene:ENSG0000013961)
- [Entity Viewer, non-existing genome](http://fix-404.review.ensembl.org/entity-viewer/grch3)
- [Species page, non-existing genome](http://fix-404.review.ensembl.org/species/grch3)
- [Non-existing route](http://fix-404.review.ensembl.org/foo)