### PR TITLE
Fix infinite requests to Thoas on broken network

### DIFF
--- a/src/content/app/entity-viewer/EntityViewer.tsx
+++ b/src/content/app/entity-viewer/EntityViewer.tsx
@@ -90,23 +90,21 @@ const EntityViewer = () => {
   );
 
   return (
-    <EntityViewerIdsContextProvider>
-      <div className={styles.entityViewer}>
-        <EntityViewerAppBar />
-        {isMissingGenomeId ? (
-          <MissingGenomeError genomeId={genomeIdInUrl as string} />
-        ) : isMalformedEntityId ? (
-          <MissingFeatureError
-            featureId={entityIdInUrl as string}
-            genome={genome}
-            showTopBar={true}
-            onContinue={openEntityViewerInterstitial}
-          />
-        ) : (
-          renderEntityViewerRoutes()
-        )}
-      </div>
-    </EntityViewerIdsContextProvider>
+    <div className={styles.entityViewer}>
+      <EntityViewerAppBar />
+      {isMissingGenomeId ? (
+        <MissingGenomeError genomeId={genomeIdInUrl as string} />
+      ) : isMalformedEntityId ? (
+        <MissingFeatureError
+          featureId={entityIdInUrl as string}
+          genome={genome}
+          showTopBar={true}
+          onContinue={openEntityViewerInterstitial}
+        />
+      ) : (
+        renderEntityViewerRoutes()
+      )}
+    </div>
   );
 };
 
@@ -224,4 +222,12 @@ const useEntityViewerRouting = () => {
   ]);
 };
 
-export default EntityViewer;
+const WrappedEntityViewer = () => {
+  return (
+    <EntityViewerIdsContextProvider>
+      <EntityViewer />
+    </EntityViewerIdsContextProvider>
+  );
+};
+
+export default WrappedEntityViewer;

--- a/src/content/app/entity-viewer/EntityViewer.tsx
+++ b/src/content/app/entity-viewer/EntityViewer.tsx
@@ -39,6 +39,7 @@ import {
   initializeSidebar
 } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSlice';
 
+import EntityViewerIdsContextProvider from 'src/content/app/entity-viewer/contexts/entity-viewer-ids-context/EntityViewerIdsContextProvider';
 import { StandardAppLayout } from 'src/shared/components/layout';
 import EntityViewerAppBar from './shared/components/entity-viewer-app-bar/EntityViewerAppBar';
 import EntityViewerSidebarToolstrip from './shared/components/entity-viewer-sidebar/entity-viewer-sidebar-toolstrip/EntityViewerSidebarToolstrip';
@@ -89,21 +90,23 @@ const EntityViewer = () => {
   );
 
   return (
-    <div className={styles.entityViewer}>
-      <EntityViewerAppBar />
-      {isMissingGenomeId ? (
-        <MissingGenomeError genomeId={genomeIdInUrl as string} />
-      ) : isMalformedEntityId ? (
-        <MissingFeatureError
-          featureId={entityIdInUrl as string}
-          genome={genome}
-          showTopBar={true}
-          onContinue={openEntityViewerInterstitial}
-        />
-      ) : (
-        renderEntityViewerRoutes()
-      )}
-    </div>
+    <EntityViewerIdsContextProvider>
+      <div className={styles.entityViewer}>
+        <EntityViewerAppBar />
+        {isMissingGenomeId ? (
+          <MissingGenomeError genomeId={genomeIdInUrl as string} />
+        ) : isMalformedEntityId ? (
+          <MissingFeatureError
+            featureId={entityIdInUrl as string}
+            genome={genome}
+            showTopBar={true}
+            onContinue={openEntityViewerInterstitial}
+          />
+        ) : (
+          renderEntityViewerRoutes()
+        )}
+      </div>
+    </EntityViewerIdsContextProvider>
   );
 };
 

