### PR TITLE
Use Intl NumberFormat for number formatting

### DIFF
--- a/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -21,7 +21,7 @@ import classNames from 'classnames';
 import { useAppDispatch } from 'src/store';
 import useGeneViewIds from 'src/content/app/entity-viewer/gene-view/hooks/useGeneViewIds';
 
-import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
+import { formatNumber } from 'src/shared/helpers/formatters/numberFormatter';
 import { getFormattedLocation } from 'src/shared/helpers/formatters/regionFormatter';
 import {
   isProteinCodingTranscript,
@@ -117,13 +117,9 @@ export const TranscriptsListItemInfo = (
     });
   };
 
-  const splicedRNALength = getCommaSeparatedNumber(
-    getSplicedRNALength(transcript)
-  );
+  const splicedRNALength = formatNumber(getSplicedRNALength(transcript));
 
-  const aminoAcidLength = getCommaSeparatedNumber(
-    getProductAminoAcidLength(transcript)
-  );
+  const aminoAcidLength = formatNumber(getProductAminoAcidLength(transcript));
 
   const mainStyles = classNames(transcriptsListStyles.row, styles.listItemInfo);
   const midStyles = classNames(transcriptsListStyles.middle, styles.middle);

--- a/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.test.tsx
+++ b/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.test.tsx
@@ -23,7 +23,7 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import merge from 'lodash/fp/merge';
 
-import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
+import { formatNumber } from 'src/shared/helpers/formatters/numberFormatter';
 
 import restApiSlice from 'src/shared/state/api-slices/restSlice';
 
@@ -149,9 +149,7 @@ describe('BrowserLocationIndicator', () => {
       await waitFor(() => {
         const renderedLocation = container.querySelector('.chrRegion');
         expect(renderedLocation?.textContent).toBe(
-          `${getCommaSeparatedNumber(startPosition)}-${getCommaSeparatedNumber(
-            endPosition
-          )}`
+          `${formatNumber(startPosition)}-${formatNumber(endPosition)}`
         );
       });
     });

--- a/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.tsx
+++ b/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.tsx
@@ -16,7 +16,7 @@
 
 import React from 'react';
 
-import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
+import { formatNumber } from 'src/shared/helpers/formatters/numberFormatter';
 
 import { useAppSelector } from 'src/store';
 import { useGenomeKaryotypeQuery } from 'src/shared/state/genome/genomeApiSlice';
@@ -52,9 +52,9 @@ export const BrowserLocationIndicator = () => {
           <div className={styles.chrCode}>{chrCode}</div>
         )}
         <div className={styles.chrRegion}>
-          <span>{getCommaSeparatedNumber(chrStart as number)}</span>
+          <span>{formatNumber(chrStart as number)}</span>
           <span className={styles.chrSeparator}>-</span>
-          <span>{getCommaSeparatedNumber(chrEnd as number)}</span>
+          <span>{formatNumber(chrEnd as number)}</span>
         </div>
       </div>
     </div>

--- a/src/content/app/genome-browser/components/chromosome-navigator/ChromosomeNavigator.test.tsx
+++ b/src/content/app/genome-browser/components/chromosome-navigator/ChromosomeNavigator.test.tsx
@@ -19,7 +19,7 @@ import { render } from '@testing-library/react';
 import random from 'lodash/random';
 
 import * as textHelpers from 'src/shared/helpers/textHelpers';
-import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
+import { formatNumber } from 'src/shared/helpers/formatters/numberFormatter';
 
 import * as constants from './chromosomeNavigatorConstants';
 
