### PR TITLE
Use new variant id schema

### DIFF
--- a/src/content/app/genome-browser/contexts/genome-browser-ids-context/useGenomeBrowserUrlValidator.ts
+++ b/src/content/app/genome-browser/contexts/genome-browser-ids-context/useGenomeBrowserUrlValidator.ts
@@ -224,23 +224,23 @@ const checkFocusLocation = async (params: CheckFocusObjectParams) => {
 
 const checkFocusVariant = async (params: CheckFocusObjectParams) => {
   // NOTE: so far, only checking that focus variant id conforms to the following format
-  // <region_name>:<start_coordinate>:<variant_name>:<reference_sequence>
+  // <region_name>:<start_coordinate>:<variant_name>
   const { parsedFocusObjectId } = params;
   const { objectId } = parsedFocusObjectId;
 
   const variantIdParts = objectId.split(':');
 
-  if (variantIdParts.length !== 4) {
-    // expect four parts in a focus variant id
+  if (variantIdParts.length !== 3) {
+    // expect three parts in a focus variant id
     return {
       isMissingFocusObject: true
     };
   }
 
-  const [regionName, start, variantName, referenceSequence] = variantIdParts; // eslint-disable-line
+  const [regionName, start, variantName] = variantIdParts; // eslint-disable-line
 
-  // we know that at least start coordinate must be a number, and reference sequence consists only of letters
-  if (/\D/.test(start) || /[^a-z]/i.test(referenceSequence)) {
+  // we know that at least the start coordinate must consist only of digits
+  if (/\D/.test(start)) {
     return {
       isMissingFocusObject: true
     };

--- a/src/content/app/genome-browser/contexts/genome-browser-ids-context/useGenomeBrowserUrlValidator.ts
+++ b/src/content/app/genome-browser/contexts/genome-browser-ids-context/useGenomeBrowserUrlValidator.ts
@@ -229,8 +229,11 @@ const checkFocusVariant = async (params: CheckFocusObjectParams) => {
   const { objectId } = parsedFocusObjectId;
 
   const variantIdParts = objectId.split(':');
+  // a valid id consists of three non-empty parts
+  const hasValidIdParts =
+    variantIdParts.length === 3 && variantIdParts.every((part) => part.length);
 
-  if (variantIdParts.length !== 3) {
+  if (!hasValidIdParts) {
     // expect three parts in a focus variant id
     return {
       isMissingFocusObject: true

--- a/src/content/app/genome-browser/contexts/genome-browser-ids-context/useGenomeBrowserUrlValidator.ts
+++ b/src/content/app/genome-browser/contexts/genome-browser-ids-context/useGenomeBrowserUrlValidator.ts
@@ -162,6 +162,8 @@ const checkFocusObject = async (
     return checkFocusGene(params);
   } else if (type === 'location') {
     return checkFocusLocation(params);
+  } else if (type === 'variant') {
+    return checkFocusVariant(params);
   }
 
   return { isMissingFocusObject: false }; // largely unnecessary line (code should never reach it), to satisfy the function contract
@@ -218,6 +220,35 @@ const checkFocusLocation = async (params: CheckFocusObjectParams) => {
   }
 
   return { isMissingFocusObject };
+};
+
+const checkFocusVariant = async (params: CheckFocusObjectParams) => {
+  // NOTE: so far, only checking that focus variant id conforms to the following format
+  // <region_name>:<start_coordinate>:<variant_name>:<reference_sequence>
+  const { parsedFocusObjectId } = params;
+  const { objectId } = parsedFocusObjectId;
+
+  const variantIdParts = objectId.split(':');
+
+  if (variantIdParts.length !== 4) {
+    // expect four parts in a focus variant id
+    return {
+      isMissingFocusObject: true
+    };
+  }
+
+  const [regionName, start, variantName, referenceSequence] = variantIdParts; // eslint-disable-line
+
+  // we know that at least start coordinate must be a number, and reference sequence consists only of letters
+  if (/\D/.test(start) || /[^a-z]/i.test(referenceSequence)) {
+    return {
+      isMissingFocusObject: true
+    };
+  }
+
+  return {
+    isMissingFocusObject: false
+  };
 };
 
 type CheckLocationFromUrlParams = {

--- a/src/content/app/genome-browser/services/genome-browser-service/genomeBrowserCommands.ts
+++ b/src/content/app/genome-browser/services/genome-browser-service/genomeBrowserCommands.ts
@@ -132,8 +132,15 @@ const setFocusGene: typeof setFocus = (payload) => {
 const setFocusVariant: typeof setFocus = (payload) => {
   const { genomeBrowser, genomeId, focusId, bringIntoView } = payload;
 
+  const [regionName, start, variantName] = focusId.split(':');
+
   if (bringIntoView) {
-    genomeBrowser.jump(`focus:variant:${genomeId}:${focusId}`);
+    const startNumber = parseInt(start);
+    const viewportStart = startNumber - 25;
+    const viewportEnd = startNumber + 25;
+
+    genomeBrowser.set_stick(`${genomeId}:${regionName}`);
+    genomeBrowser.goto(viewportStart, viewportEnd);
     genomeBrowser.wait();
   }
 
@@ -141,7 +148,7 @@ const setFocusVariant: typeof setFocus = (payload) => {
   genomeBrowser.switch(['track', 'focus', 'label'], true);
   genomeBrowser.switch(['track', 'focus', 'item', 'variant'], {
     genome_id: genomeId,
-    variant_id: focusId
+    variant_id: variantName
   });
 };
 

--- a/src/content/app/genome-browser/state/api/genomeBrowserApiSlice.ts
+++ b/src/content/app/genome-browser/state/api/genomeBrowserApiSlice.ts
@@ -95,9 +95,11 @@ const genomeBrowserApiSlice = graphqlApiSlice.injectEndpoints({
         const { variantId } = params;
         const knownVariantIds = ['rs699', 'rs71197234', 'rs202155613'];
 
-        const variantIdToImport = knownVariantIds.includes(variantId)
-          ? variantId
-          : knownVariantIds[1];
+        const foundVariantId = knownVariantIds.find((id) =>
+          variantId.includes(id)
+        );
+
+        const variantIdToImport = foundVariantId || knownVariantIds[1];
 
         const variantDataModule = await import(
           `tests/fixtures/variation/${variantIdToImport}`

--- a/src/content/app/genome-browser/state/focus-object/focusObjectSlice.ts
+++ b/src/content/app/genome-browser/state/focus-object/focusObjectSlice.ts
@@ -130,13 +130,14 @@ const buildFocusVariantObject = (payload: {
   variantId: string;
 }): FocusVariant => {
   const { genomeId, objectId, variantId } = payload;
+  const variantName = variantId.split(':')[2];
 
   return {
     type: 'variant',
     genome_id: genomeId,
     object_id: objectId,
     variant_id: variantId,
-    label: variantId,
+    label: variantName,
     location: {
       // just some arbitrary hardcoded location; this will change to proper data in the future
       chromosome: '13',


### PR DESCRIPTION
## Description
As agreed with the Variation team, the ids in the url that are able to uniquely identify a variant need to contain region name, variant start coordinate, variant name (e.g. an rsID), and the sequence of the reference allele, in the following format:

`<region_name>:<start>:<variant_name>`

This PR switches to this convention. The variant string is read from the url, and parsed into significant parts, which are used to direct the genome browser to bring the variant into view. The viewport is calculated as start±25bp. This will allow us to retire the jump file for variants. 

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2016

## Deployment URL(s)
http://new-variant-id.review.ensembl.org

**Examples to try:**
- http://new-variant-id.review.ensembl.org/genome-browser/grch38?focus=variant:1:230710048:rs699
- http://new-variant-id.review.ensembl.org/genome-browser/grch38?focus=variant:13:57932509:rs71197234
- http://new-variant-id.review.ensembl.org/genome-browser/grch38?focus=variant:13:32379902:rs202155613