### PR TITLE
Update popular species list payload

### DIFF
--- a/src/content/app/new-species-selector/components/genome-selector-by-search-query/GenomeSelectorBySearchQuery.tsx
+++ b/src/content/app/new-species-selector/components/genome-selector-by-search-query/GenomeSelectorBySearchQuery.tsx
@@ -42,8 +42,8 @@ const GenomeSelectorBySearchQuery = (props: Props) => {
 
   const {
     genomes,
-    preselectedGenomes,
-    setPreselectedGenomes,
+    stagedGenomes,
+    setStagedGenomes,
     isTableExpanded,
     onTableExpandToggle,
     onGenomePreselectToggle
@@ -55,7 +55,7 @@ const GenomeSelectorBySearchQuery = (props: Props) => {
 
   const onInput = () => {
     setHasQueryChangedSinceSubmission(true);
-    setPreselectedGenomes([]); // remove all preselected species because user has changed value of the search field
+    setStagedGenomes([]); // remove all preselected species because user has changed value of the search field
   };
 
   const onSearchSubmit = () => {
@@ -64,10 +64,10 @@ const GenomeSelectorBySearchQuery = (props: Props) => {
   };
 
   const onSpeciesAdd = () => {
-    props.onSpeciesAdd(preselectedGenomes);
+    props.onSpeciesAdd(stagedGenomes);
   };
 
-  const speciesSearchFieldMode = preselectedGenomes.length
+  const speciesSearchFieldMode = stagedGenomes.length
     ? 'species-add'
     : 'species-search';
 

--- a/src/content/app/new-species-selector/components/genome-selector-by-species-taxonomy-id/GenomeSelectorBySpeciesTaxonomyId.tsx
+++ b/src/content/app/new-species-selector/components/genome-selector-by-species-taxonomy-id/GenomeSelectorBySpeciesTaxonomyId.tsx
@@ -41,7 +41,7 @@ const GenomeSelectorBySpeciesTaxonomyId = (props: Props) => {
 
   const {
     genomes,
-    preselectedGenomes,
+    stagedGenomes,
     isTableExpanded,
     onTableExpandToggle,
     onGenomePreselectToggle
@@ -58,7 +58,7 @@ const GenomeSelectorBySpeciesTaxonomyId = (props: Props) => {
           <TopContent
             {...props}
             genomes={genomes}
-            preselectedGenomes={preselectedGenomes}
+            stagedGenomes={stagedGenomes}
           />
           <div className={styles.tableContainer}>
             <SpeciesSearchResultsTable
@@ -76,17 +76,15 @@ const GenomeSelectorBySpeciesTaxonomyId = (props: Props) => {
 
 type TopContentProps = Props & {
   genomes: ReturnType<typeof useSelectableGenomesTable>['genomes'];
-  preselectedGenomes: ReturnType<
-    typeof useSelectableGenomesTable
-  >['preselectedGenomes'];
+  stagedGenomes: ReturnType<typeof useSelectableGenomesTable>['stagedGenomes'];
 };
 
 const TopContent = (props: TopContentProps) => {
-  const { speciesImageUrl, genomes, preselectedGenomes } = props;
+  const { speciesImageUrl, genomes, stagedGenomes } = props;
   const dispatch = useAppDispatch();
 
   const onSpeciesAdd = () => {
-    dispatch(commitSelectedSpeciesAndSave(preselectedGenomes));
+    dispatch(commitSelectedSpeciesAndSave(stagedGenomes));
   };
 
   const selectedGenomesCount = genomes.filter(
@@ -109,7 +107,7 @@ const TopContent = (props: TopContentProps) => {
       </span>
       <PrimaryButton
         className={styles.addButton}
-        disabled={preselectedGenomes.length === 0}
+        disabled={stagedGenomes.length === 0}
         onClick={onSpeciesAdd}
       >
         Add

--- a/src/content/app/new-species-selector/components/popular-species-button/PopularSpeciesButton.scss
+++ b/src/content/app/new-species-selector/components/popular-species-button/PopularSpeciesButton.scss
@@ -37,7 +37,7 @@ $button-size: 57px;
   }
 }
 
-.membersCount {
+.genomesCount {
   --border-radius: 14px;
   position: absolute;
   bottom: 0;

--- a/src/content/app/new-species-selector/components/popular-species-button/PopularSpeciesButton.test.tsx
+++ b/src/content/app/new-species-selector/components/popular-species-button/PopularSpeciesButton.test.tsx
@@ -75,7 +75,7 @@ describe('<PopularSpeciesButton />', () => {
       />
     );
 
-    const countPill = container.querySelector('.membersCount') as HTMLElement;
+    const countPill = container.querySelector('.genomesCount') as HTMLElement;
 
     expect(countPill).toBeTruthy();
     expect(countPill.innerHTML).toBe(`${humanData.genomes_count}`);
@@ -90,7 +90,7 @@ describe('<PopularSpeciesButton />', () => {
       />
     );
 
-    const countPill = container.querySelector('.membersCount') as HTMLElement;
+    const countPill = container.querySelector('.genomesCount') as HTMLElement;
 
     expect(countPill).toBeFalsy();
   });

--- a/src/content/app/new-species-selector/components/popular-species-button/PopularSpeciesButton.test.tsx
+++ b/src/content/app/new-species-selector/components/popular-species-button/PopularSpeciesButton.test.tsx
@@ -23,11 +23,10 @@ import PopularSpeciesButton from './PopularSpeciesButton';
 import type { PopularSpecies } from 'src/content/app/new-species-selector/types/popularSpecies';
 
 const humanData: PopularSpecies = {
-  id: 1,
+  species_taxonomy_id: 1,
   name: 'Human',
   image: 'image.svg',
-  members_count: 2,
-  is_selected: false
+  genomes_count: 2
 };
 
 beforeEach(() => {
@@ -37,7 +36,11 @@ beforeEach(() => {
 describe('<PopularSpeciesButton />', () => {
   it('applies correct classes when species is not selected', () => {
     const { container } = render(
-      <PopularSpeciesButton species={humanData} onClick={jest.fn()} />
+      <PopularSpeciesButton
+        species={humanData}
+        isSelected={false}
+        onClick={jest.fn()}
+      />
     );
 
     const button = container.querySelector('button') as HTMLElement;
@@ -50,7 +53,8 @@ describe('<PopularSpeciesButton />', () => {
   it('applies correct classes when species is selected', () => {
     const { container } = render(
       <PopularSpeciesButton
-        species={{ ...humanData, is_selected: true }}
+        species={humanData}
+        isSelected={true}
         onClick={jest.fn()}
       />
     );
@@ -64,19 +68,24 @@ describe('<PopularSpeciesButton />', () => {
 
   it('renders a pill with genomes count if it is greater than 1', () => {
     const { container } = render(
-      <PopularSpeciesButton species={humanData} onClick={jest.fn()} />
+      <PopularSpeciesButton
+        species={humanData}
+        isSelected={false}
+        onClick={jest.fn()}
+      />
     );
 
     const countPill = container.querySelector('.membersCount') as HTMLElement;
 
     expect(countPill).toBeTruthy();
-    expect(countPill.innerHTML).toBe(`${humanData.members_count}`);
+    expect(countPill.innerHTML).toBe(`${humanData.genomes_count}`);
   });
 
   it('does not render a genomes count pill if species only has one genome', () => {
     const { container } = render(
       <PopularSpeciesButton
-        species={{ ...humanData, members_count: 1 }}
+        species={{ ...humanData, genomes_count: 1 }}
+        isSelected={false}
         onClick={jest.fn()}
       />
     );
@@ -90,7 +99,8 @@ describe('<PopularSpeciesButton />', () => {
     const clickHandler = jest.fn();
     const { container } = render(
       <PopularSpeciesButton
-        species={{ ...humanData, members_count: 1 }}
+        species={{ ...humanData, genomes_count: 1 }}
+        isSelected={false}
         onClick={clickHandler}
       />
     );

--- a/src/content/app/new-species-selector/components/popular-species-button/PopularSpeciesButton.tsx
+++ b/src/content/app/new-species-selector/components/popular-species-button/PopularSpeciesButton.tsx
@@ -27,11 +27,12 @@ import styles from './PopularSpeciesButton.scss';
 
 export type Props = {
   species: PopularSpecies;
+  isSelected: boolean;
   onClick: (species: PopularSpecies) => void;
 };
 
 const PopularSpeciesButton = (props: Props) => {
-  const { species } = props;
+  const { species, isSelected } = props;
   const [hoverRef, isHovered] = useHover<HTMLButtonElement>();
 
   const handleClick = () => {
@@ -39,14 +40,14 @@ const PopularSpeciesButton = (props: Props) => {
   };
 
   const buttonClasses = classNames(styles.popularSpeciesButton, {
-    [styles.popularSpeciesButtonSelected]: species.is_selected
+    [styles.popularSpeciesButtonSelected]: isSelected
   });
 
   return (
     <button className={buttonClasses} ref={hoverRef} onClick={handleClick}>
       <img src={species.image} />
-      {species.members_count > 1 && (
-        <span className={styles.membersCount}>{species.members_count}</span>
+      {species.genomes_count > 1 && (
+        <span className={styles.genomesCount}>{species.genomes_count}</span>
       )}
       {isHovered && (
         <Tooltip anchor={hoverRef.current} autoAdjust={true}>

--- a/src/content/app/new-species-selector/components/popular-species-list/PopularSpeciesList.tsx
+++ b/src/content/app/new-species-selector/components/popular-species-list/PopularSpeciesList.tsx
@@ -39,14 +39,17 @@ const PopularSpeciesList = () => {
     dispatch(setModalView('popular-species-genomes'));
   };
 
+  // TODO: after we include species taxonomy id in the committed species payload,
+  // we will use real data for the isSelected property
   return (
     <>
       <h1 className={styles.sectionHeading}>Popular</h1>
       <div className={styles.container}>
         {currentData?.popular_species.map((species) => (
           <PopularSpeciesButton
-            key={species.id}
+            key={species.species_taxonomy_id}
             species={species}
+            isSelected={false}
             onClick={() => onPopularSpeciesButtonClick(species)}
           />
         ))}

--- a/src/content/app/new-species-selector/components/selectable-genomes-table/useSelectableGenomesTable.ts
+++ b/src/content/app/new-species-selector/components/selectable-genomes-table/useSelectableGenomesTable.ts
@@ -24,27 +24,25 @@ import type { SpeciesSearchMatch } from 'src/content/app/new-species-selector/ty
 
 export type SelectableGenome = SpeciesSearchMatch & {
   isSelected: boolean;
-  isPreselected: boolean;
+  isStaged: boolean;
 };
 
 const useSelectableGenomesTable = (genomes: SpeciesSearchMatch[]) => {
-  const [preselectedGenomes, setPreselectedGenomes] = useState<
-    SpeciesSearchMatch[]
-  >([]);
+  const [stagedGenomes, setStagedGenomes] = useState<SpeciesSearchMatch[]>([]);
   const [isTableExpanded, setIsTableExpanded] = useState(false);
-  const selectableGenomes = useMarkedGenomes(genomes, preselectedGenomes);
+  const selectableGenomes = useMarkedGenomes(genomes, stagedGenomes);
 
   const onGenomePreselectToggle = (
     genome: SpeciesSearchMatch,
     isAdding?: boolean
   ) => {
     if (isAdding) {
-      setPreselectedGenomes([...preselectedGenomes, genome]);
+      setStagedGenomes([...stagedGenomes, genome]);
     } else {
-      const updatedList = preselectedGenomes.filter(
+      const updatedList = stagedGenomes.filter(
         ({ genome_id }) => genome_id !== genome.genome_id
       );
-      setPreselectedGenomes(updatedList);
+      setStagedGenomes(updatedList);
     }
   };
 
@@ -54,11 +52,11 @@ const useSelectableGenomesTable = (genomes: SpeciesSearchMatch[]) => {
 
   return {
     genomes: selectableGenomes,
-    preselectedGenomes,
+    stagedGenomes,
     onGenomePreselectToggle,
     isTableExpanded,
     onTableExpandToggle,
-    setPreselectedGenomes
+    setStagedGenomes
   };
 };
 
@@ -83,7 +81,7 @@ const useMarkedGenomes = (
   return genomes.map((genome) => ({
     ...genome,
     isSelected: committedSpeciesIds.has(genome.genome_id),
-    isPreselected: preselectedGenomeIds.has(genome.genome_id)
+    isStaged: preselectedGenomeIds.has(genome.genome_id)
   }));
 };
 

--- a/src/content/app/new-species-selector/components/species-search-results-table/SpeciesSearchResultsTable.tsx
+++ b/src/content/app/new-species-selector/components/species-search-results-table/SpeciesSearchResultsTable.tsx
@@ -46,7 +46,7 @@ const SpeciesSearchResultsTable = (props: Props) => {
   const { isExpanded, results, onSpeciesSelectToggle } = props;
 
   const onSpeciesPreselect = (species: SelectableGenome) => {
-    const isAdding = !species.isPreselected;
+    const isAdding = !species.isStaged;
     onSpeciesSelectToggle(species, isAdding);
   };
 
@@ -88,7 +88,7 @@ const SpeciesSearchResultsTable = (props: Props) => {
             <td>
               <Checkbox
                 disabled={searchMatch.isSelected}
-                checked={searchMatch.isPreselected}
+                checked={searchMatch.isStaged}
                 onChange={() => onSpeciesPreselect(searchMatch)}
               />
             </td>

--- a/src/content/app/new-species-selector/state/species-selector-api-slice/speciesSelectorSampleData.ts
+++ b/src/content/app/new-species-selector/state/species-selector-api-slice/speciesSelectorSampleData.ts
@@ -18,339 +18,256 @@ import type { SpeciesSearchMatch } from 'src/content/app/new-species-selector/ty
 
 export const popularSpecies: PopularSpecies[] = [
   {
-    id: 1,
-    name: 'Human',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/homo_sapiens_GCA_000001405_14.svg', // TODO: change this to updated human image
-    members_count: 2,
-    is_selected: false
+    species_taxonomy_id: 9606,
+    name: 'human',
+    image: 'https://beta.ensembl.org/static/genome_images/9606.svg',
+    genomes_count: 99
   },
   {
-    id: 2,
-    name: 'Mouse',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/mus_musculus.svg',
-    members_count: 16,
-    is_selected: false
+    species_taxonomy_id: 10090,
+    name: 'mouse',
+    image: 'https://beta.ensembl.org/static/genome_images/10090.svg',
+    genomes_count: 16
   },
   {
-    id: 3,
-    name: 'Zebrafish',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/danio_rerio.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 7955,
+    name: 'zebrafish',
+    image: 'https://beta.ensembl.org/static/genome_images/7955.svg',
+    genomes_count: 1
   },
   {
-    id: 4,
-    name: 'Wheat',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/triticum_aestivum.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 4565,
+    name: 'bread wheat',
+    image: 'https://beta.ensembl.org/static/genome_images/4565.svg',
+    genomes_count: 18
   },
   {
-    id: 5,
-    name: 'Rice',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/oryza_sativa.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 4530,
+    name: 'Japanese rice',
+    image: 'https://beta.ensembl.org/static/genome_images/4530.svg',
+    genomes_count: 16
   },
   {
-    id: 6,
-    name: 'Thale cress',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/arabidopsis_thaliana.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 3702,
+    name: 'thale-cress',
+    image: 'https://beta.ensembl.org/static/genome_images/3702.svg',
+    genomes_count: 1
   },
   {
-    id: 7,
-    name: 'Cattle',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/bos_taurus.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 9913,
+    name: 'cattle',
+    image: 'https://beta.ensembl.org/static/genome_images/9913.svg',
+    genomes_count: 1
   },
   {
-    id: 8,
-    name: 'Rat',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/rattus_norvegicus.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 10116,
+    name: 'Norway rat',
+    image: 'https://beta.ensembl.org/static/genome_images/10116.svg',
+    genomes_count: 4
   },
   {
-    id: 9,
-    name: 'Pig',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/sus_scrofa.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 9823,
+    name: 'pig',
+    image: 'https://beta.ensembl.org/static/genome_images/9823.svg',
+    genomes_count: 13
   },
   {
-    id: 10,
-    name: 'Maize',
-    image: 'https://staging-2020.ensembl.org/static/genome_images/zea_mays.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 4577,
+    name: 'maize',
+    image: 'https://beta.ensembl.org/static/genome_images/4577.svg',
+    genomes_count: 1
   },
   {
-    id: 11,
-    name: 'Chicken',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/gallus_gallus.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 9031,
+    name: 'chicken',
+    image: 'https://beta.ensembl.org/static/genome_images/9031.svg',
+    genomes_count: 3
   },
   {
-    id: 12,
-    name: 'Dog',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/canis_familiaris.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 9612,
+    name: 'dog',
+    image: 'https://beta.ensembl.org/static/genome_images/9612.svg',
+    genomes_count: 5
   },
   {
-    id: 13,
-    name: 'Barley',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/hordeum_vulgare.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 4513,
+    name: 'domesticated barley',
+    image: 'https://beta.ensembl.org/static/genome_images/4513.svg',
+    genomes_count: 2
   },
   {
-    id: 14,
-    name: 'Drosophila melanogaster',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/drosophila_melanogaster.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 7227,
+    name: 'Fruit fly',
+    image: 'https://beta.ensembl.org/static/genome_images/7227.svg',
+    genomes_count: 1
   },
   {
-    id: 15,
-    name: 'Japanese rice fish',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/oryzias_latipes.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 8090,
+    name: 'Japanese medaka HdrR',
+    image: 'https://beta.ensembl.org/static/genome_images/8090.svg',
+    genomes_count: 15
   },
   {
-    id: 16,
-    name: 'Sheep',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/ovis_aries.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 9940,
+    name: 'sheep',
+    image: 'https://beta.ensembl.org/static/genome_images/9940.svg',
+    genomes_count: 2
   },
   {
-    id: 17,
-    name: 'Grape',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/vitis_vinifera.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 29760,
+    name: 'wine grape',
+    image: 'https://beta.ensembl.org/static/genome_images/29760.svg',
+    genomes_count: 1
   },
   {
-    id: 18,
-    name: 'Tomato',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/solanum_lycopersicum.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 4081,
+    name: 'tomato',
+    image: 'https://beta.ensembl.org/static/genome_images/4081.svg',
+    genomes_count: 1
   },
   {
-    id: 19,
-    name: 'Horse',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/equus_caballus.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 9796,
+    name: 'horse',
+    image: 'https://beta.ensembl.org/static/genome_images/9796.svg',
+    genomes_count: 1
   },
   {
-    id: 20,
-    name: 'Rapeseed',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/brassica_napus.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 3708,
+    name: 'oilseed rape',
+    image: 'https://beta.ensembl.org/static/genome_images/3708.svg',
+    genomes_count: 1
   },
   {
-    id: 21,
-    name: 'Potato',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/solanum_tuberosum.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 4113,
+    name: 'potato',
+    image: 'https://beta.ensembl.org/static/genome_images/4113.svg',
+    genomes_count: 1
   },
   {
-    id: 22,
-    name: 'Rabbit',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/oryctolagus_cuniculus.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 9986,
+    name: 'rabbit',
+    image: 'https://beta.ensembl.org/static/genome_images/9986.svg',
+    genomes_count: 1
   },
   {
-    id: 23,
-    name: 'Saccharomyces cerevisiae',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/saccharomyces_cerevisiae.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 4932,
+    name: "baker's yeast",
+    image: 'https://beta.ensembl.org/static/genome_images/4932.svg',
+    genomes_count: 1
   },
   {
-    id: 24,
-    name: 'C. elegans',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/caenorhabditis_elegans.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 6239,
+    name: 'Roundworm',
+    image: 'https://beta.ensembl.org/static/genome_images/6239.svg',
+    genomes_count: 1
   },
   {
-    id: 25,
-    name: 'Cat',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/felis_catus.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 9685,
+    name: 'domestic cat',
+    image: 'https://beta.ensembl.org/static/genome_images/9685.svg',
+    genomes_count: 1
   },
   {
-    id: 26,
+    species_taxonomy_id: 9544,
     name: 'Macaque',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/macaca_mulatta.svg',
-    members_count: 1,
-    is_selected: false
+    image: 'https://beta.ensembl.org/static/genome_images/9544.svg',
+    genomes_count: 1
   },
   {
-    id: 27,
+    species_taxonomy_id: 7994,
     name: 'Mexican tetra',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/astyanax_mexicanus.svg',
-    members_count: 1,
-    is_selected: false
+    image: 'https://beta.ensembl.org/static/genome_images/7994.svg',
+    genomes_count: 6
   },
   {
-    id: 28,
-    name: 'Chimpanzee',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/pan_troglodytes.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 4567,
+    name: 'durum wheat',
+    image: 'https://beta.ensembl.org/static/genome_images/4567.svg',
+    genomes_count: 1
   },
   {
-    id: 29,
+    species_taxonomy_id: 9598,
+    name: 'chimpanzee',
+    image: 'https://beta.ensembl.org/static/genome_images/9598.svg',
+    genomes_count: 1
+  },
+  {
+    species_taxonomy_id: 8128,
     name: 'Nile tilapia',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/oreochromis_niloticus.svg',
-    members_count: 1,
-    is_selected: false
+    image: 'https://beta.ensembl.org/static/genome_images/8128.svg',
+    genomes_count: 1
   },
   {
-    id: 30,
+    species_taxonomy_id: 9925,
     name: 'Goat',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/capra_hircus.svg',
-    members_count: 1,
-    is_selected: false
+    image: 'https://beta.ensembl.org/static/genome_images/9925.svg',
+    genomes_count: 2
   },
   {
-    id: 31,
-    name: 'Brassica oleracea',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/brassica_oleracea.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 3712,
+    name: 'wild cabbage',
+    image: 'https://beta.ensembl.org/static/genome_images/3712.svg',
+    genomes_count: 1
   },
   {
-    id: 32,
-    name: 'Tropical clawed frog',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/xenopus_tropicalis.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 8364,
+    name: 'tropical clawed frog',
+    image: 'https://beta.ensembl.org/static/genome_images/8364.svg',
+    genomes_count: 1
   },
   {
-    id: 33,
-    name: 'Soybean',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/glycine_max.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 3847,
+    name: 'soybeans',
+    image: 'https://beta.ensembl.org/static/genome_images/3847.svg',
+    genomes_count: 1
   },
   {
-    id: 34,
+    species_taxonomy_id: 10029,
     name: 'Chinese hamster',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/cricetulus_griseus.svg',
-    members_count: 1,
-    is_selected: false
+    image: 'https://beta.ensembl.org/static/genome_images/10029.svg',
+    genomes_count: 3
   },
   {
-    id: 35,
-    name: 'Medicago truncatula',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/medicago_truncatula.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 3880,
+    name: 'barrel medic',
+    image: 'https://beta.ensembl.org/static/genome_images/3880.svg',
+    genomes_count: 1
   },
   {
-    id: 36,
-    name: 'Brassica rapa',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/brassica_rapa.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 3711,
+    name: 'field mustard',
+    image: 'https://beta.ensembl.org/static/genome_images/3711.svg',
+    genomes_count: 1
   },
   {
-    id: 37,
-    name: 'Sorghum bicolor',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/sorghum_bicolor.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 4558,
+    name: 'sorghum',
+    image: 'https://beta.ensembl.org/static/genome_images/4558.svg',
+    genomes_count: 1
   },
   {
-    id: 38,
+    species_taxonomy_id: 8030,
     name: 'Atlantic salmon',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/salmo_salar.svg',
-    members_count: 1,
-    is_selected: false
+    image: 'https://beta.ensembl.org/static/genome_images/8030.svg',
+    genomes_count: 4
   },
   {
-    id: 39,
-    name: 'Aegilops tauschii',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/aegilops_tauschii.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 37682,
+    name: "Tausch's goatgrass",
+    image: 'https://beta.ensembl.org/static/genome_images/37682.svg',
+    genomes_count: 1
   },
   {
-    id: 40,
-    name: 'E. coli',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/escherichia_coli.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 562,
+    name: 'Escherichia coli str. K-12 substr. MG1655 str. K12',
+    image: 'https://beta.ensembl.org/static/genome_images/562.svg',
+    genomes_count: 1
   },
   {
-    id: 41,
-    name: 'Plasmodium falciparum',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/plasmodium_falciparum.svg',
-    members_count: 1,
-    is_selected: false
-  },
-  {
-    id: 42,
-    name: 'Durum wheat',
-    image:
-      'https://staging-2020.ensembl.org/static/genome_images/triticum_aestivum.svg',
-    members_count: 1,
-    is_selected: false
+    species_taxonomy_id: 5833,
+    name: 'Plasmodium falciparum 3D7',
+    image: 'https://beta.ensembl.org/static/genome_images/5833.svg',
+    genomes_count: 1
   }
 ];
 

--- a/src/content/app/new-species-selector/types/popularSpecies.ts
+++ b/src/content/app/new-species-selector/types/popularSpecies.ts
@@ -15,9 +15,8 @@
  */
 
 export type PopularSpecies = {
-  id: string | number; // <-- an id of the collection of genomes associated with this species
+  species_taxonomy_id: string | number; // <-- an id of the collection of genomes associated with this species
   name: string; // <-- human-friendly text we are going to show in the tooltip
   image: string; // <-- url of the associated svg
-  members_count: number; // <-- the number to show in the lozenge (could name the field "genomes_count")
-  is_selected: boolean; // <-- to display popular species button as selected
+  genomes_count: number; // <-- the number to show in the lozenge (could name the field "genomes_count")
 };

--- a/src/content/app/new-species-selector/views/species-selector-results-view/SpeciesSelectorResultsView.tsx
+++ b/src/content/app/new-species-selector/views/species-selector-results-view/SpeciesSelectorResultsView.tsx
@@ -65,7 +65,7 @@ const Content = () => {
     <GenomeSelectorBySearchQuery query={query} onSpeciesAdd={onSpeciesAdd} />
   ) : selectedPopularSpecies ? (
     <GenomeSelectorBySpeciesTaxonomyId
-      speciesTaxonomyId={selectedPopularSpecies.id}
+      speciesTaxonomyId={selectedPopularSpecies.species_taxonomy_id}
       speciesImageUrl={selectedPopularSpecies.image}
     />
   ) : null; // this last option should never happen

--- a/stories/species-selector/popular-species-button/PopularSpeciesButton.stories.tsx
+++ b/stories/species-selector/popular-species-button/PopularSpeciesButton.stories.tsx
@@ -25,11 +25,10 @@ import zebrafishIconUrl from './danio_rerio.svg?url';
 import type { PopularSpecies } from 'src/content/app/new-species-selector/types/popularSpecies';
 
 const humanData: PopularSpecies = {
-  id: 1,
+  species_taxonomy_id: 1,
   name: 'Human',
   image: humanIconUrl,
-  members_count: 2,
-  is_selected: false
+  genomes_count: 2
 };
 
 const humanWithManyGenomesData = {
@@ -37,24 +36,30 @@ const humanWithManyGenomesData = {
   members_count: 5289
 };
 
-const zebrafisData: PopularSpecies = {
-  id: 2,
+const zebrafishData: PopularSpecies = {
+  species_taxonomy_id: 2,
   name: 'Zebrafish',
   image: zebrafishIconUrl,
-  members_count: 1,
-  is_selected: false
+  genomes_count: 1
 };
 
 export const UnselectedSmallCountStory = {
   name: 'Unselected, small count',
-  render: () => <PopularSpeciesButton species={humanData} onClick={noop} />
+  render: () => (
+    <PopularSpeciesButton
+      species={humanData}
+      isSelected={false}
+      onClick={noop}
+    />
+  )
 };
 
 export const SelectedSmallCountStory = {
   name: 'Selected, small count',
   render: () => (
     <PopularSpeciesButton
-      species={{ ...humanData, is_selected: true }}
+      species={humanData}
+      isSelected={true}
       onClick={noop}
     />
   )
@@ -63,7 +68,11 @@ export const SelectedSmallCountStory = {
 export const UnselectedLargeCountStory = {
   name: 'Unselected, large count',
   render: () => (
-    <PopularSpeciesButton species={humanWithManyGenomesData} onClick={noop} />
+    <PopularSpeciesButton
+      species={humanWithManyGenomesData}
+      isSelected={false}
+      onClick={noop}
+    />
   )
 };
 
@@ -71,7 +80,8 @@ export const SelectedLargeCountStory = {
   name: 'Selected, large count',
   render: () => (
     <PopularSpeciesButton
-      species={{ ...humanWithManyGenomesData, is_selected: true }}
+      species={humanWithManyGenomesData}
+      isSelected={true}
       onClick={noop}
     />
   )
@@ -79,14 +89,21 @@ export const SelectedLargeCountStory = {
 
 export const UnselectedNoCountStory = {
   name: 'Unselected, no count',
-  render: () => <PopularSpeciesButton species={zebrafisData} onClick={noop} />
+  render: () => (
+    <PopularSpeciesButton
+      species={zebrafishData}
+      isSelected={false}
+      onClick={noop}
+    />
+  )
 };
 
 export const SelectedNoCountStory = {
   name: 'Selected, no count',
   render: () => (
     <PopularSpeciesButton
-      species={{ ...zebrafisData, is_selected: true }}
+      species={zebrafishData}
+      isSelected={true}
       onClick={noop}
     />
   )


### PR DESCRIPTION
## Description
This PR is split from https://github.com/Ensembl/ensembl-client/pull/1027

- Popular species payload got updated (see https://github.com/Ensembl/ensembl-web-metadata-api/pull/15/files#diff-8722f7698391300a563ab11172301f35b1f8447b8c3408d3fee65395e2f515d6R6-R9) such that:
  - id has been renamed to species_taxonomy_id
  - members_count has been renamed to genomes_count
  - is_selected field has been removed from the payload

This PR makes updates to the code that consumes this payload. It uses the example payload provided by Kamal in [this message on Slack](https://genomes-ebi.slack.com/archives/CC2RKR525/p1695380711339459).

Note: the updated payload is also using the updated paths to the svg files.


## Related JIRA Issue(s)
<!--_Please provide the URL(s) for any JIRA issues related to this PR._-->

## Deployment URL(s)
http://update-popular-species-list.review.ensembl.org