### PR TITLE
Add Zmenu for regulatory features

### DIFF
--- a/src/content/app/genome-browser/components/drawer/Drawer.tsx
+++ b/src/content/app/genome-browser/components/drawer/Drawer.tsx
@@ -23,6 +23,7 @@ import GeneSummary from './drawer-views/gene-summary/GeneSummary';
 import TranscriptSummary from './drawer-views/transcript-summary/TranscriptSummary';
 import VariantSummary from './drawer-views/variant-summary/VariantSummary';
 import VariantGroupLegend from './drawer-views/variant-group-legend/VariantGroupLegend';
+import RegulationLegend from './drawer-views/regulation-legend/RegulationLegend';
 
 import { getActiveDrawerView } from 'src/content/app/genome-browser/state/drawer/drawerSelectors';
 
@@ -49,6 +50,8 @@ export const Drawer = () => {
         return <DrawerBookmarks />;
       case 'variant_group_legend':
         return <VariantGroupLegend drawerView={drawerView} />;
+      case 'regulation_legend':
+        return <RegulationLegend drawerView={drawerView} />;
     }
   };
 

--- a/src/content/app/genome-browser/components/drawer/drawer-views/regulation-legend/RegulationLegend.scss
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/regulation-legend/RegulationLegend.scss
@@ -1,0 +1,41 @@
+@import 'src/styles/common';
+
+.container {
+  margin: 10px 0 0 80px;
+  
+  max-width: 950px;
+}
+
+.labelTextStrong {
+  font-size: 12px;
+  font-weight: $bold;
+  margin-left: 10px;
+}
+
+.regulationColour1 {
+  background-color: $red;
+}
+.regulationColour2 {
+  background-color: $dark-yellow;
+}
+.regulationColour3 {
+  background-color: $grey;
+}
+.regulationColour4 {
+  background-color: $neon-blue;
+}
+.regulationColour5 {
+  background-color: $purple;
+}
+
+.colourMarker {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+}
+
+.labelDefinition {
+  font-size: 12px;
+  margin-left: 20px;
+  margin-top: 20px;
+}

