### PR TITLE
add regulation legends

### DIFF
--- a/src/content/app/genome-browser/components/drawer/Drawer.tsx
+++ b/src/content/app/genome-browser/components/drawer/Drawer.tsx
@@ -23,6 +23,7 @@ import GeneSummary from './drawer-views/gene-summary/GeneSummary';
 import TranscriptSummary from './drawer-views/transcript-summary/TranscriptSummary';
 import VariantSummary from './drawer-views/variant-summary/VariantSummary';
 import VariantGroupLegend from './drawer-views/variant-group-legend/VariantGroupLegend';
+import RegulationLegend from './drawer-views/regulation-legend/RegulationLegend';
 
 import { getActiveDrawerView } from 'src/content/app/genome-browser/state/drawer/drawerSelectors';
 
@@ -49,6 +50,8 @@ export const Drawer = () => {
         return <DrawerBookmarks />;
       case 'variant_group_legend':
         return <VariantGroupLegend drawerView={drawerView} />;
+      case 'regulation_legend':
+        return <RegulationLegend drawerView={drawerView} />;
     }
   };
 

--- a/src/content/app/genome-browser/components/drawer/drawer-views/regulation-legend/RegulationLegend.scss
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/regulation-legend/RegulationLegend.scss
@@ -1,0 +1,35 @@
+@import 'src/styles/common';
+
+.container {
+  margin: 10px 0 0 80px;
+  
+  max-width: 950px;
+}
+
+.labelTextStrong {
+  font-size: 12px;
+  font-weight: $bold;
+  margin-left: 10px;
+}
+
+.regulationColour1 {
+  background-color: $red;
+}
+.regulationColour2 {
+  background-color: $dark-yellow;
+}
+.regulationColour3 {
+  background-color: $grey;
+}
+.regulationColour4 {
+  background-color: $neon-blue;
+}
+.regulationColour5 {
+  background-color: $purple;
+}
+
+.colourMarker {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+}

