### PR TITLE
Add default sorting option for downloaded tables

### DIFF
--- a/src/content/app/tools/blast/blast-download/createBlastCSVTable.ts
+++ b/src/content/app/tools/blast/blast-download/createBlastCSVTable.ts
@@ -66,6 +66,8 @@ export const createCSVForGenomicBlast = (blastJobResult: BlastJobResult) => {
     }
   }
 
+  sortTableRows(rows);
+
   return formatCSV(rows);
 };
 
@@ -114,6 +116,8 @@ export const createCSVForTranscriptBlast = (blastJobResult: BlastJobResult) => {
       rows.push(newRow);
     }
   }
+
+  sortTableRows(rows);
 
   return formatCSV(rows);
 };
@@ -164,6 +168,8 @@ export const createCSVForProteinBlast = (blastJobResult: BlastJobResult) => {
     }
   }
 
+  sortTableRows(rows);
+
   return formatCSV(rows);
 };
 
@@ -185,4 +191,18 @@ const getCommonFields = ({
 
 const formatCSV = (table: (string | number)[][]) => {
   return table.map((row) => row.join(',')).join('\n');
+};
+
+// by default, downloaded tables of BLAST results should be sorted according to the e-value
+const sortTableRows = (rows: Array<string | number>[]) => {
+  rows.sort((row1, row2) => {
+    const [evalue1] = row1;
+    const [evalue2] = row2;
+
+    if (typeof evalue1 === 'string' || typeof evalue2 === 'string') {
+      return 0;
+    } else {
+      return evalue1 - evalue2;
+    }
+  });
 };

--- a/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
@@ -336,10 +336,6 @@ const HitsTable = (props: HitsTableProps) => {
     sortingOptions: {
       columnId: 'e_value',
       sortingOrder: SortingOrder.ASC
-    },
-    defaultSortingOptionsForDownload: {
-      columnId: 'e_value',
-      sortingOrder: SortingOrder.ASC
     }
   });
 

--- a/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
@@ -58,7 +58,7 @@ import {
   type TableCellRendererParams,
   type TableRowsSortingFunction,
   type TableCellStructuredData,
-  SortingDirection,
+  SortingOrder,
   TableAction
 } from 'src/shared/components/data-table/dataTableTypes';
 
@@ -86,7 +86,7 @@ const sortByGenomicLocation: TableRowsSortingFunction = (
   const iteratee = (data: TableRow) =>
     getStructuredContentFromCellInRow<{ hit: BlastHit }>(data, columnIndex).hit
       .hit_acc;
-  const orderDirection = direction === SortingDirection.DESC ? 'desc' : 'asc';
+  const orderDirection = direction === SortingOrder.DESC ? 'desc' : 'asc';
   return orderBy(rows, [iteratee], [orderDirection]);
 };
 
@@ -333,9 +333,13 @@ const HitsTable = (props: HitsTableProps) => {
 
   const [tableState, setTableState] = useState<Partial<DataTableState>>({
     rowsPerPage: 100,
-    sortedColumn: {
+    sortingOptions: {
       columnId: 'e_value',
-      sortedDirection: SortingDirection.ASC
+      sortingOrder: SortingOrder.ASC
+    },
+    defaultSortingOptionsForDownload: {
+      columnId: 'e_value',
+      sortingOrder: SortingOrder.ASC
     }
   });
 

--- a/src/shared/components/data-table/DataTable.test.tsx
+++ b/src/shared/components/data-table/DataTable.test.tsx
@@ -29,7 +29,7 @@ import {
   type TableData,
   type TableCellStructuredData,
   type DataTableColumns,
-  SortingDirection
+  SortingOrder
 } from './dataTableTypes';
 
 export const createDataTableSampleData = (
@@ -191,7 +191,7 @@ describe('<DataTable />', () => {
           const data = cellData.data as { text: string };
           return <span className="part1">{data.text}</span>;
         },
-        sortFn: (rows, columnIndex, direction) => {
+        sortFn: (rows, columnIndex, order) => {
           return [...rows].sort((rowA, rowB) => {
             const { rank: rank1 } = getStructuredContentFromCellInRow<{
               rank: number;
@@ -199,9 +199,7 @@ describe('<DataTable />', () => {
             const { rank: rank2 } = getStructuredContentFromCellInRow<{
               rank: number;
             }>(rowB, columnIndex);
-            return direction === SortingDirection.ASC
-              ? rank1 - rank2
-              : rank2 - rank1;
+            return order === SortingOrder.ASC ? rank1 - rank2 : rank2 - rank1;
           });
         }
       }

--- a/src/shared/components/data-table/components/main/components/table-header/components/table-header-cell/TableHeaderCell.tsx
+++ b/src/shared/components/data-table/components/main/components/table-header/components/table-header-cell/TableHeaderCell.tsx
@@ -21,7 +21,7 @@ import QuestionButton from 'src/shared/components/question-button/QuestionButton
 import { TableContext } from 'src/shared/components/data-table/DataTable';
 import {
   type IndividualColumn,
-  SortingDirection
+  SortingOrder
 } from 'src/shared/components/data-table/dataTableTypes';
 
 import SortIcon from 'static/icons/icon_arrow.svg';
@@ -32,29 +32,26 @@ const TableHeaderCell = (props: IndividualColumn) => {
   const { title, helpText, isSortable, columnId, width, headerCellClassName } =
     props;
 
-  const { dispatch, sortedColumn } = useContext(TableContext) || {};
+  const { dispatch, sortingOptions } = useContext(TableContext) || {};
 
-  const { columnId: sortedColumnId, sortedDirection } = sortedColumn || {};
+  const { columnId: sortedColumnId, sortingOrder } = sortingOptions || {};
 
   if (!dispatch) {
     return null;
   }
 
-  let currentColumnSortingDirection = SortingDirection.NONE;
-  if (columnId === sortedColumnId && sortedDirection === SortingDirection.ASC) {
-    currentColumnSortingDirection = SortingDirection.ASC;
+  let currentColumnSortingDirection = SortingOrder.NONE;
+  if (columnId === sortedColumnId && sortingOrder === SortingOrder.ASC) {
+    currentColumnSortingDirection = SortingOrder.ASC;
   }
 
   const onSort = () => {
-    let directionToSet = SortingDirection.NONE;
-    if (
-      columnId !== sortedColumnId ||
-      sortedDirection === SortingDirection.NONE
-    ) {
-      directionToSet = SortingDirection.DESC;
-    } else if (sortedDirection === SortingDirection.DESC) {
-      directionToSet = SortingDirection.ASC;
-    } else if (sortedDirection === SortingDirection.ASC) {
+    let directionToSet = SortingOrder.NONE;
+    if (columnId !== sortedColumnId || sortingOrder === SortingOrder.NONE) {
+      directionToSet = SortingOrder.DESC;
+    } else if (sortingOrder === SortingOrder.DESC) {
+      directionToSet = SortingOrder.ASC;
+    } else if (sortingOrder === SortingOrder.ASC) {
       dispatch({
         type: 'clear_sorted_column'
       });
@@ -65,14 +62,14 @@ const TableHeaderCell = (props: IndividualColumn) => {
       type: 'set_sorted_column',
       payload: {
         columnId,
-        sortedDirection: directionToSet
+        sortingOrder: directionToSet
       }
     });
   };
 
   const sortArrowClassNames = classNames(styles.sortArrow, {
     [styles.sortArrowActive]: columnId === sortedColumnId,
-    [styles.sortArrowUp]: currentColumnSortingDirection === SortingDirection.ASC
+    [styles.sortArrowUp]: currentColumnSortingDirection === SortingOrder.ASC
   });
 
   const headerCellClassNames = classNames(styles.headerCell, {

--- a/src/shared/components/data-table/components/table-controls/components/table-actions/TableActions.tsx
+++ b/src/shared/components/data-table/components/table-controls/components/table-actions/TableActions.tsx
@@ -70,7 +70,7 @@ const TableActions = () => {
     disabledActions,
     rowsPerPage,
     currentPageNumber,
-    sortedColumn,
+    sortingOptions,
     searchText,
     selectedRowIds,
     hiddenRowIds,
@@ -88,7 +88,7 @@ const TableActions = () => {
     setRestorableTableState({
       currentPageNumber,
       rowsPerPage,
-      sortedColumn,
+      sortingOptions,
       searchText,
       selectedRowIds,
       hiddenRowIds,

--- a/src/shared/components/data-table/components/table-controls/components/table-actions/components/download-data/DownloadData.tsx
+++ b/src/shared/components/data-table/components/table-controls/components/table-actions/components/download-data/DownloadData.tsx
@@ -17,6 +17,7 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import useDataTable from 'src/shared/components/data-table/hooks/useDataTable';
 import { downloadTextAsFile } from 'src/shared/helpers/downloadAsFile';
+import { sortDataTableRows } from 'src/shared/components/data-table/helpers/sortDataTableRows';
 
 import { ControlledLoadingButton } from 'src/shared/components/loading-button';
 
@@ -31,6 +32,7 @@ const DownloadData = () => {
     rows,
     downloadFileName,
     columns,
+    defaultSortingOptionsForDownload,
     selectedAction,
     hiddenRowIds,
     downloadHandler
@@ -88,7 +90,15 @@ const DownloadData = () => {
         ? rows
         : rows.filter((row) => !hiddenRowIds.has(row.rowId));
 
-    rowsToDownload.forEach((row, rowIndex) => {
+    const sortedRowsToDownload = defaultSortingOptionsForDownload
+      ? sortDataTableRows({
+          rows: rowsToDownload,
+          columns,
+          sortingOptions: defaultSortingOptionsForDownload
+        })
+      : rowsToDownload;
+
+    sortedRowsToDownload.forEach((row, rowIndex) => {
       dataForExport[rowIndex + 1] = [];
       row.cells.forEach((cell, cellIndex) => {
         const { downloadRenderer, isExportable } = columns[cellIndex];

--- a/src/shared/components/data-table/dataTableReducer.ts
+++ b/src/shared/components/data-table/dataTableReducer.ts
@@ -23,7 +23,7 @@ export const defaultDataTableState: DataTableState = {
   searchText: '',
   isSelectable: true,
   selectedAction: TableAction.DEFAULT,
-  sortedColumn: null,
+  sortingOptions: null,
   fixedHeader: false,
   selectedRowIds: new Set(),
   hiddenRowIds: new Set(),
@@ -70,9 +70,9 @@ export const tableReducer = (
     case 'set_selected_action':
       return { ...state, selectedAction: action.payload };
     case 'set_sorted_column':
-      return { ...state, sortedColumn: action.payload };
+      return { ...state, sortingOptions: action.payload };
     case 'clear_sorted_column':
-      return { ...state, sortedColumn: null };
+      return { ...state, sortingOptions: null };
     case 'restore_defaults':
       return {
         ...state,

--- a/src/shared/components/data-table/dataTableTypes.ts
+++ b/src/shared/components/data-table/dataTableTypes.ts
@@ -16,15 +16,15 @@
 
 import type { ReactNode } from 'react';
 
-export enum SortingDirection {
+export enum SortingOrder {
   ASC = 'ascending',
   DESC = 'descending',
   NONE = 'none'
 }
 
-export type SortedColumn = {
+export type SortingOptions = {
   columnId: string;
-  sortedDirection: SortingDirection;
+  sortingOrder: SortingOrder;
 };
 
 export enum TableAction {
@@ -62,7 +62,7 @@ export type TableCellRendererParams = {
 export type TableRowsSortingFunction = (
   rows: TableRows,
   columnIndex: number,
-  direction?: SortingDirection
+  order?: SortingOrder
 ) => TableRows;
 
 export type IndividualColumn = {
@@ -96,7 +96,8 @@ export type DataTableState = {
   searchText: string;
   isSelectable: boolean;
   selectedAction: TableAction;
-  sortedColumn: SortedColumn | null;
+  sortingOptions: SortingOptions | null;
+  defaultSortingOptionsForDownload?: SortingOptions | null;
   fixedHeader: boolean;
   selectedRowIds: TableSelectedRowIds;
   hiddenRowIds: TableSelectedRowIds;
@@ -122,7 +123,7 @@ type SetSelectedActionAction = {
 };
 type SetSortedColumnAction = {
   type: 'set_sorted_column';
-  payload: SortedColumn;
+  payload: SortingOptions;
 };
 
 type ClearSortedColumnAction = {

--- a/src/shared/components/data-table/helpers/sortDataTableRows.ts
+++ b/src/shared/components/data-table/helpers/sortDataTableRows.ts
@@ -1,0 +1,58 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import orderBy from 'lodash/orderBy';
+import {
+  type TableRows,
+  type DataTableColumns,
+  type SortingOptions,
+  type TableRowsSortingFunction,
+  SortingOrder
+} from 'src/shared/components/data-table/dataTableTypes';
+
+export const sortDataTableRows = (params: {
+  rows: TableRows;
+  columns: DataTableColumns;
+  sortingOptions: SortingOptions;
+}) => {
+  const { rows, columns, sortingOptions } = params;
+
+  const columnIndex = columns.findIndex(
+    (column) => column.columnId === sortingOptions.columnId
+  );
+
+  if (columnIndex === -1) {
+    // shouldn't happen; but better safe than sorry
+    return rows;
+  }
+
+  const sortFunction = columns[columnIndex].sortFn ?? plainSorter;
+
+  return sortFunction(rows, columnIndex, sortingOptions.sortingOrder);
+};
+
+// useful for sorting strings and numbers in ascending or descending order
+const plainSorter: TableRowsSortingFunction = (
+  tableRows,
+  columnIndex,
+  sortingOrder
+) => {
+  const iteratee = (data: any) => data.cells[columnIndex] as string | number;
+  // translate our magic words to Lodash's magic words
+  const lodashSortingOrder =
+    sortingOrder === SortingOrder.DESC ? 'desc' : 'asc';
+  return orderBy(tableRows, [iteratee], [lodashSortingOrder]);
+};

--- a/src/shared/components/data-table/hooks/useDataTable.ts
+++ b/src/shared/components/data-table/hooks/useDataTable.ts
@@ -15,14 +15,12 @@
  */
 
 import { useContext, useEffect, useState } from 'react';
-import orderBy from 'lodash/orderBy';
+
+import { sortDataTableRows } from '../helpers/sortDataTableRows';
 
 import { TableContext } from 'src/shared/components/data-table/DataTable';
 
-import {
-  SortingDirection,
-  type TableRowsSortingFunction
-} from '../dataTableTypes';
+import { SortingOrder } from '../dataTableTypes';
 
 const useDataTable = () => {
   const dataTableContext = useContext(TableContext);
@@ -37,7 +35,7 @@ const useDataTable = () => {
     rowsPerPage,
     columns,
     hiddenRowIds,
-    sortedColumn,
+    sortingOptions,
     dispatch,
     searchText
   } = dataTableContext;
@@ -76,21 +74,12 @@ const useDataTable = () => {
     const rowIndexLowerBound = (currentPageNumber - 1) * rowsPerPage;
     const rowIndexUpperBound = rowIndexLowerBound + rowsPerPage;
 
-    if (
-      sortedColumn &&
-      sortedColumn.sortedDirection !== SortingDirection.NONE
-    ) {
-      const sortedColumnIndex = columns.findIndex(
-        (column) => column.columnId === sortedColumn.columnId
-      );
-
-      const sortFunction = columns[sortedColumnIndex].sortFn ?? plainSorter;
-
-      rows = sortFunction(
+    if (sortingOptions && sortingOptions.sortingOrder !== SortingOrder.NONE) {
+      rows = sortDataTableRows({
         rows,
-        sortedColumnIndex,
-        sortedColumn.sortedDirection
-      );
+        columns,
+        sortingOptions
+      });
     }
 
     return totalRows > rowsPerPage
@@ -117,18 +106,6 @@ const useDataTable = () => {
     filteredRows,
     ...dataTableContext
   };
-};
-
-// useful for sorting strings and numbers in ascending or descending order
-const plainSorter: TableRowsSortingFunction = (
-  tableRows,
-  columnIndex,
-  direction
-) => {
-  const iteratee = (data: any) => data.cells[columnIndex] as string | number;
-  // translate our magic words to Lodash's magic words
-  const orderDirection = direction === SortingDirection.DESC ? 'desc' : 'asc';
-  return orderBy(tableRows, [iteratee], [orderDirection]);
 };
 
 export default useDataTable;


### PR DESCRIPTION
## Description
- Updated names of types and variables:
  -  "sorted column" -> "sorting options"
  - `SortingDirection` -> `SortingOrder`
- Added `defaultSortingOptionsForDownload` field to the DataTable state, for passing information about how to sort the table when it is downloaded.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1853

## Deployment URL(s)
http://blast-sort-download-table.review.ensembl.org