### PR TITLE
Add FASTA header with feature id when passing a sequence from genome browser to BLAST form

### DIFF
--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.tsx
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.tsx
@@ -46,6 +46,7 @@ const sequenceLabelsMap: Record<SequenceType, string> = {
 // TODO: we probably also want to pass a sequence header in order to be able to blast it
 type Props = {
   genomeId: string;
+  featureId: string;
   isExpanded: boolean;
   toggleSequenceVisibility: () => void;
   sequence?: string;
@@ -62,6 +63,7 @@ type Props = {
 const DrawerSequenceView = (props: Props) => {
   const {
     genomeId,
+    featureId,
     isExpanded,
     isError,
     isLoading,
@@ -128,6 +130,7 @@ const DrawerSequenceView = (props: Props) => {
             <BlastSequenceButton
               className={styles.blastSequenceButton}
               sequence={sequence}
+              header={featureId}
               species={species}
               sequenceType={sequenceTypeForBlast}
             />

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.tsx
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/DrawerSequenceView.tsx
@@ -130,7 +130,11 @@ const DrawerSequenceView = (props: Props) => {
             <BlastSequenceButton
               className={styles.blastSequenceButton}
               sequence={sequence}
-              header={featureId}
+              header={getBlastHeader({
+                featureId,
+                sequenceType: selectedSequenceType,
+                isReverseComplement
+              })}
               species={species}
               sequenceType={sequenceTypeForBlast}
             />
@@ -220,6 +224,21 @@ const Loading = () => {
       <CircleLoader size="small" />
     </div>
   );
+};
+
+const getBlastHeader = (params: {
+  featureId: string;
+  sequenceType: SequenceType;
+  isReverseComplement: boolean;
+}) => {
+  const { featureId, sequenceType, isReverseComplement } = params;
+  const sequenceTypeLabel = sequenceLabelsMap[sequenceType];
+
+  const blasttHeader = `${featureId} ${sequenceTypeLabel}`;
+
+  return isReverseComplement
+    ? `${blasttHeader} Reverse complement`
+    : blasttHeader;
 };
 
 export default DrawerSequenceView;

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/GeneSequenceView.tsx
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/GeneSequenceView.tsx
@@ -75,6 +75,7 @@ export const GeneSequenceView = (props: Props) => {
   return (
     <DrawerSequenceView
       genomeId={genomeId}
+      featureId={gene.stable_id}
       isExpanded={isExpanded}
       isError={isError}
       isLoading={isFetching}

--- a/src/content/app/genome-browser/components/drawer/components/sequence-view/TranscriptSequenceView.tsx
+++ b/src/content/app/genome-browser/components/drawer/components/sequence-view/TranscriptSequenceView.tsx
@@ -82,6 +82,7 @@ const TranscriptSequenceView = (props: Props) => {
   return (
     <DrawerSequenceView
       genomeId={genomeId}
+      featureId={transcript.stable_id}
       isExpanded={isExpanded}
       isError={isError}
       isLoading={isFetching}

--- a/src/shared/components/blast-sequence-button/BlastSequenceButton.tsx
+++ b/src/shared/components/blast-sequence-button/BlastSequenceButton.tsx
@@ -31,11 +31,11 @@ import type { SequenceType } from 'src/content/app/tools/blast/types/blastSettin
 
 import styles from './BlastSequenceButton.scss';
 
-// TODO: think about the possible header for the sequence
 type Props = {
   label?: string;
   species: Species;
   sequence?: string; // if the sequence isn't provided, the button will be disabled
+  header?: string;
   sequenceType: SequenceType;
   className?: string;
 };
@@ -45,6 +45,7 @@ const BlastSequenceButton = (props: Props) => {
   const {
     label = defaultLabel,
     species,
+    header,
     sequence,
     sequenceType,
     className
@@ -59,7 +60,7 @@ const BlastSequenceButton = (props: Props) => {
     }
 
     setSequenceForGenome({
-      sequence: { value: sequence },
+      sequence: { header, value: sequence },
       species,
       sequenceType
     });


### PR DESCRIPTION
## Description
When populating BLAST sequence box with a sequence passed from the genome browser, add a FASTA header containing the feature id.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1612

## Deployment URL(s)
http://gb-to-blast-fasta-head.review.ensembl.org