### PR TITLE
Fix an error due to accessing a field that is undefined or null

### DIFF
--- a/src/content/app/genome-browser/contexts/genome-browser-ids-context/useGenomeBrowserUrlValidator.ts
+++ b/src/content/app/genome-browser/contexts/genome-browser-ids-context/useGenomeBrowserUrlValidator.ts
@@ -189,7 +189,7 @@ const checkFocusGene = async (params: CheckFocusObjectParams) => {
   const isMissingGene =
     isGeneQueryError &&
     'meta' in geneQueryError &&
-    geneQueryError.meta.data.gene === null;
+    geneQueryError.meta?.data?.gene === null;
 
   return {
     isMissingFocusObject: isMissingGene

--- a/src/content/app/genome-browser/contexts/genome-browser-ids-context/useGenomeBrowserUrlValidator.ts
+++ b/src/content/app/genome-browser/contexts/genome-browser-ids-context/useGenomeBrowserUrlValidator.ts
@@ -189,7 +189,7 @@ const checkFocusGene = async (params: CheckFocusObjectParams) => {
   const isMissingGene =
     isGeneQueryError &&
     'meta' in geneQueryError &&
-    geneQueryError.meta?.data?.gene === null;
+    geneQueryError.meta.data?.gene === null;
 
   return {
     isMissingFocusObject: isMissingGene


### PR DESCRIPTION
## Description
If Thoas is down, and the response is a 400 or a 500-kind error, the error.meta object will not contain the `data`, and the attempt to read the `gene` field from it will result in an error:

From Sentry:

![image](https://user-images.githubusercontent.com/6834224/227951888-895af265-f1a1-40bc-9e0e-5379145de40e.png)


## Deployment URL(s)
http://fix-gene-query-error.review.ensembl.org (but it's mostly pointless; there won't be api errors)

## Views affected
Genome browser page