@@ -359,12 +359,10 @@ describe('Chromosome Navigator', () => {
       const { labels } = getRenderedLabels(props);
       const expectedLabel1X =
         props.focusRegion.start * scalingFactor - mockLabelWidth / 2;
-      const expectedLabel1Text = getCommaSeparatedNumber(
-        props.focusRegion.start
-      );
+      const expectedLabel1Text = formatNumber(props.focusRegion.start);
       const expectedLabel2X =
         props.focusRegion.end * scalingFactor - mockLabelWidth / 2;
-      const expectedLabel2Text = getCommaSeparatedNumber(props.focusRegion.end);
+      const expectedLabel2Text = formatNumber(props.focusRegion.end);
       assertLabels(labels, [
         { x: expectedLabel1X, text: expectedLabel1Text },
         { x: expectedLabel2X, text: expectedLabel2Text }
@@ -384,9 +382,9 @@ describe('Chromosome Navigator', () => {
           2;
       const expectedLabelX = midpointBetweenPointers - mockLabelWidth / 2;
       const expectedLabelText =
-        getCommaSeparatedNumber(props.focusRegion.start) +
+        formatNumber(props.focusRegion.start) +
         '-' +
-        getCommaSeparatedNumber(props.focusRegion.end);
+        formatNumber(props.focusRegion.end);
       assertLabels(labels, [{ x: expectedLabelX, text: expectedLabelText }]);
     });
 
@@ -406,9 +404,7 @@ describe('Chromosome Navigator', () => {
       const { labels } = getRenderedLabels(props);
 
       const expectedLabelX = focusPosition * scalingFactor - mockLabelWidth / 2;
-      const expectedLabelText = getCommaSeparatedNumber(
-        props.focusRegion.start
-      );
+      const expectedLabelText = formatNumber(props.focusRegion.start);
       assertLabels(labels, [{ x: expectedLabelX, text: expectedLabelText }]);
     });
   });

--- a/src/content/app/genome-browser/components/chromosome-navigator/chromosomeNavigatorHelper.ts
+++ b/src/content/app/genome-browser/components/chromosome-navigator/chromosomeNavigatorHelper.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
+import { formatNumber } from 'src/shared/helpers/formatters/numberFormatter';
 import { measureText } from 'src/shared/helpers/textHelpers';
 
 import * as constants from './chromosomeNavigatorConstants';
@@ -284,8 +284,8 @@ const getLabelStyles = (
     return null;
   }
 
-  const formattedStart = getCommaSeparatedNumber(params.focusRegion.start);
-  const formattedEnd = getCommaSeparatedNumber(params.focusRegion.end);
+  const formattedStart = formatNumber(params.focusRegion.start);
+  const formattedEnd = formatNumber(params.focusRegion.end);
   const labelFont = '11px "IBM Plex Mono"';
 
   if (focusPointerStyles.length === 1) {

--- a/src/content/app/genome-browser/components/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
@@ -19,7 +19,7 @@ import classNames from 'classnames';
 
 import { getFormattedLocation } from 'src/shared/helpers/formatters/regionFormatter';
 import { getStrandDisplayName } from 'src/shared/helpers/formatters/strandFormatter';
-import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
+import { formatNumber } from 'src/shared/helpers/formatters/numberFormatter';
 import { getGeneName } from 'src/shared/helpers/formatters/geneFormatter';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
@@ -107,11 +107,9 @@ const TranscriptSummary = (props: Props) => {
     (xref) => xref.source.id === 'CCDS'
   );
 
-  const splicedRNALength = getCommaSeparatedNumber(
-    getSplicedRNALength(transcript)
-  );
+  const splicedRNALength = formatNumber(getSplicedRNALength(transcript));
 
-  const productAminoAcidLength = getCommaSeparatedNumber(
+  const productAminoAcidLength = formatNumber(
     defaultProductGeneratingContext?.cds?.protein_length || 0
   );
 
@@ -221,7 +219,7 @@ const TranscriptSummary = (props: Props) => {
       <div className={`${styles.row} ${styles.spaceAbove}`}>
         <div className={styles.label}>Transcript length</div>
         <div className={styles.value}>
-          {getCommaSeparatedNumber(transcript.slice.location.length)}{' '}
+          {formatNumber(transcript.slice.location.length)}{' '}
           <span className={styles.unit}>bp</span>{' '}
         </div>
       </div>

--- a/src/content/app/new-species-selector/components/species-search-results-table/SpeciesSearchResultsTable.tsx
+++ b/src/content/app/new-species-selector/components/species-search-results-table/SpeciesSearchResultsTable.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import upperFirst from 'lodash/upperFirst';
 
-import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
+import { formatNumber } from 'src/shared/helpers/formatters/numberFormatter';
 
 import { Table } from 'src/shared/components/table';
 import Checkbox from 'src/shared/components/checkbox/Checkbox';
@@ -109,12 +109,10 @@ const SpeciesSearchResultsTable = (props: Props) => {
 
             {isExpanded && (
               <>
-                <td>
-                  {getCommaSeparatedNumber(searchMatch.coding_genes_count)}
-                </td>
+                <td>{formatNumber(searchMatch.coding_genes_count)}</td>
                 <td>
                   {searchMatch.contig_n50
-                    ? getCommaSeparatedNumber(searchMatch.contig_n50)
+                    ? formatNumber(searchMatch.contig_n50)
                     : '-'}
                 </td>
                 <td>

--- a/src/content/app/species/state/general/speciesGeneralHelper.ts
+++ b/src/content/app/species/state/general/speciesGeneralHelper.ts
@@ -603,7 +603,9 @@ const buildIndividualStat = (
   } = statsFormattingOptions[section][primaryKey] as StatsFormattingOption;
 
   if (typeof primaryValue === 'number') {
-    primaryValue = getCommaSeparatedNumber(primaryValue) + primaryValuePostfix;
+    primaryValue =
+      getCommaSeparatedNumber(primaryValue, { maximumFractionDigits: 2 }) +
+      primaryValuePostfix;
   }
 
   return {
@@ -633,7 +635,9 @@ const buildHeaderStat = (
   ][primaryKey] as StatsFormattingOption;
 
   if (typeof primaryValue === 'number') {
-    primaryValue = getCommaSeparatedNumber(primaryValue) + primaryValuePostfix;
+    primaryValue =
+      getCommaSeparatedNumber(primaryValue, { maximumFractionDigits: 2 }) +
+      primaryValuePostfix;
   }
 
   return {

--- a/src/content/app/species/state/general/speciesGeneralHelper.ts
+++ b/src/content/app/species/state/general/speciesGeneralHelper.ts
@@ -15,7 +15,7 @@
  */
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
-import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
+import { formatNumber } from 'src/shared/helpers/formatters/numberFormatter';
 
 import { SpeciesStatsProps as IndividualStat } from 'src/content/app/species/components/species-stats/SpeciesStats';
 import { ExampleFocusObject } from 'src/shared/state/genome/genomeTypes';
@@ -604,7 +604,7 @@ const buildIndividualStat = (
 
   if (typeof primaryValue === 'number') {
     primaryValue =
-      getCommaSeparatedNumber(primaryValue, { maximumFractionDigits: 2 }) +
+      formatNumber(primaryValue, { maximumFractionDigits: 2 }) +
       primaryValuePostfix;
   }
 
@@ -636,7 +636,7 @@ const buildHeaderStat = (
 
   if (typeof primaryValue === 'number') {
     primaryValue =
-      getCommaSeparatedNumber(primaryValue, { maximumFractionDigits: 2 }) +
+      formatNumber(primaryValue, { maximumFractionDigits: 2 }) +
       primaryValuePostfix;
   }
 

--- a/src/shared/components/data-table/components/main/components/table-header/TableHeader.tsx
+++ b/src/shared/components/data-table/components/main/components/table-header/TableHeader.tsx
@@ -16,7 +16,7 @@
 
 import React, { useContext } from 'react';
 
-import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
+import { formatNumber } from 'src/shared/helpers/formatters/numberFormatter';
 
 import { TableContext } from 'src/shared/components/data-table/DataTable';
 import TableHeaderCell from './components/table-header-cell/TableHeaderCell';
@@ -87,12 +87,12 @@ const HeaderStats = (props: {
         <span>
           <span className={styles.rowsCountText}>Showing </span>
           <span className={styles.rowsCountNumberProminent}>
-            {getCommaSeparatedNumber(visibleRowsCount)}
+            {formatNumber(visibleRowsCount)}
           </span>
           <span className={styles.rowsCountText}> of</span>
         </span>
         <span>
-          <span>{getCommaSeparatedNumber(totalRows)}</span>
+          <span>{formatNumber(totalRows)}</span>
           <span className={styles.rowsCountText}> rows</span>
         </span>
       </div>

--- a/src/shared/components/feature-length-ruler/FeatureLengthRuler.tsx
+++ b/src/shared/components/feature-length-ruler/FeatureLengthRuler.tsx
@@ -34,7 +34,7 @@ import { scaleLinear, ScaleLinear } from 'd3';
 
 import { getTicks } from './featureLengthRulerHelper';
 
-import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
+import { formatNumber } from 'src/shared/helpers/formatters/numberFormatter';
 
 import styles from './FeatureLengthRuler.scss';
 
@@ -96,7 +96,7 @@ const FeatureLengthRuler = (props: Props) => {
           <rect className={styles.tick} width={1} height={6} />
           {labelledTicks.includes(tick) && (
             <text className={styles.label} x={0} y={20} textAnchor="middle">
-              {getCommaSeparatedNumber(tick)}
+              {formatNumber(tick)}
             </text>
           )}
         </g>
@@ -108,7 +108,7 @@ const FeatureLengthRuler = (props: Props) => {
         textAnchor="start"
         transform={`translate(${scale(props.length)})`}
       >
-        {getCommaSeparatedNumber(props.length)}
+        {formatNumber(props.length)}
       </text>
     </g>
   );

--- a/src/shared/components/in-app-search/InAppSearch.tsx
+++ b/src/shared/components/in-app-search/InAppSearch.tsx
@@ -32,7 +32,7 @@ import {
 } from 'src/shared/state/in-app-search/inAppSearchSelectors';
 
 import { pluralise } from 'src/shared/helpers/formatters/pluralisationFormatter';
-import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
+import { formatNumber } from 'src/shared/helpers/formatters/numberFormatter';
 
 import analyticsTracking from 'src/services/analytics-service';
 
@@ -137,7 +137,7 @@ const InAppSearch = (props: Props) => {
         {!isLoading && searchResult && (
           <div className={styles.hitsCount}>
             <span className={styles.hitsNumber}>
-              {getCommaSeparatedNumber(searchResult.meta.total_hits)}
+              {formatNumber(searchResult.meta.total_hits)}
             </span>{' '}
             {pluralise('gene', searchResult.meta.total_hits)}
           </div>

--- a/src/shared/helpers/formatters/numberFormater.test.ts
+++ b/src/shared/helpers/formatters/numberFormater.test.ts
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import { getCommaSeparatedNumber } from './numberFormatter';
+import { formatNumber } from './numberFormatter';
 
 import { faker } from '@faker-js/faker';
 
-describe('getCommaSeparatedNumber', () => {
+describe('formatNumber', () => {
   it('returns x,xxx for the input number xxxx', () => {
     const randomNumber = faker.number.int({ min: 1000, max: 9999 });
 
-    const formattedRandomNumber = getCommaSeparatedNumber(randomNumber);
+    const formattedRandomNumber = formatNumber(randomNumber);
 
     const numberSplitByComma = formattedRandomNumber.split(',');
 
@@ -41,7 +41,7 @@ describe('getCommaSeparatedNumber', () => {
   it('returns xx,xxx for the input number xxxxx', () => {
     const randomNumber = faker.number.int({ min: 10000, max: 99999 });
 
-    const formattedRandomNumber = getCommaSeparatedNumber(randomNumber);
+    const formattedRandomNumber = formatNumber(randomNumber);
 
     const numberSplitByComma = formattedRandomNumber.split(',');
 
@@ -60,7 +60,7 @@ describe('getCommaSeparatedNumber', () => {
   it('returns xxx,xxx for the input number xxxxxx', () => {
     const randomNumber = faker.number.int({ min: 100000, max: 999999 });
 
-    const formattedRandomNumber = getCommaSeparatedNumber(randomNumber);
+    const formattedRandomNumber = formatNumber(randomNumber);
 
     const numberSplitByComma = formattedRandomNumber.split(',');
 
@@ -79,7 +79,7 @@ describe('getCommaSeparatedNumber', () => {
   it('returns x,xxx,xxx for the input number xxxxxxx', () => {
     const randomNumber = faker.number.int({ min: 1000000, max: 9999999 });
 
-    const formattedRandomNumber = getCommaSeparatedNumber(randomNumber);
+    const formattedRandomNumber = formatNumber(randomNumber);
 
     const numberSplitByComma = formattedRandomNumber.split(',');
 
@@ -101,7 +101,7 @@ describe('getCommaSeparatedNumber', () => {
   it('returns -x,xxx for the input number -xxxx', () => {
     const randomNumber = faker.number.int({ min: -9999, max: -1000 });
 
-    const formattedRandomNumber = getCommaSeparatedNumber(randomNumber);
+    const formattedRandomNumber = formatNumber(randomNumber);
 
     const numberSplitByComma = formattedRandomNumber.split(',');
 
@@ -122,7 +122,7 @@ describe('getCommaSeparatedNumber', () => {
       faker.number.int({ min: 1000, max: 9999 }) +
       faker.number.int({ min: 1, max: 9 }) / 10;
 
-    const formattedRandomNumber = getCommaSeparatedNumber(randomNumber);
+    const formattedRandomNumber = formatNumber(randomNumber);
 
     const numberSplitByComma = formattedRandomNumber.split(',');
 

--- a/src/shared/helpers/formatters/numberFormatter.ts
+++ b/src/shared/helpers/formatters/numberFormatter.ts
@@ -18,7 +18,7 @@
     Formats the input number to comma separated representation
     eg: 10000 -> 10,000
 */
-export const getCommaSeparatedNumber = (
+export const formatNumber = (
   input: number,
   options?: Intl.NumberFormatOptions
 ) => {

--- a/src/shared/helpers/formatters/numberFormatter.ts
+++ b/src/shared/helpers/formatters/numberFormatter.ts
@@ -18,8 +18,12 @@
     Formats the input number to comma separated representation
     eg: 10000 -> 10,000
 */
-export const getCommaSeparatedNumber = (input: number) => {
-  return input.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+export const getCommaSeparatedNumber = (
+  input: number,
+  options?: Intl.NumberFormatOptions
+) => {
+  const numberFormat = Intl.NumberFormat('en-GB', options);
+  return numberFormat.format(input);
 };
 
 export const getNumberWithoutCommas = (input: string) => {

--- a/src/shared/helpers/formatters/regionFormatter.ts
+++ b/src/shared/helpers/formatters/regionFormatter.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { getCommaSeparatedNumber } from 'src/shared/helpers/formatters/numberFormatter';
+import { formatNumber } from 'src/shared/helpers/formatters/numberFormatter';
 
 import { FocusObjectLocation } from 'src/shared/types/focus-object/focusObjectTypes';
 
 export const getFormattedLocation = (location: FocusObjectLocation) => {
-  const start = getCommaSeparatedNumber(location.start);
-  const end = getCommaSeparatedNumber(location.end);
+  const start = formatNumber(location.start);
+  const end = formatNumber(location.end);
 
   if (start === end) {
     return `${location.chromosome}:${start}`;


### PR DESCRIPTION
## Description
Replace the old implementation of the function that we had for formatting numbers to comma-separated strings with a proper Intl-based solution.

Not only is this the right thing to do, but it also will fix the problem discovered when reviewing species stats:

![image](https://github.com/Ensembl/ensembl-client/assets/6834224/bd846683-7798-4e6e-b2e2-fb859ca98d57)

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1971

## Deployment URL(s)
http://number-formatting.review.ensembl.org
