### PR TITLE
Fix warning from incorrect SimpleSelect usage in tests of DataTable component

### DIFF
--- a/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/navigate-modal/LocationNavigation.tsx
+++ b/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/navigate-modal/LocationNavigation.tsx
@@ -130,8 +130,7 @@ const LocationNavigation = () => {
   const getKaryotypeOptions = () =>
     genomeKaryotype.map(({ name }) => ({
       value: name,
-      label: name,
-      isSelected: regionNameInput === name
+      label: name
     }));
 
   const updateRegionNameInput = (event: FormEvent<HTMLSelectElement>) => {
@@ -203,6 +202,7 @@ const LocationNavigation = () => {
                 onChange={updateRegionNameInput}
                 onKeyUp={handleKeyPress}
                 options={getKaryotypeOptions()}
+                value={regionNameInput}
                 disabled={singleInputActive}
                 className={styles.rangeNameSelect}
                 placeholder="Select"

--- a/src/shared/components/simple-select/SimpleSelect.test.tsx
+++ b/src/shared/components/simple-select/SimpleSelect.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useState, ChangeEvent } from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -58,10 +58,70 @@ describe('SimpleSelect', () => {
     );
   });
 
+  it('has the first option selected by default', async () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <SimpleSelect options={options} onChange={onChange} />
+    );
+
+    const selectElement = container.querySelector(
+      'select'
+    ) as HTMLSelectElement;
+
+    expect(selectElement.value).toBe(options[0].value);
+
+    const secondOption = selectElement.querySelector(
+      'option:nth-child(2)'
+    ) as HTMLOptionElement;
+
+    await userEvent.selectOptions(selectElement, secondOption);
+
+    expect(onChange.mock.calls[0][0].target.value).toBe('2');
+  });
+
+  it('selects correct option based on value property', async () => {
+    const TestComponent = () => {
+      const [selectValue, setSelectValue] = useState(options[1].value);
+
+      const onChange = (event: ChangeEvent<HTMLSelectElement>) => {
+        setSelectValue(event.target.value);
+      };
+
+      return (
+        <SimpleSelect
+          options={options}
+          value={selectValue}
+          onChange={onChange}
+        />
+      );
+    };
+
+    const { container } = render(<TestComponent />);
+
+    const selectElement = container.querySelector(
+      'select'
+    ) as HTMLSelectElement;
+
+    // check if default value is selected
+    expect(selectElement.value).toBe(options[1].value);
+
+    const firstOption = selectElement.querySelector(
+      'option'
+    ) as HTMLOptionElement;
+
+    await userEvent.selectOptions(selectElement, firstOption);
+
+    expect(selectElement.value).toBe(options[0].value);
+  });
+
   it('renders an empty placeholder option', () => {
     const placeholderText = 'I am placeholder!';
     const { container } = render(
-      <SimpleSelect options={options} placeholder={placeholderText} />
+      <SimpleSelect
+        options={options}
+        placeholder={placeholderText}
+        onChange={jest.fn()}
+      />
     );
     const optionElements = container.querySelectorAll('option');
     const placeholderOption = optionElements[0];

--- a/src/shared/components/simple-select/SimpleSelect.test.tsx
+++ b/src/shared/components/simple-select/SimpleSelect.test.tsx
@@ -117,11 +117,7 @@ describe('SimpleSelect', () => {
   it('renders an empty placeholder option', () => {
     const placeholderText = 'I am placeholder!';
     const { container } = render(
-      <SimpleSelect
-        options={options}
-        placeholder={placeholderText}
-        onChange={jest.fn()}
-      />
+      <SimpleSelect options={options} placeholder={placeholderText} />
     );
     const optionElements = container.querySelectorAll('option');
     const placeholderOption = optionElements[0];

--- a/src/shared/components/simple-select/SimpleSelect.tsx
+++ b/src/shared/components/simple-select/SimpleSelect.tsx
@@ -74,7 +74,7 @@ const SimpleSelect = (
   props: SimpleSelectProps,
   ref: ForwardedRef<{ clear: () => void }>
 ) => {
-  const { className, placeholder, value, ...otherProps } = props;
+  const { className, placeholder, ...otherProps } = props;
   const selectRef = useRef<HTMLSelectElement | null>(null);
 
   useImperativeHandle(ref, () => ({
@@ -99,14 +99,6 @@ const SimpleSelect = (
   );
 
   let selectChildren: ReactNode;
-
-  const getSelectValue = () => {
-    if (value) {
-      return value;
-    }
-
-    return placeholder ? '' : undefined;
-  };
 
   if ('optionGroups' in otherProps) {
     selectChildren = otherProps.optionGroups.map(
@@ -133,7 +125,6 @@ const SimpleSelect = (
       <select
         ref={selectRef}
         className={styles.selectResetDefaults}
-        value={getSelectValue()}
         {...selectProps}
       >
         {placeholder && renderPlaceholder(placeholder)}

--- a/src/shared/components/simple-select/SimpleSelect.tsx
+++ b/src/shared/components/simple-select/SimpleSelect.tsx
@@ -26,7 +26,6 @@ import classNames from 'classnames';
 import pickBy from 'lodash/pickBy';
 
 import styles from './SimpleSelect.scss';
-import { noop } from 'lodash';
 
 type HTMLSelectProps = SelectHTMLAttributes<HTMLSelectElement>;
 
@@ -41,7 +40,6 @@ type HTMLSelectProps = SelectHTMLAttributes<HTMLSelectElement>;
 export type Option = {
   value: string;
   label: string;
-  isSelected?: boolean;
 };
 
 export type OptionGroup = {
@@ -103,30 +101,11 @@ const SimpleSelect = (
   let selectChildren: ReactNode;
 
   const getSelectValue = () => {
-    // no point going through all these options if value is already available
     if (value) {
       return value;
     }
 
-    let selectValue = placeholder ? '' : undefined;
-
-    if ('optionGroups' in otherProps) {
-      otherProps.optionGroups.forEach((optionGroup) => {
-        optionGroup.options.forEach((option) => {
-          if (option.isSelected) {
-            selectValue = option.value;
-          }
-        });
-      });
-    } else {
-      otherProps.options.forEach((option) => {
-        if (option.isSelected) {
-          selectValue = option.value;
-        }
-      });
-    }
-
-    return selectValue;
+    return placeholder ? '' : undefined;
   };
 
   if ('optionGroups' in otherProps) {
@@ -155,7 +134,6 @@ const SimpleSelect = (
         ref={selectRef}
         className={styles.selectResetDefaults}
         value={getSelectValue()}
-        onChange={selectProps.onChange ?? noop}
         {...selectProps}
       >
         {placeholder && renderPlaceholder(placeholder)}


### PR DESCRIPTION
## Description
This happened due to using `defaultValue` to specify the placeholder in `SimpleSelect` as React doesn't like this. This PR tries to come with a workaround for this by using the `value` to either specify the selected value or the placeholder (if no option is selected).

## Related JIRA Issue(s)
[ENSWBSITES-1828](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1828)

## Deployment URL(s)
http://fix-simple-select.review.ensembl.org

## Views affected
BLAST settings
Genome browser -> Navigation panel -> Go to new location