### PR TITLE
Show contextual help button on the BLAST page

### DIFF
--- a/src/content/app/tools/blast/components/blast-app-bar/BlastAppBar.tsx
+++ b/src/content/app/tools/blast/components/blast-app-bar/BlastAppBar.tsx
@@ -35,6 +35,7 @@ import { getBlastView } from 'src/content/app/tools/blast/state/general/blastGen
 import AppBar from 'src/shared/components/app-bar/AppBar';
 import { SpeciesLozenge } from 'src/shared/components/selected-species';
 import SpeciesTabsWrapper from 'src/shared/components/species-tabs-wrapper/SpeciesTabsWrapper';
+import { HelpPopupButton } from 'src/shared/components/help-popup';
 
 import { AppName } from 'src/global/globalConfig';
 import type { CommittedItem } from 'src/content/app/species-selector/types/species-search';
@@ -93,7 +94,13 @@ const BlastAppBar = () => {
     <SpeciesTabsWrapper speciesTabs={speciesTabs} link={speciesSelectorLink} />
   );
 
-  return <AppBar appName={AppName.TOOLS} mainContent={wrappedSpecies} />;
+  return (
+    <AppBar
+      appName={AppName.TOOLS}
+      mainContent={wrappedSpecies}
+      aside={<HelpPopupButton slug="blast" />}
+    />
+  );
 };
 
 export default BlastAppBar;

--- a/src/content/app/tools/blast/components/blast-app-bar/BlastAppBar.tsx
+++ b/src/content/app/tools/blast/components/blast-app-bar/BlastAppBar.tsx
@@ -54,8 +54,13 @@ const BlastAppBar = () => {
     return <Link to={urlFor.speciesSelector()}>Change</Link>;
   }, []);
 
+  const appBarProps = {
+    appName: AppName.TOOLS,
+    aside: <HelpPopupButton slug="blast" />
+  };
+
   if (!speciesList.length) {
-    return <AppBar appName={AppName.TOOLS} mainContent={placeholderMessage} />;
+    return <AppBar mainContent={placeholderMessage} {...appBarProps} />;
   }
 
   const speciesLozengeClick = (species: CommittedItem) => {
@@ -94,13 +99,7 @@ const BlastAppBar = () => {
     <SpeciesTabsWrapper speciesTabs={speciesTabs} link={speciesSelectorLink} />
   );
 
-  return (
-    <AppBar
-      appName={AppName.TOOLS}
-      mainContent={wrappedSpecies}
-      aside={<HelpPopupButton slug="blast" />}
-    />
-  );
+  return <AppBar mainContent={wrappedSpecies} {...appBarProps} />;
 };
 
 export default BlastAppBar;


### PR DESCRIPTION
## Description
Show contextual help button in the header of the BLAST page

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1820

## Deployment URL(s)
http://enable-blast-contextual-help.review.ensembl.org