### PR TITLE
Add 404 screens for Help and About pages; and update their page meta

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -61,7 +61,9 @@ const getBaseApiUrls = (): BaseApiUrls => {
     genomeSearchBaseUrl:
       process.env.SSR_GENOME_SEARCH_BASE_URL ??
       `${defaultServerHost}${defaultApiUrls.genomeSearchBaseUrl}`,
-    docsBaseUrl: process.env.SSR_DOCS_BASE_URL ?? defaultApiUrls.docsBaseUrl,
+    docsBaseUrl:
+      process.env.SSR_DOCS_BASE_URL ??
+      `${defaultServerHost}${defaultApiUrls.docsBaseUrl}`,
     genomeBrowserBackendBaseUrl: defaultApiUrls.genomeBrowserBackendBaseUrl, // irrelevant for server-side rendering
     refgetBaseUrl: defaultApiUrls.refgetBaseUrl, // irrelevant for server-side rendering
     tracksApiBaseUrl: defaultApiUrls.tracksApiBaseUrl, // irrelevant for server-side rendering

--- a/src/content/app/about/About.tsx
+++ b/src/content/app/about/About.tsx
@@ -14,10 +14,22 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useLocation } from 'react-router';
 
-import useApiService from 'src/shared/hooks/useApiService';
+import { useAppDispatch } from 'src/store';
+
+import {
+  useGetHelpArticleQuery,
+  useGetHelpMenuQuery,
+  isArticleNotFoundError
+} from 'src/content/app/help/state/api/helpApiSlice';
+import { updatePageMeta } from 'src/shared/state/page-meta/pageMetaSlice';
+
+import {
+  createAboutPageTitle,
+  ABOUT_PAGE_FALLBACK_DESCRIPTION
+} from './helpers/aboutPageMetaHelpers';
 
 import { buildBreadcrumbs } from '../help/Help';
 
@@ -30,23 +42,39 @@ import HelpMenu from 'src/content/app/help/components/help-menu/HelpMenu';
 import Breadcrumbs from 'src/shared/components/breadcrumbs/Breadcrumbs';
 import { CircleLoader } from 'src/shared/components/loader';
 import ConversationIcon from 'src/shared/components/communication-framework/ConversationIcon';
