### PR TITLE
Update genome browser version to 0.5.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ensembl/ensembl-genome-browser": "0.5.3",
+        "@ensembl/ensembl-genome-browser": "0.5.4",
         "@react-spring/web": "9.4.5-beta.1",
         "@reduxjs/toolkit": "1.9.0",
         "@sentry/browser": "7.21.1",
@@ -2426,9 +2426,9 @@
       }
     },
     "node_modules/@ensembl/ensembl-genome-browser": {
-      "version": "0.5.3",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.3.tgz",
-      "integrity": "sha1-Jfbb6H6k8fbCPT7YPA3XwCgZbV4="
+      "version": "0.5.4",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.4.tgz",
+      "integrity": "sha1-hJTRG9JRd3YyCSDwpGVEDZWNsWI="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
@@ -43098,9 +43098,9 @@
       "dev": true
     },
     "@ensembl/ensembl-genome-browser": {
-      "version": "0.5.3",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.3.tgz",
-      "integrity": "sha1-Jfbb6H6k8fbCPT7YPA3XwCgZbV4="
+      "version": "0.5.4",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.4.tgz",
+      "integrity": "sha1-hJTRG9JRd3YyCSDwpGVEDZWNsWI="
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "coverage": "jest --coverage"
   },
   "dependencies": {
-    "@ensembl/ensembl-genome-browser": "0.5.3",
+    "@ensembl/ensembl-genome-browser": "0.5.4",
     "@react-spring/web": "9.4.5-beta.1",
     "@reduxjs/toolkit": "1.9.0",
     "@sentry/browser": "7.21.1",


### PR DESCRIPTION
## Description
Genome browser version has been updated to 0.5.4. The only change is that animations for changes of genome browser's position are now running faster.

Related PR in the ensembl-genome-browser repo: https://github.com/Ensembl/ensembl-genome-browser/pull/20

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1825

## Deployment URL(s)
http://genome-browser-0-5-4.review.ensembl.org