### PR TITLE
Update protein domains image to show domain information in a tooltip

### DIFF
--- a/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.scss
+++ b/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.scss
@@ -10,7 +10,7 @@
   min-height: 300px;
   margin-right: 30px;
   padding-bottom: 100px;
-  z-index: 0; // so that a tooltip pointing at an element in the body does not get positioned in from of the header while scrolling
+  z-index: 0; // so that a tooltip brought up iside the body does not overlay the panel header when scrolling, but instead go behind the header
 }
 
 .header {

--- a/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.scss
+++ b/src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction.scss
@@ -10,6 +10,7 @@
   min-height: 300px;
   margin-right: 30px;
   padding-bottom: 100px;
+  z-index: 0; // so that a tooltip pointing at an element in the body does not get positioned in from of the header while scrolling
 }
 
 .header {

--- a/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.scss
+++ b/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.scss
@@ -5,7 +5,8 @@
 }
 
 .domain {
-  fill: $grey;
+  fill: $blue;
+  cursor: pointer;
 }
 
 .track {
@@ -42,11 +43,12 @@
 }
 
 .resourceImage {
+  position: relative;
   display: grid;
   grid-template-columns: [image] min-content [description] max-content;
   margin-bottom: 6px;
 
-  & svg {
+  & .containerSvg {
     grid-column: image;
   }
 
@@ -55,4 +57,18 @@
     padding-left: 27px;
     color: $black;
   }
+}
+
+.tooltipRow {
+  font-weight: $normal;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  justify-items: start;
+  align-items: start;
+  column-gap: 1rem;
+  max-width: 280px;
+}
+
+.tooltipFieldLabel {
+  font-weight: $light;
 }

--- a/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.scss
+++ b/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.scss
@@ -60,6 +60,10 @@
   }
 }
 
