### PR TITLE
Add example location links to species and genome browser pages

### DIFF
--- a/src/content/app/genome-browser/components/interstitial/BrowserInterstitial.tsx
+++ b/src/content/app/genome-browser/components/interstitial/BrowserInterstitial.tsx
@@ -23,7 +23,10 @@ import useGenomeBrowserAnalytics from 'src/content/app/genome-browser/hooks/useG
 
 import { fetchExampleFocusObjects } from 'src/content/app/genome-browser/state/focus-object/focusObjectSlice';
 
-import { getExampleGenes } from 'src/content/app/genome-browser/state/focus-object/focusObjectSelectors';
+import {
+  getExampleGenes,
+  getExampleLocations
+} from 'src/content/app/genome-browser/state/focus-object/focusObjectSelectors';
 
 import {
   parseFocusObjectId,
@@ -72,8 +75,9 @@ const BrowserInterstitial = () => {
 const ExampleLinks = () => {
   const { genomeIdForUrl } = useGenomeBrowserIds();
   const focusObjects = useAppSelector(getExampleGenes);
+  const focusLocations = useAppSelector(getExampleLocations);
 
-  const links = focusObjects.map((exampleObject) => {
+  const geneLinks = focusObjects.map((exampleObject) => {
     const parsedFocusObjectId = parseFocusObjectId(exampleObject.object_id);
     const focusId = buildFocusIdForUrl(parsedFocusObjectId);
     const path = urlFor.browser({
@@ -90,7 +94,29 @@ const ExampleLinks = () => {
     );
   });
 
-  return <div className={styles.exampleLinks}>{links}</div>;
+  const locationLinks = focusLocations.map((exampleObject) => {
+    const parsedFocusObjectId = parseFocusObjectId(exampleObject.object_id);
+    const focusId = buildFocusIdForUrl(parsedFocusObjectId);
+    const path = urlFor.browser({
+      genomeId: genomeIdForUrl,
+      focus: focusId
+    });
+
+    return (
+      <div key={exampleObject.object_id}>
+        <Link to={path} replace>
+          Example {exampleObject.type}
+        </Link>
+      </div>
+    );
+  });
+
+  return (
+    <div className={styles.exampleLinks}>
+      {geneLinks}
+      {locationLinks}
+    </div>
+  );
 };
 
 export default BrowserInterstitial;

--- a/src/content/app/genome-browser/components/interstitial/browser-interstitial-instructions/BrowserInterstitialInstructions.tsx
+++ b/src/content/app/genome-browser/components/interstitial/browser-interstitial-instructions/BrowserInterstitialInstructions.tsx
@@ -66,12 +66,12 @@ const BrowserInterstitialInstructions = () => {
         <div className={styles.stepWrapper}>
           <Step
             count={3}
-            label="Use Search or the example links to view a gene or region"
+            label="Use Search or the example links to view a gene or location"
           >
             <div className={styles.searchDescription}>
               <SearchIcon className={styles.searchIcon} />
               <div className={styles.exampleText}>Example gene</div>
-              <div className={styles.exampleText}>Example region</div>
+              <div className={styles.exampleText}>Example location</div>
             </div>
           </Step>
         </div>

--- a/src/content/app/genome-browser/state/focus-object/focusObjectSelectors.ts
+++ b/src/content/app/genome-browser/state/focus-object/focusObjectSelectors.ts
@@ -80,6 +80,12 @@ export const getExampleGenes = (state: RootState): FocusObject[] => {
   );
 };
 
+export const getExampleLocations = (state: RootState): FocusObject[] => {
+  return getExampleFocusObjects(state).filter(
+    (entity) => entity.type === 'location'
+  );
+};
+
 export const getFocusGene = (
   state: RootState,
   focusGeneId: string

--- a/src/content/app/genome-browser/state/focus-object/focusObjectSlice.ts
+++ b/src/content/app/genome-browser/state/focus-object/focusObjectSlice.ts
@@ -164,8 +164,12 @@ export const fetchFocusObject = createAsyncThunk(
       return;
     }
 
-    if (payload.type === 'location') {
-      const focusLocationObject = buildFocusLocationObject(payload);
+    // TODO: Remove checking for region and overriding the payload type when location is properly supported
+    if (payload.type === 'location' || payload.type === 'region') {
+      const focusLocationObject = buildFocusLocationObject({
+        ...payload,
+        type: 'location'
+      });
       return buildLoadedObject({
         id: focusObjectId,
         data: focusLocationObject

--- a/src/content/app/species/state/general/speciesGeneralHelper.ts
+++ b/src/content/app/species/state/general/speciesGeneralHelper.ts
@@ -175,8 +175,7 @@ export const sectionGroupsMap: SpeciesStatsSectionGroups = {
   },
   [SpeciesStatsSection.ASSEMBLY]: {
     title: 'Assembly',
-    // TODO: Uncomment me when we need to re-enable example region links
-    // exampleLinkText: 'Example region',
+    exampleLinkText: 'Example location',
     groups: [Groups.ASSEMBLY, Groups.ASSEMBLY_ANALYSIS],
     summaryStatsKeys: [Stats.CHROMOSOMES]
   },
@@ -678,31 +677,30 @@ const getExampleLinks = (props: {
         }
       };
     }
+  } else if (section === SpeciesStatsSection.ASSEMBLY) {
+    // TODO: Change the type check to location when data type returned switches to location
+    const regionExample = exampleFocusObjects.find(
+      (object) => object.type === 'region'
+    );
+
+    const focusId = regionExample?.id
+      ? buildFocusIdForUrl({
+          type: 'location',
+          objectId: regionExample.id
+        })
+      : undefined;
+
+    if (focusId) {
+      exampleLinks = {
+        genomeBrowser: {
+          url: urlFor.browser({
+            genomeId: genomeIdForUrl,
+            focus: focusId
+          })
+        }
+      };
+    }
   }
-  // TODO: Uncomment me when we need to re-enable example region links
-  // else if (section === SpeciesStatsSection.ASSEMBLY) {
-  //   const regionExample = exampleFocusObjects.find(
-  //     (object) => object.type === 'region'
-  //   );
-
-  //   const focusId = regionExample?.id
-  //     ? buildFocusIdForUrl({
-  //         type: 'region',
-  //         objectId: regionExample.id
-  //       })
-  //     : undefined;
-
-  //   if (focusId) {
-  //     exampleLinks = {
-  //       genomeBrowser: {
-  //         url: urlFor.browser({
-  //           genomeId: genome_id,
-  //           focus: focusId
-  //         })
-  //       }
-  //     };
-  //   }
-  // }
 
   return exampleLinks;
 };


### PR DESCRIPTION
## Description
Previously region links were shown in the interstitial page of the genome browser and the species page. However, they were removed after some time. Recently, the genome browser started supporting location focus objects, which replaces the regions. So we can now display location example  links in species and genome browser pages.

The data sent by the endpoint still mentions `region` rather than `location` as the type. So this might need to be changed in the future when it sends `location` as the type.

To test this in the species page, you just need to go the species page of a particular genome. However, for the genome browser you will need to go to the interstitial page of a genome.

## Related JIRA Issue(s)
(ENSWBSITES-1780)[https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1780]

## Deployment URL(s)
http://restore-links.review.ensembl.org

## Views affected
Species page
Genome browser