### PR TITLE
Remove default props from React function components

### DIFF
--- a/src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript.tsx
@@ -45,7 +45,7 @@ export type UnsplicedTranscriptProps = {
     backbone?: string;
     exon?: string;
   };
-  standalone: boolean;
+  standalone?: boolean;
 };
 
 /*
@@ -102,10 +102,6 @@ const UnsplicedTranscript = (props: UnsplicedTranscriptProps) => {
   ) : (
     renderedTranscript
   );
-};
-
-UnsplicedTranscript.defaultProps = {
-  standalone: false
 };
 
 type BackboneProps = {

--- a/src/content/app/help/components/labelled-app-icon/LabelledAppIcon.tsx
+++ b/src/content/app/help/components/labelled-app-icon/LabelledAppIcon.tsx
@@ -32,7 +32,7 @@ type Size = 'regular' | 'small';
 
 type Props = {
   app: AppName;
-  size: Size;
+  size?: Size;
 };
 
 const appNameToIcon: Record<AppName, React.FunctionComponent> = {
@@ -48,7 +48,7 @@ const appNameToLabel: Record<AppName, string> = {
 };
 
 const LabelledAppIcon = (props: Props) => {
-  const { app, size } = props;
+  const { app, size = 'regular' } = props;
 
   const IconComponent = appNameToIcon[app];
   const label = appNameToLabel[app];
@@ -71,10 +71,6 @@ const LabelledAppIcon = (props: Props) => {
       <div className={labelStyles}>{label}</div>
     </div>
   );
-};
-
-LabelledAppIcon.defaultProps = {
-  size: 'regular'
 };
 
 export default LabelledAppIcon;

--- a/src/header/launchbar/LaunchbarButton.tsx
+++ b/src/header/launchbar/LaunchbarButton.tsx
@@ -32,7 +32,7 @@ export type LaunchbarButtonProps = {
   path: string;
   description: string;
   icon: FunctionComponent<unknown> | string;
-  enabled: boolean;
+  enabled?: boolean;
   isActive?: boolean;
 };
 
@@ -40,6 +40,7 @@ const LaunchbarButton: FunctionComponent<LaunchbarButtonProps> = (
   props: LaunchbarButtonProps
 ) => {
   const location = useLocation();
+  const isButtonEnabled = props.enabled ?? true;
 
   const { trackLaunchbarAppChange } = useHeaderAnalytics();
   const isActive =
@@ -47,7 +48,7 @@ const LaunchbarButton: FunctionComponent<LaunchbarButtonProps> = (
       ? (props.isActive as boolean)
       : new RegExp(`^${props.path}`).test(location.pathname);
   const imageButtonStatus = getImageButtonStatus({
-    isDisabled: !props.enabled,
+    isDisabled: !isButtonEnabled,
     isActive
   });
 
@@ -68,7 +69,7 @@ const LaunchbarButton: FunctionComponent<LaunchbarButtonProps> = (
     styles.launchbarButtonSelected
   );
 
-  return props.enabled ? (
+  return isButtonEnabled ? (
     <NavLink
       className={({ isActive }) =>
         isActive ? activeButtonClass : styles.launchbarButton

--- a/src/header/launchbar/LaunchbarButtonWithNotification.tsx
+++ b/src/header/launchbar/LaunchbarButtonWithNotification.tsx
@@ -52,8 +52,4 @@ const LaunchbarButtonWithNotification = (
   return <LaunchbarButton {...props} icon={WrappedIcon} />;
 };
 
-LaunchbarButtonWithNotification.defaultProps = {
-  enabled: true
-};
-
 export default LaunchbarButtonWithNotification;

--- a/src/shared/components/accordion/components/Accordion.tsx
+++ b/src/shared/components/accordion/components/Accordion.tsx
@@ -26,19 +26,19 @@ type AccordionProps = Pick<
   Exclude<keyof DivAttributes, 'onChange'>
 > & {
   preExpanded?: UUID[];
-  allowMultipleExpanded: boolean;
-  allowZeroExpanded: boolean;
-  extendDefaultStyles: boolean;
+  allowMultipleExpanded?: boolean;
+  allowZeroExpanded?: boolean;
+  extendDefaultStyles?: boolean;
   onChange?(args: UUID[]): void;
 };
 
 const Accordion = (props: AccordionProps) => {
   const {
     preExpanded,
-    allowMultipleExpanded,
-    allowZeroExpanded,
+    allowMultipleExpanded = false,
+    allowZeroExpanded = true,
     className,
-    extendDefaultStyles,
+    extendDefaultStyles = true,
     onChange,
     ...rest
   } = props;
@@ -65,12 +65,6 @@ const Accordion = (props: AccordionProps) => {
       <Consumer>{renderAccordion}</Consumer>
     </Provider>
   );
-};
-
-Accordion.defaultProps = {
-  allowMultipleExpanded: false,
-  allowZeroExpanded: true,
-  extendDefaultStyles: true
 };
 
 export default Accordion;

--- a/src/shared/components/accordion/components/AccordionContext.tsx
+++ b/src/shared/components/accordion/components/AccordionContext.tsx
@@ -23,7 +23,7 @@ import AccordionStore, {
 import { UUID } from './ItemContext';
 
 export interface ProviderProps {
-  preExpanded: UUID[];
+  preExpanded?: UUID[];
   allowMultipleExpanded?: boolean;
   allowZeroExpanded?: boolean;
   children?: React.ReactNode;
@@ -31,8 +31,8 @@ export interface ProviderProps {
 }
 
 export interface AccordionContext {
-  allowMultipleExpanded: boolean;
-  allowZeroExpanded: boolean;
+  allowMultipleExpanded?: boolean;
+  allowZeroExpanded?: boolean;
   toggleExpanded(uuid: UUID): void;
   isItemDisabled(uuid: UUID): boolean;
   isItemExpanded(uuid: UUID): boolean;
@@ -44,11 +44,12 @@ export interface AccordionContext {
 const Context = React.createContext(null as AccordionContext | null);
 
 export const Provider = (props: ProviderProps) => {
+  const { preExpanded = [] } = props;
   const [store, setStore] = useState(
     new AccordionStore({
-      allowMultipleExpanded: props.allowMultipleExpanded,
-      allowZeroExpanded: props.allowZeroExpanded,
-      expanded: props.preExpanded
+      allowMultipleExpanded: props.allowMultipleExpanded ?? false,
+      allowZeroExpanded: props.allowZeroExpanded ?? false,
+      expanded: preExpanded
     })
   );
 
@@ -60,13 +61,13 @@ export const Provider = (props: ProviderProps) => {
 
   useEffect(() => {
     const differences = store.expanded.filter(
-      (uuid) => !props.preExpanded.includes(uuid)
+      (uuid) => !preExpanded.includes(uuid)
     ).length;
 
-    if (store.expanded.length !== props.preExpanded.length || differences) {
-      setStore(store.setExpanded(props.preExpanded));
+    if (store.expanded.length !== preExpanded.length || differences) {
+      setStore(store.setExpanded(preExpanded));
     }
-  }, [props.preExpanded]);
+  }, [preExpanded]);
 
   const toggleExpanded = (key: UUID): void => {
     setStore(store.toggleExpanded(key));
@@ -112,11 +113,6 @@ export const Provider = (props: ProviderProps) => {
   );
 };
 
-Provider.defaultProps = {
-  allowMultipleExpanded: false,
-  allowZeroExpanded: false,
-  preExpanded: []
-};
 export class Consumer extends React.PureComponent<{
   children(container: AccordionContext): React.ReactNode;
 }> {

--- a/src/shared/components/accordion/components/AccordionContext.tsx
+++ b/src/shared/components/accordion/components/AccordionContext.tsx
@@ -67,7 +67,7 @@ export const Provider = (props: ProviderProps) => {
     if (store.expanded.length !== preExpanded.length || differences) {
       setStore(store.setExpanded(preExpanded));
     }
-  }, [preExpanded]);
+  }, [props.preExpanded]);
 
   const toggleExpanded = (key: UUID): void => {
     setStore(store.toggleExpanded(key));

--- a/src/shared/components/accordion/components/AccordionItem.tsx
+++ b/src/shared/components/accordion/components/AccordionItem.tsx
@@ -15,16 +15,17 @@
  */
 
 import React from 'react';
