### PR TITLE
Fix broken restore defaults in data table

### DIFF
--- a/src/shared/components/data-table/components/table-controls/components/table-actions/TableActions.test.tsx
+++ b/src/shared/components/data-table/components/table-controls/components/table-actions/TableActions.test.tsx
@@ -64,14 +64,14 @@ describe('<TableActions />', () => {
 
   it('respects the disabledActions list', () => {
     container = renderTableActions({
-      disabledActions: [TableAction.FILTERS, TableAction.DEFAULT]
+      disabledActions: [TableAction.FILTERS, TableAction.FIND_IN_TABLE]
     }).container;
 
     const filterOption = document.querySelector(
       `option[value="${TableAction.FILTERS}"`
     );
     const defaultOption = document.querySelector(
-      `option[value="${TableAction.DEFAULT}"`
+      `option[value="${TableAction.FIND_IN_TABLE}"`
     );
     const downloadOption = document.querySelector(
       `option[value="${TableAction.DOWNLOAD_ALL_DATA}"`

--- a/src/shared/components/data-table/components/table-controls/components/table-actions/TableActions.tsx
+++ b/src/shared/components/data-table/components/table-controls/components/table-actions/TableActions.tsx
@@ -30,10 +30,6 @@ import {
 
 const actionOptions = [
   {
-    value: TableAction.DEFAULT,
-    label: 'Actions'
-  },
-  {
     value: TableAction.FIND_IN_TABLE,
     label: 'Find in table'
   },
@@ -107,7 +103,6 @@ const TableActions = () => {
         type: 'restore_defaults',
         payload: restorableTableState
       });
-      return;
     }
 
     dispatch({

--- a/src/shared/components/data-table/components/table-controls/components/table-actions/components/show-hide-columns/ShowHideColumns.tsx
+++ b/src/shared/components/data-table/components/table-controls/components/table-actions/components/show-hide-columns/ShowHideColumns.tsx
@@ -23,17 +23,18 @@ import styles from './ShowHideColumns.scss';
 
 const ShowHideColumns = () => {
   const { hiddenColumnIds, dispatch, columns } = useDataTable();
+  const updatedHiddenColumnIds = new Set(hiddenColumnIds);
 
   const onChange = (columnId: string, checked: boolean) => {
     if (!checked) {
-      hiddenColumnIds.add(columnId);
+      updatedHiddenColumnIds.add(columnId);
     } else {
-      hiddenColumnIds.delete(columnId);
+      updatedHiddenColumnIds.delete(columnId);
     }
 
     dispatch({
       type: 'set_hidden_column_ids',
-      payload: hiddenColumnIds
+      payload: updatedHiddenColumnIds
     });
   };
 
@@ -46,7 +47,7 @@ const ShowHideColumns = () => {
             <Checkbox
               key={key}
               label={column.title}
-              checked={!hiddenColumnIds.has(column.columnId)}
+              checked={!updatedHiddenColumnIds.has(column.columnId)}
               onChange={(checked) => onChange(column.columnId, checked)}
               className={styles.checkbox}
             />

--- a/src/shared/components/data-table/dataTableTypes.ts
+++ b/src/shared/components/data-table/dataTableTypes.ts
@@ -28,7 +28,7 @@ export type SortingOptions = {
 };
 
 export enum TableAction {
-  DEFAULT = 'default',
+  DEFAULT = '',
   FIND_IN_TABLE = 'find_in_table',
   FILTERS = 'filters',
   SHOW_HIDE_COLUMNS = 'show_hide_columns',


### PR DESCRIPTION
## Description
The `Restore defaults` action in the `DataTable` was not properly restoring the hidden columns when selected. This was because the `TableContext` which is used to pass to the reducer for restoring, was being modified when hiding the columns. Changing the code to not to modify fixes the issue.

Steps to reproduce:

1. Run a BLAST job
2. Select the results when it has finished running
3. Click on the genome in a sequence it was run against to open the results table (far right)
4. Click on the `Actions` select field (far left) in the table header
5. Select `Show/hide columns` option and select any fields in the popup panel to hide
6. Now select `Restore defaults` to see if the hidden columns have been restored

## Related JIRA Issue(s)
[ENSWBSITES-1870](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1870)

## Deployment URL(s)
http://fix-data-table.review.ensembl.org


## Views affected
BLAST -> Results view -> Sequence -> Results table