### PR TITLE
Update search field behaviour in new species selector

### DIFF
--- a/src/content/app/new-species-selector/components/species-search-field/SpeciesSearchField.scss
+++ b/src/content/app/new-species-selector/components/species-search-field/SpeciesSearchField.scss
@@ -1,3 +1,5 @@
+@import 'src/styles/common';
+
 .speciesSearchField {
   display: grid;
   grid-template-areas:
@@ -17,7 +19,11 @@
   grid-area: input;
 }
 
-.submit {
+.button {
   grid-area: button;
   align-self: center;
+}
+
+.submit {
+  --primary-button-color: #{$blue};
 }

--- a/src/content/app/new-species-selector/components/species-search-results-table/SpeciesSearchResultsTable.scss
+++ b/src/content/app/new-species-selector/components/species-search-results-table/SpeciesSearchResultsTable.scss
@@ -4,10 +4,18 @@
   --table-background: $light-grey;
 }
 
+.assemblyName {
+  font-weight: $light;
+}
+
 .showMore {
   color: $blue;
 }
 
 .referenceGenome {
   font-style: italic;
+}
+
+.isAlreadySelected {
+  color: $grey;
 }

--- a/src/content/app/new-species-selector/components/species-search-results-table/SpeciesSearchResultsTable.scss
+++ b/src/content/app/new-species-selector/components/species-search-results-table/SpeciesSearchResultsTable.scss
@@ -17,5 +17,6 @@
 }
 
 .isAlreadySelected {
-  color: $grey;
+  color: $medium-dark-grey;
+  --dot-solid-color: #{$medium-light-grey};
 }

--- a/src/content/app/new-species-selector/components/species-search-results-table/SpeciesSearchResultsTable.tsx
+++ b/src/content/app/new-species-selector/components/species-search-results-table/SpeciesSearchResultsTable.tsx
@@ -15,6 +15,7 @@
  */
 
 import React from 'react';
+import classNames from 'classnames';
 import upperFirst from 'lodash/upperFirst';
 
 import { formatNumber } from 'src/shared/helpers/formatters/numberFormatter';
@@ -23,6 +24,8 @@ import { Table } from 'src/shared/components/table';
 import Checkbox from 'src/shared/components/checkbox/Checkbox';
 import SolidDot from 'src/shared/components/table/dot/SolidDot';
 import EmptyDot from 'src/shared/components/table/dot/EmptyDot';
+import ExternalLink from 'src/shared/components/external-link/ExternalLink';
+import DisabledExternalLink from 'src/shared/components/external-link/DisabledExternalLink';
 
 import type { SpeciesSearchMatch } from 'src/content/app/new-species-selector/types/speciesSearchMatch';
 