--- a/src/content/app/genome-browser/components/drawer/drawer-views/regulation-legend/RegulationLegend.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/regulation-legend/RegulationLegend.tsx
@@ -1,0 +1,55 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import regulationLegends from 'src/content/app/genome-browser/constants/regulationLegends';
+
+import type { RegulationLegendView } from 'src/content/app/genome-browser/state/drawer/types';
+
+import styles from './RegulationLegend.scss';
+import classNames from 'classnames';
+
+type Props = {
+  drawerView: RegulationLegendView;
+};
+
+const RegulationLegend = (props: Props) => {
+  const activeLegend = regulationLegends.find(
+    ({ label }) => label === props.drawerView.group
+  );
+
+  const groupColorMarkerClass = classNames(
+    styles.colourMarker,
+    styles[`regulationColour${activeLegend?.id}`]
+  );
+
+  if (!activeLegend) {
+    return null;
+  }
+
+  return (
+    <div className={styles.container}>
+      <div>
+        <span className={groupColorMarkerClass} />
+        <span className={styles.labelTextStrong}>{activeLegend.label}</span>
+      </div>
+      <div className={styles.labelDefinition}>{activeLegend.definition}</div>
+    </div>
+  );
+};
+
+export default RegulationLegend;

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
@@ -44,6 +44,7 @@ import {
 
 import { TrackSet } from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
 import TrackPanelVariantGroupLegend from './track-panel-items/TrackPanelVariantGroupLegend';
+import TrackPanelRegulationLegend from './track-panel-items/TrackPanelRegulationLegend';
 
 import SearchIcon from 'static/icons/icon_search.svg';
 import ResetIcon from 'static/icons/icon_reset.svg';
@@ -104,10 +105,20 @@ export const TrackPanelList = () => {
         <Accordion
           className={styles.trackPanelAccordion}
           allowMultipleExpanded={true}
-          preExpanded={[...trackCategoryIds, 'variant_legend']}
+          preExpanded={[
+            ...trackCategoryIds,
+            'variant_legend',
+            'regulation_legend'
+          ]}
         >
           {selectedTrackPanelTab === TrackSet.VARIATION && (
             <TrackPanelVariantGroupLegend
+              disabled={trackCategoryIds.length === 0}
+            />
+          )}
+
+          {selectedTrackPanelTab === TrackSet.REGULATION && (
+            <TrackPanelRegulationLegend
               disabled={trackCategoryIds.length === 0}
             />
           )}

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelRegulationLegend.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelRegulationLegend.tsx
@@ -1,0 +1,113 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import classNames from 'classnames';
+import { useDispatch } from 'react-redux';
+import { useAppSelector } from 'src/store';
+
+import useGenomeBrowserAnalytics from 'src/content/app/genome-browser/hooks/useGenomeBrowserAnalytics';
+
+import {
+  AccordionItem,
+  AccordionItemHeading,
+  AccordionItemButton,
+  AccordionItemPanel
+} from 'src/shared/components/accordion';
+import SimpleTrackPanelItemLayout from './track-panel-item-layout/SimpleTrackPanelItemLayout';
+import regulationLegends from 'src/content/app/genome-browser/constants/regulationLegends';
+
+import { changeDrawerViewForGenome } from 'src/content/app/genome-browser/state/drawer/drawerSlice';
+import { getBrowserActiveGenomeId } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
+
+import styles from '../TrackPanelList.scss';
+import trackPanelItemStyles from './TrackPanelItem.scss';
+import regulationStyles from 'src/content/app/genome-browser/components/drawer/drawer-views/regulation-legend/RegulationLegend.scss';
+
+const TrackPanelRegulationLegend = (props: { disabled: boolean }) => {
+  const activeGenomeId = useAppSelector(getBrowserActiveGenomeId) as string;
+  const dispatch = useDispatch();
+  const { trackDrawerOpened, reportTrackPanelSectionToggled } =
+    useGenomeBrowserAnalytics();
+  const accordionHeading = 'Regulatory features';
+
+  const accordionButtonClassNames = classNames(
+    styles.trackPanelAccordionButton,
+    {
+      [styles.trackPanelAccordionButtonDisabled]: props.disabled
+    }
+  );
+
+  const onShowMore = (group: string) => {
+    trackDrawerOpened('regulation_legend');
+    dispatch(
+      changeDrawerViewForGenome({
+        genomeId: activeGenomeId,
+        drawerView: {
+          name: 'regulation_legend',
+          group
+        }
+      })
+    );
+  };
+
+  return (
+    <AccordionItem
+      className={styles.trackPanelAccordionItem}
+      uuid="regulation_legend"
+    >
+      <AccordionItemHeading className={styles.trackPanelAccordionHeader}>
+        <AccordionItemButton
+          disabled={props.disabled}
+          className={accordionButtonClassNames}
+          onToggle={(isExpanded: boolean) =>
+            reportTrackPanelSectionToggled(accordionHeading, isExpanded)
+          }
+        >
+          {accordionHeading}
+        </AccordionItemButton>
+      </AccordionItemHeading>
+      {!props.disabled ? (
+        <AccordionItemPanel className={styles.trackPanelAccordionItemContent}>
+          <dl>
+            {regulationLegends.map((legend) => {
+              const groupColourMarkerClass = classNames(
+                regulationStyles.colourMarker,
+                regulationStyles[`regulationColour${legend.id}`]
+              );
+
+              return (
+                <SimpleTrackPanelItemLayout
+                  key={legend.id}
+                  onShowMore={() => onShowMore(legend.label)}
+                >
+                  <div className={trackPanelItemStyles.label}>
+                    <span className={groupColourMarkerClass} />
+                    <span className={trackPanelItemStyles.labelText}>
+                      {legend.label}
+                    </span>
+                  </div>
+                </SimpleTrackPanelItemLayout>
+              );
+            })}
+          </dl>
+        </AccordionItemPanel>
+      ) : null}
+    </AccordionItem>
+  );
+};
+
+export default TrackPanelRegulationLegend;

--- a/src/content/app/genome-browser/components/track-panel/trackPanelConfig.ts
+++ b/src/content/app/genome-browser/components/track-panel/trackPanelConfig.ts
@@ -29,7 +29,7 @@ export type TrackActivityStatus = Status.SELECTED | Status.UNSELECTED;
 export enum TrackSet {
   GENOMIC = 'Genomic',
   VARIATION = 'Variation',
-  EXPRESSION = 'Regulation'
+  REGULATION = 'Regulation'
 }
 
 export type TrackSetKey = keyof typeof TrackSet;

--- a/src/content/app/genome-browser/components/zmenu/Zmenu.test.tsx
+++ b/src/content/app/genome-browser/components/zmenu/Zmenu.test.tsx
@@ -56,6 +56,7 @@ jest.mock('./ZmenuContent', () => () => (
 jest.mock('./ZmenuInstantDownload', () => () => (
   <div>ZmenuInstantDownload</div>
 ));
+jest.mock('./zmenus/RegulationZmenu', () => () => <div>RegulationZmenu</div>);
 
 const chrName = faker.lorem.word();
 const startPosition = faker.datatype.number({ min: 1, max: 1000000 });

--- a/src/content/app/genome-browser/components/zmenu/Zmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/Zmenu.tsx
@@ -29,6 +29,7 @@ import { getActualChrLocation } from 'src/content/app/genome-browser/state/brows
 import { Toolbox, ToolboxPosition } from 'src/shared/components/toolbox';
 import GeneAndOneTranscriptZmenu from './zmenus/GeneAndOneTranscriptZmenu';
 import VariantZmenu from './zmenus/VariantZmenu';
+import RegulationZmenu from './zmenus/RegulationZmenu';
 
 import {
   ZmenuPayloadVarietyType,
@@ -90,9 +91,13 @@ const Zmenu = (props: ZmenuProps) => {
         onDestroy={destroyZmenu}
       />
     );
-  } else if (zmenuType === 'variant') {
+  } else if (zmenuType === ZmenuPayloadVarietyType.VARIANT) {
     zmenuContent = (
       <VariantZmenu payload={props.payload} onDestroy={destroyZmenu} />
+    );
+  } else if (zmenuType === ZmenuPayloadVarietyType.REGULATION) {
+    zmenuContent = (
+      <RegulationZmenu payload={props.payload} onDestroy={destroyZmenu} />
     );
   }
 

--- a/src/content/app/genome-browser/components/zmenu/ZmenuContent.tsx
+++ b/src/content/app/genome-browser/components/zmenu/ZmenuContent.tsx
@@ -29,13 +29,19 @@ import {
   Markup,
   ZmenuContentTranscript,
   ZmenuContentGene,
-  ZmenuContentVariant
+  ZmenuContentVariant,
+  ZmenuContentRegulation
 } from 'src/content/app/genome-browser/services/genome-browser-service/types/zmenu';
 
 import styles from './Zmenu.scss';
 
 export type ZmenuContentProps = {
-  features: (ZmenuContentTranscript | ZmenuContentGene | ZmenuContentVariant)[];
+  features: (
+    | ZmenuContentTranscript
+    | ZmenuContentGene
+    | ZmenuContentVariant
+    | ZmenuContentRegulation
+  )[];
   featureId: string;
   destroyZmenu: () => void;
 };

--- a/src/content/app/genome-browser/components/zmenu/zmenus/RegulationZmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/zmenus/RegulationZmenu.tsx
@@ -1,0 +1,48 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import ZmenuContent from '../ZmenuContent';
+
+import type {
+  ZmenuPayload,
+  ZmenuContentVariantMetadata
+} from 'src/content/app/genome-browser/services/genome-browser-service/types/zmenu';
+
+type Props = {
+  payload: ZmenuPayload;
+  onDestroy: () => void;
+};
+
+const RegulationZmenu = (props: Props) => {
+  const { content } = props.payload;
+
+  const variantMetadata = content[0]?.metadata as
+    | ZmenuContentVariantMetadata
+    | undefined;
+  const variantId = variantMetadata?.id ?? '';
+
+  return (
+    <ZmenuContent
+      features={content}
+      featureId={`variant:${variantId}`}
+      destroyZmenu={props.onDestroy}
+    />
+  );
+};
+
+export default RegulationZmenu;

--- a/src/content/app/genome-browser/components/zmenu/zmenus/RegulationZmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/zmenus/RegulationZmenu.tsx
@@ -16,11 +16,20 @@
 
 import React from 'react';
 
+import { useAppSelector } from 'src/store';
+
+import { getBrowserActiveGenomeId } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
+
 import ZmenuContent from '../ZmenuContent';
+import {
+  ToolboxExpandableContent,
+  ToggleButton
+} from 'src/shared/components/toolbox';
+import InstantDownloadRegFeature from 'src/shared/components/instant-download/instant-download-transcript/InstantDownloadRegFeature';
 
 import type {
   ZmenuPayload,
-  ZmenuContentVariantMetadata
+  ZmenuContentRegulation
 } from 'src/content/app/genome-browser/services/genome-browser-service/types/zmenu';
 
 type Props = {
@@ -30,19 +39,46 @@ type Props = {
 
 const RegulationZmenu = (props: Props) => {
   const { content } = props.payload;
+  const genomeId = useAppSelector(getBrowserActiveGenomeId) || '';
 
-  const variantMetadata = content[0]?.metadata as
-    | ZmenuContentVariantMetadata
-    | undefined;
-  const variantId = variantMetadata?.id ?? '';
+  const featureMetadata = extractFeatureMetadata(props.payload);
+
+  const mainContent = (
+    <div>
+      <ZmenuContent
+        features={content}
+        featureId={`regulation:${featureMetadata.id}`} /* we can't navigate to regulatory feature anyway */
+        destroyZmenu={props.onDestroy}
+      />
+      <ToggleButton label="Download" />
+    </div>
+  );
+
+  const footerContent = genomeId ? (
+    <InstantDownloadRegFeature genomeId={genomeId} {...featureMetadata} />
+  ) : null;
 
   return (
-    <ZmenuContent
-      features={content}
-      featureId={`variant:${variantId}`}
-      destroyZmenu={props.onDestroy}
+    <ToolboxExpandableContent
+      mainContent={mainContent}
+      footerContent={footerContent}
     />
   );
+};
+
+const extractFeatureMetadata = (payload: ZmenuPayload) => {
+  const zmenuContent = payload.content[0] as ZmenuContentRegulation;
+  const featureMetadata = zmenuContent.metadata;
+
+  return {
+    id: featureMetadata.id,
+    regionName: featureMetadata.region_name,
+    featureType: featureMetadata.feature_type,
+    start: featureMetadata.start,
+    end: featureMetadata.end,
+    coreStart: featureMetadata.core_start,
+    coreEnd: featureMetadata.core_end
+  };
 };
 
 export default RegulationZmenu;

--- a/src/content/app/genome-browser/components/zmenu/zmenus/RegulationZmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/zmenus/RegulationZmenu.tsx
@@ -25,7 +25,7 @@ import {
   ToolboxExpandableContent,
   ToggleButton
 } from 'src/shared/components/toolbox';
-import InstantDownloadRegFeature from 'src/shared/components/instant-download/instant-download-transcript/InstantDownloadRegFeature';
+import InstantDownloadRegFeature from 'src/shared/components/instant-download/instant-download-regulation/InstantDownloadRegFeature';
 
 import type {
   ZmenuPayload,

--- a/src/content/app/genome-browser/constants/regulationLegends.ts
+++ b/src/content/app/genome-browser/constants/regulationLegends.ts
@@ -1,0 +1,50 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const regulationLegends = [
+  {
+    id: 1,
+    label: 'Promoter',
+    definition:
+      'Promoters and enhancers in human and mouse are identified by their epigenomic activity across different cell types. The Ensembl Regulatory build is more likely to classify a regulatory feature as a promoter if it is near the 5’ end of an annotated transcript'
+  },
+  {
+    id: 2,
+    label: 'Enhancer',
+    definition:
+      'Promoters and enhancers in human and mouse are identified by their epigenomic activity across different cell types. Enhancers tend to be further from known transcripts than promoters'
+  },
+  {
+    id: 3,
+    label: 'Open chromatin',
+    definition:
+      'Open chromatin regions in human and mouse are identified as having epigenomic activity, but without the marks typically associated with enhancers or promoters'
+  },
+  {
+    id: 4,
+    label: 'CTCF',
+    definition:
+      'CTCF-binding regions are identified after segmenting the genome according to epigenomic activity. Specifically, they correspond to segmentation states where there is a high degree of CTCF binding'
+  },
+  {
+    id: 5,
+    label: 'TF binding',
+    definition:
+      'These sites are enriched for Transcription Factor binding, but they lack epigenomic evidence to be classified as an enhancer or promoter'
+  }
+];
+
+export default regulationLegends;

--- a/src/content/app/genome-browser/services/genome-browser-service/types/zmenu.ts
+++ b/src/content/app/genome-browser/services/genome-browser-service/types/zmenu.ts
@@ -92,7 +92,8 @@ export type ZmenuContent =
 
 export enum ZmenuPayloadVarietyType {
   GENE_AND_ONE_TRANSCRIPT = 'gene-and-one-transcript',
-  VARIANT = 'variant'
+  VARIANT = 'variant',
+  REGULATION = 'regulation'
 }
 
 export type ZmenuPayloadVariety = {

--- a/src/content/app/genome-browser/services/genome-browser-service/types/zmenu.ts
+++ b/src/content/app/genome-browser/services/genome-browser-service/types/zmenu.ts
@@ -26,7 +26,8 @@ export enum Markup {
 export enum ZmenuFeatureType {
   GENE = 'gene',
   TRANSCRIPT = 'transcript',
-  VARIANT = 'variant'
+  VARIANT = 'variant',
+  REGULATORY_FEATURE = 'regulatory_feature'
 }
 
 export type ZmenuContentItem = {
@@ -70,6 +71,17 @@ export type ZmenuContentVariantMetadata = {
   type: ZmenuFeatureType.VARIANT;
 };
 
+export type ZmenuContentRegulationMetadata = {
+  id: string; // identifier of the regulatory feature
+  type: ZmenuFeatureType.REGULATORY_FEATURE;
+  feature_type: string; // e.g. Promoter, Enhancer, etc.
+  region_name: string;
+  start: number; // start coordinate of the feature bounds (always forward strand)
+  end: number; // end coordinate of the feature bounds (always forward strand)
+  core_start: number; // start coordinate of the feature core
+  core_end: number; // end coordinate of the feature core
+};
+
 export type ZmenuContentGene = {
   data: ZmenuContentLine[];
   metadata: ZmenuContentGeneMetadata;
@@ -85,10 +97,16 @@ export type ZmenuContentVariant = {
   metadata: ZmenuContentVariantMetadata;
 };
 
+export type ZmenuContentRegulation = {
+  data: ZmenuContentLine[];
+  metadata: ZmenuContentRegulationMetadata;
+};
+
 export type ZmenuContent =
   | ZmenuContentGene
   | ZmenuContentTranscript
-  | ZmenuContentVariant;
+  | ZmenuContentVariant
+  | ZmenuContentRegulation;
 
 export enum ZmenuPayloadVarietyType {
   GENE_AND_ONE_TRANSCRIPT = 'gene-and-one-transcript',

--- a/src/content/app/genome-browser/state/drawer/types.ts
+++ b/src/content/app/genome-browser/state/drawer/types.ts
@@ -43,10 +43,16 @@ export type VariantLegendView = {
   group: string;
 };
 
+export type RegulationLegendView = {
+  name: 'regulation_legend';
+  group: string;
+};
+
 export type DrawerView =
   | BookmarksDrawerView
   | GeneDrawerView
   | TranscriptDrawerView
   | VariantDrawerView
   | GenericTrackView
-  | VariantLegendView;
+  | VariantLegendView
+  | RegulationLegendView;

--- a/src/shared/components/instant-download/instant-download-button/InstantDownloadButton.tsx
+++ b/src/shared/components/instant-download/instant-download-button/InstantDownloadButton.tsx
@@ -24,7 +24,7 @@ import styles from './InstantDownloadButton.scss';
 type Theme = 'light' | 'dark';
 
 type Props = {
-  isDisabled?: boolean;
+  disabled?: boolean;
   theme: Theme;
   classNames?: {
     wrapper: string;
@@ -35,7 +35,7 @@ type Props = {
 const InstantDownloadButton = (props: Props) => {
   const buttonClass = classNames({
     [styles.themeDark]: props.theme === 'dark',
-    [styles.disabled]: props.isDisabled
+    [styles.disabled]: props.disabled
   });
   const allClassNames = { ...props.classNames, button: buttonClass };
   const propsToPass = { ...props, classNames: allClassNames };

--- a/src/shared/components/instant-download/instant-download-fetch/fetchRegulatoryFeature.ts
+++ b/src/shared/components/instant-download/instant-download-fetch/fetchRegulatoryFeature.ts
@@ -1,0 +1,134 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { wrap } from 'comlink';
+
+import * as urlFor from 'src/shared/helpers/urlHelper';
+
+import { fetchRegionSequenceChecksum } from './fetchSequenceChecksums';
+
+import { downloadTextAsFile } from 'src/shared/helpers/downloadAsFile';
+
+import type {
+  WorkerApi,
+  SingleSequenceFetchParams
+} from 'src/shared/workers/sequenceFetcher.worker';
+
+export const fetchRegulatoryFeatureSequences = async (payload: {
+  id: string;
+  genomeId: string;
+  featureType: string;
+  regionName: string;
+  coreRegion?: {
+    start: number;
+    end: number;
+  };
+  boundaryRegion?: {
+    start: number;
+    end: number;
+  };
+}) => {
+  const { id, genomeId, featureType, regionName, coreRegion, boundaryRegion } =
+    payload;
+
+  if (!coreRegion && !boundaryRegion) {
+    throw new Error('Feature location for download was not provided');
+  }
+
+  const regionSequenceChecksum = await fetchRegionSequenceChecksum({
+    genomeId,
+    regionName
+  });
+
+  const downloadParameters: SingleSequenceFetchParams[] = [];
+
+  if (coreRegion) {
+    const { start, end } = coreRegion;
+    const label = buildFastaHeader({
+      id,
+      featureType,
+      regionName,
+      start,
+      end
+    });
+    downloadParameters.push(
+      prepareRegulatoryFeatureDownloadParameters({
+        label,
+        checksum: regionSequenceChecksum,
+        start,
+        end
+      })
+    );
+  }
+
+  if (boundaryRegion) {
+    const { start, end } = boundaryRegion;
+    const label = buildFastaHeader({
+      id,
+      featureType,
+      regionName,
+      start,
+      end
+    });
+    downloadParameters.push(
+      prepareRegulatoryFeatureDownloadParameters({
+        label,
+        checksum: regionSequenceChecksum,
+        start,
+        end
+      })
+    );
+  }
+
+  const worker = new Worker(
+    new URL('src/shared/workers/sequenceFetcher.worker.ts', import.meta.url)
+  );
+
+  const service = wrap<WorkerApi>(worker);
+  const sequences = await service.downloadSequences(downloadParameters);
+
+  worker.terminate();
+
+  await downloadTextAsFile(sequences, `${id}.fasta`, {
+    type: 'text/x-fasta'
+  });
+};
+
+const prepareRegulatoryFeatureDownloadParameters = (params: {
+  label: string;
+  checksum: string;
+  start: number;
+  end: number;
+}) => {
+  const { label, start, end, checksum } = params;
+  const url = urlFor.refget({ checksum, start, end });
+
+  return {
+    label,
+    url
+  };
+};
+
+const buildFastaHeader = (params: {
+  id: string;
+  featureType: string;
+  regionName: string;
+  start: number;
+  end: number;
+}) => {
+  const { id, featureType, regionName, start, end } = params;
+  return `>er|${id}|${featureType}|${regionName}:${start}-${end}`;
+};

--- a/src/shared/components/instant-download/instant-download-fetch/fetchSequenceChecksums.ts
+++ b/src/shared/components/instant-download/instant-download-fetch/fetchSequenceChecksums.ts
@@ -106,6 +106,14 @@ type TranscriptQueryResult = {
   transcript: TranscriptInResponse;
 };
 
+type RegionSequenceChecksumQueryResult = {
+  region: {
+    sequence: {
+      checksum: string;
+    };
+  };
+};
+
 type GeneAndTranscriptQueryVariables = {
   genomeId: string;
   geneId: string;
@@ -219,6 +227,16 @@ const transcriptChecksumsQuery = gql`
   ${transcriptQueryFragment}
 `;
 
+const regioSequenceChecksumQuery = gql`
+  query Region($genomeId: String!, $regionName: String!) {
+    region(by_name: { genome_id: $genomeId, name: $regionName }) {
+      sequence {
+        checksum
+      }
+    }
+  }
+`;
+
 const processGeneAndTranscriptData = (data: GeneAndTranscriptQueryResult) => {
   const { gene, transcript } = data;
 
@@ -304,4 +322,16 @@ export const fetchTranscriptSequenceMetadata = (
     transcriptChecksumsQuery,
     variables
   ).then((data) => processTranscriptData(data.transcript));
+};
+
+export const fetchRegionSequenceChecksum = async (variables: {
+  genomeId: string;
+  regionName: string;
+}): Promise<string> => {
+  const data = await request<RegionSequenceChecksumQueryResult>(
+    '/api/thoas',
+    regioSequenceChecksumQuery,
+    variables
+  );
+  return data.region.sequence.checksum;
 };

--- a/src/shared/components/instant-download/instant-download-fetch/fetchSequenceChecksums.ts
+++ b/src/shared/components/instant-download/instant-download-fetch/fetchSequenceChecksums.ts
@@ -330,7 +330,7 @@ export const fetchRegionSequenceChecksum = async (variables: {
 }): Promise<string> => {
   const data = await request<RegionSequenceChecksumQueryResult>(
     '/api/thoas',
-    regioSequenceChecksumQuery,
+    regionSequenceChecksumQuery,
     variables
   );
   return data.region.sequence.checksum;

--- a/src/shared/components/instant-download/instant-download-fetch/fetchSequenceChecksums.ts
+++ b/src/shared/components/instant-download/instant-download-fetch/fetchSequenceChecksums.ts
@@ -227,7 +227,7 @@ const transcriptChecksumsQuery = gql`
   ${transcriptQueryFragment}
 `;
 
-const regioSequenceChecksumQuery = gql`
+const regionSequenceChecksumQuery = gql`
   query Region($genomeId: String!, $regionName: String!) {
     region(by_name: { genome_id: $genomeId, name: $regionName }) {
       sequence {

--- a/src/shared/components/instant-download/instant-download-gene/InstantDownloadGene.tsx
+++ b/src/shared/components/instant-download/instant-download-gene/InstantDownloadGene.tsx
@@ -165,7 +165,7 @@ const InstantDownloadGene = (props: Props) => {
         onChange={onTranscriptOptionChange}
       />
       <InstantDownloadButton
-        isDisabled={isButtonDisabled}
+        disabled={isButtonDisabled}
         onClick={onSubmit}
         theme={theme}
         classNames={{

--- a/src/shared/components/instant-download/instant-download-protein/InstantDownloadProtein.tsx
+++ b/src/shared/components/instant-download/instant-download-protein/InstantDownloadProtein.tsx
@@ -103,7 +103,7 @@ const InstantDownloadProtein = (props: InstantDownloadProteinProps) => {
         theme="lighter"
       />
       <InstantDownloadButton
-        isDisabled={isDownloadDisabled()}
+        disabled={isDownloadDisabled()}
         onClick={onSubmit}
         theme="light"
       />

--- a/src/shared/components/instant-download/instant-download-regulation/InstantDownloadRegFeature.scss
+++ b/src/shared/components/instant-download/instant-download-regulation/InstantDownloadRegFeature.scss
@@ -1,0 +1,27 @@
+@import 'src/styles/common';
+
+.container label {
+  display: flex;
+  align-items: center;
+  margin: 10px 0 0 36px;
+}
+
+.container label span {
+  font-weight: $light;
+  margin-left: 0.6rem;
+}
+
+.featurePart {
+  display: flex;
+  column-gap: 0.6rem;
+}
+
+.featurePartLabel {
+  font-weight: $light;
+}
+
+.download {
+  display: flex;
+  justify-content: end;
+  margin-top: 1rem;
+}

--- a/src/shared/components/instant-download/instant-download-regulation/InstantDownloadRegFeature.scss
+++ b/src/shared/components/instant-download/instant-download-regulation/InstantDownloadRegFeature.scss
@@ -1,20 +1,20 @@
 @import 'src/styles/common';
 
-.checkbox {
-  margin-left: 36px;
+.container {
+  margin-top: 0.6rem;
+  margin-bottom: 0.5rem;
 }
 
-.container label span {
-  font-weight: $light;
-  margin-left: 0.6rem;
+.checkboxContainer {
+  padding-left: 18px; // same as for transcript download
 }
 
-.featurePart {
+.feature {
   display: flex;
   column-gap: 0.6rem;
 }
 
-.featurePartLabel {
+.featureType {
   font-weight: $light;
 }
 

--- a/src/shared/components/instant-download/instant-download-regulation/InstantDownloadRegFeature.scss
+++ b/src/shared/components/instant-download/instant-download-regulation/InstantDownloadRegFeature.scss
@@ -1,9 +1,7 @@
 @import 'src/styles/common';
 
-.container label {
-  display: flex;
-  align-items: center;
-  margin: 10px 0 0 36px;
+.checkbox {
+  margin-left: 36px;
 }
 
 .container label span {

--- a/src/shared/components/instant-download/instant-download-regulation/InstantDownloadRegFeature.tsx
+++ b/src/shared/components/instant-download/instant-download-regulation/InstantDownloadRegFeature.tsx
@@ -22,6 +22,8 @@ import { fetchRegulatoryFeatureSequences } from '../instant-download-fetch/fetch
 import Checkbox from 'src/shared/components/checkbox/Checkbox';
 import InstantDownloadButton from '../instant-download-button/InstantDownloadButton';
 
+import styles from './InstantDownloadRegFeature.scss';
+
 type Props = {
   id: string;
   genomeId: string;
@@ -61,9 +63,9 @@ const InstantDownloadRegFeature = (props: Props) => {
   };
 
   return (
-    <div>
-      <div>
-        <span>Core region</span>
+    <div className={styles.container}>
+      <div className={styles.featurePart}>
+        <span className={styles.featurePartLabel}>Core region</span>
         <span>{formattedLocation}</span>
       </div>
       <label>
@@ -74,7 +76,7 @@ const InstantDownloadRegFeature = (props: Props) => {
         />
         <span>Genomic sequence</span>
       </label>
-      <div>
+      <div className={styles.download}>
         <InstantDownloadButton
           disabled={!isCoreSequenceSelected}
           onClick={onSubmit}

--- a/src/shared/components/instant-download/instant-download-regulation/InstantDownloadRegFeature.tsx
+++ b/src/shared/components/instant-download/instant-download-regulation/InstantDownloadRegFeature.tsx
@@ -16,7 +16,6 @@
 
 import React, { useState } from 'react';
 
-import { getFormattedLocation } from 'src/shared/helpers/formatters/regionFormatter';
 import { fetchRegulatoryFeatureSequences } from '../instant-download-fetch/fetchRegulatoryFeature';
 
 import Checkbox from 'src/shared/components/checkbox/Checkbox';
@@ -36,19 +35,13 @@ type Props = {
 const InstantDownloadRegFeature = (props: Props) => {
   const [isCoreSequenceSelected, setIsCoreSequenceSelected] = useState(false);
 
-  const formattedLocation = getFormattedLocation({
-    chromosome: props.regionName,
-    start: props.start,
-    end: props.end
-  });
-
   const onSubmit = async () => {
     const payload = {
       id: props.id,
       genomeId: props.genomeId,
       featureType: props.featureType,
       regionName: props.regionName,
-      coreRegion: {
+      boundsRegion: {
         start: props.start,
         end: props.end
       }
@@ -64,16 +57,15 @@ const InstantDownloadRegFeature = (props: Props) => {
 
   return (
     <div className={styles.container}>
-      <div className={styles.featurePart}>
-        <span className={styles.featurePartLabel}>Core region</span>
-        <span>{formattedLocation}</span>
+      <div className={styles.feature}>
+        <span className={styles.featureType}>{props.featureType}</span>
+        <span>{props.id}</span>
       </div>
-      <div>
+      <div className={styles.checkboxContainer}>
         <Checkbox
           theme="dark"
           checked={isCoreSequenceSelected}
           onChange={setIsCoreSequenceSelected}
-          className={styles.checkbox}
           label="Genomic sequence"
         />
       </div>

--- a/src/shared/components/instant-download/instant-download-regulation/InstantDownloadRegFeature.tsx
+++ b/src/shared/components/instant-download/instant-download-regulation/InstantDownloadRegFeature.tsx
@@ -68,14 +68,15 @@ const InstantDownloadRegFeature = (props: Props) => {
         <span className={styles.featurePartLabel}>Core region</span>
         <span>{formattedLocation}</span>
       </div>
-      <label>
+      <div>
         <Checkbox
           theme="dark"
           checked={isCoreSequenceSelected}
           onChange={setIsCoreSequenceSelected}
+          className={styles.checkbox}
+          label="Genomic sequence"
         />
-        <span>Genomic sequence</span>
-      </label>
+      </div>
       <div className={styles.download}>
         <InstantDownloadButton
           disabled={!isCoreSequenceSelected}

--- a/src/shared/components/instant-download/instant-download-transcript/InstantDownloadRegFeature.tsx
+++ b/src/shared/components/instant-download/instant-download-transcript/InstantDownloadRegFeature.tsx
@@ -1,0 +1,88 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from 'react';
+
+import { getFormattedLocation } from 'src/shared/helpers/formatters/regionFormatter';
+import { fetchRegulatoryFeatureSequences } from '../instant-download-fetch/fetchRegulatoryFeature';
+
+import Checkbox from 'src/shared/components/checkbox/Checkbox';
+import InstantDownloadButton from '../instant-download-button/InstantDownloadButton';
+
+type Props = {
+  id: string;
+  genomeId: string;
+  featureType: string;
+  regionName: string;
+  start: number;
+  end: number;
+};
+
+const InstantDownloadRegFeature = (props: Props) => {
+  const [isCoreSequenceSelected, setIsCoreSequenceSelected] = useState(false);
+
+  const formattedLocation = getFormattedLocation({
+    chromosome: props.regionName,
+    start: props.start,
+    end: props.end
+  });
+
+  const onSubmit = async () => {
+    const payload = {
+      id: props.id,
+      genomeId: props.genomeId,
+      featureType: props.featureType,
+      regionName: props.regionName,
+      coreRegion: {
+        start: props.start,
+        end: props.end
+      }
+    };
+
+    await fetchRegulatoryFeatureSequences(payload);
+    resetCheckboxes();
+  };
+
+  const resetCheckboxes = () => {
+    setIsCoreSequenceSelected(false);
+  };
+
+  return (
+    <div>
+      <div>
+        <span>Core region</span>
+        <span>{formattedLocation}</span>
+      </div>
+      <label>
+        <Checkbox
+          theme="dark"
+          checked={isCoreSequenceSelected}
+          onChange={setIsCoreSequenceSelected}
+        />
+        <span>Genomic sequence</span>
+      </label>
+      <div>
+        <InstantDownloadButton
+          disabled={!isCoreSequenceSelected}
+          onClick={onSubmit}
+          theme="dark"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default InstantDownloadRegFeature;

--- a/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.tsx
+++ b/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.tsx
@@ -195,7 +195,7 @@ const InstantDownloadTranscript = (props: Props) => {
         onChange={onGeneOptionChange}
       />
       <InstantDownloadButton
-        isDisabled={isButtonDisabled}
+        disabled={isButtonDisabled}
         onClick={onSubmit}
         theme={theme}
         classNames={{

--- a/src/styles/_settings.scss
+++ b/src/styles/_settings.scss
@@ -30,6 +30,9 @@ $shadow-color: rgba(0, 0, 0, 0.4);
 $blue: #0099ff; // blue on white
 $light-blue: #33adff; // blue on black
 $ice-blue: #e5f5ff; // text highlight
+$teal: #327C89;
+$duckegg-blue: #96D0C9;
+$neon-blue: #8ef4f8;
 
 $light-grey: #f1f2f4;
 $medium-light-grey: #d4d9de;
@@ -38,16 +41,15 @@ $medium-dark-grey: #9aa7b1;
 $dark-grey: #6f8190;
 
 $red: #d90000;
+$dark-pink: #e685ae;
+$purple: #ca81ff;
+
 $orange: #ff9900;
 $mustard: #cc9933;
+$dark-yellow: #f8c041;
 
 $green: #47d147;
-
-$dark-pink: #E685AE;
-$dark-yellow: #F8C041;
-$lime: #84FA3A;
-$teal: #327C89;
-$duckegg-blue: #96D0C9;
+$lime: #84fa3a;
 
 $global-box-shadow: $medium-light-grey;
 $form-field-shadow: inset 2px 2px 4px -2px $medium-dark-grey,

--- a/tests/fixtures/genomes.ts
+++ b/tests/fixtures/genomes.ts
@@ -40,7 +40,7 @@ export const createGenomeCategories = (): GenomeTrackCategory[] => [
     label: faker.lorem.words(),
     track_category_id: faker.lorem.words(),
     track_list: [],
-    types: [TrackSet.EXPRESSION]
+    types: [TrackSet.REGULATION]
   }
 ];
 


### PR DESCRIPTION
## Description
- Adds Zmenu for regulatory features
- Zmenu can download sequences of regulatory features
- Colour legend merged from https://github.com/Ensembl/ensembl-client/pull/988

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1954

## Deployment URL(s)
http://regulation.review.ensembl.org