### PR TITLE
Update Species page layout for smaller screens

### DIFF
--- a/src/content/app/species/components/species-main-view/SpeciesMainView.scss
+++ b/src/content/app/species/components/species-main-view/SpeciesMainView.scss
@@ -55,6 +55,7 @@
     [title] 120px [statistics] 1fr
     [example-link] 150px;
     align-items: center;
+    width: 100%;
   }
 
   .title {
@@ -104,13 +105,16 @@
   }
 }
 
+@container species-statistics-section-collapsed (max-width: 395px) {
+  /* reduce the width of stats elements */
+  .collapsedContent .summaryStat {
+    width: 220px;
+  }
+}
+
 .expandedContent {
   container-name: species-statistics-section-expanded;
   container-type: inline-size;
-  // display: flex;
-  // align-items: center;
-  // padding: 6px 20px;
-  // min-height: 50px;
 }
 
 .statsGroup {
@@ -149,6 +153,13 @@
     grid-area: example-link;
     display: inline-block;
     margin-bottom: 30px;
+  }
+}
+
+@container species-statistics-section-expanded (max-width: 395px) {
+  /* reduce the width of stats elements */
+  .stats > * {
+    width: 220px;
   }
 }
 

--- a/src/content/app/species/components/species-main-view/SpeciesMainView.scss
+++ b/src/content/app/species/components/species-main-view/SpeciesMainView.scss
@@ -1,7 +1,9 @@
 @import 'src/styles/common';
 
 .speciesContainer {
+  width: 100%;
   max-width: 1380px;
+  overflow-x: auto;
 }
 
 .speciesMainViewTop {

--- a/src/content/app/species/components/species-main-view/SpeciesMainView.scss
+++ b/src/content/app/species/components/species-main-view/SpeciesMainView.scss
@@ -19,7 +19,6 @@
 
 .statsWrapper {
   padding: 5px 20px $global-padding-bottom 140px;
-  min-width: 980px;
 }
 
 .exampleLinkText {
@@ -43,14 +42,20 @@
 }
 
 .collapsedContent {
-  display: grid;
-  padding: 6px 20px;
-  grid-template-columns:
-    [title] 120px [first_summary_stat] minmax(250px, 350px)
-    [second_summary_stat] minmax(250px, 350px)
-    [example-link] 150px;
+  container-name: species-statistics-section-collapsed;
+  container-type: inline-size;
+  display: flex;
   align-items: center;
+  padding: 6px 20px;
   min-height: 50px;
+
+  .collapsedContentGrid {
+    display: grid;
+    grid-template-columns:
+    [title] 120px [statistics] 1fr
+    [example-link] 150px;
+    align-items: center;
+  }
 
   .title {
     grid-column: title;
@@ -58,8 +63,14 @@
     font-weight: $light;
   }
 
+  .statisticsContainer {
+    grid-column: statistics;
+    display: flex;
+    flex-wrap: wrap;
+  }
+
   .summaryStat {
-    grid-column: first_summary_stat;
+    width: 250px;
     white-space: nowrap;
 
     .value {
@@ -73,10 +84,6 @@
     }
   }
 
-  .summaryStat + .summaryStat {
-    grid-column: second_summary_stat;
-  }
-
   .exampleLink {
     grid-column: example-link;
   }
@@ -85,6 +92,25 @@
     top: 2px;
     position: relative;
   }
+}
+
+@container species-statistics-section-collapsed (max-width: 549px) {
+  .collapsedContent .collapsedContentGrid {
+    grid-template-columns:
+    [title] 120px [statistics] 1fr;
+  }
+  .collapsedContent .exampleLink {
+    grid-column: statistics;
+  }
+}
+
+.expandedContent {
+  container-name: species-statistics-section-expanded;
+  container-type: inline-size;
+  // display: flex;
+  // align-items: center;
+  // padding: 6px 20px;
+  // min-height: 50px;
 }
 
 .statsGroup {
@@ -108,6 +134,21 @@
 
   .exampleLink {
     grid-column: example-link;
+  }
+}
+
+@container species-statistics-section-expanded (max-width: 549px) {
+  .statsGroupWithExampleLink {
+    grid-template-areas:
+      "title stats"
+      ". example-link";
+    grid-template-columns: 120px 1fr;
+  }
+
+  .statsGroupWithExampleLink .exampleLink {
+    grid-area: example-link;
+    display: inline-block;
+    margin-bottom: 30px;
   }
 }
 

