### PR TITLE
Integrate focus variant track

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ensembl/ensembl-genome-browser": "0.6.1",
+        "@ensembl/ensembl-genome-browser": "0.6.1-var",
         "@react-spring/web": "9.4.5-beta.1",
         "@reduxjs/toolkit": "1.9.0",
         "@sentry/browser": "7.21.1",
@@ -2426,9 +2426,9 @@
       }
     },
     "node_modules/@ensembl/ensembl-genome-browser": {
-      "version": "0.6.1",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.1.tgz",
-      "integrity": "sha1-JK79OHxBHpN6DTXl95fQPN8GJS0="
+      "version": "0.6.1-var",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.1-var.tgz",
+      "integrity": "sha1-5/WP3mVgAMFNI6AOR+Ipd9/V4f0="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
@@ -43098,9 +43098,9 @@
       "dev": true
     },
     "@ensembl/ensembl-genome-browser": {
-      "version": "0.6.1",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.1.tgz",
-      "integrity": "sha1-JK79OHxBHpN6DTXl95fQPN8GJS0="
+      "version": "0.6.1-var",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.1-var.tgz",
+      "integrity": "sha1-5/WP3mVgAMFNI6AOR+Ipd9/V4f0="
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ensembl/ensembl-genome-browser": "0.6.1-var",
+        "@ensembl/ensembl-genome-browser": "0.6.2-var",
         "@react-spring/web": "9.4.5-beta.1",
         "@reduxjs/toolkit": "1.9.0",
         "@sentry/browser": "7.21.1",
@@ -2426,9 +2426,9 @@
       }
     },
     "node_modules/@ensembl/ensembl-genome-browser": {
-      "version": "0.6.1-var",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.1-var.tgz",
-      "integrity": "sha1-5/WP3mVgAMFNI6AOR+Ipd9/V4f0="
+      "version": "0.6.2-var",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.2-var.tgz",
+      "integrity": "sha1-dxBIUiImWAvJr+UtZfiIw7liAVQ="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
@@ -43098,9 +43098,9 @@
       "dev": true
     },
     "@ensembl/ensembl-genome-browser": {
-      "version": "0.6.1-var",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.1-var.tgz",
-      "integrity": "sha1-5/WP3mVgAMFNI6AOR+Ipd9/V4f0="
+      "version": "0.6.2-var",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.2-var.tgz",
+      "integrity": "sha1-dxBIUiImWAvJr+UtZfiIw7liAVQ="
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ensembl/ensembl-genome-browser": "0.6.2-var",
+        "@ensembl/ensembl-genome-browser": "0.6.3-var",
         "@react-spring/web": "9.4.5-beta.1",
         "@reduxjs/toolkit": "1.9.0",
         "@sentry/browser": "7.21.1",
@@ -2426,9 +2426,9 @@
       }
     },
     "node_modules/@ensembl/ensembl-genome-browser": {
-      "version": "0.6.2-var",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.2-var.tgz",
-      "integrity": "sha1-dxBIUiImWAvJr+UtZfiIw7liAVQ="
+      "version": "0.6.3-var",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.3-var.tgz",
+      "integrity": "sha1-PbIZP5Td/g6U/ui64Lsl4pe+qmQ="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
@@ -43098,9 +43098,9 @@
       "dev": true
     },
     "@ensembl/ensembl-genome-browser": {
-      "version": "0.6.2-var",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.2-var.tgz",
-      "integrity": "sha1-dxBIUiImWAvJr+UtZfiIw7liAVQ="
+      "version": "0.6.3-var",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.3-var.tgz",
+      "integrity": "sha1-PbIZP5Td/g6U/ui64Lsl4pe+qmQ="
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2428,7 +2428,7 @@
     "node_modules/@ensembl/ensembl-genome-browser": {
       "version": "0.6.3-var",
       "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.3-var.tgz",
-      "integrity": "sha1-ZmF8BbuY08ocMwg/DafXZbGAi70="
+      "integrity": "sha1-x1ryJT6F6bhGfrPERjatm6lSXk4="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
@@ -43100,7 +43100,7 @@
     "@ensembl/ensembl-genome-browser": {
       "version": "0.6.3-var",
       "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.3-var.tgz",
-      "integrity": "sha1-ZmF8BbuY08ocMwg/DafXZbGAi70="
+      "integrity": "sha1-x1ryJT6F6bhGfrPERjatm6lSXk4="
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2428,7 +2428,7 @@
     "node_modules/@ensembl/ensembl-genome-browser": {
       "version": "0.6.3-var",
       "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.3-var.tgz",
-      "integrity": "sha1-PbIZP5Td/g6U/ui64Lsl4pe+qmQ="
+      "integrity": "sha1-ZmF8BbuY08ocMwg/DafXZbGAi70="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
@@ -43100,7 +43100,7 @@
     "@ensembl/ensembl-genome-browser": {
       "version": "0.6.3-var",
       "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.3-var.tgz",
-      "integrity": "sha1-PbIZP5Td/g6U/ui64Lsl4pe+qmQ="
+      "integrity": "sha1-ZmF8BbuY08ocMwg/DafXZbGAi70="
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ensembl/ensembl-genome-browser": "0.6.3-var",
+        "@ensembl/ensembl-genome-browser": "0.6.3",
         "@react-spring/web": "9.4.5-beta.1",
         "@reduxjs/toolkit": "1.9.0",
         "@sentry/browser": "7.21.1",
@@ -2426,9 +2426,9 @@
       }
     },
     "node_modules/@ensembl/ensembl-genome-browser": {
-      "version": "0.6.3-var",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.3-var.tgz",
-      "integrity": "sha1-x1ryJT6F6bhGfrPERjatm6lSXk4="
+      "version": "0.6.3",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.3.tgz",
+      "integrity": "sha1-dg0ChhlPPIzVpima2EQ8XMbWgKc="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
@@ -43098,9 +43098,9 @@
       "dev": true
     },
     "@ensembl/ensembl-genome-browser": {
-      "version": "0.6.3-var",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.3-var.tgz",
-      "integrity": "sha1-x1ryJT6F6bhGfrPERjatm6lSXk4="
+      "version": "0.6.3",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.3.tgz",
+      "integrity": "sha1-dg0ChhlPPIzVpima2EQ8XMbWgKc="
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "coverage": "jest --coverage"
   },
   "dependencies": {
-    "@ensembl/ensembl-genome-browser": "0.6.1",
+    "@ensembl/ensembl-genome-browser": "0.6.1-var",
     "@react-spring/web": "9.4.5-beta.1",
     "@reduxjs/toolkit": "1.9.0",
     "@sentry/browser": "7.21.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "coverage": "jest --coverage"
   },
   "dependencies": {
-    "@ensembl/ensembl-genome-browser": "0.6.2-var",
+    "@ensembl/ensembl-genome-browser": "0.6.3-var",
     "@react-spring/web": "9.4.5-beta.1",
     "@reduxjs/toolkit": "1.9.0",
     "@sentry/browser": "7.21.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "coverage": "jest --coverage"
   },
   "dependencies": {
-    "@ensembl/ensembl-genome-browser": "0.6.1-var",
+    "@ensembl/ensembl-genome-browser": "0.6.2-var",
     "@react-spring/web": "9.4.5-beta.1",
     "@reduxjs/toolkit": "1.9.0",
     "@sentry/browser": "7.21.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "coverage": "jest --coverage"
   },
   "dependencies": {
-    "@ensembl/ensembl-genome-browser": "0.6.3-var",
+    "@ensembl/ensembl-genome-browser": "0.6.3",
     "@react-spring/web": "9.4.5-beta.1",
     "@reduxjs/toolkit": "1.9.0",
     "@sentry/browser": "7.21.1",

--- a/src/content/app/genome-browser/components/browser-cog/BrowserCogList.tsx
+++ b/src/content/app/genome-browser/components/browser-cog/BrowserCogList.tsx
@@ -18,6 +18,7 @@ import React, { useEffect, memo } from 'react';
 import {
   IncomingActionType,
   type UpdateTrackSummaryAction,
+  type TrackSummary,
   type TrackSummaryList
 } from '@ensembl/ensembl-genome-browser';
 
@@ -58,7 +59,7 @@ export const BrowserCogList = () => {
 
   const updateDisplayedTracks = (trackSummaryList: TrackSummaryList) => {
     const payload = trackSummaryList.map((track) => ({
-      id: track['switch-id'],
+      id: getTrackId(track),
       height: track.height as unknown as number, // FIXME: fix genome browser types
       offsetTop: track.offset as unknown as number // FIXME: fix genome browser types
     }));
@@ -83,6 +84,14 @@ export const BrowserCogList = () => {
       </div>
     </div>
   ) : null;
+};
+
+const getTrackId = (trackSummary: TrackSummary) => {
+  if (trackSummary['switch-id'] === 'focus' && 'variant-id' in trackSummary) {
+    return 'focus-variant';
+  } else {
+    return trackSummary['switch-id'];
+  }
 };
 
 export default memo(BrowserCogList);

--- a/src/content/app/genome-browser/components/browser-cog/BrowserCogList.tsx
+++ b/src/content/app/genome-browser/components/browser-cog/BrowserCogList.tsx
@@ -60,8 +60,8 @@ export const BrowserCogList = () => {
   const updateDisplayedTracks = (trackSummaryList: TrackSummaryList) => {
     const payload = trackSummaryList.map((track) => ({
       id: getTrackId(track),
-      height: track.height as unknown as number, // FIXME: fix genome browser types
-      offsetTop: track.offset as unknown as number // FIXME: fix genome browser types
+      height: track.height,
+      offsetTop: track.offset
     }));
 
     dispatch(setDisplayedTracks(payload));

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
@@ -164,7 +164,7 @@ const FocusObject = (props: { focusObject: FocusObjectType | null }) => {
   }
 
   if (content) {
-    return <section className={`${styles.mainTrackItem}`}>{content}</section>;
+    return <section className={styles.mainTrackItem}>{content}</section>;
   } else {
     return null;
   }

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { memo } from 'react';
+import React, { memo, type ReactNode } from 'react';
 import classNames from 'classnames';
 
 import { useAppDispatch, useAppSelector } from 'src/store';
@@ -32,6 +32,7 @@ import {
 } from 'src/content/app/genome-browser/state/browser-sidebar-modal/browserSidebarModalSlice';
 
 import TrackPanelGene from './track-panel-items/TrackPanelGene';
+import TrackPanelVariant from './track-panel-items/TrackPanelVariant';
 import TrackPanelRegularItem from './track-panel-items/TrackPanelRegularItem';
 import {
   Accordion,
@@ -41,10 +42,15 @@ import {
   AccordionItemPanel
 } from 'src/shared/components/accordion';
 
-import type { GenomeTrackCategory } from 'src/content/app/genome-browser/state/types/tracks';
-
 import SearchIcon from 'static/icons/icon_search.svg';
 import ResetIcon from 'static/icons/icon_reset.svg';
+
+import type { GenomeTrackCategory } from 'src/content/app/genome-browser/state/types/tracks';
+import type {
+  FocusObject as FocusObjectType,
+  FocusGene as FocusGeneType,
+  FocusVariant as FocusVariantType
+} from 'src/shared/types/focus-object/focusObjectTypes';
 
 import styles from './TrackPanelList.scss';
 
@@ -78,18 +84,7 @@ export const TrackPanelList = () => {
 
   return (
     <div className={styles.trackPanelList}>
-      {activeFocusObject?.type === 'gene' &&
-      activeGenomeId &&
-      activeFocusObject.stable_id ? (
-        <section className={`${styles.mainTrackItem}`}>
-          <TrackPanelGene
-            focusObjectId={activeFocusObject.object_id}
-            genomeId={activeGenomeId}
-            geneId={activeFocusObject.stable_id}
-          />
-        </section>
-      ) : null}
-
+      <FocusObject focusObject={activeFocusObject} />
       <div className={styles.modalLinksWrapper}>
         <div className={styles.modalLink} onClick={openSearch}>
           <span>Find a gene</span>
@@ -156,6 +151,39 @@ export const TrackPanelList = () => {
       </div>
     </div>
   );
+};
+
+const FocusObject = (props: { focusObject: FocusObjectType | null }) => {
+  const { focusObject } = props;
+  let content: ReactNode;
+
+  if (focusObject?.type === 'gene') {
+    content = <FocusGene focusGene={focusObject} />;
+  } else if (focusObject?.type === 'variant') {
+    content = <FocusVariant focusVariant={focusObject} />;
+  }
+
+  if (content) {
+    return <section className={`${styles.mainTrackItem}`}>{content}</section>;
+  } else {
+    return null;
+  }
+};
+
+const FocusGene = (props: { focusGene: FocusGeneType }) => {
+  const { genome_id, object_id, stable_id } = props.focusGene;
+
+  return (
+    <TrackPanelGene
+      focusObjectId={object_id}
+      genomeId={genome_id}
+      geneId={stable_id}
+    />
+  );
+};
+
+const FocusVariant = (props: { focusVariant: FocusVariantType }) => {
+  return <TrackPanelVariant focusVariant={props.focusVariant} />;
 };
 
 export default memo(TrackPanelList);

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelVariant.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelVariant.tsx
@@ -1,0 +1,37 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import SimpleTrackPanelItemLayout from './track-panel-item-layout/SimpleTrackPanelItemLayout';
+
+import type { FocusVariant } from 'src/shared/types/focus-object/focusObjectTypes';
+
+import styles from './TrackPanelItem.scss';
+
+const TrackPanelVariant = (props: { focusVariant: FocusVariant }) => {
+  const { focusVariant } = props;
+
+  const children = (
+    <div className={styles.label}>
+      <span className={styles.labelTextStrong}>{focusVariant.label}</span>
+    </div>
+  );
+
+  return <SimpleTrackPanelItemLayout>{children}</SimpleTrackPanelItemLayout>;
+};
+
+export default TrackPanelVariant;

--- a/src/content/app/genome-browser/components/track-settings-panel/TrackSettingsPanel.tsx
+++ b/src/content/app/genome-browser/components/track-settings-panel/TrackSettingsPanel.tsx
@@ -19,6 +19,7 @@ import React, { useRef } from 'react';
 import useOutsideClick from 'src/shared/hooks/useOutsideClick';
 
 import GeneTrackSettings from './track-settings-views/GeneTrackSettings';
+import VariantTrackSettings from './track-settings-views/VariantTrackSettings';
 import RegularTrackSettings from './track-settings-views/RegularTrackSettings';
 
 import { getTrackType } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSlice';
@@ -34,6 +35,8 @@ const getTrackSettingsPanelComponent = (trackType: TrackType) => {
     case TrackType.GENE:
     case TrackType.FOCUS_GENE:
       return GeneTrackSettings;
+    case TrackType.FOCUS_VARIANT:
+      return VariantTrackSettings;
     case TrackType.REGULAR:
       return RegularTrackSettings;
   }

--- a/src/content/app/genome-browser/components/track-settings-panel/track-settings-views/VariantTrackSettings.tsx
+++ b/src/content/app/genome-browser/components/track-settings-panel/track-settings-views/VariantTrackSettings.tsx
@@ -1,0 +1,156 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState, forwardRef, type ForwardedRef } from 'react';
+
+import useGenomeBrowser from 'src/content/app/genome-browser/hooks/useGenomeBrowser';
+
+import SlideToggle from 'src/shared/components/slide-toggle/SlideToggle';
+
+import styles from '../TrackSettingsPanel.scss';
+
+type Props = {
+  trackId: string;
+};
+
+const VariantTrackSettings = (
+  props: Props,
+  ref: ForwardedRef<HTMLDivElement>
+) => {
+  const [shouldShowSnvIds, setShouldShowSnvIds] = useState(false);
+  const [shouldShowSnvAlleles, setShouldShowSnvAlleles] = useState(false);
+  const [shouldShowOtherVariantIds, setShouldShowOtherVariantIds] =
+    useState(false);
+  const [shouldShowOtherVariantAlleles, setShouldShowOtherVariantAlleles] =
+    useState(false);
+  const [shouldShowVariantExtent, setShouldShowVariantExtent] = useState(false);
+
+  const { toggleFocusVariantTrackSetting } = useGenomeBrowser();
+
+  const onSnvIdsToggle = () => {
+    toggleFocusVariantTrackSetting({
+      settingName: 'label-snv-id',
+      isOn: !shouldShowSnvIds
+    });
+    setShouldShowSnvIds(!shouldShowSnvIds);
+  };
+
+  const onSnvAllelesToggle = () => {
+    toggleFocusVariantTrackSetting({
+      settingName: 'label-snv-alleles',
+      isOn: !shouldShowSnvAlleles
+    });
+    setShouldShowSnvAlleles(!shouldShowSnvAlleles);
+  };
+
+  const onOtherVariantIdsToggle = () => {
+    toggleFocusVariantTrackSetting({
+      settingName: 'label-other-id',
+      isOn: !shouldShowOtherVariantIds
+    });
+    setShouldShowOtherVariantIds(!shouldShowOtherVariantIds);
+  };
+
+  const onOtherVariantAllelesToggle = () => {
+    toggleFocusVariantTrackSetting({
+      settingName: 'label-other-alleles',
+      isOn: !shouldShowOtherVariantAlleles
+    });
+    setShouldShowOtherVariantAlleles(!shouldShowOtherVariantAlleles);
+  };
+
+  const onVariantExtentToggle = () => {
+    toggleFocusVariantTrackSetting({
+      settingName: 'show-extents',
+      isOn: !shouldShowVariantExtent
+    });
+    setShouldShowVariantExtent(!shouldShowVariantExtent);
+  };
+
+  const onTrackNameToggle = () => {
+    console.log('later'); // eslint-disable-line no-console
+  };
+
+  return (
+    <div className={styles.trackSettingsPanel} ref={ref}>
+      <div className={styles.section}>
+        <div className={styles.subLabel}>SNVs</div>
+        <div>
+          <div className={styles.toggleWrapper}>
+            <label>Variant IDs</label>
+            <SlideToggle
+              isOn={shouldShowSnvIds}
+              onChange={onSnvIdsToggle}
+              className={styles.slideToggle}
+            />
+          </div>
+          <div className={styles.toggleWrapper}>
+            <label>Variant alleles</label>
+            <SlideToggle
+              isOn={shouldShowSnvAlleles}
+              onChange={onSnvAllelesToggle}
+              className={styles.slideToggle}
+            />
+          </div>
+        </div>
+      </div>
+      <div className={styles.section}>
+        <div className={styles.subLabel}>Other classes</div>
+        <div>
+          <div className={styles.toggleWrapper}>
+            <label>Variant IDs</label>
+            <SlideToggle
+              isOn={shouldShowOtherVariantIds}
+              onChange={onOtherVariantIdsToggle}
+              className={styles.slideToggle}
+            />
+          </div>
+          <div className={styles.toggleWrapper}>
+            <label>Variant alleles</label>
+            <SlideToggle
+              isOn={shouldShowOtherVariantAlleles}
+              onChange={onOtherVariantAllelesToggle}
+              className={styles.slideToggle}
+            />
+          </div>
+          <div className={styles.toggleWrapper}>
+            <label>Variant extent</label>
+            <SlideToggle
+              isOn={shouldShowVariantExtent}
+              onChange={onVariantExtentToggle}
+              className={styles.slideToggle}
+            />
+          </div>
+        </div>
+      </div>
+      <div className={styles.section}>
+        <div className={styles.subLabel}>All tracks</div>
+        <div>
+          <div className={styles.toggleWrapper}>
+            <label>Track name</label>
+            <SlideToggle
+              isOn={false}
+              onChange={onTrackNameToggle}
+              className={styles.slideToggle}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default forwardRef(VariantTrackSettings);

--- a/src/content/app/genome-browser/components/track-settings-panel/track-settings-views/VariantTrackSettings.tsx
+++ b/src/content/app/genome-browser/components/track-settings-panel/track-settings-views/VariantTrackSettings.tsx
@@ -37,8 +37,10 @@ const VariantTrackSettings = (
   const [shouldShowOtherVariantAlleles, setShouldShowOtherVariantAlleles] =
     useState(false);
   const [shouldShowVariantExtent, setShouldShowVariantExtent] = useState(false);
+  const [shouldShowTrackName, setShouldShowTrackName] = useState(false);
 
-  const { toggleFocusVariantTrackSetting } = useGenomeBrowser();
+  const { toggleFocusVariantTrackSetting, toggleTrackName } =
+    useGenomeBrowser();
 
   const onSnvIdsToggle = () => {
     toggleFocusVariantTrackSetting({
@@ -81,7 +83,12 @@ const VariantTrackSettings = (
   };
 
   const onTrackNameToggle = () => {
-    console.log('later'); // eslint-disable-line no-console
+    toggleTrackName({
+      trackId: 'focus',
+      shouldShowTrackName: !shouldShowTrackName
+    });
+
+    setShouldShowTrackName(!shouldShowTrackName);
   };
 
   return (

--- a/src/content/app/genome-browser/hooks/useFocusTrack.ts
+++ b/src/content/app/genome-browser/hooks/useFocusTrack.ts
@@ -41,7 +41,10 @@ import type {
   FocusGeneTrack,
   FocusGeneTrackSettings
 } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSlice';
-import type { FocusGene } from 'src/shared/types/focus-object/focusObjectTypes';
+import type {
+  FocusGene,
+  FocusVariant
+} from 'src/shared/types/focus-object/focusObjectTypes';
 
 /**
  * The purposes of this hook are:
@@ -66,18 +69,27 @@ const useFocusTrack = () => {
     focusObjectId
   });
 
+  useFocusVariant({
+    genomeBrowserMethods,
+    focusVariant:
+      parsedFocusObjectId?.type === 'variant'
+        ? (focusObject as FocusVariant)
+        : null,
+    focusObjectId
+  });
+
   /**
    * TODO: move the code for saving previous focus object here
    */
 };
 
-type Params = {
+type UseFocusGeneParams = {
   focusGene: FocusGene | null;
   focusObjectId: string;
   genomeBrowserMethods: ReturnType<typeof useGenomeBrowser>;
 };
 
-const useFocusGene = (params: Params) => {
+const useFocusGene = (params: UseFocusGeneParams) => {
   const { focusGene, genomeBrowserMethods, focusObjectId } = params;
   const { genomeBrowser, updateFocusGeneTranscripts, setFocusGene } =
     genomeBrowserMethods;
@@ -287,6 +299,26 @@ const sendFocusGeneTrackSettings = (
         break;
     }
   });
+};
+
+type UseFocusVariantParams = {
+  focusVariant: FocusVariant | null;
+  focusObjectId: string;
+  genomeBrowserMethods: ReturnType<typeof useGenomeBrowser>;
+};
+
+const useFocusVariant = (params: UseFocusVariantParams) => {
+  const { focusVariant, genomeBrowserMethods } = params;
+  const { setFocusGene, genomeBrowser } = genomeBrowserMethods;
+
+  useEffect(() => {
+    if (!focusVariant || !genomeBrowser) {
+      return;
+    }
+
+    // FIXME: rename setFocusGene method!
+    setFocusGene(focusVariant.object_id);
+  }, [genomeBrowser, focusVariant?.object_id]);
 };
 
 const isLozengeClickMessage = (

--- a/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
@@ -234,6 +234,19 @@ const useGenomeBrowser = () => {
     }
   };
 
+  const toggleFocusVariantTrackSetting = (params: {
+    settingName: string;
+    isOn: boolean;
+  }) => {
+    genomeBrowser?.send({
+      type: OutgoingActionType.TOGGLE_FOCUS_VARIANT_TRACK_SETTING,
+      payload: {
+        setting_name: params.settingName,
+        is_on: params.isOn
+      }
+    });
+  };
+
   const updateFocusGeneTranscripts = (
     visibleTranscriptIds: string[] | null
   ) => {
@@ -259,6 +272,7 @@ const useGenomeBrowser = () => {
     toggleFeatureLabels,
     toggleSeveralTranscripts,
     toggleTranscriptIds,
+    toggleFocusVariantTrackSetting,
     genomeBrowser,
     zmenus
   };

--- a/src/content/app/genome-browser/state/track-settings/trackSettingsConstants.ts
+++ b/src/content/app/genome-browser/state/track-settings/trackSettingsConstants.ts
@@ -27,6 +27,7 @@ import type {
 export enum TrackType {
   GENE = 'gene',
   FOCUS_GENE = 'gene-focus',
+  FOCUS_VARIANT = 'focus-variant',
   REGULAR = 'regular'
 }
 

--- a/src/content/app/genome-browser/state/track-settings/trackSettingsConstants.ts
+++ b/src/content/app/genome-browser/state/track-settings/trackSettingsConstants.ts
@@ -26,7 +26,7 @@ import type {
 
 export enum TrackType {
   GENE = 'gene',
-  FOCUS_GENE = 'gene-focus',
+  FOCUS_GENE = 'focus-gene',
   FOCUS_VARIANT = 'focus-variant',
   REGULAR = 'regular'
 }

--- a/src/content/app/genome-browser/state/track-settings/trackSettingsSlice.ts
+++ b/src/content/app/genome-browser/state/track-settings/trackSettingsSlice.ts
@@ -151,6 +151,8 @@ export const getTrackType = (trackId: string) => {
 
   if (trackId.startsWith('gene') || trackId === 'focus') {
     return TrackType.GENE;
+  } else if (trackId === 'focus-variant') {
+    return TrackType.FOCUS_VARIANT;
   } else {
     return TrackType.REGULAR;
   }

--- a/src/shared/types/focus-object/focusObjectTypes.ts
+++ b/src/shared/types/focus-object/focusObjectTypes.ts
@@ -22,7 +22,7 @@ export type FocusObjectLocation = {
   start: number;
 };
 
-export type FocusObjectType = 'gene' | 'location';
+export type FocusObjectType = 'gene' | 'location' | 'variant';
 
 type BasicFocusObject = {
   object_id: string;
@@ -45,7 +45,11 @@ export type FocusLocation = BasicFocusObject & {
   type: 'location';
 };
 
-export type FocusObject = FocusGene | FocusLocation;
+export type FocusVariant = BasicFocusObject & {
+  type: 'variant';
+};
+
+export type FocusObject = FocusGene | FocusLocation | FocusVariant;
 
 export type FocusObjectResponse = FocusGene;
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { configureStore, type Action } from '@reduxjs/toolkit';
+import {
+  configureStore,
+  createAsyncThunk,
+  type Action
+} from '@reduxjs/toolkit';
 import {
   useDispatch,
   useSelector,
@@ -61,3 +65,9 @@ export type RootState = ReturnType<typeof rootReducer>;
 export type AppDispatch = AppStore['dispatch'];
 export const useAppDispatch = () => useDispatch<AppDispatch>();
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
+export const createAppAsyncThunk = createAsyncThunk.withTypes<{
+  state: RootState;
+  dispatch: AppDispatch;
+  rejectValue: string;
+}>();
+export type ThunkApi = Parameters<Parameters<typeof createAppAsyncThunk>[1]>[1];


### PR DESCRIPTION
## Description
- Update genome browser to version 0.6.3 (see related PR [here](https://github.com/Ensembl/ensembl-genome-browser/pull/23))
- Add focus variant to the list of supported focus objects
- A focus variant can be set via the url, using the `?focus=variant:<variant_id>` query parameter
  - Example url: http://focus-variant-init.review.ensembl.org/genome-browser/grch38?focus=variant:rs779377781
- When a focus variant has been set, genome browser is told to render the focus variant track, and right-hand sidebar is showing the focus variant id
- Added a config panel for the variant focus track

## TODO (in subsequent PRs)
- Connect the track settings panel to redux
- Persist settings for focus variant track
- Show zmenu for the focus variant track

## Related JIRA Issue(s)
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1831
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1868

## Deployment URL(s)
http://focus-variant-init.review.ensembl.org/genome-browser/grch38?focus=variant:rs779377781