### PR TITLE
Add the 'scope' option when registering the service worker

### DIFF
--- a/src/registerServiceWorker.ts
+++ b/src/registerServiceWorker.ts
@@ -18,7 +18,7 @@ export function registerSW() {
   if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
       navigator.serviceWorker
-        .register('/static/service-worker.js')
+        .register('/static/service-worker.js', { scope: '/' })
         .then((registration) => {
           console.info('SW registered: ', registration);
         })


### PR DESCRIPTION
## Description
By default, service workers can only control network requests to the directory they are served from, and to its subdirectories. However, there is a convenient way to override this default limitation, by adding a `Service-Worker-Allowed` header to the server, which directory of the domain the service worker can be responsible for. For maximum flexibility, we wanted our service worker to be able to control traffic for all our site, which we did by adding the header to server responses, as you can see by running `curl -I https://beta.ensembl.org/static/service-worker.js`.

![image](https://user-images.githubusercontent.com/6834224/210158717-3eb3a62f-2165-4bf4-ba7d-82d4e29882c5.png)

However, what we forgot, was that that if we wanted this to be the case, we also needed to specify the `scope` option when registering the service worker. See example from the [spec](https://w3c.github.io/ServiceWorker/#service-worker-allowed):

## How to test
Because our review deployments are served over `http` rather than `https`; and because there isn't anything in our service worker at the moment that wants to control the traffic from `/`, there is no way to test this in a review deployment.

In order to test this locally, you can follow these steps:

- Run `npm run build` to generate a production build of the site
- Open the generated service worker file at `dist/static/service-worker.js`. Delete its content and replace it with the following:

```
console.log('hello from worker');

self.addEventListener('activate', (ev) => {
  console.log('activated');
});

self.addEventListener("fetch", (event) => {
  console.log(`Handling fetch event for ${event.request.url}`);
});
```

- Now, start the server to run the production build (`node dist/server/server.js`)
- Open the console and inspect the output. You will notice logs for requests not only from the `/static` path, but also from other paths, e.g. from `/api`:
 
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/6834224/210160200-6fc86f2f-c22d-4793-ab9c-85146b32749b.png">

If you are not seeing anything in the console, you may want to unregister any service worker that may be currently active (`Application` tab in Chrome Dev Tools):

<img width="1425" alt="image" src="https://user-images.githubusercontent.com/6834224/210160289-38b6f541-31f9-4bee-8a75-d645ae2c468e.png">