--- a/src/content/app/entity-viewer/contexts/entity-viewer-ids-context/EntityViewerIdsContext.ts
+++ b/src/content/app/entity-viewer/contexts/entity-viewer-ids-context/EntityViewerIdsContext.ts
@@ -1,0 +1,67 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import type { FocusObjectIdConstituents } from 'src/shared/types/focus-object/focusObjectTypes';
+
+/**
+ * Lots of ids present here. Here’s what they all mean
+ *
+ * - genomeIdInUrl — could be the actual id of a genome, or a genome tag used instead of genome id for url stability over time
+ * - genomeIdForUrl — same; but generated considering what the active genome id is
+ * - entityIdInUrl — a combination of the entity type with the stable id of the entity
+ * - genomeId — actual id of a genome, as retrieved from the backend
+ * - entityId — the full id that is used on the client as a key when storing entity information;
+ *   is comprised of genome id, entity type, and entity stable id
+ * - activeGenomeId — the id of the genome that is currently being viewed
+ * - activeEntityId — the full id of the entity that that is currently being viewed
+ */
+
+export type EntityViewerIdsContextType = {
+  activeGenomeId: string | null;
+  activeEntityId: string | null;
+  genomeIdInUrl: string | undefined;
+  entityIdInUrl: string | undefined;
+  genomeIdForUrl: string | undefined;
+  entityIdForUrl: string | undefined;
+  genomeId: string | undefined;
+  entityId: string | undefined;
+  parsedEntityId: FocusObjectIdConstituents | undefined;
+  hasActiveGenomeIdChanged: boolean;
+  hasActiveEntityIdChanged: boolean;
+  isMissingGenomeId: boolean;
+  isMalformedEntityId: boolean;
+};
+
+const defaultContext: EntityViewerIdsContextType = {
+  activeGenomeId: null,
+  activeEntityId: null,
+  genomeIdInUrl: undefined,
+  entityIdInUrl: undefined,
+  genomeIdForUrl: undefined,
+  entityIdForUrl: undefined,
+  genomeId: undefined,
+  entityId: undefined,
+  parsedEntityId: undefined,
+  hasActiveGenomeIdChanged: false,
+  hasActiveEntityIdChanged: false,
+  isMissingGenomeId: false,
+  isMalformedEntityId: false
+};
+
+export const EntityViewerIdsContext =
+  React.createContext<EntityViewerIdsContextType>(defaultContext);

