### PR TITLE
Enable programmatic reset for the SimpleSelect component

### DIFF
--- a/src/shared/components/simple-select/SimpleSelect.test.tsx
+++ b/src/shared/components/simple-select/SimpleSelect.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useRef, useEffect } from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import SimpleSelect, { type SimpleSelectMethods } from './SimpleSelect';
+
+const options = [
+  {
+    value: '1',
+    label: 'One'
+  },
+  {
+    value: '2',
+    label: 'Two'
+  },
+  {
+    value: '3',
+    label: 'Three'
+  }
+];
+
+describe('SimpleSelect', () => {
+  it('renders a list of options', () => {
+    const { container } = render(<SimpleSelect options={options} />);
+    const simpleSelectElement = container.firstElementChild as HTMLElement;
+
+    // SimpleSelect renders a div element (for styling purposes)
+    expect(simpleSelectElement.tagName.toLowerCase()).toBe('div');
+
+    // The div returned by SimpleSelect contains a native select element
+    expect(simpleSelectElement.querySelector('select')).toBeTruthy();
+
+    // The component renders html option elements for the options prop that it receives
+    expect(simpleSelectElement.querySelectorAll('option')?.length).toBe(
+      options.length
+    );
+  });
+
+  it('renders an empty placeholder option', () => {
+    const placeholderText = 'I am placeholder!';
+    const { container } = render(
+      <SimpleSelect options={options} placeholder={placeholderText} />
+    );
+    const optionElements = container.querySelectorAll('option');
+    const placeholderOption = optionElements[0];
+
+    expect(placeholderOption.textContent).toBe(placeholderText);
+    expect(placeholderOption.getAttribute('value')).toBe('');
+    expect(placeholderOption.hasAttribute('hidden')).toBe(true);
+  });
+
+  // to consider: https://nordhealth.design/components/select/
+  it('exposes a method for resetting the select', async () => {
+    let selectComponentRef = { clear: jest.fn() };
+
+    // prepare a wrapper component for testing
+    const TestComponent = () => {
+      const simpleSelectRef = useRef<SimpleSelectMethods | null>(null);
+
+      useEffect(() => {
+        selectComponentRef =
+          simpleSelectRef.current as typeof selectComponentRef;
+      });
+
+      return <SimpleSelect ref={simpleSelectRef} options={options} />;
+    };
+    const { container } = render(<TestComponent />);
+
+    const selectElement = container.querySelector(
+      'select'
+    ) as HTMLSelectElement;
+
+    // select the last option
+    await userEvent.selectOptions(
+      selectElement,
+      options.at(-1)?.value as string
+    );
+
+    // check that the last option is, in fact, selected
+    expect(selectElement.selectedIndex).toBe(options.length - 1);
+
+    selectComponentRef.clear();
+    expect(selectElement.selectedIndex).toBe(-1); // selected index of -1 means that no option is selected
+  });
+});

