### PR TITLE
Move the blast form step toggle buttons to the left

### DIFF
--- a/src/content/app/tools/blast/views/blast-form/BlastForm.scss
+++ b/src/content/app/tools/blast/views/blast-form/BlastForm.scss
@@ -40,6 +40,7 @@
   padding-top: 20px;
   background-color: $white;
   position: sticky;
+  top: 0;
   z-index: 1;
 }
 

--- a/src/content/app/tools/blast/views/blast-form/BlastForm.scss
+++ b/src/content/app/tools/blast/views/blast-form/BlastForm.scss
@@ -36,14 +36,10 @@
 
 .blastFormStepToggle {
   display: flex;
-  justify-content: flex-end;
   gap: 10px;
-  max-width: 1770px; //TODO: To replace with global variables for spaces on the blast form (see ENSWBSITES-1602)
-  margin-left: -2px;
   padding-top: 20px;
   background-color: $white;
   position: sticky;
-  top: 0px;
   z-index: 1;
 }
 


### PR DESCRIPTION
## Description
This is a small change to move the step toggle buttons (that appear in smaller screens) in the BLAST form from the right to the left.


## Related JIRA Issue(s)
[ENSWBSITES-1829](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1829)

## Deployment URL(s)
http://blast-form-workflow.review.ensembl.org


## Views affected
BLAST form in smaller screens