-
-import { Menu as MenuType } from 'src/shared/types/help-and-docs/menu';
-import { TextArticleData } from 'src/shared/types/help-and-docs/article';
+import { NotFoundErrorScreen } from 'src/shared/components/error-screen';
 
 import helpStyles from '../help/Help.scss';
 import styles from './About.scss';
 
 const About = () => {
   const { pathname } = useLocation();
-  const { data: menu } = useApiService<MenuType>({
-    endpoint: `/api/docs/menus?name=about`
-  });
-  const { data: article } = useApiService<TextArticleData>({
-    endpoint: `/api/docs/article?url=${encodeURIComponent(pathname)}`
+  const dispatch = useAppDispatch();
+
+  const { currentData: menu } = useGetHelpMenuQuery({ name: 'about' });
+
+  const { currentData: article, error: articleError } = useGetHelpArticleQuery({
+    pathname
   });
 
   let breadcrumbs: string[] = [];
+
+  useEffect(() => {
+    if (!article) {
+      return;
+    }
+
+    dispatch(
+      updatePageMeta({
+        title: createAboutPageTitle(article.title),
+        description: article.description || ABOUT_PAGE_FALLBACK_DESCRIPTION
+      })
+    );
+  }, [article]);
+
+  if (isArticleNotFoundError(articleError)) {
+    return <NotFoundErrorScreen />;
+  }
 
   if (menu) {
     breadcrumbs = buildBreadcrumbs(menu, { url: pathname });
@@ -62,7 +90,7 @@ const About = () => {
         </div>
         <div className={helpStyles.articleContainer}>
           <HelpArticleGrid className={helpStyles.grid}>
-            {article ? (
+            {article?.type === 'article' ? (
               <TextArticle article={article} />
             ) : (
               <div className={styles.spinnerContainer}>

--- a/src/content/app/about/About.tsx
+++ b/src/content/app/about/About.tsx
@@ -21,10 +21,10 @@ import { useAppDispatch } from 'src/store';
 
 import {
   useGetHelpArticleQuery,
-  useGetHelpMenuQuery,
-  isArticleNotFoundError
+  useGetHelpMenuQuery
 } from 'src/content/app/help/state/api/helpApiSlice';
 import { updatePageMeta } from 'src/shared/state/page-meta/pageMetaSlice';
+import { isMissingResourceError } from 'src/shared/state/api-slices/restSlice';
 
 import {
   createAboutPageTitle,
@@ -72,7 +72,7 @@ const About = () => {
     );
   }, [article]);
 
-  if (isArticleNotFoundError(articleError)) {
+  if (isMissingResourceError(articleError)) {
     return <NotFoundErrorScreen />;
   }
 

--- a/src/content/app/about/AboutPage.tsx
+++ b/src/content/app/about/AboutPage.tsx
@@ -19,10 +19,8 @@ import React from 'react';
 import useHasMounted from 'src/shared/hooks/useHasMounted';
 
 import { updatePageMeta } from 'src/shared/state/page-meta/pageMetaSlice';
-import {
-  getHelpArticle,
-  isArticleNotFoundError
-} from 'src/content/app/help/state/api/helpApiSlice';
+import { getHelpArticle } from 'src/content/app/help/state/api/helpApiSlice';
+import { isMissingResourceError } from 'src/shared/state/api-slices/restSlice';
 
 import {
   createAboutPageTitle,
@@ -50,7 +48,7 @@ export const serverFetch: ServerFetch = async (params) => {
 
   const { data: article, error: articleError } = await articlePromise;
 
-  if (isArticleNotFoundError(articleError)) {
+  if (isMissingResourceError(articleError)) {
     return {
       status: 404
     };

--- a/src/content/app/about/AboutPage.tsx
+++ b/src/content/app/about/AboutPage.tsx
@@ -14,44 +14,52 @@
  * limitations under the License.
  */
 
-import React, { useEffect } from 'react';
+import React from 'react';
 
-import { useAppDispatch } from 'src/store';
 import useHasMounted from 'src/shared/hooks/useHasMounted';
 
 import { updatePageMeta } from 'src/shared/state/page-meta/pageMetaSlice';
+import {
+  getHelpArticle,
+  isArticleNotFoundError
+} from 'src/content/app/help/state/api/helpApiSlice';
+
+import {
+  createAboutPageTitle,
+  ABOUT_PAGE_FALLBACK_DESCRIPTION
+} from './helpers/aboutPageMetaHelpers';
 
 import type { ServerFetch } from 'src/routes/routesConfig';
 
 const LazilyLoadedAbout = React.lazy(() => import('./About'));
 
-const pageTitle = 'About Ensembl';
-const pageDescription = 'About the Ensembl project';
-
 const AboutPage = () => {
   const hasMounted = useHasMounted();
-  const dispatch = useAppDispatch();
-
-  useEffect(() => {
-    dispatch(
-      updatePageMeta({
-        title: pageTitle,
-        description: pageDescription
-      })
-    );
-  }, []);
 
   return hasMounted ? <LazilyLoadedAbout /> : null;
 };
 
 export default AboutPage;
 
-// not really fetching anything; just setting page meta
 export const serverFetch: ServerFetch = async (params) => {
-  params.store.dispatch(
+  const { path, store } = params;
+
+  const articlePromise = store.dispatch(
+    getHelpArticle.initiate({ pathname: path })
+  );
+
+  const { data: article, error: articleError } = await articlePromise;
+
+  if (isArticleNotFoundError(articleError)) {
+    return {
+      status: 404
+    };
+  }
+
+  store.dispatch(
     updatePageMeta({
-      title: pageTitle,
-      description: pageDescription
+      title: createAboutPageTitle(article.title),
+      description: article.description || ABOUT_PAGE_FALLBACK_DESCRIPTION
     })
   );
 };

--- a/src/content/app/about/helpers/aboutPageMetaHelpers.ts
+++ b/src/content/app/about/helpers/aboutPageMetaHelpers.ts
@@ -1,0 +1,27 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const postfix = 'About Ensembl';
+
+export const ABOUT_PAGE_FALLBACK_DESCRIPTION = 'About the Ensembl project';
+
+export const createAboutPageTitle = (title?: string) => {
+  if (!title) {
+    return postfix;
+  }
+
+  return `${title} — ${postfix}`;
+};

--- a/src/content/app/help/Help.tsx
+++ b/src/content/app/help/Help.tsx
@@ -22,10 +22,10 @@ import { useAppDispatch } from 'src/store';
 import useHelpHistory from 'src/content/app/help/hooks/useHelpHistory';
 import {
   useGetHelpArticleQuery,
-  useGetHelpMenuQuery,
-  isArticleNotFoundError
+  useGetHelpMenuQuery
 } from 'src/content/app/help/state/api/helpApiSlice';
 import { updatePageMeta } from 'src/shared/state/page-meta/pageMetaSlice';
+import { isMissingResourceError } from 'src/shared/state/api-slices/restSlice';
 
 import { createHelpPageMeta } from './helpers/helpPageMetaHelpers';
 import { isHelpIndexRoute } from './helpers/isHelpIndexRoute';
@@ -86,7 +86,7 @@ const Help = () => {
     breadcrumbs = buildBreadcrumbs(menu, { url: pathname });
   }
 
-  if (isArticleNotFoundError(articleError)) {
+  if (isMissingResourceError(articleError)) {
     return <NotFoundErrorScreen />;
   }
 

--- a/src/content/app/help/Help.tsx
+++ b/src/content/app/help/Help.tsx
@@ -14,11 +14,21 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
-import useApiService from 'src/shared/hooks/useApiService';
+import { useAppDispatch } from 'src/store';
+
 import useHelpHistory from 'src/content/app/help/hooks/useHelpHistory';
+import {
+  useGetHelpArticleQuery,
+  useGetHelpMenuQuery,
+  isArticleNotFoundError
+} from 'src/content/app/help/state/api/helpApiSlice';
+import { updatePageMeta } from 'src/shared/state/page-meta/pageMetaSlice';
+
+import { createHelpPageMeta } from './helpers/helpPageMetaHelpers';
+import { isHelpIndexRoute } from './helpers/isHelpIndexRoute';
 
 import ConversationIcon from 'src/shared/components/communication-framework/ConversationIcon';
 import HelpMenu from './components/help-menu/HelpMenu';
@@ -31,6 +41,7 @@ import {
 } from 'src/shared/components/help-article';
 import Breadcrumbs from 'src/shared/components/breadcrumbs/Breadcrumbs';
 import HistoryButtons from 'src/shared/components/help-popup/HistoryButtons';
+import { NotFoundErrorScreen } from 'src/shared/components/error-screen';
 
 import {
   Menu as MenuType,
@@ -47,20 +58,36 @@ type ArticleData = TextArticleData | VideoArticleData;
 
 const Help = () => {
   const { pathname } = useLocation();
-  const isIndexPage = isIndexRoute(pathname);
-  const { data: menu } = useApiService<MenuType>({
-    endpoint: `/api/docs/menus?name=help`
-  });
-  const { data: article } = useApiService<any>({
-    endpoint: `/api/docs/article?url=${encodeURIComponent(pathname)}`,
-    skip: isIndexPage
-  });
+  const isIndexPage = isHelpIndexRoute(pathname);
+  const dispatch = useAppDispatch();
+
+  const { currentData: menu } = useGetHelpMenuQuery({ name: 'help' });
+
+  const { currentData: article, error: articleError } = useGetHelpArticleQuery(
+    { pathname },
+    {
+      skip: isIndexPage
+    }
+  );
+
   const { hasNext, hasPrevious } = useHelpHistory();
 
   let breadcrumbs: string[] = [];
 
+  useEffect(() => {
+    if (!article) {
+      return;
+    }
+
+    dispatch(updatePageMeta(createHelpPageMeta({ path: pathname, article })));
+  }, [pathname, article]);
+
   if (menu) {
     breadcrumbs = buildBreadcrumbs(menu, { url: pathname });
+  }
+
+  if (isArticleNotFoundError(articleError)) {
+    return <NotFoundErrorScreen />;
   }
 
   const main = isIndexPage ? (
@@ -201,11 +228,6 @@ const collectBreadcrumbs = (
   }
 
   return null;
-};
-
-export const isIndexRoute = (pathname: string) => {
-  // handle both /help and /help/
-  return pathname.replaceAll('/', '') === 'help';
 };
 
 export default Help;

--- a/src/content/app/help/HelpPage.tsx
+++ b/src/content/app/help/HelpPage.tsx
@@ -14,44 +14,50 @@
  * limitations under the License.
  */
 
-import React, { useEffect } from 'react';
+import React from 'react';
 
-import { useAppDispatch } from 'src/store';
 import useHasMounted from 'src/shared/hooks/useHasMounted';
 
 import { updatePageMeta } from 'src/shared/state/page-meta/pageMetaSlice';
+import {
+  getHelpArticle,
+  isArticleNotFoundError
+} from 'src/content/app/help/state/api/helpApiSlice';
+
+import { createHelpPageMeta } from './helpers/helpPageMetaHelpers';
+import { isHelpIndexRoute } from './helpers/isHelpIndexRoute';
 
 import type { ServerFetch } from 'src/routes/routesConfig';
 
 const LazilyLoadedHelp = React.lazy(() => import('./Help'));
 
-const pageTitle = 'Help and documentation — Ensembl';
-const pageDescription = 'Ensembl help and documentation';
-
 const HelpPage = () => {
   const hasMounted = useHasMounted();
-  const dispatch = useAppDispatch();
-
-  useEffect(() => {
-    dispatch(
-      updatePageMeta({
-        title: pageTitle,
-        description: pageDescription
-      })
-    );
-  }, []);
 
   return hasMounted ? <LazilyLoadedHelp /> : null;
 };
 
 export default HelpPage;
 
-// not really fetching anything; just setting page meta
 export const serverFetch: ServerFetch = async (params) => {
-  params.store.dispatch(
-    updatePageMeta({
-      title: pageTitle,
-      description: pageDescription
-    })
+  const { path, store } = params;
+
+  if (isHelpIndexRoute(path)) {
+    store.dispatch(updatePageMeta(createHelpPageMeta({ path })));
+    return;
+  }
+
+  const articlePromise = store.dispatch(
+    getHelpArticle.initiate({ pathname: path })
   );
+
+  const { data: article, error: articleError } = await articlePromise;
+
+  if (isArticleNotFoundError(articleError)) {
+    return {
+      status: 404
+    };
+  }
+
+  store.dispatch(updatePageMeta(createHelpPageMeta({ article, path })));
 };

--- a/src/content/app/help/HelpPage.tsx
+++ b/src/content/app/help/HelpPage.tsx
@@ -19,10 +19,8 @@ import React from 'react';
 import useHasMounted from 'src/shared/hooks/useHasMounted';
 
 import { updatePageMeta } from 'src/shared/state/page-meta/pageMetaSlice';
-import {
-  getHelpArticle,
-  isArticleNotFoundError
-} from 'src/content/app/help/state/api/helpApiSlice';
+import { getHelpArticle } from 'src/content/app/help/state/api/helpApiSlice';
+import { isMissingResourceError } from 'src/shared/state/api-slices/restSlice';
 
 import { createHelpPageMeta } from './helpers/helpPageMetaHelpers';
 import { isHelpIndexRoute } from './helpers/isHelpIndexRoute';
@@ -53,7 +51,7 @@ export const serverFetch: ServerFetch = async (params) => {
 
   const { data: article, error: articleError } = await articlePromise;
 
-  if (isArticleNotFoundError(articleError)) {
+  if (isMissingResourceError(articleError)) {
     return {
       status: 404
     };

--- a/src/content/app/help/helpers/helpPageMetaHelpers.ts
+++ b/src/content/app/help/helpers/helpPageMetaHelpers.ts
@@ -1,0 +1,57 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isHelpIndexRoute } from './isHelpIndexRoute';
+
+import {
+  TextArticleData,
+  VideoArticleData
+} from 'src/shared/types/help-and-docs/article';
+
+type Article = TextArticleData | VideoArticleData;
+
+const postfix = 'Help and documentation — Ensembl';
+
+export const HELP_PAGE_FALLBACK_DESCRIPTION = 'Ensembl help and documentation';
+
+export const createHelpPageTitle = (title?: string) => {
+  if (!title) {
+    return postfix;
+  }
+
+  return `${title} — ${postfix}`;
+};
+
+export const createHelpPageMeta = (params: {
+  article?: Article;
+  path: string;
+}) => {
+  const { article, path } = params;
+
+  const useFallbacks = !article || isHelpIndexRoute(path);
+
+  const pageTitle = useFallbacks ? postfix : createHelpPageTitle(article.title);
+
+  const pageDescription =
+    useFallbacks || !article.description
+      ? HELP_PAGE_FALLBACK_DESCRIPTION
+      : article.description;
+
+  return {
+    title: pageTitle,
+    description: pageDescription
+  };
+};

--- a/src/content/app/help/helpers/isHelpIndexRoute.ts
+++ b/src/content/app/help/helpers/isHelpIndexRoute.ts
@@ -1,0 +1,20 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const isHelpIndexRoute = (pathname: string) => {
+  // handle both /help and /help/
+  return pathname.replaceAll('/', '') === 'help';
+};

--- a/src/content/app/help/state/api/helpApiSlice.ts
+++ b/src/content/app/help/state/api/helpApiSlice.ts
@@ -1,0 +1,70 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { FetchBaseQueryError } from '@reduxjs/toolkit/query';
+import type { SerializedError } from '@reduxjs/toolkit';
+
+import config from 'config';
+
+import restApiSlice from 'src/shared/state/api-slices/restSlice';
+
+import type {
+  TextArticleData,
+  VideoArticleData
+} from 'src/shared/types/help-and-docs/article';
+import type { Menu } from 'src/shared/types/help-and-docs/menu';
+
+type HelpArticleResponse = TextArticleData | VideoArticleData;
+
+type HelpArticleQueryParams = {
+  pathname: string;
+};
+
+type MenuQueryParams = {
+  name: string;
+};
+
+const helpApiSlice = restApiSlice.injectEndpoints({
+  endpoints: (builder) => ({
+    getHelpMenu: builder.query<Menu, MenuQueryParams>({
+      query: (params) => ({
+        url: `${config.docsBaseUrl}/menus?name=${params.name}`
+      })
+    }),
+    getHelpArticle: builder.query<HelpArticleResponse, HelpArticleQueryParams>({
+      query: (params) => ({
+        url: `${config.docsBaseUrl}/article?url=${encodeURIComponent(
+          params.pathname
+        )}`
+      })
+    })
+  })
+});
+
+export const { getHelpArticle } = helpApiSlice.endpoints;
+export const { useGetHelpArticleQuery, useGetHelpMenuQuery } = helpApiSlice;
+
+export const isArticleNotFoundError = (
+  error?: SerializedError | FetchBaseQueryError
+): boolean => {
+  const hasErrorStatus = error && 'status' in error;
+  if (!hasErrorStatus) {
+    return false;
+  }
+
+  const errorStatus = error.status;
+  return typeof errorStatus === 'number' && errorStatus === 404;
+};

--- a/src/content/app/help/state/api/helpApiSlice.ts
+++ b/src/content/app/help/state/api/helpApiSlice.ts
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-import type { FetchBaseQueryError } from '@reduxjs/toolkit/query';
-import type { SerializedError } from '@reduxjs/toolkit';
-
 import config from 'config';
 
 import restApiSlice from 'src/shared/state/api-slices/restSlice';
@@ -56,15 +53,3 @@ const helpApiSlice = restApiSlice.injectEndpoints({
 
 export const { getHelpArticle } = helpApiSlice.endpoints;
 export const { useGetHelpArticleQuery, useGetHelpMenuQuery } = helpApiSlice;
-
-export const isArticleNotFoundError = (
-  error?: SerializedError | FetchBaseQueryError
-): boolean => {
-  const hasErrorStatus = error && 'status' in error;
-  if (!hasErrorStatus) {
-    return false;
-  }
-
-  const errorStatus = error.status;
-  return typeof errorStatus === 'number' && errorStatus === 404;
-};

--- a/src/shared/state/api-slices/restSlice.ts
+++ b/src/shared/state/api-slices/restSlice.ts
@@ -22,6 +22,8 @@ import {
   Response as crossFetchResponse
 } from 'cross-fetch';
 
+import type { FetchBaseQueryError } from '@reduxjs/toolkit/query';
+import type { SerializedError } from '@reduxjs/toolkit';
 import type { FetchArgs } from '@reduxjs/toolkit/dist/query/fetchBaseQuery';
 
 /**
@@ -62,6 +64,18 @@ const staggeredBaseQueryWithBailout = retry(
     maxRetries: 5
   }
 );
+
+export const isMissingResourceError = (
+  error?: SerializedError | FetchBaseQueryError
+): boolean => {
+  const hasErrorStatus = error && 'status' in error;
+  if (!hasErrorStatus) {
+    return false;
+  }
+
+  const errorStatus = error.status;
+  return errorStatus === 404;
+};
 
 export default createApi({
   reducerPath: 'restApi',


### PR DESCRIPTION
## Description
- Added handling of not found articles to the Help and About apps
  - Server should respond with a `404` http status code
  - The page will show a "not found" screen
- Made page metadata for help pages dynamic
  - Dynamic `title` tag
  - Dynamic meta description
  - Fallbacks if metadata is unavailable

**WARNING:** do not merge until https://github.com/Ensembl/ensembl-client/pull/994 has been merged, and the updated config map applied to staging and production environments.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1808

## Deployment URL(s)
http://help-404.review.ensembl.org