@@ -30,14 +33,13 @@ import styles from './SpeciesSearchResultsTable.scss';
 
 type Props = {
   isExpanded: boolean;
-  results: SpeciesSearchMatch[];
+  results: Array<SpeciesSearchMatch & { isSelected: boolean }>;
   preselectedSpecies: SpeciesSearchMatch[];
   onTableExpandToggle: () => void;
   onSpeciesSelectToggle: (
     species: SpeciesSearchMatch,
     isAdding?: boolean
   ) => void;
-  // TODO: add selectedGenomes — they should be shown but disabled
 };
 
 const SpeciesSearchResultsTable = (props: Props) => {
@@ -81,9 +83,15 @@ const SpeciesSearchResultsTable = (props: Props) => {
       </thead>
       <tbody>
         {results.map((searchMatch) => (
-          <tr key={searchMatch.genome_id}>
+          <tr
+            key={searchMatch.genome_id}
+            className={classNames({
+              [styles.isAlreadySelected]: searchMatch.isSelected
+            })}
+          >
             <td>
               <Checkbox
+                disabled={searchMatch.isSelected}
                 checked={preselectedSpeciesIds.has(searchMatch.genome_id)}
                 onChange={() => onSpeciesPreselect(searchMatch)}
               />
@@ -93,15 +101,18 @@ const SpeciesSearchResultsTable = (props: Props) => {
             <td>
               <SpeciesType species={searchMatch} />
             </td>
-            <td>{searchMatch.assembly.name}</td>
+            <td className={styles.assemblyName}>{searchMatch.assembly.name}</td>
             <td>
-              <a
-                href={searchMatch.assembly.url}
-                target="_blank"
-                rel="noreferrer"
-              >
-                {searchMatch.assembly.accession_id}
-              </a>
+              {!searchMatch.isSelected ? (
+                <ExternalLink
+                  to={searchMatch.assembly.url}
+                  linkText={searchMatch.assembly.accession_id}
+                />
+              ) : (
+                <DisabledExternalLink>
+                  {searchMatch.assembly.accession_id}
+                </DisabledExternalLink>
+              )}
             </td>
 
             {/* empty column under the 'show more' heading */}

--- a/src/content/app/new-species-selector/state/species-selector-api-slice/speciesSelectorSampleData.ts
+++ b/src/content/app/new-species-selector/state/species-selector-api-slice/speciesSelectorSampleData.ts
@@ -13,9 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import { nanoid } from '@reduxjs/toolkit';
-
 import type { PopularSpecies } from 'src/content/app/new-species-selector/types/popularSpecies';
 import type { SpeciesSearchMatch } from 'src/content/app/new-species-selector/types/speciesSearchMatch';
 
@@ -992,7 +989,7 @@ export const createHumanPangenomeSearchMatches = () => {
 
   return humanPangenomeAssemblies.map((assemblyData) => {
     const searchMatch = structuredClone(humanSearchMatch);
-    searchMatch.genome_id = nanoid();
+    searchMatch.genome_id = assemblyData.assembly_accession_id;
     searchMatch.assembly.accession_id = assemblyData.assembly_accession_id;
     searchMatch.assembly.name = assemblyData.assembly_name;
     searchMatch.assembly.url = assemblyData.assembly_link;

--- a/src/shared/components/external-link/DisabledExternalLink.scss
+++ b/src/shared/components/external-link/DisabledExternalLink.scss
@@ -1,0 +1,20 @@
+@import 'src/styles/common';
+
+.container {
+  display: inline-grid;
+  grid-template-columns:  [icon] auto [text] auto;
+  column-gap: 5px;
+  align-items: baseline;
+}
+
+.icon {
+  fill: var(--disabled-external-link-icon-color, #{$grey});
+  grid-column: icon;
+  height: 12px;
+  width: 12px;
+}
+
+.text {
+  grid-column: text;
+  color: var(--disabled-external-link-text-color, #{$grey});
+}

--- a/src/shared/components/external-link/DisabledExternalLink.tsx
+++ b/src/shared/components/external-link/DisabledExternalLink.tsx
@@ -1,0 +1,48 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { type ReactNode } from 'react';
+import classNames from 'classnames';
+
+import LinkIcon from 'static/icons/icon_xlink.svg';
+
+import styles from './DisabledExternalLink.scss';
+
+/**
+ * It's very rare that one would need to use this component.
+ * Links are not something that tend to get disabled.
+ * But in the rare case that it needs to happen, it's easier
+ * to have a dedicated component for this purpose than to modify
+ * the regular ExternalLink component using CSS
+ */
+
+type Props = {
+  children: ReactNode;
+  className?: string;
+};
+
+const DisabledExternalLink = (props: Props) => {
+  const componentClasses = classNames(styles.container, props.className);
+
+  return (
+    <span className={componentClasses}>
+      <LinkIcon className={styles.icon} />
+      <span className={styles.text}>{props.children}</span>
+    </span>
+  );
+};
+
+export default DisabledExternalLink;


### PR DESCRIPTION
## Description
- Add a distinction between a "Find" and an "Add" button
- The "Find" button is disabled if the search field content is less than 3 characters
- On pre-selection of one or more genomes in the search results table, the "Find" button changes to "Add"
- Changing the text in the search field removes the table of search results as well as any pre-selected genomes
- Clicking the "Add" button adds selected species
- Added placeholder text and help icon to the search field 
- Added dedicated style for the selected species rows in the search results table
- Added a dedicated DisabledExternalLink component to use in the search results table for selected species

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2049

## Deployment URL(s)
http://species-search-field.review.ensembl.org/new-species-selector