### PR TITLE
Fix non-detectable clicks on ViewInAppPopup's buttons

### DIFF
--- a/src/shared/components/pointer-box/PointerBox.tsx
+++ b/src/shared/components/pointer-box/PointerBox.tsx
@@ -65,7 +65,7 @@ export type PointerBoxProps = {
     pointer?: string;
   };
   children: ReactNode;
-  onOutsideClick?: () => void;
+  onOutsideClick?: (() => void) | ((event: Event) => void);
   onClose?: () => void;
 };
 

--- a/src/shared/components/view-in-app-popup/ViewInAppPopup.tsx
+++ b/src/shared/components/view-in-app-popup/ViewInAppPopup.tsx
@@ -39,14 +39,32 @@ const ViewInAppPopup = (props: ViewInAppPopupProps) => {
     setShowPointerBox(!showPointerBox);
   };
 
+  const onClose = () => {
+    setShowPointerBox(false);
+  };
+
+  const onOutsideClick = (event: Event) => {
+    // If the PointerBox is rendered outside the anchor (i.e. as a top-level child of the document body)
+    // (to avoid adjacent elements from being positioned in front of the popup and intercepting clicks on its buttons),
+    // then a click on any of the props.children will be outside the anchor.
+    // Thus, an extra check of the click target relative to the anchor becomes necessary.
+    // All this will go away when we can switch to the popover api.
+    if (!anchorRef.current?.contains(event.target as HTMLElement)) {
+      onClose();
+    }
+  };
+
   return (
-    <span className={styles.wrapper} ref={anchorRef} onClick={onAnchorClick}>
-      {children}
+    <>
+      <span className={styles.wrapper} ref={anchorRef} onClick={onAnchorClick}>
+        {children}
+      </span>
       {showPointerBox && anchorRef.current && (
         <PointerBox
           anchor={anchorRef.current}
-          renderInsideAnchor={true}
-          onOutsideClick={() => setShowPointerBox(false)}
+          renderInsideAnchor={false}
+          onOutsideClick={onOutsideClick}
+          onClose={onClose}
           position={position}
           autoAdjust={true}
           classNames={{
@@ -57,7 +75,7 @@ const ViewInAppPopup = (props: ViewInAppPopupProps) => {
           <ViewInApp theme="dark" links={links} />
         </PointerBox>
       )}
-    </span>
+    </>
   );
 };
 

--- a/src/shared/hooks/useOutsideClick.tsx
+++ b/src/shared/hooks/useOutsideClick.tsx
@@ -18,7 +18,7 @@ import { useEffect } from 'react';
 
 export default function useOutsideClick<T extends HTMLElement>(
   refOrRefs: React.RefObject<T> | React.RefObject<T>[],
-  callback: () => void
+  callback: (() => void) | ((event: Event) => void)
 ) {
   const refs = Array.isArray(refOrRefs) ? refOrRefs : [refOrRefs];
 
@@ -32,7 +32,7 @@ export default function useOutsideClick<T extends HTMLElement>(
     }
 
     if (!isClickInside) {
-      callback();
+      callback(event);
     }
   };
 


### PR DESCRIPTION
## Description
**Bug:** clicks on the buttons in the ViewInAppPopup on the species page do not get detected:

https://github.com/Ensembl/ensembl-client/assets/6834224/cc94580d-7a28-423e-8032-51b2868829b6

**Cause:** after the stats layout was updated to adapt to small screens, the stats sections from below started obstructing the ViewInAppPopup:

![image](https://github.com/Ensembl/ensembl-client/assets/6834224/b5c89fee-a537-4abb-b99d-155b24e74eb7)

If there is a clean CSS solution for this, I couldn't think of one (tried pointer-events: none; that didn't help). So I went with a javascript solution, making the popup render not into anchor, but in document.body.

As a negative consequence of this, the popup will disappear if the user scrolls. I don't think it's a particularly big deal.

We will refactor our popups when the popover api becomes adopted by our target browsers. Hopefully, in a year or so.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2079

## Deployment URL(s)
http://fix-view-in-app-popup.review.ensembl.org