+.tooltipAnchor {
+  position: absolute;
+}
+
 .tooltipRow {
   font-weight: $normal;
   display: grid;

--- a/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.scss
+++ b/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.scss
@@ -6,6 +6,7 @@
 
 .domain {
   fill: $blue;
+  opacity: 20%;
   cursor: pointer;
 }
 
@@ -67,6 +68,10 @@
   align-items: start;
   column-gap: 1rem;
   max-width: 280px;
+}
+
+.tooltipRow:not(:last-child) {
+  margin-bottom: 3px;
 }
 
 .tooltipFieldLabel {

--- a/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.tsx
@@ -294,14 +294,17 @@ const ProteinDomainInfoTooltip = (props: {
   );
 
   const anchorStyle = {
-    position: 'absolute' as any, // FIXME: move to css file
     top: `${y}px`,
     left: `${x}px`
   };
 
   return (
     <>
-      <div ref={setAnchorElement} style={anchorStyle} />
+      <div
+        ref={setAnchorElement}
+        className={styles.tooltipAnchor}
+        style={anchorStyle}
+      />
       {anchorElement && (
         <Toolbox
           anchor={anchorElement}

--- a/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.tsx
@@ -318,10 +318,7 @@ const ProteinDomainInfoTooltip = (props: {
               <span className={styles.tooltipFieldLabel}>
                 {domainInfo.resourceName}
               </span>
-              <ExternalLink
-                linkText={domainInfo.resourceName}
-                to={domainInfo.url}
-              />
+              <ExternalLink linkText={domainInfo.name} to={domainInfo.url} />
             </div>
           )}
           {domainInfo.closestDataProviderName &&

--- a/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.tsx
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import classNames from 'classnames';
 import { scaleLinear, ScaleLinear } from 'd3';
+
+import { Toolbox, ToolboxPosition } from 'src/shared/components/toolbox';
+import ExternalLink from 'src/shared/components/external-link/ExternalLink';
 
 import type { FamilyMatchInProduct } from 'src/content/app/entity-viewer/state/api/queries/proteinDomainsQuery';
 
@@ -30,6 +33,7 @@ export type ProteinDomainImageProps = {
   trackLength: number;
   width: number; // available width for drawing, in pixels
   classNames?: {
+    // FIXME: is this needed?
     track?: string;
     domain?: string;
   };
@@ -43,10 +47,25 @@ type ProteinDomainLocation = {
 type ProteinDomainImageData = {
   [resource_name: string]: {
     [domain_name: string]: {
-      description: string;
+      name: string;
+      description: string | null;
+      descriptionFromClosestDataProvider: string | null;
+      url: string | null;
+      urlForClosestDataProvider: string | null;
+      resourceName: string;
+      accessionIdInClosestDataProvider: string | null;
+      closestDataProviderName: string | null;
       locations: ProteinDomainLocation[];
     };
   };
+};
+
+export type SingleProteinDomainData = Omit<
+  ProteinDomainImageData[string][string],
+  'locations'
+> & {
+  start: number;
+  end: number;
 };
 
 export const getDomainsByResourceGroups = (
@@ -56,19 +75,34 @@ export const getDomainsByResourceGroups = (
 
   proteinDomains.forEach((domain) => {
     const {
-      sequence_family: { name: domainName, description },
       sequence_family: {
+        name: domainName,
+        description,
+        url,
         source: { name: resource_name }
       },
-      relative_location: { start, end }
+      relative_location: { start, end },
+      via: closestDataProvider
     } = domain;
+    const {
+      description: descriptionFromClosestDataProvider = null,
+      url: urlForClosestDataProvider = null
+    } = closestDataProvider ?? {};
 
     if (!groupedDomains[resource_name]) {
       groupedDomains[resource_name] = {};
     }
     if (!groupedDomains[resource_name][domainName]) {
       groupedDomains[resource_name][domainName] = {
+        name: domainName,
         description,
+        url,
+        descriptionFromClosestDataProvider,
+        urlForClosestDataProvider,
+        resourceName: resource_name,
+        accessionIdInClosestDataProvider:
+          closestDataProvider?.accession_id ?? null,
+        closestDataProviderName: closestDataProvider?.source.name ?? null,
         locations: []
       };
     }
@@ -102,34 +136,84 @@ const ProteinDomainImage = (props: ProteinDomainImageProps) => {
             <div className={styles.resourceName}>{resource}</div>
             <div className={styles.resourceImages}>
               {domainsGroup.map((trackData, index) => (
-                <div key={index} className={styles.resourceImage}>
-                  <svg
-                    className={styles.containerSvg}
-                    width={props.width}
-                    height={BLOCK_HEIGHT}
-                  >
-                    <g>
-                      <Track {...props} />
-                      {trackData.locations.map((domain, index) => (
-                        <DomainBlock
-                          key={index}
-                          domain={domain}
-                          className={props.classNames?.domain}
-                          scale={scale}
-                        />
-                      ))}
-                    </g>
-                  </svg>
-
-                  <div className={styles.resourceDescription}>
-                    {trackData.description ?? '-'}
-                  </div>
-                </div>
+                <TrackWithDomains
+                  key={index}
+                  trackWidth={props.width}
+                  scale={scale}
+                  trackData={trackData}
+                />
               ))}
             </div>
           </div>
         )
       )}
+    </div>
+  );
+};
+
+const TrackWithDomains = (props: {
+  trackWidth: number;
+  scale: ScaleLinear<number, number>;
+  trackData: TrackData;
+}) => {
+  const { trackWidth, scale, trackData } = props;
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [proteinDomainTooltipData, setProteinDomainTooltipData] = useState<{
+    domainInfo: SingleProteinDomainData;
+    x: number;
+    y: number;
+  } | null>(null);
+
+  const onProteinDomainClick = (
+    domainInfo: SingleProteinDomainData,
+    clickCoords: { x: number; y: number }
+  ) => {
+    const containerRect =
+      containerRef.current?.getBoundingClientRect() as DOMRect;
+    const { x } = containerRect;
+    const tooltipData = {
+      domainInfo,
+      x: clickCoords.x - x,
+      y: 12 // making the tooltip point at the middle of a protein domain rectangle; strangely, it looks better when it's a bit over BLOCK_HEIGHT / 2
+    };
+    setProteinDomainTooltipData(tooltipData);
+  };
+
+  const onProteinDomainTooltipHide = () => {
+    setProteinDomainTooltipData(null);
+  };
+
+  return (
+    <div ref={containerRef} className={styles.resourceImage}>
+      <svg
+        className={styles.containerSvg}
+        width={trackWidth}
+        height={BLOCK_HEIGHT}
+      >
+        <g>
+          <Track width={trackWidth} />
+          {trackData.locations.map((domain, index) => (
+            <DomainBlock
+              key={index}
+              domain={domain}
+              trackData={trackData}
+              onClick={onProteinDomainClick}
+              scale={scale}
+            />
+          ))}
+        </g>
+      </svg>
+
+      {proteinDomainTooltipData && (
+        <ProteinDomainInfoTooltip
+          {...proteinDomainTooltipData}
+          onHide={onProteinDomainTooltipHide}
+        />
+      )}
+
+      <div className={styles.resourceDescription}>
+        {getProteinDomainsTrackDescription(trackData)}
+      </div>
     </div>
   );
 };
@@ -150,6 +234,11 @@ type DomainBlockProps = {
     start: number;
     end: number;
   };
+  trackData: TrackData;
+  onClick: (
+    domainData: SingleProteinDomainData,
+    clickCoords: { x: number; y: number }
+  ) => void;
   className?: string;
   scale: ScaleLinear<number, number>;
 };
@@ -158,23 +247,113 @@ const DomainBlock = (props: DomainBlockProps) => {
   const y = 3;
   const domainClasses = classNames(styles.domain, props.className);
 
+  const onClick = (event: React.TouchEvent | React.MouseEvent) => {
+    let clientX = 0;
+    let clientY = 0;
+    if ('touches' in event) {
+      clientX = event.touches[0].clientX;
+      clientY = event.touches[0].clientY;
+    } else {
+      clientX = event.clientX;
+      clientY = event.clientY;
+    }
+
+    const payload = {
+      ...props.trackData,
+      start: props.domain.start,
+      end: props.domain.end
+    };
+
+    props.onClick(payload, { x: clientX, y: clientY });
+  };
+
   return (
-    <rect
-      key={props.domain.start}
-      className={domainClasses}
-      y={y}
-      height={BLOCK_HEIGHT}
-      x={props.scale(props.domain.start)}
-      width={props.scale(props.domain.end - props.domain.start + 1)}
-    />
+    <>
+      <rect
+        key={props.domain.start}
+        className={domainClasses}
+        y={y}
+        height={BLOCK_HEIGHT}
+        x={props.scale(props.domain.start)}
+        width={props.scale(props.domain.end - props.domain.start + 1)}
+        onClick={onClick}
+      />
+    </>
   );
 };
 
-type TrackData = {
-  name: string;
-  description: string | null;
-  locations: ProteinDomainLocation[];
+const ProteinDomainInfoTooltip = (props: {
+  domainInfo: SingleProteinDomainData;
+  x: number;
+  y: number;
+  onHide: () => void;
+}) => {
+  const { domainInfo, x, y, onHide } = props;
+  const anchorRef = useRef<HTMLDivElement | null>(null);
+  const [anchorElement, setAnchorElement] = useState<HTMLDivElement | null>(
+    null
+  );
+
+  useEffect(() => {
+    setAnchorElement(anchorRef.current);
+  }, []);
+
+  const anchorStyle = {
+    position: 'absolute' as any, // FIXME: move to css file
+    top: `${y}px`,
+    left: `${x}px`
+  };
+
+  return (
+    <>
+      <div ref={anchorRef} style={anchorStyle} />
+      {anchorElement && (
+        <Toolbox
+          anchor={anchorElement}
+          position={ToolboxPosition.RIGHT}
+          onOutsideClick={onHide}
+        >
+          {domainInfo.url && domainInfo.resourceName && (
+            <div className={styles.tooltipRow}>
+              <span className={styles.tooltipFieldLabel}>
+                {domainInfo.resourceName}
+              </span>
+              <ExternalLink
+                linkText={domainInfo.resourceName}
+                to={domainInfo.url}
+              />
+            </div>
+          )}
+          {domainInfo.closestDataProviderName &&
+            domainInfo.urlForClosestDataProvider &&
+            domainInfo.accessionIdInClosestDataProvider && (
+              <div className={styles.tooltipRow}>
+                <span className={styles.tooltipFieldLabel}>
+                  {domainInfo.closestDataProviderName}
+                </span>
+                <ExternalLink
+                  linkText={domainInfo.accessionIdInClosestDataProvider}
+                  to={domainInfo.urlForClosestDataProvider}
+                />
+              </div>
+            )}
+          <div className={styles.tooltipRow}>
+            <span className={styles.tooltipFieldLabel}>Description</span>
+            <span>{getProteinDomainsTrackDescription(domainInfo)}</span>
+          </div>
+          <div className={styles.tooltipRow}>
+            <span className={styles.tooltipFieldLabel}>Position</span>
+            <span>
+              {domainInfo.start}-{domainInfo.end} aa
+            </span>
+          </div>
+        </Toolbox>
+      )}
+    </>
+  );
 };
+
+type TrackData = ProteinDomainImageData['string']['string'];
 
 type SortedTracksForResource = [string, TrackData[]];
 
@@ -208,5 +387,13 @@ const getSortedProteinDomains = (
     })
     .map(([name, domain]) => ({ ...domain, name }));
 };
+
+const getProteinDomainsTrackDescription = (
+  trackData: Pick<
+    TrackData,
+    'descriptionFromClosestDataProvider' | 'description'
+  >
+) =>
+  trackData.descriptionFromClosestDataProvider || trackData.description || '-';
 
 export default ProteinDomainImage;

--- a/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useRef } from 'react';
 import classNames from 'classnames';
 import { scaleLinear, ScaleLinear } from 'd3';
 
@@ -289,14 +289,9 @@ const ProteinDomainInfoTooltip = (props: {
   onHide: () => void;
 }) => {
   const { domainInfo, x, y, onHide } = props;
-  const anchorRef = useRef<HTMLDivElement | null>(null);
   const [anchorElement, setAnchorElement] = useState<HTMLDivElement | null>(
     null
   );
-
-  useEffect(() => {
-    setAnchorElement(anchorRef.current);
-  }, []);
 
   const anchorStyle = {
     position: 'absolute' as any, // FIXME: move to css file
@@ -306,7 +301,7 @@ const ProteinDomainInfoTooltip = (props: {
 
   return (
     <>
-      <div ref={anchorRef} style={anchorStyle} />
+      <div ref={setAnchorElement} style={anchorStyle} />
       {anchorElement && (
         <Toolbox
           anchor={anchorElement}

--- a/src/content/app/entity-viewer/state/api/queries/proteinDomainsQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/proteinDomainsQuery.ts
@@ -17,7 +17,10 @@
 import { gql } from 'graphql-request';
 import { Pick2, Pick3 } from 'ts-multipick';
 
-import type { FamilyMatch } from 'src/shared/types/thoas/product';
+import type {
+  FamilyMatch,
+  ClosestDataProvider
+} from 'src/shared/types/thoas/product';
 
 export const proteinDomainsQuery = gql`
   query ProteinDomains($genomeId: String!, $productId: String!) {
@@ -31,6 +34,15 @@ export const proteinDomainsQuery = gql`
         sequence_family {
           name
           description
+          url
+          source {
+            name
+          }
+        }
+        via {
+          accession_id
+          description
+          url
           source {
             name
           }
@@ -45,8 +57,14 @@ export type FamilyMatchInProduct = Pick2<
   'relative_location',
   'start' | 'end'
 > &
-  Pick2<FamilyMatch, 'sequence_family', 'name' | 'description'> &
-  Pick3<FamilyMatch, 'sequence_family', 'source', 'name'>;
+  Pick2<FamilyMatch, 'sequence_family', 'name' | 'description' | 'url'> &
+  Pick3<FamilyMatch, 'sequence_family', 'source', 'name'> & {
+    via:
+      | (Pick<ClosestDataProvider, 'accession_id' | 'description' | 'url'> & {
+          source: Pick<ClosestDataProvider['source'], 'name'>;
+        })
+      | null;
+  };
 
 export type ProteinDomainsQueryResult = {
   product: {

--- a/src/shared/types/thoas/product.ts
+++ b/src/shared/types/thoas/product.ts
@@ -26,11 +26,21 @@ export enum ProductType {
 type SequenceFamily = {
   name: string;
   description: string;
+  url: string | null;
   source: Source;
 };
+
+export type ClosestDataProvider = {
+  accession_id: string;
+  description: string | null;
+  url: string;
+  source: Source;
+};
+
 export type FamilyMatch = {
   relative_location: LocationWithinRegion;
   sequence_family: SequenceFamily;
+  via: ClosestDataProvider | null;
 };
 
 // TODO: have at least two types of products:

--- a/tests/fixtures/entity-viewer/product.ts
+++ b/tests/fixtures/entity-viewer/product.ts
@@ -76,12 +76,14 @@ const createFamilyMatches = (proteinLength: number): FamilyMatch[] => {
       sequence_family: {
         name: faker.random.words(),
         description: faker.random.words(),
+        url: faker.internet.url(),
         source: {
           id: faker.datatype.uuid(),
           name: faker.random.word(),
           url: faker.internet.url()
         }
-      }
+      },
+      via: null
     };
   });
 };


### PR DESCRIPTION
## Description
Upon a click on a protein domain rectangle in the protein diagram in Entity Viewer, the user will see a tooltip containing details about this domain.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1674

## Deployment URL(s)
http://protein-domains-image.review.ensembl.org