### PR TITLE
Update genome browser to version 0.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ensembl/ensembl-genome-browser": "0.5.2-focus-loc",
+        "@ensembl/ensembl-genome-browser": "0.5.3",
         "@react-spring/web": "9.4.5-beta.1",
         "@reduxjs/toolkit": "1.9.0",
         "@sentry/browser": "7.21.1",
@@ -2426,9 +2426,9 @@
       }
     },
     "node_modules/@ensembl/ensembl-genome-browser": {
-      "version": "0.5.2-focus-loc",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.2-focus-loc.tgz",
-      "integrity": "sha1-MRykg6Z9RMGLFjYGJDMZFOgc9ng="
+      "version": "0.5.3",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.3.tgz",
+      "integrity": "sha1-Jfbb6H6k8fbCPT7YPA3XwCgZbV4="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
@@ -43098,9 +43098,9 @@
       "dev": true
     },
     "@ensembl/ensembl-genome-browser": {
-      "version": "0.5.2-focus-loc",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.2-focus-loc.tgz",
-      "integrity": "sha1-MRykg6Z9RMGLFjYGJDMZFOgc9ng="
+      "version": "0.5.3",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.3.tgz",
+      "integrity": "sha1-Jfbb6H6k8fbCPT7YPA3XwCgZbV4="
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "coverage": "jest --coverage"
   },
   "dependencies": {
-    "@ensembl/ensembl-genome-browser": "0.5.2-focus-loc",
+    "@ensembl/ensembl-genome-browser": "0.5.3",
     "@react-spring/web": "9.4.5-beta.1",
     "@reduxjs/toolkit": "1.9.0",
     "@sentry/browser": "7.21.1",

--- a/src/content/app/genome-browser/hooks/useFocusTrack.ts
+++ b/src/content/app/genome-browser/hooks/useFocusTrack.ts
@@ -29,7 +29,6 @@ import { getAllTrackSettings } from 'src/content/app/genome-browser/state/track-
 
 import { updateFocusGeneTranscriptsVisibility } from 'src/content/app/genome-browser/state/focus-object/focusObjectSlice';
 
-import { Status } from 'src/shared/types/status';
 import type {
   FocusGeneTrack,
   FocusGeneTrackSettings
@@ -72,12 +71,8 @@ type Params = {
 
 const useFocusGene = (params: Params) => {
   const { focusGene, genomeBrowserMethods, focusObjectId } = params;
-  const {
-    genomeBrowser,
-    updateFocusGeneTranscripts,
-    setFocusGene,
-    toggleTrack
-  } = genomeBrowserMethods;
+  const { genomeBrowser, updateFocusGeneTranscripts, setFocusGene } =
+    genomeBrowserMethods;
   const geneStableId = focusGene?.stable_id;
   const focusObjectIdRef = useRef(focusObjectId);
   const geneIdRef = useRef(geneStableId);
@@ -115,16 +110,7 @@ const useFocusGene = (params: Params) => {
       return;
     }
 
-    const trackStatus =
-      Array.isArray(visibleTranscriptIds) && !visibleTranscriptIds.length
-        ? Status.UNSELECTED
-        : Status.SELECTED;
-
-    if (trackStatus === Status.SELECTED) {
-      setFocusGene(focusObjectId);
-    } else {
-      toggleTrack({ trackId: 'focus', isTurnedOn: false });
-    }
+    setFocusGene(focusObjectId);
   }, [
     genomeBrowser,
     focusObjectId,
@@ -133,11 +119,12 @@ const useFocusGene = (params: Params) => {
   ]);
 
   useEffect(() => {
+    if (!geneStableId) {
+      return;
+    }
     // Even if the user has disabled all gene's transcripts, re-focusing on this gene should show at least one transcript
     // (it's possible that this logic will change when no selected transcripts results in showing a ghosted transcript)
-    const transcriptsParam = visibleTranscriptIds?.length
-      ? visibleTranscriptIds
-      : null;
+    const transcriptsParam = visibleTranscriptIds ? visibleTranscriptIds : null;
     updateFocusGeneTranscripts(transcriptsParam);
   }, [
     genomeBrowser, // updateFocusGeneTranscripts requires genomeBrowser to be defined
@@ -146,7 +133,7 @@ const useFocusGene = (params: Params) => {
   ]);
 
   useEffect(() => {
-    if (!trackSettingsForGenome) {
+    if (!geneStableId || !trackSettingsForGenome) {
       return;
     }
     sendFocusGeneTrackSettings(

--- a/src/content/app/genome-browser/hooks/useFocusTrack.ts
+++ b/src/content/app/genome-browser/hooks/useFocusTrack.ts
@@ -124,7 +124,7 @@ const useFocusGene = (params: Params) => {
     }
     // Even if the user has disabled all gene's transcripts, re-focusing on this gene should show at least one transcript
     // (it's possible that this logic will change when no selected transcripts results in showing a ghosted transcript)
-    const transcriptsParam = visibleTranscriptIds ? visibleTranscriptIds : null;
+    const transcriptsParam = visibleTranscriptIds ?? null;
     updateFocusGeneTranscripts(transcriptsParam);
   }, [
     genomeBrowser, // updateFocusGeneTranscripts requires genomeBrowser to be defined


### PR DESCRIPTION
## Description
Update genome browser to version 0.5.3

This version includes the following new functionality:
- Shows a ghosted default transcript for a gene with all transcripts switched off (see changes in the `useFocusTrack` hook in this PR; we are no longer switching off the focus track when user unselects all transcripts)
- Collapses focus gene into a single rectangle at a certain zoom-out level
- Enables proper focus locations (see https://github.com/Ensembl/ensembl-genome-browser/pull/19 for relevant changes)
- Shows a red dotted line when user presses on the ruler

## Deployment URL(s)
http://gb-update-053.review.ensembl.org