### PR TITLE
Update launchbar buttons

### DIFF
--- a/src/header/launchbar/Launchbar.scss
+++ b/src/header/launchbar/Launchbar.scss
@@ -28,21 +28,24 @@
   flex: 0 0 auto;
 }
 
+.launchbarButtonWrapperLink {
+  font-size: 0;
+}
+
 .launchbarButton {
   display: inline-block;
   height: 32px;
   width: 32px;
-  --image-button-width: 32px;
-  --image-button-height: 32px;
+  background-color: $blue;
+  fill: $white;
+}
 
-  --image-button-unselected-bg-color: #{$blue};
-  --image-button-unselected-svg-color: #{$white};
+.launchbarButtonSelected {
+  background-color: $black;
+}
 
-  --image-button-selected-bg-color: #{$black};
-  --image-button-selected-svg-color: #{$white};
-
-  --image-button-disabled-bg-color: #{$grey};
-  --image-button-disabled-svg-color: #{$white};
+.launchbarButtonDisabled {
+  background-color: $grey;
 }
 
 .category {

--- a/src/header/launchbar/Launchbar.tsx
+++ b/src/header/launchbar/Launchbar.tsx
@@ -19,11 +19,11 @@ import { Link } from 'react-router-dom';
 
 import {
   GenomeBrowserIcon,
-  SpeciesSelectorIcon,
   GlobalSearchIcon,
   HelpIcon
 } from 'src/shared/components/app-icon';
 import LaunchbarButton from './LaunchbarButton';
+import SpeciesSelectorLaunchbarButton from './SpeciesSelectorLaunchbarButton';
 import EntityViewerLaunchbarButton from './EntityViewerLaunchbarButton';
 import BlastLaunchbarButton from './BlastLaunchbarButton';
 
@@ -48,12 +48,7 @@ const Launchbar = () => {
               icon={GlobalSearchIcon}
               enabled={false}
             />
-            <LaunchbarButton
-              path="/species-selector"
-              description="Species selector"
-              icon={SpeciesSelectorIcon}
-              enabled={true}
-            />
+            <SpeciesSelectorLaunchbarButton />
           </div>
           <div className={styles.category}>
             <LaunchbarButton

--- a/src/header/launchbar/SpeciesSelectorLaunchbarButton.tsx
+++ b/src/header/launchbar/SpeciesSelectorLaunchbarButton.tsx
@@ -1,0 +1,49 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { useLocation } from 'react-router';
+
+import * as urlHelper from 'src/shared/helpers/urlHelper';
+
+import LaunchbarButton from './LaunchbarButton';
+import { SpeciesSelectorIcon } from 'src/shared/components/app-icon';
+
+/**
+ * Intended behaviour of SpeciesSelectorLaunchbarButton is
+ * - to be marked as active (black) both for the Species Selector page and for the Species page
+ *  - i.e. the button pretends that Species Selector and Species page are one and the same 'app'
+ *  - (which means that both on Species Selector page and on Species page, clicks on this button don't do anything)
+ * - when not active, this button should take the user to the Species Selector page
+ */
+
+const SpeciesSelectorLaunchbarButton = () => {
+  const location = useLocation();
+  const urlPathnameParts = location.pathname.split('/').filter(Boolean);
+  const firstPathnamePart = urlPathnameParts[0];
+
+  return (
+    <LaunchbarButton
+      path={urlHelper.speciesSelector()}
+      description="Species selector"
+      icon={SpeciesSelectorIcon}
+      enabled={true}
+      isActive={['species', 'species-selector'].includes(firstPathnamePart)}
+    />
+  );
+};
+
+export default SpeciesSelectorLaunchbarButton;


### PR DESCRIPTION
## Description
The specific focus of this PR is to make sure that the SpeciesSelector button in the launchbar:
- appears pressed both when the user is on the Species Selector page and on the Species page (Species page is considered by designers to be part of Species Selector "app")
- does not respond to clicks when appears pressed
- when it does respond to clicks (i.e. when the user is in a different "app"), it always navigates to the Species Selector page (i.e. `/species-selector`) regardless of whether the user had been on the species selector or on the species page when he left this "app"

It also refactors the `LaunchbarButton` component:
- Currently, the html structure of `LaunchbarButton` is a `button` element wrapped in an `a` element, which doesn't make much sense. This PR replaces the `ImageButton` component inside `LaunchbarButton` with just a plain svg icon

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1318

## Deployment URL(s)
http://species-selector-nav-button.review.ensembl.org