### PR TITLE
Update genome browser to version 0.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ensembl/ensembl-genome-browser": "0.6.0",
+        "@ensembl/ensembl-genome-browser": "0.6.1",
         "@react-spring/web": "9.4.5-beta.1",
         "@reduxjs/toolkit": "1.9.0",
         "@sentry/browser": "7.21.1",
@@ -2426,9 +2426,9 @@
       }
     },
     "node_modules/@ensembl/ensembl-genome-browser": {
-      "version": "0.6.0",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.0.tgz",
-      "integrity": "sha1-hWVXJUeugrxOZ1XKMBDZ3HzNoMU="
+      "version": "0.6.1",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.1.tgz",
+      "integrity": "sha1-JK79OHxBHpN6DTXl95fQPN8GJS0="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
@@ -43098,9 +43098,9 @@
       "dev": true
     },
     "@ensembl/ensembl-genome-browser": {
-      "version": "0.6.0",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.0.tgz",
-      "integrity": "sha1-hWVXJUeugrxOZ1XKMBDZ3HzNoMU="
+      "version": "0.6.1",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.1.tgz",
+      "integrity": "sha1-JK79OHxBHpN6DTXl95fQPN8GJS0="
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "coverage": "jest --coverage"
   },
   "dependencies": {
-    "@ensembl/ensembl-genome-browser": "0.6.0",
+    "@ensembl/ensembl-genome-browser": "0.6.1",
     "@react-spring/web": "9.4.5-beta.1",
     "@reduxjs/toolkit": "1.9.0",
     "@sentry/browser": "7.21.1",

--- a/src/content/app/genome-browser/components/browser-track-legend/BrowserTrackLegend.tsx
+++ b/src/content/app/genome-browser/components/browser-track-legend/BrowserTrackLegend.tsx
@@ -92,9 +92,7 @@ const BrowserTrackLegend = (props: Props) => {
 const isTrackLegendHotspot = (
   payload: HotspotPayload
 ): payload is TrackLegendHotspotPayload => {
-  return !!payload.variety.find(
-    (variety: any) => variety.type === 'track-hover'
-  );
+  return payload.variety[0].type === 'track-hover';
 };
 
 const Message = () => (

--- a/src/content/app/genome-browser/components/zmenu/ZmenuController.tsx
+++ b/src/content/app/genome-browser/components/zmenu/ZmenuController.tsx
@@ -81,9 +81,7 @@ const ZmenuController = (props: Props) => {
 const isZmenuPayload = (
   payload: HotspotPayload
 ): payload is ZmenuCreatePayload => {
-  // NOTE: check for payload.variety.length should be unnecessary;
-  // but as of now, genome browser can't separate track's left corner hotspot from transcript zmenu hotspot
-  return payload.variety.length === 1 && payload.variety[0].type === 'zmenu';
+  return payload.variety[0].type === 'zmenu';
 };
 
 export default memo(ZmenuController);


### PR DESCRIPTION
## Description
Update genome browser to version 0.6.1

0.6.1 has fixed the problem with hotspots, when mousing over the left corner of a track produced messages from the genome browser that contained both the transcript zmenu payload and the `track-hover` payload.

As a result, the defensive code that guarded the client against such mixed payload has been removed in this PR

### Related PRs:
Genome browser: https://github.com/Ensembl/ensembl-genome-browser/pull/22

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1844

## Deployment URL(s)
http://gb-0-6-1.review.ensembl.org