### PR TITLE
Update gene homology example

### DIFF
--- a/src/content/app/entity-viewer/gene-view/components/gene-homology/GeneHomologyTable.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-homology/GeneHomologyTable.tsx
@@ -70,7 +70,7 @@ const prepareTableData = (homologies: GeneHomology[]) => {
           geneId: homology.target_gene.stable_id
         }
       },
-      homology.subtype
+      homology.subtype.label
     ];
   });
 };

--- a/src/content/app/entity-viewer/state/api/fixtures/mockHomologyData.ts
+++ b/src/content/app/entity-viewer/state/api/fixtures/mockHomologyData.ts
@@ -25,9 +25,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: '00d87371-57f1-4dc2-8f21-6bd825146a49',
-        common_name: null,
+        common_name: 'Cow',
         scientific_name: 'Bos taurus',
-        genome_type: 'Cow',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_002263795.2',
           name: 'ARS-UCD1.2',
@@ -42,9 +42,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -65,59 +65,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 27.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 27.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: '00d87371-57f1-4dc2-8f21-6bd825146a49',
-        common_name: null,
-        scientific_name: 'Bos taurus',
-        genome_type: 'Cow',
-        assembly: {
-          accession_id: 'GCA_002263795.2',
-          name: 'ARS-UCD1.2',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSBTAG00000000967.6',
-        symbol: 'DET1',
-        version: 6,
-        unversioned_stable_id: 'ENSBTAG00000000967'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 27.0,
         query_percent_coverage: 100.0,
@@ -129,9 +77,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: '0de83847-786a-4e31-9aed-4be7b10ec75f',
-        common_name: null,
+        common_name: 'Dog',
         scientific_name: 'Canis lupus familiaris',
-        genome_type: 'Dog',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_014441545.1',
           name: 'ROS_Cfam_1.0',
@@ -146,9 +94,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -169,59 +117,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 27.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 27.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: '0de83847-786a-4e31-9aed-4be7b10ec75f',
-        common_name: null,
-        scientific_name: 'Canis lupus familiaris',
-        genome_type: 'Dog',
-        assembly: {
-          accession_id: 'GCA_014441545.1',
-          name: 'ROS_Cfam_1.0',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSCAFG00845003631.1',
-        symbol: 'DET1',
-        version: 1,
-        unversioned_stable_id: 'ENSCAFG00845003631'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 27.0,
         query_percent_coverage: 100.0,
@@ -233,9 +129,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: '17318423-cb79-462f-a24f-d1a0d57d17cf',
-        common_name: null,
+        common_name: 'Chinese hamster CHOK1GS',
         scientific_name: 'Cricetulus griseus',
-        genome_type: 'Chinese hamster CHOK1GS',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_900186095.1',
           name: 'CHOK1GS_HDv1',
@@ -250,9 +146,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -273,59 +169,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 27.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 27.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: '17318423-cb79-462f-a24f-d1a0d57d17cf',
-        common_name: null,
-        scientific_name: 'Cricetulus griseus',
-        genome_type: 'Chinese hamster CHOK1GS',
-        assembly: {
-          accession_id: 'GCA_900186095.1',
-          name: 'CHOK1GS_HDv1',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSCGRG00001015151.1',
-        symbol: 'Det1',
-        version: 1,
-        unversioned_stable_id: 'ENSCGRG00001015151'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 27.0,
         query_percent_coverage: 100.0,
@@ -337,9 +181,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: '1c7f87d0-246c-4bad-9227-8d036259d868',
-        common_name: null,
+        common_name: 'Mexican tetra',
         scientific_name: 'Astyanax mexicanus',
-        genome_type: 'Mexican tetra',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000372685.2',
           name: 'Astyanax_mexicanus-2.0',
@@ -354,9 +198,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -377,59 +221,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 27.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 27.0,
-        target_percent_coverage: 99.1055
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: '1c7f87d0-246c-4bad-9227-8d036259d868',
-        common_name: null,
-        scientific_name: 'Astyanax mexicanus',
-        genome_type: 'Mexican tetra',
-        assembly: {
-          accession_id: 'GCA_000372685.2',
-          name: 'Astyanax_mexicanus-2.0',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSAMXG00000000376.2',
-        symbol: 'det1',
-        version: 2,
-        unversioned_stable_id: 'ENSAMXG00000000376'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 27.0,
         query_percent_coverage: 100.0,
@@ -441,9 +233,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: '21c5a530-56b3-4929-af7e-61273298b4d2',
-        common_name: null,
+        common_name: 'Horse',
         scientific_name: 'Equus caballus',
-        genome_type: 'Horse',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_002863925.1',
           name: 'EquCab3.0',
@@ -458,9 +250,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -481,59 +273,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 26.0,
-        query_percent_coverage: 92.5788,
-        target_percent_id: 26.0,
-        target_percent_coverage: 87.6977
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: '21c5a530-56b3-4929-af7e-61273298b4d2',
-        common_name: null,
-        scientific_name: 'Equus caballus',
-        genome_type: 'Horse',
-        assembly: {
-          accession_id: 'GCA_002863925.1',
-          name: 'EquCab3.0',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSECAG00000021247.4',
-        symbol: 'DET1',
-        version: 4,
-        unversioned_stable_id: 'ENSECAG00000021247'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 26.0,
         query_percent_coverage: 92.5788,
@@ -545,9 +285,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: '29981a48-c29d-4ec7-8ca6-67e8a2015d80',
-        common_name: null,
+        common_name: 'Macaque',
         scientific_name: 'Macaca mulatta',
-        genome_type: 'Macaque',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_003339765.3',
           name: 'Mmul_10',
@@ -562,9 +302,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -585,59 +325,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 27.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 27.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: '29981a48-c29d-4ec7-8ca6-67e8a2015d80',
-        common_name: null,
-        scientific_name: 'Macaca mulatta',
-        genome_type: 'Macaque',
-        assembly: {
-          accession_id: 'GCA_003339765.3',
-          name: 'Mmul_10',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSMMUG00000005758.4',
-        symbol: 'DET1',
-        version: 4,
-        unversioned_stable_id: 'ENSMMUG00000005758'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 27.0,
         query_percent_coverage: 100.0,
@@ -649,9 +337,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: '359326eb-1ee5-499a-890b-08c383f90d20',
-        common_name: null,
+        common_name: 'Pig',
         scientific_name: 'Sus scrofa',
-        genome_type: 'Pig',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000003025.6',
           name: 'Sscrofa11.1',
@@ -666,9 +354,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -689,59 +377,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 27.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 27.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: '359326eb-1ee5-499a-890b-08c383f90d20',
-        common_name: null,
-        scientific_name: 'Sus scrofa',
-        genome_type: 'Pig',
-        assembly: {
-          accession_id: 'GCA_000003025.6',
-          name: 'Sscrofa11.1',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSSSCG00000005103.6',
-        symbol: 'DET1',
-        version: 6,
-        unversioned_stable_id: 'ENSSSCG00000005103'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 27.0,
         query_percent_coverage: 100.0,
@@ -753,9 +389,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: '3c48f919-0dc9-4b20-8d9e-90744b7d7a32',
-        common_name: null,
+        common_name: 'Rabbit',
         scientific_name: 'Oryctolagus cuniculus',
-        genome_type: 'Rabbit',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000003625.1',
           name: 'OryCun2.0',
@@ -770,9 +406,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -793,59 +429,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 27.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 27.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: '3c48f919-0dc9-4b20-8d9e-90744b7d7a32',
-        common_name: null,
-        scientific_name: 'Oryctolagus cuniculus',
-        genome_type: 'Rabbit',
-        assembly: {
-          accession_id: 'GCA_000003625.1',
-          name: 'OryCun2.0',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSOCUG00000017555.4',
-        symbol: 'DET1',
-        version: 4,
-        unversioned_stable_id: 'ENSOCUG00000017555'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 27.0,
         query_percent_coverage: 100.0,
@@ -857,9 +441,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: '3d9faa38-0913-4e54-8678-ed9773f76e60',
-        common_name: null,
+        common_name: 'Zebrafish',
         scientific_name: 'Danio rerio',
-        genome_type: 'Zebrafish',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000002035.4',
           name: 'GRCz11',
@@ -874,9 +458,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -897,59 +481,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 27.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 27.0,
-        target_percent_coverage: 99.1119
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: '3d9faa38-0913-4e54-8678-ed9773f76e60',
-        common_name: null,
-        scientific_name: 'Danio rerio',
-        genome_type: 'Zebrafish',
-        assembly: {
-          accession_id: 'GCA_000002035.4',
-          name: 'GRCz11',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSDARG00000098247.2',
-        symbol: 'det1',
-        version: 2,
-        unversioned_stable_id: 'ENSDARG00000098247'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 27.0,
         query_percent_coverage: 100.0,
@@ -961,9 +493,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: '44183b9a-e6c3-4fbe-bb46-c73b4a7b3c7e',
-        common_name: null,
+        common_name: 'Atlantic salmon',
         scientific_name: 'Salmo salar',
-        genome_type: 'Atlantic salmon',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_905237065.2',
           name: 'Ssal_v3.1',
@@ -978,9 +510,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -1001,59 +533,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 27.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 27.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: '44183b9a-e6c3-4fbe-bb46-c73b4a7b3c7e',
-        common_name: null,
-        scientific_name: 'Salmo salar',
-        genome_type: 'Atlantic salmon',
-        assembly: {
-          accession_id: 'GCA_905237065.2',
-          name: 'Ssal_v3.1',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSSSAG00000054657.2',
-        symbol: 'DET1',
-        version: 2,
-        unversioned_stable_id: 'ENSSSAG00000054657'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 27.0,
         query_percent_coverage: 100.0,
@@ -1065,9 +545,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: '49f32f73-df6b-49e9-8acb-45e8fe5ebbdf',
-        common_name: null,
+        common_name: 'Glycine max',
         scientific_name: 'Glycine max',
-        genome_type: 'Glycine max',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000004515.4',
           name: 'Glycine_max_v2.1',
@@ -1082,9 +562,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -1105,59 +585,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 22.0,
-        query_percent_coverage: 96.475,
-        target_percent_id: 22.0,
-        target_percent_coverage: 97.0149
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: '49f32f73-df6b-49e9-8acb-45e8fe5ebbdf',
-        common_name: null,
-        scientific_name: 'Glycine max',
-        genome_type: 'Glycine max',
-        assembly: {
-          accession_id: 'GCA_000004515.4',
-          name: 'Glycine_max_v2.1',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'GLYMA_01G231700',
-        symbol: null,
-        version: null,
-        unversioned_stable_id: 'GLYMA_01G231700'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 22.0,
         query_percent_coverage: 96.475,
@@ -1169,9 +597,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: '4ad2a6aa-6cf5-4c2e-a324-cfbc95c2af8b',
-        common_name: null,
+        common_name: 'Chimpanzee',
         scientific_name: 'Pan troglodytes',
-        genome_type: 'Chimpanzee',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001515.5',
           name: 'Pan_tro_3.0',
@@ -1186,9 +614,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -1209,59 +637,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 27.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 27.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: '4ad2a6aa-6cf5-4c2e-a324-cfbc95c2af8b',
-        common_name: null,
-        scientific_name: 'Pan troglodytes',
-        genome_type: 'Chimpanzee',
-        assembly: {
-          accession_id: 'GCA_000001515.5',
-          name: 'Pan_tro_3.0',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSPTRG00000007421.6',
-        symbol: 'DET1',
-        version: 6,
-        unversioned_stable_id: 'ENSPTRG00000007421'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 27.0,
         query_percent_coverage: 100.0,
@@ -1273,9 +649,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: '541201d9-635a-4349-81fc-fd0a2f1030b1',
-        common_name: null,
+        common_name: 'Zea mays',
         scientific_name: 'Zea mays',
-        genome_type: 'Zea mays',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_902167145.1',
           name: 'Zm-B73-REFERENCE-NAM-5.0',
@@ -1290,9 +666,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -1313,59 +689,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 23.0,
-        query_percent_coverage: 94.4341,
-        target_percent_id: 23.0,
-        target_percent_coverage: 99.8039
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: '541201d9-635a-4349-81fc-fd0a2f1030b1',
-        common_name: null,
-        scientific_name: 'Zea mays',
-        genome_type: 'Zea mays',
-        assembly: {
-          accession_id: 'GCA_902167145.1',
-          name: 'Zm-B73-REFERENCE-NAM-5.0',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'Zm00001eb341540',
-        symbol: null,
-        version: null,
-        unversioned_stable_id: 'Zm00001eb341540'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 23.0,
         query_percent_coverage: 94.4341,
@@ -1377,9 +701,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: '5ca8d1a1-3b42-40fc-bafe-5bc13d33382c',
-        common_name: null,
+        common_name: 'Goat',
         scientific_name: 'Capra hircus',
-        genome_type: 'Goat',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_001704415.1',
           name: 'ARS1',
@@ -1394,9 +718,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -1417,59 +741,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 27.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 27.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: '5ca8d1a1-3b42-40fc-bafe-5bc13d33382c',
-        common_name: null,
-        scientific_name: 'Capra hircus',
-        genome_type: 'Goat',
-        assembly: {
-          accession_id: 'GCA_001704415.1',
-          name: 'ARS1',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSCHIG00000010346.1',
-        symbol: 'DET1',
-        version: 1,
-        unversioned_stable_id: 'ENSCHIG00000010346'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 27.0,
         query_percent_coverage: 100.0,
@@ -1481,9 +753,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: '5d8fce33-6171-4755-8c31-984a57ba8244',
-        common_name: null,
+        common_name: 'Brassica oleracea',
         scientific_name: 'Brassica oleracea var. oleracea',
-        genome_type: 'Brassica oleracea',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000695525.1',
           name: 'BOL',
@@ -1498,9 +770,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -1521,59 +793,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 25.0,
-        query_percent_coverage: 98.8868,
-        target_percent_id: 25.0,
-        target_percent_coverage: 99.4403
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: '5d8fce33-6171-4755-8c31-984a57ba8244',
-        common_name: null,
-        scientific_name: 'Brassica oleracea var. oleracea',
-        genome_type: 'Brassica oleracea',
-        assembly: {
-          accession_id: 'GCA_000695525.1',
-          name: 'BOL',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'Bo3g044580',
-        symbol: null,
-        version: null,
-        unversioned_stable_id: 'Bo3g044580'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 25.0,
         query_percent_coverage: 98.8868,
@@ -1585,9 +805,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: '63b9c430-329c-48bd-9165-ca830086f2c9',
-        common_name: null,
+        common_name: 'Cat',
         scientific_name: 'Felis catus',
-        genome_type: 'Cat',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000181335.4',
           name: 'Felis_catus_9.0',
@@ -1602,9 +822,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -1625,59 +845,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 27.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 27.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: '63b9c430-329c-48bd-9165-ca830086f2c9',
-        common_name: null,
-        scientific_name: 'Felis catus',
-        genome_type: 'Cat',
-        assembly: {
-          accession_id: 'GCA_000181335.4',
-          name: 'Felis_catus_9.0',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSFCAG00000014968.6',
-        symbol: 'DET1',
-        version: 6,
-        unversioned_stable_id: 'ENSFCAG00000014968'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 27.0,
         query_percent_coverage: 100.0,
@@ -1689,9 +857,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: '6f293c50-17a5-4801-aa8c-b4dba1f876ed',
-        common_name: null,
+        common_name: 'Sheep (texel)',
         scientific_name: 'Ovis aries',
-        genome_type: 'Sheep (texel)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000298735.1',
           name: 'Oar_v3.1',
@@ -1706,9 +874,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -1729,59 +897,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 28.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 28.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: '6f293c50-17a5-4801-aa8c-b4dba1f876ed',
-        common_name: null,
-        scientific_name: 'Ovis aries',
-        genome_type: 'Sheep (texel)',
-        assembly: {
-          accession_id: 'GCA_000298735.1',
-          name: 'Oar_v3.1',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSOARG00000010954.1',
-        symbol: null,
-        version: 1,
-        unversioned_stable_id: 'ENSOARG00000010954'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 28.0,
         query_percent_coverage: 100.0,
@@ -1793,9 +909,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: '76c06dd6-5a7e-4656-b223-b1fdb63d567f',
-        common_name: null,
+        common_name: 'Arabidopsis thaliana',
         scientific_name: 'Arabidopsis thaliana',
-        genome_type: 'Arabidopsis thaliana',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001735.1',
           name: 'TAIR10',
@@ -1810,9 +926,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -1833,59 +949,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 23.0,
-        query_percent_coverage: 99.0724,
-        target_percent_id: 23.0,
-        target_percent_coverage: 98.3425
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: '76c06dd6-5a7e-4656-b223-b1fdb63d567f',
-        common_name: null,
-        scientific_name: 'Arabidopsis thaliana',
-        genome_type: 'Arabidopsis thaliana',
-        assembly: {
-          accession_id: 'GCA_000001735.1',
-          name: 'TAIR10',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'AT4G10180',
-        symbol: 'DET1',
-        version: null,
-        unversioned_stable_id: 'AT4G10180'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 23.0,
         query_percent_coverage: 99.0724,
@@ -1897,9 +961,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: '88abdf6b-e16a-48fd-9767-3555b8b9b365',
-        common_name: null,
+        common_name: 'Aegilops tauschii',
         scientific_name: 'Aegilops tauschii subsp. strangulata',
-        genome_type: 'Aegilops tauschii',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_002575655.1',
           name: 'Aet v4.0',
@@ -1914,9 +978,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -1937,59 +1001,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 25.0,
-        query_percent_coverage: 93.692,
-        target_percent_id: 25.0,
-        target_percent_coverage: 91.9854
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: '88abdf6b-e16a-48fd-9767-3555b8b9b365',
-        common_name: null,
-        scientific_name: 'Aegilops tauschii subsp. strangulata',
-        genome_type: 'Aegilops tauschii',
-        assembly: {
-          accession_id: 'GCA_002575655.1',
-          name: 'Aet v4.0',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'AET3Gv20472500',
-        symbol: null,
-        version: null,
-        unversioned_stable_id: 'AET3Gv20472500'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 25.0,
         query_percent_coverage: 93.692,
@@ -2001,9 +1013,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: '8fe05926-0402-488f-b971-db4825c6d72e',
-        common_name: null,
+        common_name: 'Rat',
         scientific_name: 'Rattus norvegicus',
-        genome_type: 'Rat',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_015227675.2',
           name: 'mRatBN7.2',
@@ -2018,9 +1030,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -2041,59 +1053,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 27.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 27.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: '8fe05926-0402-488f-b971-db4825c6d72e',
-        common_name: null,
-        scientific_name: 'Rattus norvegicus',
-        genome_type: 'Rat',
-        assembly: {
-          accession_id: 'GCA_015227675.2',
-          name: 'mRatBN7.2',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSRNOG00000018515.7',
-        symbol: 'Det1',
-        version: 7,
-        unversioned_stable_id: 'ENSRNOG00000018515'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 27.0,
         query_percent_coverage: 100.0,
@@ -2105,9 +1065,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: '915ac71a-ecc9-49a6-add1-f739ecde2b90',
-        common_name: null,
+        common_name: 'Mouse',
         scientific_name: 'Mus musculus',
-        genome_type: 'Mouse',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001635.9',
           name: 'GRCm39',
@@ -2122,9 +1082,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -2145,59 +1105,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 27.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 27.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: '915ac71a-ecc9-49a6-add1-f739ecde2b90',
-        common_name: null,
-        scientific_name: 'Mus musculus',
-        genome_type: 'Mouse',
-        assembly: {
-          accession_id: 'GCA_000001635.9',
-          name: 'GRCm39',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSMUSG00000030610.14',
-        symbol: 'Det1',
-        version: 14,
-        unversioned_stable_id: 'ENSMUSG00000030610'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 27.0,
         query_percent_coverage: 100.0,
@@ -2209,9 +1117,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: 'a7335667-93e7-11ec-a39d-005056b38ce3',
-        common_name: null,
+        common_name: 'Human',
         scientific_name: 'Homo sapiens',
-        genome_type: 'Human',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001405.28',
           name: 'GRCh38.p13',
@@ -2226,9 +1134,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -2249,59 +1157,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 27.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 27.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'a7335667-93e7-11ec-a39d-005056b38ce3',
-        common_name: null,
-        scientific_name: 'Homo sapiens',
-        genome_type: 'Human',
-        assembly: {
-          accession_id: 'GCA_000001405.28',
-          name: 'GRCh38.p13',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSG00000140543.15',
-        symbol: 'DET1',
-        version: 15,
-        unversioned_stable_id: 'ENSG00000140543'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 27.0,
         query_percent_coverage: 100.0,
@@ -2313,9 +1169,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: 'a73357ab-93e7-11ec-a39d-005056b38ce3',
-        common_name: null,
+        common_name: 'Triticum aestivum',
         scientific_name: 'Triticum aestivum',
-        genome_type: 'Triticum aestivum',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_900519105.1',
           name: 'IWGSC',
@@ -2330,9 +1186,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -2353,59 +1209,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 25.0,
-        query_percent_coverage: 93.692,
-        target_percent_id: 25.0,
-        target_percent_coverage: 98.8258
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'a73357ab-93e7-11ec-a39d-005056b38ce3',
-        common_name: null,
-        scientific_name: 'Triticum aestivum',
-        genome_type: 'Triticum aestivum',
-        assembly: {
-          accession_id: 'GCA_900519105.1',
-          name: 'IWGSC',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'TraesCS3A02G194600',
-        symbol: null,
-        version: null,
-        unversioned_stable_id: 'TraesCS3A02G194600'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 25.0,
         query_percent_coverage: 93.692,
@@ -2417,9 +1221,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: 'a8ddb817-82de-4230-897c-06384a8f01eb',
-        common_name: null,
+        common_name: 'Nile tilapia',
         scientific_name: 'Oreochromis niloticus',
-        genome_type: 'Nile tilapia',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_001858045.3',
           name: 'O_niloticus_UMD_NMBU',
@@ -2434,9 +1238,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -2457,59 +1261,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 28.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 28.0,
-        target_percent_coverage: 96.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'a8ddb817-82de-4230-897c-06384a8f01eb',
-        common_name: null,
-        scientific_name: 'Oreochromis niloticus',
-        genome_type: 'Nile tilapia',
-        assembly: {
-          accession_id: 'GCA_001858045.3',
-          name: 'O_niloticus_UMD_NMBU',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSONIG00000011104.2',
-        symbol: 'det1',
-        version: 2,
-        unversioned_stable_id: 'ENSONIG00000011104'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 28.0,
         query_percent_coverage: 100.0,
@@ -2521,9 +1273,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: 'afaeb837-45a3-4a03-8ac4-c5e0118ca1cc',
-        common_name: null,
+        common_name: 'Hordeum vulgare',
         scientific_name: 'Hordeum vulgare subsp. vulgare',
-        genome_type: 'Hordeum vulgare',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_904849725.1',
           name: 'MorexV3_pseudomolecules_assembly',
@@ -2538,9 +1290,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -2561,59 +1313,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 25.0,
-        query_percent_coverage: 93.5065,
-        target_percent_id: 25.0,
-        target_percent_coverage: 98.6301
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'afaeb837-45a3-4a03-8ac4-c5e0118ca1cc',
-        common_name: null,
-        scientific_name: 'Hordeum vulgare subsp. vulgare',
-        genome_type: 'Hordeum vulgare',
-        assembly: {
-          accession_id: 'GCA_904849725.1',
-          name: 'MorexV3_pseudomolecules_assembly',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'HORVU.MOREX.r3.3HG0262020',
-        symbol: null,
-        version: null,
-        unversioned_stable_id: 'HORVU.MOREX.r3.3HG0262020'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 25.0,
         query_percent_coverage: 93.5065,
@@ -2625,9 +1325,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: 'ba3074a6-b9de-45c7-be4c-3036990305d8',
-        common_name: null,
+        common_name: 'Vitis vinifera',
         scientific_name: 'Vitis vinifera',
-        genome_type: 'Vitis vinifera',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_910591555.1',
           name: 'PN40024.v4',
@@ -2642,9 +1342,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -2665,59 +1365,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 23.0,
-        query_percent_coverage: 97.4026,
-        target_percent_id: 23.0,
-        target_percent_coverage: 98.8701
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'ba3074a6-b9de-45c7-be4c-3036990305d8',
-        common_name: null,
-        scientific_name: 'Vitis vinifera',
-        genome_type: 'Vitis vinifera',
-        assembly: {
-          accession_id: 'GCA_910591555.1',
-          name: 'PN40024.v4',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'Vitvi15g00849',
-        symbol: null,
-        version: null,
-        unversioned_stable_id: 'Vitvi15g00849'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 23.0,
         query_percent_coverage: 97.4026,
@@ -2729,9 +1377,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: 'bc069fc1-f4b2-48af-997e-ea1fbb1429ea',
-        common_name: null,
+        common_name: 'Medicago truncatula',
         scientific_name: 'Medicago truncatula',
-        genome_type: 'Medicago truncatula',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000219495.2',
           name: 'MedtrA17_4.0',
@@ -2746,9 +1394,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -2769,59 +1417,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 22.0,
-        query_percent_coverage: 97.0315,
-        target_percent_id: 22.0,
-        target_percent_coverage: 97.0315
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'bc069fc1-f4b2-48af-997e-ea1fbb1429ea',
-        common_name: null,
-        scientific_name: 'Medicago truncatula',
-        genome_type: 'Medicago truncatula',
-        assembly: {
-          accession_id: 'GCA_000219495.2',
-          name: 'MedtrA17_4.0',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'MTR_5g008710',
-        symbol: null,
-        version: null,
-        unversioned_stable_id: 'MTR_5g008710'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 22.0,
         query_percent_coverage: 97.0315,
@@ -2833,9 +1429,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: 'c7550d32-923f-4597-80f6-e4a6c8a67db9',
-        common_name: null,
+        common_name: 'Chicken',
         scientific_name: 'Gallus gallus',
-        genome_type: 'Chicken',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_016699485.1',
           name: 'bGalGal1.mat.broiler.GRCg7b',
@@ -2850,9 +1446,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -2873,59 +1469,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 26.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 26.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'c7550d32-923f-4597-80f6-e4a6c8a67db9',
-        common_name: null,
-        scientific_name: 'Gallus gallus',
-        genome_type: 'Chicken',
-        assembly: {
-          accession_id: 'GCA_016699485.1',
-          name: 'bGalGal1.mat.broiler.GRCg7b',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSGALG00010020199.1',
-        symbol: 'DET1',
-        version: 1,
-        unversioned_stable_id: 'ENSGALG00010020199'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 26.0,
         query_percent_coverage: 100.0,
@@ -2937,9 +1481,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: 'd8223875-5f6e-4eed-980f-7d8dd53a58ba',
-        common_name: null,
+        common_name: 'Solanum tuberosum',
         scientific_name: 'Solanum tuberosum',
-        genome_type: 'Solanum tuberosum',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000226075.1',
           name: 'SolTub_3.0',
@@ -2954,9 +1498,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -2977,59 +1521,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 23.0,
-        query_percent_coverage: 51.7625,
-        target_percent_id: 23.0,
-        target_percent_coverage: 93.9394
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'd8223875-5f6e-4eed-980f-7d8dd53a58ba',
-        common_name: null,
-        scientific_name: 'Solanum tuberosum',
-        genome_type: 'Solanum tuberosum',
-        assembly: {
-          accession_id: 'GCA_000226075.1',
-          name: 'SolTub_3.0',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'PGSC0003DMG400031459',
-        symbol: null,
-        version: null,
-        unversioned_stable_id: 'PGSC0003DMG400031459'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 23.0,
         query_percent_coverage: 51.7625,
@@ -3041,9 +1533,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: 'ddc0e9cc-8453-4837-b9ba-3e86f5d5f420',
-        common_name: null,
+        common_name: 'Brassica napus',
         scientific_name: 'Brassica napus',
-        genome_type: 'Brassica napus',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000751015.1',
           name: 'AST_PRJEB5043_v1',
@@ -3058,9 +1550,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -3081,59 +1573,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 24.0,
-        query_percent_coverage: 98.8868,
-        target_percent_id: 24.0,
-        target_percent_coverage: 99.2551
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'ddc0e9cc-8453-4837-b9ba-3e86f5d5f420',
-        common_name: null,
-        scientific_name: 'Brassica napus',
-        genome_type: 'Brassica napus',
-        assembly: {
-          accession_id: 'GCA_000751015.1',
-          name: 'AST_PRJEB5043_v1',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'GSBRNA2T00151439001',
-        symbol: 'BnaA03g24270D',
-        version: null,
-        unversioned_stable_id: 'GSBRNA2T00151439001'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 24.0,
         query_percent_coverage: 98.8868,
@@ -3145,9 +1585,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: 'dedc3834-8dad-4b41-a03a-68719648cae4',
-        common_name: null,
+        common_name: 'Triticum turgidum',
         scientific_name: 'Triticum turgidum subsp. durum',
-        genome_type: 'Triticum turgidum',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_900231445.1',
           name: 'svevo',
@@ -3162,9 +1602,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -3185,59 +1625,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 25.0,
-        query_percent_coverage: 93.8775,
-        target_percent_id: 25.0,
-        target_percent_coverage: 98.8281
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'dedc3834-8dad-4b41-a03a-68719648cae4',
-        common_name: null,
-        scientific_name: 'Triticum turgidum subsp. durum',
-        genome_type: 'Triticum turgidum',
-        assembly: {
-          accession_id: 'GCA_900231445.1',
-          name: 'svevo',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'TRITD3Av1G105180',
-        symbol: null,
-        version: null,
-        unversioned_stable_id: 'TRITD3Av1G105180'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 25.0,
         query_percent_coverage: 93.8775,
@@ -3249,9 +1637,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: 'e36e7b9d-3901-4d9f-bd44-853b200a8caf',
-        common_name: null,
+        common_name: 'Tropical clawed frog',
         scientific_name: 'Xenopus tropicalis',
-        genome_type: 'Tropical clawed frog',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000004195.4',
           name: 'UCB_Xtro_10.0',
@@ -3266,9 +1654,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -3289,59 +1677,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 27.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 27.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'e36e7b9d-3901-4d9f-bd44-853b200a8caf',
-        common_name: null,
-        scientific_name: 'Xenopus tropicalis',
-        genome_type: 'Tropical clawed frog',
-        assembly: {
-          accession_id: 'GCA_000004195.4',
-          name: 'UCB_Xtro_10.0',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSXETG00000007591.5',
-        symbol: 'det1',
-        version: 5,
-        unversioned_stable_id: 'ENSXETG00000007591'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 27.0,
         query_percent_coverage: 100.0,
@@ -3353,9 +1689,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: 'ea877d68-4819-43c4-8dee-157728cac494',
-        common_name: null,
+        common_name: 'Oryza sativa Japonica Group',
         scientific_name: 'Oryza sativa Japonica Group',
-        genome_type: 'Oryza sativa Japonica Group',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_001433935.1',
           name: 'IRGSP-1.0',
@@ -3370,9 +1706,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -3393,59 +1729,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 24.0,
-        query_percent_coverage: 91.4657,
-        target_percent_id: 24.0,
-        target_percent_coverage: 96.4775
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'ea877d68-4819-43c4-8dee-157728cac494',
-        common_name: null,
-        scientific_name: 'Oryza sativa Japonica Group',
-        genome_type: 'Oryza sativa Japonica Group',
-        assembly: {
-          accession_id: 'GCA_001433935.1',
-          name: 'IRGSP-1.0',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'Os01g0104600',
-        symbol: 'OsDET1',
-        version: null,
-        unversioned_stable_id: 'Os01g0104600'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 24.0,
         query_percent_coverage: 91.4657,
@@ -3457,9 +1741,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: 'eee9c096-9196-4bc1-a6ad-f1ff18d3fd89',
-        common_name: null,
+        common_name: 'Brassica rapa',
         scientific_name: 'Brassica rapa',
-        genome_type: 'Brassica rapa',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000309985.1',
           name: 'Brapa_1.0',
@@ -3474,9 +1758,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -3497,59 +1781,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 24.0,
-        query_percent_coverage: 98.8868,
-        target_percent_id: 24.0,
-        target_percent_coverage: 99.2551
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'eee9c096-9196-4bc1-a6ad-f1ff18d3fd89',
-        common_name: null,
-        scientific_name: 'Brassica rapa',
-        genome_type: 'Brassica rapa',
-        assembly: {
-          accession_id: 'GCA_000309985.1',
-          name: 'Brapa_1.0',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'Bra000702',
-        symbol: null,
-        version: null,
-        unversioned_stable_id: 'Bra000702'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 24.0,
         query_percent_coverage: 98.8868,
@@ -3561,9 +1793,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: 'f1756fce-9cab-48cb-826f-ed10afbb9bbb',
-        common_name: null,
+        common_name: 'Japanese medaka HdrR',
         scientific_name: 'Oryzias latipes',
-        genome_type: 'Japanese medaka HdrR',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_002234675.1',
           name: 'ASM223467v1',
@@ -3578,9 +1810,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -3601,59 +1833,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 28.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 28.0,
-        target_percent_coverage: 98.7633
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'f1756fce-9cab-48cb-826f-ed10afbb9bbb',
-        common_name: null,
-        scientific_name: 'Oryzias latipes',
-        genome_type: 'Japanese medaka HdrR',
-        assembly: {
-          accession_id: 'GCA_002234675.1',
-          name: 'ASM223467v1',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSORLG00000012676.2',
-        symbol: 'det1',
-        version: 2,
-        unversioned_stable_id: 'ENSORLG00000012676'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 28.0,
         query_percent_coverage: 100.0,
@@ -3665,9 +1845,9 @@ const homologies = {
     {
       target_genome: {
         genome_id: 'fdfbd78d-76bc-48ad-bb4d-135ed7ee9ab1',
-        common_name: null,
+        common_name: 'Sorghum bicolor',
         scientific_name: 'Sorghum bicolor',
-        genome_type: 'Sorghum bicolor',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000003195.3',
           name: 'Sorghum_bicolor_NCBIv3',
@@ -3682,9 +1862,9 @@ const homologies = {
       },
       query_genome: {
         genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
+        common_name: 'Drosophila melanogaster (Fruit fly)',
         scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        genome_type: null,
         assembly: {
           accession_id: 'GCA_000001215.4',
           name: 'BDGP6.46',
@@ -3705,59 +1885,7 @@ const homologies = {
         definition: 'Reciprocal best BLAST hit homolog',
         description: null
       },
-      release_version: 100.1,
-      stats: {
-        query_percent_id: 24.0,
-        query_percent_coverage: 95.3618,
-        target_percent_id: 24.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'fdfbd78d-76bc-48ad-bb4d-135ed7ee9ab1',
-        common_name: null,
-        scientific_name: 'Sorghum bicolor',
-        genome_type: 'Sorghum bicolor',
-        assembly: {
-          accession_id: 'GCA_000003195.3',
-          name: 'Sorghum_bicolor_NCBIv3',
-          url: null
-        }
-      },
-      target_gene: {
-        stable_id: 'SORBI_3007G058100',
-        symbol: null,
-        version: null,
-        unversioned_stable_id: 'SORBI_3007G058100'
-      },
-      query_genome: {
-        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
-        common_name: null,
-        scientific_name: 'Drosophila melanogaster',
-        genome_type: 'Drosophila melanogaster (Fruit fly)',
-        assembly: {
-          accession_id: 'GCA_000001215.4',
-          name: 'BDGP6.46',
-          url: null
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: null,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: {
-        accession_id: 'homology_subtype.homolog_rbbh',
-        label: 'RBBH',
-        value: 'homolog_rbbh',
-        definition: 'Reciprocal best BLAST hit homolog',
-        description: null
-      },
-      release_version: 100.1,
+      release_version: 101.0,
       stats: {
         query_percent_id: 24.0,
         query_percent_coverage: 95.3618,

--- a/src/content/app/entity-viewer/state/api/fixtures/mockHomologyData.ts
+++ b/src/content/app/entity-viewer/state/api/fixtures/mockHomologyData.ts
@@ -24,106 +24,326 @@ const homologies = {
   homologies: [
     {
       target_genome: {
-        genome_id: 'aegilops_tauschii',
-        common_name: 'aegilops_tauschii',
-        scientific_name: 'aegilops_tauschii',
-        genome_type: 'reference',
+        genome_id: '00d87371-57f1-4dc2-8f21-6bd825146a49',
+        common_name: null,
+        scientific_name: 'Bos taurus',
+        genome_type: 'Cow',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_002263795.2',
+          name: 'ARS-UCD1.2',
+          url: null
         }
       },
       target_gene: {
-        stable_id: 'AET3Gv20472500',
-        symbol: null,
-        version: 0,
-        unversioned_stable_id: 'AET3Gv20472500'
-      },
-      query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: 0,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
-      stats: {
-        query_percent_id: 25.0,
-        query_percent_coverage: 93.692,
-        target_percent_id: 25.0,
-        target_percent_coverage: 91.9854
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'arabidopsis_thaliana',
-        common_name: 'arabidopsis_thaliana',
-        scientific_name: 'arabidopsis_thaliana',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      target_gene: {
-        stable_id: 'AT4G10180',
+        stable_id: 'ENSBTAG00000000967.6',
         symbol: 'DET1',
-        version: 0,
-        unversioned_stable_id: 'AT4G10180'
+        version: 6,
+        unversioned_stable_id: 'ENSBTAG00000000967'
       },
       query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
         }
       },
       query_gene: {
         stable_id: 'FBgn0000018',
         symbol: 'abo',
-        version: 0,
+        version: null,
         unversioned_stable_id: 'FBgn0000018'
       },
       type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
       stats: {
-        query_percent_id: 23.0,
-        query_percent_coverage: 99.0724,
-        target_percent_id: 23.0,
-        target_percent_coverage: 98.3425
+        query_percent_id: 27.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 27.0,
+        target_percent_coverage: 100.0
       },
       alignment: null
     },
     {
       target_genome: {
-        genome_id: 'astyanax_mexicanus',
-        common_name: 'astyanax_mexicanus',
-        scientific_name: 'astyanax_mexicanus',
-        genome_type: 'reference',
+        genome_id: '00d87371-57f1-4dc2-8f21-6bd825146a49',
+        common_name: null,
+        scientific_name: 'Bos taurus',
+        genome_type: 'Cow',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_002263795.2',
+          name: 'ARS-UCD1.2',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSBTAG00000000967.6',
+        symbol: 'DET1',
+        version: 6,
+        unversioned_stable_id: 'ENSBTAG00000000967'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 27.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 27.0,
+        target_percent_coverage: 100.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '0de83847-786a-4e31-9aed-4be7b10ec75f',
+        common_name: null,
+        scientific_name: 'Canis lupus familiaris',
+        genome_type: 'Dog',
+        assembly: {
+          accession_id: 'GCA_014441545.1',
+          name: 'ROS_Cfam_1.0',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSCAFG00845003631.1',
+        symbol: 'DET1',
+        version: 1,
+        unversioned_stable_id: 'ENSCAFG00845003631'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 27.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 27.0,
+        target_percent_coverage: 100.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '0de83847-786a-4e31-9aed-4be7b10ec75f',
+        common_name: null,
+        scientific_name: 'Canis lupus familiaris',
+        genome_type: 'Dog',
+        assembly: {
+          accession_id: 'GCA_014441545.1',
+          name: 'ROS_Cfam_1.0',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSCAFG00845003631.1',
+        symbol: 'DET1',
+        version: 1,
+        unversioned_stable_id: 'ENSCAFG00845003631'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 27.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 27.0,
+        target_percent_coverage: 100.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '17318423-cb79-462f-a24f-d1a0d57d17cf',
+        common_name: null,
+        scientific_name: 'Cricetulus griseus',
+        genome_type: 'Chinese hamster CHOK1GS',
+        assembly: {
+          accession_id: 'GCA_900186095.1',
+          name: 'CHOK1GS_HDv1',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSCGRG00001015151.1',
+        symbol: 'Det1',
+        version: 1,
+        unversioned_stable_id: 'ENSCGRG00001015151'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 27.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 27.0,
+        target_percent_coverage: 100.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '17318423-cb79-462f-a24f-d1a0d57d17cf',
+        common_name: null,
+        scientific_name: 'Cricetulus griseus',
+        genome_type: 'Chinese hamster CHOK1GS',
+        assembly: {
+          accession_id: 'GCA_900186095.1',
+          name: 'CHOK1GS_HDv1',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSCGRG00001015151.1',
+        symbol: 'Det1',
+        version: 1,
+        unversioned_stable_id: 'ENSCGRG00001015151'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 27.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 27.0,
+        target_percent_coverage: 100.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '1c7f87d0-246c-4bad-9227-8d036259d868',
+        common_name: null,
+        scientific_name: 'Astyanax mexicanus',
+        genome_type: 'Mexican tetra',
+        assembly: {
+          accession_id: 'GCA_000372685.2',
+          name: 'Astyanax_mexicanus-2.0',
+          url: null
         }
       },
       target_gene: {
@@ -133,25 +353,31 @@ const homologies = {
         unversioned_stable_id: 'ENSAMXG00000000376'
       },
       query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
         }
       },
       query_gene: {
         stable_id: 'FBgn0000018',
         symbol: 'abo',
-        version: 0,
+        version: null,
         unversioned_stable_id: 'FBgn0000018'
       },
       type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
       stats: {
         query_percent_id: 27.0,
         query_percent_coverage: 100.0,
@@ -162,382 +388,66 @@ const homologies = {
     },
     {
       target_genome: {
-        genome_id: 'bos_taurus',
-        common_name: 'bos_taurus',
-        scientific_name: 'bos_taurus',
-        genome_type: 'reference',
+        genome_id: '1c7f87d0-246c-4bad-9227-8d036259d868',
+        common_name: null,
+        scientific_name: 'Astyanax mexicanus',
+        genome_type: 'Mexican tetra',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_000372685.2',
+          name: 'Astyanax_mexicanus-2.0',
+          url: null
         }
       },
       target_gene: {
-        stable_id: 'ENSBTAG00000000967.6',
-        symbol: 'DET1',
-        version: 6,
-        unversioned_stable_id: 'ENSBTAG00000000967'
-      },
-      query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: 0,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
-      stats: {
-        query_percent_id: 27.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 27.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'brassica_napus',
-        common_name: 'brassica_napus',
-        scientific_name: 'brassica_napus',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      target_gene: {
-        stable_id: 'GSBRNA2T00151439001',
-        symbol: 'BnaA03g24270D',
-        version: 0,
-        unversioned_stable_id: 'GSBRNA2T00151439001'
-      },
-      query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: 0,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
-      stats: {
-        query_percent_id: 24.0,
-        query_percent_coverage: 98.8868,
-        target_percent_id: 24.0,
-        target_percent_coverage: 99.2551
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'brassica_oleracea',
-        common_name: 'brassica_oleracea',
-        scientific_name: 'brassica_oleracea',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      target_gene: {
-        stable_id: 'Bo3g044580',
-        symbol: null,
-        version: 0,
-        unversioned_stable_id: 'Bo3g044580'
-      },
-      query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: 0,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
-      stats: {
-        query_percent_id: 25.0,
-        query_percent_coverage: 98.8868,
-        target_percent_id: 25.0,
-        target_percent_coverage: 99.4403
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'brassica_rapa',
-        common_name: 'brassica_rapa',
-        scientific_name: 'brassica_rapa',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      target_gene: {
-        stable_id: 'Bra000702',
-        symbol: null,
-        version: 0,
-        unversioned_stable_id: 'Bra000702'
-      },
-      query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: 0,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
-      stats: {
-        query_percent_id: 24.0,
-        query_percent_coverage: 98.8868,
-        target_percent_id: 24.0,
-        target_percent_coverage: 99.2551
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'canis_lupus_familiaris',
-        common_name: 'canis_lupus_familiaris',
-        scientific_name: 'canis_lupus_familiaris',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSCAFG00845003631.1',
-        symbol: 'DET1',
-        version: 1,
-        unversioned_stable_id: 'ENSCAFG00845003631'
-      },
-      query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: 0,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
-      stats: {
-        query_percent_id: 27.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 27.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'capra_hircus',
-        common_name: 'capra_hircus',
-        scientific_name: 'capra_hircus',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSCHIG00000010346.1',
-        symbol: 'DET1',
-        version: 1,
-        unversioned_stable_id: 'ENSCHIG00000010346'
-      },
-      query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: 0,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
-      stats: {
-        query_percent_id: 27.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 27.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'cricetulus_griseus_chok1gshd',
-        common_name: 'cricetulus_griseus_chok1gshd',
-        scientific_name: 'cricetulus_griseus_chok1gshd',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSCGRG00001015151.1',
-        symbol: 'Det1',
-        version: 1,
-        unversioned_stable_id: 'ENSCGRG00001015151'
-      },
-      query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: 0,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
-      stats: {
-        query_percent_id: 27.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 27.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'danio_rerio',
-        common_name: 'danio_rerio',
-        scientific_name: 'danio_rerio',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSDARG00000098247.2',
+        stable_id: 'ENSAMXG00000000376.2',
         symbol: 'det1',
         version: 2,
-        unversioned_stable_id: 'ENSDARG00000098247'
+        unversioned_stable_id: 'ENSAMXG00000000376'
       },
       query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
         }
       },
       query_gene: {
         stable_id: 'FBgn0000018',
         symbol: 'abo',
-        version: 0,
+        version: null,
         unversioned_stable_id: 'FBgn0000018'
       },
       type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
       stats: {
         query_percent_id: 27.0,
         query_percent_coverage: 100.0,
         target_percent_id: 27.0,
-        target_percent_coverage: 99.1119
+        target_percent_coverage: 99.1055
       },
       alignment: null
     },
     {
       target_genome: {
-        genome_id: 'equus_caballus',
-        common_name: 'equus_caballus',
-        scientific_name: 'equus_caballus',
-        genome_type: 'reference',
+        genome_id: '21c5a530-56b3-4929-af7e-61273298b4d2',
+        common_name: null,
+        scientific_name: 'Equus caballus',
+        genome_type: 'Horse',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_002863925.1',
+          name: 'EquCab3.0',
+          url: null
         }
       },
       target_gene: {
@@ -547,25 +457,31 @@ const homologies = {
         unversioned_stable_id: 'ENSECAG00000021247'
       },
       query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
         }
       },
       query_gene: {
         stable_id: 'FBgn0000018',
         symbol: 'abo',
-        version: 0,
+        version: null,
         unversioned_stable_id: 'FBgn0000018'
       },
       type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
       stats: {
         query_percent_id: 26.0,
         query_percent_coverage: 92.5788,
@@ -576,42 +492,100 @@ const homologies = {
     },
     {
       target_genome: {
-        genome_id: 'felis_catus',
-        common_name: 'felis_catus',
-        scientific_name: 'felis_catus',
-        genome_type: 'reference',
+        genome_id: '21c5a530-56b3-4929-af7e-61273298b4d2',
+        common_name: null,
+        scientific_name: 'Equus caballus',
+        genome_type: 'Horse',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_002863925.1',
+          name: 'EquCab3.0',
+          url: null
         }
       },
       target_gene: {
-        stable_id: 'ENSFCAG00000014968.6',
+        stable_id: 'ENSECAG00000021247.4',
         symbol: 'DET1',
-        version: 6,
-        unversioned_stable_id: 'ENSFCAG00000014968'
+        version: 4,
+        unversioned_stable_id: 'ENSECAG00000021247'
       },
       query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
         }
       },
       query_gene: {
         stable_id: 'FBgn0000018',
         symbol: 'abo',
-        version: 0,
+        version: null,
         unversioned_stable_id: 'FBgn0000018'
       },
       type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 26.0,
+        query_percent_coverage: 92.5788,
+        target_percent_id: 26.0,
+        target_percent_coverage: 87.6977
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '29981a48-c29d-4ec7-8ca6-67e8a2015d80',
+        common_name: null,
+        scientific_name: 'Macaca mulatta',
+        genome_type: 'Macaque',
+        assembly: {
+          accession_id: 'GCA_003339765.3',
+          name: 'Mmul_10',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSMMUG00000005758.4',
+        symbol: 'DET1',
+        version: 4,
+        unversioned_stable_id: 'ENSMMUG00000005758'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
       stats: {
         query_percent_id: 27.0,
         query_percent_coverage: 100.0,
@@ -622,88 +596,516 @@ const homologies = {
     },
     {
       target_genome: {
-        genome_id: 'gallus_gallus',
-        common_name: 'gallus_gallus',
-        scientific_name: 'gallus_gallus',
-        genome_type: 'reference',
+        genome_id: '29981a48-c29d-4ec7-8ca6-67e8a2015d80',
+        common_name: null,
+        scientific_name: 'Macaca mulatta',
+        genome_type: 'Macaque',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_003339765.3',
+          name: 'Mmul_10',
+          url: null
         }
       },
       target_gene: {
-        stable_id: 'ENSGALG00010020199.1',
+        stable_id: 'ENSMMUG00000005758.4',
         symbol: 'DET1',
-        version: 1,
-        unversioned_stable_id: 'ENSGALG00010020199'
+        version: 4,
+        unversioned_stable_id: 'ENSMMUG00000005758'
       },
       query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
         }
       },
       query_gene: {
         stable_id: 'FBgn0000018',
         symbol: 'abo',
-        version: 0,
+        version: null,
         unversioned_stable_id: 'FBgn0000018'
       },
       type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
       stats: {
-        query_percent_id: 26.0,
+        query_percent_id: 27.0,
         query_percent_coverage: 100.0,
-        target_percent_id: 26.0,
+        target_percent_id: 27.0,
         target_percent_coverage: 100.0
       },
       alignment: null
     },
     {
       target_genome: {
-        genome_id: 'glycine_max',
-        common_name: 'glycine_max',
-        scientific_name: 'glycine_max',
-        genome_type: 'reference',
+        genome_id: '359326eb-1ee5-499a-890b-08c383f90d20',
+        common_name: null,
+        scientific_name: 'Sus scrofa',
+        genome_type: 'Pig',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_000003025.6',
+          name: 'Sscrofa11.1',
+          url: null
         }
       },
       target_gene: {
-        stable_id: 'GLYMA_01G231700',
-        symbol: null,
-        version: 0,
-        unversioned_stable_id: 'GLYMA_01G231700'
+        stable_id: 'ENSSSCG00000005103.6',
+        symbol: 'DET1',
+        version: 6,
+        unversioned_stable_id: 'ENSSSCG00000005103'
       },
       query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
         }
       },
       query_gene: {
         stable_id: 'FBgn0000018',
         symbol: 'abo',
-        version: 0,
+        version: null,
         unversioned_stable_id: 'FBgn0000018'
       },
       type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 27.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 27.0,
+        target_percent_coverage: 100.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '359326eb-1ee5-499a-890b-08c383f90d20',
+        common_name: null,
+        scientific_name: 'Sus scrofa',
+        genome_type: 'Pig',
+        assembly: {
+          accession_id: 'GCA_000003025.6',
+          name: 'Sscrofa11.1',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSSSCG00000005103.6',
+        symbol: 'DET1',
+        version: 6,
+        unversioned_stable_id: 'ENSSSCG00000005103'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 27.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 27.0,
+        target_percent_coverage: 100.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '3c48f919-0dc9-4b20-8d9e-90744b7d7a32',
+        common_name: null,
+        scientific_name: 'Oryctolagus cuniculus',
+        genome_type: 'Rabbit',
+        assembly: {
+          accession_id: 'GCA_000003625.1',
+          name: 'OryCun2.0',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSOCUG00000017555.4',
+        symbol: 'DET1',
+        version: 4,
+        unversioned_stable_id: 'ENSOCUG00000017555'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 27.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 27.0,
+        target_percent_coverage: 100.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '3c48f919-0dc9-4b20-8d9e-90744b7d7a32',
+        common_name: null,
+        scientific_name: 'Oryctolagus cuniculus',
+        genome_type: 'Rabbit',
+        assembly: {
+          accession_id: 'GCA_000003625.1',
+          name: 'OryCun2.0',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSOCUG00000017555.4',
+        symbol: 'DET1',
+        version: 4,
+        unversioned_stable_id: 'ENSOCUG00000017555'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 27.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 27.0,
+        target_percent_coverage: 100.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '3d9faa38-0913-4e54-8678-ed9773f76e60',
+        common_name: null,
+        scientific_name: 'Danio rerio',
+        genome_type: 'Zebrafish',
+        assembly: {
+          accession_id: 'GCA_000002035.4',
+          name: 'GRCz11',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSDARG00000098247.2',
+        symbol: 'det1',
+        version: 2,
+        unversioned_stable_id: 'ENSDARG00000098247'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 27.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 27.0,
+        target_percent_coverage: 99.1119
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '3d9faa38-0913-4e54-8678-ed9773f76e60',
+        common_name: null,
+        scientific_name: 'Danio rerio',
+        genome_type: 'Zebrafish',
+        assembly: {
+          accession_id: 'GCA_000002035.4',
+          name: 'GRCz11',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSDARG00000098247.2',
+        symbol: 'det1',
+        version: 2,
+        unversioned_stable_id: 'ENSDARG00000098247'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 27.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 27.0,
+        target_percent_coverage: 99.1119
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '44183b9a-e6c3-4fbe-bb46-c73b4a7b3c7e',
+        common_name: null,
+        scientific_name: 'Salmo salar',
+        genome_type: 'Atlantic salmon',
+        assembly: {
+          accession_id: 'GCA_905237065.2',
+          name: 'Ssal_v3.1',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSSSAG00000054657.2',
+        symbol: 'DET1',
+        version: 2,
+        unversioned_stable_id: 'ENSSSAG00000054657'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 27.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 27.0,
+        target_percent_coverage: 100.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '44183b9a-e6c3-4fbe-bb46-c73b4a7b3c7e',
+        common_name: null,
+        scientific_name: 'Salmo salar',
+        genome_type: 'Atlantic salmon',
+        assembly: {
+          accession_id: 'GCA_905237065.2',
+          name: 'Ssal_v3.1',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSSSAG00000054657.2',
+        symbol: 'DET1',
+        version: 2,
+        unversioned_stable_id: 'ENSSSAG00000054657'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 27.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 27.0,
+        target_percent_coverage: 100.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '49f32f73-df6b-49e9-8acb-45e8fe5ebbdf',
+        common_name: null,
+        scientific_name: 'Glycine max',
+        genome_type: 'Glycine max',
+        assembly: {
+          accession_id: 'GCA_000004515.4',
+          name: 'Glycine_max_v2.1',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'GLYMA_01G231700',
+        symbol: null,
+        version: null,
+        unversioned_stable_id: 'GLYMA_01G231700'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
       stats: {
         query_percent_id: 22.0,
         query_percent_coverage: 96.475,
@@ -714,474 +1116,66 @@ const homologies = {
     },
     {
       target_genome: {
-        genome_id: 'homo_sapiens',
-        common_name: 'homo_sapiens',
-        scientific_name: 'homo_sapiens',
-        genome_type: 'reference',
+        genome_id: '49f32f73-df6b-49e9-8acb-45e8fe5ebbdf',
+        common_name: null,
+        scientific_name: 'Glycine max',
+        genome_type: 'Glycine max',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_000004515.4',
+          name: 'Glycine_max_v2.1',
+          url: null
         }
       },
       target_gene: {
-        stable_id: 'ENSG00000140543.15',
-        symbol: 'DET1',
-        version: 15,
-        unversioned_stable_id: 'ENSG00000140543'
-      },
-      query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: 0,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
-      stats: {
-        query_percent_id: 27.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 27.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'hordeum_vulgare',
-        common_name: 'hordeum_vulgare',
-        scientific_name: 'hordeum_vulgare',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      target_gene: {
-        stable_id: 'HORVU.MOREX.r3.3HG0262020',
+        stable_id: 'GLYMA_01G231700',
         symbol: null,
-        version: 0,
-        unversioned_stable_id: 'HORVU.MOREX.r3.3HG0262020'
+        version: null,
+        unversioned_stable_id: 'GLYMA_01G231700'
       },
       query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
         }
       },
       query_gene: {
         stable_id: 'FBgn0000018',
         symbol: 'abo',
-        version: 0,
+        version: null,
         unversioned_stable_id: 'FBgn0000018'
       },
       type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
-      stats: {
-        query_percent_id: 25.0,
-        query_percent_coverage: 93.5065,
-        target_percent_id: 25.0,
-        target_percent_coverage: 98.6301
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
       },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'macaca_mulatta',
-        common_name: 'macaca_mulatta',
-        scientific_name: 'macaca_mulatta',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSMMUG00000005758.4',
-        symbol: 'DET1',
-        version: 4,
-        unversioned_stable_id: 'ENSMMUG00000005758'
-      },
-      query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: 0,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
-      stats: {
-        query_percent_id: 27.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 27.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'medicago_truncatula',
-        common_name: 'medicago_truncatula',
-        scientific_name: 'medicago_truncatula',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      target_gene: {
-        stable_id: 'MTR_5g008710',
-        symbol: null,
-        version: 0,
-        unversioned_stable_id: 'MTR_5g008710'
-      },
-      query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: 0,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
+      release_version: 100.1,
       stats: {
         query_percent_id: 22.0,
-        query_percent_coverage: 97.0315,
+        query_percent_coverage: 96.475,
         target_percent_id: 22.0,
-        target_percent_coverage: 97.0315
+        target_percent_coverage: 97.0149
       },
       alignment: null
     },
     {
       target_genome: {
-        genome_id: 'mus_musculus',
-        common_name: 'mus_musculus',
-        scientific_name: 'mus_musculus',
-        genome_type: 'reference',
+        genome_id: '4ad2a6aa-6cf5-4c2e-a324-cfbc95c2af8b',
+        common_name: null,
+        scientific_name: 'Pan troglodytes',
+        genome_type: 'Chimpanzee',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSMUSG00000030610.14',
-        symbol: 'Det1',
-        version: 14,
-        unversioned_stable_id: 'ENSMUSG00000030610'
-      },
-      query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: 0,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
-      stats: {
-        query_percent_id: 27.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 27.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'oreochromis_niloticus',
-        common_name: 'oreochromis_niloticus',
-        scientific_name: 'oreochromis_niloticus',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSONIG00000011104.2',
-        symbol: 'det1',
-        version: 2,
-        unversioned_stable_id: 'ENSONIG00000011104'
-      },
-      query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: 0,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
-      stats: {
-        query_percent_id: 28.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 28.0,
-        target_percent_coverage: 96.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'oryctolagus_cuniculus',
-        common_name: 'oryctolagus_cuniculus',
-        scientific_name: 'oryctolagus_cuniculus',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSOCUG00000017555.4',
-        symbol: 'DET1',
-        version: 4,
-        unversioned_stable_id: 'ENSOCUG00000017555'
-      },
-      query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: 0,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
-      stats: {
-        query_percent_id: 27.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 27.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'oryza_sativa',
-        common_name: 'oryza_sativa',
-        scientific_name: 'oryza_sativa',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      target_gene: {
-        stable_id: 'Os01g0104600',
-        symbol: 'OsDET1',
-        version: 0,
-        unversioned_stable_id: 'Os01g0104600'
-      },
-      query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: 0,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
-      stats: {
-        query_percent_id: 24.0,
-        query_percent_coverage: 91.4657,
-        target_percent_id: 24.0,
-        target_percent_coverage: 96.4775
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'oryzias_latipes',
-        common_name: 'oryzias_latipes',
-        scientific_name: 'oryzias_latipes',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSORLG00000012676.2',
-        symbol: 'det1',
-        version: 2,
-        unversioned_stable_id: 'ENSORLG00000012676'
-      },
-      query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: 0,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
-      stats: {
-        query_percent_id: 28.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 28.0,
-        target_percent_coverage: 98.7633
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'ovis_aries',
-        common_name: 'ovis_aries',
-        scientific_name: 'ovis_aries',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSOARG00000010954.1',
-        symbol: null,
-        version: 1,
-        unversioned_stable_id: 'ENSOARG00000010954'
-      },
-      query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: 0,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
-      stats: {
-        query_percent_id: 28.0,
-        query_percent_coverage: 100.0,
-        target_percent_id: 28.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'pan_troglodytes',
-        common_name: 'pan_troglodytes',
-        scientific_name: 'pan_troglodytes',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_000001515.5',
+          name: 'Pan_tro_3.0',
+          url: null
         }
       },
       target_gene: {
@@ -1191,25 +1185,31 @@ const homologies = {
         unversioned_stable_id: 'ENSPTRG00000007421'
       },
       query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
         }
       },
       query_gene: {
         stable_id: 'FBgn0000018',
         symbol: 'abo',
-        version: 0,
+        version: null,
         unversioned_stable_id: 'FBgn0000018'
       },
       type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
       stats: {
         query_percent_id: 27.0,
         query_percent_coverage: 100.0,
@@ -1220,14 +1220,794 @@ const homologies = {
     },
     {
       target_genome: {
-        genome_id: 'rattus_norvegicus',
-        common_name: 'rattus_norvegicus',
-        scientific_name: 'rattus_norvegicus',
-        genome_type: 'reference',
+        genome_id: '4ad2a6aa-6cf5-4c2e-a324-cfbc95c2af8b',
+        common_name: null,
+        scientific_name: 'Pan troglodytes',
+        genome_type: 'Chimpanzee',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_000001515.5',
+          name: 'Pan_tro_3.0',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSPTRG00000007421.6',
+        symbol: 'DET1',
+        version: 6,
+        unversioned_stable_id: 'ENSPTRG00000007421'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 27.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 27.0,
+        target_percent_coverage: 100.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '541201d9-635a-4349-81fc-fd0a2f1030b1',
+        common_name: null,
+        scientific_name: 'Zea mays',
+        genome_type: 'Zea mays',
+        assembly: {
+          accession_id: 'GCA_902167145.1',
+          name: 'Zm-B73-REFERENCE-NAM-5.0',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'Zm00001eb341540',
+        symbol: null,
+        version: null,
+        unversioned_stable_id: 'Zm00001eb341540'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 23.0,
+        query_percent_coverage: 94.4341,
+        target_percent_id: 23.0,
+        target_percent_coverage: 99.8039
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '541201d9-635a-4349-81fc-fd0a2f1030b1',
+        common_name: null,
+        scientific_name: 'Zea mays',
+        genome_type: 'Zea mays',
+        assembly: {
+          accession_id: 'GCA_902167145.1',
+          name: 'Zm-B73-REFERENCE-NAM-5.0',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'Zm00001eb341540',
+        symbol: null,
+        version: null,
+        unversioned_stable_id: 'Zm00001eb341540'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 23.0,
+        query_percent_coverage: 94.4341,
+        target_percent_id: 23.0,
+        target_percent_coverage: 99.8039
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '5ca8d1a1-3b42-40fc-bafe-5bc13d33382c',
+        common_name: null,
+        scientific_name: 'Capra hircus',
+        genome_type: 'Goat',
+        assembly: {
+          accession_id: 'GCA_001704415.1',
+          name: 'ARS1',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSCHIG00000010346.1',
+        symbol: 'DET1',
+        version: 1,
+        unversioned_stable_id: 'ENSCHIG00000010346'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 27.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 27.0,
+        target_percent_coverage: 100.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '5ca8d1a1-3b42-40fc-bafe-5bc13d33382c',
+        common_name: null,
+        scientific_name: 'Capra hircus',
+        genome_type: 'Goat',
+        assembly: {
+          accession_id: 'GCA_001704415.1',
+          name: 'ARS1',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSCHIG00000010346.1',
+        symbol: 'DET1',
+        version: 1,
+        unversioned_stable_id: 'ENSCHIG00000010346'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 27.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 27.0,
+        target_percent_coverage: 100.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '5d8fce33-6171-4755-8c31-984a57ba8244',
+        common_name: null,
+        scientific_name: 'Brassica oleracea var. oleracea',
+        genome_type: 'Brassica oleracea',
+        assembly: {
+          accession_id: 'GCA_000695525.1',
+          name: 'BOL',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'Bo3g044580',
+        symbol: null,
+        version: null,
+        unversioned_stable_id: 'Bo3g044580'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 25.0,
+        query_percent_coverage: 98.8868,
+        target_percent_id: 25.0,
+        target_percent_coverage: 99.4403
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '5d8fce33-6171-4755-8c31-984a57ba8244',
+        common_name: null,
+        scientific_name: 'Brassica oleracea var. oleracea',
+        genome_type: 'Brassica oleracea',
+        assembly: {
+          accession_id: 'GCA_000695525.1',
+          name: 'BOL',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'Bo3g044580',
+        symbol: null,
+        version: null,
+        unversioned_stable_id: 'Bo3g044580'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 25.0,
+        query_percent_coverage: 98.8868,
+        target_percent_id: 25.0,
+        target_percent_coverage: 99.4403
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '63b9c430-329c-48bd-9165-ca830086f2c9',
+        common_name: null,
+        scientific_name: 'Felis catus',
+        genome_type: 'Cat',
+        assembly: {
+          accession_id: 'GCA_000181335.4',
+          name: 'Felis_catus_9.0',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSFCAG00000014968.6',
+        symbol: 'DET1',
+        version: 6,
+        unversioned_stable_id: 'ENSFCAG00000014968'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 27.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 27.0,
+        target_percent_coverage: 100.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '63b9c430-329c-48bd-9165-ca830086f2c9',
+        common_name: null,
+        scientific_name: 'Felis catus',
+        genome_type: 'Cat',
+        assembly: {
+          accession_id: 'GCA_000181335.4',
+          name: 'Felis_catus_9.0',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSFCAG00000014968.6',
+        symbol: 'DET1',
+        version: 6,
+        unversioned_stable_id: 'ENSFCAG00000014968'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 27.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 27.0,
+        target_percent_coverage: 100.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '6f293c50-17a5-4801-aa8c-b4dba1f876ed',
+        common_name: null,
+        scientific_name: 'Ovis aries',
+        genome_type: 'Sheep (texel)',
+        assembly: {
+          accession_id: 'GCA_000298735.1',
+          name: 'Oar_v3.1',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSOARG00000010954.1',
+        symbol: null,
+        version: 1,
+        unversioned_stable_id: 'ENSOARG00000010954'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 28.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 28.0,
+        target_percent_coverage: 100.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '6f293c50-17a5-4801-aa8c-b4dba1f876ed',
+        common_name: null,
+        scientific_name: 'Ovis aries',
+        genome_type: 'Sheep (texel)',
+        assembly: {
+          accession_id: 'GCA_000298735.1',
+          name: 'Oar_v3.1',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSOARG00000010954.1',
+        symbol: null,
+        version: 1,
+        unversioned_stable_id: 'ENSOARG00000010954'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 28.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 28.0,
+        target_percent_coverage: 100.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '76c06dd6-5a7e-4656-b223-b1fdb63d567f',
+        common_name: null,
+        scientific_name: 'Arabidopsis thaliana',
+        genome_type: 'Arabidopsis thaliana',
+        assembly: {
+          accession_id: 'GCA_000001735.1',
+          name: 'TAIR10',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'AT4G10180',
+        symbol: 'DET1',
+        version: null,
+        unversioned_stable_id: 'AT4G10180'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 23.0,
+        query_percent_coverage: 99.0724,
+        target_percent_id: 23.0,
+        target_percent_coverage: 98.3425
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '76c06dd6-5a7e-4656-b223-b1fdb63d567f',
+        common_name: null,
+        scientific_name: 'Arabidopsis thaliana',
+        genome_type: 'Arabidopsis thaliana',
+        assembly: {
+          accession_id: 'GCA_000001735.1',
+          name: 'TAIR10',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'AT4G10180',
+        symbol: 'DET1',
+        version: null,
+        unversioned_stable_id: 'AT4G10180'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 23.0,
+        query_percent_coverage: 99.0724,
+        target_percent_id: 23.0,
+        target_percent_coverage: 98.3425
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '88abdf6b-e16a-48fd-9767-3555b8b9b365',
+        common_name: null,
+        scientific_name: 'Aegilops tauschii subsp. strangulata',
+        genome_type: 'Aegilops tauschii',
+        assembly: {
+          accession_id: 'GCA_002575655.1',
+          name: 'Aet v4.0',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'AET3Gv20472500',
+        symbol: null,
+        version: null,
+        unversioned_stable_id: 'AET3Gv20472500'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 25.0,
+        query_percent_coverage: 93.692,
+        target_percent_id: 25.0,
+        target_percent_coverage: 91.9854
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '88abdf6b-e16a-48fd-9767-3555b8b9b365',
+        common_name: null,
+        scientific_name: 'Aegilops tauschii subsp. strangulata',
+        genome_type: 'Aegilops tauschii',
+        assembly: {
+          accession_id: 'GCA_002575655.1',
+          name: 'Aet v4.0',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'AET3Gv20472500',
+        symbol: null,
+        version: null,
+        unversioned_stable_id: 'AET3Gv20472500'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 25.0,
+        query_percent_coverage: 93.692,
+        target_percent_id: 25.0,
+        target_percent_coverage: 91.9854
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: '8fe05926-0402-488f-b971-db4825c6d72e',
+        common_name: null,
+        scientific_name: 'Rattus norvegicus',
+        genome_type: 'Rat',
+        assembly: {
+          accession_id: 'GCA_015227675.2',
+          name: 'mRatBN7.2',
+          url: null
         }
       },
       target_gene: {
@@ -1237,25 +2017,31 @@ const homologies = {
         unversioned_stable_id: 'ENSRNOG00000018515'
       },
       query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
         }
       },
       query_gene: {
         stable_id: 'FBgn0000018',
         symbol: 'abo',
-        version: 0,
+        version: null,
         unversioned_stable_id: 'FBgn0000018'
       },
       type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
       stats: {
         query_percent_id: 27.0,
         query_percent_coverage: 100.0,
@@ -1266,42 +2052,48 @@ const homologies = {
     },
     {
       target_genome: {
-        genome_id: 'salmo_salar',
-        common_name: 'salmo_salar',
-        scientific_name: 'salmo_salar',
-        genome_type: 'reference',
+        genome_id: '8fe05926-0402-488f-b971-db4825c6d72e',
+        common_name: null,
+        scientific_name: 'Rattus norvegicus',
+        genome_type: 'Rat',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_015227675.2',
+          name: 'mRatBN7.2',
+          url: null
         }
       },
       target_gene: {
-        stable_id: 'ENSSSAG00000054657.2',
-        symbol: 'DET1',
-        version: 2,
-        unversioned_stable_id: 'ENSSSAG00000054657'
+        stable_id: 'ENSRNOG00000018515.7',
+        symbol: 'Det1',
+        version: 7,
+        unversioned_stable_id: 'ENSRNOG00000018515'
       },
       query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
         }
       },
       query_gene: {
         stable_id: 'FBgn0000018',
         symbol: 'abo',
-        version: 0,
+        version: null,
         unversioned_stable_id: 'FBgn0000018'
       },
       type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
       stats: {
         query_percent_id: 27.0,
         query_percent_coverage: 100.0,
@@ -1312,180 +2104,48 @@ const homologies = {
     },
     {
       target_genome: {
-        genome_id: 'solanum_lycopersicum',
-        common_name: 'solanum_lycopersicum',
-        scientific_name: 'solanum_lycopersicum',
-        genome_type: 'reference',
+        genome_id: '915ac71a-ecc9-49a6-add1-f739ecde2b90',
+        common_name: null,
+        scientific_name: 'Mus musculus',
+        genome_type: 'Mouse',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_000001635.9',
+          name: 'GRCm39',
+          url: null
         }
       },
       target_gene: {
-        stable_id: 'Solyc01g056340.3',
-        symbol: 'DET1',
-        version: 0,
-        unversioned_stable_id: 'Solyc01g056340.3'
+        stable_id: 'ENSMUSG00000030610.14',
+        symbol: 'Det1',
+        version: 14,
+        unversioned_stable_id: 'ENSMUSG00000030610'
       },
       query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
         }
       },
       query_gene: {
         stable_id: 'FBgn0000018',
         symbol: 'abo',
-        version: 0,
+        version: null,
         unversioned_stable_id: 'FBgn0000018'
       },
       type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
-      stats: {
-        query_percent_id: 22.0,
-        query_percent_coverage: 94.4341,
-        target_percent_id: 22.0,
-        target_percent_coverage: 97.3231
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
       },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'solanum_tuberosum',
-        common_name: 'solanum_tuberosum',
-        scientific_name: 'solanum_tuberosum',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      target_gene: {
-        stable_id: 'PGSC0003DMG400031459',
-        symbol: null,
-        version: 0,
-        unversioned_stable_id: 'PGSC0003DMG400031459'
-      },
-      query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: 0,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
-      stats: {
-        query_percent_id: 23.0,
-        query_percent_coverage: 51.7625,
-        target_percent_id: 23.0,
-        target_percent_coverage: 93.9394
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'sorghum_bicolor',
-        common_name: 'sorghum_bicolor',
-        scientific_name: 'sorghum_bicolor',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      target_gene: {
-        stable_id: 'SORBI_3007G058100',
-        symbol: null,
-        version: 0,
-        unversioned_stable_id: 'SORBI_3007G058100'
-      },
-      query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: 0,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
-      stats: {
-        query_percent_id: 24.0,
-        query_percent_coverage: 95.3618,
-        target_percent_id: 24.0,
-        target_percent_coverage: 100.0
-      },
-      alignment: null
-    },
-    {
-      target_genome: {
-        genome_id: 'sus_scrofa',
-        common_name: 'sus_scrofa',
-        scientific_name: 'sus_scrofa',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      target_gene: {
-        stable_id: 'ENSSSCG00000005103.6',
-        symbol: 'DET1',
-        version: 6,
-        unversioned_stable_id: 'ENSSSCG00000005103'
-      },
-      query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
-        assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
-        }
-      },
-      query_gene: {
-        stable_id: 'FBgn0000018',
-        symbol: 'abo',
-        version: 0,
-        unversioned_stable_id: 'FBgn0000018'
-      },
-      type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
+      release_version: 100.1,
       stats: {
         query_percent_id: 27.0,
         query_percent_coverage: 100.0,
@@ -1496,42 +2156,204 @@ const homologies = {
     },
     {
       target_genome: {
-        genome_id: 'triticum_aestivum',
-        common_name: 'triticum_aestivum',
-        scientific_name: 'triticum_aestivum',
-        genome_type: 'reference',
+        genome_id: '915ac71a-ecc9-49a6-add1-f739ecde2b90',
+        common_name: null,
+        scientific_name: 'Mus musculus',
+        genome_type: 'Mouse',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_000001635.9',
+          name: 'GRCm39',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSMUSG00000030610.14',
+        symbol: 'Det1',
+        version: 14,
+        unversioned_stable_id: 'ENSMUSG00000030610'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 27.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 27.0,
+        target_percent_coverage: 100.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'a7335667-93e7-11ec-a39d-005056b38ce3',
+        common_name: null,
+        scientific_name: 'Homo sapiens',
+        genome_type: 'Human',
+        assembly: {
+          accession_id: 'GCA_000001405.28',
+          name: 'GRCh38.p13',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSG00000140543.15',
+        symbol: 'DET1',
+        version: 15,
+        unversioned_stable_id: 'ENSG00000140543'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 27.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 27.0,
+        target_percent_coverage: 100.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'a7335667-93e7-11ec-a39d-005056b38ce3',
+        common_name: null,
+        scientific_name: 'Homo sapiens',
+        genome_type: 'Human',
+        assembly: {
+          accession_id: 'GCA_000001405.28',
+          name: 'GRCh38.p13',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSG00000140543.15',
+        symbol: 'DET1',
+        version: 15,
+        unversioned_stable_id: 'ENSG00000140543'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 27.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 27.0,
+        target_percent_coverage: 100.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'a73357ab-93e7-11ec-a39d-005056b38ce3',
+        common_name: null,
+        scientific_name: 'Triticum aestivum',
+        genome_type: 'Triticum aestivum',
+        assembly: {
+          accession_id: 'GCA_900519105.1',
+          name: 'IWGSC',
+          url: null
         }
       },
       target_gene: {
         stable_id: 'TraesCS3A02G194600',
         symbol: null,
-        version: 0,
+        version: null,
         unversioned_stable_id: 'TraesCS3A02G194600'
       },
       query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
         }
       },
       query_gene: {
         stable_id: 'FBgn0000018',
         symbol: 'abo',
-        version: 0,
+        version: null,
         unversioned_stable_id: 'FBgn0000018'
       },
       type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
       stats: {
         query_percent_id: 25.0,
         query_percent_coverage: 93.692,
@@ -1542,88 +2364,308 @@ const homologies = {
     },
     {
       target_genome: {
-        genome_id: 'triticum_turgidum',
-        common_name: 'triticum_turgidum',
-        scientific_name: 'triticum_turgidum',
-        genome_type: 'reference',
+        genome_id: 'a73357ab-93e7-11ec-a39d-005056b38ce3',
+        common_name: null,
+        scientific_name: 'Triticum aestivum',
+        genome_type: 'Triticum aestivum',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_900519105.1',
+          name: 'IWGSC',
+          url: null
         }
       },
       target_gene: {
-        stable_id: 'TRITD3Av1G105180',
+        stable_id: 'TraesCS3A02G194600',
         symbol: null,
-        version: 0,
-        unversioned_stable_id: 'TRITD3Av1G105180'
+        version: null,
+        unversioned_stable_id: 'TraesCS3A02G194600'
       },
       query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
         }
       },
       query_gene: {
         stable_id: 'FBgn0000018',
         symbol: 'abo',
-        version: 0,
+        version: null,
         unversioned_stable_id: 'FBgn0000018'
       },
       type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
       stats: {
         query_percent_id: 25.0,
-        query_percent_coverage: 93.8775,
+        query_percent_coverage: 93.692,
         target_percent_id: 25.0,
-        target_percent_coverage: 98.8281
+        target_percent_coverage: 98.8258
       },
       alignment: null
     },
     {
       target_genome: {
-        genome_id: 'vitis_vinifera',
-        common_name: 'vitis_vinifera',
-        scientific_name: 'vitis_vinifera',
-        genome_type: 'reference',
+        genome_id: 'a8ddb817-82de-4230-897c-06384a8f01eb',
+        common_name: null,
+        scientific_name: 'Oreochromis niloticus',
+        genome_type: 'Nile tilapia',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_001858045.3',
+          name: 'O_niloticus_UMD_NMBU',
+          url: null
         }
       },
       target_gene: {
-        stable_id: 'Vitvi15g00849',
-        symbol: null,
-        version: 0,
-        unversioned_stable_id: 'Vitvi15g00849'
+        stable_id: 'ENSONIG00000011104.2',
+        symbol: 'det1',
+        version: 2,
+        unversioned_stable_id: 'ENSONIG00000011104'
       },
       query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
         }
       },
       query_gene: {
         stable_id: 'FBgn0000018',
         symbol: 'abo',
-        version: 0,
+        version: null,
         unversioned_stable_id: 'FBgn0000018'
       },
       type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 28.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 28.0,
+        target_percent_coverage: 96.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'a8ddb817-82de-4230-897c-06384a8f01eb',
+        common_name: null,
+        scientific_name: 'Oreochromis niloticus',
+        genome_type: 'Nile tilapia',
+        assembly: {
+          accession_id: 'GCA_001858045.3',
+          name: 'O_niloticus_UMD_NMBU',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSONIG00000011104.2',
+        symbol: 'det1',
+        version: 2,
+        unversioned_stable_id: 'ENSONIG00000011104'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 28.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 28.0,
+        target_percent_coverage: 96.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'afaeb837-45a3-4a03-8ac4-c5e0118ca1cc',
+        common_name: null,
+        scientific_name: 'Hordeum vulgare subsp. vulgare',
+        genome_type: 'Hordeum vulgare',
+        assembly: {
+          accession_id: 'GCA_904849725.1',
+          name: 'MorexV3_pseudomolecules_assembly',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'HORVU.MOREX.r3.3HG0262020',
+        symbol: null,
+        version: null,
+        unversioned_stable_id: 'HORVU.MOREX.r3.3HG0262020'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 25.0,
+        query_percent_coverage: 93.5065,
+        target_percent_id: 25.0,
+        target_percent_coverage: 98.6301
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'afaeb837-45a3-4a03-8ac4-c5e0118ca1cc',
+        common_name: null,
+        scientific_name: 'Hordeum vulgare subsp. vulgare',
+        genome_type: 'Hordeum vulgare',
+        assembly: {
+          accession_id: 'GCA_904849725.1',
+          name: 'MorexV3_pseudomolecules_assembly',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'HORVU.MOREX.r3.3HG0262020',
+        symbol: null,
+        version: null,
+        unversioned_stable_id: 'HORVU.MOREX.r3.3HG0262020'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 25.0,
+        query_percent_coverage: 93.5065,
+        target_percent_id: 25.0,
+        target_percent_coverage: 98.6301
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'ba3074a6-b9de-45c7-be4c-3036990305d8',
+        common_name: null,
+        scientific_name: 'Vitis vinifera',
+        genome_type: 'Vitis vinifera',
+        assembly: {
+          accession_id: 'GCA_910591555.1',
+          name: 'PN40024.v4',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'Vitvi15g00849',
+        symbol: null,
+        version: null,
+        unversioned_stable_id: 'Vitvi15g00849'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
       stats: {
         query_percent_id: 23.0,
         query_percent_coverage: 97.4026,
@@ -1634,14 +2676,586 @@ const homologies = {
     },
     {
       target_genome: {
-        genome_id: 'xenopus_tropicalis',
-        common_name: 'xenopus_tropicalis',
-        scientific_name: 'xenopus_tropicalis',
-        genome_type: 'reference',
+        genome_id: 'ba3074a6-b9de-45c7-be4c-3036990305d8',
+        common_name: null,
+        scientific_name: 'Vitis vinifera',
+        genome_type: 'Vitis vinifera',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_910591555.1',
+          name: 'PN40024.v4',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'Vitvi15g00849',
+        symbol: null,
+        version: null,
+        unversioned_stable_id: 'Vitvi15g00849'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 23.0,
+        query_percent_coverage: 97.4026,
+        target_percent_id: 23.0,
+        target_percent_coverage: 98.8701
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'bc069fc1-f4b2-48af-997e-ea1fbb1429ea',
+        common_name: null,
+        scientific_name: 'Medicago truncatula',
+        genome_type: 'Medicago truncatula',
+        assembly: {
+          accession_id: 'GCA_000219495.2',
+          name: 'MedtrA17_4.0',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'MTR_5g008710',
+        symbol: null,
+        version: null,
+        unversioned_stable_id: 'MTR_5g008710'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 22.0,
+        query_percent_coverage: 97.0315,
+        target_percent_id: 22.0,
+        target_percent_coverage: 97.0315
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'bc069fc1-f4b2-48af-997e-ea1fbb1429ea',
+        common_name: null,
+        scientific_name: 'Medicago truncatula',
+        genome_type: 'Medicago truncatula',
+        assembly: {
+          accession_id: 'GCA_000219495.2',
+          name: 'MedtrA17_4.0',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'MTR_5g008710',
+        symbol: null,
+        version: null,
+        unversioned_stable_id: 'MTR_5g008710'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 22.0,
+        query_percent_coverage: 97.0315,
+        target_percent_id: 22.0,
+        target_percent_coverage: 97.0315
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'c7550d32-923f-4597-80f6-e4a6c8a67db9',
+        common_name: null,
+        scientific_name: 'Gallus gallus',
+        genome_type: 'Chicken',
+        assembly: {
+          accession_id: 'GCA_016699485.1',
+          name: 'bGalGal1.mat.broiler.GRCg7b',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSGALG00010020199.1',
+        symbol: 'DET1',
+        version: 1,
+        unversioned_stable_id: 'ENSGALG00010020199'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 26.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 26.0,
+        target_percent_coverage: 100.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'c7550d32-923f-4597-80f6-e4a6c8a67db9',
+        common_name: null,
+        scientific_name: 'Gallus gallus',
+        genome_type: 'Chicken',
+        assembly: {
+          accession_id: 'GCA_016699485.1',
+          name: 'bGalGal1.mat.broiler.GRCg7b',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSGALG00010020199.1',
+        symbol: 'DET1',
+        version: 1,
+        unversioned_stable_id: 'ENSGALG00010020199'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 26.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 26.0,
+        target_percent_coverage: 100.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'd8223875-5f6e-4eed-980f-7d8dd53a58ba',
+        common_name: null,
+        scientific_name: 'Solanum tuberosum',
+        genome_type: 'Solanum tuberosum',
+        assembly: {
+          accession_id: 'GCA_000226075.1',
+          name: 'SolTub_3.0',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'PGSC0003DMG400031459',
+        symbol: null,
+        version: null,
+        unversioned_stable_id: 'PGSC0003DMG400031459'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 23.0,
+        query_percent_coverage: 51.7625,
+        target_percent_id: 23.0,
+        target_percent_coverage: 93.9394
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'd8223875-5f6e-4eed-980f-7d8dd53a58ba',
+        common_name: null,
+        scientific_name: 'Solanum tuberosum',
+        genome_type: 'Solanum tuberosum',
+        assembly: {
+          accession_id: 'GCA_000226075.1',
+          name: 'SolTub_3.0',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'PGSC0003DMG400031459',
+        symbol: null,
+        version: null,
+        unversioned_stable_id: 'PGSC0003DMG400031459'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 23.0,
+        query_percent_coverage: 51.7625,
+        target_percent_id: 23.0,
+        target_percent_coverage: 93.9394
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'ddc0e9cc-8453-4837-b9ba-3e86f5d5f420',
+        common_name: null,
+        scientific_name: 'Brassica napus',
+        genome_type: 'Brassica napus',
+        assembly: {
+          accession_id: 'GCA_000751015.1',
+          name: 'AST_PRJEB5043_v1',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'GSBRNA2T00151439001',
+        symbol: 'BnaA03g24270D',
+        version: null,
+        unversioned_stable_id: 'GSBRNA2T00151439001'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 24.0,
+        query_percent_coverage: 98.8868,
+        target_percent_id: 24.0,
+        target_percent_coverage: 99.2551
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'ddc0e9cc-8453-4837-b9ba-3e86f5d5f420',
+        common_name: null,
+        scientific_name: 'Brassica napus',
+        genome_type: 'Brassica napus',
+        assembly: {
+          accession_id: 'GCA_000751015.1',
+          name: 'AST_PRJEB5043_v1',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'GSBRNA2T00151439001',
+        symbol: 'BnaA03g24270D',
+        version: null,
+        unversioned_stable_id: 'GSBRNA2T00151439001'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 24.0,
+        query_percent_coverage: 98.8868,
+        target_percent_id: 24.0,
+        target_percent_coverage: 99.2551
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'dedc3834-8dad-4b41-a03a-68719648cae4',
+        common_name: null,
+        scientific_name: 'Triticum turgidum subsp. durum',
+        genome_type: 'Triticum turgidum',
+        assembly: {
+          accession_id: 'GCA_900231445.1',
+          name: 'svevo',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'TRITD3Av1G105180',
+        symbol: null,
+        version: null,
+        unversioned_stable_id: 'TRITD3Av1G105180'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 25.0,
+        query_percent_coverage: 93.8775,
+        target_percent_id: 25.0,
+        target_percent_coverage: 98.8281
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'dedc3834-8dad-4b41-a03a-68719648cae4',
+        common_name: null,
+        scientific_name: 'Triticum turgidum subsp. durum',
+        genome_type: 'Triticum turgidum',
+        assembly: {
+          accession_id: 'GCA_900231445.1',
+          name: 'svevo',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'TRITD3Av1G105180',
+        symbol: null,
+        version: null,
+        unversioned_stable_id: 'TRITD3Av1G105180'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 25.0,
+        query_percent_coverage: 93.8775,
+        target_percent_id: 25.0,
+        target_percent_coverage: 98.8281
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'e36e7b9d-3901-4d9f-bd44-853b200a8caf',
+        common_name: null,
+        scientific_name: 'Xenopus tropicalis',
+        genome_type: 'Tropical clawed frog',
+        assembly: {
+          accession_id: 'GCA_000004195.4',
+          name: 'UCB_Xtro_10.0',
+          url: null
         }
       },
       target_gene: {
@@ -1651,25 +3265,31 @@ const homologies = {
         unversioned_stable_id: 'ENSXETG00000007591'
       },
       query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
         }
       },
       query_gene: {
         stable_id: 'FBgn0000018',
         symbol: 'abo',
-        version: 0,
+        version: null,
         unversioned_stable_id: 'FBgn0000018'
       },
       type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
       stats: {
         query_percent_id: 27.0,
         query_percent_coverage: 100.0,
@@ -1680,47 +3300,469 @@ const homologies = {
     },
     {
       target_genome: {
-        genome_id: 'zea_mays',
-        common_name: 'zea_mays',
-        scientific_name: 'zea_mays',
-        genome_type: 'reference',
+        genome_id: 'e36e7b9d-3901-4d9f-bd44-853b200a8caf',
+        common_name: null,
+        scientific_name: 'Xenopus tropicalis',
+        genome_type: 'Tropical clawed frog',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_000004195.4',
+          name: 'UCB_Xtro_10.0',
+          url: null
         }
       },
       target_gene: {
-        stable_id: 'Zm00001eb341540',
-        symbol: null,
-        version: 0,
-        unversioned_stable_id: 'Zm00001eb341540'
+        stable_id: 'ENSXETG00000007591.5',
+        symbol: 'det1',
+        version: 5,
+        unversioned_stable_id: 'ENSXETG00000007591'
       },
       query_genome: {
-        genome_id: 'drosophila_melanogaster',
-        common_name: 'drosophila_melanogaster',
-        scientific_name: 'drosophila_melanogaster',
-        genome_type: 'reference',
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
         assembly: {
-          accession_id: 'drosophila_melanogaster',
-          name: 'drosophila_melanogaster',
-          url: 'drosophila_melanogaster'
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
         }
       },
       query_gene: {
         stable_id: 'FBgn0000018',
         symbol: 'abo',
-        version: 0,
+        version: null,
         unversioned_stable_id: 'FBgn0000018'
       },
       type: 'homology',
-      subtype: 'homolog_rbbh',
-      version: 100.0,
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
       stats: {
-        query_percent_id: 23.0,
-        query_percent_coverage: 94.4341,
-        target_percent_id: 23.0,
-        target_percent_coverage: 99.8039
+        query_percent_id: 27.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 27.0,
+        target_percent_coverage: 100.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'ea877d68-4819-43c4-8dee-157728cac494',
+        common_name: null,
+        scientific_name: 'Oryza sativa Japonica Group',
+        genome_type: 'Oryza sativa Japonica Group',
+        assembly: {
+          accession_id: 'GCA_001433935.1',
+          name: 'IRGSP-1.0',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'Os01g0104600',
+        symbol: 'OsDET1',
+        version: null,
+        unversioned_stable_id: 'Os01g0104600'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 24.0,
+        query_percent_coverage: 91.4657,
+        target_percent_id: 24.0,
+        target_percent_coverage: 96.4775
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'ea877d68-4819-43c4-8dee-157728cac494',
+        common_name: null,
+        scientific_name: 'Oryza sativa Japonica Group',
+        genome_type: 'Oryza sativa Japonica Group',
+        assembly: {
+          accession_id: 'GCA_001433935.1',
+          name: 'IRGSP-1.0',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'Os01g0104600',
+        symbol: 'OsDET1',
+        version: null,
+        unversioned_stable_id: 'Os01g0104600'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 24.0,
+        query_percent_coverage: 91.4657,
+        target_percent_id: 24.0,
+        target_percent_coverage: 96.4775
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'eee9c096-9196-4bc1-a6ad-f1ff18d3fd89',
+        common_name: null,
+        scientific_name: 'Brassica rapa',
+        genome_type: 'Brassica rapa',
+        assembly: {
+          accession_id: 'GCA_000309985.1',
+          name: 'Brapa_1.0',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'Bra000702',
+        symbol: null,
+        version: null,
+        unversioned_stable_id: 'Bra000702'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 24.0,
+        query_percent_coverage: 98.8868,
+        target_percent_id: 24.0,
+        target_percent_coverage: 99.2551
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'eee9c096-9196-4bc1-a6ad-f1ff18d3fd89',
+        common_name: null,
+        scientific_name: 'Brassica rapa',
+        genome_type: 'Brassica rapa',
+        assembly: {
+          accession_id: 'GCA_000309985.1',
+          name: 'Brapa_1.0',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'Bra000702',
+        symbol: null,
+        version: null,
+        unversioned_stable_id: 'Bra000702'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 24.0,
+        query_percent_coverage: 98.8868,
+        target_percent_id: 24.0,
+        target_percent_coverage: 99.2551
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'f1756fce-9cab-48cb-826f-ed10afbb9bbb',
+        common_name: null,
+        scientific_name: 'Oryzias latipes',
+        genome_type: 'Japanese medaka HdrR',
+        assembly: {
+          accession_id: 'GCA_002234675.1',
+          name: 'ASM223467v1',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSORLG00000012676.2',
+        symbol: 'det1',
+        version: 2,
+        unversioned_stable_id: 'ENSORLG00000012676'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 28.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 28.0,
+        target_percent_coverage: 98.7633
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'f1756fce-9cab-48cb-826f-ed10afbb9bbb',
+        common_name: null,
+        scientific_name: 'Oryzias latipes',
+        genome_type: 'Japanese medaka HdrR',
+        assembly: {
+          accession_id: 'GCA_002234675.1',
+          name: 'ASM223467v1',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'ENSORLG00000012676.2',
+        symbol: 'det1',
+        version: 2,
+        unversioned_stable_id: 'ENSORLG00000012676'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 28.0,
+        query_percent_coverage: 100.0,
+        target_percent_id: 28.0,
+        target_percent_coverage: 98.7633
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'fdfbd78d-76bc-48ad-bb4d-135ed7ee9ab1',
+        common_name: null,
+        scientific_name: 'Sorghum bicolor',
+        genome_type: 'Sorghum bicolor',
+        assembly: {
+          accession_id: 'GCA_000003195.3',
+          name: 'Sorghum_bicolor_NCBIv3',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'SORBI_3007G058100',
+        symbol: null,
+        version: null,
+        unversioned_stable_id: 'SORBI_3007G058100'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 24.0,
+        query_percent_coverage: 95.3618,
+        target_percent_id: 24.0,
+        target_percent_coverage: 100.0
+      },
+      alignment: null
+    },
+    {
+      target_genome: {
+        genome_id: 'fdfbd78d-76bc-48ad-bb4d-135ed7ee9ab1',
+        common_name: null,
+        scientific_name: 'Sorghum bicolor',
+        genome_type: 'Sorghum bicolor',
+        assembly: {
+          accession_id: 'GCA_000003195.3',
+          name: 'Sorghum_bicolor_NCBIv3',
+          url: null
+        }
+      },
+      target_gene: {
+        stable_id: 'SORBI_3007G058100',
+        symbol: null,
+        version: null,
+        unversioned_stable_id: 'SORBI_3007G058100'
+      },
+      query_genome: {
+        genome_id: '80e3e488-2977-4872-8d1a-21dff4dab8a8',
+        common_name: null,
+        scientific_name: 'Drosophila melanogaster',
+        genome_type: 'Drosophila melanogaster (Fruit fly)',
+        assembly: {
+          accession_id: 'GCA_000001215.4',
+          name: 'BDGP6.46',
+          url: null
+        }
+      },
+      query_gene: {
+        stable_id: 'FBgn0000018',
+        symbol: 'abo',
+        version: null,
+        unversioned_stable_id: 'FBgn0000018'
+      },
+      type: 'homology',
+      subtype: {
+        accession_id: 'homology_subtype.homolog_rbbh',
+        label: 'RBBH',
+        value: 'homolog_rbbh',
+        definition: 'Reciprocal best BLAST hit homolog',
+        description: null
+      },
+      release_version: 100.1,
+      stats: {
+        query_percent_id: 24.0,
+        query_percent_coverage: 95.3618,
+        target_percent_id: 24.0,
+        target_percent_coverage: 100.0
       },
       alignment: null
     }

--- a/src/content/app/entity-viewer/state/api/types/geneHomology.ts
+++ b/src/content/app/entity-viewer/state/api/types/geneHomology.ts
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+import type { ValueSetMetadata } from 'src/shared/types/core-api/metadata';
+
 type GenomeInHomology = {
   genome_id: string;
-  common_name: string;
+  common_name: string | null;
   scientific_name: string;
   assembly: {
     accession_id: string;
@@ -45,6 +47,7 @@ export type GeneHomology = {
   query_genome: GenomeInHomology;
   query_gene: GeneInHomology;
   type: 'homology';
-  subtype: string;
+  release_version: number;
+  subtype: ValueSetMetadata;
   stats: GeneHomologyStatistics;
 };


### PR DESCRIPTION
## Description
Use more a more realistic homology example generated by the Compara team:
-  Added proper common names and scientific names
- Assembly names and accession ids are now correct; they are not just for Drosophila melanogaster anymore
- The `subtype` field has been changed to have a shape of a ValueSet item
- The `version` field has been renamed to `release_version`

**Note:** there is an error in the data, where common names are written to the genome_type field. Expect the data to be regenerated

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2150

## Deployment URL(s)
http://update-homology-example.review.ensembl.org