### PR TITLE
Add route for developing a new species selector

### DIFF
--- a/src/content/app/new-species-selector/SpeciesSelector.scss
+++ b/src/content/app/new-species-selector/SpeciesSelector.scss
@@ -1,0 +1,6 @@
+.grid {
+  display: grid;
+  grid-template-rows: max-content 1fr;
+  height: 100%;
+  overflow: auto;
+}

--- a/src/content/app/new-species-selector/SpeciesSelector.tsx
+++ b/src/content/app/new-species-selector/SpeciesSelector.tsx
@@ -1,0 +1,36 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import noop from 'lodash/noop';
+
+import SpeciesSelectorAppBar from './components/species-selector-app-bar/SpeciesSelectorAppBar';
+
+import styles from './SpeciesSelector.scss';
+
+const SpeciesSelector = () => {
+  return (
+    <div className={styles.grid}>
+      <SpeciesSelectorAppBar
+        onGeneSearchToggle={noop}
+        isGeneSearchMode={false}
+      />
+      <div>This will be the page for our new species selector</div>
+    </div>
+  );
+};
+
+export default SpeciesSelector;

--- a/src/content/app/new-species-selector/SpeciesSelectorPage.tsx
+++ b/src/content/app/new-species-selector/SpeciesSelectorPage.tsx
@@ -1,0 +1,60 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect } from 'react';
+
+import { useAppDispatch } from 'src/store';
+
+import useHasMounted from 'src/shared/hooks/useHasMounted';
+
+import { updatePageMeta } from 'src/shared/state/page-meta/pageMetaSlice';
+
+import type { ServerFetch } from 'src/routes/routesConfig';
+
+const LazilyLoadedSpeciesSelector = React.lazy(
+  () => import('./SpeciesSelector')
+);
+
+const pageTitle = 'Species selector — Ensembl';
+const pageDescription = 'Select one or more species to start using Ensembl';
+
+const SpeciesSelectorPage = () => {
+  const hasMounted = useHasMounted();
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    dispatch(
+      updatePageMeta({
+        title: pageTitle,
+        description: pageDescription
+      })
+    );
+  }, []);
+
+  return hasMounted ? <LazilyLoadedSpeciesSelector /> : null;
+};
+
+export default SpeciesSelectorPage;
+
+// not really fetching anything; just setting page meta
+export const serverFetch: ServerFetch = async (params) => {
+  params.store.dispatch(
+    updatePageMeta({
+      title: pageTitle,
+      description: pageDescription
+    })
+  );
+};

--- a/src/content/app/new-species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.scss
+++ b/src/content/app/new-species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.scss
@@ -1,0 +1,3 @@
+.placeholderMessage {
+  font-size: 14px;
+}

