### PR TITLE
Fix error in which a key could be checked on an undefined value

### DIFF
--- a/src/content/app/genome-browser/hooks/useGenomicTracks.ts
+++ b/src/content/app/genome-browser/hooks/useGenomicTracks.ts
@@ -103,10 +103,10 @@ const prepareTrackIdsList = (
     .map(({ track_id }) => {
       const track = trackSettings[track_id];
       const isVisibleTrack =
-        'isVisible' in track?.settings && track.settings.isVisible;
+        (track?.settings as { isVisible?: boolean })?.isVisible ?? true;
       return {
         trackId: track_id,
-        isTurnedOn: isVisibleTrack ?? true
+        isTurnedOn: isVisibleTrack
       };
     });
   return trackIdsList;


### PR DESCRIPTION
## Description
An error from Sentry:

<img width="842" alt="image" src="https://user-images.githubusercontent.com/6834224/219906620-14e7229b-6d8a-440e-a894-0a9cb355ff03.png">

It's easy to see where the problem is: the code is trying to check whether the `isVisible` field exists in `track?.settings` object, before trying to access it. But, in javascript, you can't use the `in` operator with an undefined value, which, as the optional chaining (`track?.settings`) suggests, is a possibility.

Why didn't I write `track?.settings?.isVisible`, you might ask? Well, this is where typescript was more of an obstacle than help. The type of `track.settings` is a union of several types, one of which does not have the `isVisible` property on it; and typescript doesn't allow one to simply query a property that is absent from some members of the union.

The update in the PR looks ugly; but should work.

## Deployment URL(s)
http://fix-is-visible-track.review.ensembl.org