### PR TITLE
Avoid line break at external reference icon

### DIFF
--- a/src/shared/components/help-article/HelpArticle.scss
+++ b/src/shared/components/help-article/HelpArticle.scss
@@ -62,12 +62,12 @@ $textColumnWidth: 450px;
   // But the version copied here has the fill color set inline, because it is being accessed as an external image via url
   a[href^='http'] {
     &::before {
-      content: url('static/icons/icon_xlink_orange.svg');
-      display: inline-block;
+      content: '';
+      background-image: url('static/icons/icon_xlink_orange.svg');
+      background-repeat: no-repeat;
+      background-position: center;
       margin: 0 0.125rem;
-      position: relative;
-      height: 10px;
-      width: 10px;
+      padding: 0 5px;
     }
   }
 }


### PR DESCRIPTION
## Description
On Help&Docs page, we noticed that the external link icon can get separated from the link text and stay on the previous line due to line wrapping.

Problem ([link](http://staging-2020.ensembl.org/help/articles/assemblies-and-sequence)):

![image](https://github.com/Ensembl/ensembl-client/assets/6834224/4fdadc59-9aae-4d48-9960-9090f0ceca40)

After the fix:

![image](https://github.com/Ensembl/ensembl-client/assets/6834224/1800be8b-e141-43d8-975b-539ecc9e69e7)

## Deployment URL(s)
http://fix-ext-link-decoration.review.ensembl.org

See in particular http://fix-ext-link-decoration.review.ensembl.org/help/articles/assemblies-and-sequence
