### PR TITLE
Update the test for the Tabs component

### DIFF
--- a/src/shared/components/tabs/Tabs.test.tsx
+++ b/src/shared/components/tabs/Tabs.test.tsx
@@ -25,20 +25,16 @@ import Tabs, { Tab } from './Tabs';
 const onTabChange = jest.fn();
 
 const createTabGroup = (): Tab[] => {
-  const options = times(10, () => ({
-    title: faker.datatype.uuid(),
-    isDisabled: faker.datatype.boolean()
-  }));
-
-  // Make sure we have atleast one enabled and one disabled entry
-  options.push({
-    title: faker.datatype.uuid(),
-    isDisabled: true
-  });
-  options.push({
-    title: faker.datatype.uuid(),
-    isDisabled: false
-  });
+  const options = [
+    ...times(5, () => ({
+      title: faker.datatype.uuid(),
+      isDisabled: false
+    })),
+    ...times(5, () => ({
+      title: faker.datatype.uuid(),
+      isDisabled: true
+    }))
+  ];
 
   return options;
 };


### PR DESCRIPTION
## Description
A test just randomly [failed](https://gitlab.ebi.ac.uk/ensembl-web/ensembl-client/-/jobs/1176669):

![image](https://user-images.githubusercontent.com/6834224/222441415-645360f0-c3d8-483a-885c-831fd4d92854.png)

Here's the code of the failed test:

```
    const unselectedTabIndex = tabsData.findIndex(
      (tab) => tab.title !== defaultProps.selectedTab && !tab.isDisabled
    );
    const unselectedTab =
      container.querySelectorAll('.tab')[unselectedTabIndex];

    await userEvent.click(unselectedTab);

    expect(onTabChange).toBeCalledWith(tabsData[unselectedTabIndex].title);
```

From the source code of the test, it looks like the test couldn't find a second tab which would not be disabled. The only likely reason for this failure is that all the 10 tabs generated in the test with the field `isDisabled: faker.datatype.boolean()` had it set to true. What are the odds! However, if this indeed happened, then we aren't guaranteed this won't happen again; so I updated the test to generate five enabled tabs and five disabled tabs. It should be more than enough for the test to run.