### PR TITLE
Update url for genes search

### DIFF
--- a/src/shared/state/api-slices/searchApiSlice.ts
+++ b/src/shared/state/api-slices/searchApiSlice.ts
@@ -32,7 +32,7 @@ const searchApiSlice = restApiSlice.injectEndpoints({
     searchGenes: builder.query<SearchResults, SearchGenesParams>({
       query: (params) => {
         return {
-          url: config.searchApiBaseUrl,
+          url: `${config.searchApiBaseUrl}/genes`,
           method: 'POST',
           body: params
         };


### PR DESCRIPTION
## Description
The search api has changed its endpoint that we used for in-app search from `/search` to `/search/genes` (see [commit](https://gitlab.ebi.ac.uk/ensembl-web/ensembl_search_hub/-/commit/f67b8634edd9a2656deda7413c1487ac5bc7c90c#41f8d09f837b948109977366756b32f55aad92c9_21_20)).

While this may eventually prove to be a wrong choice — it is likely we will need to search for multiple types of entities, not just genes, in the interface where our "in-app search" field is present — the client has to update now to use this new endpoint.

## Deployment URL(s)
http://change-gene-search-url.review.ensembl.org — but it doesn't seem to be connected to the appropriate backend APIs