### PR TITLE
update thoas deprecated byId to by_id

### DIFF
--- a/src/content/app/entity-viewer/state/api/queries/defaultGeneQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/defaultGeneQuery.ts
@@ -26,7 +26,7 @@ import type { TranscriptMetadata } from 'src/shared/types/thoas/metadata';
 
 export const defaultGeneQuery = gql`
   query DefaultEntityViewerGene($genomeId: String!, $geneId: String!) {
-    gene(byId: { genome_id: $genomeId, stable_id: $geneId }) {
+    gene(by_id: { genome_id: $genomeId, stable_id: $geneId }) {
       stable_id
       symbol
       unversioned_stable_id

--- a/src/content/app/entity-viewer/state/api/queries/geneExternalReferencesQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/geneExternalReferencesQuery.ts
@@ -25,7 +25,7 @@ import type { ExternalReference } from 'src/shared/types/thoas/externalReference
 
 export const geneExternalReferencesQuery = gql`
   query GeneExternalReferences($geneId: String!, $genomeId: String!) {
-    gene(byId: { stable_id: $geneId, genome_id: $genomeId }) {
+    gene(by_id: { stable_id: $geneId, genome_id: $genomeId }) {
       stable_id
       symbol
       external_references {

--- a/src/content/app/entity-viewer/state/api/queries/geneForSequenceDownloadQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/geneForSequenceDownloadQuery.ts
@@ -21,7 +21,7 @@ import type { FullProductGeneratingContext } from 'src/shared/types/thoas/produc
 
 export const geneForSequenceDownloadQuery = gql`
   query GeneForSequenceDownload($genomeId: String!, $geneId: String!) {
-    gene(byId: { genome_id: $genomeId, stable_id: $geneId }) {
+    gene(by_id: { genome_id: $genomeId, stable_id: $geneId }) {
       stable_id
       transcripts {
         product_generating_contexts {

--- a/src/content/app/entity-viewer/state/api/queries/geneOverviewQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/geneOverviewQuery.ts
@@ -22,7 +22,7 @@ import type { FullGene } from 'src/shared/types/thoas/gene';
 // It looks very similar to geneSummaryQuery; but has a potential of becoming heavier
 export const geneOverviewQuery = gql`
   query GeneOverview($genomeId: String!, $geneId: String!) {
-    gene(byId: { genome_id: $genomeId, stable_id: $geneId }) {
+    gene(by_id: { genome_id: $genomeId, stable_id: $geneId }) {
       alternative_symbols
       name
       stable_id

--- a/src/content/app/entity-viewer/state/api/queries/genePageMetaQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/genePageMetaQuery.ts
@@ -18,7 +18,7 @@ import { gql } from 'graphql-request';
 
 export const genePageMetaQuery = gql`
   query GenePageMeta($genomeId: String!, $geneId: String!) {
-    gene(byId: { genome_id: $genomeId, stable_id: $geneId }) {
+    gene(by_id: { genome_id: $genomeId, stable_id: $geneId }) {
       stable_id
       symbol
     }

--- a/src/content/app/entity-viewer/state/api/queries/geneSummaryQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/geneSummaryQuery.ts
@@ -23,7 +23,7 @@ import type { FullGene } from 'src/shared/types/thoas/gene';
 // Useful for populating the top bar and example links in the interstitial.
 export const geneSummaryQuery = gql`
   query GeneSummary($genomeId: String!, $geneId: String!) {
-    gene(byId: { genome_id: $genomeId, stable_id: $geneId }) {
+    gene(by_id: { genome_id: $genomeId, stable_id: $geneId }) {
       stable_id
       unversioned_stable_id
       symbol

--- a/src/content/app/entity-viewer/state/api/queries/proteinDomainsQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/proteinDomainsQuery.ts
@@ -21,7 +21,7 @@ import type { FamilyMatch } from 'src/shared/types/thoas/product';
 
 export const proteinDomainsQuery = gql`
   query ProteinDomains($genomeId: String!, $productId: String!) {
-    product(genome_id: $genomeId, stable_id: $productId) {
+    product(by_id: { genome_id: $genomeId, stable_id: $productId }) {
       length
       family_matches {
         relative_location {

--- a/src/content/app/genome-browser/state/api/queries/geneSummaryQuery.ts
+++ b/src/content/app/genome-browser/state/api/queries/geneSummaryQuery.ts
@@ -23,7 +23,7 @@ import { FullProductGeneratingContext } from 'src/shared/types/thoas/productGene
 
 export const geneSummaryQuery = gql`
   query Gene($genomeId: String!, $geneId: String!) {
-    gene(byId: { genome_id: $genomeId, stable_id: $geneId }) {
+    gene(by_id: { genome_id: $genomeId, stable_id: $geneId }) {
       alternative_symbols
       name
       stable_id

--- a/src/content/app/genome-browser/state/api/queries/trackPanelGeneQuery.ts
+++ b/src/content/app/genome-browser/state/api/queries/trackPanelGeneQuery.ts
@@ -23,7 +23,7 @@ type Params = {
 
 const trackPanelGeneQuery = (params: Params) => gql`
   query TrackPanelGene {
-    gene(byId: { genome_id: "${params.genomeId}", stable_id: "${params.geneId}" }) {
+    gene(by_id: { genome_id: "${params.genomeId}", stable_id: "${params.geneId}" }) {
       stable_id
       unversioned_stable_id
       symbol

--- a/src/content/app/genome-browser/state/api/queries/transcriptInZmenuQuery.ts
+++ b/src/content/app/genome-browser/state/api/queries/transcriptInZmenuQuery.ts
@@ -22,7 +22,7 @@ import { FullProductGeneratingContext } from 'src/shared/types/thoas/productGene
 
 export const transcriptZmenuQuery = gql`
   query Transcript($genomeId: String!, $transcriptId: String!) {
-    transcript(byId: { genome_id: $genomeId, stable_id: $transcriptId }) {
+    transcript(by_id: { genome_id: $genomeId, stable_id: $transcriptId }) {
       product_generating_contexts {
         product_type
       }

--- a/src/content/app/genome-browser/state/api/queries/transcriptSummaryQuery.ts
+++ b/src/content/app/genome-browser/state/api/queries/transcriptSummaryQuery.ts
@@ -25,7 +25,7 @@ import type { TranscriptMetadata } from 'src/shared/types/thoas/metadata';
 
 export const transcriptSummaryQuery = gql`
   query TranscriptSummary($genomeId: String!, $transcriptId: String!) {
-    transcript(byId: { genome_id: $genomeId, stable_id: $transcriptId }) {
+    transcript(by_id: { genome_id: $genomeId, stable_id: $transcriptId }) {
       stable_id
       unversioned_stable_id
       external_references {

--- a/src/shared/components/instant-download/instant-download-fetch/fetchSequenceChecksums.ts
+++ b/src/shared/components/instant-download/instant-download-fetch/fetchSequenceChecksums.ts
@@ -186,10 +186,10 @@ const geneAndTranscriptChecksumsQuery = gql`
     $geneId: String!
     $transcriptId: String!
   ) {
-    gene(byId: { genome_id: $genomeId, stable_id: $geneId }) {
+    gene(by_id: { genome_id: $genomeId, stable_id: $geneId }) {
       ...GeneDetails
     }
-    transcript(byId: { genome_id: $genomeId, stable_id: $transcriptId }) {
+    transcript(by_id: { genome_id: $genomeId, stable_id: $transcriptId }) {
       ...TranscriptDetails
     }
   }
@@ -199,7 +199,7 @@ const geneAndTranscriptChecksumsQuery = gql`
 
 const geneChecksumsQuery = gql`
   query Gene($genomeId: String!, $geneId: String!) {
-    gene(byId: { genome_id: $genomeId, stable_id: $geneId }) {
+    gene(by_id: { genome_id: $genomeId, stable_id: $geneId }) {
       ...GeneDetails
       transcripts {
         ...TranscriptDetails
@@ -212,7 +212,7 @@ const geneChecksumsQuery = gql`
 
 const transcriptChecksumsQuery = gql`
   query Transcript($genomeId: String!, $transcriptId: String!) {
-    transcript(byId: { genome_id: $genomeId, stable_id: $transcriptId }) {
+    transcript(by_id: { genome_id: $genomeId, stable_id: $transcriptId }) {
       ...TranscriptDetails
     }
   }


### PR DESCRIPTION
## Description
See jira ticket for description of task. Mostly the query files that needs updating to change byId to by_id.

Thoas schema/docs can be seen here:
http://thoas-update.review.ensembl.org/api/thoas (click on the docs button on the right side)

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1775

## Deployment URL(s)
http://thoas-update.review.ensembl.org


## Views affected
Good to check all views to make sure nothing breaks but mostly entity viewer, genome browser (sidebar)