--- a/src/content/app/genome-browser/components/drawer/drawer-views/regulation-legend/RegulationLegend.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/regulation-legend/RegulationLegend.tsx
@@ -1,0 +1,54 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import regulationLegends from 'src/content/app/genome-browser/constants/regulationLegends';
+
+import type { RegulationLegendView } from 'src/content/app/genome-browser/state/drawer/types';
+
+import styles from './RegulationLegend.scss';
+import classNames from 'classnames';
+
+type Props = {
+  drawerView: RegulationLegendView;
+};
+
+const RegulationLegend = (props: Props) => {
+  const activeLegend = regulationLegends.find(
+    ({ label }) => label === props.drawerView.group
+  );
+
+  const groupColorMarkerClass = classNames(
+    styles.colourMarker,
+    styles[`regulationColour${activeLegend?.id}`]
+  );
+
+  if (!activeLegend) {
+    return null;
+  }
+
+  return (
+    <div className={styles.container}>
+      <div>
+        <span className={groupColorMarkerClass} />
+        <span className={styles.labelTextStrong}>{activeLegend.label}</span>
+      </div>
+    </div>
+  );
+};
+
+export default RegulationLegend;

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
@@ -44,6 +44,7 @@ import {
 
 import { TrackSet } from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
 import TrackPanelVariantGroupLegend from './track-panel-items/TrackPanelVariantGroupLegend';
+import TrackPanelRegulationLegend from './track-panel-items/TrackPanelRegulationLegend';
 
 import SearchIcon from 'static/icons/icon_search.svg';
 import ResetIcon from 'static/icons/icon_reset.svg';
@@ -108,6 +109,12 @@ export const TrackPanelList = () => {
         >
           {selectedTrackPanelTab === TrackSet.VARIATION && (
             <TrackPanelVariantGroupLegend
+              disabled={trackCategoryIds.length === 0}
+            />
+          )}
+
+          {selectedTrackPanelTab === TrackSet.REGULATION && (
+            <TrackPanelRegulationLegend
               disabled={trackCategoryIds.length === 0}
             />
           )}

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelRegulationLegend.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelRegulationLegend.tsx
@@ -1,0 +1,115 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import classNames from 'classnames';
+import { useDispatch } from 'react-redux';
+import { useAppSelector } from 'src/store';
+
+import useGenomeBrowserAnalytics from 'src/content/app/genome-browser/hooks/useGenomeBrowserAnalytics';
+
+import {
+  AccordionItem,
+  AccordionItemHeading,
+  AccordionItemButton,
+  AccordionItemPanel
+} from 'src/shared/components/accordion';
+import SimpleTrackPanelItemLayout from './track-panel-item-layout/SimpleTrackPanelItemLayout';
+import regulationLegends from 'src/content/app/genome-browser/constants/regulationLegends';
+
+import { changeDrawerViewForGenome } from 'src/content/app/genome-browser/state/drawer/drawerSlice';
+import { getBrowserActiveGenomeId } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
+
+import styles from '../TrackPanelList.scss';
+import trackPanelItemStyles from './TrackPanelItem.scss';
+import regulationStyles from 'src/content/app/genome-browser/components/drawer/drawer-views/regulation-legend/RegulationLegend.scss';
+
+const TrackPanelRegulationLegend = (props: { disabled: boolean }) => {
+  const activeGenomeId = useAppSelector(getBrowserActiveGenomeId) as string;
+  const dispatch = useDispatch();
+  const { trackDrawerOpened, reportTrackPanelSectionToggled } =
+    useGenomeBrowserAnalytics();
+  const accordionHeading = 'Regulatory features';
+
+  const accordionButtonClassNames = classNames(
+    styles.trackPanelAccordionButton,
+    {
+      [styles.trackPanelAccordionButtonDisabled]: props.disabled
+    }
+  );
+
+  const onShowMore = (group: string) => {
+    trackDrawerOpened('regulation_legend');
+    dispatch(
+      changeDrawerViewForGenome({
+        genomeId: activeGenomeId,
+        drawerView: {
+          name: 'regulation_legend',
+          group
+        }
+      })
+    );
+  };
+
+  return (
+    <>
+      <AccordionItem
+        className={styles.trackPanelAccordionItem}
+        uuid="regulation_legend"
+      >
+        <AccordionItemHeading className={styles.trackPanelAccordionHeader}>
+          <AccordionItemButton
+            disabled={props.disabled}
+            className={accordionButtonClassNames}
+            onToggle={(isExpanded: boolean) =>
+              reportTrackPanelSectionToggled(accordionHeading, isExpanded)
+            }
+          >
+            {accordionHeading}
+          </AccordionItemButton>
+        </AccordionItemHeading>
+        {!props.disabled ? (
+          <AccordionItemPanel className={styles.trackPanelAccordionItemContent}>
+            <dl>
+              {regulationLegends.map((legend) => {
+                const groupColourMarkerClass = classNames(
+                  regulationStyles.colourMarker,
+                  regulationStyles[`regulationColour${legend.id}`]
+                );
+
+                return (
+                  <SimpleTrackPanelItemLayout
+                    key={legend.id}
+                    onShowMore={() => onShowMore(legend.label)}
+                  >
+                    <div className={trackPanelItemStyles.label}>
+                      <span className={groupColourMarkerClass} />
+                      <span className={trackPanelItemStyles.labelText}>
+                        {legend.label}
+                      </span>
+                    </div>
+                  </SimpleTrackPanelItemLayout>
+                );
+              })}
+            </dl>
+          </AccordionItemPanel>
+        ) : null}
+      </AccordionItem>
+    </>
+  );
+};
+
+export default TrackPanelRegulationLegend;

--- a/src/content/app/genome-browser/components/track-panel/trackPanelConfig.ts
+++ b/src/content/app/genome-browser/components/track-panel/trackPanelConfig.ts
@@ -29,7 +29,7 @@ export type TrackActivityStatus = Status.SELECTED | Status.UNSELECTED;
 export enum TrackSet {
   GENOMIC = 'Genomic',
   VARIATION = 'Variation',
-  EXPRESSION = 'Regulation'
+  REGULATION = 'Regulation'
 }
 
 export type TrackSetKey = keyof typeof TrackSet;

--- a/src/content/app/genome-browser/constants/regulationLegends.ts
+++ b/src/content/app/genome-browser/constants/regulationLegends.ts
@@ -1,0 +1,40 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const regulationLegends = [
+  {
+    id: 1,
+    label: 'Promoter'
+  },
+  {
+    id: 2,
+    label: 'Enhancer'
+  },
+  {
+    id: 3,
+    label: 'Open chromatin'
+  },
+  {
+    id: 4,
+    label: 'CTCF'
+  },
+  {
+    id: 5,
+    label: 'TF binding'
+  }
+];
+
+export default regulationLegends;

--- a/src/content/app/genome-browser/state/drawer/types.ts
+++ b/src/content/app/genome-browser/state/drawer/types.ts
@@ -43,10 +43,16 @@ export type VariantLegendView = {
   group: string;
 };
 
+export type RegulationLegendView = {
+  name: 'regulation_legend';
+  group: string;
+};
+
 export type DrawerView =
   | BookmarksDrawerView
   | GeneDrawerView
   | TranscriptDrawerView
   | VariantDrawerView
   | GenericTrackView
-  | VariantLegendView;
+  | VariantLegendView
+  | RegulationLegendView;

--- a/src/styles/_settings.scss
+++ b/src/styles/_settings.scss
@@ -30,6 +30,9 @@ $shadow-color: rgba(0, 0, 0, 0.4);
 $blue: #0099ff; // blue on white
 $light-blue: #33adff; // blue on black
 $ice-blue: #e5f5ff; // text highlight
+$teal: #327C89;
+$duckegg-blue: #96D0C9;
+$neon-blue: #8ef4f8;
 
 $light-grey: #f1f2f4;
 $medium-light-grey: #d4d9de;
@@ -38,16 +41,15 @@ $medium-dark-grey: #9aa7b1;
 $dark-grey: #6f8190;
 
 $red: #d90000;
+$dark-pink: #E685AE;
+$purple: #ca81ff;
+
 $orange: #ff9900;
 $mustard: #cc9933;
+$dark-yellow: #F8C041;
 
 $green: #47d147;
-
-$dark-pink: #E685AE;
-$dark-yellow: #F8C041;
 $lime: #84FA3A;
-$teal: #327C89;
-$duckegg-blue: #96D0C9;
 
 $global-box-shadow: $medium-light-grey;
 $form-field-shadow: inset 2px 2px 4px -2px $medium-dark-grey,


### PR DESCRIPTION
## Description
Add the legend with colours of regulatory features to the track panel. See [this XD](https://xd.adobe.com/view/5e8fd2b0-a507-4b07-b272-4c386b02af37-0bdc/screen/e926e62b-4735-4c80-86d9-6b14ad69e454) for reference.

`...` expands the drawer to show the coloured square box and title


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1958

## Deployment URL(s)
http://regulation-legends.review.ensembl.org


## Views affected
GB