### PR TITLE
Bring interface of our button components in accordance with standard html buttons

### DIFF
--- a/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-toolstrip/EntityViewerSidebarToolstrip.tsx
+++ b/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-toolstrip/EntityViewerSidebarToolstrip.tsx
@@ -15,7 +15,6 @@
  */
 
 import React from 'react';
-import noop from 'lodash/noop';
 
 import { useAppSelector, useAppDispatch } from 'src/store';
 import useEntityViewerAnalytics from 'src/content/app/entity-viewer/hooks/useEntityViewerAnalytics';
@@ -90,7 +89,6 @@ export const EntityViewerSidebarToolstrip = () => {
         description="Share"
         className={styles.sidebarIcon}
         key="share"
-        onClick={noop}
         image={ShareIcon}
       />
       <ImageButton

--- a/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/navigate-modal/LocationNavigation.tsx
+++ b/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/navigate-modal/LocationNavigation.tsx
@@ -272,7 +272,7 @@ const LocationNavigation = () => {
           )}
           <PrimaryButton
             onClick={handleSubmit}
-            isDisabled={shouldDisableSubmission}
+            disabled={shouldDisableSubmission}
           >
             Go
           </PrimaryButton>

--- a/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/navigate-modal/RegionNavigation.tsx
+++ b/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/navigate-modal/RegionNavigation.tsx
@@ -235,7 +235,7 @@ const RegionNavigation = () => {
           )}
           <PrimaryButton
             onClick={handleSubmit}
-            isDisabled={shouldDisableSubmission}
+            disabled={shouldDisableSubmission}
           >
             Go
           </PrimaryButton>

--- a/src/content/app/species/components/species-sidebar-toolstrip/SpeciesSidebarToolstrip.tsx
+++ b/src/content/app/species/components/species-sidebar-toolstrip/SpeciesSidebarToolstrip.tsx
@@ -15,7 +15,6 @@
  */
 
 import React from 'react';
-import noop from 'lodash/noop';
 
 import { useAppSelector, useAppDispatch } from 'src/store';
 import useSpeciesAnalytics from 'src/content/app/species/hooks/useSpeciesAnalytics';
