### PR TITLE
Species search results table

### DIFF
--- a/src/content/app/new-species-selector/components/species-search-results-summary/SpeciesSearchResultsSummary.scss
+++ b/src/content/app/new-species-selector/components/species-search-results-summary/SpeciesSearchResultsSummary.scss
@@ -1,0 +1,11 @@
+@import 'src/styles/common';
+
+.container {
+  min-height: 86px;
+  padding-top: 32px;
+  padding-left: 20px;
+}
+
+.searchMatchesCount {
+  font-weight: $bold;
+}

--- a/src/content/app/new-species-selector/components/species-search-results-summary/SpeciesSearchResultsSummary.tsx
+++ b/src/content/app/new-species-selector/components/species-search-results-summary/SpeciesSearchResultsSummary.tsx
@@ -1,0 +1,49 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import type { SpeciesSearchResponse } from 'src/content/app/new-species-selector/state/species-selector-api-slice/speciesSelectorApiSlice';
+
+import styles from './SpeciesSearchResultsSummary.scss';
+
+// TODO update the props to reflect the fact that results may come from either search or from a popular species
+type Props = {
+  searchResult?: SpeciesSearchResponse;
+};
+
+// TODO: add a filter component to this section
+
+const SpeciesSearchResultsSummary = (props: Props) => {
+  const searchMatchesCount = props.searchResult?.meta.total_count;
+
+  // TODO: style the contents differently if the results are from a popular species
+
+  return (
+    <section className={styles.container}>
+      {searchMatchesCount && searchMatchesCount > 1 && (
+        <span>
+          <span className={styles.searchMatchesCount}>
+            {searchMatchesCount}
+          </span>{' '}
+          results
+        </span>
+      )}
+    </section>
+  );
+};
+
+export default SpeciesSearchResultsSummary;

--- a/src/content/app/new-species-selector/components/species-search-results-table/SpeciesSearchResultsTable.scss
+++ b/src/content/app/new-species-selector/components/species-search-results-table/SpeciesSearchResultsTable.scss
@@ -1,0 +1,13 @@
+@import 'src/styles/common';
+
+.table {
+  --table-background: $light-grey;
+}
+
+.showMore {
+  color: $blue;
+}
+
+.referenceGenome {
+  font-style: italic;
+}

--- a/src/content/app/new-species-selector/components/species-search-results-table/SpeciesSearchResultsTable.tsx
+++ b/src/content/app/new-species-selector/components/species-search-results-table/SpeciesSearchResultsTable.tsx
@@ -16,6 +16,8 @@
 
 import React from 'react';
 
+import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
+
 import { Table } from 'src/shared/components/table';
 import Checkbox from 'src/shared/components/checkbox/Checkbox';
 
