### PR TITLE
Enable the menu with links to help articles for Help page in production

### DIFF
--- a/src/content/app/help/components/help-menu/HelpMenu.tsx
+++ b/src/content/app/help/components/help-menu/HelpMenu.tsx
@@ -16,9 +16,8 @@
 
 import React, { useEffect, useState, useRef } from 'react';
 import classNames from 'classnames';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
-import { isEnvironment, Environment } from 'src/shared/helpers/environment';
 import useHelpAppAnalytics from '../../hooks/useHelpAppAnalytics';
 
 import Chevron from 'src/shared/components/chevron/Chevron';
@@ -41,19 +40,7 @@ const HelpMenu = (props: Props) => {
   const [submenuItems, setSubmenuItems] = useState<MenuItem[] | null>(null);
   const clickedMenuRef = useRef<number | null>(null);
 
-  // the two lines below are temporary, while we are hiding the meganav menu for the Help app
-  const location = useLocation();
-  const isHelpApp = location.pathname.startsWith('/help');
-
   const { trackTopLevelMenu } = useHelpAppAnalytics();
-
-  if (isEnvironment([Environment.PRODUCTION]) && isHelpApp) {
-    return (
-      <div className={styles.helpMenu}>
-        <div className={styles.menuBar}>Overview</div>
-      </div>
-    );
-  }
 
   const toggleMegaMenu = (
     items: MenuItem[],


### PR DESCRIPTION
## Description
Enable the menu with links to help articles in production

**Question:**
Should we also open up this section of the page in production? There's no "Ensembl annotation and prediction" among our docs yet; but there is a "Using Ensembl"

![image](https://user-images.githubusercontent.com/6834224/207864725-6efeecb2-329a-434b-a393-674bb7452ea1.png)

**UPDATED:** the decision is to keep that section of the main page hidden in production.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1747

## Deployment URL(s)
Irrelevant. Review deployments will have a different runtime environment. I ran a check for a local build.