### PR TITLE
Update blast error message for failed submission

### DIFF
--- a/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.tsx
@@ -23,7 +23,10 @@ import * as urlFor from 'src/shared/helpers/urlHelper';
 
 import { getFormattedDateTime } from 'src/shared/helpers/formatters/dateFormatter';
 import { areSubmissionResultsAvailable } from 'src/content/app/tools/blast/utils/blastResultsAvailability';
-import { isFailedBlastSubmission } from 'src/content/app/tools/blast/utils/blastSubmisionTypeNarrowing';
+import {
+  haveAllJobsFailed,
+  isFailedBlastSubmission
+} from 'src/content/app/tools/blast/utils/blastSubmisionTypeNarrowing';
 import downloadBlastSubmission from 'src/content/app/tools/blast/blast-download/submissionDownload';
 
 import { fillBlastForm } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
@@ -50,7 +53,8 @@ import type { BlastProgram } from 'src/content/app/tools/blast/types/blastSettin
 import styles from './BlastSubmissionHeader.scss';
 
 export const UNAVAILABLE_RESULTS_WARNING = 'Results no longer available';
-export const FAILED_SUBMISSION_WARNING = 'All jobs failed';
+export const FAILED_SUBMISSION_WARNING = 'Submission failed';
+export const ALL_JOBS_FAILED_WARNING = 'All jobs have failed';
 
 export type Props = {
   submission: BlastSubmission;
@@ -196,6 +200,16 @@ const ControlsSection = (props: {
         <DeleteButton onClick={onDelete} disabled={isInDeleteMode} />
         <div className={styles.errorMessage}>
           <span>{FAILED_SUBMISSION_WARNING}</span>
+          <QuestionButton helpText={<FailedSubmissionHelpText />} />
+        </div>
+      </div>
+    );
+  } else if (haveAllJobsFailed(submission)) {
+    return (
+      <div className={styles.controlsSection}>
+        <DeleteButton onClick={onDelete} disabled={isInDeleteMode} />
+        <div className={styles.errorMessage}>
+          <span>{ALL_JOBS_FAILED_WARNING}</span>
           <QuestionButton helpText={<FailedSubmissionHelpText />} />
         </div>
       </div>

--- a/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.tsx
@@ -23,10 +23,7 @@ import * as urlFor from 'src/shared/helpers/urlHelper';
 
 import { getFormattedDateTime } from 'src/shared/helpers/formatters/dateFormatter';
 import { areSubmissionResultsAvailable } from 'src/content/app/tools/blast/utils/blastResultsAvailability';
-import {
-  haveAllJobsFailed,
-  isFailedBlastSubmission
-} from 'src/content/app/tools/blast/utils/blastSubmisionTypeNarrowing';
+import { isFailedBlastSubmission } from 'src/content/app/tools/blast/utils/blastSubmisionTypeNarrowing';
 import downloadBlastSubmission from 'src/content/app/tools/blast/blast-download/submissionDownload';
 
 import { fillBlastForm } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
@@ -54,7 +51,6 @@ import styles from './BlastSubmissionHeader.scss';
 
 export const UNAVAILABLE_RESULTS_WARNING = 'Results no longer available';
 export const FAILED_SUBMISSION_WARNING = 'Submission failed';
-export const ALL_JOBS_FAILED_WARNING = 'All jobs have failed';
 
 export type Props = {
   submission: BlastSubmission;
@@ -200,16 +196,6 @@ const ControlsSection = (props: {
         <DeleteButton onClick={onDelete} disabled={isInDeleteMode} />
         <div className={styles.errorMessage}>
           <span>{FAILED_SUBMISSION_WARNING}</span>
-          <QuestionButton helpText={<FailedSubmissionHelpText />} />
-        </div>
-      </div>
-    );
-  } else if (haveAllJobsFailed(submission)) {
-    return (
-      <div className={styles.controlsSection}>
-        <DeleteButton onClick={onDelete} disabled={isInDeleteMode} />
-        <div className={styles.errorMessage}>
-          <span>{ALL_JOBS_FAILED_WARNING}</span>
           <QuestionButton helpText={<FailedSubmissionHelpText />} />
         </div>
       </div>

--- a/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.tsx
@@ -23,7 +23,10 @@ import * as urlFor from 'src/shared/helpers/urlHelper';
 
 import { getFormattedDateTime } from 'src/shared/helpers/formatters/dateFormatter';
 import { areSubmissionResultsAvailable } from 'src/content/app/tools/blast/utils/blastResultsAvailability';
-import { isFailedBlastSubmission } from 'src/content/app/tools/blast/utils/blastSubmisionTypeNarrowing';
+import {
+  isFailedBlastSubmission,
+  haveAllJobsFailed
+} from 'src/content/app/tools/blast/utils/blastSubmisionTypeNarrowing';
 import downloadBlastSubmission from 'src/content/app/tools/blast/blast-download/submissionDownload';
 
 import { fillBlastForm } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
@@ -190,7 +193,7 @@ const ControlsSection = (props: {
     props;
   const isExpiredSubmission = !areSubmissionResultsAvailable(submission);
 
-  if (isFailedBlastSubmission(submission)) {
+  if (isFailedBlastSubmission(submission) || haveAllJobsFailed(submission)) {
     return (
       <div className={styles.controlsSection}>
         <DeleteButton onClick={onDelete} disabled={isInDeleteMode} />

--- a/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.tsx
@@ -50,7 +50,7 @@ import type { BlastProgram } from 'src/content/app/tools/blast/types/blastSettin
 import styles from './BlastSubmissionHeader.scss';
 
 export const UNAVAILABLE_RESULTS_WARNING = 'Results no longer available';
-export const FAILED_SUBMISSION_WARNING = 'Submission failed';
+export const FAILED_SUBMISSION_WARNING = 'All jobs failed';
 
 export type Props = {
   submission: BlastSubmission;

--- a/src/content/app/tools/blast/components/listed-blast-submission/ListedBlastSubmission.tsx
+++ b/src/content/app/tools/blast/components/listed-blast-submission/ListedBlastSubmission.tsx
@@ -15,7 +15,6 @@
  */
 
 import React from 'react';
-import classNames from 'classnames';
 
 import { useAppDispatch, useAppSelector } from 'src/store';
 
@@ -162,16 +161,12 @@ export const JobStatus = (props: JobStatusProps) => {
   const hasAllFailedJobs = jobs.every((job) => job.status === 'FAILURE');
   const hasSomeFailedJobs = jobs.some((job) => job.status === 'FAILURE');
 
-  const elementClasses = classNames({
-    [styles.jobStatusProminent]: hasRunningJobs || hasSomeFailedJobs
-  });
-
   if (hasRunningJobs) {
-    return <span className={elementClasses}>Running...</span>;
+    return <span className={styles.jobStatusProminent}>Running...</span>;
   } else if (hasAllFailedJobs) {
-    return <span className={elementClasses}>Job failed</span>;
+    return <span className={styles.jobStatusProminent}>Job failed</span>;
   } else if (hasSomeFailedJobs) {
-    return <span className={elementClasses}>Part failed</span>;
+    return <span className={styles.jobStatusProminent}>Part failed</span>;
   } else {
     return null;
   }

--- a/src/content/app/tools/blast/utils/blastSubmisionTypeNarrowing.ts
+++ b/src/content/app/tools/blast/utils/blastSubmisionTypeNarrowing.ts
@@ -39,3 +39,9 @@ export const isFailedBlastSubmission = (
     return 'error' in submission;
   }
 };
+
+export const haveAllJobsFailed = (
+  submission?: SuccessfulBlastSubmission
+): boolean => {
+  return submission?.results?.every((job) => job.status === 'FAILURE') ?? false;
+};

--- a/src/content/app/tools/blast/utils/blastSubmisionTypeNarrowing.ts
+++ b/src/content/app/tools/blast/utils/blastSubmisionTypeNarrowing.ts
@@ -39,3 +39,13 @@ export const isFailedBlastSubmission = (
     return 'error' in submission;
   }
 };
+
+export const haveAllJobsFailed = (
+  submission?: SuccessfulBlastSubmission
+): boolean => {
+  if (!submission) {
+    return false;
+  } else {
+    return submission.results?.every((job) => job.status === 'FAILURE');
+  }
+};

--- a/src/content/app/tools/blast/utils/blastSubmisionTypeNarrowing.ts
+++ b/src/content/app/tools/blast/utils/blastSubmisionTypeNarrowing.ts
@@ -39,13 +39,3 @@ export const isFailedBlastSubmission = (
     return 'error' in submission;
   }
 };
-
-export const haveAllJobsFailed = (
-  submission?: SuccessfulBlastSubmission
-): boolean => {
-  if (!submission) {
-    return false;
-  } else {
-    return submission.results?.every((job) => job.status === 'FAILURE');
-  }
-};


### PR DESCRIPTION
## Description
Change the blast error message for all jobs failing.

XD: https://xd.adobe.com/view/f585eb32-fbdd-4233-9451-bbb965678c1c-a0d6/screen/0c0b6eed-35b4-4b91-9ccb-de8899af197b?fullscreen

*NOTE*: The changes proposed in the ticket were already available except for blast submission error message. Hence, the one liner for this PR.

## Related JIRA Issue(s)
[ENSWBSITES-1836](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1836)

## Deployment URL(s)
http://update-blast-error-messages.review.ensembl.org

## Views affected
BLAST