### PR TITLE
Use hotspot area coordinates to position tooltip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ensembl/ensembl-genome-browser": "0.6.4",
+        "@ensembl/ensembl-genome-browser": "0.6.5",
         "@react-spring/web": "9.4.5-beta.1",
         "@reduxjs/toolkit": "1.9.0",
         "@sentry/browser": "7.21.1",
@@ -2426,9 +2426,9 @@
       }
     },
     "node_modules/@ensembl/ensembl-genome-browser": {
-      "version": "0.6.4",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.4.tgz",
-      "integrity": "sha1-Anee4naVBKCllslVfIYRhWhWcOA="
+      "version": "0.6.5",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.5.tgz",
+      "integrity": "sha1-ERhl36Yg2nByyY+2xL7Oht6RcSM="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
@@ -43098,9 +43098,9 @@
       "dev": true
     },
     "@ensembl/ensembl-genome-browser": {
-      "version": "0.6.4",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.4.tgz",
-      "integrity": "sha1-Anee4naVBKCllslVfIYRhWhWcOA="
+      "version": "0.6.5",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.5.tgz",
+      "integrity": "sha1-ERhl36Yg2nByyY+2xL7Oht6RcSM="
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "coverage": "jest --coverage"
   },
   "dependencies": {
-    "@ensembl/ensembl-genome-browser": "0.6.4",
+    "@ensembl/ensembl-genome-browser": "0.6.5",
     "@react-spring/web": "9.4.5-beta.1",
     "@reduxjs/toolkit": "1.9.0",
     "@sentry/browser": "7.21.1",

--- a/src/content/app/genome-browser/components/browser-track-legend/BrowserTrackLegend.tsx
+++ b/src/content/app/genome-browser/components/browser-track-legend/BrowserTrackLegend.tsx
@@ -59,8 +59,13 @@ const BrowserTrackLegend = (props: Props) => {
     if (!isTrackLegendHotspot(payload)) {
       return;
     }
+
+    const { bottom, top, right } = payload['hotspot-area'];
+    const toolTipX = right;
+    const toolTipY = top + (bottom - top) / 2 + 4;
+
     if (payload.start) {
-      setPosition({ x: payload.x, y: payload.y });
+      setPosition({ x: toolTipX, y: toolTipY });
     } else {
       setPosition(null);
     }

--- a/src/content/app/genome-browser/components/browser-track-legend/BrowserTrackLegend.tsx
+++ b/src/content/app/genome-browser/components/browser-track-legend/BrowserTrackLegend.tsx
@@ -61,7 +61,7 @@ const BrowserTrackLegend = (props: Props) => {
     }
 
     const { bottom, top, right } = payload['hotspot-area'];
-    const toolTipX = right;
+    const toolTipX = right - 5;
     const toolTipY = top + (bottom - top) / 2 + 4;
 
     if (payload.start) {


### PR DESCRIPTION
## Description
Use the "hotspot-area" block from the payload to position the tooltip, rather than the "x" and "y" fields of the payload.

There is a change needed in ensembl-genome-browser repo which is in [this PR](https://github.com/Ensembl/ensembl-genome-browser/pull/25)

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1882

## Deployment URL(s)
http://track-tooltip-position.review.ensembl.org


## Views affected
GB