--- a/src/content/app/entity-viewer/contexts/entity-viewer-ids-context/EntityViewerIdsContextProvider.tsx
+++ b/src/content/app/entity-viewer/contexts/entity-viewer-ids-context/EntityViewerIdsContextProvider.tsx
@@ -1,0 +1,139 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import {
+  parseFocusObjectId,
+  buildFocusObjectId,
+  parseFocusIdFromUrl,
+  buildFocusIdForUrl
+} from 'src/shared/helpers/focusObjectHelpers';
+
+import { useAppSelector } from 'src/store';
+import usePrevious from 'src/shared/hooks/usePrevious';
+import { useUrlParams } from 'src/shared/hooks/useUrlParams';
+import { useGenomeInfoQuery } from 'src/shared/state/genome/genomeApiSlice';
+
+import {
+  getEntityViewerActiveGenomeId,
+  getEntityViewerActiveEntityId,
+  getEntityViewerActiveEntityIds
+} from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors';
+import { getCommittedSpeciesById } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
+
+import {
+  EntityViewerIdsContext,
+  type EntityViewerIdsContextType
+} from './EntityViewerIdsContext';
+
+import type { FetchBaseQueryError } from '@reduxjs/toolkit/query';
+
+const EntityViewerIdsContextProvider = (props: {
+  children: React.ReactNode;
+}) => {
+  const activeGenomeId = useAppSelector(getEntityViewerActiveGenomeId);
+  const allActiveEntityIds = useAppSelector(getEntityViewerActiveEntityIds);
+  const activeEntityId = useAppSelector(getEntityViewerActiveEntityId);
+  const savedGenomeInfo = useAppSelector((state) =>
+    getCommittedSpeciesById(state, activeGenomeId ?? '')
+  );
+  const previousActiveGenomeId = usePrevious(activeGenomeId);
+  const previousActiveEntityId = usePrevious(activeEntityId);
+  const params = useUrlParams<'genomeId' | 'entityId'>([
+    '/entity-viewer/:genomeId',
+    '/entity-viewer/:genomeId/:entityId'
+  ]);
+  const { genomeId: genomeIdInUrl, entityId: entityIdInUrl } = params;
+
+  const { currentData: genomeInfo, error } = useGenomeInfoQuery(
+    genomeIdInUrl ?? '',
+    {
+      skip: !genomeIdInUrl
+    }
+  );
+
+  const genomeId = genomeInfo?.genomeId;
+  const genomeIdForUrl =
+    genomeIdInUrl ??
+    genomeInfo?.genomeTag ??
+    genomeInfo?.genomeId ??
+    savedGenomeInfo?.genome_tag ??
+    savedGenomeInfo?.genome_id;
+
+  let entityId;
+  let parsedEntityId;
+  let isMalformedEntityId = false;
+
+  if (genomeId && params.entityId) {
+    try {
+      parsedEntityId = {
+        genomeId,
+        ...parseFocusIdFromUrl(params.entityId)
+      };
+      entityId = buildFocusObjectId(parsedEntityId);
+    } catch {
+      isMalformedEntityId = true;
+    }
+  }
+
+  // FIXME: sometimes we actually want to generate entity id for url from a provided genome id
+  // (e.g. from active entity id); whereas other times, we want to use the entity id from the url
+  const entityIdForUrl =
+    genomeId && allActiveEntityIds[genomeId]
+      ? buildFocusIdForUrl(parseFocusObjectId(allActiveEntityIds[genomeId]))
+      : undefined;
+
+  const hasActiveGenomeIdChanged = Boolean(
+    activeGenomeId &&
+      previousActiveGenomeId &&
+      activeGenomeId !== previousActiveGenomeId
+  );
+
+  const hasActiveEntityIdChanged = Boolean(
+    activeEntityId &&
+      previousActiveEntityId &&
+      activeEntityId !== previousActiveEntityId
+  );
+
+  const isMissingGenomeId =
+    typeof (error as FetchBaseQueryError)?.status === 'number' &&
+    (error as FetchBaseQueryError).status >= 400; // FIXME change status to 404 when the backend behaves
+
+  const context: EntityViewerIdsContextType = {
+    activeGenomeId,
+    activeEntityId,
+    genomeIdInUrl,
+    entityIdInUrl,
+    genomeIdForUrl,
+    entityIdForUrl,
+    genomeId,
+    entityId,
+    parsedEntityId,
+    hasActiveGenomeIdChanged,
+    hasActiveEntityIdChanged,
+    isMissingGenomeId,
+    isMalformedEntityId
+  };
+
+  return (
+    <EntityViewerIdsContext.Provider value={context}>
+      {props.children}
+    </EntityViewerIdsContext.Provider>
+  );
+};
+
+export default EntityViewerIdsContextProvider;

--- a/src/content/app/entity-viewer/hooks/useEntityViewerIds.ts
+++ b/src/content/app/entity-viewer/hooks/useEntityViewerIds.ts
@@ -14,123 +14,20 @@
  * limitations under the License.
  */
 
-import {
-  parseFocusObjectId,
-  buildFocusObjectId,
-  parseFocusIdFromUrl,
-  buildFocusIdForUrl
-} from 'src/shared/helpers/focusObjectHelpers';
+import { useContext } from 'react';
 
