### PR TITLE
Download combined table of BLAST results and combined raw file

### DIFF
--- a/src/content/app/tools/blast/blast-download/renderSubmissionTable.ts
+++ b/src/content/app/tools/blast/blast-download/renderSubmissionTable.ts
@@ -145,6 +145,8 @@ const printData = (submission: BlastSubmissionWithJobsWithResults) => {
   let table = '';
   table += '\n[DATA]\n';
 
+  table += `${jobRenderer.printHead()}\n`;
+
   for (const species of submission.submittedData.species) {
     for (const sequence of submission.submittedData.sequences) {
       const job = submission.results.find(
@@ -156,13 +158,11 @@ const printData = (submission: BlastSubmissionWithJobsWithResults) => {
         continue;
       }
 
-      const tableHead = jobRenderer.printHead();
       const tableForJob = jobRenderer.printBody({
         species,
         sequence,
         job
       });
-      table += `${tableHead}\n`;
       table += tableForJob;
     }
   }

--- a/src/content/app/tools/blast/blast-download/renderSubmissionTable.ts
+++ b/src/content/app/tools/blast/blast-download/renderSubmissionTable.ts
@@ -56,11 +56,12 @@ const printMetadata = (submission: BlastSubmissionWithJobsWithResults) => {
   rows.push(
     tabulate(['Blast type', submission.submittedData.parameters.program])
   );
-  // TODO: store query sequence type
-  // rows.push(tabulate([
-  //   'Query sequence type',
-  //   formatSequenceType(submission.submittedData.parameters.)
-  // ]));
+  rows.push(
+    tabulate([
+      'Query sequence type',
+      formatSequenceType(submission.submittedData.sequenceType)
+    ])
+  );
   rows.push(
     tabulate([
       'Database type queried',
@@ -409,13 +410,13 @@ const printCommonCells = (params: {
   };
 };
 
-// const formatSequenceType = (type: string) => {
-//   if (type === 'protein') {
-//     return 'Protein';
-//   } else {
-//     return 'Nucleotide';
-//   }
-// };
+const formatSequenceType = (type: string) => {
+  if (type === 'protein') {
+    return 'Protein';
+  } else {
+    return 'Nucleotide';
+  }
+};
 
 const formatDatabaseType = (type: string) => {
   if (type === 'pep') {

--- a/src/content/app/tools/blast/blast-download/renderSubmissionTable.ts
+++ b/src/content/app/tools/blast/blast-download/renderSubmissionTable.ts
@@ -147,6 +147,8 @@ const printData = (submission: BlastSubmissionWithJobsWithResults) => {
 
   table += `${jobRenderer.printHead()}\n`;
 
+  const tableBody: string[] = [];
+
   for (const species of submission.submittedData.species) {
     for (const sequence of submission.submittedData.sequences) {
       const job = submission.results.find(
@@ -163,9 +165,14 @@ const printData = (submission: BlastSubmissionWithJobsWithResults) => {
         sequence,
         job
       });
-      table += tableForJob;
+
+      if (tableForJob) {
+        tableBody.push(tableForJob);
+      }
     }
   }
+
+  table += tableBody.join('\n');
 
   return table;
 };

--- a/src/content/app/tools/blast/blast-download/renderSubmissionTable.ts
+++ b/src/content/app/tools/blast/blast-download/renderSubmissionTable.ts
@@ -1,0 +1,444 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  SuccessfulBlastSubmission,
+  SubmittedBlastData,
+  BlastJobWithResults
+} from 'src/content/app/tools/blast/state/blast-results/blastResultsSlice';
+import type { BlastHit, HSP } from 'src/content/app/tools/blast/types/blastJob';
+
+type BlastSubmissionWithJobsWithResults = Omit<
+  SuccessfulBlastSubmission,
+  'results'
+> & {
+  results: BlastJobWithResults[];
+};
+
+export const printBlastSubmissionTable = (
+  submission: BlastSubmissionWithJobsWithResults
+) => {
+  let table = '';
+  table += printMetadata(submission);
+  table += printData(submission);
+  return table;
+};
+
+const printMetadata = (submission: BlastSubmissionWithJobsWithResults) => {
+  const rows: string[] = [];
+  const submissionDate = new Date(submission.submittedAt);
+  const dateFormatter = new Intl.DateTimeFormat('en-GB', { timeZone: 'UTC' });
+  const timeFormatter = new Intl.DateTimeFormat('en-GB', {
+    hour: 'numeric',
+    minute: 'numeric'
+  });
+  const formattedDate = dateFormatter.format(submissionDate);
+  const formattedTime = `${timeFormatter.format(submissionDate)} GMT`;
+
+  rows.push('[METADATA]');
+  rows.push(tabulate(['Submission id', submission.id]));
+  rows.push(tabulate(['Date', formattedDate]));
+  rows.push(tabulate(['Time', formattedTime]));
+  rows.push('[PARAMETERS]');
+  rows.push(
+    tabulate(['Blast type', submission.submittedData.parameters.program])
+  );
+  // TODO: store query sequence type
+  // rows.push(tabulate([
+  //   'Query sequence type',
+  //   formatSequenceType(submission.submittedData.parameters.)
+  // ]));
+  rows.push(
+    tabulate([
+      'Database type queried',
+      formatDatabaseType(submission.submittedData.parameters.database)
+    ])
+  );
+  rows.push(tabulate(['Sensitivity', submission.submittedData.preset]));
+  rows.push(
+    tabulate(['Max alignments', submission.submittedData.parameters.alignments])
+  );
+  rows.push(
+    tabulate(['Max scores', submission.submittedData.parameters.scores])
+  );
+  rows.push(tabulate(['E-threshold', submission.submittedData.parameters.exp]));
+  rows.push(
+    tabulate([
+      'Statistical accuracy',
+      submission.submittedData.parameters.compstats
+    ])
+  );
+  rows.push(
+    tabulate(['HSPs per hit', submission.submittedData.parameters.hsps])
+  );
+  rows.push(
+    tabulate(['Drop-off', submission.submittedData.parameters.dropoff])
+  );
+
+  if (submission.submittedData.parameters.gapopen) {
+    rows.push(
+      tabulate(['Gap opening', submission.submittedData.parameters.gapopen])
+    );
+  }
+  if (submission.submittedData.parameters.gapext) {
+    rows.push(
+      tabulate(['Gap extension', submission.submittedData.parameters.gapext])
+    );
+  }
+
+  rows.push(
+    tabulate(['Word size', submission.submittedData.parameters.wordsize])
+  );
+
+  if (submission.submittedData.parameters.match_scores) {
+    rows.push(
+      tabulate([
+        'Match/mismatch',
+        submission.submittedData.parameters.match_scores
+      ])
+    );
+  }
+  if (submission.submittedData.parameters.matrix) {
+    rows.push(
+      tabulate(['Scoring matrix', submission.submittedData.parameters.matrix])
+    );
+  }
+
+  if (submission.submittedData.parameters.gapalign) {
+    rows.push(
+      tabulate([
+        'Align gaps',
+        formatGapAlign(submission.submittedData.parameters.gapalign)
+      ])
+    );
+  }
+
+  rows.push(
+    tabulate([
+      'Filter low complexity regions',
+      formatLowComplexityFilter(submission.submittedData.parameters.filter)
+    ])
+  );
+
+  return rows.join('\n');
+};
+
+const printData = (submission: BlastSubmissionWithJobsWithResults) => {
+  const jobRenderer = getJobRenderer(
+    submission.submittedData.parameters.database
+  );
+
+  let table = '';
+  table += '\n[DATA]\n';
+
+  for (const species of submission.submittedData.species) {
+    for (const sequence of submission.submittedData.sequences) {
+      const job = submission.results.find(
+        (job) =>
+          job.genomeId === species.genome_id && job.sequenceId === sequence.id
+      );
+      if (!job) {
+        // shouldn't happen
+        continue;
+      }
+
+      const tableForJob = jobRenderer({
+        species,
+        sequence,
+        job
+      });
+      table += tableForJob;
+    }
+  }
+
+  return table;
+};
+
+const getJobRenderer = (blastDatabase: string) => {
+  switch (blastDatabase) {
+    case 'pep':
+      return printProteinsTable;
+    case 'cdna':
+      return printTranscriptsTable;
+    default:
+      return printGenomicTable;
+  }
+};
+
+const printGenomicTable = (params: {
+  species: SubmittedBlastData['species'][number];
+  sequence: SubmittedBlastData['sequences'][number];
+  job: BlastJobWithResults;
+}) => {
+  const { species, sequence, job } = params;
+  const table: (string | number)[][] = [];
+  const headerRow = [
+    'Query sequence no.',
+    'Query sequence header',
+    'Query full length',
+    'Species scientific name',
+    'Assembly name',
+    'E-value',
+    'Hit length',
+    '% ID',
+    'Bit score',
+    'Genomic location',
+    'Hit orientation',
+    'Hit start',
+    'Hit end',
+    'Query start',
+    'Query end',
+    'Alignment length',
+    'Query sequence',
+    'Hit sequence'
+  ];
+  table.push(headerRow);
+
+  const hspsWithHits = job.data.hits.flatMap((hit) => {
+    return hit.hit_hsps.map((hsp) => ({ ...hsp, hit }));
+  });
+  hspsWithHits.sort(sortByEValue);
+
+  for (const hsp of hspsWithHits) {
+    const commonCells = printCommonCells({
+      species,
+      sequence,
+      hsp,
+      hit: hsp.hit
+    });
+    const row = [
+      commonCells.sequenceId,
+      commonCells.sequenceHeader,
+      commonCells.queryLength,
+      commonCells.speciesName,
+      commonCells.assemblyName,
+      commonCells.evalue,
+      commonCells.hitLength,
+      commonCells.percentIdentity,
+      commonCells.bitScore,
+      `${hsp.hit.hit_acc}:${hsp.hsp_hit_from}-${hsp.hsp_hit_to}`,
+      commonCells.hitOrientation,
+      commonCells.hitStart,
+      commonCells.hitEnd,
+      commonCells.queryStart,
+      commonCells.queryEnd,
+      commonCells.alignmentLength,
+      commonCells.querySequence,
+      commonCells.hitSequence
+    ];
+    table.push(row);
+  }
+
+  return table.map(tabulate).join('\n');
+};
+
+const printTranscriptsTable = (params: {
+  species: SubmittedBlastData['species'][number];
+  sequence: SubmittedBlastData['sequences'][number];
+  job: BlastJobWithResults;
+}) => {
+  const { species, sequence, job } = params;
+  const table: (string | number)[][] = [];
+  const headerRow = [
+    'Query sequence no.',
+    'Query sequence header',
+    'Query full length',
+    'Species scientific name',
+    'Assembly name',
+    'E-value',
+    'Hit length',
+    '% ID',
+    'Bit score',
+    'Transcript ID',
+    'Hit orientation',
+    'Hit start',
+    'Hit end',
+    'Query start',
+    'Query end',
+    'Alignment length',
+    'Query sequence',
+    'Hit sequence'
+  ];
+  table.push(headerRow);
+
+  const hspsWithHits = job.data.hits.flatMap((hit) => {
+    return hit.hit_hsps.map((hsp) => ({ ...hsp, hit }));
+  });
+  hspsWithHits.sort(sortByEValue);
+
+  for (const hsp of hspsWithHits) {
+    const commonCells = printCommonCells({
+      species,
+      sequence,
+      hsp,
+      hit: hsp.hit
+    });
+    const row = [
+      commonCells.sequenceId,
+      commonCells.sequenceHeader,
+      commonCells.queryLength,
+      commonCells.speciesName,
+      commonCells.assemblyName,
+      commonCells.evalue,
+      commonCells.hitLength,
+      commonCells.percentIdentity,
+      commonCells.bitScore,
+      hsp.hit.hit_acc,
+      commonCells.hitOrientation,
+      commonCells.hitStart,
+      commonCells.hitEnd,
+      commonCells.queryStart,
+      commonCells.queryEnd,
+      commonCells.alignmentLength,
+      commonCells.querySequence,
+      commonCells.hitSequence
+    ];
+    table.push(row);
+  }
+
+  return table.map(tabulate).join('\n');
+};
+
+const printProteinsTable = (params: {
+  species: SubmittedBlastData['species'][number];
+  sequence: SubmittedBlastData['sequences'][number];
+  job: BlastJobWithResults;
+}) => {
+  const { species, sequence, job } = params;
+  const table: (string | number)[][] = [];
+  const headerRow = [
+    'Query sequence no.',
+    'Query sequence header',
+    'Query full length',
+    'Species scientific name',
+    'Assembly name',
+    'E-value',
+    'Hit length',
+    '% ID',
+    'Bit score',
+    'Protein ID',
+    'Hit orientation',
+    'Hit start',
+    'Hit end',
+    'Query start',
+    'Query end',
+    'Alignment length',
+    'Query sequence',
+    'Hit sequence'
+  ];
+  table.push(headerRow);
+
+  const hspsWithHits = job.data.hits.flatMap((hit) => {
+    return hit.hit_hsps.map((hsp) => ({ ...hsp, hit }));
+  });
+  hspsWithHits.sort(sortByEValue);
+
+  for (const hsp of hspsWithHits) {
+    const commonCells = printCommonCells({
+      species,
+      sequence,
+      hsp,
+      hit: hsp.hit
+    });
+    const row = [
+      commonCells.sequenceId,
+      commonCells.sequenceHeader,
+      commonCells.queryLength,
+      commonCells.speciesName,
+      commonCells.assemblyName,
+      commonCells.evalue,
+      commonCells.hitLength,
+      commonCells.percentIdentity,
+      commonCells.bitScore,
+      hsp.hit.hit_acc,
+      commonCells.hitOrientation,
+      commonCells.hitStart,
+      commonCells.hitEnd,
+      commonCells.queryStart,
+      commonCells.queryEnd,
+      commonCells.alignmentLength,
+      commonCells.querySequence,
+      commonCells.hitSequence
+    ];
+    table.push(row);
+  }
+
+  return table.map(tabulate).join('\n');
+};
+
+const printCommonCells = (params: {
+  species: SubmittedBlastData['species'][number];
+  sequence: SubmittedBlastData['sequences'][number];
+  hit: BlastHit;
+  hsp: HSP;
+}) => {
+  const { species, sequence, hit, hsp } = params;
+  const sequenceHeader = sequence.header ?? `Sequence ${sequence.id}`;
+
+  return {
+    sequenceId: `sequence ${sequence.id}`,
+    sequenceHeader,
+    queryLength: sequence.value.length,
+    speciesName: species.scientific_name,
+    assemblyName: species.assembly_name,
+    alignmentLength: hsp.hsp_align_len,
+    evalue: hsp.hsp_expect,
+    hitLength: hit.hit_len,
+    percentIdentity: hsp.hsp_identity,
+    bitScore: hsp.hsp_bit_score,
+    hitOrientation: hsp.hsp_hit_frame === '1' ? 'Forward' : 'Reverse',
+    hitStart: hsp.hsp_hit_from,
+    hitEnd: hsp.hsp_hit_to,
+    queryStart: hsp.hsp_query_from,
+    queryEnd: hsp.hsp_query_to,
+    querySequence: hsp.hsp_qseq,
+    hitSequence: hsp.hsp_hseq
+  };
+};
+
+// const formatSequenceType = (type: string) => {
+//   if (type === 'protein') {
+//     return 'Protein';
+//   } else {
+//     return 'Nucleotide';
+//   }
+// };
+
+const formatDatabaseType = (type: string) => {
+  if (type === 'pep') {
+    return 'Proteins';
+  } else if (type === 'cdna') {
+    return 'Transcripts';
+  } else if (type === 'dna_sm') {
+    return 'Genomic (softmasked)';
+  } else {
+    return 'Genomic';
+  }
+};
+
+const formatGapAlign = (value: string) => {
+  return value === 'true' ? 'Yes' : 'No';
+};
+
+const formatLowComplexityFilter = (value: string) => {
+  return value === 'T' ? 'Yes' : 'No';
+};
+
+const sortByEValue = (a: HSP, b: HSP) => {
+  return a.hsp_expect - b.hsp_expect;
+};
+
+const tabulate = (strings: (string | number)[]) => strings.join('\t');

--- a/src/content/app/tools/blast/blast-download/renderSubmissionTable.ts
+++ b/src/content/app/tools/blast/blast-download/renderSubmissionTable.ts
@@ -156,11 +156,13 @@ const printData = (submission: BlastSubmissionWithJobsWithResults) => {
         continue;
       }
 
-      const tableForJob = jobRenderer({
+      const tableHead = jobRenderer.printHead();
+      const tableForJob = jobRenderer.printBody({
         species,
         sequence,
         job
       });
+      table += `${tableHead}\n`;
       table += tableForJob;
     }
   }
@@ -171,22 +173,25 @@ const printData = (submission: BlastSubmissionWithJobsWithResults) => {
 const getJobRenderer = (blastDatabase: string) => {
   switch (blastDatabase) {
     case 'pep':
-      return printProteinsTable;
+      return {
+        printHead: printProteinsTableHead,
+        printBody: printProteinsTable
+      };
     case 'cdna':
-      return printTranscriptsTable;
+      return {
+        printHead: printTranscriptsTableHead,
+        printBody: printTranscriptsTable
+      };
     default:
-      return printGenomicTable;
+      return {
+        printHead: printGenomicTableHead,
+        printBody: printGenomicTable
+      };
   }
 };
 
-const printGenomicTable = (params: {
-  species: SubmittedBlastData['species'][number];
-  sequence: SubmittedBlastData['sequences'][number];
-  job: BlastJobWithResults;
-}) => {
-  const { species, sequence, job } = params;
-  const table: (string | number)[][] = [];
-  const headerRow = [
+const printGenomicTableHead = () => {
+  const columnNames = [
     'Query sequence no.',
     'Query sequence header',
     'Query full length',
@@ -195,7 +200,7 @@ const printGenomicTable = (params: {
     'E-value',
     'Hit length',
     '% ID',
-    'Bit score',
+    'Score',
     'Genomic location',
     'Hit orientation',
     'Hit start',
@@ -206,7 +211,16 @@ const printGenomicTable = (params: {
     'Query sequence',
     'Hit sequence'
   ];
-  table.push(headerRow);
+  return tabulate(columnNames);
+};
+
+const printGenomicTable = (params: {
+  species: SubmittedBlastData['species'][number];
+  sequence: SubmittedBlastData['sequences'][number];
+  job: BlastJobWithResults;
+}) => {
+  const { species, sequence, job } = params;
+  const table: (string | number)[][] = [];
 
   const hspsWithHits = job.data.hits.flatMap((hit) => {
     return hit.hit_hsps.map((hsp) => ({ ...hsp, hit }));
@@ -246,14 +260,8 @@ const printGenomicTable = (params: {
   return table.map(tabulate).join('\n');
 };
 
-const printTranscriptsTable = (params: {
-  species: SubmittedBlastData['species'][number];
-  sequence: SubmittedBlastData['sequences'][number];
-  job: BlastJobWithResults;
-}) => {
-  const { species, sequence, job } = params;
-  const table: (string | number)[][] = [];
-  const headerRow = [
+const printTranscriptsTableHead = () => {
+  const columnNames = [
     'Query sequence no.',
     'Query sequence header',
     'Query full length',
@@ -262,7 +270,7 @@ const printTranscriptsTable = (params: {
     'E-value',
     'Hit length',
     '% ID',
-    'Bit score',
+    'Score',
     'Transcript ID',
     'Hit orientation',
     'Hit start',
@@ -273,7 +281,16 @@ const printTranscriptsTable = (params: {
     'Query sequence',
     'Hit sequence'
   ];
-  table.push(headerRow);
+  return tabulate(columnNames);
+};
+
+const printTranscriptsTable = (params: {
+  species: SubmittedBlastData['species'][number];
+  sequence: SubmittedBlastData['sequences'][number];
+  job: BlastJobWithResults;
+}) => {
+  const { species, sequence, job } = params;
+  const table: (string | number)[][] = [];
 
   const hspsWithHits = job.data.hits.flatMap((hit) => {
     return hit.hit_hsps.map((hsp) => ({ ...hsp, hit }));
@@ -313,14 +330,8 @@ const printTranscriptsTable = (params: {
   return table.map(tabulate).join('\n');
 };
 
-const printProteinsTable = (params: {
-  species: SubmittedBlastData['species'][number];
-  sequence: SubmittedBlastData['sequences'][number];
-  job: BlastJobWithResults;
-}) => {
-  const { species, sequence, job } = params;
-  const table: (string | number)[][] = [];
-  const headerRow = [
+const printProteinsTableHead = () => {
+  const columnNames = [
     'Query sequence no.',
     'Query sequence header',
     'Query full length',
@@ -329,7 +340,7 @@ const printProteinsTable = (params: {
     'E-value',
     'Hit length',
     '% ID',
-    'Bit score',
+    'Score',
     'Protein ID',
     'Hit orientation',
     'Hit start',
@@ -340,7 +351,17 @@ const printProteinsTable = (params: {
     'Query sequence',
     'Hit sequence'
   ];
-  table.push(headerRow);
+
+  return tabulate(columnNames);
+};
+
+const printProteinsTable = (params: {
+  species: SubmittedBlastData['species'][number];
+  sequence: SubmittedBlastData['sequences'][number];
+  job: BlastJobWithResults;
+}) => {
+  const { species, sequence, job } = params;
+  const table: (string | number)[][] = [];
 
   const hspsWithHits = job.data.hits.flatMap((hit) => {
     return hit.hit_hsps.map((hsp) => ({ ...hsp, hit }));

--- a/src/content/app/tools/blast/blast-download/submissionDownload.ts
+++ b/src/content/app/tools/blast/blast-download/submissionDownload.ts
@@ -66,14 +66,6 @@ const downloadBlastSubmission = async (
     ''
   );
 
-  // const allBlastJobsWithRawData = fetchedRawJobResults.map((job, index) => {
-  //   const jobWithoutRawData = allBlastJobsWithTSVs[index];
-  //   return {
-  //     ...jobWithoutRawData,
-  //     raw: job.result
-  //   };
-  // });
-
   const zip = await createZipArchive({
     submission,
     table: blastSubmissionTable,

--- a/src/content/app/tools/blast/components/blast-job-submit/BlastJobSubmit.test.tsx
+++ b/src/content/app/tools/blast/components/blast-job-submit/BlastJobSubmit.test.tsx
@@ -86,6 +86,7 @@ const expectedPayload = {
     value: seq.value
   })),
   preset: 'normal',
+  sequenceType: 'dna',
   submissionName,
   parameters: {
     database,

--- a/src/content/app/tools/blast/components/blast-job-submit/BlastJobSubmit.tsx
+++ b/src/content/app/tools/blast/components/blast-job-submit/BlastJobSubmit.tsx
@@ -47,6 +47,7 @@ export type PayloadParams = {
   species: Species[];
   sequences: SubmittedSequence[];
   preset: string;
+  sequenceType: string;
   submissionName: string;
   parameters: Partial<Record<BlastParameterName, string>> & {
     stype: SequenceType;
@@ -100,6 +101,7 @@ export const createBlastSubmissionData = (
     species: blastFormData.selectedSpecies,
     sequences,
     preset: blastFormData.settings.preset,
+    sequenceType: blastFormData.settings.sequenceType,
     submissionName: blastFormData.settings.submissionName,
     parameters: {
       database: blastFormData.settings.parameters.database,

--- a/src/content/app/tools/blast/state/blast-api/blastApiSlice.ts
+++ b/src/content/app/tools/blast/state/blast-api/blastApiSlice.ts
@@ -37,6 +37,7 @@ export type BlastSubmissionPayload = {
   species: Species[];
   sequences: SubmittedSequence[];
   preset: string;
+  sequenceType: string;
   submissionName: string;
   parameters: Record<string, string>;
 };
@@ -225,6 +226,7 @@ const prepareSuccessfulSubmissionPayload = (
         species: payload.species,
         sequences: payload.sequences,
         preset: payload.preset,
+        sequenceType: payload.sequenceType,
         submissionName: payload.submissionName,
         parameters: payload.parameters
       },

--- a/src/content/app/tools/blast/state/blast-results/blastResultsSlice.ts
+++ b/src/content/app/tools/blast/state/blast-results/blastResultsSlice.ts
@@ -71,7 +71,7 @@ export type BlastJobWithResults = Omit<BlastJob, 'data'> & {
   data: BlastJobResultsFromAPI;
 };
 
-type SubmittedBlastData = {
+export type SubmittedBlastData = {
   species: Species[];
   sequences: SubmittedSequence[];
   preset: string;

--- a/src/content/app/tools/blast/state/blast-results/blastResultsSlice.ts
+++ b/src/content/app/tools/blast/state/blast-results/blastResultsSlice.ts
@@ -75,6 +75,7 @@ export type SubmittedBlastData = {
   species: Species[];
   sequences: SubmittedSequence[];
   preset: string;
+  sequenceType: string;
   submissionName: string;
   parameters: BlastSubmissionParameters;
 };

--- a/src/content/app/tools/blast/state/epics/tests/fixtures/blastSubmissionFixtures.ts
+++ b/src/content/app/tools/blast/state/epics/tests/fixtures/blastSubmissionFixtures.ts
@@ -39,6 +39,7 @@ export const createBlastSubmissionPayload = (
     species: [human],
     sequences: [{ id: 1, value: 'ACGT' }],
     preset: 'normal',
+    sequenceType: 'dna',
     submissionName: '',
     parameters: {}
   };

--- a/tests/fixtures/blast/blastSubmission.ts
+++ b/tests/fixtures/blast/blastSubmission.ts
@@ -39,7 +39,6 @@ export const createBlastSubmission = (params?: {
   const { sequencesCount = 2, speciesCount = 1 } = params?.options ?? {};
   const species = times(speciesCount, () => createSelectedSpecies());
   const sequences = createSubmittedSequences(sequencesCount);
-  const preset = 'normal';
   const submissionName = '';
 
   return {
@@ -47,7 +46,8 @@ export const createBlastSubmission = (params?: {
     submittedData: {
       species,
       sequences,
-      preset,
+      preset: 'normal',
+      sequenceType: 'dna',
       submissionName,
       parameters: defaultBlastParameters
     },


### PR DESCRIPTION
## Description
According to the updated spec (see [ENSWBSITES-1768)](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1768)), submission download payload has been updated, such that:
- All BLAST job results are saved into a single table file
- All raw outputs are collated into a single txt file

## Related JIRA Issue(s)
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1843
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1768

## Deployment URL(s)
http://blast-download-update.review.ensembl.org