### PR TITLE
Fetch missing data from variation graphql api

### DIFF
--- a/src/content/app/genome-browser/state/api/genomeBrowserApiSlice.ts
+++ b/src/content/app/genome-browser/state/api/genomeBrowserApiSlice.ts
@@ -39,7 +39,6 @@ import { regionQuery, type RegionQueryResult } from './queries/regionQuery';
 
 import type { GenomeTrackCategory } from 'src/content/app/genome-browser/state/types/tracks';
 import type { TrackPanelGene } from '../types/track-panel-gene';
-import type { Variant } from 'src/shared/types/variation-api/variant';
 
 type GeneQueryParams = { genomeId: string; geneId: string };
 type TranscriptQueryParams = { genomeId: string; transcriptId: string };
@@ -97,48 +96,7 @@ const genomeBrowserApiSlice = graphqlApiSlice.injectEndpoints({
         url: config.variationApiUrl,
         body: variantDetailsQuery,
         variables: params
-      }),
-      transformResponse: async (data: VariantQueryResult, _, params) => {
-        // This is a temporary method
-        // to add the missing data to the response while the api is not providing it.
-        const { variantId } = params;
-        const knownVariantIds = ['rs699', 'rs71197234', 'rs202155613'];
-
-        const foundVariantId = knownVariantIds.find((id) =>
-          variantId.includes(id)
-        );
-
-        if (foundVariantId) {
-          const variantDataModule = await import(
-            `tests/fixtures/variation/${foundVariantId}`
-          );
-          const importedVariantData = variantDataModule.default as Variant;
-
-          data.variant.prediction_results =
-            importedVariantData.prediction_results;
-          data.variant.alleles.forEach((allele, index) => {
-            const importedVariantAllele = importedVariantData.alleles[index];
-            allele.phenotype_assertions =
-              importedVariantAllele.phenotype_assertions ?? [];
-            allele.population_frequencies =
-              importedVariantAllele.population_frequencies ?? [];
-            allele.prediction_results =
-              importedVariantAllele.prediction_results ?? [];
-          });
-        } else {
-          data.variant.prediction_results = [];
-
-          data.variant.alleles.forEach((allele) => {
-            allele.phenotype_assertions = [];
-            allele.population_frequencies = [];
-            allele.prediction_results = [];
-          });
-        }
-
-        data.variant.alternative_names = []; // TODO Agree with the Variation team what the value of alternative names should be if none exist
-
-        return data;
-      }
+      })
     })
   })
 });

--- a/src/content/app/genome-browser/state/api/queries/variantQuery.ts
+++ b/src/content/app/genome-browser/state/api/queries/variantQuery.ts
@@ -54,6 +54,13 @@ export const variantDetailsQuery = gql`
           release
         }
       }
+      prediction_results {
+        score
+        result
+        analysis_method {
+          tool
+        }
+      }
       alleles {
         name
         allele_type {
@@ -67,6 +74,21 @@ export const variantDetailsQuery = gql`
         }
         allele_sequence
         reference_sequence
+        phenotype_assertions {
+          feature
+        }
+        prediction_results {
+          score
+          result
+          analysis_method {
+            tool
+          }
+        }
+        population_frequencies {
+          is_minor_allele
+          is_hpmaf
+          allele_frequency
+        }
       }
     }
   }


### PR DESCRIPTION
## Description
Instead of hard-coded variation payloads, this PR updates ensembl-client to use the data from the variation api response. It is a continuation of what was started in https://github.com/Ensembl/ensembl-client/pull/1016

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2167

## Deployment URL(s)
http://use-variation-api.review.ensembl.org

(example: http://use-variation-api.review.ensembl.org/genome-browser/grch38?focus=variant:1:230710055:rs1571976675&location=1:230710039-230710071)