### PR TITLE
Add breadcrumbs to About app

### DIFF
--- a/src/content/app/about/About.scss
+++ b/src/content/app/about/About.scss
@@ -18,11 +18,6 @@ $article-right-padding: 1.5rem;
   }
 }
 
-.textArticle {
-  height: calc(100vh - 370px);
-  overflow-y: auto;
-}
-
 .spinnerContainer {
   display: flex;
   height: 100%;

--- a/src/content/app/about/About.scss
+++ b/src/content/app/about/About.scss
@@ -18,16 +18,16 @@ $article-right-padding: 1.5rem;
   }
 }
 
+.textArticle {
+  height: calc(100vh - 370px);
+  overflow-y: auto;
+}
+
 .spinnerContainer {
   display: flex;
   height: 100%;
   justify-content: center;
   align-items: center;
-}
-
-.grid {
-  height: 100%;
-  padding: 44px 0 $global-padding-bottom 80px;
 }
 
 .aside {

--- a/src/content/app/about/About.tsx
+++ b/src/content/app/about/About.tsx
@@ -63,7 +63,7 @@ const About = () => {
         <div className={helpStyles.articleContainer}>
           <HelpArticleGrid className={helpStyles.grid}>
             {article ? (
-              <TextArticle article={article} className={styles.textArticle} />
+              <TextArticle article={article} />
             ) : (
               <div className={styles.spinnerContainer}>
                 <CircleLoader />

--- a/src/content/app/about/About.tsx
+++ b/src/content/app/about/About.tsx
@@ -19,12 +19,15 @@ import { useLocation } from 'react-router';
 
 import useApiService from 'src/shared/hooks/useApiService';
 
+import { buildBreadcrumbs } from '../help/Help';
+
 import {
   TextArticle,
   RelatedArticles,
   HelpArticleGrid
 } from 'src/shared/components/help-article';
 import HelpMenu from 'src/content/app/help/components/help-menu/HelpMenu';
+import Breadcrumbs from 'src/shared/components/breadcrumbs/Breadcrumbs';
 import { CircleLoader } from 'src/shared/components/loader';
 import ConversationIcon from 'src/shared/components/communication-framework/ConversationIcon';
 
@@ -35,36 +38,49 @@ import helpStyles from '../help/Help.scss';
 import styles from './About.scss';
 
 const About = () => {
-  const location = useLocation();
+  const { pathname } = useLocation();
   const { data: menu } = useApiService<MenuType>({
     endpoint: `/api/docs/menus?name=about`
   });
   const { data: article } = useApiService<TextArticleData>({
-    endpoint: `/api/docs/article?url=${encodeURIComponent(location.pathname)}`
+    endpoint: `/api/docs/article?url=${encodeURIComponent(pathname)}`
   });
+
+  let breadcrumbs: string[] = [];
+
+  if (menu) {
+    breadcrumbs = buildBreadcrumbs(menu, { url: pathname });
+  }
 
   return (
     <div className={helpStyles.help}>
       <AppBar />
-      {menu && <HelpMenu menu={menu} currentUrl={location.pathname} />}
-      <HelpArticleGrid className={styles.grid}>
-        {article ? (
-          <TextArticle article={article} />
-        ) : (
-          <div className={styles.spinnerContainer}>
-            <CircleLoader />
-          </div>
-        )}
-        <aside className={styles.aside}>
-          {!!article?.related_articles.length && (
-            <RelatedArticles
-              title="More about…"
-              articles={article.related_articles}
-              highlightActiveArticle={true}
-            />
-          )}
-        </aside>
-      </HelpArticleGrid>
+      {menu && <HelpMenu menu={menu} currentUrl={pathname} />}
+      <div className={helpStyles.main}>
+        <div className={helpStyles.breadcrumbsContainer}>
+          <Breadcrumbs breadcrumbs={breadcrumbs} />
+        </div>
+        <div className={helpStyles.articleContainer}>
+          <HelpArticleGrid className={helpStyles.grid}>
+            {article ? (
+              <TextArticle article={article} className={styles.textArticle} />
+            ) : (
+              <div className={styles.spinnerContainer}>
+                <CircleLoader />
+              </div>
+            )}
+            <aside className={styles.aside}>
+              {!!article?.related_articles.length && (
+                <RelatedArticles
+                  title="More about…"
+                  articles={article.related_articles}
+                  highlightActiveArticle={true}
+                />
+              )}
+            </aside>
+          </HelpArticleGrid>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/content/app/help/Help.scss
+++ b/src/content/app/help/Help.scss
@@ -30,7 +30,7 @@
   grid-template-areas:
     'breadcrumbs breadcrumbs navigation'
     '.  article  article';
-  grid-template-rows: 40px auto;
+  grid-template-rows: 40px calc(100% - 65px);
   grid-template-columns: 36px 1fr;
 
   .breadcrumbsContainer {


### PR DESCRIPTION
## Description
The Help app has breadcrumbs, whereas the About app does not. This PR adds it to the latter, by reusing the breadcrumbs generation code in the former.

## Related JIRA Issue(s)
[ENSWBSITES-1815](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1815)

## Deployment URL(s)
http://about-app-breadcrumbs.review.ensembl.org


## Views affected
About app