--- a/src/content/app/species/components/species-main-view/SpeciesMainView.scss
+++ b/src/content/app/species/components/species-main-view/SpeciesMainView.scss
@@ -1,9 +1,7 @@
 @import 'src/styles/common';
 
 .speciesContainer {
-  width: 100%;
   max-width: 1380px;
-  overflow-x: auto;
 }
 
 .speciesMainViewTop {

--- a/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
+++ b/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
@@ -80,30 +80,37 @@ const getCollapsedContent = (props: ContentProps) => {
 
   return (
     <div className={styles.collapsedContent}>
-      <span className={styles.title}>{title}</span>
-      {summaryStats?.length ? (
-        summaryStats.map((summaryStat, index) => {
-          return (
-            <div className={styles.summaryStat} key={index}>
-              <span className={styles.value}>{summaryStat.primaryValue}</span>
-              <span className={styles.unit}>{summaryStat.primaryUnit}</span>
-              {helpText && (
-                <span className={styles.questionButton}>
-                  <QuestionButton helpText={helpText} />
-                </span>
-              )}
-            </div>
-          );
-        })
-      ) : (
-        <div className={styles.noData}>no data</div>
-      )}
+      <div className={styles.collapsedContentGrid}>
+        <span className={styles.title}>{title}</span>
 
-      {exampleLinks && species.isEnabled && (
-        <ExampleLinkWithPopup links={exampleLinks}>
-          <span onClick={onExampleLinkClick}>{exampleLinkText}</span>
-        </ExampleLinkWithPopup>
-      )}
+        <div className={styles.statisticsContainer}>
+          {summaryStats?.length ? (
+            summaryStats.map((summaryStat, index) => {
+              return (
+                <div className={styles.summaryStat} key={index}>
+                  <span className={styles.value}>
+                    {summaryStat.primaryValue}
+                  </span>
+                  <span className={styles.unit}>{summaryStat.primaryUnit}</span>
+                  {helpText && (
+                    <span className={styles.questionButton}>
+                      <QuestionButton helpText={helpText} />
+                    </span>
+                  )}
+                </div>
+              );
+            })
+          ) : (
+            <div className={styles.noData}>no data</div>
+          )}
+        </div>
+
+        {exampleLinks && species.isEnabled && (
+          <ExampleLinkWithPopup links={exampleLinks}>
+            <span onClick={onExampleLinkClick}>{exampleLinkText}</span>
+          </ExampleLinkWithPopup>
+        )}
+      </div>
     </div>
   );
 };
@@ -153,6 +160,7 @@ const getExpandedContent = (props: ContentProps) => {
     })
     .filter(Boolean);
 
+  // TODO: here
   return expandedContent.length ? (
     <div className={styles.expandedContent}>{expandedContent}</div>
   ) : null;

--- a/src/content/app/species/components/species-stats/SpeciesStats.tsx
+++ b/src/content/app/species/components/species-stats/SpeciesStats.tsx
@@ -112,7 +112,7 @@ const SpeciesStats = (props: SpeciesStatsProps) => {
         </div>
       )}
 
-      <span className={styles.link}>{props.link}</span>
+      {props.link && <span className={styles.link}>{props.link}</span>}
     </div>
   );
 };

--- a/src/content/app/species/components/species-title-area/SpeciesTitleArea.scss
+++ b/src/content/app/species/components/species-title-area/SpeciesTitleArea.scss
@@ -3,15 +3,15 @@
 $container-padding-right: 20px;
 
 .speciesTitleArea {
+  container-name: species-page-title-area;
+  container-type: inline-size;
+  margin-left: $double-standard-gutter;
+}
+
+.grid {
   display: grid;
-  grid-template-areas:
-    'icon species-name usage-toggle search remove'
-    '. remove-message remove-message remove-message remove-message';
-  grid-template-columns: 60px fit-content(60%) minmax(200px, 680px) auto 1fr;
-  grid-template-rows: 80px auto;
-  grid-column-gap: 20px;
   align-items: center;
-  margin-left: 60px;
+  grid-column-gap: 20px;
   padding-right: $container-padding-right;
 }
 
@@ -42,7 +42,6 @@ $container-padding-right: 20px;
 
 .speciesToggle {
   grid-area: usage-toggle;
-  padding-left: 25px;
 }
 
 .speciesRemove {
@@ -79,31 +78,52 @@ $container-padding-right: 20px;
   }
 }
 
