### PR TITLE
Refactor thunk actions

### DIFF
--- a/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
+++ b/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
@@ -17,10 +17,10 @@
 import {
   createAsyncThunk,
   createSlice,
+  type Action,
+  type ThunkAction,
   type PayloadAction
 } from '@reduxjs/toolkit';
-import type { Action } from 'redux';
-import type { ThunkAction } from 'redux-thunk';
 import cloneDeep from 'lodash/cloneDeep';
 
 import entityViewerStorageService from 'src/content/app/entity-viewer/services/entity-viewer-storage-service';
@@ -30,14 +30,13 @@ import {
   getEntityViewerActiveEntityId
 } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors';
 
-import { TranscriptMetadata } from 'src/shared/types/thoas/metadata';
-
 import {
   getExpandedTranscriptIds,
   getExpandedTranscriptDownloadIds,
   getExpandedTranscriptMoreInfoIds
 } from './geneViewTranscriptsSelectors';
 
+import type { TranscriptMetadata } from 'src/shared/types/thoas/metadata';
 import type { RootState } from 'src/store';
 
 export enum SortingRule {

--- a/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
+++ b/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice.ts
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 
-import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { Action } from 'redux';
-import { ThunkAction } from 'redux-thunk';
+import {
+  createAsyncThunk,
+  createSlice,
+  type PayloadAction
+} from '@reduxjs/toolkit';
+import type { Action } from 'redux';
+import type { ThunkAction } from 'redux-thunk';
 import cloneDeep from 'lodash/cloneDeep';
 
 import entityViewerStorageService from 'src/content/app/entity-viewer/services/entity-viewer-storage-service';
@@ -34,7 +38,7 @@ import {
   getExpandedTranscriptMoreInfoIds
 } from './geneViewTranscriptsSelectors';
 
-import { RootState } from 'src/store';
+import type { RootState } from 'src/store';
 
 export enum SortingRule {
   DEFAULT = 'default',
@@ -87,8 +91,8 @@ const defaultStatePerGene: TranscriptsStatePerGene = {
 };
 
 export const resetFilterPanel =
-  (): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  (): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const state = getState();
     const activeGenomeId = getEntityViewerActiveGenomeId(state);
     const activeEntityId = getEntityViewerActiveEntityId(state);
@@ -105,8 +109,10 @@ export const resetFilterPanel =
   };
 
 export const setFilterPanel =
-  (filterPanelOpen: boolean): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  (
+    filterPanelOpen: boolean
+  ): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const state = getState();
     const activeGenomeId = getEntityViewerActiveGenomeId(state);
     const activeEntityId = getEntityViewerActiveEntityId(state);
@@ -123,8 +129,8 @@ export const setFilterPanel =
   };
 
 export const setFilters =
-  (filters: Filters): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  (filters: Filters): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const state = getState();
     const activeGenomeId = getEntityViewerActiveGenomeId(state);
     const activeEntityId = getEntityViewerActiveEntityId(state);
@@ -149,8 +155,10 @@ export const setFilters =
   };
 
 export const setSortingRule =
-  (sortingRule: SortingRule): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  (
+    sortingRule: SortingRule
+  ): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const state = getState();
     const activeGenomeId = getEntityViewerActiveGenomeId(state);
     const activeEntityId = getEntityViewerActiveEntityId(state);
@@ -176,8 +184,8 @@ export const setSortingRule =
   };
 
 export const toggleTranscriptInfo =
-  (transcriptId: string): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  (transcriptId: string): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const state = getState();
     const activeGenomeId = getEntityViewerActiveGenomeId(state);
     const activeEntityId = getEntityViewerActiveEntityId(state);
@@ -202,8 +210,8 @@ export const toggleTranscriptInfo =
   };
 
 export const toggleTranscriptDownload =
-  (transcriptId: string): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  (transcriptId: string): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const state = getState();
     const activeGenomeId = getEntityViewerActiveGenomeId(state);
     const activeEntityId = getEntityViewerActiveEntityId(state);
@@ -230,8 +238,8 @@ export const toggleTranscriptDownload =
   };
 
 export const toggleTranscriptMoreInfo =
