### PR TITLE
Add grey background to code snippets

### DIFF
--- a/src/shared/components/help-article/HelpArticle.scss
+++ b/src/shared/components/help-article/HelpArticle.scss
@@ -70,6 +70,11 @@ $textColumnWidth: 450px;
       padding: 0 5px;
     }
   }
+
+  pre {
+    background-color: #F1F2F4; // Add a background color to code snippets
+    padding: 15px;
+  }
 }
 
 .indexArticle {

--- a/src/shared/components/help-article/HelpArticle.scss
+++ b/src/shared/components/help-article/HelpArticle.scss
@@ -72,7 +72,7 @@ $textColumnWidth: 450px;
   }
 
   pre {
-    background-color: #F1F2F4; // Add a background color to code snippets
+    background-color: $light-grey; // Add a background color to code snippets
     padding: 15px;
   }
 }


### PR DESCRIPTION
## Description
Add a grey background to code snippets

![image](https://github.com/Ensembl/ensembl-client/assets/62993769/f3840e8f-15d9-4427-93f0-6c3b75e26102)

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/EA-1081

## Deployment URL(s)
http://add-background-code-snippets.review.ensembl.org
> No changes will be visible since there are no code snippets in the docs yet


## Views affected
Help and Docs with code snippets