### PR TITLE
Update rules for focusing on variants via zmenu

### DIFF
--- a/src/content/app/genome-browser/components/zmenu/zmenus/VariantZmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/zmenus/VariantZmenu.tsx
@@ -92,11 +92,12 @@ const VariantZmenu = (props: Props) => {
 
 /**
  * Consider that the genome browser shows the detailed zoomed-in view for variants
- * at scales 2**1 to 2**6 base pairs. 2**6 is 64; and when the genome browser zooms out to this point,
+ * at scales between 2**1 and 2**6 base pairs. 2**6 is 64; and when the genome browser zooms out to this point,
  * it switches to the zoomed-out view.
  */
-const MAX_NUCLEOTIDES_PER_VIEWPORT = 64 - 2;
-const MIN_NUCLEOTIDES_PER_VIEWPORT = 32;
+const VARIANT_DETAILS_MAX_NUCLEOTIDES = 2 ** 6 - 1; // variant details program of the genome browser shows up to 63 nucleotides
+const MAX_NUCLEOTIDES_PER_VIEWPORT = VARIANT_DETAILS_MAX_NUCLEOTIDES - 2; // to leave at least one nucleotide on either side
+const MIN_NUCLEOTIDES_PER_VIEWPORT = 32; // genome browser doesn't zoom past 32 nucleotides in viewport
 
 const calculateLocation = (
   regionName: string,

--- a/src/content/app/genome-browser/components/zmenu/zmenus/VariantZmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/zmenus/VariantZmenu.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
+import { getChrLocationStr } from 'src/content/app/genome-browser/helpers/browserHelper';
 import { buildFocusVariantId } from 'src/shared/helpers/focusObjectHelpers';
 import { isEnvironment, Environment } from 'src/shared/helpers/environment';
 
@@ -56,9 +57,16 @@ const VariantZmenu = (props: Props) => {
     variantName: variantMetadata.id
   });
 
+  const locationForVariant = calculateLocation(
+    variantMetadata.region_name,
+    variantMetadata.start,
+    variantMetadata.end
+  );
+
   const linkToVariantInGenomeBrowser = urlFor.browser({
     genomeId: genomeIdForUrl,
-    focus: variantId
+    focus: variantId,
+    location: locationForVariant
   });
 
   return (
@@ -80,6 +88,41 @@ const VariantZmenu = (props: Props) => {
       )}
     </>
   );
+};
+
+/**
+ * Consider that the genome browser shows the detailed zoomed-in view for variants
+ * at scales 2**1 to 2**6 base pairs. 2**6 is 64; and when the genome browser zooms out to this point,
+ * it switches to the zoomed-out view.
+ */
+const MAX_NUCLEOTIDES_PER_VIEWPORT = 64 - 2;
+const MIN_NUCLEOTIDES_PER_VIEWPORT = 32;
+
+const calculateLocation = (
+  regionName: string,
+  variantStart: number,
+  variantEnd: number
+) => {
+  const variantLength = variantEnd - variantStart;
+  const variantMidpoint = variantStart + Math.ceil(variantLength / 2);
+
+  let start: number;
+  let end: number;
+
+  if (variantLength < MIN_NUCLEOTIDES_PER_VIEWPORT) {
+    start = variantMidpoint - MIN_NUCLEOTIDES_PER_VIEWPORT / 2;
+    end = variantMidpoint + MIN_NUCLEOTIDES_PER_VIEWPORT / 2;
+  } else if (variantLength <= MAX_NUCLEOTIDES_PER_VIEWPORT) {
+    start = variantMidpoint - MAX_NUCLEOTIDES_PER_VIEWPORT / 2;
+    end = variantMidpoint + MAX_NUCLEOTIDES_PER_VIEWPORT / 2;
+  } else {
+    const viewportSize = variantLength / 0.7; // variant should take 70% of the viewport
+    const halfViewportSize = Math.ceil(viewportSize / 2);
+    start = Math.max(variantMidpoint - halfViewportSize, 0);
+    end = variantMidpoint + halfViewportSize; // hopefully, this won't exceed region length; might be a problem for circular chromosomes
+  }
+
+  return getChrLocationStr([regionName, start, end]);
 };
 
 export default VariantZmenu;

--- a/src/content/app/genome-browser/services/genome-browser-service/genomeBrowserCommands.ts
+++ b/src/content/app/genome-browser/services/genome-browser-service/genomeBrowserCommands.ts
@@ -45,6 +45,9 @@ export const setBrowserLocation = (payload: {
   const { genomeBrowser, regionName, start, end, genomeId, focus } = payload;
   genomeBrowser.set_stick(`${genomeId}:${regionName}`);
 
+  genomeBrowser.goto(start, end);
+  genomeBrowser.wait();
+
   if (focus) {
     setFocus({
       genomeBrowser,
@@ -53,8 +56,6 @@ export const setBrowserLocation = (payload: {
       focusType: focus.type
     });
   }
-
-  genomeBrowser.goto(start, end);
 };
 
 export const toggleTrack = (payload: {

--- a/src/content/app/genome-browser/services/genome-browser-service/types/zmenu.ts
+++ b/src/content/app/genome-browser/services/genome-browser-service/types/zmenu.ts
@@ -68,6 +68,7 @@ export type ZmenuContentVariantMetadata = {
   id: string; // just the rsID; will have to be combined with region name and start coordinate for full id
   region_name: string; // needed to generate full variant id
   start: number; // needed to generate full variant id
+  end: number; // needed to correctly size the viewport when focusing on a variant
   position: string; // formatted as "region:start-end". NOTE: start and end coordinates have commas in them
   variety: string; // e.g. SNV, INS... Do we have a full list of such varieties?
   type: ZmenuFeatureType.VARIANT;


### PR DESCRIPTION
## Description
As defined in the XD, when variant length is greater than the viewport, genome browser is expected to zoom out, such that the variant occupies 70% of the viewport.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2140

## Deployment URL(s)
http://variant-refocus.review.ensembl.org

### Example of how to test
Navigate to http://variant-refocus.review.ensembl.org/genome-browser/grch38?focus=variant:1:230710246:rs1471899965&location=1:230710230-230710262, and then click on the deletion immediately to the left of the SNV

![image](https://github.com/Ensembl/ensembl-client/assets/6834224/d002b4c8-3f1d-42c2-8754-ff0dbd6b1210)