-  (transcriptId: string): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  (transcriptId: string): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const state = getState();
     const activeGenomeId = getEntityViewerActiveGenomeId(state);
     const activeEntityId = getEntityViewerActiveEntityId(state);

--- a/src/content/app/entity-viewer/state/gene-view/view/geneViewViewSlice.ts
+++ b/src/content/app/entity-viewer/state/gene-view/view/geneViewViewSlice.ts
@@ -14,16 +14,19 @@
  * limitations under the License.
  */
 
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { Action } from 'redux';
-import { ThunkAction } from 'redux-thunk';
+import {
+  createSlice,
+  type Action,
+  type ThunkAction,
+  type PayloadAction
+} from '@reduxjs/toolkit';
 
 import {
   getEntityViewerActiveGenomeId,
   getEntityViewerActiveEntityId
 } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors';
 
-import { RootState } from 'src/store';
+import type { RootState } from 'src/store';
 
 export enum View {
   TRANSCRIPTS = 'transcripts',

--- a/src/content/app/entity-viewer/state/gene-view/view/geneViewViewSlice.ts
+++ b/src/content/app/entity-viewer/state/gene-view/view/geneViewViewSlice.ts
@@ -143,8 +143,8 @@ const initialStatePerGene: ViewStatePerGene = {
 };
 
 export const updateView =
-  (view: View): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  (view: View): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const activeGenomeId = getEntityViewerActiveGenomeId(getState());
     const activeObjectId = getEntityViewerActiveEntityId(getState());
     if (!activeGenomeId || !activeObjectId) {

--- a/src/content/app/entity-viewer/state/general/entityViewerGeneralSlice.ts
+++ b/src/content/app/entity-viewer/state/general/entityViewerGeneralSlice.ts
@@ -14,8 +14,12 @@
  * limitations under the License.
  */
 
-import { createSlice, type PayloadAction, type Action } from '@reduxjs/toolkit';
-import { type ThunkAction } from 'redux-thunk';
+import {
+  createSlice,
+  type Action,
+  type ThunkAction,
+  type PayloadAction
+} from '@reduxjs/toolkit';
 import pickBy from 'lodash/pickBy';
 
 import entityViewerStorageService from 'src/content/app/entity-viewer/services/entity-viewer-storage-service';
@@ -27,7 +31,7 @@ import {
 } from './entityViewerGeneralSelectors';
 import { getCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 
-import { RootState } from 'src/store';
+import type { RootState } from 'src/store';
 
 export type EntityViewerGeneralState = Readonly<{
   activeGenomeId: string | null;

--- a/src/content/app/entity-viewer/state/general/entityViewerGeneralSlice.ts
+++ b/src/content/app/entity-viewer/state/general/entityViewerGeneralSlice.ts
@@ -45,8 +45,10 @@ export const initialState: EntityViewerGeneralState = {
 };
 
 export const setActiveIds =
-  (params: EntityViewerParams): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  (
+    params: EntityViewerParams
+  ): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const state = getState();
     const { genomeId, entityId } = params;
 
@@ -82,8 +84,8 @@ export const setActiveIds =
 // If/when we remove the redirect from /entity-viewer/:genomeId to /entity-viewer/:genomeId/:entityId,
 // the synchronous nature of this thunk will become irrelevant
 export const deleteActiveEntityIdAndSave =
-  (): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  (): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const state = getState();
 
     const activeGenomeId = getEntityViewerActiveGenomeId(state);
@@ -107,8 +109,8 @@ export const deleteActiveEntityIdAndSave =
   };
 
 export const setDefaultActiveGenomeId =
-  (): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  (): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const state = getState();
     const [firstCommittedSpecies] = getCommittedSpecies(state);
     const activeGenomeId = firstCommittedSpecies?.genome_id;

--- a/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSlice.ts
+++ b/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSlice.ts
@@ -69,8 +69,10 @@ export type EntityViewerSidebarUIState = {
 };
 
 export const setSidebarTabName =
-  (tabName: SidebarTabName): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  (
+    tabName: SidebarTabName
+  ): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const genomeId = getEntityViewerActiveGenomeId(getState());
 
     if (!genomeId) {
@@ -86,8 +88,8 @@ export const setSidebarTabName =
   };
 
 export const toggleSidebar =
-  (status?: ToggleStatus): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  (status?: ToggleStatus): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const state = getState();
 
     const genomeId = getEntityViewerActiveGenomeId(state);
@@ -111,8 +113,8 @@ export const closeSidebar = () => toggleSidebar(Status.CLOSED);
 export const updateEntityUI =
   (
     fragment: Partial<EntityViewerSidebarUIState>
-  ): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  ): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const state = getState();
     const genomeId = getEntityViewerActiveGenomeId(state);
     const entityId = getEntityViewerActiveEntityId(state);
@@ -127,8 +129,8 @@ export const updateEntityUI =
 export const openSidebarModal =
   (
     sidebarModalView: SidebarModalView
-  ): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  ): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const state = getState();
 
     const genomeId = getEntityViewerActiveGenomeId(state);
@@ -147,8 +149,8 @@ export const openSidebarModal =
   };
 
 export const closeSidebarModal =
