### PR TITLE
Disable species search field

### DIFF
--- a/src/content/app/new-species-selector/components/genome-selector-by-search-query/GenomeSelectorBySearchQuery.tsx
+++ b/src/content/app/new-species-selector/components/genome-selector-by-search-query/GenomeSelectorBySearchQuery.tsx
@@ -31,10 +31,11 @@ import styles from './GenomeSelectorBySearchQuery.scss';
 type Props = {
   query: string;
   onSpeciesAdd: (genomes: SpeciesSearchMatch[]) => void;
+  onClose: () => void;
 };
 
 const GenomeSelectorBySearchQuery = (props: Props) => {
-  const { query } = props;
+  const { query, onClose } = props;
   const [searchTrigger, result] = useLazyGetSpeciesSearchResultsQuery();
   const { currentData } = result;
 
@@ -60,6 +61,7 @@ const GenomeSelectorBySearchQuery = (props: Props) => {
         query={query}
         canAdd={stagedGenomes.length > 0}
         onAdd={onSpeciesAdd}
+        onCancel={onClose}
       />
       {currentData && (
         <>

--- a/src/content/app/new-species-selector/components/genome-selector-by-search-query/GenomeSelectorBySearchQuery.tsx
+++ b/src/content/app/new-species-selector/components/genome-selector-by-search-query/GenomeSelectorBySearchQuery.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 
 import { useLazyGetSpeciesSearchResultsQuery } from 'src/content/app/new-species-selector/state/species-selector-api-slice/speciesSelectorApiSlice';
 
 import useSelectableGenomesTable from 'src/content/app/new-species-selector/components/selectable-genomes-table/useSelectableGenomesTable';
 
-import SpeciesSearchField from 'src/content/app/new-species-selector/components/species-search-field/SpeciesSearchField';
+import AddFoundSpecies from 'src/content/app/new-species-selector/components/species-search-field/AddFoundSpecies';
 import SpeciesSearchResultsSummary from 'src/content/app/new-species-selector/components/species-search-results-summary/SpeciesSearchResultsSummary';
 import SpeciesSearchResultsTable from 'src/content/app/new-species-selector/components/species-search-results-table/SpeciesSearchResultsTable';
 
@@ -35,15 +35,12 @@ type Props = {
 
 const GenomeSelectorBySearchQuery = (props: Props) => {
   const { query } = props;
-  const [hasQueryChangedSinceSubmission, setHasQueryChangedSinceSubmission] =
-    useState(false);
   const [searchTrigger, result] = useLazyGetSpeciesSearchResultsQuery();
   const { currentData } = result;
 
   const {
     genomes,
     stagedGenomes,
-    setStagedGenomes,
     isTableExpanded,
     onTableExpandToggle,
     onGenomePreselectToggle
@@ -53,34 +50,18 @@ const GenomeSelectorBySearchQuery = (props: Props) => {
     searchTrigger({ query });
   }, []);
 
-  const onInput = () => {
-    setHasQueryChangedSinceSubmission(true);
-    setStagedGenomes([]); // remove all preselected species because user has changed value of the search field
-  };
-
-  const onSearchSubmit = () => {
-    searchTrigger({ query });
-    setHasQueryChangedSinceSubmission(false);
-  };
-
   const onSpeciesAdd = () => {
     props.onSpeciesAdd(stagedGenomes);
   };
 
-  const speciesSearchFieldMode = stagedGenomes.length
-    ? 'species-add'
-    : 'species-search';
-
   return (
     <div className={styles.main}>
-      <SpeciesSearchField
-        onInput={onInput}
-        onSearchSubmit={onSearchSubmit}
-        mode={speciesSearchFieldMode}
-        onSpeciesAdd={onSpeciesAdd}
-        canSubmit={hasQueryChangedSinceSubmission}
+      <AddFoundSpecies
+        query={query}
+        canAdd={stagedGenomes.length > 0}
+        onAdd={onSpeciesAdd}
       />
-      {currentData && !hasQueryChangedSinceSubmission && (
+      {currentData && (
         <>
           <SpeciesSearchResultsSummary searchResult={currentData} />
           <div className={styles.tableContainer}>

--- a/src/content/app/new-species-selector/components/genome-selector-by-search-query/GenomeSelectorBySearchQuery.tsx
+++ b/src/content/app/new-species-selector/components/genome-selector-by-search-query/GenomeSelectorBySearchQuery.tsx
@@ -21,6 +21,7 @@ import { useLazyGetSpeciesSearchResultsQuery } from 'src/content/app/new-species
 import useSelectableGenomesTable from 'src/content/app/new-species-selector/components/selectable-genomes-table/useSelectableGenomesTable';
 
 import AddFoundSpecies from 'src/content/app/new-species-selector/components/species-search-field/AddFoundSpecies';
+import SpeciesSearchField from '../species-search-field/SpeciesSearchField';
 import SpeciesSearchResultsSummary from 'src/content/app/new-species-selector/components/species-search-results-summary/SpeciesSearchResultsSummary';
 import SpeciesSearchResultsTable from 'src/content/app/new-species-selector/components/species-search-results-table/SpeciesSearchResultsTable';
 
@@ -55,25 +56,37 @@ const GenomeSelectorBySearchQuery = (props: Props) => {
     props.onSpeciesAdd(stagedGenomes);
   };
 
+  const onSearchSubmit = () => {
+    searchTrigger({ query });
+  };
+
   return (
     <div className={styles.main}>
-      <AddFoundSpecies
-        query={query}
-        canAdd={stagedGenomes.length > 0}
-        onAdd={onSpeciesAdd}
-        onCancel={onClose}
-      />
+      {currentData?.matches.length ? (
+        <AddFoundSpecies
+          query={query}
+          canAdd={stagedGenomes.length > 0}
+          onAdd={onSpeciesAdd}
+          onCancel={onClose}
+        />
+      ) : (
+        <SpeciesSearchField onSearchSubmit={onSearchSubmit} />
+      )}
+
       {currentData && (
         <>
           <SpeciesSearchResultsSummary searchResult={currentData} />
-          <div className={styles.tableContainer}>
-            <SpeciesSearchResultsTable
-              results={genomes}
-              isExpanded={isTableExpanded}
-              onTableExpandToggle={onTableExpandToggle}
-              onSpeciesSelectToggle={onGenomePreselectToggle}
-            />
-          </div>
+
+          {currentData.matches.length > 0 && (
+            <div className={styles.tableContainer}>
+              <SpeciesSearchResultsTable
+                results={genomes}
+                isExpanded={isTableExpanded}
+                onTableExpandToggle={onTableExpandToggle}
+                onSpeciesSelectToggle={onGenomePreselectToggle}
+              />
+            </div>
+          )}
         </>
       )}
     </div>

--- a/src/content/app/new-species-selector/components/genome-selector-by-search-query/GenomeSelectorBySearchQuery.tsx
+++ b/src/content/app/new-species-selector/components/genome-selector-by-search-query/GenomeSelectorBySearchQuery.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import { useLazyGetSpeciesSearchResultsQuery } from 'src/content/app/new-species-selector/state/species-selector-api-slice/speciesSelectorApiSlice';
 
@@ -37,6 +37,7 @@ type Props = {
 
 const GenomeSelectorBySearchQuery = (props: Props) => {
   const { query, onClose } = props;
+  const [canSubmitSearch, setCanSubmitSearch] = useState(false);
   const [searchTrigger, result] = useLazyGetSpeciesSearchResultsQuery();
   const { currentData } = result;
 
@@ -52,12 +53,19 @@ const GenomeSelectorBySearchQuery = (props: Props) => {
     searchTrigger({ query });
   }, []);
 
+  const onSearchInput = () => {
+    if (!canSubmitSearch) {
+      setCanSubmitSearch(true);
+    }
+  };
+
   const onSpeciesAdd = () => {
     props.onSpeciesAdd(stagedGenomes);
   };
 
   const onSearchSubmit = () => {
     searchTrigger({ query });
+    setCanSubmitSearch(false);
   };
 
   return (
@@ -70,7 +78,11 @@ const GenomeSelectorBySearchQuery = (props: Props) => {
           onCancel={onClose}
         />
       ) : (
-        <SpeciesSearchField onSearchSubmit={onSearchSubmit} />
+        <SpeciesSearchField
+          onInput={onSearchInput}
+          canSubmit={canSubmitSearch}
+          onSearchSubmit={onSearchSubmit}
+        />
       )}
 
       {currentData && (

--- a/src/content/app/new-species-selector/components/genome-selector-by-search-query/GenomeSelectorBySearchQuery.tsx
+++ b/src/content/app/new-species-selector/components/genome-selector-by-search-query/GenomeSelectorBySearchQuery.tsx
@@ -20,7 +20,7 @@ import { useLazyGetSpeciesSearchResultsQuery } from 'src/content/app/new-species
 
 import useSelectableGenomesTable from 'src/content/app/new-species-selector/components/selectable-genomes-table/useSelectableGenomesTable';
 
-import AddFoundSpecies from 'src/content/app/new-species-selector/components/species-search-field/AddFoundSpecies';
+import AddSpecies from 'src/content/app/new-species-selector/components/species-search-field/AddSpecies';
 import SpeciesSearchField from '../species-search-field/SpeciesSearchField';
 import SpeciesSearchResultsSummary from 'src/content/app/new-species-selector/components/species-search-results-summary/SpeciesSearchResultsSummary';
 import SpeciesSearchResultsTable from 'src/content/app/new-species-selector/components/species-search-results-table/SpeciesSearchResultsTable';
@@ -71,7 +71,7 @@ const GenomeSelectorBySearchQuery = (props: Props) => {
   return (
     <div className={styles.main}>
       {currentData?.matches.length ? (
-        <AddFoundSpecies
+        <AddSpecies
           query={query}
           canAdd={stagedGenomes.length > 0}
           onAdd={onSpeciesAdd}

--- a/src/content/app/new-species-selector/components/species-search-field/AddFoundSpecies.tsx
+++ b/src/content/app/new-species-selector/components/species-search-field/AddFoundSpecies.tsx
@@ -27,10 +27,11 @@ export type Props = {
   query: string;
   canAdd: boolean;
   onAdd: () => void;
+  onCancel: () => void;
 };
 
 const AddFoundSpecies = (props: Props) => {
-  const { query, canAdd, onAdd } = props;
+  const { query, canAdd, onAdd, onCancel } = props;
 
   return (
     <div className={styles.grid}>
@@ -45,7 +46,7 @@ const AddFoundSpecies = (props: Props) => {
         <PrimaryButton disabled={!canAdd} onClick={onAdd}>
           Add
         </PrimaryButton>
-        <TextButton>Cancel</TextButton>
+        <TextButton onClick={onCancel}>Cancel</TextButton>
       </div>
     </div>
   );

--- a/src/content/app/new-species-selector/components/species-search-field/AddFoundSpecies.tsx
+++ b/src/content/app/new-species-selector/components/species-search-field/AddFoundSpecies.tsx
@@ -1,0 +1,54 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import classNames from 'classnames';
+
+import ShadedInput from 'src/shared/components/input/ShadedInput';
+import { PrimaryButton } from 'src/shared/components/button/Button';
+import TextButton from 'src/shared/components/text-button/TextButton';
+
+import styles from './SpeciesSearchField.scss';
+
+export type Props = {
+  query: string;
+  canAdd: boolean;
+  onAdd: () => void;
+};
+
+const AddFoundSpecies = (props: Props) => {
+  const { query, canAdd, onAdd } = props;
+
+  return (
+    <div className={styles.grid}>
+      <label>Find a species</label>
+      <ShadedInput
+        size="large"
+        className={styles.input}
+        value={query}
+        disabled={true}
+      />
+      <div className={classNames(styles.controls, styles.addSpeciesControls)}>
+        <PrimaryButton disabled={!canAdd} onClick={onAdd}>
+          Add
+        </PrimaryButton>
+        <TextButton>Cancel</TextButton>
+      </div>
+    </div>
+  );
+};
+
+export default AddFoundSpecies;

--- a/src/content/app/new-species-selector/components/species-search-field/AddSpecies.tsx
+++ b/src/content/app/new-species-selector/components/species-search-field/AddSpecies.tsx
@@ -30,7 +30,7 @@ export type Props = {
   onCancel: () => void;
 };
 
-const AddFoundSpecies = (props: Props) => {
+const AddSpecies = (props: Props) => {
   const { query, canAdd, onAdd, onCancel } = props;
 
   return (
@@ -52,4 +52,4 @@ const AddFoundSpecies = (props: Props) => {
   );
 };
 
-export default AddFoundSpecies;
+export default AddSpecies;

--- a/src/content/app/new-species-selector/components/species-search-field/SpeciesSearchField.scss
+++ b/src/content/app/new-species-selector/components/species-search-field/SpeciesSearchField.scss
@@ -1,11 +1,11 @@
 @import 'src/styles/common';
 
-.speciesSearchField {
+.grid {
   display: grid;
   grid-template-areas:
     'label .'
-    'input button';
-  grid-template-columns: 486px 64px;
+    'input controls';
+  grid-template-columns: 486px max-content;
   row-gap: 10px;
   column-gap: 45px;
 }
@@ -19,11 +19,17 @@
   grid-area: input;
 }
 
-.button {
-  grid-area: button;
+.controls {
+  grid-area: controls;
   align-self: center;
 }
 
 .submit {
   --primary-button-color: #{$blue};
+}
+
+.addSpeciesControls {
+  display: flex;
+  align-items: center;
+  gap: 30px;
 }

--- a/src/content/app/new-species-selector/components/species-search-field/SpeciesSearchField.tsx
+++ b/src/content/app/new-species-selector/components/species-search-field/SpeciesSearchField.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { type MouseEvent, FormEvent } from 'react';
+import React, { FormEvent } from 'react';
 import classNames from 'classnames';
 
 import { useAppDispatch, useAppSelector } from 'src/store';
@@ -27,19 +27,15 @@ import { PrimaryButton } from 'src/shared/components/button/Button';
 
 import styles from './SpeciesSearchField.scss';
 
-type Mode = 'species-search' | 'species-add';
-
 export type Props = {
   onSearchSubmit: () => void;
-  mode?: Mode; // FIXME: no need
   canSubmit?: boolean;
-  disabled?: boolean; // FIXME: no need
   onSpeciesAdd?: () => void;
   onInput?: ((event: FormEvent<HTMLInputElement>) => void) | (() => void);
 };
 
 const SpeciesSearchField = (props: Props) => {
-  const { mode = 'species-search', canSubmit = true } = props;
+  const { canSubmit = true } = props;
   const dispatch = useAppDispatch();
   const query = useAppSelector(getSpeciesSearchQuery);
 
@@ -54,11 +50,6 @@ const SpeciesSearchField = (props: Props) => {
     props.onSearchSubmit();
   };
 
-  const onAdd = (event: MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault(); // to avoid triggering form submission
-    props.onSpeciesAdd?.();
-  };
-
   return (
     <form className={styles.grid} onSubmit={onSubmit}>
       <label>Find a species</label>
@@ -71,20 +62,13 @@ const SpeciesSearchField = (props: Props) => {
         placeholder={placeholderText}
         help={helpText}
         minLength={3}
-        disabled={props.disabled}
       />
-      {mode === 'species-search' ? (
-        <PrimaryButton
-          disabled={!canSubmit || query.length < 3}
-          className={classNames(styles.controls, styles.submit)}
-        >
-          Find
-        </PrimaryButton>
-      ) : (
-        <PrimaryButton className={styles.controls} onClick={onAdd}>
-          Add
-        </PrimaryButton>
-      )}
+      <PrimaryButton
+        disabled={!canSubmit || query.length < 3}
+        className={classNames(styles.controls, styles.submit)}
+      >
+        Find
+      </PrimaryButton>
     </form>
   );
 };

--- a/src/content/app/new-species-selector/components/species-search-field/SpeciesSearchField.tsx
+++ b/src/content/app/new-species-selector/components/species-search-field/SpeciesSearchField.tsx
@@ -31,8 +31,9 @@ type Mode = 'species-search' | 'species-add';
 
 export type Props = {
   onSearchSubmit: () => void;
-  mode?: Mode;
+  mode?: Mode; // FIXME: no need
   canSubmit?: boolean;
+  disabled?: boolean; // FIXME: no need
   onSpeciesAdd?: () => void;
   onInput?: ((event: FormEvent<HTMLInputElement>) => void) | (() => void);
 };
@@ -59,7 +60,7 @@ const SpeciesSearchField = (props: Props) => {
   };
 
   return (
-    <form className={styles.speciesSearchField} onSubmit={onSubmit}>
+    <form className={styles.grid} onSubmit={onSubmit}>
       <label>Find a species</label>
       <ShadedInput
         size="large"
@@ -70,16 +71,17 @@ const SpeciesSearchField = (props: Props) => {
         placeholder={placeholderText}
         help={helpText}
         minLength={3}
+        disabled={props.disabled}
       />
       {mode === 'species-search' ? (
         <PrimaryButton
           disabled={!canSubmit || query.length < 3}
-          className={classNames(styles.button, styles.submit)}
+          className={classNames(styles.controls, styles.submit)}
         >
           Find
         </PrimaryButton>
       ) : (
-        <PrimaryButton className={styles.button} onClick={onAdd}>
+        <PrimaryButton className={styles.controls} onClick={onAdd}>
           Add
         </PrimaryButton>
       )}

--- a/src/content/app/new-species-selector/components/species-search-results-summary/SpeciesSearchResultsSummary.scss
+++ b/src/content/app/new-species-selector/components/species-search-results-summary/SpeciesSearchResultsSummary.scss
@@ -9,3 +9,21 @@
 .searchMatchesCount {
   font-weight: $bold;
 }
+
+.noMatchesMessage {
+  color: $red;
+  margin-top: 40px;
+  margin-bottom: 30px;
+}
+
+.searchHelp p {
+  margin: 0;
+}
+
+.searchHelp ul {
+  padding-inline-start: 20px;
+}
+
+.searchHelp li {
+  list-style: disc;
+}

--- a/src/content/app/new-species-selector/components/species-search-results-summary/SpeciesSearchResultsSummary.tsx
+++ b/src/content/app/new-species-selector/components/species-search-results-summary/SpeciesSearchResultsSummary.tsx
@@ -28,21 +28,56 @@ type Props = {
 // TODO: add a filter component to this section
 
 const SpeciesSearchResultsSummary = (props: Props) => {
-  const searchMatchesCount = props.searchResult?.meta.total_count;
+  const searchMatchesCount = props.searchResult?.meta.total_count ?? 0;
 
-  // TODO: style the contents differently if the results are from a popular species
+  return searchMatchesCount > 0 ? (
+    <SuccessfulSearchResults count={searchMatchesCount} />
+  ) : (
+    <NoResults />
+  );
+};
+
+const SuccessfulSearchResults = (props: { count: number }) => {
+  const { count } = props;
 
   return (
     <section className={styles.container}>
-      {searchMatchesCount && searchMatchesCount > 1 && (
-        <span>
-          <span className={styles.searchMatchesCount}>
-            {searchMatchesCount}
-          </span>{' '}
-          results
-        </span>
-      )}
+      <span>
+        <span className={styles.searchMatchesCount}>{count}</span> results
+      </span>
     </section>
+  );
+};
+
+const NoResults = () => {
+  return (
+    <section className={styles.container}>
+      <div>
+        <span>
+          <span className={styles.searchMatchesCount}>0</span> results
+        </span>
+      </div>
+      <div className={styles.noMatchesMessage}>
+        Sorry, we don’t recognise, or may not have data for this species
+      </div>
+      <SearchHelp />
+    </section>
+  );
+};
+
+const SearchHelp = () => {
+  return (
+    <div className={styles.searchHelp}>
+      <p>
+        In order to help you find what you’re really looking for, could we
+        suggest
+      </p>
+      <ul>
+        <li>only search for a species</li>
+        <li>use a full name where possible</li>
+        <li>try a different name or identifier</li>
+      </ul>
+    </div>
   );
 };
 

--- a/src/content/app/new-species-selector/views/species-selector-results-view/SpeciesSelectorResultsView.tsx
+++ b/src/content/app/new-species-selector/views/species-selector-results-view/SpeciesSelectorResultsView.tsx
@@ -46,12 +46,12 @@ const SpeciesSelectorResultslView = () => {
 
   return (
     <ModalView onClose={onClose}>
-      <Content />
+      <Content onClose={onClose} />
     </ModalView>
   );
 };
 
-const Content = () => {
+const Content = (props: { onClose: () => void }) => {
   const modalView = useAppSelector(getSpeciesSelectorModalView);
   const query = useAppSelector(getSpeciesSearchQuery);
   const selectedPopularSpecies = useAppSelector(getSelectedPopularSpecies);
@@ -62,7 +62,11 @@ const Content = () => {
   };
 
   return modalView === 'species-search' ? (
-    <GenomeSelectorBySearchQuery query={query} onSpeciesAdd={onSpeciesAdd} />
+    <GenomeSelectorBySearchQuery
+      query={query}
+      onSpeciesAdd={onSpeciesAdd}
+      onClose={props.onClose}
+    />
   ) : selectedPopularSpecies ? (
     <GenomeSelectorBySpeciesTaxonomyId
       speciesTaxonomyId={selectedPopularSpecies.species_taxonomy_id}

--- a/src/shared/components/input/Input.scss
+++ b/src/shared/components/input/Input.scss
@@ -48,6 +48,10 @@
   }
 }
 
+.shadedInputDisabled {
+  background-color: $light-grey;
+}
+
 .flatInputWrapper {
   background-color: var(--flat-input-background-colour, $white);
   padding: 0 15px;

--- a/src/shared/components/input/ShadedInput.test.tsx
+++ b/src/shared/components/input/ShadedInput.test.tsx
@@ -51,8 +51,33 @@ describe('<ShadedInput />', () => {
     expect(component.classList).toContain('shadedInputWrapperSmall');
   });
 
+  it('cannot be interacted with if disabled', async () => {
+    // before disabling
+    const { container, rerender } = render(<ShadedInput />);
+    const wrapper = container.querySelector(
+      '.shadedInputWrapper'
+    ) as HTMLElement;
+    const inputElement = container.querySelector('input') as HTMLInputElement;
+
+    const inputText = 'Hello world';
+
+    await userEvent.type(inputElement, inputText);
+
+    expect(inputElement.value).toBe(inputText);
+    expect(wrapper.classList.contains('shadedInputDisabled')).toBe(false);
+
+    rerender(<ShadedInput disabled={true} />);
+
+    await userEvent.type(inputElement, 'Goodbye!');
+
+    // the disabled input element should still be showing the initial text;
+    // but no additional interactions should be able to modify it
+    expect(inputElement.value).toBe(inputText);
+    expect(wrapper.classList.contains('shadedInputDisabled')).toBe(true);
+  });
+
   describe('help element', () => {
-    it('can show help element', () => {
+    it('appears if help text is provided', () => {
       // no help element rendered if no help text provided
       const { container, rerender } = render(<ShadedInput />);
       expect(container.querySelector('.rightCorner')).toBeFalsy();
@@ -61,6 +86,18 @@ describe('<ShadedInput />', () => {
       expect(
         container.querySelector('.rightCorner .questionButton')
       ).toBeTruthy();
+    });
+
+    it('does not show up in a disabled shaded input', () => {
+      // we already know fron another test
+      // that a help element appears if help text is provided
+      const { container } = render(
+        <ShadedInput help="More info..." disabled={true} />
+      );
+
+      expect(
+        container.querySelector('.rightCorner .questionButton')
+      ).toBeFalsy();
     });
   });
 
@@ -102,6 +139,13 @@ describe('<ShadedInput />', () => {
       await userEvent.click(clearButton);
       expect(inputElement.value).toBe('');
       expect(onInput).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not show the clear button if input is disabled', async () => {
+      const { container } = render(
+        <ShadedInput type="search" defaultValue="hello" disabled={true} />
+      );
+      expect(container.querySelector('.closeButton')).toBeFalsy();
     });
   });
 });

--- a/src/shared/components/input/ShadedInput.tsx
+++ b/src/shared/components/input/ShadedInput.tsx
@@ -45,6 +45,7 @@ export type Props = Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> & {
 const ShadedInput = (props: Props, ref: ForwardedRef<HTMLInputElement>) => {
   const {
     className: classNameFromProps,
+    disabled = false,
     size,
     help,
     type = 'text',
@@ -64,6 +65,7 @@ const ShadedInput = (props: Props, ref: ForwardedRef<HTMLInputElement>) => {
     styles.shadedInputWrapper,
     classNameFromProps,
     {
+      [styles.shadedInputDisabled]: disabled,
       [styles.shadedInputWrapperLarge]: size === 'large',
       [styles.shadedInputWrapperSmall]: size === 'small'
     }
@@ -83,11 +85,12 @@ const ShadedInput = (props: Props, ref: ForwardedRef<HTMLInputElement>) => {
     <div className={wrapperClasses}>
       <Input
         ref={innerRef}
+        disabled={disabled}
         type={type === 'search' ? undefined : props.type}
         placeholder={placeholder}
         {...otherProps}
       />
-      {rightCornerContent && (
+      {!disabled && rightCornerContent && (
         <div className={styles.rightCorner}>{rightCornerContent}</div>
       )}
     </div>

--- a/src/shared/components/text-button/TextButton.scss
+++ b/src/shared/components/text-button/TextButton.scss
@@ -1,0 +1,5 @@
+@import 'src/styles/common';
+
+.textButton {
+  color: var(--text-button-color, #{$blue});
+}

--- a/src/shared/components/text-button/TextButton.tsx
+++ b/src/shared/components/text-button/TextButton.tsx
@@ -1,0 +1,40 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, {
+  type DetailedHTMLProps,
+  type ButtonHTMLAttributes
+} from 'react';
+import classNames from 'classnames';
+
+import styles from './TextButton.scss';
+
+type Props = DetailedHTMLProps<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  HTMLButtonElement
+>;
+
+export const TextButton = (props: Props) => {
+  const buttonClasses = classNames(styles.textButton, props.className);
+
+  return (
+    <button {...props} className={buttonClasses}>
+      {props.children}
+    </button>
+  );
+};
+
+export default TextButton;

--- a/stories/shared-components/input/ShadedInputStory.tsx
+++ b/stories/shared-components/input/ShadedInputStory.tsx
@@ -32,6 +32,7 @@ export const ShadedInputPlayground = () => {
   const [withPlaceholder, setWithPlaceholder] = useState(false);
   const [withHelp, setWithHelp] = useState(false);
   const [isSearch, setIsSearch] = useState(false);
+  const [isDisabled, setIsDisabled] = useState(false);
 
   const wrapperClasses = classNames(styles.shadedInputWrapper, {
     [styles.greyStage]: isDarkBackground
@@ -47,6 +48,7 @@ export const ShadedInputPlayground = () => {
           minLength={minLength}
           help={withHelp ? helpText : undefined}
           type={isSearch ? 'search' : 'text'}
+          disabled={isDisabled}
         />
       </div>
       <div>
@@ -63,6 +65,8 @@ export const ShadedInputPlayground = () => {
           setWithHelp={setWithHelp}
           isSearch={isSearch}
           setIsSearch={setIsSearch}
+          isDisabled={isDisabled}
+          setIsDisabled={setIsDisabled}
         />
       </div>
     </div>
@@ -82,6 +86,8 @@ const Options = (props: {
   setWithHelp: (x: boolean) => void;
   isSearch: boolean;
   setIsSearch: (x: boolean) => void;
+  isDisabled: boolean;
+  setIsDisabled: (x: boolean) => void;
 }) => {
   const [minLength, setMinLength] = useState(defaultMinLength);
 
@@ -159,6 +165,14 @@ const Options = (props: {
           disabled={props.minLength === undefined}
           value={props.minLength}
           onChange={onMinimumLengthChange}
+        />
+      </label>
+      <label>
+        Is disabled
+        <input
+          type="checkbox"
+          checked={props.isDisabled}
+          onChange={() => props.setIsDisabled(!props.isDisabled)}
         />
       </label>
     </div>

--- a/stories/shared-components/text-button/TextButton.stories.tsx
+++ b/stories/shared-components/text-button/TextButton.stories.tsx
@@ -1,0 +1,28 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import TextButton from 'src/shared/components/text-button/TextButton';
+
+export const TextButtonStory = {
+  name: 'default',
+  render: () => <TextButton>Click me</TextButton>
+};
+
+export default {
+  title: 'Components/Shared Components/TextButton'
+};


### PR DESCRIPTION
## Description
Andrea has updated the design of the species search results view. In it she disables the species search field. See [XD](https://xd.adobe.com/view/b8d67194-34d7-40de-bcd9-a3413ea5d727-ed85/screen/d06762a7-6b1e-43e8-baba-1ef4b7996d0a)

While I think disabling the input field is hostile to users, because they cannot easily correct their query, and that this is a mistake that we will later have to correct, it is easy to set up. In fact, this decision simplifies our code. This is what this PR is about.

Also, added a view for empty search results (see [XD](https://xd.adobe.com/view/b8d67194-34d7-40de-bcd9-a3413ea5d727-ed85/screen/bd236467-8165-4187-8384-b6b34f366630))

Also in the PR:
- Added the `disabled` behaviour to the ShadedInput component
- Added a `TextButton` component, which uses native html button and thus is better for accessibility than spans or divs

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2197

## Deployment URL(s)
http://disable-species-search-field.review.ensembl.org