-import { DivAttributes } from '../helpers/types';
 
 import { Provider as ItemProvider, UUID } from './ItemContext';
 import classNames from 'classnames';
 import { generateId } from 'src/shared/helpers/generateId';
 
+import type { DivAttributes } from '../helpers/types';
+
 import defaultStyles from '../css/Accordion.scss';
 
 type Props = DivAttributes & {
-  extendDefaultStyles: boolean;
+  extendDefaultStyles?: boolean;
   uuid?: UUID;
 };
 
@@ -33,7 +34,7 @@ const AccordionItem = (props: Props) => {
 
   const {
     uuid = instanceUuid,
-    extendDefaultStyles,
+    extendDefaultStyles = true,
     className,
     ...rest
   } = props;
@@ -53,10 +54,6 @@ const AccordionItem = (props: Props) => {
       />
     </ItemProvider>
   );
-};
-
-AccordionItem.defaultProps = {
-  extendDefaultStyles: true
 };
 
 export default AccordionItem;

--- a/src/shared/components/accordion/components/AccordionItemButton.tsx
+++ b/src/shared/components/accordion/components/AccordionItemButton.tsx
@@ -28,7 +28,7 @@ import { DivAttributes } from '../helpers/types';
 import defaultStyles from '../css/Accordion.scss';
 
 type Props = DivAttributes & {
-  extendDefaultStyles: boolean;
+  extendDefaultStyles?: boolean;
   toggleExpanded: () => void;
   disabled?: boolean;
   onToggle?: (isExpanded: boolean) => void;
@@ -37,7 +37,7 @@ type Props = DivAttributes & {
 export const AccordionItemButton = (props: Props) => {
   const {
     className,
-    extendDefaultStyles,
+    extendDefaultStyles = true,
     toggleExpanded,
     disabled,
     children,
@@ -79,10 +79,6 @@ export const AccordionItemButton = (props: Props) => {
       )}
     </div>
   );
-};
-
-AccordionItemButton.defaultProps = {
-  extendDefaultStyles: true
 };
 
 type WrapperProps = {

--- a/src/shared/components/accordion/components/AccordionItemHeading.tsx
+++ b/src/shared/components/accordion/components/AccordionItemHeading.tsx
@@ -55,10 +55,6 @@ export const AccordionItemHeading = (props: Props) => {
   );
 };
 
-AccordionItemHeading.defaultProps = {
-  'aria-level': 3
-};
-
 type WrapperProps = Pick<
   DivAttributes,
   Exclude<keyof DivAttributes, keyof InjectedHeadingAttributes>

--- a/src/shared/components/accordion/components/AccordionItemPanel.tsx
+++ b/src/shared/components/accordion/components/AccordionItemPanel.tsx
@@ -21,11 +21,11 @@ import defaultStyles from '../css/Accordion.scss';
 import classNames from 'classnames';
 
 type Props = DivAttributes & {
-  extendDefaultStyles: boolean;
+  extendDefaultStyles?: boolean;
 };
 
 const AccordionItemPanel = (props: Props) => {
-  const { className, extendDefaultStyles, ...rest } = props;
+  const { className, extendDefaultStyles = true, ...rest } = props;
 
   let styles = className;
 
@@ -47,10 +47,6 @@ const AccordionItemPanel = (props: Props) => {
       }}
     </ItemConsumer>
   );
-};
-
-AccordionItemPanel.defaultProps = {
-  extendDefaultStyles: true
 };
 
 export default AccordionItemPanel;

--- a/src/shared/components/autosuggest-search-field/AutosuggestSearchField.test.tsx
+++ b/src/shared/components/autosuggest-search-field/AutosuggestSearchField.test.tsx
@@ -21,7 +21,9 @@ import { faker } from '@faker-js/faker';
 import times from 'lodash/times';
 import random from 'lodash/random';
 
