### PR TITLE
Focus variant track settings

### DIFF
--- a/src/content/app/genome-browser/components/track-settings-panel/TrackSettingsPanel.test.tsx
+++ b/src/content/app/genome-browser/components/track-settings-panel/TrackSettingsPanel.test.tsx
@@ -144,10 +144,12 @@ describe('<TrackSettingsPanel />', () => {
         isTrackNameShown: true,
         trackId: selectedTrackId
       });
-      expect(
-        updatedState.browser.trackSettings[genomeId]
-          .settingsForIndividualTracks[selectedTrackId].settings.showTrackName
-      ).toBeTruthy();
+
+      const updatedTrackSettings = updatedState.browser.trackSettings[genomeId]
+        .settingsForIndividualTracks[selectedTrackId].settings as {
+        showTrackName: boolean;
+      };
+      expect(updatedTrackSettings.showTrackName).toBe(true);
     });
 
     it('toggles feature labels on the track', async () => {

--- a/src/content/app/genome-browser/components/track-settings-panel/track-settings-views/VariantTrackSettings.tsx
+++ b/src/content/app/genome-browser/components/track-settings-panel/track-settings-views/VariantTrackSettings.tsx
@@ -14,9 +14,19 @@
  * limitations under the License.
  */
 
-import React, { useState, forwardRef, type ForwardedRef } from 'react';
+import React, { forwardRef, type ForwardedRef } from 'react';
+
+import { useAppSelector, useAppDispatch } from 'src/store';
 
 import useGenomeBrowser from 'src/content/app/genome-browser/hooks/useGenomeBrowser';
+
+import { getBrowserActiveGenomeId } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
+import { getAllTrackSettingsForGenome } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSelectors';
+
+import {
+  updateTrackSettingsAndSave,
+  type FocusVariantTrack
+} from 'src/content/app/genome-browser/state/track-settings/trackSettingsSlice';
 
 import SlideToggle from 'src/shared/components/slide-toggle/SlideToggle';
 
@@ -30,65 +40,45 @@ const VariantTrackSettings = (
   props: Props,
   ref: ForwardedRef<HTMLDivElement>
 ) => {
-  const [shouldShowSnvIds, setShouldShowSnvIds] = useState(false);
-  const [shouldShowSnvAlleles, setShouldShowSnvAlleles] = useState(false);
-  const [shouldShowOtherVariantIds, setShouldShowOtherVariantIds] =
-    useState(false);
-  const [shouldShowOtherVariantAlleles, setShouldShowOtherVariantAlleles] =
-    useState(false);
-  const [shouldShowVariantExtent, setShouldShowVariantExtent] = useState(false);
-  const [shouldShowTrackName, setShouldShowTrackName] = useState(false);
+  const activeGenomeId = useAppSelector(getBrowserActiveGenomeId) as string;
+  const allTrackSettings = useAppSelector((state) =>
+    getAllTrackSettingsForGenome(state, activeGenomeId)
+  );
+
+  const trackSettings = allTrackSettings?.settingsForIndividualTracks[
+    props.trackId
+  ] as FocusVariantTrack | undefined;
+  const dispatch = useAppDispatch();
 
   const { toggleFocusVariantTrackSetting, toggleTrackName } =
     useGenomeBrowser();
 
-  const onSnvIdsToggle = () => {
+  const onSettingToggle = (setting: string, isOn: boolean) => {
     toggleFocusVariantTrackSetting({
-      settingName: 'label-snv-id',
-      isOn: !shouldShowSnvIds
+      settingName: setting,
+      isOn
     });
-    setShouldShowSnvIds(!shouldShowSnvIds);
+    dispatch(
+      updateTrackSettingsAndSave({
+        genomeId: activeGenomeId,
+        trackId: props.trackId,
+        settings: { [setting]: isOn }
+      })
+    );
   };
 
-  const onSnvAllelesToggle = () => {
-    toggleFocusVariantTrackSetting({
-      settingName: 'label-snv-alleles',
-      isOn: !shouldShowSnvAlleles
-    });
-    setShouldShowSnvAlleles(!shouldShowSnvAlleles);
-  };
-
-  const onOtherVariantIdsToggle = () => {
-    toggleFocusVariantTrackSetting({
-      settingName: 'label-other-id',
-      isOn: !shouldShowOtherVariantIds
-    });
-    setShouldShowOtherVariantIds(!shouldShowOtherVariantIds);
-  };
-
-  const onOtherVariantAllelesToggle = () => {
-    toggleFocusVariantTrackSetting({
-      settingName: 'label-other-alleles',
-      isOn: !shouldShowOtherVariantAlleles
-    });
-    setShouldShowOtherVariantAlleles(!shouldShowOtherVariantAlleles);
-  };
-
-  const onVariantExtentToggle = () => {
-    toggleFocusVariantTrackSetting({
-      settingName: 'show-extents',
-      isOn: !shouldShowVariantExtent
-    });
-    setShouldShowVariantExtent(!shouldShowVariantExtent);
-  };
-
-  const onTrackNameToggle = () => {
+  const onTrackNameToggle = (isOn: boolean) => {
     toggleTrackName({
       trackId: 'focus',
-      shouldShowTrackName: !shouldShowTrackName
+      shouldShowTrackName: isOn
     });
-
-    setShouldShowTrackName(!shouldShowTrackName);
+    dispatch(
+      updateTrackSettingsAndSave({
+        genomeId: activeGenomeId,
+        trackId: props.trackId,
+        settings: { name: isOn }
+      })
+    );
   };
 
   return (
@@ -99,16 +89,16 @@ const VariantTrackSettings = (
           <div className={styles.toggleWrapper}>
             <label>Variant IDs</label>
             <SlideToggle
-              isOn={shouldShowSnvIds}
-              onChange={onSnvIdsToggle}
+              isOn={trackSettings?.settings['label-snv-id'] ?? false}
+              onChange={(isOn) => onSettingToggle('label-snv-id', isOn)}
               className={styles.slideToggle}
             />
           </div>
           <div className={styles.toggleWrapper}>
             <label>Variant alleles</label>
             <SlideToggle
-              isOn={shouldShowSnvAlleles}
-              onChange={onSnvAllelesToggle}
+              isOn={trackSettings?.settings['label-snv-alleles'] ?? false}
+              onChange={(isOn) => onSettingToggle('label-snv-alleles', isOn)}
               className={styles.slideToggle}
             />
           </div>
@@ -120,24 +110,24 @@ const VariantTrackSettings = (
           <div className={styles.toggleWrapper}>
             <label>Variant IDs</label>
             <SlideToggle
-              isOn={shouldShowOtherVariantIds}
-              onChange={onOtherVariantIdsToggle}
+              isOn={trackSettings?.settings['label-other-id'] ?? false}
+              onChange={(isOn) => onSettingToggle('label-other-id', isOn)}
               className={styles.slideToggle}
             />
           </div>
           <div className={styles.toggleWrapper}>
             <label>Variant alleles</label>
             <SlideToggle
-              isOn={shouldShowOtherVariantAlleles}
-              onChange={onOtherVariantAllelesToggle}
+              isOn={trackSettings?.settings['label-other-alleles'] ?? false}
+              onChange={(isOn) => onSettingToggle('label-other-alleles', isOn)}
               className={styles.slideToggle}
             />
           </div>
           <div className={styles.toggleWrapper}>
             <label>Variant extent</label>
             <SlideToggle
-              isOn={shouldShowVariantExtent}
-              onChange={onVariantExtentToggle}
+              isOn={trackSettings?.settings['show-extents'] ?? false}
+              onChange={(isOn) => onSettingToggle('show-extents', isOn)}
               className={styles.slideToggle}
             />
           </div>
@@ -149,7 +139,7 @@ const VariantTrackSettings = (
           <div className={styles.toggleWrapper}>
             <label>Track name</label>
             <SlideToggle
-              isOn={false}
+              isOn={trackSettings?.settings['name'] ?? false}
               onChange={onTrackNameToggle}
               className={styles.slideToggle}
             />

--- a/src/content/app/genome-browser/hooks/useFocusTrack.ts
+++ b/src/content/app/genome-browser/hooks/useFocusTrack.ts
@@ -315,8 +315,12 @@ type UseFocusVariantParams = {
 
 const useFocusVariant = (params: UseFocusVariantParams) => {
   const { focusVariant, genomeBrowserMethods } = params;
-  const { setFocusGene, toggleFocusVariantTrackSetting, genomeBrowser } =
-    genomeBrowserMethods;
+  const {
+    setFocusGene,
+    toggleFocusVariantTrackSetting,
+    toggleTrackName,
+    genomeBrowser
+  } = genomeBrowserMethods;
   const dispatch = useAppDispatch();
 
   useEffect(() => {
@@ -324,16 +328,13 @@ const useFocusVariant = (params: UseFocusVariantParams) => {
       return;
     }
 
-    // - read track settings from IndexedDB — this should only be done once after focus track has switched on
-    // - pass these track settings to redux
-    // - send these track settings to the genome browser
-    // Remember — run this after the focus track has been enabled by the genome browser!
     restoreTrackSettings(focusVariant.genome_id);
 
     // FIXME: rename setFocusGene method!
     setFocusGene(focusVariant.object_id);
   }, [genomeBrowser, focusVariant?.object_id]);
 
+  // NOTE: ideally, this should be run once per genome id change or once per focus object type change
   const restoreTrackSettings = async (genomeId: string) => {
     const savedTrackSettings = await getTrackSettingsFromStorage(
       genomeId,
@@ -365,10 +366,17 @@ const useFocusVariant = (params: UseFocusVariantParams) => {
 
   const applyGenomeBrowserSettings = (trackSettings: TrackSettings) => {
     for (const [key, value] of Object.entries(trackSettings.settings)) {
-      toggleFocusVariantTrackSetting({
-        settingName: key,
-        isOn: value
-      });
+      if (key === 'name') {
+        toggleTrackName({
+          trackId: 'focus',
+          shouldShowTrackName: value
+        });
+      } else {
+        toggleFocusVariantTrackSetting({
+          settingName: key,
+          isOn: value
+        });
+      }
     }
   };
 };

--- a/src/content/app/genome-browser/hooks/useGenomicTracks.ts
+++ b/src/content/app/genome-browser/hooks/useGenomicTracks.ts
@@ -23,7 +23,7 @@ import useGenomeBrowser from 'src/content/app/genome-browser/hooks/useGenomeBrow
 import useGenomeBrowserIds from './useGenomeBrowserIds';
 import { useGenomeTracksQuery } from 'src/content/app/genome-browser/state/api/genomeBrowserApiSlice';
 
-import { getAllTrackSettings } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSelectors';
+import { getAllNonFocusTrackSettingsForGenome } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSelectors';
 
 import type { GenomeTrackCategory } from 'src/content/app/genome-browser/state/types/tracks';
 import type { TrackSettingsPerTrack } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSlice';
@@ -39,8 +39,9 @@ import type { TrackSettingsPerTrack } from 'src/content/app/genome-browser/state
 
 const useGenomicTracks = () => {
   const { activeGenomeId } = useGenomeBrowserIds();
-  const trackSettingsForGenome =
-    useAppSelector(getAllTrackSettings)?.settingsForIndividualTracks;
+  const trackSettingsForGenome = useAppSelector((state) =>
+    getAllNonFocusTrackSettingsForGenome(state, activeGenomeId ?? '')
+  );
   const { genomeBrowser, ...genomeBrowserMethods } = useGenomeBrowser();
   const genomeIdInitialisedRef = useRef('');
 
@@ -63,7 +64,7 @@ const useGenomicTracks = () => {
 
     const trackIdsList = prepareTrackIdsList(
       genomeTrackCategories ?? [],
-      trackSettingsForGenome
+      trackSettingsForGenome ?? {}
     );
     trackIdsList.forEach(genomeBrowserMethods.toggleTrack);
     genomeIdInitialisedRef.current = activeGenomeId as string;

--- a/src/content/app/genome-browser/services/track-settings/trackSettingsStorageConstants.ts
+++ b/src/content/app/genome-browser/services/track-settings/trackSettingsStorageConstants.ts
@@ -17,6 +17,7 @@
 import {
   getDefaultGeneTrackSettings,
   getDefaultFocusGeneTrackSettings,
+  getDefaultFocusVariantTrackSettings,
   getDefaultRegularTrackSettings
 } from 'src/content/app/genome-browser/state/track-settings/trackSettingsConstants';
 
@@ -37,4 +38,8 @@ trackSettingFieldsMap.set(
 trackSettingFieldsMap.set(
   TrackType.REGULAR,
   new Set(Object.keys(getDefaultRegularTrackSettings()))
+);
+trackSettingFieldsMap.set(
+  TrackType.FOCUS_VARIANT,
+  new Set(Object.keys(getDefaultFocusVariantTrackSettings()))
 );

--- a/src/content/app/genome-browser/state/track-settings/trackSettingsConstants.ts
+++ b/src/content/app/genome-browser/state/track-settings/trackSettingsConstants.ts
@@ -17,8 +17,11 @@
 import type {
   GeneTrackSettings,
   FocusGeneTrackSettings,
+  VariantTrackSettings,
+  FocusVariantTrackSettings,
   RegularTrackSettings,
   GeneTrack,
+  FocusVariantTrack,
   FocusGeneTrack,
   RegularTrack,
   TrackSettings
@@ -39,12 +42,30 @@ export const getDefaultGeneTrackSettings = (): GeneTrackSettings => ({
   isVisible: true
 });
 
+export const getDefaultVariantTrackSettings = (): VariantTrackSettings => ({
+  'label-snv-id': false,
+  'label-snv-alleles': false,
+  'label-other-id': false,
+  'label-other-alleles': false,
+  'show-extents': false,
+  name: false,
+  isVisible: true
+});
+
 export const getDefaultFocusGeneTrackSettings = (): FocusGeneTrackSettings => {
   const geneTrackSettings =
     getDefaultGeneTrackSettings() as Partial<GeneTrackSettings>;
   delete geneTrackSettings.isVisible;
   return geneTrackSettings as FocusGeneTrackSettings;
 };
+
+export const getDefaultFocusVariantTrackSettings =
+  (): FocusVariantTrackSettings => {
+    const variantTrackSettings =
+      getDefaultVariantTrackSettings() as Partial<VariantTrackSettings>;
+    delete variantTrackSettings.isVisible;
+    return variantTrackSettings as FocusVariantTrackSettings;
+  };
 
 export const getDefaultRegularTrackSettings = (): RegularTrackSettings => ({
   showTrackName: false,
@@ -64,6 +85,14 @@ export const buildDefaultFocusGeneTrack = (
   trackType: TrackType.FOCUS_GENE,
   settings: getDefaultGeneTrackSettings()
 });
+
+export const buildDefaultFocusVariantTrack = (): FocusVariantTrack => {
+  return {
+    id: 'focus-variant',
+    trackType: TrackType.FOCUS_VARIANT,
+    settings: getDefaultFocusVariantTrackSettings()
+  };
+};
 
 export const buildDefaultRegularTrack = (trackId: string): RegularTrack => ({
   id: trackId,

--- a/src/content/app/genome-browser/state/track-settings/trackSettingsSelectors.ts
+++ b/src/content/app/genome-browser/state/track-settings/trackSettingsSelectors.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { createSelector } from '@reduxjs/toolkit';
+
 import { getBrowserActiveGenomeId } from '../browser-general/browserGeneralSelectors';
 
 import type {
@@ -56,3 +58,21 @@ export const getAllTrackSettingsForGenome = (
 ): TrackSettingsForGenome | null => {
   return state.browser.trackSettings[genomeId] ?? null;
 };
+
+export const getAllNonFocusTrackSettingsForGenome = createSelector(
+  getAllTrackSettingsForGenome,
+  (trackSettingsForGenome) => {
+    if (!trackSettingsForGenome) {
+      return null;
+    }
+    const settings: Record<string, TrackSettings> = {};
+    for (const [trackId, trackSettings] of Object.entries(
+      trackSettingsForGenome.settingsForIndividualTracks
+    )) {
+      if (trackId !== 'focus' && trackId !== 'focus-variant') {
+        settings[trackId] = trackSettings;
+      }
+    }
+    return settings;
+  }
+);

--- a/src/content/app/genome-browser/state/track-settings/trackSettingsSlice.ts
+++ b/src/content/app/genome-browser/state/track-settings/trackSettingsSlice.ts
@@ -36,7 +36,18 @@ export type GeneTrackSettings = {
   isVisible: boolean;
 };
 
+export type VariantTrackSettings = {
+  'label-snv-id': boolean;
+  'label-snv-alleles': boolean;
+  'label-other-id': boolean;
+  'label-other-alleles': boolean;
+  'show-extents': boolean;
+  name: boolean;
+  isVisible: boolean;
+};
+
 export type FocusGeneTrackSettings = Omit<GeneTrackSettings, 'isVisible'>;
+export type FocusVariantTrackSettings = Omit<VariantTrackSettings, 'isVisible'>;
 
 export type RegularTrackSettings = {
   showTrackName: boolean;
@@ -55,13 +66,23 @@ export type FocusGeneTrack = {
   settings: FocusGeneTrackSettings;
 };
 
+export type FocusVariantTrack = {
+  id: string;
+  trackType: TrackType.FOCUS_VARIANT;
+  settings: FocusVariantTrackSettings;
+};
+
 export type RegularTrack = {
   id: string;
   trackType: TrackType.REGULAR;
   settings: RegularTrackSettings;
 };
 
-export type TrackSettings = GeneTrack | FocusGeneTrack | RegularTrack;
+export type TrackSettings =
+  | GeneTrack
+  | FocusGeneTrack
+  | FocusVariantTrack
+  | RegularTrack;
 
 export type TrackSettingsPerTrack = {
   [trackId: string]: TrackSettings;
@@ -175,6 +196,7 @@ const trackSettingsSlice = createSlice({
       state[genomeId] = {
         ...defaultTrackSettingsForGenome,
         settingsForIndividualTracks: {
+          ...state[genomeId]?.settingsForIndividualTracks,
           ...trackSettings
         }
       };
@@ -190,7 +212,9 @@ const trackSettingsSlice = createSlice({
       const { genomeId, trackId, isTrackNameShown } = action.payload;
       const trackSettingsState =
         state[genomeId].settingsForIndividualTracks[trackId];
-      trackSettingsState.settings.showTrackName = isTrackNameShown;
+      (
+        trackSettingsState.settings as { showTrackName: boolean }
+      ).showTrackName = isTrackNameShown;
     },
     updateFeatureLabelsVisibility(
       state,
@@ -247,6 +271,20 @@ const trackSettingsSlice = createSlice({
 
       trackSettingsState.settings.showTranscriptIds = shouldShowTranscriptIds;
     },
+    addSettingsForTrack(
+      state,
+      action: PayloadAction<{
+        genomeId: string;
+        trackId: string;
+        trackSettings: TrackSettings;
+      }>
+    ) {
+      const { genomeId, trackId, trackSettings } = action.payload;
+      if (!state[genomeId]) {
+        state[genomeId] = { settingsForIndividualTracks: {} };
+      }
+      state[genomeId].settingsForIndividualTracks[trackId] = trackSettings;
+    },
     deleteTrackSettingsForGenome(state, action: PayloadAction<string>) {
       const genomeId = action.payload;
       delete state[genomeId];
@@ -277,7 +315,8 @@ export const {
   updateFeatureLabelsVisibility,
   updateShowSeveralTranscripts,
   updateShowTranscriptIds,
-  deleteTrackSettingsForGenome
+  deleteTrackSettingsForGenome,
+  addSettingsForTrack
 } = trackSettingsSlice.actions;
 
 export default trackSettingsSlice.reducer;


### PR DESCRIPTION
## Description
This PR connects the focus track settings panel both to redux and to IndexedDB.
- If you toggle track settings, close the settings panel, and open it again, you should see the toggles turned correctly on or off
- If you refresh the browser window, the settings should be preserved and applied to the focus variant track when it loads.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1876

## Deployment URL(s)
http://focus-variant-track-settings.review.ensembl.org/genome-browser/grch38?focus=variant:rs779377781