### PR TITLE
Update ViewInApp component

### DIFF
--- a/src/content/app/entity-viewer/gene-view/GeneView.scss
+++ b/src/content/app/entity-viewer/gene-view/GeneView.scss
@@ -119,7 +119,3 @@ $backgroundColor: $black;
     top: -2px;
   }
 }
-
-.viewInAppLabel {
-  font-weight: 300;
-}

--- a/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -169,10 +169,7 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
         />
       </div>
       <div className={styles.viewInLinks}>
-        <ViewInApp
-          links={{ genomeBrowser: { url: gbUrl } }}
-          classNames={{ label: styles.viewInAppLabel }}
-        />
+        <ViewInApp links={{ genomeBrowser: { url: gbUrl } }} theme="dark" />
       </div>
       <div className={styles.geneViewTabs}>
         <div

--- a/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -282,7 +282,10 @@ export const TranscriptsListItemInfo = (
       </div>
       <div className={transcriptsListStyles.right}>
         <div className={styles.viewInApp}>
-          <ViewInApp links={{ genomeBrowser: { url: getBrowserLink() } }} />
+          <ViewInApp
+            theme="dark"
+            links={{ genomeBrowser: { url: getBrowserLink() } }}
+          />
         </div>
       </div>
     </div>

--- a/src/content/app/genome-browser/components/drawer/drawer-views/gene-summary/GeneSummary.scss
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/gene-summary/GeneSummary.scss
@@ -96,8 +96,3 @@
   right: 0;
   top: 0;
 }
-
-.viewInAppLabel {
-  color: $black;
-  font-weight: 300;
-}

--- a/src/content/app/genome-browser/components/drawer/drawer-views/gene-summary/GeneSummary.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/gene-summary/GeneSummary.tsx
@@ -200,10 +200,7 @@ const GeneSummary = () => {
 
       <div className={rowClasses}>
         <div className={styles.value}>
-          <ViewInApp
-            links={{ entityViewer: { url: entityViewerUrl } }}
-            classNames={{ label: styles.viewInAppLabel }}
-          />
+          <ViewInApp links={{ entityViewer: { url: entityViewerUrl } }} />
         </div>
       </div>
     </div>

--- a/src/content/app/genome-browser/components/drawer/drawer-views/transcript-summary/TranscriptSummary.scss
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/transcript-summary/TranscriptSummary.scss
@@ -54,11 +54,6 @@
   font-weight: $light;
 }
 
-.viewInAppLabel {
-  color: $black;
-  font-weight: 300;
-}
-
 .unit {
   font-weight: $light;
   font-size: 12px;

--- a/src/content/app/genome-browser/components/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
@@ -299,10 +299,7 @@ const TranscriptSummary = (props: Props) => {
 
       <div className={`${styles.row} ${styles.spaceAbove}`}>
         <div className={styles.value}>
-          <ViewInApp
-            classNames={{ label: styles.viewInAppLabel }}
-            links={{ entityViewer: { url: entityViewerUrl } }}
-          />
+          <ViewInApp links={{ entityViewer: { url: entityViewerUrl } }} />
         </div>
       </div>
     </div>

--- a/src/content/app/genome-browser/components/zmenu/ZmenuAppLinks.tsx
+++ b/src/content/app/genome-browser/components/zmenu/ZmenuAppLinks.tsx
@@ -83,7 +83,11 @@ const ZmenuAppLinks = (props: Props) => {
         className={styles.zmenuToggleFooter}
         label="Download"
       />
-      <ViewInApp links={links} onAnyAppClick={props.destroyZmenu} />
+      <ViewInApp
+        theme="dark"
+        links={links}
+        onAnyAppClick={props.destroyZmenu}
+      />
     </div>
   );
 };

--- a/src/shared/components/gene-search-panel/GeneSearchPanel.tsx
+++ b/src/shared/components/gene-search-panel/GeneSearchPanel.tsx
@@ -282,7 +282,7 @@ const GeneMatch = (props: { match: SearchMatch; species: CommittedItem }) => {
           position={PointerBoxPosition.RIGHT_TOP}
           onOutsideClick={handleClick}
         >
-          <ViewInApp links={links} />
+          <ViewInApp theme="dark" links={links} />
         </PointerBox>
       )}
     </>

