### PR TITLE
Wrap calls to IndexedDB in try-catch

### DIFF
--- a/src/content/app/genome-browser/services/focus-objects/focusObjectStorageService.ts
+++ b/src/content/app/genome-browser/services/focus-objects/focusObjectStorageService.ts
@@ -35,17 +35,25 @@ export type StoredFocusGene = {
 
 export const saveFocusObject = async (focusObject: StorableFocusObject) => {
   const storableData = buildFocusObjectDataForStorage(focusObject);
-  await IndexedDB.set(
-    GB_FOCUS_OBJECTS_STORE_NAME,
-    focusObject.object_id,
-    storableData
-  );
+  try {
+    await IndexedDB.set(
+      GB_FOCUS_OBJECTS_STORE_NAME,
+      focusObject.object_id,
+      storableData
+    );
+  } catch {
+    // exit without error
+  }
 };
 
 export const getFocusObject = async (
   focusObjectId: string
 ): Promise<StoredFocusObject | undefined> => {
-  return await IndexedDB.get(GB_FOCUS_OBJECTS_STORE_NAME, focusObjectId);
+  try {
+    return await IndexedDB.get(GB_FOCUS_OBJECTS_STORE_NAME, focusObjectId);
+  } catch {
+    return undefined;
+  }
 };
 
 export const updateFocusObject = async (
@@ -70,21 +78,29 @@ export const updateFocusObject = async (
 };
 
 export const deleteFocusObject = async (focusObjectId: string) => {
-  await IndexedDB.delete(GB_FOCUS_OBJECTS_STORE_NAME, focusObjectId);
+  try {
+    await IndexedDB.delete(GB_FOCUS_OBJECTS_STORE_NAME, focusObjectId);
+  } catch {
+    // doesn't matter; exit without error
+  }
 };
 
 // useful for cleanup after a species is removed
 export const deleteAllFocusObjectsForGenome = async (genomeId: string) => {
-  const database = await IndexedDB.getDB();
-  const focusObjectsForGenome: Awaited<StoredFocusObject[]> =
-    await database.getAllFromIndex(
-      GB_FOCUS_OBJECTS_STORE_NAME,
-      'genomeId',
-      genomeId
-    );
+  try {
+    const database = await IndexedDB.getDB();
+    const focusObjectsForGenome: Awaited<StoredFocusObject[]> =
+      await database.getAllFromIndex(
+        GB_FOCUS_OBJECTS_STORE_NAME,
+        'genomeId',
+        genomeId
+      );
 
-  for (const focusObject of focusObjectsForGenome) {
-    await IndexedDB.delete(GB_FOCUS_OBJECTS_STORE_NAME, focusObject.id);
+    for (const focusObject of focusObjectsForGenome) {
+      await IndexedDB.delete(GB_FOCUS_OBJECTS_STORE_NAME, focusObject.id);
+    }
+  } catch {
+    // doesn't matter; exit without error
   }
 };
 


### PR DESCRIPTION
## Description
If a browser refuses to access IndexedDB — for which in our case the most likely candidate in Firefox in private browsing mode — then some of the pages of the site would not work. Example:

https://user-images.githubusercontent.com/6834224/223164366-f41e43da-21d6-4f32-b1ec-69d0535fa5cf.mov

This PR wraps the calls to IndexedDB in try-catch blocks, such that even if the browser cannot connect to the db, it will just go on about its business instead of stalling.

https://user-images.githubusercontent.com/6834224/223167863-c88ce86c-ecc2-44cd-8ba5-8d61be3dbdb1.mov

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1806

## Deployment URL(s)
http://handle-problematic-indexedb.review.ensembl.org