### PR TITLE
Variant link zmenu

### DIFF
--- a/src/content/app/genome-browser/components/zmenu/Zmenu.scss
+++ b/src/content/app/genome-browser/components/zmenu/Zmenu.scss
@@ -36,10 +36,15 @@
   color: $blue;
 }
 
-.zmenuAppLinks {
-  display: flex;
+.zmenuLinksGrid {
+  display: grid;
+  grid-template-columns: auto [app-links] 1fr;
   align-items: center;
-  justify-content: space-between;
+}
+
+.zmenuAppLinks {
+  grid-column: app-links;
+  justify-self: end;
 }
 
 .zmenuToggleFooter {

--- a/src/content/app/genome-browser/components/zmenu/Zmenu.test.tsx
+++ b/src/content/app/genome-browser/components/zmenu/Zmenu.test.tsx
@@ -57,7 +57,9 @@ jest.mock('./ZmenuInstantDownload', () => () => (
   <div>ZmenuInstantDownload</div>
 ));
 jest.mock('./zmenus/GeneAndOneTranscriptZmenu', () => () => (
-  <div>GeneAndOneTranscriptZmenu</div>
+  <div data-test-id="gene-and-one-transcript-zmenu">
+    GeneAndOneTranscriptZmenu
+  </div>
 ));
 jest.mock('./zmenus/VariantZmenu', () => () => <div>VariantZmenu</div>);
 jest.mock('./zmenus/RegulationZmenu', () => () => <div>RegulationZmenu</div>);
@@ -115,9 +117,9 @@ const defaultProps: ZmenuProps = {
 
 describe('<Zmenu />', () => {
   describe('rendering', () => {
-    it.skip('renders zmenu content', () => {
+    it('renders zmenu content', () => {
       const { queryByTestId } = renderComponent();
-      expect(queryByTestId('zmenuContent')).toBeTruthy();
+      expect(queryByTestId('gene-and-one-transcript-zmenu')).toBeTruthy();
     });
   });
 

--- a/src/content/app/genome-browser/components/zmenu/Zmenu.test.tsx
+++ b/src/content/app/genome-browser/components/zmenu/Zmenu.test.tsx
@@ -56,6 +56,10 @@ jest.mock('./ZmenuContent', () => () => (
 jest.mock('./ZmenuInstantDownload', () => () => (
   <div>ZmenuInstantDownload</div>
 ));
+jest.mock('./zmenus/GeneAndOneTranscriptZmenu', () => () => (
+  <div>GeneAndOneTranscriptZmenu</div>
+));
+jest.mock('./zmenus/VariantZmenu', () => () => <div>VariantZmenu</div>);
 jest.mock('./zmenus/RegulationZmenu', () => () => <div>RegulationZmenu</div>);
 
 const chrName = faker.lorem.word();
@@ -111,7 +115,7 @@ const defaultProps: ZmenuProps = {
 
 describe('<Zmenu />', () => {
   describe('rendering', () => {
-    it('renders zmenu content', () => {
+    it.skip('renders zmenu content', () => {
       const { queryByTestId } = renderComponent();
       expect(queryByTestId('zmenuContent')).toBeTruthy();
     });

--- a/src/content/app/genome-browser/components/zmenu/ZmenuAppLinks.tsx
+++ b/src/content/app/genome-browser/components/zmenu/ZmenuAppLinks.tsx
@@ -17,14 +17,12 @@
 import React from 'react';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
-import { parseFocusIdFromUrl } from 'src/shared/helpers/focusObjectHelpers';
 
 import useGenomeBrowserIds from 'src/content/app/genome-browser/hooks/useGenomeBrowserIds';
 import useGenomeBrowser from '../../hooks/useGenomeBrowser';
 
-import { ToggleButton as ToolboxToggleButton } from 'src/shared/components/toolbox';
 import ViewInApp, {
-  LinksConfig
+  type LinksConfig
 } from 'src/shared/components/view-in-app/ViewInApp';
 
 import styles from './Zmenu.scss';
@@ -41,12 +39,6 @@ const ZmenuAppLinks = (props: Props) => {
     useGenomeBrowserIds();
   const { changeFocusObject } = useGenomeBrowser();
   const navigate = useNavigate();
-
-  const { type: featureType } = parseFocusIdFromUrl(featureId);
-
-  if (featureType !== 'gene') {
-    return null;
-  }
 
   const onGenomeBrowserAppClick = () => {
     if (!(focusObjectIdForUrl && focusObjectId)) {
@@ -79,10 +71,6 @@ const ZmenuAppLinks = (props: Props) => {
 
   return (
     <div className={styles.zmenuAppLinks}>
-      <ToolboxToggleButton
-        className={styles.zmenuToggleFooter}
-        label="Download"
-      />
       <ViewInApp
         theme="dark"
         links={links}

--- a/src/content/app/genome-browser/components/zmenu/ZmenuContent.tsx
+++ b/src/content/app/genome-browser/components/zmenu/ZmenuContent.tsx
@@ -22,8 +22,6 @@ import * as urlFor from 'src/shared/helpers/urlHelper';
 
 import useGenomeBrowserIds from 'src/content/app/genome-browser/hooks/useGenomeBrowserIds';
 
-import ZmenuAppLinks from './ZmenuAppLinks';
-
 import {
   ZmenuContentItem as ZmenuContentItemType,
   Markup,
@@ -60,7 +58,6 @@ export const ZmenuContent = (props: ZmenuContentProps) => {
           />
         </p>
       ))}
-      <ZmenuAppLinks featureId={featureId} destroyZmenu={props.destroyZmenu} />
     </>
   );
 

--- a/src/content/app/genome-browser/components/zmenu/zmenus/GeneAndOneTranscriptZmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/zmenus/GeneAndOneTranscriptZmenu.tsx
@@ -20,9 +20,13 @@ import { useAppDispatch } from 'src/store';
 
 import { changeHighlightedTrackId } from 'src/content/app/genome-browser/state/track-panel/trackPanelSlice';
 
-import { ToolboxExpandableContent } from 'src/shared/components/toolbox';
+import {
+  ToolboxExpandableContent,
+  ToggleButton as ToolboxToggleButton
+} from 'src/shared/components/toolbox';
 import ZmenuContent from '../ZmenuContent';
 import ZmenuInstantDownload from '../ZmenuInstantDownload';
+import ZmenuAppLinks from '../ZmenuAppLinks';
 
 import type {
   ZmenuContentTranscript,
@@ -73,11 +77,20 @@ const GeneAndOneTranscriptZmenu = (props: Props) => {
   }, []);
 
   const mainContent = (
-    <ZmenuContent
-      features={features}
-      featureId={featureId}
-      destroyZmenu={props.onDestroy}
-    />
+    <>
+      <ZmenuContent
+        features={features}
+        featureId={featureId}
+        destroyZmenu={props.onDestroy}
+      />
+      <div className={styles.zmenuLinksGrid}>
+        <ToolboxToggleButton
+          className={styles.zmenuToggleFooter}
+          label="Download"
+        />
+        <ZmenuAppLinks featureId={featureId} destroyZmenu={props.onDestroy} />
+      </div>
+    </>
   );
 
   const footerContent = (

--- a/src/content/app/genome-browser/components/zmenu/zmenus/VariantZmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/zmenus/VariantZmenu.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
+import { isEnvironment, Environment } from 'src/shared/helpers/environment';
 
 import useGenomeBrowserIds from 'src/content/app/genome-browser/hooks/useGenomeBrowserIds';
 
@@ -64,14 +65,16 @@ const VariantZmenu = (props: Props) => {
         featureId={featureId}
         destroyZmenu={props.onDestroy}
       />
-      <div className={styles.zmenuLinksGrid}>
-        <ViewInApp
-          theme="dark"
-          links={{ genomeBrowser: { url: linkToVariantInGenomeBrowser } }}
-          onAnyAppClick={props.onDestroy}
-          className={styles.zmenuAppLinks}
-        />
-      </div>
+      {isEnvironment([Environment.DEVELOPMENT, Environment.INTERNAL]) && (
+        <div className={styles.zmenuLinksGrid}>
+          <ViewInApp
+            theme="dark"
+            links={{ genomeBrowser: { url: linkToVariantInGenomeBrowser } }}
+            onAnyAppClick={props.onDestroy}
+            className={styles.zmenuAppLinks}
+          />
+        </div>
+      )}
     </>
   );
 };

--- a/src/content/app/genome-browser/components/zmenu/zmenus/VariantZmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/zmenus/VariantZmenu.tsx
@@ -16,12 +16,19 @@
 
 import React from 'react';
 
+import * as urlFor from 'src/shared/helpers/urlHelper';
+
+import useGenomeBrowserIds from 'src/content/app/genome-browser/hooks/useGenomeBrowserIds';
+
 import ZmenuContent from '../ZmenuContent';
+import ViewInApp from 'src/shared/components/view-in-app/ViewInApp';
 
 import type {
   ZmenuPayload,
   ZmenuContentVariantMetadata
 } from 'src/content/app/genome-browser/services/genome-browser-service/types/zmenu';
+
+import styles from '../Zmenu.scss';
 
 type Props = {
   payload: ZmenuPayload;
@@ -30,18 +37,42 @@ type Props = {
 
 const VariantZmenu = (props: Props) => {
   const { content } = props.payload;
+  const { genomeIdForUrl } = useGenomeBrowserIds();
 
   const variantMetadata = content[0]?.metadata as
     | ZmenuContentVariantMetadata
     | undefined;
-  const variantId = variantMetadata?.id ?? '';
+
+  if (!variantMetadata) {
+    // something has gone wrong
+    return null;
+  }
+
+  const { region_name, start, id } = variantMetadata;
+  const variantId = `${region_name}:${start}:${id}`;
+  const featureId = `variant:${variantId}`;
+
+  const linkToVariantInGenomeBrowser = urlFor.browser({
+    genomeId: genomeIdForUrl,
+    focus: featureId
+  });
 
   return (
-    <ZmenuContent
-      features={content}
-      featureId={`variant:${variantId}`}
-      destroyZmenu={props.onDestroy}
-    />
+    <>
+      <ZmenuContent
+        features={content}
+        featureId={featureId}
+        destroyZmenu={props.onDestroy}
+      />
+      <div className={styles.zmenuLinksGrid}>
+        <ViewInApp
+          theme="dark"
+          links={{ genomeBrowser: { url: linkToVariantInGenomeBrowser } }}
+          onAnyAppClick={props.onDestroy}
+          className={styles.zmenuAppLinks}
+        />
+      </div>
+    </>
   );
 };
 

--- a/src/content/app/genome-browser/components/zmenu/zmenus/VariantZmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/zmenus/VariantZmenu.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
+import { buildFocusVariantId } from 'src/shared/helpers/focusObjectHelpers';
 import { isEnvironment, Environment } from 'src/shared/helpers/environment';
 
 import useGenomeBrowserIds from 'src/content/app/genome-browser/hooks/useGenomeBrowserIds';
@@ -49,20 +50,22 @@ const VariantZmenu = (props: Props) => {
     return null;
   }
 
-  const { region_name, start, id } = variantMetadata;
-  const variantId = `${region_name}:${start}:${id}`;
-  const featureId = `variant:${variantId}`;
+  const variantId = buildFocusVariantId({
+    regionName: variantMetadata.region_name,
+    start: variantMetadata.start,
+    variantName: variantMetadata.id
+  });
 
   const linkToVariantInGenomeBrowser = urlFor.browser({
     genomeId: genomeIdForUrl,
-    focus: featureId
+    focus: variantId
   });
 
   return (
     <>
       <ZmenuContent
         features={content}
-        featureId={featureId}
+        featureId={variantId}
         destroyZmenu={props.onDestroy}
       />
       {isEnvironment([Environment.DEVELOPMENT, Environment.INTERNAL]) && (

--- a/src/content/app/genome-browser/services/genome-browser-service/types/zmenu.ts
+++ b/src/content/app/genome-browser/services/genome-browser-service/types/zmenu.ts
@@ -65,7 +65,9 @@ export type ZmenuContentGeneMetadata = {
 export type ZmenuContentVariantMetadata = {
   alleles: string;
   consequence: string;
-  id: string;
+  id: string; // just the rsID; will have to be combined with region name and start coordinate for full id
+  region_name: string; // needed to generate full variant id
+  start: number; // needed to generate full variant id
   position: string; // formatted as "region:start-end". NOTE: start and end coordinates have commas in them
   variety: string; // e.g. SNV, INS... Do we have a full list of such varieties?
   type: ZmenuFeatureType.VARIANT;

--- a/src/server/middleware/proxyMiddleware.ts
+++ b/src/server/middleware/proxyMiddleware.ts
@@ -55,25 +55,15 @@ const serverConfig = getConfigForServer();
 */
 
 const createApiProxyMiddleware = () => {
-  const apiProxyMiddleware = createHttpProxyMiddleware(
-    ['/api/**', '!/api/browser/**'],
-    {
-      target: 'https://staging-2020.ensembl.org',
-      changeOrigin: true,
-      secure: false
-    }
-  );
-
-  const browserProxyMiddleware = createHttpProxyMiddleware('/api/browser/**', {
-    target: 'http://localhost:3333',
-    pathRewrite: {
-      '^/api/browser': '/api' // rewrite path
-    },
+  const apiProxyMiddleware = createHttpProxyMiddleware('/api', {
+    target: 'https://staging-2020.ensembl.org',
     changeOrigin: true,
     secure: false
   });
 
-  return [apiProxyMiddleware, browserProxyMiddleware];
+  // returning an array so that the specific proxies can be easily modified in local development
+  // (see example in the comment block above)
+  return [apiProxyMiddleware];
 };
 
 const createStaticAssetsMiddleware = () => {

--- a/src/server/middleware/proxyMiddleware.ts
+++ b/src/server/middleware/proxyMiddleware.ts
@@ -55,15 +55,25 @@ const serverConfig = getConfigForServer();
 */
 
 const createApiProxyMiddleware = () => {
-  const apiProxyMiddleware = createHttpProxyMiddleware('/api', {
-    target: 'https://staging-2020.ensembl.org',
+  const apiProxyMiddleware = createHttpProxyMiddleware(
+    ['/api/**', '!/api/browser/**'],
+    {
+      target: 'https://staging-2020.ensembl.org',
+      changeOrigin: true,
+      secure: false
+    }
+  );
+
+  const browserProxyMiddleware = createHttpProxyMiddleware('/api/browser/**', {
+    target: 'http://localhost:3333',
+    pathRewrite: {
+      '^/api/browser': '/api' // rewrite path
+    },
     changeOrigin: true,
     secure: false
   });
 
-  // returning an array so that the specific proxies can be easily modified in local development
-  // (see example in the comment block above)
-  return [apiProxyMiddleware];
+  return [apiProxyMiddleware, browserProxyMiddleware];
 };
 
 const createStaticAssetsMiddleware = () => {

--- a/src/shared/components/view-in-app/ViewInApp.tsx
+++ b/src/shared/components/view-in-app/ViewInApp.tsx
@@ -77,6 +77,7 @@ export type ViewInAppProps = {
   onAppClick?: AppClickHandlers;
   onAnyAppClick?: (appName?: AppName) => void;
   theme?: Theme;
+  className?: string;
 };
 
 export const ViewInApp = (props: ViewInAppProps) => {
@@ -107,7 +108,7 @@ export const ViewInApp = (props: ViewInAppProps) => {
     }
   };
 
-  const componentClasses = classNames(styles.viewInApp, {
+  const componentClasses = classNames(styles.viewInApp, props.className, {
     [styles.viewInAppLight]: theme === 'light',
     [styles.viewInAppDark]: theme === 'dark'
   });

--- a/src/shared/helpers/focusObjectHelpers.ts
+++ b/src/shared/helpers/focusObjectHelpers.ts
@@ -83,3 +83,12 @@ export const parseFocusObjectIdFromUrl = (
 
 export const getDisplayStableId = (focusObject: Partial<FocusGene>) =>
   focusObject.versioned_stable_id || focusObject.stable_id || '';
+
+export const buildFocusVariantId = (params: {
+  regionName: string;
+  start: number;
+  variantName: string;
+}) => {
+  const { regionName, start, variantName } = params;
+  return `variant:${regionName}:${start}:${variantName}`;
+};


### PR DESCRIPTION
## Description
- Moved the ZmenuAppLinks component out of the ZmenuContent component for better flexibility/composability
- Updated the typing of zmenu payload (supporting changes in https://github.com/Ensembl/ensembl-dauphin-style-compiler/pull/77)
- Added the "view in genome browser" button to VariantZmenu
- The the "view in genome browser" button should only show up in non-production environments

Related PR for the genome browser: https://github.com/Ensembl/ensembl-dauphin-style-compiler/pull/77. Notice that in that PR, changes to data file locations will have to be undone before it can be merged. This should not block the review of this PR though.


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2043

## Deployment URL(s)
http://variant-link-zmenu.review.ensembl.org/genome-browser/grch38?focus=variant:1:10019:rs1570391708