### PR TITLE
Make description and url fields of ExternalReference type nullable

### DIFF
--- a/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -189,7 +189,7 @@ export const TranscriptsListItemInfo = (
                 onClick={() => handleExternalReferenceClick('RefSeq match')}
               />
             )}
-            {!!transcriptCCDS?.url && (
+            {transcriptCCDS?.url && (
               <ExternalReference
                 classNames={{
                   link: styles.externalRefLink

--- a/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -189,7 +189,7 @@ export const TranscriptsListItemInfo = (
                 onClick={() => handleExternalReferenceClick('RefSeq match')}
               />
             )}
-            {!!transcriptCCDS && (
+            {!!transcriptCCDS?.url && (
               <ExternalReference
                 classNames={{
                   link: styles.externalRefLink

--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.tsx
@@ -173,23 +173,25 @@ const ExternalReferencesGroup = (props: {
     setExternalReferencesGroupOpen(!isExternalReferencesGroupOpen);
 
   const { references, source } = props.externalReferencesGroup;
-  const externalReferencesList = references.map((entry, key) => (
-    <ExternalReference
-      label={
-        entry.description === entry.accession_id ||
-        source.name === entry.description
-          ? ''
-          : entry.description
-      }
-      to={entry.url}
-      linkText={entry.accession_id}
-      key={key}
-      classNames={{
-        container: styles.externalReferenceContainer,
-        link: styles.externalReferenceLink
-      }}
-    />
-  ));
+  const externalReferencesList = references.map((entry, key) =>
+    entry.url ? (
+      <ExternalReference
+        label={
+          entry.description === entry.accession_id ||
+          source.name === entry.description
+            ? ''
+            : entry.description
+        }
+        to={entry.url}
+        linkText={entry.accession_id}
+        key={key}
+        classNames={{
+          container: styles.externalReferenceContainer,
+          link: styles.externalReferenceLink
+        }}
+      />
+    ) : null
+  );
 
   return (
     <>
@@ -257,16 +259,18 @@ const renderExternalReferencesGroups = (
     (externalReferencesGroup, key) => (
       <div key={key}>
         {externalReferencesGroup.references.length === 1 ? (
-          <ExternalReference
-            label={externalReferencesGroup.source.name}
-            to={externalReferencesGroup.references[0].url}
-            linkText={externalReferencesGroup.references[0].accession_id}
-            onClick={() => onClick(externalReferencesGroup.source.name)}
-            classNames={{
-              container: styles.externalReferenceContainer,
-              link: styles.externalReferenceLink
-            }}
-          />
+          externalReferencesGroup.references[0].url ? (
+            <ExternalReference
+              label={externalReferencesGroup.source.name}
+              to={externalReferencesGroup.references[0].url}
+              linkText={externalReferencesGroup.references[0].accession_id}
+              onClick={() => onClick(externalReferencesGroup.source.name)}
+              classNames={{
+                container: styles.externalReferenceContainer,
+                link: styles.externalReferenceLink
+              }}
+            />
+          ) : null
         ) : (
           <ExternalReferencesGroup
             externalReferencesGroup={externalReferencesGroup}

--- a/src/content/app/genome-browser/components/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
@@ -254,7 +254,7 @@ const TranscriptSummary = (props: Props) => {
             {product && (
               <div className={styles.lightText}>{product.stable_id}</div>
             )}
-            {uniprotXref && (
+            {uniprotXref?.url && (
               <ExternalReference
                 label={'UniProtKB/Swiss-Prot'}
                 to={uniprotXref.url}
@@ -265,7 +265,7 @@ const TranscriptSummary = (props: Props) => {
         </div>
       )}
 
-      {ccdsXref && (
+      {ccdsXref?.url && (
         <div className={`${styles.row} ${styles.spaceAbove}`}>
           <div className={styles.value}>
             <ExternalReference

--- a/src/shared/components/external-reference/ExternalReference.tsx
+++ b/src/shared/components/external-reference/ExternalReference.tsx
@@ -22,7 +22,7 @@ import ExternalLink from '../external-link/ExternalLink';
 import styles from './ExternalReference.scss';
 
 export type ExternalReferenceProps = {
-  label?: string;
+  label?: string | null;
   to: string;
   linkText: string;
   classNames?: {

--- a/src/shared/types/thoas/externalReference.ts
+++ b/src/shared/types/thoas/externalReference.ts
@@ -19,8 +19,8 @@ import { Source } from './source';
 export type ExternalReference = {
   accession_id: string;
   name: string;
-  description: string;
-  url: string;
+  description: string | null;
+  url: string | null;
   source: Source;
 };
 


### PR DESCRIPTION
## Description
According to [CDM](https://github.com/Ensembl/ensembl-cdm-docs/blob/main/src/docs/external_reference.md), the `description` and the `url` fields of `ExternalReference` type are allowed to be `null`; but in the type definitions on the client, these fields are defined as mandatory strings. Updating the `ExternalReference` type resulted in several type errors, which are fixed in this PR.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1949

## Deployment URL(s)
http://external-reference-types.review.ensembl.org