-import AutosuggestSearchField from './AutosuggestSearchField';
+import AutosuggestSearchField, {
+  defaultNotFoundText
+} from './AutosuggestSearchField';
 import { GroupOfMatchesType } from './AutosuggestionPanel';
 
 const generateMatch = () => {
@@ -257,7 +259,7 @@ describe('<AutosuggestSearchField />', () => {
         const { container } = render(<AutosuggestSearchField {...props} />);
 
         const panel = container.querySelector('.autosuggestionPlate');
-        const defaultMessage = AutosuggestSearchField.defaultProps.notFoundText;
+        const defaultMessage = defaultNotFoundText;
 
         expect(panel?.textContent).toBe(defaultMessage);
       });

--- a/src/shared/components/autosuggest-search-field/AutosuggestSearchField.tsx
+++ b/src/shared/components/autosuggest-search-field/AutosuggestSearchField.tsx
@@ -213,13 +213,14 @@ const AutosuggestSearchField = (props: Props) => {
     setIsSelected(true);
   };
 
-  const shouldShowSuggestions =
+  const shouldShowSuggestions = Boolean(
     props.search &&
-    !props.notFound &&
-    matchGroups.length > 0 &&
-    canShowSuggesions &&
-    !isSelected &&
-    !preventSuggestionsProp;
+      !props.notFound &&
+      matchGroups.length > 0 &&
+      canShowSuggesions &&
+      !isSelected &&
+      !preventSuggestionsProp
+  );
 
   const className = classNames(
     styles.autosuggestionSearchField,

--- a/src/shared/components/chevron/Chevron.tsx
+++ b/src/shared/components/chevron/Chevron.tsx
@@ -25,7 +25,7 @@ export type Direction = 'up' | 'down' | 'left' | 'right';
 
 export type Props = {
   direction: Direction;
-  animate: boolean;
+  animate?: boolean;
   className?: string;
 };
 
@@ -39,10 +39,6 @@ const Chevron = (props: Props) => {
     props.className
   );
   return <ChevronDown className={chevronClasses} />;
-};
-
-Chevron.defaultProps = {
-  animate: false
 };
 
 export default Chevron;

--- a/src/shared/components/data-table/DataTable.tsx
+++ b/src/shared/components/data-table/DataTable.tsx
@@ -127,8 +127,8 @@ const DataTable = (props: TableProps) => {
           cells: row
         })),
         theme: props.theme,
-        selectableColumnIndex: props.selectableColumnIndex,
-        expandedContent: props.expandedContent,
+        selectableColumnIndex: props.selectableColumnIndex ?? 0,
+        expandedContent: props.expandedContent ?? {},
         disabledActions: props.disabledActions,
         downloadFileName: props.downloadFileName,
         downloadHandler: props.downloadHandler
@@ -145,12 +145,6 @@ const DataTable = (props: TableProps) => {
       </div>
     </TableContext.Provider>
   );
-};
-
-DataTable.defaultProps = {
-  theme: 'light',
-  selectableColumnIndex: 0,
-  expandedContent: {}
 };
 
 export default DataTable;

--- a/src/shared/components/expandable-section/ExpandableSection.tsx
+++ b/src/shared/components/expandable-section/ExpandableSection.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactNode, useState, useEffect } from 'react';
+import React, { useState, useEffect, type ReactNode } from 'react';
 import classNames from 'classnames';
 
 import Chevron from 'src/shared/components/chevron/Chevron';
@@ -24,7 +24,7 @@ import styles from './ExpandableSection.scss';
 export type ExpandableSectionProps = {
   collapsedContent: ReactNode;
   expandedContent: ReactNode;
-  isExpanded: boolean;
+  isExpanded?: boolean;
   classNames?: {
     wrapper?: string;
     expanded?: string;
@@ -34,13 +34,14 @@ export type ExpandableSectionProps = {
 };
 
 const ExpandableSection = (props: ExpandableSectionProps) => {
-  const [isExpanded, setIsExpanded] = useState(props.isExpanded);
+  const { isExpanded: isExpandedProp = false } = props;
+  const [isExpanded, setIsExpanded] = useState(isExpandedProp);
 
   useEffect(() => {
-    if (isExpanded !== props.isExpanded) {
-      setIsExpanded(props.isExpanded);
+    if (isExpanded !== isExpandedProp) {
+      setIsExpanded(isExpandedProp);
     }
-  }, [props.isExpanded]);
+  }, [isExpandedProp]);
 
   const wrapperClassNames = classNames(
     styles.expandableSection,
@@ -83,10 +84,6 @@ const ExpandableSection = (props: ExpandableSectionProps) => {
       )}
     </div>
   );
-};
-
-ExpandableSection.defaultProps = {
-  isExpanded: false
 };
 
 export default ExpandableSection;

