### PR TITLE
Add Attributes section to EV sidebar

### DIFF
--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.scss
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.scss
@@ -31,6 +31,12 @@
   margin-right: 10px;
 }
 
+.attributeLabel {
+  font-size: 12px;
+  font-weight: 300;
+  margin-right: 10px;
+}
+
 .accordionContainer {
   width: 100%;
 

--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.scss
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.scss
@@ -31,10 +31,27 @@
   margin-right: 10px;
 }
 
+.attributeRow {
+  line-height: 1;
+
+  > span {
+    display: inline-block;
+  }
+}
+
 .attributeLabel {
   font-size: 12px;
   font-weight: 300;
   margin-right: 10px;
+}
+
+.biotypeValue {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  position: relative;
+  top: 2px;
+  width: 240px;
 }
 
 .accordionContainer {

--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.test.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.test.tsx
@@ -141,7 +141,7 @@ describe('<GeneOverview />', () => {
       const xrefElement = container.querySelector(
         '.externalLinkContainer .link'
       );
-      const biotypeValueElement = queryByTestId('biotypeValue');
+      const biotypeValueElement = container.querySelector('.biotypeValue');
 
       // child components
       const genePublications = container.querySelector('.genePublications');

--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.test.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.test.tsx
@@ -72,6 +72,9 @@ const metadata = {
   name: {
     accession_id: 'name_accession_id',
     url: 'name_url'
+  },
+  biotype: {
+    value: 'protein_coding_gene'
   }
 };
 
@@ -80,7 +83,7 @@ const completeGeneData = {
   stable_id: stableId,
   symbol: geneSymbol,
   alternative_symbols: alternativeSymbols,
-  metadata: metadata
+  metadata
 };
 
 describe('<GeneOverview />', () => {
@@ -138,6 +141,7 @@ describe('<GeneOverview />', () => {
       const xrefElement = container.querySelector(
         '.externalLinkContainer .link'
       );
+      const biotypeValueElement = queryByTestId('biotypeValue');
 
       // child components
       const genePublications = container.querySelector('.genePublications');
@@ -149,6 +153,7 @@ describe('<GeneOverview />', () => {
       expect(synonymsElement?.textContent).toMatch(
         alternativeSymbols.join(', ')
       );
+      expect(biotypeValueElement?.textContent).toMatch(metadata.biotype.value);
       expect(genePublications).toBeTruthy();
     });
   });

--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
@@ -126,7 +126,7 @@ const GeneOverview = () => {
           <div className={styles.attributes}>
             <div>
               <span className={styles.attributeLabel}>Biotype</span>{' '}
-              {geneBiotype?.value}
+              <span data-test-id="biotypeValue">{geneBiotype?.value}</span>
             </div>
           </div>
         </div>

--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
@@ -124,9 +124,9 @@ const GeneOverview = () => {
         <div className={styles.sectionHead}>Attributes</div>
         <div className={styles.sectionContent}>
           <div className={styles.attributes}>
-            <div>
+            <div className={styles.attributeRow}>
               <span className={styles.attributeLabel}>Biotype</span>{' '}
-              <span data-test-id="biotypeValue">{geneBiotype.value}</span>
+              <span className={styles.biotypeValue}>{geneBiotype.value}</span>
             </div>
           </div>
         </div>

--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
@@ -126,7 +126,7 @@ const GeneOverview = () => {
           <div className={styles.attributes}>
             <div>
               <span className={styles.attributeLabel}>Biotype</span>{' '}
-              <span data-test-id="biotypeValue">{geneBiotype?.value}</span>
+              <span data-test-id="biotypeValue">{geneBiotype.value}</span>
             </div>
           </div>
         </div>

--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
@@ -62,7 +62,7 @@ const GeneOverview = () => {
 
   const { gene } = currentData;
   const {
-    metadata: { name: geneNameMetadata }
+    metadata: { name: geneNameMetadata, biotype: geneBiotype }
   } = gene;
 
   const trackLink = () => {
@@ -116,6 +116,18 @@ const GeneOverview = () => {
             {gene.alternative_symbols.length
               ? gene.alternative_symbols.join(', ')
               : 'None'}
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <div className={styles.sectionHead}>Attributes</div>
+        <div className={styles.sectionContent}>
+          <div className={styles.attributes}>
+            <div>
+              <span className={styles.attributeLabel}>Biotype</span>{' '}
+              {geneBiotype?.value}
+            </div>
           </div>
         </div>
       </section>

--- a/src/content/app/entity-viewer/state/api/queries/geneOverviewQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/geneOverviewQuery.ts
@@ -49,7 +49,7 @@ export type GeneOverview = Pick<
       NonNullable<FullGene['metadata']['name']>,
       'accession_id' | 'url'
     > | null;
-    biotype: Pick<NonNullable<FullGene['metadata']['biotype']>, 'value'> | null;
+    biotype: Pick<FullGene['metadata']['biotype'], 'value'>;
   };
 };
 

--- a/src/content/app/entity-viewer/state/api/queries/geneOverviewQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/geneOverviewQuery.ts
@@ -32,6 +32,9 @@ export const geneOverviewQuery = gql`
           accession_id
           url
         }
+        biotype {
+          value
+        }
       }
     }
   }
@@ -46,6 +49,7 @@ export type GeneOverview = Pick<
       NonNullable<FullGene['metadata']['name']>,
       'accession_id' | 'url'
     > | null;
+    biotype: Pick<NonNullable<FullGene['metadata']['biotype']>, 'value'> | null;
   };
 };
 


### PR DESCRIPTION
## Description
Added the new Attributes section to EV sidebar. It only contains the biotype attribute label and value for now.

## Related JIRA Issue(s)
[ENSWBSITES-951](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-951)

## Deployment URL(s)
http://ev-sidebar-attributes.review.ensembl.org


## Views affected
Entity viewer -> Sidebar