### PR TITLE
Clear IndexedDB on site reset

### DIFF
--- a/src/registerServiceWorker.ts
+++ b/src/registerServiceWorker.ts
@@ -18,7 +18,7 @@ export function registerSW() {
   if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
       navigator.serviceWorker
-        .register('/static/service-worker.js')
+        .register('/static/service-worker.js', { scope: '/' })
         .then((registration) => {
           console.info('SW registered: ', registration);
         })

--- a/src/services/indexeddb-service.ts
+++ b/src/services/indexeddb-service.ts
@@ -88,6 +88,14 @@ class IndexedDB {
     const db = await this.getDB();
     return db.getAllKeys(store);
   }
+
+  static async clearDatabase() {
+    const db = await this.getDB();
+    const objectStoreNames = db.objectStoreNames;
+    for (const store of objectStoreNames) {
+      await db.clear(store);
+    }
+  }
 }
 
 export default IndexedDB;

--- a/src/services/tests/indexeddb-service.test.ts
+++ b/src/services/tests/indexeddb-service.test.ts
@@ -1,0 +1,89 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'fake-indexeddb/auto';
+import { IDBFactory } from 'fake-indexeddb';
+import { openDB } from 'idb/with-async-ittr';
+import { faker } from '@faker-js/faker';
+
+import IndexedDB from 'src/services/indexeddb-service';
+
+indexedDB = new IDBFactory(); // should create a completely fresh copy of in-memory mock indexedDB
+
+const FIRST_STORE_NAME = 'first-store';
+const SECOND_STORE_NAME = 'second-store';
+
+const getDatabase = async () => {
+  return await openDB('test-db', 1, {
+    upgrade(db) {
+      db.createObjectStore(FIRST_STORE_NAME);
+      db.createObjectStore(SECOND_STORE_NAME);
+    }
+  });
+};
+
+jest.spyOn(IndexedDB, 'getDB').mockImplementation(() => getDatabase());
+
+describe('IndexedDB service', () => {
+  afterEach(async () => {
+    await IndexedDB.clear(FIRST_STORE_NAME);
+    await IndexedDB.clear(SECOND_STORE_NAME);
+  });
+
+  describe('IndexedDB.clearDatabase', () => {
+    const mockRecordsCount = 10;
+
+    const fillDbWithMockData = async () => {
+      for (let i = 0; i < mockRecordsCount; i++) {
+        await IndexedDB.set(
+          FIRST_STORE_NAME,
+          `entry-${i}`,
+          faker.lorem.sentence()
+        );
+        await IndexedDB.set(
+          SECOND_STORE_NAME,
+          `entry-${i}`,
+          faker.lorem.sentence()
+        );
+      }
+    };
+
+    const getRecordsFromStore = async (storeName: string) => {
+      const db = await IndexedDB.getDB();
+      return await db.getAll(storeName);
+    };
+
+    it('clears all object stores in the database', async () => {
+      // Initial setup: fill the database with mock data
+      await fillDbWithMockData();
+
+      // Verify that the mock data has indeed been stored in the database
+      let recordsInFirstStore = await getRecordsFromStore(FIRST_STORE_NAME);
+      let recordsInSecondStore = await getRecordsFromStore(SECOND_STORE_NAME);
+      expect(recordsInFirstStore.length).toBe(mockRecordsCount);
+      expect(recordsInSecondStore.length).toBe(mockRecordsCount);
+
+      // Now clear the database
+      await IndexedDB.clearDatabase();
+
+      // Verify that all object stores in the database have been cleared
+      recordsInFirstStore = await getRecordsFromStore(FIRST_STORE_NAME);
+      recordsInSecondStore = await getRecordsFromStore(SECOND_STORE_NAME);
+      expect(recordsInFirstStore.length).toBe(0);
+      expect(recordsInSecondStore.length).toBe(0);
+    });
+  });
+});

--- a/src/shared/components/error-screen/GeneralErrorScreen.tsx
+++ b/src/shared/components/error-screen/GeneralErrorScreen.tsx
@@ -18,6 +18,7 @@ import React, { useState } from 'react';
 import classNames from 'classnames';
 
 import storageService from 'src/services/storage-service';
+import IndexedDB from 'src/services/indexeddb-service';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
 
@@ -40,8 +41,9 @@ const GeneralErrorScreen = () => {
     window.location.reload();
   };
 
-  const resetPage = () => {
+  const resetSite = async () => {
     storageService.clearAll();
+    await IndexedDB.clearDatabase();
     window.location.replace(urlFor.home());
   };
 
@@ -85,7 +87,7 @@ const GeneralErrorScreen = () => {
                 All your species, configuration of views &amp; history will be
                 lost
               </div>
-              <PrimaryButton onClick={resetPage}>Reset the site</PrimaryButton>
+              <PrimaryButton onClick={resetSite}>Reset the site</PrimaryButton>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Description
The "Reset the site" button on the error screen does not currently clear data stored in IndexedDB. This PR fixes this omission. 

## Deployment URL(s)
http://clear-indexeddb-on-reset.review.ensembl.org — but there shouldn't be anything to see in review deployment.

You can test the PR locally by forcing the app to error during render (e.g. add a `throw` statement to a component that you expect to get rendered), and pressing on the "Reset the site" button on the error screen.