### PR TITLE
Add zmenu for focus variant track

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ensembl/ensembl-genome-browser": "0.6.3",
+        "@ensembl/ensembl-genome-browser": "0.6.4",
         "@react-spring/web": "9.4.5-beta.1",
         "@reduxjs/toolkit": "1.9.0",
         "@sentry/browser": "7.21.1",
@@ -2426,9 +2426,9 @@
       }
     },
     "node_modules/@ensembl/ensembl-genome-browser": {
-      "version": "0.6.3",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.3.tgz",
-      "integrity": "sha1-dg0ChhlPPIzVpima2EQ8XMbWgKc="
+      "version": "0.6.4",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.4.tgz",
+      "integrity": "sha1-Anee4naVBKCllslVfIYRhWhWcOA="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
@@ -43098,9 +43098,9 @@
       "dev": true
     },
     "@ensembl/ensembl-genome-browser": {
-      "version": "0.6.3",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.3.tgz",
-      "integrity": "sha1-dg0ChhlPPIzVpima2EQ8XMbWgKc="
+      "version": "0.6.4",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.4.tgz",
+      "integrity": "sha1-Anee4naVBKCllslVfIYRhWhWcOA="
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "coverage": "jest --coverage"
   },
   "dependencies": {
-    "@ensembl/ensembl-genome-browser": "0.6.3",
+    "@ensembl/ensembl-genome-browser": "0.6.4",
     "@react-spring/web": "9.4.5-beta.1",
     "@reduxjs/toolkit": "1.9.0",
     "@sentry/browser": "7.21.1",

--- a/src/content/app/genome-browser/components/zmenu/ZmenuContent.tsx
+++ b/src/content/app/genome-browser/components/zmenu/ZmenuContent.tsx
@@ -28,13 +28,14 @@ import {
   ZmenuContentItem as ZmenuContentItemType,
   Markup,
   ZmenuContentTranscript,
-  ZmenuContentGene
+  ZmenuContentGene,
+  ZmenuContentVariant
 } from '@ensembl/ensembl-genome-browser';
 
 import styles from './Zmenu.scss';
 
 export type ZmenuContentProps = {
-  features: (ZmenuContentTranscript | ZmenuContentGene)[];
+  features: (ZmenuContentTranscript | ZmenuContentGene | ZmenuContentVariant)[];
   featureId: string;
   destroyZmenu: () => void;
 };

--- a/src/content/app/genome-browser/components/zmenu/zmenus/GeneAndOneTranscriptZmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/zmenus/GeneAndOneTranscriptZmenu.tsx
@@ -1,0 +1,98 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect } from 'react';
+
+import { useAppDispatch } from 'src/store';
+
+import { changeHighlightedTrackId } from 'src/content/app/genome-browser/state/track-panel/trackPanelSlice';
+
+import { ToolboxExpandableContent } from 'src/shared/components/toolbox';
+import ZmenuContent from '../ZmenuContent';
+import ZmenuInstantDownload from '../ZmenuInstantDownload';
+
+import {
+  type ZmenuContentTranscript,
+  type ZmenuContentGene,
+  type ZmenuCreatePayload
+} from '@ensembl/ensembl-genome-browser';
+
+import styles from '../Zmenu.scss';
+
+type Props = {
+  payload: ZmenuCreatePayload;
+  onDestroy: () => void;
+};
+
+const GeneAndOneTranscriptZmenu = (props: Props) => {
+  const { content } = props.payload;
+  const dispatch = useAppDispatch();
+
+  let featureId = '',
+    transcriptId = '',
+    gene: ZmenuContentGene | undefined;
+
+  const features: (ZmenuContentTranscript | ZmenuContentGene)[] = [];
+
+  const transcript = content.find(
+    (feature) => feature.metadata.type === 'transcript'
+  ) as ZmenuContentTranscript;
+
+  if (transcript) {
+    features.push(transcript);
+
+    gene = content.find(
+      (feature) =>
+        feature.metadata.type === 'gene' &&
+        feature.metadata.versioned_id === transcript?.metadata.gene_id
+    ) as ZmenuContentGene;
+
+    if (gene) {
+      features.push(gene);
+    }
+
+    transcriptId = transcript.metadata.versioned_id;
+    featureId = `gene:${gene.metadata.unversioned_id}`;
+  }
+
+  useEffect(() => {
+    gene && dispatch(changeHighlightedTrackId(gene.metadata.track));
+  }, []);
+
+  const mainContent = (
+    <ZmenuContent
+      features={features}
+      featureId={featureId}
+      destroyZmenu={props.onDestroy}
+    />
+  );
+
+  const footerContent = (
+    <div className={styles.zmenuFooterContent}>
+      <ZmenuInstantDownload id={transcriptId} />
+    </div>
+  );
+
+  return (
+    <ToolboxExpandableContent
+      mainContent={mainContent}
+      footerContent={footerContent}
+      className={styles.toolBox}
+    />
+  );
+};
+
+export default GeneAndOneTranscriptZmenu;

--- a/src/content/app/genome-browser/components/zmenu/zmenus/VariantZmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/zmenus/VariantZmenu.tsx
@@ -1,0 +1,48 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import ZmenuContent from '../ZmenuContent';
+
+import {
+  type ZmenuCreatePayload,
+  type ZmenuContentVariantMetadata
+} from '@ensembl/ensembl-genome-browser';
+
+type Props = {
+  payload: ZmenuCreatePayload;
+  onDestroy: () => void;
+};
+
+const VariantZmenu = (props: Props) => {
+  const { content } = props.payload;
+
+  const variantMetadata = content[0]?.metadata as
+    | ZmenuContentVariantMetadata
+    | undefined;
+  const variantId = variantMetadata?.id ?? '';
+
+  return (
+    <ZmenuContent
+      features={content}
+      featureId={`variant:${variantId}`}
+      destroyZmenu={props.onDestroy}
+    />
+  );
+};
+
+export default VariantZmenu;


### PR DESCRIPTION
## Description
Show zmenu when clicking on a variant in the variant track (see https://github.com/Ensembl/ensembl-genome-browser/pull/24)

- Update genome browser package so as to include updated type definitions
- Extracted gene-and-one-transcript zmenu and a variant zmenu from the Zmenu component

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1874

## Deployment URL(s)
http://zmenu-variant.review.ensembl.org