### PR TITLE
Fix BLAST results table for cDNA

### DIFF
--- a/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
@@ -437,6 +437,11 @@ const HitsTable = (props: HitsTableProps) => {
     tableColumns[genomicLocationColumnIndex] = {
       columnId: 'protein_id',
       title: 'Protein ID',
+      isSortable: true,
+      renderer: tableColumns[genomicLocationColumnIndex].renderer,
+      downloadRenderer:
+        tableColumns[genomicLocationColumnIndex].downloadRenderer,
+      sortFn: tableColumns[genomicLocationColumnIndex].sortFn,
       helpText: (
         <span>Proteins in this species that contain sequence similarity</span>
       )
@@ -445,6 +450,11 @@ const HitsTable = (props: HitsTableProps) => {
     tableColumns[genomicLocationColumnIndex] = {
       columnId: 'transcript_id',
       title: 'Transcript ID',
+      isSortable: true,
+      renderer: tableColumns[genomicLocationColumnIndex].renderer,
+      downloadRenderer:
+        tableColumns[genomicLocationColumnIndex].downloadRenderer,
+      sortFn: tableColumns[genomicLocationColumnIndex].sortFn,
       helpText: (
         <span>
           Transcripts in this species that contain sequence similarity


### PR DESCRIPTION
## Description
### Bug reproduction steps
- Create a new BLAST submission agains a database of cDNAs or proteins
- Wait until jobs in this submission are completed, and open the results page
- Open the table with results of a single job
- Bug: the page explodes

### Cause
The bug must have been introduced in https://github.com/Ensembl/ensembl-client/pull/919, when we added table sorting by genomic location. This necessitated changing the shape of the data passed in the genomic location column. The same column is used for showing transcript ids and protein ids; but it has not been appropriately updated to handle these two cases.

This PR makes a minimum amount of changes needed to fix the bug. It isn't very clean or pretty.

## Deployment URL(s)
http://fix-blast-results-cdna-protein.review.ensembl.org