### PR TITLE
Fix disappearing or extra genome browser tracks when switching species

### DIFF
--- a/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
@@ -27,8 +27,6 @@ import * as genomeBrowserCommands from 'src/content/app/genome-browser/services/
 
 import { GenomeBrowserContext } from 'src/content/app/genome-browser/contexts/GenomeBrowserContext';
 
-import usePrevious from 'src/shared/hooks/usePrevious';
-
 import { getBrowserActiveGenomeId } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
 import { useGenomeTracksQuery } from 'src/content/app/genome-browser/state/api/genomeBrowserApiSlice';
 
@@ -216,6 +214,11 @@ const useGenomeBrowser = () => {
 const useTrackIdToTrackPathMap = () => {
   const activeGenomeId = useAppSelector(getBrowserActiveGenomeId);
 
+  const trackCategoriesRef = useRef<{
+    previous: GenomeTrackCategory[];
+    current: GenomeTrackCategory[];
+  }>({ previous: [], current: [] });
+
   const { currentData: trackCategories = [] } = useGenomeTracksQuery(
     activeGenomeId ?? '',
     {
@@ -223,11 +226,19 @@ const useTrackIdToTrackPathMap = () => {
     }
   );
 
-  const previousTrackCategories = usePrevious(trackCategories) ?? [];
+  useEffect(() => {
+    if (
+      trackCategories.length &&
+      trackCategories !== trackCategoriesRef.current.previous
+    ) {
+      trackCategoriesRef.current.previous = trackCategoriesRef.current.current;
+      trackCategoriesRef.current.current = trackCategories;
+    }
+  }, [trackCategories]);
 
   const trackIdToPathMap = getTrackIdToTrackPathMap([
-    ...trackCategories,
-    ...previousTrackCategories
+    ...trackCategoriesRef.current.previous,
+    ...trackCategoriesRef.current.current
   ]);
 
   return trackIdToPathMap;

--- a/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
@@ -16,6 +16,7 @@
 import { useContext, useRef, useEffect } from 'react';
 
 import config from 'config';
+import { useAppSelector } from 'src/store';
 
 import {
   GenomeBrowserLoader,
@@ -26,7 +27,8 @@ import * as genomeBrowserCommands from 'src/content/app/genome-browser/services/
 
 import { GenomeBrowserContext } from 'src/content/app/genome-browser/contexts/GenomeBrowserContext';
 
-import { useAppSelector } from 'src/store';
+import usePrevious from 'src/shared/hooks/usePrevious';
+
 import { getBrowserActiveGenomeId } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
 import { useGenomeTracksQuery } from 'src/content/app/genome-browser/state/api/genomeBrowserApiSlice';
 
@@ -48,14 +50,7 @@ const useGenomeBrowser = () => {
   const genomeBrowserContext = useMandatoryGenomeBrowserContext();
   const activeGenomeId = useAppSelector(getBrowserActiveGenomeId);
 
-  const { currentData: trackCategories } = useGenomeTracksQuery(
-    activeGenomeId ?? '',
-    {
-      skip: !activeGenomeId
-    }
-  );
-
-  const trackIdToPathMap = getTrackIdToTrackPathMap(trackCategories ?? []);
+  const trackIdToPathMap = useTrackIdToTrackPathMap();
 
   const {
     genomeBrowser,
@@ -203,13 +198,51 @@ const useGenomeBrowser = () => {
   };
 };
 
+/**
+ * There is, currently, a disconnect between what information genome browser needs
+ * to toggle a track on or off (it needs a full "path" to the track, expressed in
+ * the "trigger" field of track payload), and what the genome browser sends back
+ * in its message about which tracks are being displayed (it only sends the last part
+ * of the path, i.e. the last string of the "trigger" array).
+ *
+ * This hook creates a map between a track id and the trigger required for
+ * messages to the genome browser. The map includes non-focus tracks
+ * for the currently active genome, as well as for the previous active genome.
+ * The reason for storing information about tracks of the previous active genome
+ * is to be able to turn off previous genome's tracks that don't even exist
+ * for the currently active genome (e.g. a variation track may exist for human,
+ * but not for some bacterium).
+ */
+const useTrackIdToTrackPathMap = () => {
+  const activeGenomeId = useAppSelector(getBrowserActiveGenomeId);
+
+  const { currentData: trackCategories = [] } = useGenomeTracksQuery(
+    activeGenomeId ?? '',
+    {
+      skip: !activeGenomeId
+    }
+  );
+
+  const previousTrackCategories = usePrevious(trackCategories) ?? [];
+
+  const trackIdToPathMap = getTrackIdToTrackPathMap([
+    ...trackCategories,
+    ...previousTrackCategories
+  ]);
+
+  return trackIdToPathMap;
+};
+
 const getTrackIdToTrackPathMap = (trackCategories: GenomeTrackCategory[]) => {
   const tracks = trackCategories.flatMap(({ track_list }) => track_list);
 
-  return tracks.reduce((accumulator, track) => {
-    accumulator[track.track_id] = track.trigger;
-    return accumulator;
-  }, {} as Record<string, string[]>);
+  return tracks.reduce(
+    (accumulator, track) => {
+      accumulator[track.track_id] = track.trigger;
+      return accumulator;
+    },
+    {} as Record<string, string[]>
+  );
 };
 
 export default useGenomeBrowser;

--- a/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
@@ -213,7 +213,7 @@ const prepareTrackSettings = ({
  * about track visibility.
  *
  * This hack is probably good for now; but the race condition suggests that there is an underlying
- * problem with event coordination, and trat we should probably look into refactoring.
+ * problem with event coordination, and that we should probably look into refactoring.
  */
 const hasGenomicTrackSettings = (
   trackSettings: TrackSettingsPerTrack,

--- a/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
@@ -93,7 +93,7 @@ const useGenomeBrowserTracks = () => {
     });
   }, [trackCategories, focusObject, genomeId]);
 
-  // make sure to tell genome browser to hide tracks that a given genome id doesn't have
+  // make sure to tell genome browser to hide tracks that a given genome doesn't have
   useEffect(() => {
     if (
       !trackSettingsForGenome ||


### PR DESCRIPTION
## Description
This PR addresses the following bugs occurring when switching between genomes:

### Bug 1: Disappearing tracks
E.g. switch from E. coli to human, and notice how all but the focus track disappear on the screen

https://github.com/Ensembl/ensembl-client/assets/6834224/223801f7-eb84-4361-8454-d14154289a98

### Bug 2: Empty tracks that shouldn't be enabled for a given species

E.g. switch from human to Plasmodium falciparum and notice that a variation summary track remains enabled (and empty, because Plasmodium falciparum doesn't have any dbSNP variation data)

https://github.com/Ensembl/ensembl-client/assets/6834224/a40d5b9e-6876-4a07-8971-5f08b9b3bb79


## Related JIRA Issue(s)
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1881
- [message on Slack](https://genomes-ebi.slack.com/archives/C01QD9623KK/p1695330862165549)

## Deployment URL(s)
http://gb-switch-species.review.ensembl.org