### PR TITLE
Add chevrons to links that trigger meganav

### DIFF
--- a/src/content/app/help/components/help-menu/HelpMenu.scss
+++ b/src/content/app/help/components/help-menu/HelpMenu.scss
@@ -53,6 +53,10 @@ $submenuSidePadding: 30px;
   & + & {
     margin-left: 46px;
   }
+
+  &Active {
+    color: $black;
+  }
 }
 
 .submenu {

--- a/src/content/app/help/components/help-menu/HelpMenu.scss
+++ b/src/content/app/help/components/help-menu/HelpMenu.scss
@@ -8,7 +8,8 @@ $submenuSidePadding: 30px;
 }
 
 .chevron {
-  --chevron-height: 7px;
+  --chevron-height: 6px;
+  margin-left: 10px;
 }
 
 .menuBar {

--- a/src/content/app/help/components/help-menu/HelpMenu.scss
+++ b/src/content/app/help/components/help-menu/HelpMenu.scss
@@ -7,9 +7,13 @@ $submenuSidePadding: 30px;
   position: relative;
 }
 
-.chevron {
+.chevronVertical {
   --chevron-height: 6px;
   margin-left: 10px;
+}
+
+.chevronHorizontal {
+  --chevron-height: 7px;
 }
 
 .menuBar {

--- a/src/content/app/help/components/help-menu/HelpMenu.test.tsx
+++ b/src/content/app/help/components/help-menu/HelpMenu.test.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { trim } from 'lodash';
 
 import HelpMenu, { Props as HelpMenuProps } from './HelpMenu';
 
@@ -45,7 +46,9 @@ describe('<HelpMenu>', () => {
 
       expect(
         topMenuItems.every((item) =>
-          renderedMenuItems.find((element) => element.textContent === item)
+          renderedMenuItems.find(
+            (element) => trim(element.textContent as string) === item
+          )
         )
       ).toBe(true);
     });

--- a/src/content/app/help/components/help-menu/HelpMenu.test.tsx
+++ b/src/content/app/help/components/help-menu/HelpMenu.test.tsx
@@ -18,7 +18,6 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { trim } from 'lodash';
 
 import HelpMenu, { Props as HelpMenuProps } from './HelpMenu';
 
@@ -47,7 +46,7 @@ describe('<HelpMenu>', () => {
       expect(
         topMenuItems.every((item) =>
           renderedMenuItems.find(
-            (element) => trim(element.textContent as string) === item
+            (element) => element.textContent?.trim() === item
           )
         )
       ).toBe(true);

--- a/src/content/app/help/components/help-menu/HelpMenu.tsx
+++ b/src/content/app/help/components/help-menu/HelpMenu.tsx
@@ -38,6 +38,7 @@ export type Props = {
 
 const HelpMenu = (props: Props) => {
   const [submenuItems, setSubmenuItems] = useState<MenuItem[] | null>(null);
+  const [activeTopLevelMenuName, setActiveTopLevelMenuName] = useState('');
   const clickedMenuRef = useRef<number | null>(null);
 
   const { trackTopLevelMenu } = useHelpAppAnalytics();
@@ -55,9 +56,11 @@ const HelpMenu = (props: Props) => {
       // clicking on a menu item for the first time
       clickedMenuRef.current = menuIndex;
       nextValue = items;
+      setActiveTopLevelMenuName(menuName);
     } else {
       // this means a repeated click on the same menu item
       clickedMenuRef.current = null;
+      setActiveTopLevelMenuName('');
     }
     setSubmenuItems(nextValue);
     nextValue && trackTopLevelMenu(menuName);
@@ -69,28 +72,42 @@ const HelpMenu = (props: Props) => {
   };
 
   const closeMegaMenu = () => {
+    setActiveTopLevelMenuName('');
     setSubmenuItems(null);
     clickedMenuRef.current = null;
   };
 
-  const topLevelItems = props.menu.items.map((item, index) => {
-    const className = classNames(styles.topMenuItem);
-    const commonProps = {
-      key: index,
-      className
-    };
+  const getTopLevelMenuItemClasses = (menuName: string) =>
+    classNames(styles.topMenuItem, {
+      [styles.topMenuItemActive]: activeTopLevelMenuName === menuName
+    });
 
+  const getHelpMenuLinkClasses = () =>
+    classNames(styles.topMenuItem, {
+      [styles.topMenuItemActive]:
+        !activeTopLevelMenuName &&
+        ['/about', '/help'].includes(props.currentUrl)
+    });
+
+  const topLevelItems = props.menu.items.map((item, index) => {
     return item.type === 'collection' ? (
       <span
-        {...commonProps}
+        key={index}
+        className={getTopLevelMenuItemClasses(item.name)}
         onClick={() => toggleMegaMenu(item.items, index, item.name)}
       >
-        {item.name}
+        {item.name}{' '}
+        <Chevron
+          direction={item.name === activeTopLevelMenuName ? 'up' : 'down'}
+          animate={true}
+          className={styles.chevron}
+        />
       </span>
     ) : (
       <HelpMenuLink
-        {...commonProps}
+        key={index}
         to={item.url}
+        className={getHelpMenuLinkClasses()}
         onClick={() => handleHelpMenuLinkClick(item.name)}
       >
         {item.name}

--- a/src/content/app/help/components/help-menu/HelpMenu.tsx
+++ b/src/content/app/help/components/help-menu/HelpMenu.tsx
@@ -92,7 +92,7 @@ const HelpMenu = (props: Props) => {
         className={getTopLevelMenuItemClasses(index)}
         onClick={() => toggleMegaMenu(item.items, index, item.name)}
       >
-        {item.name}{' '}
+        {item.name}
         <Chevron
           direction={clickedMenuRef.current === index ? 'up' : 'down'}
           animate={true}

--- a/src/content/app/help/components/help-menu/HelpMenu.tsx
+++ b/src/content/app/help/components/help-menu/HelpMenu.tsx
@@ -95,7 +95,7 @@ const HelpMenu = (props: Props) => {
         <Chevron
           direction={clickedMenuRef.current === index ? 'up' : 'down'}
           animate={true}
-          className={styles.chevron}
+          className={styles.chevronVertical}
         />
       </span>
     ) : (
@@ -166,7 +166,7 @@ const Submenu = (props: SubmenuProps) => {
         {item.type === 'collection' ? (
           <>
             {item.name}
-            <Chevron direction="right" className={styles.chevron} />
+            <Chevron direction="right" className={styles.chevronHorizontal} />
           </>
         ) : (
           item.name

--- a/src/content/app/help/components/help-menu/HelpMenu.tsx
+++ b/src/content/app/help/components/help-menu/HelpMenu.tsx
@@ -16,7 +16,7 @@
 
 import React, { useEffect, useState, useRef } from 'react';
 import classNames from 'classnames';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 
 import useHelpAppAnalytics from '../../hooks/useHelpAppAnalytics';
 
@@ -40,6 +40,7 @@ const HelpMenu = (props: Props) => {
   const [submenuItems, setSubmenuItems] = useState<MenuItem[] | null>(null);
   const clickedMenuRef = useRef<number | null>(null);
 
+  const { pathname } = useLocation();
   const { trackTopLevelMenu } = useHelpAppAnalytics();
 
   const toggleMegaMenu = (
@@ -81,7 +82,7 @@ const HelpMenu = (props: Props) => {
   const getHelpMenuLinkClasses = (url: string) =>
     classNames(styles.topMenuItem, {
       [styles.topMenuItemActive]:
-        location.pathname === url && clickedMenuRef.current === null
+        pathname === url && clickedMenuRef.current === null
     });
 
   const topLevelItems = props.menu.items.map((item, index) => {

--- a/src/content/app/help/components/help-menu/HelpMenu.tsx
+++ b/src/content/app/help/components/help-menu/HelpMenu.tsx
@@ -38,7 +38,6 @@ export type Props = {
 
 const HelpMenu = (props: Props) => {
   const [submenuItems, setSubmenuItems] = useState<MenuItem[] | null>(null);
-  const [activeTopLevelMenuName, setActiveTopLevelMenuName] = useState('');
   const clickedMenuRef = useRef<number | null>(null);
 
   const { trackTopLevelMenu } = useHelpAppAnalytics();
@@ -56,11 +55,9 @@ const HelpMenu = (props: Props) => {
       // clicking on a menu item for the first time
       clickedMenuRef.current = menuIndex;
       nextValue = items;
-      setActiveTopLevelMenuName(menuName);
     } else {
       // this means a repeated click on the same menu item
       clickedMenuRef.current = null;
-      setActiveTopLevelMenuName('');
     }
     setSubmenuItems(nextValue);
     nextValue && trackTopLevelMenu(menuName);
@@ -72,33 +69,31 @@ const HelpMenu = (props: Props) => {
   };
 
   const closeMegaMenu = () => {
-    setActiveTopLevelMenuName('');
     setSubmenuItems(null);
     clickedMenuRef.current = null;
   };
 
-  const getTopLevelMenuItemClasses = (menuName: string) =>
+  const getTopLevelMenuItemClasses = (index: number) =>
     classNames(styles.topMenuItem, {
-      [styles.topMenuItemActive]: activeTopLevelMenuName === menuName
+      [styles.topMenuItemActive]: clickedMenuRef.current === index
     });
 
-  const getHelpMenuLinkClasses = () =>
+  const getHelpMenuLinkClasses = (url: string) =>
     classNames(styles.topMenuItem, {
       [styles.topMenuItemActive]:
-        !activeTopLevelMenuName &&
-        ['/about', '/help'].includes(props.currentUrl)
+        location.pathname === url && clickedMenuRef.current === null
     });
 
   const topLevelItems = props.menu.items.map((item, index) => {
     return item.type === 'collection' ? (
       <span
         key={index}
-        className={getTopLevelMenuItemClasses(item.name)}
+        className={getTopLevelMenuItemClasses(index)}
         onClick={() => toggleMegaMenu(item.items, index, item.name)}
       >
         {item.name}{' '}
         <Chevron
-          direction={item.name === activeTopLevelMenuName ? 'up' : 'down'}
+          direction={clickedMenuRef.current === index ? 'up' : 'down'}
           animate={true}
           className={styles.chevron}
         />
@@ -107,7 +102,7 @@ const HelpMenu = (props: Props) => {
       <HelpMenuLink
         key={index}
         to={item.url}
-        className={getHelpMenuLinkClasses()}
+        className={getHelpMenuLinkClasses(item.url)}
         onClick={() => handleHelpMenuLinkClick(item.name)}
       >
         {item.name}


### PR DESCRIPTION
## Description
These changes have been made to the help menus in the Help and About apps:

1. Added chevrons to meganav links that open menus
2. Display the text as black for the meganav links when clicked on them
3. Display the text of the help/about index links when on home page of  the app

## Related JIRA Issue(s)
[ENSWBSITES-1814](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1814)

## Deployment URL(s)
http://meganav-links-chevron.review.ensembl.org


## Views affected
Help and About apps