### PR TITLE
Add styles for H3 in Help and About articles

### DIFF
--- a/src/shared/components/help-article/HelpArticle.scss
+++ b/src/shared/components/help-article/HelpArticle.scss
@@ -17,13 +17,22 @@ $textColumnWidth: 450px;
     font-size: 15px;
     line-height: 18px;
     font-weight: $normal;
-    margin: 0 0 #{$heading-margin-bottom} -#{$heading-outdent};
+    margin: 0 0 $heading-margin-bottom -#{$heading-outdent};
+  }
+
+  h2,
+  h3 {
+    font-size: 13px;
+    margin-bottom: $line-height;
   }
 
   h2 {
-    font-size: 13px;
     margin-top: calc(2 * #{$line-height});
-    margin-bottom: $line-height;
+    margin-left: -#{$heading-outdent};
+  }
+
+  h3 {
+    margin-top: $line-height;
   }
 
   h1,
@@ -81,7 +90,7 @@ $textColumnWidth: 450px;
   }
 }
 
-@media (max-width: $pageLeftPadding + 3 * $indexItemWidth + 2 * $indexItemsHorizontalGap) {
+@media (max-width: #{$pageLeftPadding + 3 * $indexItemWidth + 2 * $indexItemsHorizontalGap}) {
   .indexArticle {
     grid-template-columns: repeat(2, #{$indexItemWidth});
   }


### PR DESCRIPTION
## Description
This PR adds styles for Heading 3 for articles in Help and About apps.

[Reference XD](https://xd.adobe.com/view/2c4fb907-05d2-427d-9033-17d5e78ce495-791c/screen/a51e945b-abd6-4070-b8f7-bef23ebee242/?fullscreen) (not as a dev-friendly export)

Text-based specs from the ticket:

```
H1, Lato 15px regular, outset
H2, Lato 13/17px bold, outset & aligned left with the H1 article title
H3, 13/17 px bold, aligned left with the article body copy
Body copy, Lato 13/17px regular
```

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1812

## Deployment URL(s)
http://help-heading-3.review.ensembl.org

_(Specifically, check out http://help-heading-3.review.ensembl.org/about/articles/browser-genome-release-agreement, which seems to already have some `h3` tags)_

## Views affected
- Help page
- About page