### PR TITLE
Use the trigger field from track api payload to pass messages to genome browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ensembl/ensembl-genome-browser": "0.6.6",
+        "@ensembl/ensembl-genome-browser": "0.6.7",
         "@react-spring/web": "9.7.3",
         "@reduxjs/toolkit": "1.9.5",
         "@sentry/browser": "7.66.0",
@@ -3095,9 +3095,9 @@
       }
     },
     "node_modules/@ensembl/ensembl-genome-browser": {
-      "version": "0.6.6",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.6.tgz",
-      "integrity": "sha1-hJsQPxHycyBp5KlDy6T8+1fi854="
+      "version": "0.6.7",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.7.tgz",
+      "integrity": "sha1-Bi6r/hTyU8HK6anGqdwp3C/tnYU="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.18.20",
@@ -31175,9 +31175,9 @@
       "requires": {}
     },
     "@ensembl/ensembl-genome-browser": {
-      "version": "0.6.6",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.6.tgz",
-      "integrity": "sha1-hJsQPxHycyBp5KlDy6T8+1fi854="
+      "version": "0.6.7",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.7.tgz",
+      "integrity": "sha1-Bi6r/hTyU8HK6anGqdwp3C/tnYU="
     },
     "@esbuild/android-arm": {
       "version": "0.18.20",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "coverage": "jest --coverage"
   },
   "dependencies": {
-    "@ensembl/ensembl-genome-browser": "0.6.6",
+    "@ensembl/ensembl-genome-browser": "0.6.7",
     "@react-spring/web": "9.7.3",
     "@reduxjs/toolkit": "1.9.5",
     "@sentry/browser": "7.66.0",

--- a/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
@@ -181,13 +181,17 @@ const prepareTrackSettings = ({
 
   trackCategories.forEach((category) => {
     category.track_list.forEach((track) => {
-      const { track_id } = track;
+      const { track_id, on_by_default } = track;
       const trackType = getTrackType(track_id);
 
       if (trackType === TrackType.GENE) {
-        defaultTrackSettings[track_id] = buildDefaultGeneTrack(track_id);
+        const trackSettings = buildDefaultGeneTrack(track_id);
+        trackSettings.settings.isVisible = on_by_default;
+        defaultTrackSettings[track_id] = trackSettings;
       } else {
-        defaultTrackSettings[track_id] = buildDefaultRegularTrack(track_id);
+        const trackSettings = buildDefaultRegularTrack(track_id);
+        trackSettings.settings.isVisible = on_by_default;
+        defaultTrackSettings[track_id] = trackSettings;
       }
     });
   });

--- a/src/content/app/genome-browser/hooks/useGenomicTracks.ts
+++ b/src/content/app/genome-browser/hooks/useGenomicTracks.ts
@@ -101,10 +101,11 @@ const prepareTrackIdsList = (
 ): TrackIdsList => {
   const trackIdsList = trackGroups
     .flatMap(({ track_list }) => track_list)
-    .map(({ track_id }) => {
+    .map(({ track_id, on_by_default }) => {
       const track = trackSettings[track_id];
       const isVisibleTrack =
-        (track?.settings as { isVisible?: boolean })?.isVisible ?? true;
+        (track?.settings as { isVisible?: boolean })?.isVisible ??
+        on_by_default;
       return {
         trackId: track_id,
         isEnabled: isVisibleTrack

--- a/src/content/app/genome-browser/services/genome-browser-service/genomeBrowserCommands.ts
+++ b/src/content/app/genome-browser/services/genome-browser-service/genomeBrowserCommands.ts
@@ -59,26 +59,26 @@ export const setBrowserLocation = (payload: {
 
 export const toggleTrack = (payload: {
   genomeBrowser: EnsemblGenomeBrowser;
-  trackId: string;
+  trackPath: string[];
   isEnabled: boolean;
 }) => {
-  const { genomeBrowser, trackId, isEnabled } = payload;
-  genomeBrowser.switch(['track', trackId], isEnabled);
+  const { genomeBrowser, trackPath, isEnabled } = payload;
+  genomeBrowser.switch(trackPath, isEnabled);
 };
 
 // NOTE: this method can only handle boolean flags
 export const toggleTrackSetting = (payload: {
   genomeBrowser: EnsemblGenomeBrowser;
-  trackId: string;
+  trackPath: string[];
   setting: string;
   isEnabled: boolean;
 }) => {
-  const { genomeBrowser, trackId, setting, isEnabled } = payload;
+  const { genomeBrowser, trackPath, setting, isEnabled } = payload;
 
-  if (trackId === 'focus-variant') {
+  if (trackPath.includes('focus-variant')) {
     toggleFocusVariantTrackSetting(payload);
   } else {
-    genomeBrowser.switch(['track', trackId, setting], isEnabled);
+    genomeBrowser.switch([...trackPath, setting], isEnabled);
   }
 };
 

--- a/src/content/app/genome-browser/state/track-settings/trackSettingsSlice.ts
+++ b/src/content/app/genome-browser/state/track-settings/trackSettingsSlice.ts
@@ -104,29 +104,6 @@ export const defaultTrackSettingsForGenome: TrackSettingsForGenome = {
   settingsForIndividualTracks: {}
 };
 
-export const saveTrackSettingsForGenome = createAsyncThunk(
-  'genome-browser-track-settings/save-track-settings-for-genome',
-  async (genomeId: string, thunkAPI) => {
-    const state = thunkAPI.getState() as RootState;
-    const trackSettingsForGenome = getAllTrackSettingsForGenome(
-      state,
-      genomeId
-    );
-    if (!trackSettingsForGenome) {
-      return; // shouldn't happen
-    }
-
-    const trackSettingsArray = Object.values(
-      trackSettingsForGenome.settingsForIndividualTracks
-    );
-
-    await trackSettingsStorageService.updateTrackSettingsForGenome(
-      genomeId,
-      trackSettingsArray
-    );
-  }
-);
-
 export const updateTrackSettingsAndSave = createAsyncThunk(
   'genome-browser-track-settings/update-track-settings-and-save',
   async (

--- a/src/content/app/genome-browser/state/types/tracks.ts
+++ b/src/content/app/genome-browser/state/types/tracks.ts
@@ -16,12 +16,36 @@
 
 import { TrackSet } from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
 
+/**
+ * NOTE ON THE TRIGGER FIELD ON THE GenomicTrack TYPE
+ *
+ * Tracks are stored in genome browser's memory in a tree-like structure,
+ * and a trigger is an array that represents the path to a given track node.
+ * Sadly, the client needs to be aware of this implementation detail,
+ * because it needs to use this trigger to toggle a track, or its settings
+ * (which are represented as tree nodes inside the track node) on and off.
+ *
+ * The contents of a trigger array for a given track are vaguely predictable,
+ * but not certain. For some tracks, the trigger to toggle the track on/off
+ * will be ["track", track_id]. For other tracks, it will be ["track", expansion_node, track_id].
+ * Since there is no way for the client to know which is which, it has
+ * to rely on track api to tell it.
+ *
+ * The content of trigger arrays for track settings is predictable,
+ * and consist of the contents of the track trigger followed by
+ * the name of the setting. Thus, triggers for settings can be generated
+ * on the client.
+ */
+
 export type GenomicTrack = {
-  colour: string; // NOTE: the backend will want to get rid of this field
-  label: string;
   track_id: string;
+  trigger: string[]; // <-- see the note about triggers above
+  label: string;
+  colour: string; // NOTE: the backend will want to get rid of this field
   additional_info: string;
   description: string;
+  on_by_default: boolean;
+  display_order: number;
   sources: Array<{
     name: string;
     url: string | null;

--- a/src/server/middleware/proxyMiddleware.ts
+++ b/src/server/middleware/proxyMiddleware.ts
@@ -55,15 +55,25 @@ const serverConfig = getConfigForServer();
 */
 
 const createApiProxyMiddleware = () => {
-  const apiProxyMiddleware = createHttpProxyMiddleware('/api', {
-    target: 'https://staging-2020.ensembl.org',
+  const apiProxyMiddleware = createHttpProxyMiddleware(
+    ['/api/**', '!/api/tracks/**'],
+    {
+      target: 'https://staging-2020.ensembl.org',
+      changeOrigin: true,
+      secure: false
+    }
+  );
+
+  const browserProxyMiddleware = createHttpProxyMiddleware('/api/tracks/**', {
+    target: 'http://update.review.ensembl.org',
+    // pathRewrite: {
+    //   '^/api/browser': '/api' // rewrite path
+    // },
     changeOrigin: true,
     secure: false
   });
 
-  // returning an array so that the specific proxies can be easily modified in local development
-  // (see example in the comment block above)
-  return [apiProxyMiddleware];
+  return [apiProxyMiddleware, browserProxyMiddleware];
 };
 
 const createStaticAssetsMiddleware = () => {

--- a/src/server/middleware/proxyMiddleware.ts
+++ b/src/server/middleware/proxyMiddleware.ts
@@ -55,25 +55,15 @@ const serverConfig = getConfigForServer();
 */
 
 const createApiProxyMiddleware = () => {
-  const apiProxyMiddleware = createHttpProxyMiddleware(
-    ['/api/**', '!/api/tracks/**'],
-    {
-      target: 'https://staging-2020.ensembl.org',
-      changeOrigin: true,
-      secure: false
-    }
-  );
-
-  const browserProxyMiddleware = createHttpProxyMiddleware('/api/tracks/**', {
-    target: 'http://update.review.ensembl.org',
-    // pathRewrite: {
-    //   '^/api/browser': '/api' // rewrite path
-    // },
+  const apiProxyMiddleware = createHttpProxyMiddleware('/api', {
+    target: 'https://staging-2020.ensembl.org',
     changeOrigin: true,
     secure: false
   });
 
-  return [apiProxyMiddleware, browserProxyMiddleware];
+  // returning an array so that the specific proxies can be easily modified in local development
+  // (see example in the comment block above)
+  return [apiProxyMiddleware];
 };
 
 const createStaticAssetsMiddleware = () => {

--- a/tests/fixtures/genomes.ts
+++ b/tests/fixtures/genomes.ts
@@ -46,10 +46,13 @@ export const createGenomeCategories = (): GenomeTrackCategory[] => [
 
 const createTrack = (): GenomicTrack => {
   return {
+    track_id: 'gene-pc-fwd',
+    trigger: ['track', 'gene-pc-fwd'],
     additional_info: faker.lorem.words(),
     colour: 'DARK_GREY',
     label: faker.lorem.words(),
-    track_id: 'gene-pc-fwd',
+    on_by_default: true,
+    display_order: 1,
     description: faker.lorem.sentence(),
     sources: [
       {


### PR DESCRIPTION
## Description
After enabling the expansion node for variation tracks in the genome browser (https://github.com/Ensembl/ensembl-dauphin-style-compiler/pull/86), the genome browser, sadly, will use different triggers for different tracks — e.g. `["track", track_id]` for tracks declared in the boot file; but `["track", expansion_node, track_id]` for tracks registered via the expansion node. It thus became necessary the additional information to browser chrome about how any given track needs to be called (see PRs https://github.com/Ensembl/ensembl-web-track-api/pull/19 and https://github.com/Ensembl/ensembl-web-track-api/pull/20).

The updates in this PR:
- use the new `trigger` field in the track api payload to build messages for the genome browser
- use the new `on_by_default` field in the track api payload to determine whether to enable a track by default (notice that 1000genomes track is hidden by default, because the track api suggests that it should not be turned on by default)

**NOTE:** It may be possible that the genome browser server will be broken at the time you review this. If this is the case, please run the branch locally.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2136

## Deployment URL(s)
http://use-track-api-updates.review.ensembl.org