### PR TITLE
update StandardAppLayout

### DIFF
--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/GeneViewSideBar.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/GeneViewSideBar.tsx
@@ -15,8 +15,10 @@
  */
 
 import React from 'react';
-import { useSelector } from 'react-redux';
 
+import { useAppSelector } from 'src/store';
+
+import Sidebar from 'src/shared/components/layout/sidebar/Sidebar';
 import GeneOverview from 'src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview';
 import GeneExternalReferences from 'src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences';
 
@@ -25,15 +27,15 @@ import { getEntityViewerSidebarTabName } from 'src/content/app/entity-viewer/sta
 import { SidebarTabName } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSlice';
 
 const GeneViewSidebar = () => {
-  const activeTabName = useSelector(getEntityViewerSidebarTabName);
+  const activeTabName = useAppSelector(getEntityViewerSidebarTabName);
 
   return (
-    <>
+    <Sidebar>
       {activeTabName === SidebarTabName.OVERVIEW && <GeneOverview />}
       {activeTabName === SidebarTabName.EXTERNAL_REFERENCES && (
         <GeneExternalReferences />
       )}
-    </>
+    </Sidebar>
   );
 };
 

--- a/src/content/app/genome-browser/components/track-panel/TrackPanel.tsx
+++ b/src/content/app/genome-browser/components/track-panel/TrackPanel.tsx
@@ -15,8 +15,10 @@
  */
 
 import React from 'react';
-import { useSelector } from 'react-redux';
 
+import { useAppSelector } from 'src/store';
+
+import Sidebar from 'src/shared/components/layout/sidebar/Sidebar';
 import TrackPanelList from './components/track-panel-list/TrackPanelList';
 import { SidebarLoader } from 'src/shared/components/loader';
 
@@ -28,15 +30,19 @@ import {
 import useGenomeBrowser from 'src/content/app/genome-browser/hooks/useGenomeBrowser';
 
 export const TrackPanel = () => {
-  const activeGenomeId = useSelector(getBrowserActiveGenomeId);
-  const activeFocusObject = useSelector(getBrowserActiveFocusObject);
+  const activeGenomeId = useAppSelector(getBrowserActiveGenomeId);
+  const activeFocusObject = useAppSelector(getBrowserActiveFocusObject);
 
   const { genomeBrowser } = useGenomeBrowser();
 
   const shouldRenderContent =
     activeGenomeId && genomeBrowser && activeFocusObject;
 
-  return shouldRenderContent ? <TrackPanelList /> : <SidebarLoader />;
+  return (
+    <Sidebar>
+      {shouldRenderContent ? <TrackPanelList /> : <SidebarLoader />}
+    </Sidebar>
+  );
 };
 
 export default TrackPanel;

--- a/src/content/app/species/components/species-page-sidebar/SpeciesPageSidebar.tsx
+++ b/src/content/app/species/components/species-page-sidebar/SpeciesPageSidebar.tsx
@@ -19,6 +19,7 @@ import classNames from 'classnames';
 
 import { useAppDispatch, useAppSelector } from 'src/store';
 
+import Sidebar from 'src/shared/components/layout/sidebar/Sidebar';
 import ExternalReference from 'src/shared/components/external-reference/ExternalReference';
 
 import { getActiveGenomeId } from 'src/content/app/species/state/general/speciesGeneralSelectors';
@@ -72,7 +73,7 @@ const SpeciesPageSidebar = () => {
   ];
 
   return (
-    <div>
+    <Sidebar>
       <div className={styles.speciesDetails}>
         {sidebarPayload.common_name && (
           <span className={styles.commonName}>
@@ -162,7 +163,7 @@ const SpeciesPageSidebar = () => {
           </div>
         );
       })}
-    </div>
+    </Sidebar>
   );
 };
 

--- a/src/shared/components/layout/StandardAppLayout.scss
+++ b/src/shared/components/layout/StandardAppLayout.scss
@@ -86,14 +86,13 @@ $drawerWindowWidth: 45px;
   height: 100%;
   width: $sidebarContentWidth;
   border-left: 1px solid $grey;
-  padding: 21px 0 0 12px;
   background-color: white;
   overflow: auto;
   scrollbar-gutter: stable;
 
   & > div {
     padding-bottom: $global-padding-bottom;
-    max-width: calc($sidebarContentWidth - 25px);
+    max-width: calc($sidebarContentWidth - 13px);
   }
 }
 

--- a/src/shared/components/layout/sidebar-modal/SidebarModal.scss
+++ b/src/shared/components/layout/sidebar-modal/SidebarModal.scss
@@ -8,6 +8,7 @@
   grid-template-columns: 1fr 20px;
   grid-template-rows: 38px 1fr;
   height: 100%;
+  padding: 21px 0 0 12px;
 }
 
 .title {

--- a/src/shared/components/layout/sidebar/Sidebar.scss
+++ b/src/shared/components/layout/sidebar/Sidebar.scss
@@ -1,0 +1,5 @@
+@import 'src/styles/common';
+
+.wrapper {
+  padding: 21px 0 0 12px;
+}

--- a/src/shared/components/layout/sidebar/Sidebar.tsx
+++ b/src/shared/components/layout/sidebar/Sidebar.tsx
@@ -15,32 +15,15 @@
  */
 
 import React, { ReactNode } from 'react';
-import classNames from 'classnames';
 
-import CloseButton from 'src/shared/components/close-button/CloseButton';
+import styles from './Sidebar.scss';
 
-import styles from './SidebarModal.scss';
-
-export type SidebarModalProps = {
-  title: string;
+export type SidebarProps = {
   children: ReactNode;
-  className?: string;
-  onClose: () => void;
 };
 
-const SidebarModal = (props: SidebarModalProps) => {
-  const { title, className, onClose } = props;
-  const wrapperClasses = classNames(styles.wrapper, className);
+const Sidebar = (props: SidebarProps) => (
+  <div className={styles.wrapper}>{props.children}</div>
+);
 
-  return (
-    <div className={wrapperClasses}>
-      <CloseButton className={styles.closeButton} onClick={onClose} />
-      <h3 className={styles.title}>{title}</h3>
-      <div className={styles.content}>
-        <div>{props.children}</div>
-      </div>
-    </div>
-  );
-};
-
-export default SidebarModal;
+export default Sidebar;


### PR DESCRIPTION
## Description
The sidebar modal for Genome browser needs to be customisable because of the new navigation panel. However, this was not possible as there was a padding specified for the parent sidebar element. So this PR does the following to fix the issue (as suggested in the JIRA ticket):

- Add a `className` prop to `SidebarModal` to customise the styling
- Add a new `Sidebar` component

## Related JIRA Issue(s)
[ENSWBSITES-1810](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1810)

## Deployment URL(s)
http://update-standard-app-layout.review.ensembl.org

## Views affected
Sidebars in Genome browser, Species page and Entity viewer