### PR TITLE
add spinner to drawer while fetching data

### DIFF
--- a/src/content/app/genome-browser/components/drawer/Drawer.scss
+++ b/src/content/app/genome-browser/components/drawer/Drawer.scss
@@ -5,3 +5,9 @@
   overflow: auto;
   font-size: 13px;
 }
+
+.spinnerContainer {
+  padding-top: 90px;
+  display: flex;
+  justify-content: center;
+}

--- a/src/content/app/genome-browser/components/drawer/Drawer.tsx
+++ b/src/content/app/genome-browser/components/drawer/Drawer.tsx
@@ -22,17 +22,10 @@ import DrawerBookmarks from './drawer-views/DrawerBookmarks';
 import GeneSummary from './drawer-views/gene-summary/GeneSummary';
 import TranscriptSummary from './drawer-views/transcript-summary/TranscriptSummary';
 import VariantGroupLegend from './drawer-views/variant-group-legend/VariantGroupLegend';
-import { CircleLoader } from 'src/shared/components/loader';
 
 import { getActiveDrawerView } from 'src/content/app/genome-browser/state/drawer/drawerSelectors';
 
 import styles from './Drawer.scss';
-
-export const Spinner = () => (
-  <div className={styles.spinnerContainer}>
-    <CircleLoader />
-  </div>
-);
 
 export const Drawer = () => {
   const drawerView = useSelector(getActiveDrawerView);

--- a/src/content/app/genome-browser/components/drawer/Drawer.tsx
+++ b/src/content/app/genome-browser/components/drawer/Drawer.tsx
@@ -22,10 +22,17 @@ import DrawerBookmarks from './drawer-views/DrawerBookmarks';
 import GeneSummary from './drawer-views/gene-summary/GeneSummary';
 import TranscriptSummary from './drawer-views/transcript-summary/TranscriptSummary';
 import VariantGroupLegend from './drawer-views/variant-group-legend/VariantGroupLegend';
+import { CircleLoader } from 'src/shared/components/loader';
 
 import { getActiveDrawerView } from 'src/content/app/genome-browser/state/drawer/drawerSelectors';
 
 import styles from './Drawer.scss';
+
+export const Spinner = () => (
+  <div className={styles.spinnerContainer}>
+    <CircleLoader />
+  </div>
+);
 
 export const Drawer = () => {
   const drawerView = useSelector(getActiveDrawerView);

--- a/src/content/app/genome-browser/components/drawer/DrawerSpinner.tsx
+++ b/src/content/app/genome-browser/components/drawer/DrawerSpinner.tsx
@@ -1,0 +1,27 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { CircleLoader } from 'src/shared/components/loader';
+
+import styles from './Drawer.scss';
+
+export const Spinner = () => (
+  <div className={styles.spinnerContainer}>
+    <CircleLoader />
+  </div>
+);

--- a/src/content/app/genome-browser/components/drawer/drawer-views/gene-summary/GeneSummary.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/gene-summary/GeneSummary.tsx
@@ -44,7 +44,7 @@ import InstantDownloadGene, {
 import ViewInApp from 'src/shared/components/view-in-app/ViewInApp';
 import ShowHide from 'src/shared/components/show-hide/ShowHide';
 import QuestionButton from 'src/shared/components/question-button/QuestionButton';
-import { Spinner } from 'src/content/app/genome-browser/components/drawer/Drawer';
+import { Spinner } from 'src/content/app/genome-browser/components/drawer/DrawerSpinner';
 
 import { FocusGene } from 'src/shared/types/focus-object/focusObjectTypes';
 

--- a/src/content/app/genome-browser/components/drawer/drawer-views/gene-summary/GeneSummary.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/gene-summary/GeneSummary.tsx
@@ -44,6 +44,7 @@ import InstantDownloadGene, {
 import ViewInApp from 'src/shared/components/view-in-app/ViewInApp';
 import ShowHide from 'src/shared/components/show-hide/ShowHide';
 import QuestionButton from 'src/shared/components/question-button/QuestionButton';
+import { Spinner } from 'src/content/app/genome-browser/components/drawer/Drawer';
 
 import { FocusGene } from 'src/shared/types/focus-object/focusObjectTypes';
 
@@ -64,7 +65,7 @@ const GeneSummary = () => {
   });
 
   if (isFetching) {
-    return null;
+    return <Spinner />;
   }
 
   if (!currentData?.gene) {

--- a/src/content/app/genome-browser/components/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
@@ -44,6 +44,7 @@ import ExternalReference from 'src/shared/components/external-reference/External
 import QuestionButton from 'src/shared/components/question-button/QuestionButton';
 import ShowHide from 'src/shared/components/show-hide/ShowHide';
 import { TranscriptQualityLabel } from 'src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel';
+import { Spinner } from 'src/content/app/genome-browser/components/drawer/Drawer';
 
 import { TranscriptDrawerView } from 'src/content/app/genome-browser/state/drawer/types';
 import type { TrackTranscriptDownloadPayload } from 'src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript';
@@ -71,7 +72,7 @@ const TranscriptSummary = (props: Props) => {
   );
 
   if (!activeGenomeId || isFetching) {
-    return null;
+    return <Spinner />;
   }
 
   if (!currentData?.transcript) {

--- a/src/content/app/genome-browser/components/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
@@ -44,7 +44,7 @@ import ExternalReference from 'src/shared/components/external-reference/External
 import QuestionButton from 'src/shared/components/question-button/QuestionButton';
 import ShowHide from 'src/shared/components/show-hide/ShowHide';
 import { TranscriptQualityLabel } from 'src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel';
-import { Spinner } from 'src/content/app/genome-browser/components/drawer/Drawer';
+import { Spinner } from 'src/content/app/genome-browser/components/drawer/DrawerSpinner';
 
 import { TranscriptDrawerView } from 'src/content/app/genome-browser/state/drawer/types';
 import type { TrackTranscriptDownloadPayload } from 'src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript';


### PR DESCRIPTION
## Description
Add a spinner to the drawer while fetching data.
Added to gene and transcripts drawer as they are ones that fetches data as of now.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1842

## Deployment URL(s)
http://drawer-spinner.review.ensembl.org


## Views affected
GB