### PR TITLE
Add gitlab-ci configuration for help-and-docs service available server-side

### DIFF
--- a/gitlab-ci-templates/.setup-review-template.yaml
+++ b/gitlab-ci-templates/.setup-review-template.yaml
@@ -25,6 +25,7 @@
     - sed -i "s#<SUB_DOMAIN>#${CI_COMMIT_REF_SLUG}#g" ensembl_client_node_ingress.yaml
     - sed -i "s#<THOAS_SERVICE_SLUG>#${THOAS_SERVICE_SLUG}#g" ensembl_client_node_cm.yaml
     - sed -i "s#<GENOME_SEARCH_SERVICE_SLUG>#${GENOME_SEARCH_SERVICE_SLUG}#g" ensembl_client_node_cm.yaml
+    - sed -i "s#<HELP_DOCS_SERVICE_SLUG>#${HELP_DOCS_SERVICE_SLUG}#g" ensembl_client_node_cm.yaml
     - sed -i "s#<DEPLOYMENT_ENV>#${CI_COMMIT_REF_SLUG}#g" ensembl_client_node_cm.yaml
     - sed -i "s#<GA_KEY>#${GA_KEY}#g" ensembl_client_node_cm.yaml
     # ensembl-new-genome-browser


### PR DESCRIPTION
## Description
In order to respond with 404 http status code when a help article is missing, ensembl-client will need to query help-and-docs service while running the code on the server. The configmap for review deployments has been updated [here](https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests/-/blob/wp-k8s-review/ensembl_client_node_cm.yaml#L9)

Required before https://github.com/Ensembl/ensembl-client/pull/993 can be merged.

## Deployment URL(s)
No new functionality to see; but http://update-gitlab-ci.review.ensembl.org will hopefully show that I haven't broken anything.