### PR TITLE
Update min width of species stats wrapper to avoid breaking the layout

### DIFF
--- a/src/content/app/species/components/species-main-view/SpeciesMainView.scss
+++ b/src/content/app/species/components/species-main-view/SpeciesMainView.scss
@@ -17,7 +17,7 @@
 
 .statsWrapper {
   padding: 5px 20px $global-padding-bottom 140px;
-  min-width: 820px;
+  min-width: 980px;
 }
 
 .exampleLinkText {


### PR DESCRIPTION
## Description
A simple fix for the layout of the species page.

**Before:**

https://user-images.githubusercontent.com/6834224/236496386-b82ff6a5-8372-436b-a0ed-eb299556717b.mov

**After:**

https://user-images.githubusercontent.com/6834224/236498885-a33eea5b-5be6-4d2c-b382-83dfc1657ff1.mov


## Related JIRA Issue(s)
None

## Deployment URL(s)
http://fix-species-stats-width.review.ensembl.org