--- a/src/shared/components/help-popup/HelpPopupButton.tsx
+++ b/src/shared/components/help-popup/HelpPopupButton.tsx
@@ -26,11 +26,12 @@ import styles from './HelpPopupButton.scss';
 
 type Props = {
   labelClass?: string;
-  label: string;
+  label?: string;
   slug: string;
 };
 
 const HelpPopupButton = (props: Props) => {
+  const { label: labelText = 'Help', slug } = props;
   const [shouldShowModal, setShouldShowModal] = useState(false);
   const elementRef = useRef<HTMLDivElement | null>(null);
 
@@ -61,22 +62,18 @@ const HelpPopupButton = (props: Props) => {
   return (
     <>
       <div className={styles.wrapper} onClick={openModal} ref={elementRef}>
-        <span className={labelClasses}>{props.label}</span>
+        <span className={labelClasses}>{labelText}</span>
         <div className={styles.button}>
           <HelpIcon className={styles.icon} />
         </div>
       </div>
       {shouldShowModal && (
         <Modal classNames={{ body: styles.helpPopup }} onClose={closeModal}>
-          <HelpPopupBody slug={props.slug} />
+          <HelpPopupBody slug={slug} />
         </Modal>
       )}
     </>
   );
-};
-
-HelpPopupButton.defaultProps = {
-  label: 'Help'
 };
 
 export default HelpPopupButton;

--- a/src/shared/components/instant-download/instant-download-gene/InstantDownloadGene.tsx
+++ b/src/shared/components/instant-download/instant-download-gene/InstantDownloadGene.tsx
@@ -39,7 +39,7 @@ export type InstantDownloadGeneEntityProps = {
 };
 
 type Props = InstantDownloadGeneEntityProps & {
-  theme: Theme;
+  theme?: Theme;
   onDownloadSuccess?: (params: OnDownloadPayload) => void;
   onDownloadFailure?: (params: OnDownloadPayload) => void;
 };
@@ -95,7 +95,8 @@ export const getCheckboxTheme = (theme: Theme) =>
 const InstantDownloadGene = (props: Props) => {
   const {
     genomeId,
-    gene: { id: geneId, isProteinCoding }
+    gene: { id: geneId, isProteinCoding },
+    theme = 'light'
   } = props;
   const [transcriptOptions, setTranscriptOptions] = useState(
     filterTranscriptOptions(isProteinCoding)
@@ -141,8 +142,7 @@ const InstantDownloadGene = (props: Props) => {
     }
   };
 
-  const themeClass =
-    props.theme === 'dark' ? styles.themeDark : styles.themeLight;
+  const themeClass = theme === 'dark' ? styles.themeDark : styles.themeLight;
 
   const containerClasses = classNames(styles.container, themeClass);
 
@@ -156,18 +156,18 @@ const InstantDownloadGene = (props: Props) => {
       <GeneSection
         gene={props.gene}
         isGenomicSequenceSelected={isGeneSequenceSelected}
-        theme={props.theme}
+        theme={theme}
         onChange={onGeneOptionChange}
       />
       <TranscriptSection
         options={transcriptOptions}
-        theme={props.theme}
+        theme={theme}
         onChange={onTranscriptOptionChange}
       />
       <InstantDownloadButton
         isDisabled={isButtonDisabled}
         onClick={onSubmit}
-        theme={props.theme}
+        theme={theme}
         classNames={{
           wrapper: styles.downloadButtonWrapper
         }}
@@ -175,10 +175,6 @@ const InstantDownloadGene = (props: Props) => {
     </div>
   );
 };
-
-InstantDownloadGene.defaultProps = {
-  theme: 'light'
-} as Props;
 
 const GeneSection = (props: GeneSectionProps) => (
   <div className={styles.geneSection}>

--- a/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.tsx
+++ b/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.tsx
@@ -57,8 +57,8 @@ export type InstantDownloadTranscriptEntityProps = {
 };
 
 type Props = InstantDownloadTranscriptEntityProps & {
-  layout: Layout;
-  theme: Theme;
+  layout?: Layout;
+  theme?: Theme;
 };
 
 type TranscriptSectionProps = {
@@ -120,7 +120,9 @@ const InstantDownloadTranscript = (props: Props) => {
   const {
     genomeId,
     gene: { id: geneId },
-    transcript: { id: transcriptId, isProteinCoding }
+    transcript: { id: transcriptId, isProteinCoding },
+    layout = 'horizontal',
+    theme = 'dark'
   } = props;
   const [transcriptOptions, setTranscriptOptions] = useState(
     filterTranscriptOptions(isProteinCoding)
@@ -168,10 +170,10 @@ const InstantDownloadTranscript = (props: Props) => {
     setIsGeneSequenceSelected(!isGeneSequenceSelected);
   };
 
-  const wrapperClasses =
-    props.layout === 'horizontal'
-      ? classNames(styles.layout, styles.layoutHorizontal)
-      : classNames(styles.layout, styles.layoutVertical);
+  const wrapperClasses = classNames(styles.layout, {
+    [styles.layoutHorizontal]: layout === 'horizontal',
+    [styles.layoutVertical]: layout === 'vertical'
+  });
 
   const isButtonDisabled = !hasSelectedOptions({
     ...transcriptOptions,
@@ -183,19 +185,19 @@ const InstantDownloadTranscript = (props: Props) => {
       <TranscriptSection
         transcript={props.transcript}
         options={transcriptOptions}
-        theme={props.theme}
+        theme={theme}
         onChange={onTranscriptOptionChange}
       />
       <GeneSection
         gene={props.gene}
         isGenomicSequenceSelected={isGeneSequenceSelected}
-        theme={props.theme}
+        theme={theme}
         onChange={onGeneOptionChange}
       />
       <InstantDownloadButton
         isDisabled={isButtonDisabled}
         onClick={onSubmit}
-        theme={props.theme}
+        theme={theme}
         classNames={{
           wrapper: styles.downloadButtonWrapper
         }}
@@ -203,11 +205,6 @@ const InstantDownloadTranscript = (props: Props) => {
     </div>
   );
 };
-
-InstantDownloadTranscript.defaultProps = {
-  layout: 'horizontal',
-  theme: 'dark'
-} as Props;
 
 const TranscriptSection = (props: TranscriptSectionProps) => {
   const { transcript, options } = props;

--- a/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
+++ b/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscriptVisualisation.tsx
@@ -37,18 +37,21 @@ x = totalWidth / 7
 */
 
 export type Props = {
-  isGenomicSequenceEnabled: boolean;
-  isCDNAEnabled: boolean;
-  isCDSEnabled: boolean;
-  isProteinSequenceEnabled: boolean;
-  width: number;
-  theme: 'light' | 'dark';
+  isGenomicSequenceEnabled?: boolean;
+  isCDNAEnabled?: boolean;
+  isCDSEnabled?: boolean;
+  isProteinSequenceEnabled?: boolean;
+  width?: number;
+  theme?: 'light' | 'dark';
 };
 
+const defaultImageWidth = 210;
+
 const InstantDownloadTranscriptVisualisation = (props: Props) => {
+  const fullWidth = props.width ?? defaultImageWidth;
   const exonsCount = 5;
   const exonHeight = 5;
-  const exonWidth = Math.floor(props.width / 7);
+  const exonWidth = Math.floor(fullWidth / 7);
   const proteinHeight = 4;
   const proteinBlockWidth = proteinHeight;
   const proteinBlockSpacing = 1;
@@ -174,7 +177,7 @@ const InstantDownloadTranscriptVisualisation = (props: Props) => {
   return (
     <svg
       style={{ overflow: 'visible' }}
-      width={props.width}
+      width={fullWidth}
       height={totalHeight}
       className={themeClass}
     >
@@ -185,14 +188,5 @@ const InstantDownloadTranscriptVisualisation = (props: Props) => {
     </svg>
   );
 };
-
-InstantDownloadTranscriptVisualisation.defaultProps = {
-  isGenomicSequenceEnabled: false,
-  isCDNAEnabled: false,
-  isCDSEnabled: false,
-  isProteinSequenceEnabled: false,
-  width: 210,
-  theme: 'dark'
-} as Partial<Props>;
 
 export default InstantDownloadTranscriptVisualisation;

--- a/src/shared/components/layout/StandardAppLayout.tsx
+++ b/src/shared/components/layout/StandardAppLayout.tsx
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import React, { ReactNode, useEffect, useRef } from 'react';
+import React, { ReactNode, useEffect, useRef, useCallback } from 'react';
 import classNames from 'classnames';
-import noop from 'lodash/noop';
 
 import usePrevious from 'src/shared/hooks/usePrevious';
 
@@ -45,13 +44,14 @@ type StandardAppLayoutProps = {
   topbarContent: ReactNode;
   isSidebarOpen: boolean;
   onSidebarToggle: () => void;
-  isDrawerOpen: boolean;
+  isDrawerOpen?: boolean;
   drawerContent?: ReactNode;
-  onDrawerClose: () => void;
+  onDrawerClose?: () => void;
   viewportWidth: BreakpointWidth;
 };
 
 const StandardAppLayout = (props: StandardAppLayoutProps) => {
+  const { isDrawerOpen = false } = props;
   const elementRef = useRef<HTMLDivElement | null>(null);
 
   // TODO: is there any way to run this smarter?
@@ -79,14 +79,18 @@ const StandardAppLayout = (props: StandardAppLayoutProps) => {
   const sidebarWrapperClassnames = useSidebarWrapperClassNames(props);
 
   const handleClick = () => {
-    if (props.isDrawerOpen) {
-      props.onDrawerClose();
+    if (isDrawerOpen) {
+      props?.onDrawerClose?.();
       return;
     }
 
     trackSidebarToggle();
     props.onSidebarToggle();
   };
+
+  const handleDrawerClose = useCallback(() => {
+    props?.onDrawerClose?.();
+  }, [props.onDrawerClose]);
 
   // dispatches an event that the sidebar has been opened or closed; used for analytics purposes
   const trackSidebarToggle = () => {
@@ -110,7 +114,7 @@ const StandardAppLayout = (props: StandardAppLayoutProps) => {
       <div className={styles.mainWrapper}>
         <div className={mainClassNames}>{props.mainContent}</div>
         <div className={sidebarWrapperClassnames}>
-          {props.isDrawerOpen && <DrawerWindow onClick={props.onDrawerClose} />}
+          {isDrawerOpen && <DrawerWindow onClick={handleDrawerClose} />}
           <div className={styles.sidebarToolstrip}>
             <SidebarModeToggle
               onClick={handleClick}
@@ -128,7 +132,7 @@ const StandardAppLayout = (props: StandardAppLayoutProps) => {
           <div className={styles.drawer}>
             <CloseButton
               className={styles.drawerClose}
-              onClick={props.onDrawerClose}
+              onClick={handleDrawerClose}
             />
             {props.drawerContent || null}
           </div>
@@ -136,11 +140,6 @@ const StandardAppLayout = (props: StandardAppLayoutProps) => {
       </div>
     </div>
   );
-};
-
-StandardAppLayout.defaultProps = {
-  isDrawerOpen: false,
-  onDrawerClose: noop
 };
 
 const SidebarModeToggle = (props: SidebarModeToggleProps) => {
@@ -174,7 +173,7 @@ const useSidebarWrapperClassNames = (props: StandardAppLayoutProps) => {
     { [styles.sidebarWrapperOpen]: props.isSidebarOpen },
     { [styles.sidebarWrapperClosed]: !props.isSidebarOpen },
     {
-      [styles.sidebarWrapperDrawerOpen]: props.isDrawerOpen ?? false
+      [styles.sidebarWrapperDrawerOpen]: props.isDrawerOpen
     },
     { [styles.instantaneous]: isInstantaneous }
   );

--- a/src/shared/components/pointer-box/PointerBox.tsx
+++ b/src/shared/components/pointer-box/PointerBox.tsx
@@ -52,28 +52,49 @@ type PointerProps = {
 };
 
 export type PointerBoxProps = {
-  position: Position;
+  position?: Position;
   anchor: HTMLElement;
   container?: HTMLElement | null; // area within which the box should try to position itself; defaults to window if null
-  autoAdjust: boolean; // whether to adjust pointer box position so as not to extend beyond screen bounds
-  renderInsideAnchor: boolean; // whether to render PointerBox inside the anchor (which should have position: relative to display it properly); renders to body if false
-  pointerWidth: number;
-  pointerHeight: number;
-  pointerOffset: number;
+  autoAdjust?: boolean; // whether to adjust pointer box position so as not to extend beyond screen bounds
+  renderInsideAnchor?: boolean; // whether to render PointerBox inside the anchor (which should have position: relative to display it properly); renders to body if false
+  pointerWidth?: number;
+  pointerHeight?: number;
+  pointerOffset?: number;
   classNames?: {
     box?: string;
     pointer?: string;
   };
   children: ReactNode;
-  onMouseEnter: () => void;
-  onMouseLeave: () => void;
-  onOutsideClick: () => void;
-  onClose: () => void;
+  // onMouseEnter: () => void;
+  // onMouseLeave: () => void;
+  onOutsideClick?: () => void;
+  onClose?: () => void;
+};
+
+const defaultProps = {
+  position: Position.BOTTOM_RIGHT,
+  renderInsideAnchor: false,
+  autoAdjust: false,
+  pointerWidth: POINTER_WIDTH,
+  pointerHeight: POINTER_HEIGHT,
+  pointerOffset: POINTER_OFFSET,
+  onOutsideClick: noop,
+  onClose: noop
 };
 
 const PointerBox = (props: PointerBoxProps) => {
-  const [isPositioning, setIsPositioning] = useState(props.autoAdjust);
-  const positionRef = useRef<Position | null>(props.position);
+  const {
+    position: positionFromProps = defaultProps.position,
+    renderInsideAnchor = defaultProps.renderInsideAnchor,
+    autoAdjust = defaultProps.autoAdjust,
+    pointerWidth: pointerWidthFromProps = defaultProps.pointerWidth,
+    pointerHeight: pointerHeightFromProps = defaultProps.pointerHeight,
+    pointerOffset: pointerOffsetFromProps = defaultProps.pointerOffset,
+    onOutsideClick = defaultProps.onOutsideClick,
+    onClose = defaultProps.onClose
+  } = props;
+  const [isPositioning, setIsPositioning] = useState(autoAdjust);
+  const positionRef = useRef<Position | null>(positionFromProps);
   const anchorRectRef = useRef<DOMRect | null>(null);
   const [inlineStyles, setInlineStyles] = useState<InlineStylesState>({
     boxStyles: {},
@@ -81,7 +102,7 @@ const PointerBox = (props: PointerBoxProps) => {
   });
   const pointerBoxRef = useRef<HTMLDivElement>(null);
 
-  useOutsideClick(pointerBoxRef, props.onOutsideClick);
+  useOutsideClick(pointerBoxRef, onOutsideClick);
 
   useEffect(() => {
     const pointerBoxElement = pointerBoxRef.current as HTMLDivElement;
@@ -89,27 +110,28 @@ const PointerBox = (props: PointerBoxProps) => {
     setInlineStyles(getInlineStyles(props));
     anchorRectRef.current = props.anchor.getBoundingClientRect();
 
-    if (props.autoAdjust) {
+    if (autoAdjust) {
       adjustPosition(pointerBoxElement, props.anchor);
     }
   }, []);
 
-  const closeOnScroll = once(props.onClose);
+  const closeOnScroll = once(onClose);
 
   // from Stack Overflow: https://stackoverflow.com/questions/59792071/how-to-observe-dom-element-position-changes
   // (listen to all scroll events in the event capturing phase on the body and re-evaluate anchor position)
   useEffect(() => {
-    if (!props.renderInsideAnchor) {
+    if (!renderInsideAnchor) {
       document.addEventListener('scroll', closeOnScroll, true);
       return () => document.removeEventListener('scroll', closeOnScroll, true);
     }
   }, []);
 
   const getInlineStyles = (props: PointerBoxProps) => {
-    if (props.renderInsideAnchor) {
-      return getStylesForRenderingIntoAnchor(props);
+    const params = { ...defaultProps, ...props };
+    if (renderInsideAnchor) {
+      return getStylesForRenderingIntoAnchor(params);
     } else {
-      return getStylesForRenderingIntoBody(props);
+      return getStylesForRenderingIntoBody(params);
     }
   };
 
@@ -124,10 +146,10 @@ const PointerBox = (props: PointerBoxProps) => {
       pointerBoxBoundingRect,
       anchorBoundingRect,
       rootBoundingRect,
-      position: positionRef.current || props.position,
-      pointerWidth: props.pointerWidth,
-      pointerHeight: props.pointerHeight,
-      pointerOffset: props.pointerOffset
+      position: positionRef.current || positionFromProps,
+      pointerWidth: pointerWidthFromProps,
+      pointerHeight: pointerHeightFromProps,
+      pointerOffset: pointerOffsetFromProps
     });
 
     if (optimalPosition !== positionRef.current) {
@@ -147,7 +169,7 @@ const PointerBox = (props: PointerBoxProps) => {
   const bodyClasses = classNames(
     styles.pointerBox,
     props.classNames?.box,
-    props.position,
+    positionFromProps,
     { [styles.invisible]: isPositioning || !hasInlineStyles() }
   );
 
@@ -159,29 +181,16 @@ const PointerBox = (props: PointerBoxProps) => {
     >
       <Pointer
         className={props.classNames?.pointer}
-        width={props.pointerWidth}
-        height={props.pointerWidth}
+        width={pointerWidthFromProps}
+        height={pointerHeightFromProps}
         style={inlineStyles.pointerStyles}
       />
       {props.children}
     </div>
   );
-  const renderTarget = props.renderInsideAnchor ? props.anchor : document.body;
+  const renderTarget = renderInsideAnchor ? props.anchor : document.body;
 
   return ReactDOM.createPortal(renderedPointerBox, renderTarget);
-};
-
-PointerBox.defaultProps = {
-  position: Position.BOTTOM_RIGHT,
-  renderInsideAnchor: false,
-  autoAdjust: false,
-  pointerWidth: POINTER_WIDTH,
-  pointerHeight: POINTER_HEIGHT,
-  pointerOffset: POINTER_OFFSET,
-  onMouseEnter: noop,
-  onMouseLeave: noop,
-  onOutsideClick: noop,
-  onClose: noop
 };
 
 const Pointer = (props: PointerProps) => {

--- a/src/shared/components/pointer-box/PointerBox.tsx
+++ b/src/shared/components/pointer-box/PointerBox.tsx
@@ -65,8 +65,6 @@ export type PointerBoxProps = {
     pointer?: string;
   };
   children: ReactNode;
-  // onMouseEnter: () => void;
-  // onMouseLeave: () => void;
   onOutsideClick?: () => void;
   onClose?: () => void;
 };

--- a/src/shared/components/pointer-box/pointer-box-inline-styles.ts
+++ b/src/shared/components/pointer-box/pointer-box-inline-styles.ts
@@ -17,7 +17,12 @@
 import { Position } from './pointer-box-types';
 import { PointerBoxProps, InlineStylesState } from './PointerBox';
 
-type Params = PointerBoxProps;
+type Params = Required<
+  Pick<
+    PointerBoxProps,
+    'position' | 'pointerWidth' | 'pointerHeight' | 'pointerOffset' | 'anchor'
+  >
+>;
 
 /*
   Functions for calculating inline styles of the pointer box

--- a/src/shared/components/question-button/QuestionButton.tsx
+++ b/src/shared/components/question-button/QuestionButton.tsx
@@ -33,18 +33,19 @@ export enum QuestionButtonOption {
 
 type Props = {
   helpText: React.ReactNode;
-  styleOption: QuestionButtonOption;
+  styleOption?: QuestionButtonOption;
   className?: { [key in QuestionButtonOption]?: string };
 };
 
 const QuestionButton = (props: Props) => {
+  const { helpText, styleOption = QuestionButtonOption.INLINE } = props;
   const { elementRef, onClick, onTooltipCloseSignal, shouldShowTooltip } =
     useShowTooltip();
 
   const className = classNames(
     defaultStyles.questionButton,
     {
-      [defaultStyles[props.styleOption as string]]: props.styleOption
+      [defaultStyles[styleOption]]: styleOption
     },
     props.className?.inline,
     props.className?.['in-input-field']
@@ -60,15 +61,11 @@ const QuestionButton = (props: Props) => {
           onClose={onTooltipCloseSignal}
           delay={0}
         >
-          {props.helpText}
+          {helpText}
         </Tooltip>
       )}
     </div>
   );
-};
-
-QuestionButton.defaultProps = {
-  styleOption: QuestionButtonOption.INLINE
 };
 
 export default QuestionButton;

--- a/src/shared/components/round-button/RoundButton.tsx
+++ b/src/shared/components/round-button/RoundButton.tsx
@@ -27,14 +27,15 @@ export enum RoundButtonStatus {
 
 type Props = {
   onClick: () => void;
-  status: RoundButtonStatus;
+  status?: RoundButtonStatus;
   classNames?: { [key in RoundButtonStatus]?: string };
   children: ReactNode;
 };
 
 const RoundButton = (props: Props) => {
+  const { status: buttonStatus = RoundButtonStatus.INACTIVE } = props;
   const handleClick = () => {
-    if (props.status !== RoundButtonStatus.DISABLED) {
+    if (buttonStatus !== RoundButtonStatus.DISABLED) {
       props.onClick();
     }
   };
@@ -43,17 +44,13 @@ const RoundButton = (props: Props) => {
     ? { ...defaultStyles, ...props.classNames }
     : defaultStyles;
 
-  const className = classNames(defaultStyles.default, styles[props.status]);
+  const className = classNames(defaultStyles.default, styles[buttonStatus]);
 
   return (
     <button className={className} onClick={handleClick}>
       {props.children}
     </button>
   );
-};
-
-RoundButton.defaultProps = {
-  status: RoundButtonStatus.INACTIVE
 };
 
 export default RoundButton;

--- a/src/shared/components/select/Select.tsx
+++ b/src/shared/components/select/Select.tsx
@@ -67,7 +67,7 @@ type OptionGroupsSelectProps = CommonProps & OptionGroupsSpecificProps;
 
 type SelectAdapterProps = OptionsSelectProps | OptionGroupsSelectProps;
 
-type SelectProps = OptionGroupsSelectProps & { placeholder: string };
+type SelectProps = OptionGroupsSelectProps & { placeholder?: string };
 
 const SelectControl = (props: SelectControlProps) => {
   const className = props.isOpen
@@ -82,6 +82,7 @@ const SelectControl = (props: SelectControlProps) => {
 };
 
 const Select = (props: SelectProps) => {
+  const { placeholder = defaultPlaceholderText } = props;
   const [isOpen, setIsOpen] = useState(false);
   const [selectedOption, optionGroups] = splitFromSelected(props.optionGroups);
 
@@ -132,7 +133,7 @@ const Select = (props: SelectProps) => {
     closePanel();
   };
 
-  const headerText = selectedOption ? selectedOption.label : props.placeholder;
+  const headerText = selectedOption ? selectedOption.label : placeholder;
   const className = classNames(styles.select, { [styles.selectOpen]: isOpen });
 
   return (
@@ -146,7 +147,7 @@ const Select = (props: SelectProps) => {
         isOpen={isOpen}
         selectedOption={selectedOption}
         onClick={openPanel}
-        placeholder={props.placeholder}
+        placeholder={placeholder}
       />
       {isOpen && (
         <SelectOptionsPanel
@@ -160,9 +161,7 @@ const Select = (props: SelectProps) => {
   );
 };
 
-Select.defaultProps = {
-  placeholder: 'Select'
-};
+const defaultPlaceholderText = 'Select';
 
 // the purpose of the adapter is to unify props
 // to be consumed by the Select component

--- a/src/shared/components/select/SelectArrowhead.tsx
+++ b/src/shared/components/select/SelectArrowhead.tsx
@@ -24,22 +24,19 @@ export enum Direction {
 }
 
 type Props = {
-  direction: Direction;
+  direction?: Direction;
 };
 
 const SelectArrowhead = (props: Props) => {
+  const { direction: arrowheadDirection = Direction.DOWN } = props;
   const points =
-    props.direction === Direction.DOWN ? '0,0 8,0 4,8' : '0,8 8,8 4,0';
+    arrowheadDirection === Direction.DOWN ? '0,0 8,0 4,8' : '0,8 8,8 4,0';
 
   return (
     <svg className={styles.selectArrowhead} viewBox="0 0 8 8">
       <polygon points={points} />
     </svg>
   );
-};
-
-SelectArrowhead.defaultProps = {
-  direction: Direction.DOWN
 };
 
 export default SelectArrowhead;

--- a/src/shared/components/species-tabs-wrapper/MultiLineSpeciesWrapper.tsx
+++ b/src/shared/components/species-tabs-wrapper/MultiLineSpeciesWrapper.tsx
@@ -23,7 +23,6 @@ import { Props as SelectedSpeciesProps } from 'src/shared/components/selected-sp
 import styles from './MultiLineSpeciesWrapper.scss';
 
 export type Props = {
-  isWrappable: true;
   speciesTabs: ReactElement<SelectedSpeciesProps>[];
   link?: React.ReactNode;
 };

--- a/src/shared/components/species-tabs-wrapper/SingleLineSpeciesWrapper.tsx
+++ b/src/shared/components/species-tabs-wrapper/SingleLineSpeciesWrapper.tsx
@@ -25,7 +25,6 @@ import styles from './SingleLineSpeciesWrapper.scss';
 import { Props as SelectedSpeciesProps } from 'src/shared/components/selected-species/SelectedSpecies';
 
 export type Props = {
-  isWrappable: false;
   speciesTabs: ReactElement<SelectedSpeciesProps>[];
   link?: React.ReactNode | null;
 };

--- a/src/shared/components/species-tabs-wrapper/SpeciesTabsWrapper.tsx
+++ b/src/shared/components/species-tabs-wrapper/SpeciesTabsWrapper.tsx
@@ -23,18 +23,18 @@ import MultiLineSpeciesWrapper, {
   Props as MultiLineSpeciesWrapperProps
 } from './MultiLineSpeciesWrapper';
 
-type Props = SingleLineSpeciesWrapperProps | MultiLineSpeciesWrapperProps;
+type Props = (SingleLineSpeciesWrapperProps | MultiLineSpeciesWrapperProps) & {
+  isWrappable?: boolean;
+};
 
 const SpeciesTabsWrapper = (props: Props) => {
-  return props.isWrappable ? (
+  const { isWrappable = true } = props;
+
+  return isWrappable ? (
     <MultiLineSpeciesWrapper {...props} />
   ) : (
     <SingleLineSpeciesWrapper {...props} />
   );
-};
-
-SpeciesTabsWrapper.defaultProps = {
-  isWrappable: true
 };
 
 export default SpeciesTabsWrapper;

--- a/src/shared/components/toolbox/Toolbox.tsx
+++ b/src/shared/components/toolbox/Toolbox.tsx
@@ -28,15 +28,16 @@ export enum ToolboxPosition {
 }
 
 type ToolboxProps = {
-  position: ToolboxPosition;
+  position?: ToolboxPosition;
   anchor: HTMLElement;
   onOutsideClick?: () => void;
   children: ReactNode;
 };
 
 const Toolbox = (props: ToolboxProps) => {
+  const { position: positionFromProps = ToolboxPosition.RIGHT } = props;
   const pointerBoxPosition =
-    props.position === ToolboxPosition.LEFT
+    positionFromProps === ToolboxPosition.LEFT
       ? Position.LEFT_BOTTOM
       : Position.RIGHT_BOTTOM;
 
@@ -52,9 +53,5 @@ const Toolbox = (props: ToolboxProps) => {
     </PointerBox>
   );
 };
-
-Toolbox.defaultProps = {
-  position: ToolboxPosition.RIGHT
-} as Partial<ToolboxProps>;
 
 export default Toolbox;

--- a/src/shared/components/tooltip/Tooltip.tsx
+++ b/src/shared/components/tooltip/Tooltip.tsx
@@ -27,11 +27,11 @@ import { TooltipPosition } from './tooltip-types';
 import styles from './Tooltip.scss';
 
 type Props = {
-  position: TooltipPosition;
   anchor: HTMLElement;
+  position?: TooltipPosition;
   container?: HTMLElement | null;
   autoAdjust?: boolean; // try to adjust tooltip position so as not to extend beyond screen bounds
-  delay: number;
+  delay?: number;
   children: ReactNode;
   onClose?: () => void;
 };
@@ -46,12 +46,13 @@ const Tooltip = (props: PropsWithNullableAnchor) => {
 
 const TooltipWithAnchor = (props: Props) => {
   const [isWaiting, setIsWaiting] = useState(true);
+  const { delay = TOOLTIP_TIMEOUT } = props;
   let timeoutId: ReturnType<typeof setTimeout>;
 
   useEffect(() => {
     timeoutId = setTimeout(() => {
       setIsWaiting(false);
-    }, props.delay);
+    }, delay);
 
     return () => clearTimeout(timeoutId);
   }, []);
@@ -62,7 +63,7 @@ const TooltipWithAnchor = (props: Props) => {
 
   return (
     <PointerBox
-      position={props.position}
+      position={props.position ?? Position.BOTTOM_RIGHT}
       anchor={props.anchor}
       container={props.container}
       autoAdjust={props.autoAdjust}
@@ -73,11 +74,6 @@ const TooltipWithAnchor = (props: Props) => {
       {props.children}
     </PointerBox>
   );
-};
-
-Tooltip.defaultProps = {
-  delay: TOOLTIP_TIMEOUT,
-  position: Position.BOTTOM_RIGHT
 };
 
 export { TOOLTIP_TIMEOUT };

--- a/src/shared/components/view-in-app-popup/ViewInAppPopup.tsx
+++ b/src/shared/components/view-in-app-popup/ViewInAppPopup.tsx
@@ -27,11 +27,11 @@ import styles from './ViewInAppPopup.scss';
 export type ViewInAppPopupProps = {
   links: LinksConfig;
   children: ReactNode;
-  position: Position;
+  position?: Position;
 };
 
 const ViewInAppPopup = (props: ViewInAppPopupProps) => {
-  const { links, children } = props;
+  const { links, position = Position.BOTTOM_RIGHT, children } = props;
   const [showPointerBox, setShowPointerBox] = useState(false);
   const anchorRef = useRef<HTMLSpanElement>(null);
 
@@ -47,7 +47,7 @@ const ViewInAppPopup = (props: ViewInAppPopupProps) => {
           anchor={anchorRef.current}
           renderInsideAnchor={true}
           onOutsideClick={() => setShowPointerBox(false)}
-          position={props.position}
+          position={position}
           autoAdjust={true}
           classNames={{
             box: styles.pointerBox,
@@ -59,10 +59,6 @@ const ViewInAppPopup = (props: ViewInAppPopupProps) => {
       )}
     </span>
   );
-};
-
-ViewInAppPopup.defaultProps = {
-  position: Position.BOTTOM_RIGHT
 };
 
 export default ViewInAppPopup;

--- a/stories/shared-components/instant-download/InstantDownloadTranscript.stories.tsx
+++ b/stories/shared-components/instant-download/InstantDownloadTranscript.stories.tsx
@@ -25,6 +25,8 @@ import { InstantDownloadTranscript } from 'src/shared/components/instant-downloa
 
 import styles from './InstantDownload.stories.scss';
 
+const genomeId = 'a7335667-93e7-11ec-a39d-005056b38ce3';
+
 const buildProteinCodingGene = () => {
   const transcript = createProteinCodingTranscript({
     unversioned_stable_id: 'ENST00000496384'
@@ -75,6 +77,7 @@ export const InstantDownloadTranscriptStory = () => {
     <div className={styles.transcriptStoryContainer}>
       <div {...containerProps}>
         <InstantDownloadTranscript
+          genomeId={genomeId}
           layout={layout}
           gene={{ id: gene.unversioned_stable_id }}
           transcript={{


### PR DESCRIPTION
## Description
`.defaultProps` property for function components were supposed to be deprecated for quite some time (for example, this was already discussed in the React PR `https://github.com/facebook/react/pull/16210`, which was merged back in 2019). A recent PR to the React repo (`https://github.com/facebook/react/pull/25699`), due to be released in React 19, should add a warning if you use `.defaultProps` property on function components.

In our codebase, we have some function components with `.defaultProps`. This PR updates these components to use native javascript syntax instead.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1802

## Deployment URL(s)
http://remove-default-props.review.ensembl.org