-.speciesTitleAreaCompact {
-  grid-template-areas:
-    'icon species-name usage-toggle remove'
-    '. remove-message remove-message remove-message'
-    '. search . .';
-  grid-template-columns: 60px 150px auto 1fr;
-  grid-template-rows: 80px auto auto;
-  margin-bottom: 20px;
+.remove {
+  grid-area: remove;
+  align-self: start;
+  white-space: nowrap;
+}
+
+@container species-page-title-area (min-width: 761px) {
+  .grid {
+    display: grid;
+    grid-template-areas:
+      'icon species-name usage-toggle search remove'
+      '. remove-message remove-message remove-message remove-message';
+    grid-template-columns: 60px fit-content(60%) minmax(200px, 680px) auto 1fr;
+    grid-template-rows: 80px auto;
+  }
+
+  .speciesToggle {
+    padding-left: 25px;
+  }
+}
+
+
+@container species-page-title-area (min-width: 641px) and (max-width: 760px) {
+  .grid {
+    grid-template-areas:
+      'icon species-name usage-toggle remove'
+      '. remove-message remove-message remove-message'
+      '. search . .';
+    grid-template-columns: 60px min-content auto 1fr;
+    grid-template-rows: 80px auto auto;
+    margin-bottom: 20px;
+  }
 
   .speciesNameWrapper {
-    grid-area: species-name;
     min-height: 60px;
     display: flex;
     align-items: center;
   }
 
-  .speciesToggle {
-    grid-area: usage-toggle;
-    padding: 0;
+  .assemblyName {
+    padding-top: 3px;
+    white-space: nowrap;
   }
 
-  .remove {
-    grid-area: remove;
-    align-self: start;
-    white-space: nowrap;
+  .speciesToggle {
+    padding: 0;
   }
 
   .speciesRemove {
@@ -119,18 +139,23 @@ $container-padding-right: 20px;
     grid-area: search;
     margin: 0;
   }
+
 }
 
-.speciesTitleAreaMinimal {
-  grid-template-areas:
-    'icon species-name .'
-    '. usage-toggle remove'
-    '. remove-message remove-message'
-    '. search .';
-  grid-template-columns: 60px 150px 1fr;
-  grid-template-rows: 80px 0px auto 40px;
-  grid-row-gap: 10px;
-  margin-bottom: 20px;
+@container species-page-title-area (max-width: 640px) {
+
+  .grid {
+    grid-template-areas:
+      'icon species-name .'
+      '. usage-toggle remove'
+      '. remove-message remove-message'
+      '. search .';
+    grid-template-columns: 60px 150px 1fr;
+    grid-template-rows: 80px 0px auto 40px;
+    grid-row-gap: 10px;
+    margin-bottom: 20px;
+  }
+
 
   .speciesRemoveMessage {
     margin-top: 20px;
@@ -140,4 +165,10 @@ $container-padding-right: 20px;
   .speciesToggle {
     padding: 0;
   }
+
+}
+
+
+.speciesTitleAreaEmpty {
+  height: 80px;
 }

--- a/src/content/app/species/components/species-title-area/SpeciesTitleArea.scss
+++ b/src/content/app/species/components/species-title-area/SpeciesTitleArea.scss
@@ -6,6 +6,8 @@ $container-padding-right: 20px;
   container-name: species-page-title-area;
   container-type: inline-size;
   margin-left: $double-standard-gutter;
+  position: sticky;
+  left: $double-standard-gutter;
 }
 
 .grid {

--- a/src/content/app/species/components/species-title-area/SpeciesTitleArea.scss
+++ b/src/content/app/species/components/species-title-area/SpeciesTitleArea.scss
@@ -6,8 +6,6 @@ $container-padding-right: 20px;
   container-name: species-page-title-area;
   container-type: inline-size;
   margin-left: $double-standard-gutter;
-  position: sticky;
-  left: $double-standard-gutter;
 }
 
 .grid {


### PR DESCRIPTION
## Description
Updated the Species page to make it adapt to narrower screens.

- Update the title area layout
- Update species stats layout

**TODO:** remove position sticky for the title area

## Related JIRA Issue(s)
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1079
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1978

## Deployment URL(s)
http://species-page-title-area.review.ensembl.org