### PR TITLE
Disable checkboxes in BLAST results table

### DIFF
--- a/src/shared/components/checkbox/Checkbox.scss
+++ b/src/shared/components/checkbox/Checkbox.scss
@@ -7,6 +7,7 @@
 .grid {
   display: inline-grid;
   grid-template-columns: auto 1fr;
+  font-size: 0;
 }
 
 .checkboxDefault {
@@ -33,6 +34,7 @@
 }
 
 .checkboxDisabled {
+  border-color: var(--checkbox-disabled-border-color, #{$medium-light-grey});
   background-color: var(--checkbox-disabled-background-color, #{$light-grey});
   cursor: default;
   pointer-events: none;

--- a/src/shared/components/data-table/components/main/components/table-header/TableHeader.scss
+++ b/src/shared/components/data-table/components/main/components/table-header/TableHeader.scss
@@ -35,6 +35,24 @@
   }
 }
 
+.rowsCount {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.1;
+}
+
+.rowsCount > span {
+  white-space: nowrap;
+}
+
+.rowsCountText {
+  font-size: 10px;
+}
+
+.rowsCountNumberProminent {
+  font-weight: $normal;
+}
+
 .questionButton {
   margin-left: 15px;
   height: 14px;

--- a/src/shared/components/data-table/components/main/components/table-header/TableHeader.tsx
+++ b/src/shared/components/data-table/components/main/components/table-header/TableHeader.tsx
@@ -16,6 +16,8 @@
 
 import React, { useContext } from 'react';
 
+import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
+
 import { TableContext } from 'src/shared/components/data-table/DataTable';
 import TableHeaderCell from './components/table-header-cell/TableHeaderCell';
 
@@ -76,20 +78,24 @@ const HeaderStats = (props: {
 }) => {
   const { totalRows, hiddenRowIds } = props;
 
-  /*
-    To calculate the width in `ch`, we calculate the total number of characters that are possible in the stats
-    and multiply it by 3 and add 5 for the extra ` to ` & `/`
-  */
-  const totalCharacters = String(totalRows).length * 3 + 5;
-
-  const totalHiddenRows = Object.keys(hiddenRowIds).length;
+  const hiddenRowsCount = Object.keys(hiddenRowIds).length;
+  const visibleRowsCount = totalRows - hiddenRowsCount;
 
   return (
-    <th style={{ width: `${totalCharacters}ch`, minWidth: '75px' }}>
-      <span className={styles.totalVisibleRows}>
-        {totalRows - totalHiddenRows}
-      </span>
-      /{totalRows}
+    <th style={{ minWidth: '75px' }}>
+      <div className={styles.rowsCount}>
+        <span>
+          <span className={styles.rowsCountText}>Showing </span>
+          <span className={styles.rowsCountNumberProminent}>
+            {getCommaSeparatedNumber(visibleRowsCount)}
+          </span>
+          <span className={styles.rowsCountText}> of</span>
+        </span>
+        <span>
+          <span>{getCommaSeparatedNumber(totalRows)}</span>
+          <span className={styles.rowsCountText}> rows</span>
+        </span>
+      </div>
     </th>
   );
 };

--- a/src/shared/components/data-table/components/main/components/table-row/components/row-selector/RowSelector.tsx
+++ b/src/shared/components/data-table/components/main/components/table-row/components/row-selector/RowSelector.tsx
@@ -68,7 +68,9 @@ const RowSelector = (props: RowSelectorProps) => {
           onChange={(checked: boolean) =>
             props.onChange({ checked, rowId: props.rowId })
           }
-          disabled={true}
+          disabled={
+            true /* at the moment, there is no use case for working checkboxes */
+          }
           checked={isCurrentRowSelected}
         />
       )}

--- a/src/shared/components/data-table/components/main/components/table-row/components/row-selector/RowSelector.tsx
+++ b/src/shared/components/data-table/components/main/components/table-row/components/row-selector/RowSelector.tsx
@@ -68,6 +68,7 @@ const RowSelector = (props: RowSelectorProps) => {
           onChange={(checked: boolean) =>
             props.onChange({ checked, rowId: props.rowId })
           }
+          disabled={true}
           checked={isCurrentRowSelected}
         />
       )}


### PR DESCRIPTION
## Description
This PR introduces minor modifications to the `DataTable`

### Checkboxes
At the moment, the precise behaviour of checkboxes is still unclear (the most up-to-date description is currently in [ENSWBSITES-1852](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1852). What is certain though is that checkboxes should not just be active by default. Thus, in this PR, I am disabling the checkboxes altogether (see [ENSWBSITES-1854](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1854)

### Header of the row selection column
**Before:**

![image](https://user-images.githubusercontent.com/6834224/218449510-082681a7-e84d-4e02-ac8f-46c3fa92a41b.png)

**After:**

![image](https://user-images.githubusercontent.com/6834224/218449846-6adad4ac-a549-442f-9b3c-0af2ea49aacd.png)


## Related JIRA Issue(s)
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1854
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1759

## Deployment URL(s)
http://blast-table-disable-checkboxes.review.ensembl.org


## Views affected
<!--
_List the website view(s) that you know are affected by this change._
_If possible please provide a relative or localhost URL that can be used to view the change._
-->