### PR TITLE
Only add Hotjar script to the DOM after React has mounted

### DIFF
--- a/src/content/html/ThirdParty.tsx
+++ b/src/content/html/ThirdParty.tsx
@@ -31,10 +31,13 @@ export const HotjarScript = () => {
       hjsv: HOTJAR_SCRIPT_VERSION
     };
 
-    // FIXME: make sure this only runs once
     const script = document.createElement('script');
     script.src = scriptSrc;
-    document.body.appendChild(script);
+    document.head.appendChild(script);
+
+    return () => {
+      document.head.removeChild(script);
+    };
   }, []);
 
   return null;

--- a/src/content/html/ThirdParty.tsx
+++ b/src/content/html/ThirdParty.tsx
@@ -17,7 +17,8 @@
 import { useEffect } from 'react';
 
 const HOTJAR_ID = 2555715; // if we discover that this needs to be updated, we will extract it into an environment variable
-const scriptSrc = `https://static.hotjar.com/c/hotjar-${HOTJAR_ID}.js?sv=6`;
+const HOTJAR_SCRIPT_VERSION = 6;
+const scriptSrc = `https://static.hotjar.com/c/hotjar-${HOTJAR_ID}.js?sv=${HOTJAR_SCRIPT_VERSION}`;
 
 // TODO: remove as soon as it is no longer needed
 export const HotjarScript = () => {
@@ -25,7 +26,10 @@ export const HotjarScript = () => {
     if (!('hj' in window)) {
       (window as any).hj = hotjarQueue;
     }
-    (window as any)._hjSettings = { hjid: HOTJAR_ID, hjsv: 6 };
+    (window as any)._hjSettings = {
+      hjid: HOTJAR_ID,
+      hjsv: HOTJAR_SCRIPT_VERSION
+    };
 
     // FIXME: make sure this only runs once
     const script = document.createElement('script');

--- a/src/content/html/ThirdParty.tsx
+++ b/src/content/html/ThirdParty.tsx
@@ -14,27 +14,29 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import { useEffect } from 'react';
 
 const HOTJAR_ID = 2555715; // if we discover that this needs to be updated, we will extract it into an environment variable
+const scriptSrc = `https://static.hotjar.com/c/hotjar-${HOTJAR_ID}.js?sv=6`;
 
 // TODO: remove as soon as it is no longer needed
 export const HotjarScript = () => {
-  const stringifiedScript = `
-    (function (h, o, t, j, a, r) {
-      h.hj =
-        h.hj ||
-        function () {
-          (h.hj.q = h.hj.q || []).push(arguments);
-        };
-      h._hjSettings = { hjid: ${HOTJAR_ID}, hjsv: 6 };
-      a = o.getElementsByTagName('head')[0];
-      r = o.createElement('script');
-      r.async = 1;
-      r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
-      a.appendChild(r);
-    })(window, document, 'https://static.hotjar.com/c/hotjar-', '.js?sv=');
-  `;
+  useEffect(() => {
+    if (!('hj' in window)) {
+      (window as any).hj = hotjarQueue;
+    }
+    (window as any)._hjSettings = { hjid: HOTJAR_ID, hjsv: 6 };
 
-  return <script dangerouslySetInnerHTML={{ __html: stringifiedScript }} />;
+    // FIXME: make sure this only runs once
+    const script = document.createElement('script');
+    script.src = scriptSrc;
+    document.body.appendChild(script);
+  }, []);
+
+  return null;
 };
+
+function hotjarQueue() {
+  (window as any).hj.q = (window as any).hj.q || [];
+  (window as any).hj.q.push(arguments); // eslint-disable-line prefer-rest-params
+}


### PR DESCRIPTION
## Description
Currently, the html payload sent from the rendering server in production (see [page source view of the beta site](view-source:https://beta.ensembl.org/)) contains the code of the Hotjar snippet. This snippet modifies the html head, and downloads a script that further modifies the document head with various `script` and `style` tags.

Since, at the moment, React is in control of the whole DOM tree, I thought it would be best to add the Hotjar code client-side, after React has hydrated the app, rather than have it in the html source sent from the server. Theoretically, this may help with the hydration errors we have been seeing in Sentry; although their cause may be different still (e.g. various browser extensions that modify the DOM).

## Deployment URL(s)
No need. We do not run Hotjar in review deployments.