### PR TITLE
Add biotype label to Genome browser header bar and transcript info panel

### DIFF
--- a/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -213,6 +213,7 @@ export const TranscriptsListItemInfo = (
       <div className={midStyles}>
         <div className={styles.topLeft}>
           <div>
+            Biotype{' '}
             <span className={styles.normalText}>
               {transcript.metadata.biotype.label}
             </span>

--- a/src/shared/components/feature-summary-strip/GeneSummaryStrip.tsx
+++ b/src/shared/components/feature-summary-strip/GeneSummaryStrip.tsx
@@ -122,7 +122,12 @@ const CompactContent = ({ gene }: { gene: Gene }) => {
 const FullContent = ({ gene }: { gene: Gene }) => (
   <>
     <CompactContent gene={gene} />
-    {gene.bio_type && <div>{gene.bio_type}</div>}
+    {gene.bio_type && (
+      <div>
+        <span className={styles.featureSummaryStripLabel}>Biotype</span>
+        {gene.bio_type}
+      </div>
+    )}
     {gene.strand && <div>{getStrandDisplayName(gene.strand)}</div>}
     <div>{getFormattedLocation(gene.location)}</div>
   </>


### PR DESCRIPTION
## Description
Add biotype label to header bar in Genome browser as well as in transcript info panels.


## Related JIRA Issue(s)
[ENSWBSITES-1878](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1878)
[ENSWBSITES-1889](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1889)

## Deployment URL(s)
http://add-biotype-label.review.ensembl.org


## Views affected
Genome browser -> header bar
Entity viewer -> header bar
Entity viewer -> transcript info panel