### PR TITLE
Make blast submission in lists expanded by default

### DIFF
--- a/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.tsx
@@ -55,8 +55,8 @@ export const FAILED_SUBMISSION_WARNING = 'Submission failed';
 export type Props = {
   submission: BlastSubmission;
   isAnyJobRunning?: boolean;
-  isExpanded?: boolean;
-  toggleExpanded?: (isExpanded: boolean) => void;
+  isCollapsed?: boolean;
+  toggleCollapsed?: (isCollapsed: boolean) => void;
   sequenceCount?: number;
 };
 
@@ -151,8 +151,8 @@ export const BlastSubmissionHeader = (props: Props) => {
           {sequenceCount && sequenceCount > 1 && (
             <ShowHide
               className={styles.showHide}
-              isExpanded={props.isExpanded || false}
-              onClick={() => props.toggleExpanded?.(!props.isExpanded)}
+              isExpanded={!props.isCollapsed}
+              onClick={() => props.toggleCollapsed?.(!props.isCollapsed)}
             />
           )}
         </div>

--- a/src/content/app/tools/blast/components/listed-blast-submission/ListedBlastSubmission.scss
+++ b/src/content/app/tools/blast/components/listed-blast-submission/ListedBlastSubmission.scss
@@ -82,6 +82,7 @@ and also that it can be of variable width
 
 .jobStatus {
   justify-self: end;
+  width: 65px;
 }
 
 .jobStatusProminent {

--- a/src/content/app/tools/blast/components/listed-blast-submission/ListedBlastSubmission.test.tsx
+++ b/src/content/app/tools/blast/components/listed-blast-submission/ListedBlastSubmission.test.tsx
@@ -118,7 +118,7 @@ describe('BlastSubmissionHeader', () => {
         state: {
           ui: {
             unviewedJobsPage: {
-              expandedSubmissionIds: [submission.id]
+              collapsedSubmissionIds: [submission.id]
             }
           } as BlastResultsUI
         }

--- a/src/content/app/tools/blast/components/listed-blast-submission/ListedBlastSubmission.test.tsx
+++ b/src/content/app/tools/blast/components/listed-blast-submission/ListedBlastSubmission.test.tsx
@@ -32,7 +32,6 @@ import ListedBlastSubmission, {
 import blastFormReducer from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
 import blastGeneralReducer from 'src/content/app/tools/blast/state/general/blastGeneralSlice';
 import blastResultsReducer, {
-  BlastResultsUI,
   initialBlastResultsState,
   type BlastResultsState
 } from 'src/content/app/tools/blast/state/blast-results/blastResultsSlice';
@@ -114,14 +113,7 @@ describe('BlastSubmissionHeader', () => {
       });
 
       const { container } = renderComponent({
-        props: { submission },
-        state: {
-          ui: {
-            unviewedJobsPage: {
-              collapsedSubmissionIds: [submission.id]
-            }
-          } as BlastResultsUI
-        }
+        props: { submission }
       });
 
       expect(container.querySelectorAll('.sequenceBox').length).toBe(5);
@@ -239,7 +231,7 @@ describe('BlastSubmissionHeader', () => {
 
   describe('behaviour', () => {
     // define this behaviour better
-    it('folds jobs of a submission into a single box by default', () => {
+    it('expands jobs of a submission by default', () => {
       const submission = createBlastSubmission({
         options: { sequencesCount: 5 }
       });
@@ -248,11 +240,7 @@ describe('BlastSubmissionHeader', () => {
         props: { submission }
       });
 
-      expect(container.querySelectorAll('.sequenceBox').length).toBe(1);
-
-      expect(
-        container.querySelector('.sequenceBox')?.firstElementChild?.textContent
-      ).toBe('5 sequences');
+      expect(container.querySelectorAll('.sequenceBox').length).toBe(5);
     });
 
     // TODO: make sure that deleting a sequence stops polling for this sequence

--- a/src/content/app/tools/blast/components/listed-blast-submission/ListedBlastSubmission.tsx
+++ b/src/content/app/tools/blast/components/listed-blast-submission/ListedBlastSubmission.tsx
@@ -146,7 +146,7 @@ const SequenceBox = (props: SequenceBoxProps) => {
         <span className={styles.againstText}>Against</span> {speciesCount}{' '}
         species
       </div>
-      {<JobStatus jobs={jobs} />}
+      <div className={styles.jobStatus}>{<JobStatus jobs={jobs} />}</div>
     </div>
   );
 };
@@ -162,7 +162,7 @@ export const JobStatus = (props: JobStatusProps) => {
   const hasAllFailedJobs = jobs.every((job) => job.status === 'FAILURE');
   const hasSomeFailedJobs = jobs.some((job) => job.status === 'FAILURE');
 
-  const elementClasses = classNames(styles.jobStatus, {
+  const elementClasses = classNames({
     [styles.jobStatusProminent]: hasRunningJobs || hasSomeFailedJobs
   });
 

--- a/src/content/app/tools/blast/components/listed-blast-submission/ListedBlastSubmission.tsx
+++ b/src/content/app/tools/blast/components/listed-blast-submission/ListedBlastSubmission.tsx
@@ -47,9 +47,9 @@ const ListedBlastSubmission = (props: Props) => {
   const sequences = submission.submittedData.sequences;
   const allJobs = getBlastJobsFromSubmission(submission);
   const isAnyJobRunning = allJobs.some((job) => job.status === 'RUNNING');
-  const { expandedSubmissionIds } = uiState.unviewedJobsPage;
+  const { collapsedSubmissionIds } = uiState.unviewedJobsPage;
 
-  const isCurrentSubmissionExpanded = expandedSubmissionIds.includes(
+  const isCurrentSubmissionCollapsed = collapsedSubmissionIds.includes(
     submission.id
   );
 
@@ -62,7 +62,7 @@ const ListedBlastSubmission = (props: Props) => {
   });
 
   let sequenceContent = null;
-  if (isCurrentSubmissionExpanded || sequences.length === 1) {
+  if (!isCurrentSubmissionCollapsed || sequences.length === 1) {
     sequenceContent = jobsGroupedBySequence.map(({ sequence, jobs }) => (
       <SequenceBox
         key={sequence.id}
@@ -75,16 +75,16 @@ const ListedBlastSubmission = (props: Props) => {
     sequenceContent = <CollapsedSequencesBox submission={submission} />;
   }
 
-  const toggleExpanded = (status: boolean) => {
-    const newExpandedSubmissionIds = status
-      ? [...expandedSubmissionIds, submission.id]
-      : expandedSubmissionIds.filter((id) => id !== submission.id);
+  const toggleCollapsed = (status: boolean) => {
+    const newCollapsedSubmissionIds = status
+      ? [...collapsedSubmissionIds, submission.id]
+      : collapsedSubmissionIds.filter((id) => id !== submission.id);
 
     dispatch(
       updateSubmissionUi({
         fragment: {
           unviewedJobsPage: {
-            expandedSubmissionIds: newExpandedSubmissionIds
+            collapsedSubmissionIds: newCollapsedSubmissionIds
           }
         }
       })
@@ -96,8 +96,8 @@ const ListedBlastSubmission = (props: Props) => {
       <BlastSubmissionHeader
         {...props}
         isAnyJobRunning={isAnyJobRunning}
-        toggleExpanded={toggleExpanded}
-        isExpanded={isCurrentSubmissionExpanded}
+        toggleCollapsed={toggleCollapsed}
+        isCollapsed={isCurrentSubmissionCollapsed}
         sequenceCount={sequences.length}
       />
       {sequenceContent}

--- a/src/content/app/tools/blast/state/blast-results/blastResultsSlice.ts
+++ b/src/content/app/tools/blast/state/blast-results/blastResultsSlice.ts
@@ -99,10 +99,10 @@ export type BlastSubmission = SuccessfulBlastSubmission | FailedBlastSubmission;
 
 export type BlastResultsUI = {
   unviewedJobsPage: {
-    expandedSubmissionIds: string[];
+    collapsedSubmissionIds: string[];
   };
   viewedJobsPage: {
-    expandedSubmissionIds: string[];
+    collapsedSubmissionIds: string[];
   };
 };
 
@@ -140,10 +140,10 @@ export const initialBlastResultsState: BlastResultsState = {
   submissions: {},
   ui: {
     unviewedJobsPage: {
-      expandedSubmissionIds: []
+      collapsedSubmissionIds: []
     },
     viewedJobsPage: {
-      expandedSubmissionIds: []
+      collapsedSubmissionIds: []
     }
   }
 };


### PR DESCRIPTION
## Description
Change the default view of blast submissions in Unviewed jobs and Jobs list to be expanded. This PR changes saving of `expanded` submissions to save `collapsed` submissions in the redux state.

Steps to test:

1. Insert sequences in BLAST form and select multiple species to BLAST against and click on run
2. Check Unviewed jobs show submissions as expanded 
3. Check Jobs list show submissions as expanded

## Related JIRA Issue(s)
[ENSWBSITES-1855](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1855)

## Deployment URL(s)
http://blast-submission-expanded.review.ensembl.org


## Views affected
BLAST -> Unviewed jobs
BLAST -> Jobs list