### PR TITLE
Enable variant extent in track settings by default

### DIFF
--- a/src/content/app/genome-browser/components/track-settings-panel/track-settings-views/VariantTrackSettings.tsx
+++ b/src/content/app/genome-browser/components/track-settings-panel/track-settings-views/VariantTrackSettings.tsx
@@ -112,7 +112,7 @@ const VariantTrackSettings = (
           <div className={styles.toggleWrapper}>
             <label>Variant extent</label>
             <SlideToggle
-              isOn={trackSettings?.settings['show-extents'] ?? false}
+              isOn={trackSettings?.settings['show-extents'] ?? true}
               onChange={(isOn) => onSettingToggle('show-extents', isOn)}
               className={styles.slideToggle}
             />

--- a/src/content/app/genome-browser/state/track-settings/trackSettingsConstants.ts
+++ b/src/content/app/genome-browser/state/track-settings/trackSettingsConstants.ts
@@ -47,7 +47,7 @@ export const getDefaultVariantTrackSettings = (): VariantTrackSettings => ({
   'label-snv-alleles': false,
   'label-other-id': false,
   'label-other-alleles': false,
-  'show-extents': false,
+  'show-extents': true,
   name: false,
   isVisible: true
 });


### PR DESCRIPTION
## Description
Enable `Variable extent` in track settings for GB variation tracks.

## Related JIRA Issue(s)
[ENSWBSITES-2148](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2148)

## Deployment URL(s)
http://update-gb-var-tracks.review.ensembl.org

## Views affected
Genome browser -> variation tracks -> variation track settings