--- a/src/shared/components/simple-select/SimpleSelect.test.tsx
+++ b/src/shared/components/simple-select/SimpleSelect.test.tsx
@@ -37,11 +37,17 @@ const options = [
 
 describe('SimpleSelect', () => {
   it('renders a list of options', () => {
-    const { container } = render(<SimpleSelect options={options} />);
+    const { container } = render(
+      <SimpleSelect options={options} className={'classFromParent'} />
+    );
     const simpleSelectElement = container.firstElementChild as HTMLElement;
 
     // SimpleSelect renders a div element (for styling purposes)
     expect(simpleSelectElement.tagName.toLowerCase()).toBe('div');
+    expect(simpleSelectElement.classList.contains('select')).toBe(true);
+    expect(simpleSelectElement.classList.contains('classFromParent')).toBe(
+      true
+    );
 
     // The div returned by SimpleSelect contains a native select element
     expect(simpleSelectElement.querySelector('select')).toBeTruthy();

--- a/src/shared/components/simple-select/SimpleSelect.test.tsx
+++ b/src/shared/components/simple-select/SimpleSelect.test.tsx
@@ -68,10 +68,9 @@ describe('SimpleSelect', () => {
 
     expect(placeholderOption.textContent).toBe(placeholderText);
     expect(placeholderOption.getAttribute('value')).toBe('');
-    expect(placeholderOption.hasAttribute('hidden')).toBe(true);
+    expect(placeholderOption.hasAttribute('disabled')).toBe(true);
   });
 
-  // to consider: https://nordhealth.design/components/select/
   it('exposes a method for resetting the select', async () => {
     let selectComponentRef = { clear: jest.fn() };
 

--- a/src/shared/components/simple-select/SimpleSelect.tsx
+++ b/src/shared/components/simple-select/SimpleSelect.tsx
@@ -127,6 +127,7 @@ const SimpleSelect = (
       <select
         ref={selectRef}
         className={styles.selectResetDefaults}
+        defaultValue={placeholder ? '' : undefined}
         {...selectProps}
       >
         {placeholder && renderPlaceholder(placeholder)}
@@ -137,7 +138,7 @@ const SimpleSelect = (
 };
 
 const renderPlaceholder = (text: string) => (
-  <option data-placeholder={true} value="" hidden={true}>
+  <option data-placeholder={true} value="" disabled={true}>
     {text}
   </option>
 );

--- a/stories/shared-components/simple-select/SimpleSelect.stories.scss
+++ b/stories/shared-components/simple-select/SimpleSelect.stories.scss
@@ -1,0 +1,3 @@
+.resetButton {
+  margin-top: 1rem;
+}

--- a/stories/shared-components/simple-select/SimpleSelect.stories.tsx
+++ b/stories/shared-components/simple-select/SimpleSelect.stories.tsx
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useRef } from 'react';
 import times from 'lodash/times';
 
 import SimpleSelect, {
-  Option
+  type Option,
+  type SimpleSelectMethods
 } from 'src/shared/components/simple-select/SimpleSelect';
+import { PrimaryButton } from 'src/shared/components/button/Button';
+
+import styles from './SimpleSelect.stories.scss';
 
 const createSimpleOption = (value: string): Option => ({
   value,
@@ -42,12 +46,7 @@ export const SimpleSelectDefaultValueStory = () => {
   const options = createSimpleOptions(15);
   const lastOption = options[options.length - 1];
 
-  return (
-    <SimpleSelect
-      options={options}
-      defaultValue={lastOption.value}
-    ></SimpleSelect>
-  );
+  return <SimpleSelect options={options} defaultValue={lastOption.value} />;
 };
 
 SimpleSelectDefaultValueStory.storyName = 'with default value';
@@ -55,15 +54,63 @@ SimpleSelectDefaultValueStory.storyName = 'with default value';
 export const SimpleSelectWithPlaceholderStory = () => {
   const options = createSimpleOptions(15);
 
-  return (
-    <SimpleSelect
-      options={options}
-      placeholder="Select an option"
-    ></SimpleSelect>
-  );
+  return <SimpleSelect options={options} placeholder="Select an option" />;
 };
 
 SimpleSelectWithPlaceholderStory.storyName = 'with placeholder';
+
+export const SimpleSelectWithResetStory = () => {
+  const options = createSimpleOptions(15);
+  const firstSelectRef = useRef<SimpleSelectMethods | null>(null);
+  const secondSelectRef = useRef<SimpleSelectMethods | null>(null);
+
+  const clearFirstSelect = () => {
+    firstSelectRef.current?.clear();
+  };
+
+  const clearSecondSelect = () => {
+    secondSelectRef.current?.clear();
+  };
+
+  return (
+    <>
+      <section>
+        <p>For a select element with a placeholder</p>
+        <SimpleSelect
+          ref={firstSelectRef}
+          options={options}
+          placeholder="Select an option"
+        />
+        <div>
+          <PrimaryButton
+            className={styles.resetButton}
+            onClick={clearFirstSelect}
+          >
+            Reset
+          </PrimaryButton>
+        </div>
+      </section>
+      <section>
+        <p>For a select element with an initial value</p>
+        <SimpleSelect
+          ref={secondSelectRef}
+          options={options}
+          defaultValue={options.at(-1)?.value}
+        />
+        <div>
+          <PrimaryButton
+            className={styles.resetButton}
+            onClick={clearSecondSelect}
+          >
+            Reset
+          </PrimaryButton>
+        </div>
+      </section>
+    </>
+  );
+};
+
+SimpleSelectWithResetStory.storyName = 'reset to initial';
 
 export const GroupedOptionsStory = () => {
   const options1 = createSimpleOptions(2);


### PR DESCRIPTION
## Description
This PR adds a mechanism for resetting the `SimpleSelect` component to its initial state (either to show the placeholder text, which is the most likely use case, or to show a preselected default option).

This may come handy in https://github.com/Ensembl/ensembl-client/pull/894 if inputs in the navigation modal need to be cleared after the user has entered and confirmed the coordinates; but is a useful behaviour for the `SimpleSelect` component regardless of whether it is required for https://github.com/Ensembl/ensembl-client/pull/894.

Run the Storybook locally to check the added behaviour.