--- a/src/shared/components/in-app-search/InAppSearchMatches.tsx
+++ b/src/shared/components/in-app-search/InAppSearchMatches.tsx
@@ -201,7 +201,7 @@ const MatchDetails = (
       </div>
 
       <div>
-        <ViewInApp links={links} onAnyAppClick={props.onClick} />
+        <ViewInApp theme="dark" links={links} onAnyAppClick={props.onClick} />
       </div>
     </div>
   );

--- a/src/shared/components/view-in-app-popup/ViewInAppPopup.tsx
+++ b/src/shared/components/view-in-app-popup/ViewInAppPopup.tsx
@@ -54,7 +54,7 @@ const ViewInAppPopup = (props: ViewInAppPopupProps) => {
             pointer: styles.pointerBoxPointer
           }}
         >
-          <ViewInApp links={links} />
+          <ViewInApp theme="dark" links={links} />
         </PointerBox>
       )}
     </span>

--- a/src/shared/components/view-in-app/ViewInApp.scss
+++ b/src/shared/components/view-in-app/ViewInApp.scss
@@ -1,14 +1,22 @@
 @import 'src/styles/common';
 
-.label {
-  color: $white;
+.viewInApp {
+  display: flex;
+  align-items: center;
   white-space: nowrap;
+}
+
+.label {
+  font-weight: $light;
   font-size: 12px;
 }
 
-.viewInAppLinkButtons {
-  display: flex;
-  align-items: center;
+.viewInAppLight .label {
+  color: $black;
+}
+
+.viewInAppDark .label {
+  color: $white;
 }
 
 .viewInAppLink {

--- a/src/shared/components/view-in-app/ViewInApp.tsx
+++ b/src/shared/components/view-in-app/ViewInApp.tsx
@@ -70,17 +70,17 @@ type AppClickHandlers = Partial<Record<AppName, () => void>>;
  * into the component, which makes for an awkward api.
  */
 
+type Theme = 'light' | 'dark';
+
 export type ViewInAppProps = {
   links: LinksConfig;
   onAppClick?: AppClickHandlers;
   onAnyAppClick?: (appName?: AppName) => void;
-  classNames?: {
-    label?: string;
-  };
+  theme?: Theme;
 };
 
 export const ViewInApp = (props: ViewInAppProps) => {
-  const labelClass = classNames(styles.label, props.classNames?.label);
+  const theme = props.theme ?? 'light';
 
   const navigate = useNavigate();
   if (Object.keys(props.links).length === 0) {
@@ -107,13 +107,18 @@ export const ViewInApp = (props: ViewInAppProps) => {
     }
   };
 
+  const componentClasses = classNames(styles.viewInApp, {
+    [styles.viewInAppLight]: theme === 'light',
+    [styles.viewInAppDark]: theme === 'dark'
+  });
+
   const enabledApps = Object.keys({
     ...props.links
   }) as AppName[];
 
   return (
-    <div className={styles.viewInAppLinkButtons}>
-      <span className={labelClass}>View in</span>
+    <div className={componentClasses}>
+      <span className={styles.label}>View in</span>
 
       {enabledApps.map((appName, index) => {
         return (


### PR DESCRIPTION
## Description
- Removed the `classNames` property of the ViewInApp component
- Instead, added a `theme` property, which can be either `light` (i.e. against a light background), or `dark`, i.e. against a dark background.

## Purpose
The original problem that this PR was trying to solve is captured in the video below; but moving away from the `classNames` property is generally a good thing.

https://github.com/Ensembl/ensembl-client/assets/6834224/3198155a-722e-4ca7-beda-9708255cb947

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1916

## Deployment URL(s)
http://view-in-app-styles.review.ensembl.org