@@ -83,7 +85,7 @@ const SpeciesSearchResultsTable = (props: Props) => {
                 onChange={() => onSpeciesPreselect(searchMatch)}
               />
             </td>
-            <td>{searchMatch.common_name}</td>
+            <td>{searchMatch.common_name ?? '-'}</td>
             <td>{searchMatch.scientific_name}</td>
             <td>
               <SpeciesType species={searchMatch} />
@@ -100,8 +102,14 @@ const SpeciesSearchResultsTable = (props: Props) => {
 
             {isExpanded && (
               <>
-                <td>{searchMatch.coding_genes_count}</td>
-                <td>{searchMatch.contig_n50}</td>
+                <td>
+                  {getCommaSeparatedNumber(searchMatch.coding_genes_count)}
+                </td>
+                <td>
+                  {searchMatch.contig_n50
+                    ? getCommaSeparatedNumber(searchMatch.contig_n50)
+                    : '-'}
+                </td>
                 <td>VAR</td>
                 <td>REG</td>
                 <td>{searchMatch.annotation_provider}</td>

--- a/src/content/app/new-species-selector/components/species-search-results-table/SpeciesSearchResultsTable.tsx
+++ b/src/content/app/new-species-selector/components/species-search-results-table/SpeciesSearchResultsTable.tsx
@@ -1,0 +1,142 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { Table } from 'src/shared/components/table';
+import Checkbox from 'src/shared/components/checkbox/Checkbox';
+
+import type { SpeciesSearchMatch } from 'src/content/app/new-species-selector/types/speciesSearchMatch';
+
+import styles from './SpeciesSearchResultsTable.scss';
+
+type Props = {
+  isExpanded: boolean;
+  results: SpeciesSearchMatch[];
+  preselectedSpecies: SpeciesSearchMatch[];
+  onTableExpandToggle: () => void;
+  onSpeciesSelectToggle: (
+    species: SpeciesSearchMatch,
+    isAdding?: boolean
+  ) => void;
+  // TODO: add selectedGenomes — they should be shown but disabled
+};
+
+const SpeciesSearchResultsTable = (props: Props) => {
+  const { isExpanded, results, preselectedSpecies, onSpeciesSelectToggle } =
+    props;
+  const preselectedSpeciesIds = new Set(
+    preselectedSpecies.map(({ genome_id }) => genome_id)
+  ); // to reduce further iteration
+
+  const onSpeciesPreselect = (species: SpeciesSearchMatch) => {
+    const isAdding = !preselectedSpeciesIds.has(species.genome_id);
+    onSpeciesSelectToggle(species, isAdding);
+  };
+
+  return (
+    <Table className={styles.table}>
+      <thead>
+        <tr>
+          <th>Select to add</th>
+          <th>Common name</th>
+          <th>Scientific name</th>
+          <th>Type</th>
+          <th>Assembly</th>
+          <th>Assembly accession</th>
+
+          <th>
+            <ShowMore {...props} />
+          </th>
+
+          {isExpanded && (
+            <>
+              <th>Coding genes</th>
+              <th>N50</th>
+              <th>Variation</th>
+              <th>Regulation</th>
+              <th>Annotation provider</th>
+              <th>Annotation method</th>
+            </>
+          )}
+        </tr>
+      </thead>
+      <tbody>
+        {results.map((searchMatch) => (
+          <tr key={searchMatch.genome_id}>
+            <td>
+              <Checkbox
+                checked={preselectedSpeciesIds.has(searchMatch.genome_id)}
+                onChange={() => onSpeciesPreselect(searchMatch)}
+              />
+            </td>
+            <td>{searchMatch.common_name}</td>
+            <td>{searchMatch.scientific_name}</td>
+            <td>
+              <SpeciesType species={searchMatch} />
+            </td>
+            <td>{searchMatch.assembly.name}</td>
+            <td>
+              <a href={searchMatch.assembly.url}>
+                {searchMatch.assembly.accession_id}
+              </a>
+            </td>
+
+            {/* empty column under the 'show more' heading */}
+            <td />
+
+            {isExpanded && (
+              <>
+                <td>{searchMatch.coding_genes_count}</td>
+                <td>{searchMatch.contig_n50}</td>
+                <td>VAR</td>
+                <td>REG</td>
+                <td>{searchMatch.annotation_provider}</td>
+                <td>{searchMatch.annotation_method}</td>
+              </>
+            )}
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  );
+};
+
+const ShowMore = (props: Props) => {
+  const { isExpanded, onTableExpandToggle } = props;
+  const text = isExpanded ? 'Show less' : 'Show more';
+
+  return (
+    <button className={styles.showMore} onClick={onTableExpandToggle}>
+      {text}
+    </button>
+  );
+};
+
+const SpeciesType = (props: { species: SpeciesSearchMatch }) => {
+  const { type: speciesType, is_reference } = props.species;
+  if (is_reference) {
+    return <span className={styles.referenceGenome}>Reference</span>;
+  }
+
+  if (!speciesType) {
+    return '-';
+  }
+
+  return `${speciesType.kind} - ${speciesType.value}`;
+};
+
+export default SpeciesSearchResultsTable;

--- a/src/content/app/new-species-selector/state/species-selector-api-slice/speciesSelectorApiSlice.ts
+++ b/src/content/app/new-species-selector/state/species-selector-api-slice/speciesSelectorApiSlice.ts
@@ -19,19 +19,19 @@ import restApiSlice from 'src/shared/state/api-slices/restSlice';
 import type { PopularSpecies } from 'src/content/app/new-species-selector/types/popularSpecies';
 import type { SpeciesSearchMatch } from 'src/content/app/new-species-selector/types/speciesSearchMatch';
 
-type PopularSpeciesRequestParams = {
+export type PopularSpeciesRequestParams = {
   selected_genome_ids?: string[]; // <-- // so that the backend can tell us whether popular species contain the genomes that user has selected
 };
 
-type PopularSpeciesResponse = {
+export type PopularSpeciesResponse = {
   popular_species: PopularSpecies[];
 };
 
-type SpeciesSearchRequestParams = {
+export type SpeciesSearchRequestParams = {
   query: string;
 };
 
-type SpeciesSearchResponse = {
+export type SpeciesSearchResponse = {
   matches: SpeciesSearchMatch[];
   meta: {
     total_count: number;

--- a/src/content/app/new-species-selector/state/species-selector-api-slice/speciesSelectorApiSlice.ts
+++ b/src/content/app/new-species-selector/state/species-selector-api-slice/speciesSelectorApiSlice.ts
@@ -17,6 +17,7 @@
 import restApiSlice from 'src/shared/state/api-slices/restSlice';
 
 import type { PopularSpecies } from 'src/content/app/new-species-selector/types/popularSpecies';
+import type { SpeciesSearchMatch } from 'src/content/app/new-species-selector/types/speciesSearchMatch';
 
 type PopularSpeciesRequestParams = {
   selected_genome_ids?: string[]; // <-- // so that the backend can tell us whether popular species contain the genomes that user has selected
@@ -26,6 +27,17 @@ type PopularSpeciesResponse = {
   popular_species: PopularSpecies[];
 };
 
+type SpeciesSearchRequestParams = {
+  query: string;
+};
+
+type SpeciesSearchResponse = {
+  matches: SpeciesSearchMatch[];
+  meta: {
+    total_count: number;
+  };
+};
+
 const speciesSelectorApiSlice = restApiSlice.injectEndpoints({
   endpoints: (builder) => ({
     getPopularSpecies: builder.query<
@@ -33,14 +45,35 @@ const speciesSelectorApiSlice = restApiSlice.injectEndpoints({
       PopularSpeciesRequestParams
     >({
       queryFn: async () => {
-        // <-- TODO: change this function when BE exposes an endpoint
+        // TODO: change this function when BE exposes an endpoint
         const { popularSpecies: popularSpeciesSampleData } = await import(
           './speciesSelectorSampleData'
         );
         return { data: { popular_species: popularSpeciesSampleData } };
       }
+    }),
+    getSpeciesSearchResults: builder.query<
+      SpeciesSearchResponse,
+      SpeciesSearchRequestParams
+    >({
+      queryFn: async () => {
+        // TODO: change this function when BE exposes an endpoint
+        const { humanSearchMatches } = await import(
+          './speciesSelectorSampleData'
+        );
+
+        return {
+          data: {
+            matches: humanSearchMatches,
+            meta: { total_count: humanSearchMatches.length }
+          }
+        };
+      }
     })
   })
 });
 
-export const { useGetPopularSpeciesQuery } = speciesSelectorApiSlice;
+export const {
+  useGetPopularSpeciesQuery,
+  useLazyGetSpeciesSearchResultsQuery
+} = speciesSelectorApiSlice;

--- a/src/content/app/new-species-selector/state/species-selector-api-slice/speciesSelectorSampleData.ts
+++ b/src/content/app/new-species-selector/state/species-selector-api-slice/speciesSelectorSampleData.ts
@@ -57,9 +57,9 @@ export const humanSearchMatches: SpeciesSearchMatch[] = [
     type: null,
     is_reference: false,
     assembly: {
-      accession_id: 'GCA_000001405.28',
+      accession_id: 'GCA_000001405.14',
       name: 'GRCh37.p13',
-      url: 'https://www.ebi.ac.uk/ena/data/view/GCA_000001405.28'
+      url: 'https://www.ebi.ac.uk/ena/browser/view/GCA_000001405.14'
     },
     coding_genes_count: 20787,
     contig_n50: 38440852,

--- a/src/content/app/new-species-selector/state/species-selector-api-slice/speciesSelectorSampleData.ts
+++ b/src/content/app/new-species-selector/state/species-selector-api-slice/speciesSelectorSampleData.ts
@@ -15,6 +15,7 @@
  */
 
 import type { PopularSpecies } from 'src/content/app/new-species-selector/types/popularSpecies';
+import type { SpeciesSearchMatch } from 'src/content/app/new-species-selector/types/speciesSearchMatch';
 
 export const popularSpecies: PopularSpecies[] = [
   {
@@ -24,5 +25,48 @@ export const popularSpecies: PopularSpecies[] = [
       'https://staging-2020.ensembl.org/static/genome_images/homo_sapiens_GCA_000001405_14.svg', // TODO: change this to updated human image
     members_count: 2,
     is_selected: false
+  }
+];
+
+export const humanSearchMatches: SpeciesSearchMatch[] = [
+  {
+    genome_id: 'a7335667-93e7-11ec-a39d-005056b38ce3',
+    genome_tag: 'grch38',
+    common_name: 'Human',
+    scientific_name: 'Homo sapiens',
+    type: null,
+    is_reference: true,
+    assembly: {
+      accession_id: 'GCA_000001405.28',
+      name: 'GRCh38.p13',
+      url: 'https://www.ebi.ac.uk/ena/data/view/GCA_000001405.28'
+    },
+    coding_genes_count: 20446,
+    contig_n50: 56413054,
+    has_variation: true,
+    has_regulation: true,
+    annotation_provider: 'Ensembl',
+    annotation_method: 'Full genebuild',
+    rank: 1
+  },
+  {
+    genome_id: '704ceb1-948d-11ec-a39d-005056b38ce3',
+    genome_tag: 'grch37',
+    common_name: 'Human',
+    scientific_name: 'Homo sapiens',
+    type: null,
+    is_reference: false,
+    assembly: {
+      accession_id: 'GCA_000001405.28',
+      name: 'GRCh37.p13',
+      url: 'https://www.ebi.ac.uk/ena/data/view/GCA_000001405.28'
+    },
+    coding_genes_count: 20787,
+    contig_n50: 38440852,
+    has_variation: true,
+    has_regulation: true,
+    annotation_provider: 'Ensembl',
+    annotation_method: 'Full genebuild',
+    rank: 2
   }
 ];

--- a/src/content/app/new-species-selector/types/speciesSearchMatch.ts
+++ b/src/content/app/new-species-selector/types/speciesSearchMatch.ts
@@ -16,6 +16,7 @@
 
 export type SpeciesSearchMatch = {
   genome_id: string;
+  genome_tag: string | null;
   common_name: string | null;
   scientific_name: string;
   type: {

--- a/src/content/app/new-species-selector/views/species-selector-results-view/SpeciesSelectorResultsView.scss
+++ b/src/content/app/new-species-selector/views/species-selector-results-view/SpeciesSelectorResultsView.scss
@@ -1,0 +1,6 @@
+@import 'src/styles/common';
+
+.main {
+  height: 100%;
+  padding-left: $global-padding-left;
+}

--- a/src/content/app/new-species-selector/views/species-selector-results-view/SpeciesSelectorResultsView.scss
+++ b/src/content/app/new-species-selector/views/species-selector-results-view/SpeciesSelectorResultsView.scss
@@ -2,5 +2,11 @@
 
 .main {
   height: 100%;
+  display: grid;
+  grid-template-rows: auto auto 1fr;
   padding-left: $global-padding-left;
+}
+
+.tableContainer {
+  overflow: auto;
 }

--- a/src/content/app/new-species-selector/views/species-selector-results-view/SpeciesSelectorResultsView.tsx
+++ b/src/content/app/new-species-selector/views/species-selector-results-view/SpeciesSelectorResultsView.tsx
@@ -20,18 +20,31 @@ import { useAppDispatch } from 'src/store';
 
 import { setModalView } from 'src/content/app/new-species-selector/state/species-selector-ui-slice/speciesSelectorUISlice';
 
+import SpeciesSearchField from 'src/content/app/new-species-selector/components/species-search-field/SpeciesSearchField';
 import ModalView from 'src/shared/components/modal-view/ModalView';
 
-const SpeciesSelectorResultsView = () => {
+import styles from './SpeciesSelectorResultsView.scss';
+
+const SpeciesSelectorResultslView = () => {
   const dispatch = useAppDispatch();
 
   const onClose = () => {
     dispatch(setModalView(null));
   };
 
-  const content = 'There will be content!';
-
-  return <ModalView onClose={onClose}>{content}</ModalView>;
+  return (
+    <ModalView onClose={onClose}>
+      <Content />
+    </ModalView>
+  );
 };
 
-export default SpeciesSelectorResultsView;
+const Content = () => {
+  return (
+    <div className={styles.main}>
+      <SpeciesSearchField />
+    </div>
+  );
+};
+
+export default SpeciesSelectorResultslView;

--- a/src/content/app/new-species-selector/views/species-selector-results-view/SpeciesSelectorResultsView.tsx
+++ b/src/content/app/new-species-selector/views/species-selector-results-view/SpeciesSelectorResultsView.tsx
@@ -14,14 +14,20 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 
 import { useAppDispatch } from 'src/store';
 
+import { useLazyGetSpeciesSearchResultsQuery } from 'src/content/app/new-species-selector/state/species-selector-api-slice/speciesSelectorApiSlice';
+
 import { setModalView } from 'src/content/app/new-species-selector/state/species-selector-ui-slice/speciesSelectorUISlice';
 
-import SpeciesSearchField from 'src/content/app/new-species-selector/components/species-search-field/SpeciesSearchField';
 import ModalView from 'src/shared/components/modal-view/ModalView';
+import SpeciesSearchField from 'src/content/app/new-species-selector/components/species-search-field/SpeciesSearchField';
+import SpeciesSearchResultsSummary from 'src/content/app/new-species-selector/components/species-search-results-summary/SpeciesSearchResultsSummary';
+import SpeciesSearchResultsTable from 'src/content/app/new-species-selector/components/species-search-results-table/SpeciesSearchResultsTable';
+
+import type { SpeciesSearchMatch } from 'src/content/app/new-species-selector/types/speciesSearchMatch';
 
 import styles from './SpeciesSelectorResultsView.scss';
 
@@ -40,9 +46,50 @@ const SpeciesSelectorResultslView = () => {
 };
 
 const Content = () => {
+  const [searchTrigger, result] = useLazyGetSpeciesSearchResultsQuery();
+  const { currentData } = result;
+  const [preselectedSpecies, setPreselectedSpecies] = useState<
+    SpeciesSearchMatch[]
+  >([]);
+  const [isTableExpanded, setIsTableExpanded] = useState(false);
+
+  useEffect(() => {
+    searchTrigger({ query: 'hello' }); // TODO: read the query from the search field
+  }, []);
+
+  const onSpeciesPreselectToggle = (
+    species: SpeciesSearchMatch,
+    isAdding?: boolean
+  ) => {
+    if (isAdding) {
+      setPreselectedSpecies([...preselectedSpecies, species]);
+    } else {
+      const updatedList = preselectedSpecies.filter(
+        ({ genome_id }) => genome_id !== species.genome_id
+      );
+      setPreselectedSpecies(updatedList);
+    }
+  };
+
+  const onTableExpandToggle = () => {
+    setIsTableExpanded(!isTableExpanded);
+  };
+
   return (
     <div className={styles.main}>
       <SpeciesSearchField />
+      <SpeciesSearchResultsSummary searchResult={currentData} />
+      {currentData && (
+        <div className={styles.tableContainer}>
+          <SpeciesSearchResultsTable
+            results={currentData.matches}
+            isExpanded={isTableExpanded}
+            onTableExpandToggle={onTableExpandToggle}
+            preselectedSpecies={preselectedSpecies}
+            onSpeciesSelectToggle={onSpeciesPreselectToggle}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/shared/components/modal-view/ModalView.scss
+++ b/src/shared/components/modal-view/ModalView.scss
@@ -8,6 +8,7 @@
   background-color: $light-grey;
   padding-right: calc(#{$standard-gutter} + var(--close-button-size));
   padding-top: calc(26px + var(--close-button-size));
+  overflow: auto;
 }
 
 .closeButton {

--- a/src/shared/components/table/Table.scss
+++ b/src/shared/components/table/Table.scss
@@ -21,7 +21,7 @@
 
 .table th,
 .table td {
-  padding: var(--table-data-padding, '6px 12px');
+  padding: var(--table-data-padding, 6px 12px);
 }
 
 .table td {


### PR DESCRIPTION
## Description
This PR adds a table of search results. The table has a column of checkboxes that can be ticked or unticked.

## Will be done in subsequent PRs
- Sorting
- Filled vs empty dot in variation and regulation columns
- UI differences between a table added via search vs a table added via the pressing of the popular species button
- Left-alignment of the table column headings, as in the design

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2011

## Deployment URL(s)
http://species-search-results-table.review.ensembl.org

## Views affected
http://species-search-results-table.review.ensembl.org/new-species-selector