### PR TITLE
Make sure the sequence in the BLAST submission params section wraps over multiple lines

### DIFF
--- a/src/content/app/tools/blast/views/blast-submission-results/components/job-parameters/JobParameters.scss
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/job-parameters/JobParameters.scss
@@ -24,6 +24,7 @@
     font-family: $font-family-monospace;
     color: $dark-grey;
     overflow-y: auto;
+    overflow-wrap: break-word;
   }
 
   .parameters {


### PR DESCRIPTION
## Description
Fix the bug with a non-wrapping sequence.

**Before:**
![image](https://user-images.githubusercontent.com/6834224/206451997-bd3cbb3b-3f93-4be7-850e-e9f8001b39e3.png)

**After**
![image](https://user-images.githubusercontent.com/6834224/206452123-906ab2a7-f3c0-4a31-80f3-9cfcdc3e970e.png)

## Deployment URL(s)
http://fix-blast-params-seq-wrap.review.ensembl.org