### PR TITLE
Add a list of popular species to the new species selector screen

### DIFF
--- a/src/content/app/new-species-selector/components/popular-species-list/PopularSpeciesList.scss
+++ b/src/content/app/new-species-selector/components/popular-species-list/PopularSpeciesList.scss
@@ -1,0 +1,16 @@
+@import 'src/styles/common';
+
+.sectionHeading {
+  font-size: 13px;
+  font-weight: $light;
+  margin: 0 0 20px 0;
+  display: block;
+}
+
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: 27px;
+  row-gap: 20px;
+  max-width: 1150px;
+}

--- a/src/content/app/new-species-selector/components/popular-species-list/PopularSpeciesList.tsx
+++ b/src/content/app/new-species-selector/components/popular-species-list/PopularSpeciesList.tsx
@@ -1,0 +1,54 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { useAppDispatch } from 'src/store';
+
+import { setModalView } from 'src/content/app/new-species-selector/state/species-selector-ui-slice/speciesSelectorUISlice';
+import { useGetPopularSpeciesQuery } from 'src/content/app/new-species-selector/state/species-selector-api-slice/speciesSelectorApiSlice';
+
+import PopularSpeciesButton from 'src/content/app/new-species-selector/components/popular-species-button/PopularSpeciesButton';
+
+import styles from './PopularSpeciesList.scss';
+
+const PopularSpeciesList = () => {
+  const dispatch = useAppDispatch();
+  const { currentData } = useGetPopularSpeciesQuery({
+    selected_genome_ids: []
+  });
+
+  const openSelectionModalView = () => {
+    dispatch(setModalView('species-search'));
+  };
+
+  return (
+    <>
+      <h1 className={styles.sectionHeading}>Popular</h1>
+      <div className={styles.container}>
+        {currentData?.popular_species.map((species) => (
+          <PopularSpeciesButton
+            key={species.id}
+            species={species}
+            onClick={openSelectionModalView}
+          />
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default PopularSpeciesList;

--- a/src/content/app/new-species-selector/state/species-selector-api-slice/speciesSelectorSampleData.ts
+++ b/src/content/app/new-species-selector/state/species-selector-api-slice/speciesSelectorSampleData.ts
@@ -24,5 +24,332 @@ export const popularSpecies: PopularSpecies[] = [
       'https://staging-2020.ensembl.org/static/genome_images/homo_sapiens_GCA_000001405_14.svg', // TODO: change this to updated human image
     members_count: 2,
     is_selected: false
+  },
+  {
+    id: 2,
+    name: 'Mouse',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/mus_musculus.svg',
+    members_count: 16,
+    is_selected: false
+  },
+  {
+    id: 3,
+    name: 'Zebrafish',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/danio_rerio.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 4,
+    name: 'Wheat',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/triticum_aestivum.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 5,
+    name: 'Rice',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/oryza_sativa.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 6,
+    name: 'Thale cress',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/arabidopsis_thaliana.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 7,
+    name: 'Cattle',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/bos_taurus.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 8,
+    name: 'Rat',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/rattus_norvegicus.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 9,
+    name: 'Pig',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/sus_scrofa.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 10,
+    name: 'Maize',
+    image: 'https://staging-2020.ensembl.org/static/genome_images/zea_mays.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 11,
+    name: 'Chicken',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/gallus_gallus.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 12,
+    name: 'Dog',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/canis_familiaris.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 13,
+    name: 'Barley',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/hordeum_vulgare.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 14,
+    name: 'Drosophila melanogaster',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/drosophila_melanogaster.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 15,
+    name: 'Japanese rice fish',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/oryzias_latipes.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 16,
+    name: 'Sheep',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/ovis_aries.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 17,
+    name: 'Grape',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/vitis_vinifera.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 18,
+    name: 'Tomato',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/solanum_lycopersicum.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 19,
+    name: 'Horse',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/equus_caballus.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 20,
+    name: 'Rapeseed',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/brassica_napus.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 21,
+    name: 'Potato',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/solanum_tuberosum.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 22,
+    name: 'Rabbit',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/oryctolagus_cuniculus.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 23,
+    name: 'Saccharomyces cerevisiae',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/saccharomyces_cerevisiae.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 24,
+    name: 'C. elegans',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/caenorhabditis_elegans.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 25,
+    name: 'Cat',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/felis_catus.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 26,
+    name: 'Macaque',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/macaca_mulatta.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 27,
+    name: 'Mexican tetra',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/astyanax_mexicanus.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 28,
+    name: 'Chimpanzee',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/pan_troglodytes.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 29,
+    name: 'Nile tilapia',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/oreochromis_niloticus.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 30,
+    name: 'Goat',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/capra_hircus.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 31,
+    name: 'Brassica oleracea',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/brassica_oleracea.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 32,
+    name: 'Tropical clawed frog',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/xenopus_tropicalis.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 33,
+    name: 'Soybean',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/glycine_max.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 34,
+    name: 'Chinese hamster',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/cricetulus_griseus.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 35,
+    name: 'Medicago truncatula',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/medicago_truncatula.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 36,
+    name: 'Brassica rapa',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/brassica_rapa.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 37,
+    name: 'Sorghum bicolor',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/sorghum_bicolor.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 38,
+    name: 'Atlantic salmon',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/salmo_salar.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 39,
+    name: 'Aegilops tauschii',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/aegilops_tauschii.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 40,
+    name: 'E. coli',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/escherichia_coli.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 41,
+    name: 'Plasmodium falciparum',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/plasmodium_falciparum.svg',
+    members_count: 1,
+    is_selected: false
+  },
+  {
+    id: 42,
+    name: 'Durum wheat',
+    image:
+      'https://staging-2020.ensembl.org/static/genome_images/triticum_aestivum.svg',
+    members_count: 1,
+    is_selected: false
   }
 ];

--- a/src/content/app/new-species-selector/views/species-selector-main-view/SpeciesSelectorMainView.scss
+++ b/src/content/app/new-species-selector/views/species-selector-main-view/SpeciesSelectorMainView.scss
@@ -2,6 +2,9 @@
 
 .main {
   height: 100%;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  overflow: auto;
 }
 
 .searchPanel {
@@ -12,6 +15,10 @@
 }
 
 .popularSpecies {
+  height: 100%;
   padding-top: 26px;
   padding-left: $global-padding-left;
+  padding-right: $standard-gutter;
+  padding-bottom: $global-padding-bottom;
+  overflow: auto;
 }

--- a/src/content/app/new-species-selector/views/species-selector-main-view/SpeciesSelectorMainView.scss
+++ b/src/content/app/new-species-selector/views/species-selector-main-view/SpeciesSelectorMainView.scss
@@ -10,3 +10,8 @@
   padding-top: 38px;
   background-color: $light-grey;
 }
+
+.popularSpecies {
+  padding-top: 26px;
+  padding-left: $global-padding-left;
+}

--- a/src/content/app/new-species-selector/views/species-selector-main-view/SpeciesSelectorMainView.tsx
+++ b/src/content/app/new-species-selector/views/species-selector-main-view/SpeciesSelectorMainView.tsx
@@ -16,31 +16,19 @@
 
 import React from 'react';
 
-import { useAppDispatch } from 'src/store';
-
-import { setModalView } from 'src/content/app/new-species-selector/state/species-selector-ui-slice/speciesSelectorUISlice';
-
 import SpeciesSearchField from 'src/content/app/new-species-selector/components/species-search-field/SpeciesSearchField';
+import PopularSpeciesList from 'src/content/app/new-species-selector/components/popular-species-list/PopularSpeciesList';
 
 import styles from './SpeciesSelectorMainView.scss';
 
 const SpeciesSelectorMainView = () => {
-  const dispatch = useAppDispatch();
-
-  const openSelectionModalView = () => {
-    dispatch(setModalView('species-search'));
-  };
-
   return (
     <div className={styles.main}>
       <div className={styles.searchPanel}>
         <SpeciesSearchField />
       </div>
-      <div>
-        <label>Popular</label>
-        <div>
-          <button onClick={openSelectionModalView}>Open modal view</button>
-        </div>
+      <div className={styles.popularSpecies}>
+        <PopularSpeciesList />
       </div>
     </div>
   );


### PR DESCRIPTION
## Description
This PR adds the buttons for 42 popular species to the main view of the new species selector. When a button is clicked, the species search modal view will appear. In this PR, the modal is not yet populated with anything.

**Note**: the images appearing in the buttons are still the old ones.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2021

## Deployment URL(s)
http://popular-species-list.review.ensembl.org/new-species-selector