### PR TITLE
Pass variant start coordinate and region name to genome browser for f…

### DIFF
--- a/src/content/app/genome-browser/services/genome-browser-service/genomeBrowserCommands.ts
+++ b/src/content/app/genome-browser/services/genome-browser-service/genomeBrowserCommands.ts
@@ -149,7 +149,9 @@ const setFocusVariant: typeof setFocus = (payload) => {
   genomeBrowser.switch(['track', 'focus', 'label'], true);
   genomeBrowser.switch(['track', 'focus', 'item', 'variant'], {
     genome_id: genomeId,
-    variant_id: variantName
+    variant_id: variantName,
+    region_name: regionName,
+    start
   });
 };
 


### PR DESCRIPTION
## Description
Pass the variant start together with the variant id to the genome browser.

Intended to support changes made in https://github.com/Ensembl/ensembl-dauphin-style-compiler/pull/93 