-  (): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  (): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const state = getState();
     const genomeId = getEntityViewerActiveGenomeId(state);
 

--- a/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSlice.ts
+++ b/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSlice.ts
@@ -16,9 +16,9 @@
 
 import {
   createSlice,
-  PayloadAction,
-  Action,
-  ThunkAction
+  type PayloadAction,
+  type Action,
+  type ThunkAction
 } from '@reduxjs/toolkit';
 import merge from 'lodash/merge';
 import mergeWith from 'lodash/mergeWith';
@@ -30,9 +30,9 @@ import {
 import { isEntityViewerSidebarOpen } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors';
 
 import { Status } from 'src/shared/types/status';
-import { AccordionSectionID as OverviewMainAccordionSectionID } from 'src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/MainAccordion';
-import JSONValue from 'src/shared/types/JSON';
-import { RootState } from 'src/store';
+import type { AccordionSectionID as OverviewMainAccordionSectionID } from 'src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/MainAccordion';
+import type JSONValue from 'src/shared/types/JSON';
+import type { RootState } from 'src/store';
 
 export type ToggleStatus = Status.OPEN | Status.CLOSED;
 

--- a/src/content/app/genome-browser/state/browser-bookmarks/browserBookmarksSlice.ts
+++ b/src/content/app/genome-browser/state/browser-bookmarks/browserBookmarksSlice.ts
@@ -57,8 +57,8 @@ export const initialState: BrowserBookmarksState = {
 };
 
 export const updatePreviouslyViewedObjectsAndSave =
-  (): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  (): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const state = getState();
     const activeGenomeId = getBrowserActiveGenomeId(state);
     const activeFocusObject = getBrowserActiveFocusObject(state);
@@ -117,7 +117,7 @@ export const updatePreviouslyViewedObjectsAndSave =
   };
 
 export const loadPreviouslyViewedObjects =
