### PR TITLE
Add links from the BLAST table to genome browser

### DIFF
--- a/src/content/app/tools/blast/components/blast-app-bar/BlastAppBar.tsx
+++ b/src/content/app/tools/blast/components/blast-app-bar/BlastAppBar.tsx
@@ -70,7 +70,8 @@ const BlastAppBar = () => {
           genome_id: species.genome_id,
           common_name: species.common_name,
           scientific_name: species.scientific_name,
-          assembly_name: species.assembly_name
+          assembly_name: species.assembly_name,
+          genome_tag: species.genome_tag
         })
       );
     }

--- a/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelectorHeader.test.tsx
+++ b/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelectorHeader.test.tsx
@@ -74,14 +74,16 @@ const selectedHuman = {
   genome_id: 'human-genome-id',
   common_name: 'Human',
   scientific_name: 'Homo sapiens',
-  assembly_name: 'GRCh38'
+  assembly_name: 'GRCh38',
+  genome_tag: 'grch38'
 };
 
 const selectedMouse = {
   genome_id: 'mouse-genome-id',
   common_name: 'Mouse',
   scientific_name: 'Mus musculus',
-  assembly_name: 'GRCm39'
+  assembly_name: 'GRCm39',
+  genome_tag: 'grcm39'
 };
 
 describe('SpeciesSelectorHeader', () => {

--- a/src/content/app/tools/blast/state/blast-form/blastFormSlice.ts
+++ b/src/content/app/tools/blast/state/blast-form/blastFormSlice.ts
@@ -42,6 +42,7 @@ export type Species = {
   common_name: string | null;
   scientific_name: string;
   assembly_name: string;
+  genome_tag: string | null;
 };
 
 export type BlastFormState = {

--- a/src/content/app/tools/blast/state/epics/tests/fixtures/blastSubmissionFixtures.ts
+++ b/src/content/app/tools/blast/state/epics/tests/fixtures/blastSubmissionFixtures.ts
@@ -31,7 +31,8 @@ export const createBlastSubmissionPayload = (
     genome_id: 'human-genome-id',
     common_name: 'Human',
     scientific_name: 'Homo sapiens',
-    assembly_name: 'grch38'
+    assembly_name: 'grch38',
+    genome_tag: 'grch38'
   };
 
   const submission = {


### PR DESCRIPTION
## Description
For BLAST submissions against assembly databases (DNA, DNA softmasked), add links from genomic locations in the BLAST results table to the genome browser. Clicking on such link would treat the BLAST hit location it as a focus location for the genome browser.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1787

## Deployment URL(s)
http://blast-to-gb-link.review.ensembl.org