-import { useAppSelector } from 'src/store';
-import usePrevious from 'src/shared/hooks/usePrevious';
-import { useUrlParams } from 'src/shared/hooks/useUrlParams';
-import { useGenomeInfoQuery } from 'src/shared/state/genome/genomeApiSlice';
-
-import {
-  getEntityViewerActiveGenomeId,
-  getEntityViewerActiveEntityId,
-  getEntityViewerActiveEntityIds
-} from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors';
-import { getCommittedSpeciesById } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
-
-import type { FetchBaseQueryError } from '@reduxjs/toolkit/query';
-
-/**
- * Lots of ids going on here. Here’s what they mean
- *
- * - genomeIdInUrl — could be the actual id of a genome, or a url slug used instead of genome id for url stability over time
- * - genomeIdForUrl — same; but generated considering what the active genome id is
- * - entityIdInUrl — combines the type of the entity with the stable id of the entity
- * - genomeId — actual id of a genome, as retrieved from the backend
- * - entityId — the full id that is used on the client as a key when storing entity information;
- *   is comprised of genome id, entity type, and entity stable id
- * - activeGenomeId — the genome id that the user is currently focused on
- * - activeEntityId — the full id of the entity that the user is currently focused on
- *
- */
+import { EntityViewerIdsContext } from 'src/content/app/entity-viewer/contexts/entity-viewer-ids-context/EntityViewerIdsContext';
 
 const useEntityViewerIds = () => {
-  const activeGenomeId = useAppSelector(getEntityViewerActiveGenomeId);
-  const allActiveEntityIds = useAppSelector(getEntityViewerActiveEntityIds);
-  const activeEntityId = useAppSelector(getEntityViewerActiveEntityId);
-  const savedGenomeInfo = useAppSelector((state) =>
-    getCommittedSpeciesById(state, activeGenomeId ?? '')
-  );
-  const previousActiveGenomeId = usePrevious(activeGenomeId);
-  const previousActiveEntityId = usePrevious(activeEntityId);
-  const params = useUrlParams<'genomeId' | 'entityId'>([
-    '/entity-viewer/:genomeId',
-    '/entity-viewer/:genomeId/:entityId'
-  ]);
-  const { genomeId: genomeIdInUrl, entityId: entityIdInUrl } = params;
+  const entityViewerIdsContext = useContext(EntityViewerIdsContext);
 
-  const { currentData: genomeInfo, error } = useGenomeInfoQuery(
-    genomeIdInUrl ?? '',
-    {
-      skip: !genomeIdInUrl
-    }
-  );
-
-  const genomeId = genomeInfo?.genomeId;
-  const genomeIdForUrl =
-    genomeIdInUrl ??
-    genomeInfo?.genomeTag ??
-    genomeInfo?.genomeId ??
-    savedGenomeInfo?.genome_tag ??
-    savedGenomeInfo?.genome_id;
-
-  let entityId;
-  let parsedEntityId;
-  let isMalformedEntityId = false;
-
-  if (genomeId && params.entityId) {
-    try {
-      parsedEntityId = {
-        genomeId,
-        ...parseFocusIdFromUrl(params.entityId)
-      };
-      entityId = buildFocusObjectId(parsedEntityId);
-    } catch {
-      isMalformedEntityId = true;
-    }
+  if (!entityViewerIdsContext) {
+    throw new Error(
+      'useEntityViewerIds must be used with EntityViewerIdsContext Provider'
+    );
   }
 
-  // FIXME: sometimes we actually want to generate entity id for url from a provided genome id
-  // (e.g. from active entity id); whereas other times, we want to use the entity id from the url
-  const entityIdForUrl =
-    genomeId && allActiveEntityIds[genomeId]
-      ? buildFocusIdForUrl(parseFocusObjectId(allActiveEntityIds[genomeId]))
-      : undefined;
-
-  const hasActiveGenomeIdChanged =
-    activeGenomeId &&
-    previousActiveGenomeId &&
-    activeGenomeId !== previousActiveGenomeId;
-
-  const hasActiveEntityIdChanged =
-    activeEntityId &&
-    previousActiveEntityId &&
-    activeEntityId !== previousActiveEntityId;
-
-  const isMissingGenomeId =
-    typeof (error as FetchBaseQueryError)?.status === 'number' &&
-    (error as FetchBaseQueryError).status >= 400; // FIXME change status to 404 when the backend behaves
-
-  return {
-    activeGenomeId,
-    activeEntityId,
-    genomeIdInUrl,
-    entityIdInUrl,
-    genomeIdForUrl,
-    entityIdForUrl,
-    genomeId,
-    entityId,
-    parsedEntityId,
-    hasActiveGenomeIdChanged,
-    hasActiveEntityIdChanged,
-    isMissingGenomeId,
-    isMalformedEntityId
-  };
+  return entityViewerIdsContext;
 };
 
 export default useEntityViewerIds;

--- a/src/content/app/entity-viewer/hooks/useEntityViewerUrlChecks.ts
+++ b/src/content/app/entity-viewer/hooks/useEntityViewerUrlChecks.ts
@@ -16,6 +16,7 @@
 
 import useEntityViewerIds from 'src/content/app/entity-viewer/hooks/useEntityViewerIds';
 import { useGeneSummaryQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
+import usePrevious from 'src/shared/hooks/usePrevious';
 
 /**
  * A hook for validating individual parts of the url.
@@ -31,6 +32,11 @@ const useEntityViewerUrlCheck = () => {
     entityIdInUrl,
     parsedEntityId
   } = useEntityViewerIds();
+  const previousGenomeIdInUrl = usePrevious(genomeIdInUrl);
+  const previousEntityIdInUrl = usePrevious(entityIdInUrl);
+  const hasUrlChanged =
+    genomeIdInUrl !== previousGenomeIdInUrl ||
+    entityIdInUrl !== previousEntityIdInUrl;
 
   const isGene = parsedEntityId?.type === 'gene';
   let geneId;
@@ -49,7 +55,7 @@ const useEntityViewerUrlCheck = () => {
       geneId: geneId ?? ''
     },
     {
-      skip: !genomeId || !geneId
+      skip: !genomeId || !geneId || !hasUrlChanged
     }
   );
 

--- a/src/shared/state/api-slices/thoasSlice.ts
+++ b/src/shared/state/api-slices/thoasSlice.ts
@@ -33,14 +33,19 @@ const graphqlBaseQuery =
       return { data: result };
     } catch (error) {
       if (error instanceof ClientError) {
+        const { name, message, stack, request, response } = error;
         return {
           error: {
             status: error.response.status,
             meta: {
               data: error.response.data ?? null,
               errors: error.response.errors
-            }
-          }
+            },
+            name,
+            message,
+            stack
+          },
+          meta: { request, response }
         };
       }
       return {


### PR DESCRIPTION
## Description
**Bug** _(discovered while testing the Entity Viewer with disabled network requests):_ 
- open Entity Viewer
- open dev tools, and in the network panel, block requests to thoas
- refresh the page
- **bug:** notice that the browser is continuously querying thoas, sending to it an infinite number of requests 

https://user-images.githubusercontent.com/6834224/216271453-03c2f465-21ab-4041-b121-4f0cb1aeac72.mov


## Cause
All changes responsible for fixing this bug are in the `useEntityViewerUrlChecks` hook. The cause of the problem was that  it uses a hook — `useGeneSummaryQuery` that is also used in another component. The sequence of events causing the bug was like this:

`useEntityViewerUrlChecks` starts checking the url using `useGeneSummaryQuery`; while the check is ongoing, it returns `isVerifyingUrl` as true; `EntityViewer` component returns null while it waits for response from `useEntityViewerUrlChecks`; then the response arrives, and `isVerifyingUrl` gets set to false; `EntityViewer` renders `GeneView` component, which sends another query to `useGeneSummaryQuery`; but this resets `isVerifyingUrl` to true; this makes `EntityViewer` to unmount `GeneView` and to return `null`; and so on in a circle...

## Other changes
While not related to the bug itself, this PR contains two other changes:
- `useEntityViewerIds` changed to use the context, as on the genome browser page
- minor updates to `graphqlBaseQuery` function, to include more information in the errors (similar to what's done in `@rtk-query/graphql-request-base-query`)

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1805

## Deployment URL(s)
http://fix-infinite-thoas-requests.review.ensembl.org