-  (): ThunkAction<void, any, void, Action<string>> => (dispatch) => {
+  (): ThunkAction<void, RootState, void, Action<string>> => (dispatch) => {
     const previouslyViewedObjects =
       browserBookmarksStorageService.getPreviouslyViewedObjects();
 

--- a/src/content/app/genome-browser/state/browser-general/browserGeneralSlice.ts
+++ b/src/content/app/genome-browser/state/browser-general/browserGeneralSlice.ts
@@ -66,8 +66,8 @@ export type ParsedUrlPayload = {
 };
 
 export const fetchDataForLastVisitedObjects: ActionCreator<
-  ThunkAction<void, any, void, Action<string>>
-> = () => async (dispatch, getState: () => RootState) => {
+  ThunkAction<void, RootState, void, Action<string>>
+> = () => async (dispatch, getState) => {
   const state = getState();
   const activeFocusObjectIdsMap = getBrowserActiveFocusObjectIds(state);
   Object.values(activeFocusObjectIdsMap).forEach((objectId) =>
@@ -76,8 +76,8 @@ export const fetchDataForLastVisitedObjects: ActionCreator<
 };
 
 export const setDataFromUrlAndSave: ActionCreator<
-  ThunkAction<void, any, void, Action<string>>
-> = (payload: ParsedUrlPayload) => (dispatch, getState: () => RootState) => {
+  ThunkAction<void, RootState, void, Action<string>>
+> = (payload: ParsedUrlPayload) => (dispatch, getState) => {
   const { activeGenomeId, activeFocusObjectId, chrLocation } = payload;
   const state = getState();
   const currentActiveGenomeId = getBrowserActiveGenomeId(state);
@@ -120,8 +120,8 @@ export const setDataFromUrlAndSave: ActionCreator<
 
 export const updateBrowserActiveFocusObjectIdsAndSave = (
   activeFocusObjectId: string
-): ThunkAction<void, any, void, Action<string>> => {
-  return (dispatch, getState: () => RootState) => {
+): ThunkAction<void, RootState, void, Action<string>> => {
+  return (dispatch, getState) => {
     const state = getState();
     const activeGenomeId = getBrowserActiveGenomeId(state);
     if (!activeGenomeId) {
@@ -144,11 +144,11 @@ export const updateBrowserActiveFocusObjectIdsAndSave = (
 
 export const deleteBrowserActiveFocusObjectIdAndSave = (): ThunkAction<
   void,
-  any,
+  RootState,
   void,
   Action<string>
 > => {
-  return (dispatch, getState: () => RootState) => {
+  return (dispatch, getState) => {
     const state = getState();
     const activeGenomeId = getBrowserActiveGenomeId(state);
     if (!activeGenomeId) {
@@ -170,9 +170,9 @@ export const deleteBrowserActiveFocusObjectIdAndSave = (): ThunkAction<
 };
 
 export const setChrLocation: ActionCreator<
-  ThunkAction<any, any, null, Action<string>>
+  ThunkAction<void, RootState, null, Action<string>>
 > = (chrLocation: ChrLocation) => {
-  return (dispatch, getState: () => RootState) => {
+  return (dispatch, getState) => {
     const state = getState();
     const activeGenomeId = getBrowserActiveGenomeId(state);
     const activeFocusObjectId = getBrowserActiveFocusObjectId(state);
@@ -192,8 +192,8 @@ export const setChrLocation: ActionCreator<
 
 export const deleteSpeciesInGenomeBrowser = (
   genomeIdToRemove: string
-): ThunkAction<void, any, void, Action<string>> => {
-  return async (dispatch, getState: () => RootState) => {
+): ThunkAction<void, RootState, void, Action<string>> => {
+  return async (dispatch, getState) => {
     const state = getState();
 
     dispatch(deleteBrowserDataForGenome(genomeIdToRemove));
@@ -216,7 +216,7 @@ export const deleteSpeciesInGenomeBrowser = (
 
 export const loadBrowserGeneralState = (): ThunkAction<
   void,
-  any,
+  RootState,
   void,
   Action<string>
 > => {

--- a/src/content/app/genome-browser/state/browser-sidebar-modal/browserSidebarModalSlice.ts
+++ b/src/content/app/genome-browser/state/browser-sidebar-modal/browserSidebarModalSlice.ts
@@ -49,8 +49,8 @@ export const defaultBrowserSidebarModalStateForGenome: BrowserSidebarModalStateF
 export const openBrowserSidebarModal =
   (
     browserSidebarModalView: BrowserSidebarModalView
-  ): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  ): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const state = getState();
     const activeGenomeId = getBrowserActiveGenomeId(state);
 
@@ -72,8 +72,8 @@ export const openBrowserSidebarModal =
   };
 
 export const closeBrowserSidebarModal =
-  (): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  (): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const state = getState();
     const activeGenomeId = getBrowserActiveGenomeId(state);
 

--- a/src/content/app/genome-browser/state/drawer/drawerSlice.ts
+++ b/src/content/app/genome-browser/state/drawer/drawerSlice.ts
@@ -35,8 +35,8 @@ type DrawerState = {
 };
 
 export const closeDrawer =
-  (): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  (): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const activeGenomeId = getBrowserActiveGenomeId(getState());
 
     if (!activeGenomeId) {
@@ -52,8 +52,10 @@ export const closeDrawer =
   };
 
 export const changeDrawerViewAndOpen =
-  (drawerView: DrawerView): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  (
+    drawerView: DrawerView
+  ): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const activeGenomeId = getBrowserActiveGenomeId(getState());
 
     if (!activeGenomeId) {

--- a/src/content/app/genome-browser/state/drawer/drawerSlice.ts
+++ b/src/content/app/genome-browser/state/drawer/drawerSlice.ts
@@ -16,9 +16,9 @@
 
 import {
   createSlice,
-  Action,
-  PayloadAction,
-  ThunkAction
+  type Action,
+  type PayloadAction,
+  type ThunkAction
 } from '@reduxjs/toolkit';
 
 import { getBrowserActiveGenomeId } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';

--- a/src/content/app/genome-browser/state/focus-object/focusObjectSlice.ts
+++ b/src/content/app/genome-browser/state/focus-object/focusObjectSlice.ts
@@ -146,7 +146,7 @@ const buildFocusVariantObject = (payload: {
 };
 
 export const fetchExampleFocusObjects =
-  (genomeId: string): ThunkAction<void, any, void, Action<string>> =>
+  (genomeId: string): ThunkAction<void, RootState, void, Action<string>> =>
   async (dispatch) => {
     const genomeInfoResponsePromise = dispatch(
       fetchGenomeInfo.initiate(genomeId)

--- a/src/content/app/genome-browser/state/track-panel/trackPanelSlice.ts
+++ b/src/content/app/genome-browser/state/track-panel/trackPanelSlice.ts
@@ -53,8 +53,10 @@ export const defaultTrackPanelStateForGenome: TrackPanelStateForGenome = {
 };
 
 export const toggleTrackPanel =
-  (isTrackPanelOpened: boolean): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  (
+    isTrackPanelOpened: boolean
+  ): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const activeGenomeId = getBrowserActiveGenomeId(getState());
 
     if (!activeGenomeId) {
@@ -78,8 +80,8 @@ export const selectTrackPanelTab =
     options: {
       shouldCloseSidebarModal: boolean;
     } = { shouldCloseSidebarModal: true }
-  ): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  ): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const activeGenomeId = getBrowserActiveGenomeId(getState());
 
     if (!activeGenomeId) {
@@ -123,8 +125,10 @@ export const updateTrackPanelTabForNewFocusObject = createAsyncThunk(
 );
 
 export const changeHighlightedTrackId =
-  (highlightedTrackId: string): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  (
+    highlightedTrackId: string
+  ): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const state = getState();
     const activeGenomeId = getBrowserActiveGenomeId(state);
 

--- a/src/content/app/species-selector/state/speciesSelectorEpics.ts
+++ b/src/content/app/species-selector/state/speciesSelectorEpics.ts
@@ -16,7 +16,7 @@
 
 import { Epic } from 'redux-observable';
 import { map, switchMap, tap, filter, distinctUntilChanged } from 'rxjs';
-import { isAnyOf, isFulfilled, Action } from '@reduxjs/toolkit';
+import { isAnyOf, isFulfilled, type Action } from '@reduxjs/toolkit';
 
 import speciesSelectorStorageService from 'src/content/app/species-selector/services/species-selector-storage-service';
 import * as observableApiService from 'src/services/observable-api-service';

--- a/src/content/app/species-selector/state/speciesSelectorSlice.ts
+++ b/src/content/app/species-selector/state/speciesSelectorSlice.ts
@@ -76,8 +76,8 @@ export const fetchSpeciesSearchResults = createAction<string>(
 );
 
 export const updateSearch =
-  (text: string): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  (text: string): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const state = getState();
     const selectedItem = getSelectedItem(state);
     const previousText = getSearchText(state);
@@ -115,7 +115,8 @@ export const loadStoredSpecies = createAsyncThunk(
 );
 
 export const commitSelectedSpeciesAndSave =
-  (): ThunkAction<void, any, void, Action<string>> => (dispatch, getState) => {
+  (): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const committedSpecies = getCommittedSpecies(getState());
     const selectedItem = getSelectedItem(getState());
 
@@ -135,7 +136,7 @@ export const commitSelectedSpeciesAndSave =
   };
 
 export const toggleSpeciesUseAndSave =
-  (genomeId: string): ThunkAction<void, any, void, Action<string>> =>
+  (genomeId: string): ThunkAction<void, RootState, void, Action<string>> =>
   (dispatch, getState) => {
     const state = getState();
     const committedSpecies = getCommittedSpecies(state);
@@ -157,7 +158,7 @@ export const toggleSpeciesUseAndSave =
   };
 
 export const deleteSpeciesAndSave =
-  (genomeId: string): ThunkAction<void, any, void, Action<string>> =>
+  (genomeId: string): ThunkAction<void, RootState, void, Action<string>> =>
   (dispatch, getState) => {
     const committedSpecies = getCommittedSpecies(getState());
     const updatedCommittedSpecies = committedSpecies.filter(

--- a/src/content/app/species-selector/state/speciesSelectorSlice.ts
+++ b/src/content/app/species-selector/state/speciesSelectorSlice.ts
@@ -18,9 +18,9 @@ import {
   createSlice,
   createAction,
   createAsyncThunk,
-  PayloadAction,
-  ThunkAction,
-  Action
+  type PayloadAction,
+  type ThunkAction,
+  type Action
 } from '@reduxjs/toolkit';
 
 import apiService from 'src/services/api-service';
@@ -39,13 +39,13 @@ import {
 import { MINIMUM_SEARCH_LENGTH } from 'src/content/app/species-selector/constants/speciesSelectorConstants';
 
 import { LoadingState } from 'src/shared/types/loading-state';
-import {
+import type {
   SearchMatch,
   SearchMatches,
   CommittedItem,
   PopularSpecies
 } from 'src/content/app/species-selector/types/species-search';
-import { RootState } from 'src/store';
+import type { RootState } from 'src/store';
 
 export type CurrentItem = {
   genome_id: string; // changes every time we update strain or assembly

--- a/src/content/app/species/state/general/speciesGeneralSlice.ts
+++ b/src/content/app/species/state/general/speciesGeneralSlice.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 import {
-  Action,
   createSlice,
-  PayloadAction,
-  ThunkAction
+  type Action,
+  type PayloadAction,
+  type ThunkAction
 } from '@reduxjs/toolkit';
 import set from 'lodash/fp/set';
 
@@ -30,11 +30,11 @@ import speciesStorageService from '../../services/species-storage-service';
 
 import {
   getStatsForSection,
-  StatsSection,
+  type StatsSection,
   SpeciesStatsSection
 } from 'src/content/app/species/state/general/speciesGeneralHelper';
 
-import { RootState } from 'src/store';
+import type { RootState } from 'src/store';
 
 export type GenomeStats = StatsSection[];
 

--- a/src/content/app/species/state/general/speciesGeneralSlice.ts
+++ b/src/content/app/species/state/general/speciesGeneralSlice.ts
@@ -61,8 +61,8 @@ const initialState: SpeciesGeneralState = {
 };
 
 export const fetchStatsForActiveGenome =
-  (): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  (): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const state = getState();
     const activeGenomeId = getActiveGenomeId(state);
     if (!activeGenomeId) {
@@ -99,8 +99,8 @@ export const fetchStatsForActiveGenome =
 export const setActiveGenomeExpandedSections =
   (
     expandedSections: SpeciesStatsSection[]
-  ): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  ): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const state = getState();
     const activeGenomeId = getActiveGenomeId(state);
     if (!activeGenomeId) {

--- a/src/content/app/species/state/sidebar/speciesSidebarSlice.ts
+++ b/src/content/app/species/state/sidebar/speciesSidebarSlice.ts
@@ -86,8 +86,8 @@ type SpeciesPageSidebarState = {
 const initialState: SpeciesPageSidebarState = {};
 
 export const fetchSidebarPayload =
-  (): ThunkAction<void, any, void, Action<string>> =>
-  (dispatch, getState: () => RootState) => {
+  (): ThunkAction<void, RootState, void, Action<string>> =>
+  (dispatch, getState) => {
     const state = getState();
     const activeGenomeId = getActiveGenomeId(state);
     if (!activeGenomeId) {

--- a/src/content/app/species/state/sidebar/speciesSidebarSlice.ts
+++ b/src/content/app/species/state/sidebar/speciesSidebarSlice.ts
@@ -15,16 +15,17 @@
  */
 
 import {
-  Action,
   createSlice,
-  PayloadAction,
-  ThunkAction
+  type Action,
+  type PayloadAction,
+  type ThunkAction
 } from '@reduxjs/toolkit';
 import get from 'lodash/get';
 import merge from 'lodash/merge';
 
 import { getActiveGenomeId } from 'src/content/app/species/state/general/speciesGeneralSelectors';
-import { RootState } from 'src/store';
+
+import type { RootState } from 'src/store';
 
 import { sidebarData } from 'src/content/app/species/sample-data';
 

--- a/src/global/globalSlice.ts
+++ b/src/global/globalSlice.ts
@@ -16,16 +16,16 @@
 
 import {
   createSlice,
-  Action,
-  PayloadAction,
-  ThunkAction,
-  ActionCreator
+  type Action,
+  type PayloadAction,
+  type ThunkAction,
+  type ActionCreator
 } from '@reduxjs/toolkit';
 
 import { getBreakpointWidth } from 'src/global/globalSelectors';
 
-import { BreakpointWidth, ScrollPosition } from './globalConfig';
-import { RootState } from 'src/store';
+import { BreakpointWidth, type ScrollPosition } from './globalConfig';
+import type { RootState } from 'src/store';
 
 export type GlobalState = Readonly<{
   breakpointWidth: BreakpointWidth;

--- a/src/global/globalSlice.ts
+++ b/src/global/globalSlice.ts
@@ -40,17 +40,15 @@ export const defaultState: GlobalState = {
 };
 
 export const updateBreakpointWidth: ActionCreator<
-  ThunkAction<void, any, void, Action<string>>
-> =
-  (viewportWidth: BreakpointWidth) =>
-  async (dispatch, getState: () => RootState) => {
-    const state = getState();
-    const currentBreakpointWidth = getBreakpointWidth(state);
+  ThunkAction<void, RootState, void, Action<string>>
+> = (viewportWidth: BreakpointWidth) => async (dispatch, getState) => {
+  const state = getState();
+  const currentBreakpointWidth = getBreakpointWidth(state);
 
-    if (viewportWidth !== currentBreakpointWidth) {
-      dispatch(setBreakpointWidth(viewportWidth));
-    }
-  };
+  if (viewportWidth !== currentBreakpointWidth) {
+    dispatch(setBreakpointWidth(viewportWidth));
+  }
+};
 
 const globalSlice = createSlice({
   name: 'global',

--- a/src/shared/hooks/useApiService.ts
+++ b/src/shared/hooks/useApiService.ts
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
-import { useEffect, useReducer, Reducer } from 'react';
+import { useEffect, useReducer, type Reducer } from 'react';
 
-import apiService, { FetchOptions, APIError } from 'src/services/api-service';
+import apiService, {
+  type FetchOptions,
+  type APIError
+} from 'src/services/api-service';
 
 import { LoadingState } from 'src/shared/types/loading-state';
 


### PR DESCRIPTION
## Description
Previously the state passed to the thunk actions was typed as `any` when in fact it was `RootState`. This has been changed in this PR across all the reducers/slices. The type of the `getState` function now doesn't need to be explicitly declared as a result of this.

PS: I tried using `createAsyncThunk` as suggested in the JIRA ticket. However, it was causing the site to break and changing the state type from `any` to `RootState` seemed simpler as well.


## Related JIRA Issue(s)
[ENSWBSITES-1666](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1666)

## Deployment URL(s)
http://refactor-thunk-actions.review.ensembl.org


## Views affected
Genome browser, Entity viewer and Species selector