### PR TITLE
do not show variant legends when there is no variant data

### DIFF
--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
@@ -124,6 +124,7 @@ export const TrackPanelList = () => {
         >
           {selectedTrackPanelTab === TrackSet.VARIATION && (
             <TrackPanelVariantGroupLegend
+              shouldShowLegend={trackCategoryIds.length > 0}
               groups={variantGroups}
               onShowMore={onShowMore}
             />

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelVariantGroupLegend.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelVariantGroupLegend.tsx
@@ -35,12 +35,18 @@ import variantStyles from 'src/content/app/genome-browser/components/drawer/draw
 
 const TrackPanelVariantGroupLegend = (props: {
   groups: VariantGroups;
+  shouldShowLegend: boolean;
   onShowMore: (group: string) => void;
 }) => {
-  const { groups, onShowMore } = props;
+  const { groups, onShowMore, shouldShowLegend } = props;
   const { reportTrackPanelSectionToggled } = useGenomeBrowserAnalytics();
   const accordionHeading = 'Short variant groups';
-
+  const accordionButtonClassNames = classNames(
+    styles.trackPanelAccordionButton,
+    {
+      [styles.trackPanelAccordionButtonDisabled]: !shouldShowLegend
+    }
+  );
   return (
     <>
       <AccordionItem
@@ -49,7 +55,8 @@ const TrackPanelVariantGroupLegend = (props: {
       >
         <AccordionItemHeading className={styles.trackPanelAccordionHeader}>
           <AccordionItemButton
-            className={styles.trackPanelAccordionButton}
+            disabled={!shouldShowLegend}
+            className={accordionButtonClassNames}
             onToggle={(isExpanded: boolean) =>
               reportTrackPanelSectionToggled(accordionHeading, isExpanded)
             }
@@ -57,30 +64,32 @@ const TrackPanelVariantGroupLegend = (props: {
             {accordionHeading}
           </AccordionItemButton>
         </AccordionItemHeading>
-        <AccordionItemPanel className={styles.trackPanelAccordionItemContent}>
-          <dl>
-            {groups.map((group) => {
-              const groupColorMarkerClass = classNames(
-                variantStyles.colourMarker,
-                variantStyles[`variantColour${group.id}`]
-              );
+        {shouldShowLegend ? (
+          <AccordionItemPanel className={styles.trackPanelAccordionItemContent}>
+            <dl>
+              {groups.map((group) => {
+                const groupColorMarkerClass = classNames(
+                  variantStyles.colourMarker,
+                  variantStyles[`variantColour${group.id}`]
+                );
 
-              return (
-                <SimpleTrackPanelItemLayout
-                  key={group.id}
-                  onShowMore={() => onShowMore(group.label)}
-                >
-                  <div className={trackPanelItemStyles.label}>
-                    <span className={groupColorMarkerClass} />
-                    <span className={trackPanelItemStyles.labelText}>
-                      {group.label}
-                    </span>
-                  </div>
-                </SimpleTrackPanelItemLayout>
-              );
-            })}
-          </dl>
-        </AccordionItemPanel>
+                return (
+                  <SimpleTrackPanelItemLayout
+                    key={group.id}
+                    onShowMore={() => onShowMore(group.label)}
+                  >
+                    <div className={trackPanelItemStyles.label}>
+                      <span className={groupColorMarkerClass} />
+                      <span className={trackPanelItemStyles.labelText}>
+                        {group.label}
+                      </span>
+                    </div>
+                  </SimpleTrackPanelItemLayout>
+                );
+              })}
+            </dl>
+          </AccordionItemPanel>
+        ) : null}
       </AccordionItem>
     </>
   );


### PR DESCRIPTION
## Description
Show variant legends only when we have variant data
Done by checking tracklists in trackCategories.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1886

## Deployment URL(s)
http://dynamic-variation-legend.review.ensembl.org


## Views affected
GB