### PR TITLE
Update BLAST settings styles

### DIFF
--- a/src/content/app/tools/blast/components/blast-settings/BlastSettings.scss
+++ b/src/content/app/tools/blast/components/blast-settings/BlastSettings.scss
@@ -31,7 +31,8 @@
 }
 
 .parametersColumn .select label {
-  grid-template-columns: 140px 70px;
+  grid-template-columns: max-content 90px;
+  justify-content: end;
   text-align: right;
 }
 
@@ -42,9 +43,10 @@
   justify-self: end;
 }
 
-.parametersColumn .matrixSetting .select label,
-.parametersColumn .gapPenalties .select label {
-  grid-template-columns: 140px 110px;
+.matrixSetting.select label,
+.wordSize.select label,
+.matchScores.select label {
+  grid-template-columns: max-content 110px;
 }
 
 .bottomLevel {
@@ -54,8 +56,8 @@
   padding-top: 20px;
   margin-left: 104px;
 
-  @media (max-width: 1610px) {
-    margin-left: -10px;
+  @media (max-width: 1686px) {
+    margin-left: 0px;
   }
 }
 
@@ -84,9 +86,5 @@
 }
 
 .checkboxesColumn {
-  margin-left: 60px;
-
-  @media (min-width: 1190px) and (max-width: 1490px) {
-    margin-left: 150px;
-  }
+  margin-left: 10px;
 }

--- a/src/content/app/tools/blast/components/blast-settings/BlastSettings.tsx
+++ b/src/content/app/tools/blast/components/blast-settings/BlastSettings.tsx
@@ -284,6 +284,7 @@ const BlastSettings = ({ config }: Props) => {
               onChange={(value: string) =>
                 onBlastParameterChange('wordsize', value)
               }
+              className={styles.wordSize}
             />
             {shouldShowMatchMismatch && (
               <BlastSelect
@@ -294,21 +295,21 @@ const BlastSettings = ({ config }: Props) => {
                 onChange={(value: string) =>
                   onBlastParameterChange('match_scores', value)
                 }
+                className={styles.matchScores}
               />
             )}
-            <div className={styles.matrixSetting}>
-              {shouldShowMatrix && (
-                <BlastSelect
-                  options={config.parameters.matrix.options as Option[]}
-                  label={config.parameters.matrix.label}
-                  description={config.parameters.matrix.description}
-                  selectedOption={blastParameters.matrix as string}
-                  onChange={(value: string) =>
-                    onBlastParameterChange('matrix', value)
-                  }
-                />
-              )}
-            </div>
+            {shouldShowMatrix && (
+              <BlastSelect
+                options={config.parameters.matrix.options as Option[]}
+                label={config.parameters.matrix.label}
+                description={config.parameters.matrix.description}
+                selectedOption={blastParameters.matrix as string}
+                onChange={(value: string) =>
+                  onBlastParameterChange('matrix', value)
+                }
+                className={styles.matrixSetting}
+              />
+            )}
           </div>
 
           <div className={styles.parametersColumn}>


### PR DESCRIPTION
## Description
- Updated the width of select elements in the BLAST settings section from 70px to 90px
- Since something like BLOSUM62 won't fit in 90px, set the width of the matrix selector (as well as the select elements that can appear directly above it) to 110px
- Removed the set 140px width for labels, thus bringing the select elements closer together (as in design; consulted with Andrea)
- Updated other styles to fix behaviour at breakpoints

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1875

## Deployment URL(s)
http://blast-select-width.review.ensembl.org

## Views affected
BLAST form (specifically, the BLAST parameters section)