### PR TITLE
Use the variation graphql api instead of mock variation data

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -28,6 +28,7 @@ export type BaseApiUrls = {
   tracksApiBaseUrl: string;
   toolsApiBaseUrl: string;
   searchApiBaseUrl: string;
+  variationApiUrl: string;
 };
 
 export type PublicKeys = {
@@ -43,7 +44,8 @@ const defaultApiUrls: BaseApiUrls = {
   refgetBaseUrl: '/api/refget',
   tracksApiBaseUrl: '/api/tracks',
   toolsApiBaseUrl: '/api/tools',
-  searchApiBaseUrl: '/api/search'
+  searchApiBaseUrl: '/api/search',
+  variationApiUrl: '/api/graphql/variation'
 };
 
 const defaultKeys = {
@@ -66,6 +68,9 @@ const getBaseApiUrls = (): BaseApiUrls => {
     docsBaseUrl:
       process.env.SSR_DOCS_BASE_URL ??
       `${defaultServerHost}${defaultApiUrls.docsBaseUrl}`,
+    variationApiUrl:
+      process.env.SSR_VARIATION_GRAPHQL_API_URL ??
+      `${defaultServerHost}${defaultApiUrls.variationApiUrl}`,
     metadataApiBaseUrl: defaultApiUrls.metadataApiBaseUrl, // irrelevant for server-side rendering
     genomeBrowserBackendBaseUrl: defaultApiUrls.genomeBrowserBackendBaseUrl, // irrelevant for server-side rendering
     refgetBaseUrl: defaultApiUrls.refgetBaseUrl, // irrelevant for server-side rendering

--- a/src/content/app/genome-browser/components/drawer/drawer-views/variant-summary/VariantSummary.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/variant-summary/VariantSummary.tsx
@@ -202,19 +202,22 @@ const VariantDB = (props: { variant: VariantQueryResult['variant'] }) => {
   let dbElement;
 
   if (!primary_source.url) {
-    dbElement = <span>{primary_source.name}</span>;
+    dbElement = <span>{primary_source.source.name}</span>;
   } else {
     dbElement = (
-      <ExternalLink to={primary_source.url} linkText={primary_source.name} />
+      <ExternalLink
+        to={primary_source.url}
+        linkText={primary_source.source.name}
+      />
     );
   }
 
   return (
     <div>
       {dbElement}
-      {primary_source.release && (
+      {primary_source.source.release && (
         <span className={classNames(styles.light, styles.withSpaceLeft)}>
-          Release {primary_source.release}
+          Release {primary_source.source.release}
         </span>
       )}
     </div>

--- a/src/content/app/genome-browser/components/drawer/drawer-views/variant-summary/prepareVariantSummaryData.ts
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/variant-summary/prepareVariantSummaryData.ts
@@ -16,7 +16,7 @@
 
 import memoize from 'lodash/memoize';
 
-import type { Variant } from 'src/shared/types/variation-api/variant';
+import type { VariantDetails } from 'src/content/app/genome-browser/state/api/queries/variantQuery';
 
 type PreparedVariantSummaryData = {
   ancestralAllele?: string;
@@ -37,7 +37,7 @@ type PreparedVariantSummaryData = {
   gerpScore?: number;
 };
 
-const prepareVariantSummaryData = (variant: Variant) => {
+const prepareVariantSummaryData = (variant: VariantDetails) => {
   const variantSummaryData: Record<string, unknown> = {};
 
   addVariantPredictions(variant, variantSummaryData);
@@ -55,7 +55,7 @@ const prepareVariantSummaryData = (variant: Variant) => {
 };
 
 const checkPhenotypeAssociations = (
-  variantAllele: Variant['alleles'][0],
+  variantAllele: VariantDetails['alleles'][number],
   store: Record<string, unknown>
 ) => {
   if (variantAllele.phenotype_assertions?.length) {
@@ -64,7 +64,7 @@ const checkPhenotypeAssociations = (
 };
 
 const addVariantPredictions = (
-  variant: Variant,
+  variant: VariantDetails,
   store: Record<string, unknown>
 ) => {
   for (const prediction of variant.prediction_results) {
@@ -82,7 +82,7 @@ const addVariantPredictions = (
 
 // There could be 1-20 VariantAlleles and 0-50 PopulationAlleleFrequency records for each
 const addVariantAllelePopulationFrequencyData = (
-  variantAllele: Variant['alleles'][0],
+  variantAllele: VariantDetails['alleles'][number],
   store: Record<string, unknown>
 ) => {
   for (const populationFrequency of variantAllele.population_frequencies) {
@@ -102,7 +102,7 @@ const addVariantAllelePopulationFrequencyData = (
 };
 
 const addVariantAllelePredictions = (
-  variantAllele: Variant['alleles'][0],
+  variantAllele: VariantDetails['alleles'][number],
   store: Partial<PreparedVariantSummaryData>
 ) => {
   store.caddScores = store.caddScores ?? [];

--- a/src/content/app/genome-browser/components/drawer/drawer-views/variant-summary/variant-consequence/VariantConsequence.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/variant-summary/variant-consequence/VariantConsequence.tsx
@@ -15,6 +15,7 @@
  */
 
 import React from 'react';
+import type { Pick2 } from 'ts-multipick';
 
 import VariantColour from 'src/content/app/genome-browser/components/drawer/components/variant-colour/VariantColour';
 
@@ -22,8 +23,16 @@ import type { Variant } from 'src/shared/types/variation-api/variant';
 
 import styles from './VariantConsequence.scss';
 
+type MinimumPredictionResultData = Pick<
+  Variant['prediction_results'][number],
+  'result'
+> &
+  Pick2<Variant['prediction_results'][number], 'analysis_method', 'tool'>;
+
 type Props = {
-  variant: Pick<Variant, 'prediction_results'>;
+  variant: {
+    prediction_results: MinimumPredictionResultData[];
+  };
   withColour?: boolean;
 };
 

--- a/src/server/helpers/getConfigForClient.ts
+++ b/src/server/helpers/getConfigForClient.ts
@@ -29,7 +29,9 @@ const getBaseApiUrls = (): BaseApiUrls => {
     genomeBrowserBackendBaseUrl:
       process.env.GENOME_BROWSER_BACKEND_BASE_URL ?? '/api/browser/data',
     toolsApiBaseUrl: process.env.TOOLS_API_BASE_URL ?? '/api/tools',
-    searchApiBaseUrl: process.env.TOOLS_API_BASE_URL ?? '/api/search'
+    searchApiBaseUrl: process.env.TOOLS_API_BASE_URL ?? '/api/search',
+    variationApiUrl:
+      process.env.VARIATION_GRAPHQL_API_URL ?? '/api/graphql/variation'
   };
 };
 

--- a/src/shared/components/feature-summary-strip/VariantSummaryStrip.tsx
+++ b/src/shared/components/feature-summary-strip/VariantSummaryStrip.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, type ComponentProps } from 'react';
 import classNames from 'classnames';
 
 import useResizeObserver from 'src/shared/hooks/useResizeObserver';
@@ -26,7 +26,6 @@ import VariantLocation from 'src/content/app/genome-browser/components/drawer/dr
 import { useGbVariantQuery } from 'src/content/app/genome-browser/state/api/genomeBrowserApiSlice';
 
 import type { FocusVariant } from 'src/shared/types/focus-object/focusObjectTypes';
-import type { Variant } from 'src/shared/types/variation-api/variant';
 
 import styles from './FeatureSummaryStrip.scss';
 
@@ -74,8 +73,16 @@ const VariantSummaryWrapper = (props: {
   );
 };
 
+export type VariantForSummaryStrip = ComponentProps<
+  typeof VariantConsequence
+>['variant'] &
+  ComponentProps<typeof VariantLocation>['variant'] & {
+    name: string;
+    alleles: ComponentProps<typeof VariantAllelesSequences>['alleles'];
+  };
+
 const VariantSummaryStrip = (props: {
-  variant: Variant;
+  variant: VariantForSummaryStrip;
   isGhosted?: boolean;
   display: Display;
 }) => {
@@ -95,14 +102,14 @@ const VariantSummaryStrip = (props: {
   return <div className={stripClasses}>{content}</div>;
 };
 
-const MinimalContent = ({ variant }: { variant: Variant }) => (
+const MinimalContent = ({ variant }: { variant: VariantForSummaryStrip }) => (
   <>
     <span className={styles.featureSummaryStripLabel}>Variant</span>
     <span className={styles.featureNameEmphasized}>{variant.name}</span>
   </>
 );
 
-const FullContent = ({ variant }: { variant: Variant }) => {
+const FullContent = ({ variant }: { variant: VariantForSummaryStrip }) => {
   const mostSevereConsequence = (
     <VariantConsequence variant={variant} withColour={false} />
   );

--- a/src/shared/helpers/formatters/regionFormatter.ts
+++ b/src/shared/helpers/formatters/regionFormatter.ts
@@ -16,13 +16,17 @@
 
 import { formatNumber } from 'src/shared/helpers/formatters/numberFormatter';
 
-import { FocusObjectLocation } from 'src/shared/types/focus-object/focusObjectTypes';
+type Location = {
+  chromosome: string;
+  start: number;
+  end?: number;
+};
 
-export const getFormattedLocation = (location: FocusObjectLocation) => {
+export const getFormattedLocation = (location: Location) => {
   const start = formatNumber(location.start);
-  const end = formatNumber(location.end);
+  const end = location.end ? formatNumber(location.end) : null;
 
-  if (start === end) {
+  if (end === null || start === end) {
     return `${location.chromosome}:${start}`;
   } else {
     return `${location.chromosome}:${start}-${end}`;

--- a/src/shared/types/core-api/externalReference.ts
+++ b/src/shared/types/core-api/externalReference.ts
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-import { Source } from './source';
+import { ExternalDB } from './externalDb';
 
 export type ExternalReference = {
   accession_id: string;
   name: string;
   description: string | null;
   url: string | null;
-  source: Source;
+  source: ExternalDB;
 };
 
 export type ExternalReferenceWithoutSource = Omit<ExternalReference, 'source'>;
 
 export type ExternalReferencesGroup = {
-  source: Source;
+  source: ExternalDB;
   references: ExternalReferenceWithoutSource[];
 };

--- a/src/shared/types/variation-api/variant.ts
+++ b/src/shared/types/variation-api/variant.ts
@@ -16,7 +16,6 @@
 
 import type { Slice } from '../core-api/slice';
 import type { ExternalReference } from '../core-api/externalReference';
-import type { ExternalDB } from '../core-api/externalDb';
 import type { OntologyTermMetadata } from '../core-api/metadata';
 import type { VariantPredictionResult } from './variantPredictionResult';
 import type { VariantAllele } from './variantAllele';
@@ -27,7 +26,7 @@ export type Variant = {
   slice: Slice;
   allele_type: OntologyTermMetadata;
   alternative_names: ExternalReference[];
-  primary_source: ExternalDB;
+  primary_source: ExternalReference;
   prediction_results: VariantPredictionResult[];
   alleles: VariantAllele[];
 };

--- a/tests/fixtures/entity-viewer/external-reference.ts
+++ b/tests/fixtures/entity-viewer/external-reference.ts
@@ -34,7 +34,9 @@ export const createExternalReference = (
     source: {
       name: faker.lorem.word(),
       id: faker.lorem.word(),
-      url: faker.lorem.word()
+      url: faker.lorem.word(),
+      description: null,
+      release: null
     }
   };
 


### PR DESCRIPTION
## Description
Start using the variation api available at `/api/graphql/variation` to fetch the data for focus variants instead of using the mock data throughout.

### Note
Some fields in the Variant and VariantAllele schemas are not yet ready. These include:
-  `Variant.prediction_results`
- `VariantAllele.prediction_results`
- `VariantAllele.population_frequencies` 
- `VariantAllele.phenotype_assertions`

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2151

## Deployment URL(s)
http://use-variation-api.review.ensembl.org