### PR TITLE
Disable proxying to api servers in Ensembl deployments

### DIFF
--- a/src/server/helpers/getConfigForServer.ts
+++ b/src/server/helpers/getConfigForServer.ts
@@ -1,0 +1,30 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// To distinguish between Ensembl deployments (production, staging, internal, development),
+// we use an environment variable called "ENVIRONMENT". When this variable is not set,
+// we can assume that the code is running in local development mode, where the locally running server
+// will need to proxy api requests and requests for static assets to relevant backends.
+const isEnsemblDeployment = 'ENVIRONMENT' in process.env;
+
+const isProductionBuild = process.env.NODE_ENV === 'production';
+
+const getConfigForServer = () => ({
+  isEnsemblDeployment,
+  isProductionBuild
+});
+
+export default getConfigForServer;

--- a/src/server/middleware/proxyMiddleware.ts
+++ b/src/server/middleware/proxyMiddleware.ts
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-import { Router } from 'express';
 import { createProxyMiddleware } from 'http-proxy-middleware';
-
-const genomeBrowserRouter = Router();
 
 /**
  * Below are the rules to proxying requests to api endpoints.
@@ -65,10 +62,7 @@ const apiProxyMiddleware = createProxyMiddleware('/api', {
 let proxyMiddleware = [apiProxyMiddleware];
 
 if (process.env.NODE_ENV === 'development') {
-  proxyMiddleware = proxyMiddleware.concat([
-    genomeBrowserRouter, // NOTE: this middleware should have priority over staticAssetsMiddleware
-    staticAssetsMiddleware
-  ]);
+  proxyMiddleware = proxyMiddleware.concat([staticAssetsMiddleware]);
 }
 
 export default proxyMiddleware;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -16,7 +16,7 @@
 
 import express from 'express';
 
-import proxyMiddleware from './middleware/proxyMiddleware';
+import createProxyMiddleware from './middleware/proxyMiddleware';
 import staticMiddleware from './middleware/staticMiddleware';
 import redirectMiddleware from './middleware/redirectMiddleware';
 
@@ -31,6 +31,7 @@ const serverConfig = getConfigForServer();
 app.disable('x-powered-by'); // no need to announce to the world that we are running on Express
 
 if (!serverConfig.isEnsemblDeployment) {
+  const proxyMiddleware = createProxyMiddleware();
   app.use(proxyMiddleware);
 
   if (serverConfig.isProductionBuild) {


### PR DESCRIPTION
## Description
Kamal has been asking us not to enable in kubernetes deployments request handlers that we would normally use when developing locally, to proxy requests to appropriate backends. Although ingress rules set in kubernetes mean that requests intended for other services will never reach our rendering server, it is safer to know that if something goes wrong and such a request does get to the rendering server, the response will be a 404 error rather than something that our staging server would respond with. Failing early helps with debugging.

This PR makes use of the fact that all our kubernetes deployments will have an environment variable called "ENVIRONMENT" set (we use it to distinguish between production, staging, internal, and review deployments).
Knowing this, we can assume that if this this environment variable is not set, then the code is running in locally, and will need to proxy api requests and requests for static assets to relevant backends.

### Result

**Before,** the log from a kubernetes pod with the rendering service showed that we instantiated proxy handlers for `/api` and `/static` routes:

<img width="698" alt="image" src="https://user-images.githubusercontent.com/6834224/213126259-ea6496ee-7938-4532-90a5-48bf3df9ba32.png">

**Now,** the log from the pod shows that the rendering service does not initialize any proxies:

<img width="698" alt="image" src="https://user-images.githubusercontent.com/6834224/213126141-048630d9-e7eb-4b5a-b107-016e5b13ebe1.png">

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1517

## Deployment URL(s)
http://no-proxy-in-deployment.review.ensembl.org

## Tested
- local development mode (`npm start`) — ✅ 
- local production build (`npm run build`, then `node dist/server/server.js`) — ✅ 