### PR TITLE
Add a screen for handling invalid BLAST urls

### DIFF
--- a/src/content/app/tools/blast/BlastPage.tsx
+++ b/src/content/app/tools/blast/BlastPage.tsx
@@ -22,6 +22,8 @@ import useHasMounted from 'src/shared/hooks/useHasMounted';
 
 import { updatePageMeta } from 'src/shared/state/page-meta/pageMetaSlice';
 
+import { NotFoundErrorScreen } from 'src/shared/components/error-screen';
+
 import type { ServerFetch } from 'src/routes/routesConfig';
 
 import styles from './BlastPage.scss';
@@ -65,6 +67,7 @@ const BlastPage = () => {
           <Route index={true} element={<BlastSubmissions unviewed={false} />} />
           <Route path=":submissionId" element={<BlastSubmissionResults />} />
         </Route>
+        <Route path="*" element={<NotFoundErrorScreen />} />
       </Routes>
     </div>
   ) : null;


### PR DESCRIPTION
## Description
This PR addresses the improbable case when a BLAST url is invalid. Not in the sense that blast submission id doesn't exist (this is handled by a different piece of code that, with time, will be querying the backend about whether a submission with a given id exists), but in the sense that there are no handlers for this url.

Notice that the screen for the error is generated on client-side. The response from the server will be a 200:OK. We don't really care, for BLAST or other tools.

Examples:
- `/blast/foo` — an invalid url that will be handled by this PR
- `/blast/submissions/foo` — a valid url, although the submission with an id of `foo` probably doesn't exist; this is not covered in this PR
- `/blast/submissions/foo/bar` — an invalid url that will be handled by this PR

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1807

## Deployment URL(s)
http://blast-404.review.ensembl.org