@@ -96,7 +95,6 @@ export const SpeciesSidebarToolstrip = () => {
         description="Previously viewed"
         className={styles.sidebarIcon}
         key={SpeciesSidebarModalView.BOOKMARKS}
-        onClick={noop}
         image={BookmarkIcon}
       />
       <ImageButton
@@ -104,14 +102,12 @@ export const SpeciesSidebarToolstrip = () => {
         description="Share"
         className={styles.sidebarIcon}
         key="share"
-        onClick={noop}
         image={ShareIcon}
       />
       <ImageButton
         status={Status.DISABLED}
         description="Download"
         className={styles.sidebarIcon}
-        onClick={noop}
         image={DownloadIcon}
       />
     </>

--- a/src/content/app/species/components/species-title-area/SpeciesTitleArea.tsx
+++ b/src/content/app/species/components/species-title-area/SpeciesTitleArea.tsx
@@ -156,7 +156,7 @@ const SpeciesTitleArea = () => {
       <div className={styles.speciesRemove}>
         <SecondaryButton
           onClick={toggleRemovalDialog}
-          isDisabled={isRemoving}
+          disabled={isRemoving}
           className={classNames({ [styles.disabledRemoveButton]: isRemoving })}
         >
           Remove species

--- a/src/content/app/tools/blast/components/blast-job-submit/BlastJobSubmit.tsx
+++ b/src/content/app/tools/blast/components/blast-job-submit/BlastJobSubmit.tsx
@@ -81,7 +81,7 @@ const BlastJobSubmit = () => {
   };
 
   return (
-    <PrimaryButton onClick={onBlastSubmit} isDisabled={isDisabled}>
+    <PrimaryButton onClick={onBlastSubmit} disabled={isDisabled}>
       Run
     </PrimaryButton>
   );

--- a/src/shared/components/button/Button.scss
+++ b/src/shared/components/button/Button.scss
@@ -7,11 +7,10 @@
   font-weight: $bold;
 }
 
-.primaryButtonDisabled {
+.primaryButton:disabled {
   background-color: transparent;
   color: $grey;
   border: 1px solid $grey;
-  cursor: default;
 }
 
 .secondaryButton {

--- a/src/shared/components/button/Button.scss
+++ b/src/shared/components/button/Button.scss
@@ -1,26 +1,29 @@
 @import 'src/styles/common';
 
 .primaryButton {
-  border: 1px solid $green;
-  background-color: $green;
-  color: $white;
+  --button-border: var(--primary-button-color, 1px solid #{$green});
+  --button-color: var(--primary-button-color, #{$green});
+  --button-text-color: var(--primary-button-text-color, #{$white});
   font-weight: $bold;
 }
 
 .primaryButton:disabled {
-  background-color: transparent;
-  color: $grey;
-  border: 1px solid $grey;
+  --button-border: var(--primary-button-disabled-border, 1px solid #{$grey});
+  --button-color: var(--primary-button-disabled-color, transparent);
+  --button-text-color: var(--primary-button-disabled-text-color, #{$grey});
 }
 
 .secondaryButton {
-  border: 1px solid $blue;
-  background-color: $blue;
-  color: $white;
+  --button-border: var(--secondary-button-color, 1px solid #{$blue});
+  --button-color: var(--secondary-button-color, #{$blue});
+  --button-text-color: var(--secondary-button-text-color, #{$white});
   font-weight: $bold;
 }
 
 .button {
+  border: var(--button-border);
+  background-color: var(--button-color);
+  color: var(--button-text-color);
   padding: 7px 18px;
   border-radius: 4px;
   user-select: none;

--- a/src/shared/components/button/Button.test.tsx
+++ b/src/shared/components/button/Button.test.tsx
@@ -82,7 +82,7 @@ describe('PrimaryButton', () => {
 
   it('does not call onClick if disabled', async () => {
     const { container } = render(
-      <PrimaryButton {...defaultProps} isDisabled={true}>
+      <PrimaryButton {...defaultProps} disabled={true}>
         I am primary button
       </PrimaryButton>
     );

--- a/src/shared/components/button/Button.tsx
+++ b/src/shared/components/button/Button.tsx
@@ -14,25 +14,22 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, {
+  type DetailedHTMLProps,
+  type ButtonHTMLAttributes
+} from 'react';
 import classNames from 'classnames';
 
 import styles from './Button.scss';
 
-type Props = Omit<
-  React.HTMLProps<HTMLButtonElement>,
-  'disabled' | 'onClick'
-> & {
-  onClick: () => void;
-  isDisabled?: boolean;
-};
+type Props = DetailedHTMLProps<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  HTMLButtonElement
+>;
 
 export const PrimaryButton = (props: Props) => {
-  const className = classNames(
-    styles.primaryButton,
-    { [styles.primaryButtonDisabled]: props.isDisabled },
-    props.className
-  );
+  const className = classNames(styles.primaryButton, props.className);
+
   return <Button {...props} className={className} />;
 };
 
@@ -44,18 +41,8 @@ export const SecondaryButton = (props: Props) => (
 );
 
 const Button = (props: Props) => {
-  const handleClick = () => {
-    if (!props.isDisabled) {
-      props.onClick();
-    }
-  };
-
   return (
-    <button
-      className={classNames(styles.button, props.className)}
-      onClick={handleClick}
-      disabled={props.isDisabled}
-    >
+    <button {...props} className={classNames(styles.button, props.className)}>
       {props.children}
     </button>
   );

--- a/src/shared/components/communication-framework/contact-us/contact-us-form/ContactUsForm.scss
+++ b/src/shared/components/communication-framework/contact-us/contact-us-form/ContactUsForm.scss
@@ -96,12 +96,12 @@ $columnGapWidth: 12px;
   }
 }
 
-.submitButtonWrapper {
+.submitButton {
   grid-column: submit-right;
   justify-self: end;
 }
 
-.submitButton {
+.submitButton button {
   height: 30px;
   width: 90px;
 }

--- a/src/shared/components/communication-framework/contact-us/contact-us-form/initial/ContactUsInitialForm.tsx
+++ b/src/shared/components/communication-framework/contact-us/contact-us-form/initial/ContactUsInitialForm.tsx
@@ -22,7 +22,6 @@ import React, {
   FormEvent
 } from 'react';
 import classNames from 'classnames';
-import noop from 'lodash/noop';
 
 import { submitForm } from '../submitForm';
 import noEarlierThan from 'src/shared/utils/noEarlierThan';
@@ -356,12 +355,8 @@ const ContactUsInitialForm = () => {
           {isChallengeCompleted ? (
             <ControlledLoadingButton
               status={submissionState}
-              classNames={{
-                wrapper: commonStyles.submitButtonWrapper,
-                button: commonStyles.submitButton
-              }}
-              isDisabled={!isFormValid}
-              onClick={noop}
+              className={commonStyles.submitButton}
+              disabled={!isFormValid}
             >
               Send
             </ControlledLoadingButton>

--- a/src/shared/components/error-screen/GeneralErrorScreen.tsx
+++ b/src/shared/components/error-screen/GeneralErrorScreen.tsx
@@ -68,7 +68,7 @@ const GeneralErrorScreen = () => {
           </div>
         </div>
         <div className={styles.reloadButton}>
-          <PrimaryButton isDisabled={moreOptionExpanded} onClick={reloadPage}>
+          <PrimaryButton disabled={moreOptionExpanded} onClick={reloadPage}>
             Reload
           </PrimaryButton>
         </div>

--- a/src/shared/components/in-app-search/InAppSearch.tsx
+++ b/src/shared/components/in-app-search/InAppSearch.tsx
@@ -138,7 +138,7 @@ const InAppSearch = (props: Props) => {
         <PrimaryButton
           onClick={onSearchSubmit}
           className={styles.searchButton}
-          isDisabled={!query || isLoading}
+          disabled={!query || isLoading}
         >
           Go
         </PrimaryButton>

--- a/src/shared/components/loading-button/ControlledLoadingButton.tsx
+++ b/src/shared/components/loading-button/ControlledLoadingButton.tsx
@@ -28,32 +28,27 @@ import { LoadingState } from 'src/shared/types/loading-state';
 import styles from './LoadingButton.scss';
 
 type Props = {
-  onClick: () => unknown;
+  onClick?: () => unknown;
   status: LoadingState;
-  isDisabled?: boolean;
-  classNames?: {
-    wrapper?: string;
-    button?: string;
-  };
+  disabled?: boolean;
+  className?: string;
   children: ReactNode;
 };
 
 const ControlledLoadingButton = (props: Props) => {
   const {
     status: loadingState,
-    classNames: { wrapper: wrapperClassName, button: buttonClassName } = {},
+    className: classNameFromProps,
     ...otherProps
   } = props;
 
-  const wrapperClass = classNames(styles.buttonWrapper, wrapperClassName);
+  const wrapperClasses = classNames(styles.buttonWrapper, classNameFromProps);
 
   const buttonClass =
-    loadingState !== LoadingState.NOT_REQUESTED
-      ? classNames(buttonClassName, styles.invisible)
-      : buttonClassName;
+    loadingState !== LoadingState.NOT_REQUESTED ? styles.invisible : undefined;
 
   return (
-    <div className={wrapperClass}>
+    <div className={wrapperClasses}>
       {loadingState === LoadingState.LOADING && <Loading />}
       {loadingState === LoadingState.SUCCESS && <Success />}
       {loadingState === LoadingState.ERROR && <ErrorIndicator />}

--- a/src/shared/components/loading-button/LoadingButton.tsx
+++ b/src/shared/components/loading-button/LoadingButton.tsx
@@ -26,11 +26,8 @@ type LoadingButtonProps = {
   onClick: () => Promise<unknown>;
   onSuccess?: (x?: unknown) => void;
   onError?: (x?: unknown) => void;
-  isDisabled?: boolean;
-  classNames?: {
-    wrapper?: string;
-    button?: string;
-  };
+  disabled?: boolean;
+  className?: string;
   children: ReactNode;
 };
 
@@ -101,8 +98,8 @@ const LoadingButton = (props: LoadingButtonProps) => {
     <ControlledLoadingButton
       status={loadingState}
       onClick={onClick}
-      classNames={props.classNames}
-      isDisabled={props.isDisabled}
+      className={props.className}
+      disabled={props.disabled}
     >
       {props.children}
     </ControlledLoadingButton>

--- a/stories/shared-components/button/Button.stories.tsx
+++ b/stories/shared-components/button/Button.stories.tsx
@@ -48,13 +48,13 @@ export const DisabledPrimaryButton = (args: DefaultArgs) => (
   <>
     <p>On white background</p>
     <div className={styles.wrapper}>
-      <PrimaryButton onClick={args.onClick} isDisabled={true}>
+      <PrimaryButton onClick={args.onClick} disabled={true}>
         Primary button
       </PrimaryButton>
     </div>
     <p>On light-grey background</p>
     <div className={`${styles.wrapper} ${styles.lightGreyWrapper}`}>
-      <PrimaryButton onClick={args.onClick} isDisabled={true}>
+      <PrimaryButton onClick={args.onClick} disabled={true}>
         Primary button
       </PrimaryButton>
     </div>

--- a/stories/shared-components/delete-button/DeleteButton.stories.tsx
+++ b/stories/shared-components/delete-button/DeleteButton.stories.tsx
@@ -15,7 +15,6 @@
  */
 
 import React from 'react';
-import noop from 'lodash/noop';
 
 import DeleteButton from 'src/shared/components/delete-button/DeleteButton';
 
@@ -23,6 +22,6 @@ export default {
   title: 'Components/Shared Components/Delete button'
 };
 
-export const DefaultDeleteButton = () => <DeleteButton onClick={noop} />;
+export const DefaultDeleteButton = () => <DeleteButton />;
 
 DefaultDeleteButton.storyName = 'default';

--- a/stories/shared-components/loading-button/LoadingButton.stories.tsx
+++ b/stories/shared-components/loading-button/LoadingButton.stories.tsx
@@ -143,7 +143,7 @@ export const ControlledLoadingButtonStory = (args: DefaultArgs) => {
       <ControlledLoadingButton
         status={buttonStatus}
         onClick={args.onClick}
-        isDisabled={isDisabled}
+        disabled={isDisabled}
       >
         I am button
       </ControlledLoadingButton>

--- a/stories/shared-components/pill-button/PillButton.stories.tsx
+++ b/stories/shared-components/pill-button/PillButton.stories.tsx
@@ -15,7 +15,6 @@
  */
 
 import React from 'react';
-import noop from 'lodash/noop';
 
 import PillButton from 'src/shared/components/pill-button/PillButton';
 
@@ -26,16 +25,16 @@ export default {
 export const PlusButtonStory = () => (
   <>
     <div>
-      <PillButton onClick={noop}>+2</PillButton>
+      <PillButton>+2</PillButton>
     </div>
     <div>
-      <PillButton onClick={noop}>+42</PillButton>
+      <PillButton>+42</PillButton>
     </div>
     <div>
-      <PillButton onClick={noop}>+512</PillButton>
+      <PillButton>+512</PillButton>
     </div>
     <div>
-      <PillButton onClick={noop}>+1234</PillButton>
+      <PillButton>+1234</PillButton>
     </div>
   </>
 );

--- a/stories/shared-components/plus-button/PlusButton.stories.tsx
+++ b/stories/shared-components/plus-button/PlusButton.stories.tsx
@@ -15,7 +15,6 @@
  */
 
 import React from 'react';
-import noop from 'lodash/noop';
 
 import PlusButton from 'src/shared/components/plus-button/PlusButton';
 
@@ -23,6 +22,6 @@ export default {
   title: 'Components/Shared Components/Plus button'
 };
 
-export const PlusButtonStory = () => <PlusButton onClick={noop} />;
+export const PlusButtonStory = () => <PlusButton />;
 
 PlusButtonStory.storyName = 'default';

--- a/tests/fixtures/browser.ts
+++ b/tests/fixtures/browser.ts
@@ -186,14 +186,6 @@ export const createMockBrowserState = () => {
         regionEditorActive: false,
         regionFieldActive: false
       },
-      browserNav: {
-        browserNavButtonStates: {
-          move_right: false,
-          move_left: true,
-          zoom_out: false,
-          zoom_in: false
-        }
-      },
       trackPanel: {
         [fakeGenomeId]: {
           selectedTrackPanelTab: TrackSet.GENOMIC,


### PR DESCRIPTION
## Description
Button components (`PrimaryButton`, `SecondaryButton`...) were among the first we built for ensembl-client, and I made two wrong decisions then. I decided, first, that a button **must** have an `onClick` property (because how else do you interact with a button other than by clicking on it); and that `isDisabled` is a better property name for a button than the standard `disabled` attribute of the native html button. The first decision was wrong, because, inside of a form, a button, by default, submits the form, and does not need a click handler. Insisting on the `onClick` property has led to us passing dummy functions, such as lodash's `noop`, to the buttons, which clearly demonstrates that it was a wrong choice. As for the second decision, having to translate `isDisabled` to `disabled` inside our button component is just an unnecessary complexity.

Therefore, this PR aims to undo the damage done then. The programmatic interface of our button components is brought in accordance with the interface of native html button elements. Specifically:
- the `onClick` property is no longer required
- the `isDisabled` property is renamed to `disabled`

## Deployment URL(s)
http://update-button.review.ensembl.org