### PR TITLE
Do not use prettier for (s)css files

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -5,7 +5,6 @@
     "prettier --write"
   ],
   "*.scss": [
-    "stylelint",
-    "prettier --write"
+    "stylelint"
   ]
 }

--- a/src/shared/components/layout/StandardAppLayout.scss
+++ b/src/shared/components/layout/StandardAppLayout.scss
@@ -140,10 +140,7 @@
   padding: 15px 30px;
   border-left: solid $medium-light-grey 1px;
   background-color: white;
-  width: calc(
-    100% - var(--drawer-window-width) - var(--sidebar-toolstrip-width) -
-      var(--sidebar-content-width)
-  );
+  width: calc(100% - var(--drawer-window-width) - var(--sidebar-toolstrip-width) - var(--sidebar-content-width));
 }
 
 .drawerWindow {


### PR DESCRIPTION
## Description
Our lint-stage rules (see `.lintstagedrc.json`) included formatting of our scss files with prettier.

However, prettier had different opinions about syntax rules than `stylelint`, which produced the following situation:

Prettier split a long line in `StandardAppLayout.scss` thus:

```
  width: calc(
    100% - var(--drawer-window-width) - var(--sidebar-toolstrip-width) -
      var(--sidebar-content-width)
  );
```

To which, stylelint complained that:

![image](https://user-images.githubusercontent.com/6834224/215434944-7cdc650f-88ed-42f0-b64e-9496b09172c0.png)

There are two ways out of this problem: either [integrate prettier with stylelint](https://prettier.io/docs/en/integrating-with-linters.html), or just disable prettier for style files altogether (there isn't much stylistic variability one can exercise in css anyway). This PR suggests disabling prettier for style files.

## Deployment URL(s)
No deployment necessary.