### PR TITLE
Update genome browser to version 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ensembl/ensembl-genome-browser": "0.5.4",
+        "@ensembl/ensembl-genome-browser": "0.6.0",
         "@react-spring/web": "9.4.5-beta.1",
         "@reduxjs/toolkit": "1.9.0",
         "@sentry/browser": "7.21.1",
@@ -2426,9 +2426,9 @@
       }
     },
     "node_modules/@ensembl/ensembl-genome-browser": {
-      "version": "0.5.4",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.4.tgz",
-      "integrity": "sha1-hJTRG9JRd3YyCSDwpGVEDZWNsWI="
+      "version": "0.6.0",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.0.tgz",
+      "integrity": "sha1-hWVXJUeugrxOZ1XKMBDZ3HzNoMU="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
@@ -43098,9 +43098,9 @@
       "dev": true
     },
     "@ensembl/ensembl-genome-browser": {
-      "version": "0.5.4",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.5.4.tgz",
-      "integrity": "sha1-hJTRG9JRd3YyCSDwpGVEDZWNsWI="
+      "version": "0.6.0",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.0.tgz",
+      "integrity": "sha1-hWVXJUeugrxOZ1XKMBDZ3HzNoMU="
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "coverage": "jest --coverage"
   },
   "dependencies": {
-    "@ensembl/ensembl-genome-browser": "0.5.4",
+    "@ensembl/ensembl-genome-browser": "0.6.0",
     "@react-spring/web": "9.4.5-beta.1",
     "@reduxjs/toolkit": "1.9.0",
     "@sentry/browser": "7.21.1",

--- a/src/content/app/genome-browser/components/browser-image/BrowserImage.tsx
+++ b/src/content/app/genome-browser/components/browser-image/BrowserImage.tsx
@@ -31,6 +31,7 @@ import { ZmenuController } from 'src/content/app/genome-browser/components/zmenu
 import { CircleLoader } from 'src/shared/components/loader';
 import Overlay from 'src/shared/components/overlay/Overlay';
 import GenomeBrowserError from 'src/content/app/genome-browser/components/genome-browser-error/GenomeBrowserError';
+import BrowserTrackLegend from 'src/content/app/genome-browser/components/browser-track-legend/BrowserTrackLegend';
 
 import { BROWSER_CONTAINER_ID } from 'src/content/app/genome-browser/constants/browserConstants';
 
@@ -42,7 +43,8 @@ import {
 import styles from './BrowserImage.scss';
 
 export const BrowserImage = () => {
-  const browserRef = useRef<HTMLDivElement>(null);
+  const browserViewportRef = useRef<HTMLDivElement>(null);
+  const browserContainerRef = useRef<HTMLDivElement>(null);
   const browserActivatedRef = useRef(false);
   const [genomeBrowserError, setGenomeBrowserError] =
     useState<GenomeBrowserErrorObj | null>(null);
@@ -81,14 +83,15 @@ export const BrowserImage = () => {
   }, [genomeBrowser]);
 
   const browserImageContents = (
-    <div className={styles.browserImageWrapper}>
+    <div ref={browserViewportRef} className={styles.browserImageWrapper}>
       <div
         id={BROWSER_CONTAINER_ID}
         className={styles.browserStage}
-        ref={browserRef}
+        ref={browserContainerRef}
       >
         <BrowserCogList />
-        <ZmenuController browserRef={browserRef} />
+        <ZmenuController containerRef={browserContainerRef} />
+        <BrowserTrackLegend containerRef={browserViewportRef} />
       </div>
       {isDisabled ? <Overlay /> : null}
     </div>

--- a/src/content/app/genome-browser/components/browser-track-legend/BrowserTrackLegend.scss
+++ b/src/content/app/genome-browser/components/browser-track-legend/BrowserTrackLegend.scss
@@ -1,0 +1,29 @@
+.anchor {
+  position: absolute;
+  width: 0;
+  height: 0;
+}
+
+.message {
+  max-width: 250px;
+}
+
+.message ul {
+  padding-left: 2rem;
+}
+
+.message li {
+  padding-left: 1rem;
+}
+
+.message li:nth-child(1) {
+  list-style-type: 'G';
+}
+
+.message li:nth-child(2) {
+  list-style-type: 'V';
+}
+
+.message li:nth-child(3) {
+  list-style-type: 'R';
+}

--- a/src/content/app/genome-browser/components/zmenu/Zmenu.test.tsx
+++ b/src/content/app/genome-browser/components/zmenu/Zmenu.test.tsx
@@ -101,7 +101,7 @@ const renderComponent = (state: typeof initialState = initialState) => {
 };
 
 const defaultProps: ZmenuProps = {
-  browserRef: {
+  containerRef: {
     current: document.createElement('div')
   },
   zmenuId: '1',

--- a/src/content/app/genome-browser/components/zmenu/Zmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/Zmenu.tsx
@@ -52,7 +52,7 @@ enum Direction {
 export type ZmenuProps = {
   zmenuId: string;
   payload: ZmenuCreatePayload;
-  browserRef: React.RefObject<HTMLDivElement>;
+  containerRef: React.RefObject<HTMLDivElement>;
 };
 
 const Zmenu = (props: ZmenuProps) => {
@@ -91,7 +91,7 @@ const Zmenu = (props: ZmenuProps) => {
 
   const zmenuType = variety.find((variety: ZmenuPayloadVariety) =>
     Boolean(variety.type)
-  )?.type;
+  )?.['zmenu-type'];
 
   if (zmenuType === ZmenuPayloadVarietyType.GENE_AND_ONE_TRANSCRIPT) {
     transcript = content.find(
@@ -163,7 +163,7 @@ const getAnchorInlineStyles = (params: ZmenuProps) => {
 
 // choose how to position zmenu relative to its anchor point
 const chooseDirection = (params: ZmenuProps) => {
-  const browserElement = params.browserRef.current as HTMLDivElement;
+  const browserElement = params.containerRef.current as HTMLDivElement;
   const { width } = browserElement.getBoundingClientRect();
   const { x } = params.payload;
   return x > width / 2 ? Direction.LEFT : Direction.RIGHT;

--- a/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
@@ -15,6 +15,7 @@
  */
 
 import { useEffect } from 'react';
+import { OutgoingActionType } from '@ensembl/ensembl-genome-browser';
 
 import { useAppDispatch, useAppSelector } from 'src/store';
 import { useGenomeTracksQuery } from 'src/content/app/genome-browser/state/api/genomeBrowserApiSlice';
@@ -30,6 +31,7 @@ import {
 } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
 import { getAllTrackSettings } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSelectors';
 import { getDisplayedTrackIds } from 'src/content/app/genome-browser/state/displayed-tracks/displayedTracksSelectors';
+import { getSelectedTrackPanelTab } from 'src/content/app/genome-browser/state/track-panel/trackPanelSelectors';
 
 import {
   setInitialTrackSettingsForGenome,
@@ -65,7 +67,8 @@ const useGenomeBrowserTracks = () => {
   const trackSettingsForGenome =
     useAppSelector(getAllTrackSettings)?.settingsForIndividualTracks;
   const visibleTrackIds = useAppSelector(getDisplayedTrackIds); // get list of ids of tracks currently rendered in genome browser
-  const { toggleTrack } = useGenomeBrowser();
+  const selectedTrackPanelTab = useAppSelector(getSelectedTrackPanelTab);
+  const { toggleTrack, genomeBrowser } = useGenomeBrowser();
 
   const dispatch = useAppDispatch();
 
@@ -109,6 +112,21 @@ const useGenomeBrowserTracks = () => {
       toggleTrack({ trackId, isTurnedOn: false });
     });
   }, [trackSettingsForGenome, visibleTrackIds]);
+
+  // mark the tracks that reflect the content of the current tab inside the track panel
+  useEffect(() => {
+    if (!genomeBrowser) {
+      return;
+    }
+
+    // take the first letter of the track panel tab name, and chuck it over to the genome browser
+    const trackGroup = selectedTrackPanelTab[0].toUpperCase();
+
+    genomeBrowser.send({
+      type: OutgoingActionType.MARK_TRACK_GROUP,
+      payload: { track_group: trackGroup }
+    });
+  }, [genomeBrowser, selectedTrackPanelTab]);
 
   // run hooks responsible for communicating to genome browser the enabled tracks and their settings
   useFocusTrack();

--- a/src/server/middleware/proxyMiddleware.ts
+++ b/src/server/middleware/proxyMiddleware.ts
@@ -53,25 +53,15 @@ const proxyMiddleware = [apiProxyMiddleware, docsProxyMiddleware];
 */
 
 const createApiProxyMiddleware = () => {
-  const apiProxyMiddleware = createHttpProxyMiddleware(
-    ['/api/**', '!/api/browser/**'],
-    {
-      target: 'https://staging-2020.ensembl.org',
-      changeOrigin: true,
-      secure: false
-    }
-  );
-
-  const browserProxyMiddleware = createHttpProxyMiddleware('/api/browser/**', {
-    target: 'http://52.56.215.72:3333',
-    pathRewrite: {
-      '^/api/browser': '/api' // rewrite path
-    },
+  const apiProxyMiddleware = createHttpProxyMiddleware('/api', {
+    target: 'https://staging-2020.ensembl.org',
     changeOrigin: true,
     secure: false
   });
 
-  return [apiProxyMiddleware, browserProxyMiddleware];
+  // returning an array so that the specific proxies can be easily modified in local development
+  // (see example in the comment block above)
+  return [apiProxyMiddleware];
 };
 
 const createStaticAssetsMiddleware = () => {

--- a/src/server/middleware/proxyMiddleware.ts
+++ b/src/server/middleware/proxyMiddleware.ts
@@ -53,15 +53,25 @@ const proxyMiddleware = [apiProxyMiddleware, docsProxyMiddleware];
 */
 
 const createApiProxyMiddleware = () => {
-  const apiProxyMiddleware = createHttpProxyMiddleware('/api', {
-    target: 'https://staging-2020.ensembl.org',
+  const apiProxyMiddleware = createHttpProxyMiddleware(
+    ['/api/**', '!/api/browser/**'],
+    {
+      target: 'https://staging-2020.ensembl.org',
+      changeOrigin: true,
+      secure: false
+    }
+  );
+
+  const browserProxyMiddleware = createHttpProxyMiddleware('/api/browser/**', {
+    target: 'http://52.56.215.72:3333',
+    pathRewrite: {
+      '^/api/browser': '/api' // rewrite path
+    },
     changeOrigin: true,
     secure: false
   });
 
-  // returning an array so that the specific proxies can be easily modified in local development
-  // (see example in the comment block above)
-  return [apiProxyMiddleware];
+  return [apiProxyMiddleware, browserProxyMiddleware];
 };
 
 const createStaticAssetsMiddleware = () => {

--- a/src/shared/components/pointer-box/pointer-box-helper.ts
+++ b/src/shared/components/pointer-box/pointer-box-helper.ts
@@ -130,22 +130,22 @@ const getTooltipOutOfBoundsArea = (
   } else if (position === Position.LEFT_TOP) {
     predictedLeft = anchorLeft - pointerHeight - width;
     predictedRight = anchorLeft;
-    predictedTop = anchorCentreY - halfPointerWidth - pointerOffset;
+    predictedTop = anchorCentreY - height + halfPointerWidth + pointerOffset;
     predictedBottom = predictedTop + height;
   } else if (position === Position.LEFT_BOTTOM) {
     predictedLeft = anchorLeft - pointerHeight - width;
     predictedRight = anchorLeft;
-    predictedTop = anchorCentreY - height + halfPointerWidth + pointerOffset;
+    predictedTop = anchorCentreY - halfPointerWidth - pointerOffset;
     predictedBottom = predictedTop + height;
   } else if (position === Position.RIGHT_TOP) {
     predictedLeft = anchorRight;
     predictedRight = anchorRight + pointerHeight + width;
-    predictedTop = anchorCentreY - halfPointerWidth - pointerOffset;
+    predictedTop = anchorCentreY - height + halfPointerWidth + pointerOffset;
     predictedBottom = predictedTop + height;
   } else if (position === Position.RIGHT_BOTTOM) {
     predictedLeft = anchorRight;
     predictedRight = anchorRight + pointerHeight + width;
-    predictedTop = anchorCentreY - height + halfPointerWidth + pointerOffset;
+    predictedTop = anchorCentreY - halfPointerWidth - pointerOffset;
     predictedBottom = predictedTop + height;
   }
 

--- a/src/shared/components/tooltip/Tooltip.tsx
+++ b/src/shared/components/tooltip/Tooltip.tsx
@@ -32,6 +32,7 @@ type Props = {
   container?: HTMLElement | null;
   autoAdjust?: boolean; // try to adjust tooltip position so as not to extend beyond screen bounds
   delay?: number;
+  renderInsideAnchor?: boolean;
   children: ReactNode;
   onClose?: () => void;
 };
@@ -67,6 +68,7 @@ const TooltipWithAnchor = (props: Props) => {
       anchor={props.anchor}
       container={props.container}
       autoAdjust={props.autoAdjust}
+      renderInsideAnchor={props.renderInsideAnchor}
       onClose={props.onClose}
       classNames={{ box: styles.tooltip, pointer: styles.tooltipTip }}
       onOutsideClick={props.onClose}

--- a/src/shared/components/tooltip/tooltip-types.ts
+++ b/src/shared/components/tooltip/tooltip-types.ts
@@ -19,5 +19,9 @@ import { Position } from 'src/shared/components/pointer-box/PointerBox';
 export type TooltipPosition =
   | Position.TOP_LEFT
   | Position.TOP_RIGHT
+  | Position.RIGHT_TOP
+  | Position.RIGHT_BOTTOM
+  | Position.LEFT_TOP
+  | Position.LEFT_BOTTOM
   | Position.BOTTOM_LEFT
   | Position.BOTTOM_RIGHT;

--- a/tests/fixtures/browser.ts
+++ b/tests/fixtures/browser.ts
@@ -112,7 +112,8 @@ export const createZmenuPayload = (): ZmenuCreatePayload => {
     content: [...createZmenuContentPayload().features],
     variety: [
       {
-        type: ZmenuPayloadVarietyType.GENE_AND_ONE_TRANSCRIPT
+        type: 'zmenu',
+        'zmenu-type': ZmenuPayloadVarietyType.GENE_AND_ONE_TRANSCRIPT
       }
     ]
   };


### PR DESCRIPTION
## Description
Version 0.6.0 brings new genome browser functionality, as well as breaking changes: 

- Zmenus have been generalised to "hotspots". Other "hotspots" include lozenges and the left corner of a track
- Added support for lozenge clicks for the focus track.
- Genome browser reports when user hovers over the left corner of a track; in response to which we are showing a tooltip
- We can now ask genome browser to put a grey bar to the left of a track, thus providing a way to mark them

### Important (breaking changes)
Notice that the focus gene track now behaves differently from other gene tracks. Specifically:
- _(breaking change)_ Previously, genome browser decided on its own how many transcripts to show in the focus track, based on whether the "several transcripts" switch was on or off. It doesn't do this any longer, and requires browser chrome to explicitly send it the transcripts to be displayed. Meanwhile, for regular gene tracks, genome browser makes the decision on its own.
- _(breaking change)_ Genome browser no longer changes the number of transcripts on the screen in response to the "several tracks" switch for the focus track. It does so, however, for the regular gene tracks.
- For regular gene tracks, genome browser changes the number of visible transcripts when the user clicks on a lozenge. For a focus track, genome browser does not to that, but instead reports to the browser chrome that a lozenge has been clicked, and expects the chrome to tell it how many transcripts to display.

## Related PRs
https://github.com/Ensembl/ensembl-genome-browser/pull/21

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1823

## Deployment URL(s)
http://gb-0-6-0.review.ensembl.org