### PR TITLE
Use the same root redux reducer for both server-side and client-side

### DIFF
--- a/src/root/rootReducer.ts
+++ b/src/root/rootReducer.ts
@@ -48,16 +48,4 @@ const createRootReducer = () =>
     [restApiSlice.reducerPath]: restApiSlice.reducer
   });
 
-export const createServerSideRootReducer = () =>
-  combineReducers({
-    global,
-    pageMeta,
-    speciesSelector,
-    entityViewer,
-    genome,
-    blast,
-    [graphqlApiSlice.reducerPath]: graphqlApiSlice.reducer,
-    [restApiSlice.reducerPath]: restApiSlice.reducer
-  });
-
 export default createRootReducer;

--- a/src/server/serverSideReduxStore.ts
+++ b/src/server/serverSideReduxStore.ts
@@ -19,13 +19,15 @@ import { configureStore } from '@reduxjs/toolkit';
 import graphqlApiSlice from 'src/shared/state/api-slices/graphqlApiSlice';
 import restApiSlice from 'src/shared/state/api-slices/restSlice';
 
-import { createServerSideRootReducer } from 'src/root/rootReducer';
+import createRootReducer from 'src/root/rootReducer';
 
+// compared to the client-side store, the server-side store does not need
+// the middleware for redux-observable
 const middleware = [graphqlApiSlice.middleware, restApiSlice.middleware];
 
 export const getServerSideReduxStore = () => {
   return configureStore({
-    reducer: createServerSideRootReducer(),
+    reducer: createRootReducer(),
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware().concat(middleware)
   });


### PR DESCRIPTION
## Description
There used to be a reason to separate client-side redux root reducer from the server-side root reducer (some of the reducers were incompatible with server side, because they were calling browser apis at initialisation); but this no longer seems to be the case.

It seems more convenient and less complex to use the same root reducer for both client-side and server-side code. Any benefits from making the server-side reducer smaller are going to be negligible.


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2019

## Deployment URL(s)
http://same-root-reducer.review.ensembl.org


## Views affected
<!--
_List the website view(s) that you know are affected by this change._
_If possible please provide a relative or localhost URL that can be used to view the change._
-->