--- a/src/content/app/new-species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
+++ b/src/content/app/new-species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
@@ -1,0 +1,108 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { useAppSelector } from 'src/store';
+
+import * as urlFor from 'src/shared/helpers/urlHelper';
+
+import { getCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
+
+import AppBar from 'src/shared/components/app-bar/AppBar';
+import { HelpPopupButton } from 'src/shared/components/help-popup';
+import SpeciesLozenge from 'src/shared/components/selected-species/SpeciesLozenge';
+import SpeciesTabsWrapper from 'src/shared/components/species-tabs-wrapper/SpeciesTabsWrapper';
+import GeneSearchButton from 'src/shared/components/gene-search-button/GeneSearchButton';
+import GeneSearchCloseButton from 'src/shared/components/gene-search-button/GeneSearchCloseButton';
+
+import type { CommittedItem } from 'src/content/app/species-selector/types/species-search';
+
+import styles from './SpeciesSelectorAppBar.scss';
+
+export const placeholderMessage =
+  'Find and add your favourite species to use them across the site';
+
+const PlaceholderMessage = () => (
+  <div className={styles.placeholderMessage}>{placeholderMessage}</div>
+);
+
+type Props = {
+  onGeneSearchToggle: () => void;
+  isGeneSearchMode: boolean;
+};
+
+export const SpeciesSelectorAppBar = (props: Props) => {
+  const selectedSpecies = useAppSelector(getCommittedSpecies);
+
+  const mainContent =
+    selectedSpecies.length > 0 ? (
+      <SelectedSpeciesList selectedSpecies={selectedSpecies} {...props} />
+    ) : (
+      <PlaceholderMessage />
+    );
+
+  return (
+    <AppBar
+      appName="Species Selector"
+      mainContent={mainContent}
+      aside={<HelpPopupButton slug="species-selector-intro" />}
+    />
+  );
+};
+
+const SelectedSpeciesList = (
+  props: Props & { selectedSpecies: CommittedItem[] }
+) => {
+  const navigate = useNavigate();
+
+  const showSpeciesPage = (species: CommittedItem) => {
+    const genomeIdForUrl = species.genome_tag ?? species.genome_id;
+    const speciesPageUrl = urlFor.speciesPage({
+      genomeId: genomeIdForUrl
+    });
+
+    navigate(speciesPageUrl);
+  };
+
+  const conditionalSpeciesProps = !props.isGeneSearchMode
+    ? ({ onClick: showSpeciesPage, theme: 'blue' } as const)
+    : ({ theme: 'grey' } as const);
+
+  const selectedSpecies = props.selectedSpecies.map((species) => (
+    <SpeciesLozenge
+      key={species.genome_id}
+      species={species}
+      {...conditionalSpeciesProps}
+    />
+  ));
+
+  const geneSearchButton = props.isGeneSearchMode ? (
+    <GeneSearchCloseButton
+      key="find-a-gene"
+      onClick={props.onGeneSearchToggle}
+    />
+  ) : (
+    <GeneSearchButton key="find-a-gene" onClick={props.onGeneSearchToggle} />
+  );
+
+  const speciesTabsWrapperContent = [...selectedSpecies, geneSearchButton];
+
+  return <SpeciesTabsWrapper speciesTabs={speciesTabsWrapperContent} />;
+};
+
+export default SpeciesSelectorAppBar;

--- a/src/content/app/species-selector/SpeciesSelector.tsx
+++ b/src/content/app/species-selector/SpeciesSelector.tsx
@@ -23,6 +23,7 @@ import GeneSearchPanel from 'src/shared/components/gene-search-panel/GeneSearchP
 
 import styles from './SpeciesSelector.scss';
 
+// TODO: figure out how gene search ought to work alongside the species search results
 type View = 'default' | 'gene-search';
 
 const SpeciesSelector = () => {

--- a/src/routes/routesConfig.tsx
+++ b/src/routes/routesConfig.tsx
@@ -22,6 +22,9 @@ import HomePage, {
 import SpeciesSelectorPage, {
   serverFetch as speciesSelectorServerFetch
 } from 'src/content/app/species-selector/SpeciesSelectorPage';
+import NewSpeciesSelectorPage, {
+  serverFetch as newSpeciesSelectorServerFetch
+} from 'src/content/app/new-species-selector/SpeciesSelectorPage';
 import SpeciesPage, {
   serverFetch as speciesPageServerFetch
 } from 'src/content/app/species/SpeciesPage';
@@ -69,6 +72,12 @@ const routes: RouteConfig[] = [
     path: '/species-selector',
     element: <SpeciesSelectorPage />,
     serverFetch: speciesSelectorServerFetch
+  },
+  // TODO: For the new species selector below, change the route and the component name when we are done (remove "new")
+  {
+    path: '/new-species-selector',
+    element: <NewSpeciesSelectorPage />,
+    serverFetch: newSpeciesSelectorServerFetch
   },
   {
     path: '/species/:genomeId',


### PR DESCRIPTION
## Description
This PR adds a new route to display the new Species Selector component. 

If you navigate to `/new-species-selector`, you will see the following screen:

![localhost_8080_new-species-selector](https://github.com/Ensembl/ensembl-client/assets/6834224/935b3640-7a31-483c-b160-a10bd55234ca)

The `SpeciesSelectorAppBar` component is almost entirely a copy-paste from the current species selector. I just wanted something to show up in the top of the page. This component will be updated later to bring it closer to what's in XD.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2005

## Deployment URL(s)
http://new-species-selector-route.review.ensembl.org/new-species-selector