### PR TITLE
Update format of CADD scores

### DIFF
--- a/src/content/app/genome-browser/components/drawer/drawer-views/variant-summary/VariantSummary.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/variant-summary/VariantSummary.tsx
@@ -223,7 +223,7 @@ const ClinicalSignificance = (props: {
 
 const CADDScores = (props: { data: { sequence: string; score: number }[] }) => {
   const caddScoreString = props.data
-    .map((data) => `${data.sequence}:${data.score}`)
+    .map((data) => `${data.score} (${data.sequence})`)
     .join(', ');
 
   return <span>{caddScoreString}</span>;


### PR DESCRIPTION
## Description
Updated the format of CADD scores to display the sequence inside parenthesis rather than before the score e.g. G:0.347 to 0.347 (G)

## Related JIRA Issue(s)
[ENSWBSITES-1918](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1918)

## Deployment URL(s)
http://update-cadd-score.review.ensembl.org


## Views affected
Genome browser -> focus variant in drawer