### PR TITLE
Fix GB breaking when clicked on navigation button before loading complete

### DIFF
--- a/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/navigate-modal/RegionNavigation.tsx
+++ b/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/navigate-modal/RegionNavigation.tsx
@@ -21,6 +21,7 @@ import { useAppSelector } from 'src/store';
 import useGenomeBrowser from 'src/content/app/genome-browser/hooks/useGenomeBrowser';
 
 import {
+  getActualChrLocation,
   getBrowserActiveGenomeId,
   getChrLocation
 } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
@@ -44,6 +45,7 @@ const ERROR_MESSAGE =
 const RegionNavigation = () => {
   const activeGenomeId = useAppSelector(getBrowserActiveGenomeId) as string; // this component will never be rendered if genome id is missing
   const chrLocation = useAppSelector(getChrLocation);
+  const browserLocation = useAppSelector(getActualChrLocation) as ChrLocation;
 
   const { changeBrowserLocation } = useGenomeBrowser();
 
@@ -171,7 +173,7 @@ const RegionNavigation = () => {
         Pan and zoom, or go to a new location in this chromosome or region only
       </div>
       <div className={styles.navigateSection}>
-        <GenomeBrowserNavigationButtons />
+        {browserLocation && <GenomeBrowserNavigationButtons />}
         <div className={styles.segmentedInput}>
           <div className={styles.inputField}>
             <label>

--- a/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/navigate-modal/tests/RegionNavigation.test.tsx
+++ b/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/navigate-modal/tests/RegionNavigation.test.tsx
@@ -85,6 +85,9 @@ const renderComponent = () => {
         },
         chrLocations: {
           human: ['2', 2000, 3000]
+        },
+        actualChrLocations: {
+          human: ['2', 2000, 3000]
         }
       }
     }


### PR DESCRIPTION
## Description
The site breaks when the navigation button in the sidebar is clicked before the Genome browser loading is completed. This is because `NavigationButtons` component relies on `browserLocation` data which is not available yet and the component breaks as a result.

I tried to fix this in `NavigationButtons` component itself, but couldn't figure out a way to do it properly. Hence, the fix in `RegionNavigation`.


## Related JIRA Issue(s)
[ENSWBSITES-1919](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1919)

## Deployment URL(s)
http://bug-pressing-nav-button.review.ensembl.org


## Views affected
Genome browser sidebar