### PR TITLE
Add sorting for the species table

### DIFF
--- a/src/content/app/genome-browser/components/drawer/drawer-views/variant-group-legend/VariantGroupLegend.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/variant-group-legend/VariantGroupLegend.tsx
@@ -19,7 +19,7 @@ import React from 'react';
 import variantGroups from 'src/content/app/genome-browser/constants/variantGroups';
 
 import ExternalLink from 'src/shared/components/external-link/ExternalLink';
-import { Table } from 'src/shared/components/table';
+import { Table, ColumnHead } from 'src/shared/components/table';
 
 import type { VariantLegendView } from 'src/content/app/genome-browser/state/drawer/types';
 
@@ -57,8 +57,8 @@ const VariantGroupLegend = (props: Props) => {
         <Table stickyHeader={true}>
           <thead className={styles.tableHead}>
             <tr>
-              <th>SO term</th>
-              <th>SO accession</th>
+              <ColumnHead>SO term</ColumnHead>
+              <ColumnHead>SO accession</ColumnHead>
             </tr>
           </thead>
           <tbody>

--- a/src/content/app/new-species-selector/components/genome-selector-by-search-query/GenomeSelectorBySearchQuery.tsx
+++ b/src/content/app/new-species-selector/components/genome-selector-by-search-query/GenomeSelectorBySearchQuery.tsx
@@ -50,7 +50,9 @@ const GenomeSelectorBySearchQuery = (props: Props) => {
     stagedGenomes,
     isTableExpanded,
     onTableExpandToggle,
-    onGenomePreselectToggle
+    onGenomePreselectToggle,
+    sortRule,
+    changeSortRule
   } = useSelectableGenomesTable({
     genomes: currentData?.matches ?? [],
     filterQuery
@@ -97,6 +99,8 @@ const GenomeSelectorBySearchQuery = (props: Props) => {
           <SpeciesSearchResultsTable
             results={deferredGenomes}
             isExpanded={isTableExpanded}
+            sortRule={sortRule}
+            onSortRuleChange={changeSortRule}
             onTableExpandToggle={onTableExpandToggle}
             onSpeciesSelectToggle={onGenomePreselectToggle}
           />

--- a/src/content/app/new-species-selector/components/genome-selector-by-species-taxonomy-id/GenomeSelectorBySpeciesTaxonomyId.tsx
+++ b/src/content/app/new-species-selector/components/genome-selector-by-species-taxonomy-id/GenomeSelectorBySpeciesTaxonomyId.tsx
@@ -47,7 +47,9 @@ const GenomeSelectorBySpeciesTaxonomyId = (props: Props) => {
     stagedGenomes,
     isTableExpanded,
     onTableExpandToggle,
-    onGenomePreselectToggle
+    onGenomePreselectToggle,
+    sortRule,
+    changeSortRule
   } = useSelectableGenomesTable({
     genomes: currentData?.matches ?? [],
     filterQuery
@@ -72,8 +74,10 @@ const GenomeSelectorBySpeciesTaxonomyId = (props: Props) => {
             <SpeciesSearchResultsTable
               results={genomes}
               isExpanded={isTableExpanded}
+              sortRule={sortRule}
               onTableExpandToggle={onTableExpandToggle}
               onSpeciesSelectToggle={onGenomePreselectToggle}
+              onSortRuleChange={changeSortRule}
             />
           </div>
         </>

--- a/src/content/app/new-species-selector/components/selectable-genomes-table/useOrderedGenomes.ts
+++ b/src/content/app/new-species-selector/components/selectable-genomes-table/useOrderedGenomes.ts
@@ -1,0 +1,198 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, useCallback } from 'react';
+import type { SelectableGenome } from './useSelectableGenomesTable';
+
+type SortableColumn =
+  | 'common_name'
+  | 'scientific_name'
+  | 'type'
+  | 'assembly_name'
+  | 'assembly_accession_id'
+  | 'coding_genes_count'
+  | 'contig_n50';
+
+type SortOrder = 'asc' | 'desc';
+
+export type SortRule = {
+  column: SortableColumn;
+  sortOrder: 'asc' | 'desc';
+};
+
+export type ChangeSortRule = (
+  column: SortableColumn,
+  sortOrder: SortOrder | 'none'
+) => void;
+
+const useOrderedGenomes = (genomes: SelectableGenome[]) => {
+  const [sortRule, setSortRule] = useState<SortRule | null>(null);
+
+  let orderedGenomes = genomes;
+
+  const changeSortRule: ChangeSortRule = useCallback((column, sortOrder) => {
+    if (sortOrder === 'none') {
+      setSortRule(null);
+    } else {
+      setSortRule({ column, sortOrder });
+    }
+  }, []);
+
+  // NOTE: we could use Array.prototype.toSorted when we feel brave enough
+  if (sortRule?.column === 'common_name') {
+    if (sortRule.sortOrder === 'asc') {
+      orderedGenomes = [...genomes].sort((a, b) => {
+        return sortStringAsc(a.common_name, b.common_name);
+      });
+    } else {
+      orderedGenomes = [...genomes].sort((a, b) => {
+        return sortStringDesc(a.common_name, b.common_name);
+      });
+    }
+  } else if (sortRule?.column === 'scientific_name') {
+    if (sortRule.sortOrder === 'asc') {
+      orderedGenomes = [...genomes].sort((a, b) => {
+        return sortStringAsc(a.scientific_name, b.scientific_name);
+      });
+    } else {
+      orderedGenomes = [...genomes].sort((a, b) => {
+        return sortStringDesc(a.scientific_name, b.scientific_name);
+      });
+    }
+  } else if (sortRule?.column === 'type') {
+    if (sortRule.sortOrder === 'asc') {
+      orderedGenomes = [...genomes].sort((a, b) => {
+        return sortStringAsc(
+          createGenomeTypeString(a),
+          createGenomeTypeString(b)
+        );
+      });
+    } else {
+      orderedGenomes = [...genomes].sort((a, b) => {
+        return sortStringDesc(
+          createGenomeTypeString(a),
+          createGenomeTypeString(b)
+        );
+      });
+    }
+  } else if (sortRule?.column === 'assembly_name') {
+    if (sortRule.sortOrder === 'asc') {
+      orderedGenomes = [...genomes].sort((a, b) => {
+        return sortStringAsc(a.assembly.name, b.assembly.name);
+      });
+    } else {
+      orderedGenomes = [...genomes].sort((a, b) => {
+        return sortStringDesc(a.assembly.name, b.assembly.name);
+      });
+    }
+  } else if (sortRule?.column === 'assembly_accession_id') {
+    if (sortRule.sortOrder === 'asc') {
+      orderedGenomes = [...genomes].sort((a, b) => {
+        return sortStringAsc(a.assembly.accession_id, b.assembly.accession_id);
+      });
+    } else {
+      orderedGenomes = [...genomes].sort((a, b) => {
+        return sortStringDesc(a.assembly.accession_id, b.assembly.accession_id);
+      });
+    }
+  } else if (sortRule?.column === 'coding_genes_count') {
+    if (sortRule.sortOrder === 'asc') {
+      orderedGenomes = [...genomes].sort((a, b) => {
+        return sortNumberAsc(a.coding_genes_count, b.coding_genes_count);
+      });
+    } else {
+      orderedGenomes = [...genomes].sort((a, b) => {
+        return sortNumberDesc(a.coding_genes_count, b.coding_genes_count);
+      });
+    }
+  } else if (sortRule?.column === 'contig_n50') {
+    if (sortRule.sortOrder === 'asc') {
+      orderedGenomes = [...genomes].sort((a, b) => {
+        return sortNumberAsc(a.contig_n50, b.contig_n50);
+      });
+    } else {
+      orderedGenomes = [...genomes].sort((a, b) => {
+        return sortNumberDesc(a.contig_n50, b.contig_n50);
+      });
+    }
+  }
+
+  return {
+    orderedGenomes,
+    sortRule,
+    changeSortRule
+  };
+};
+
+const createGenomeTypeString = ({ type, is_reference }: SelectableGenome) => {
+  const { kind = '', value = '' } = type || {};
+  const referenceString = is_reference ? 'reference' : '';
+  const combinedString = `${referenceString} ${kind} ${value}`;
+  return combinedString;
+};
+
+export const getSortOrderForColumn = (
+  column: SortableColumn,
+  sortRule: SortRule | null
+) => {
+  if (sortRule?.column === column) {
+    return sortRule.sortOrder;
+  } else {
+    return 'none';
+  }
+};
+
+const sortStringAsc = (a: string | null, b: string | null) => {
+  if (!a) {
+    return 1;
+  } else if (!b) {
+    return -1;
+  } else {
+    return a.localeCompare(b);
+  }
+};
+
+const sortStringDesc = (a: string | null, b: string | null) => {
+  if (!a) {
+    return -1;
+  } else if (!b) {
+    return 1;
+  } else {
+    return b.localeCompare(a);
+  }
+};
+
+const sortNumberAsc = (a: number | null, b: number | null) => {
+  if (a === null) {
+    return 1;
+  } else if (b === null) {
+    return -1;
+  } else {
+    return a - b;
+  }
+};
+
+const sortNumberDesc = (a: number | null, b: number | null) => {
+  if (a === null) {
+    return 1;
+  } else if (b === null) {
+    return -1;
+  } else {
+    return b - a;
+  }
+};
+
+export default useOrderedGenomes;

--- a/src/content/app/new-species-selector/components/selectable-genomes-table/useOrderedGenomes.ts
+++ b/src/content/app/new-species-selector/components/selectable-genomes-table/useOrderedGenomes.ts
@@ -15,6 +15,14 @@
  */
 
 import { useState, useCallback } from 'react';
+
+import {
+  sortStringAsc,
+  sortStringDesc,
+  sortNumberAsc,
+  sortNumberDesc
+} from 'src/shared/helpers/sortingHelpers';
+
 import type { SelectableGenome } from './useSelectableGenomesTable';
 
 type SortableColumn =
@@ -152,46 +160,6 @@ export const getSortOrderForColumn = (
     return sortRule.sortOrder;
   } else {
     return 'none';
-  }
-};
-
-const sortStringAsc = (a: string | null, b: string | null) => {
-  if (!a) {
-    return 1;
-  } else if (!b) {
-    return -1;
-  } else {
-    return a.localeCompare(b);
-  }
-};
-
-const sortStringDesc = (a: string | null, b: string | null) => {
-  if (!a) {
-    return -1;
-  } else if (!b) {
-    return 1;
-  } else {
-    return b.localeCompare(a);
-  }
-};
-
-const sortNumberAsc = (a: number | null, b: number | null) => {
-  if (a === null) {
-    return 1;
-  } else if (b === null) {
-    return -1;
-  } else {
-    return a - b;
-  }
-};
-
-const sortNumberDesc = (a: number | null, b: number | null) => {
-  if (a === null) {
-    return 1;
-  } else if (b === null) {
-    return -1;
-  } else {
-    return b - a;
   }
 };
 

--- a/src/content/app/new-species-selector/components/selectable-genomes-table/useOrderedGenomes.ts
+++ b/src/content/app/new-species-selector/components/selectable-genomes-table/useOrderedGenomes.ts
@@ -24,6 +24,7 @@ import {
 } from 'src/shared/helpers/sortingHelpers';
 
 import type { SelectableGenome } from './useSelectableGenomesTable';
+import type { SortOrder, SortOrderWithNone } from 'src/shared/types/sort-order';
 
 type SortableColumn =
   | 'common_name'
@@ -34,16 +35,14 @@ type SortableColumn =
   | 'coding_genes_count'
   | 'contig_n50';
 
-type SortOrder = 'asc' | 'desc';
-
 export type SortRule = {
   column: SortableColumn;
-  sortOrder: 'asc' | 'desc';
+  sortOrder: SortOrder;
 };
 
 export type ChangeSortRule = (
   column: SortableColumn,
-  sortOrder: SortOrder | 'none'
+  sortOrder: SortOrderWithNone
 ) => void;
 
 const useOrderedGenomes = (genomes: SelectableGenome[]) => {

--- a/src/content/app/new-species-selector/components/selectable-genomes-table/useSelectableGenomesTable.ts
+++ b/src/content/app/new-species-selector/components/selectable-genomes-table/useSelectableGenomesTable.ts
@@ -20,6 +20,8 @@ import { useAppSelector } from 'src/store';
 
 import { getCommittedSpecies } from 'src/content/app/species-selector/state/speciesSelectorSelectors';
 
+import useOrderedGenomes from './useOrderedGenomes';
+
 import filterGenomes from './filterGenomes';
 
 import type { SpeciesSearchMatch } from 'src/content/app/new-species-selector/types/speciesSearchMatch';
@@ -42,6 +44,8 @@ const useSelectableGenomesTable = (params: Params) => {
     ? filterGenomes({ query: filterQuery, genomes })
     : genomes;
   const selectableGenomes = useMarkedGenomes(filteredGenomes, stagedGenomes);
+  const { orderedGenomes, sortRule, changeSortRule } =
+    useOrderedGenomes(selectableGenomes);
 
   const onGenomePreselectToggle = (
     genome: SpeciesSearchMatch,
@@ -62,12 +66,14 @@ const useSelectableGenomesTable = (params: Params) => {
   };
 
   return {
-    genomes: selectableGenomes,
+    genomes: orderedGenomes,
     stagedGenomes,
     onGenomePreselectToggle,
     isTableExpanded,
     onTableExpandToggle,
-    setStagedGenomes
+    setStagedGenomes,
+    sortRule,
+    changeSortRule
   };
 };
 

--- a/src/content/app/new-species-selector/components/species-search-results-table/SpeciesSearchResultsTable.scss
+++ b/src/content/app/new-species-selector/components/species-search-results-table/SpeciesSearchResultsTable.scss
@@ -1,7 +1,7 @@
 @import 'src/styles/common';
 
 .table {
-  --table-background: $light-grey;
+  --table-background: #{$light-grey};
 }
 
 .assemblyName {

--- a/src/content/app/new-species-selector/components/species-search-results-table/SpeciesSearchResultsTable.tsx
+++ b/src/content/app/new-species-selector/components/species-search-results-table/SpeciesSearchResultsTable.tsx
@@ -19,8 +19,9 @@ import classNames from 'classnames';
 import upperFirst from 'lodash/upperFirst';
 
 import { formatNumber } from 'src/shared/helpers/formatters/numberFormatter';
+import { getSortOrderForColumn } from 'src/content/app/new-species-selector/components/selectable-genomes-table/useOrderedGenomes';
 
-import { Table } from 'src/shared/components/table';
+import { Table, ColumnHead } from 'src/shared/components/table';
 import Checkbox from 'src/shared/components/checkbox/Checkbox';
 import SolidDot from 'src/shared/components/table/dot/SolidDot';
 import EmptyDot from 'src/shared/components/table/dot/EmptyDot';
@@ -29,21 +30,33 @@ import DisabledExternalLink from 'src/shared/components/external-link/DisabledEx
 
 import type { SpeciesSearchMatch } from 'src/content/app/new-species-selector/types/speciesSearchMatch';
 import type { SelectableGenome } from 'src/content/app/new-species-selector/components/selectable-genomes-table/useSelectableGenomesTable';
+import type {
+  SortRule,
+  ChangeSortRule
+} from 'src/content/app/new-species-selector/components/selectable-genomes-table/useOrderedGenomes';
 
 import styles from './SpeciesSearchResultsTable.scss';
 
 type Props = {
   isExpanded: boolean;
   results: SelectableGenome[];
+  sortRule: SortRule | null;
   onTableExpandToggle: () => void;
   onSpeciesSelectToggle: (
     species: SpeciesSearchMatch,
     isAdding?: boolean
   ) => void;
+  onSortRuleChange: ChangeSortRule;
 };
 
 const SpeciesSearchResultsTable = (props: Props) => {
-  const { isExpanded, results, onSpeciesSelectToggle } = props;
+  const {
+    isExpanded,
+    results,
+    onSpeciesSelectToggle,
+    sortRule,
+    onSortRuleChange
+  } = props;
 
   const onSpeciesPreselect = (species: SelectableGenome) => {
     const isAdding = !species.isStaged;
@@ -51,28 +64,78 @@ const SpeciesSearchResultsTable = (props: Props) => {
   };
 
   return (
-    <Table className={styles.table}>
+    <Table stickyHeader={true} className={styles.table}>
       <thead>
         <tr>
-          <th>Select to add</th>
-          <th>Common name</th>
-          <th>Scientific name</th>
-          <th>Type</th>
-          <th>Assembly</th>
-          <th>Assembly accession</th>
+          <ColumnHead>Select to add</ColumnHead>
+          <ColumnHead
+            sortOrder={getSortOrderForColumn('common_name', sortRule)}
+            onSortOrderChange={(newOrder) =>
+              onSortRuleChange('common_name', newOrder)
+            }
+          >
+            Common name
+          </ColumnHead>
+          <ColumnHead
+            sortOrder={getSortOrderForColumn('scientific_name', sortRule)}
+            onSortOrderChange={(newOrder) =>
+              onSortRuleChange('scientific_name', newOrder)
+            }
+          >
+            Scientific name
+          </ColumnHead>
+          <ColumnHead
+            sortOrder={getSortOrderForColumn('type', sortRule)}
+            onSortOrderChange={(newOrder) => onSortRuleChange('type', newOrder)}
+          >
+            Type
+          </ColumnHead>
+          <ColumnHead
+            sortOrder={getSortOrderForColumn('assembly_name', sortRule)}
+            onSortOrderChange={(newOrder) =>
+              onSortRuleChange('assembly_name', newOrder)
+            }
+          >
+            Assembly
+          </ColumnHead>
+          <ColumnHead
+            sortOrder={getSortOrderForColumn('assembly_accession_id', sortRule)}
+            onSortOrderChange={(newOrder) =>
+              onSortRuleChange('assembly_accession_id', newOrder)
+            }
+          >
+            Assembly accession
+          </ColumnHead>
 
-          <th>
+          <ColumnHead>
             <ShowMore {...props} />
-          </th>
+          </ColumnHead>
 
           {isExpanded && (
             <>
-              <th>Coding genes</th>
-              <th>N50</th>
-              <th>Variation</th>
-              <th>Regulation</th>
-              <th>Annotation provider</th>
-              <th>Annotation method</th>
+              <ColumnHead
+                sortOrder={getSortOrderForColumn(
+                  'coding_genes_count',
+                  sortRule
+                )}
+                onSortOrderChange={(newOrder) =>
+                  onSortRuleChange('coding_genes_count', newOrder)
+                }
+              >
+                Coding genes
+              </ColumnHead>
+              <ColumnHead
+                sortOrder={getSortOrderForColumn('contig_n50', sortRule)}
+                onSortOrderChange={(newOrder) =>
+                  onSortRuleChange('contig_n50', newOrder)
+                }
+              >
+                N50
+              </ColumnHead>
+              <ColumnHead>Variation</ColumnHead>
+              <ColumnHead>Regulation</ColumnHead>
+              <ColumnHead>Annotation provider</ColumnHead>
+              <ColumnHead>Annotation method</ColumnHead>
             </>
           )}
         </tr>

--- a/src/shared/components/external-link/ExternalLink.scss
+++ b/src/shared/components/external-link/ExternalLink.scss
@@ -3,21 +3,18 @@
 .externalLinkContainer {
   display: inline-grid;
   grid-template-columns:  [icon] auto [link] auto;
+  column-gap: 5px;
+  align-items: baseline;
 }
 
 .icon {
   display: inline-block;
   fill: $orange;
   grid-column: icon;
-  top: 1px;
-  position: relative;
   height: 12px;
   width: 12px;
 }
 
 .link {
   display: inline-block;
-  position: relative;
-  top: -2px;
-  margin-left: 5px;
 }

--- a/src/shared/components/table/ColumnHead.scss
+++ b/src/shared/components/table/ColumnHead.scss
@@ -34,8 +34,6 @@
   width: var(--_sort-arrow-width);
   transform: rotate(180deg);
   fill: $grey;
-  // display: inline-block;
-  // margin-right: var( --_sort-arrow-right-margin);
 }
 
 .sortArrowUp {

--- a/src/shared/components/table/ColumnHead.scss
+++ b/src/shared/components/table/ColumnHead.scss
@@ -1,0 +1,47 @@
+@import 'src/styles/common';
+
+.columnHead {
+  text-align: var(--table-column-head-text-align, left);
+  --_left-padding: var(--table-column-head-padding-left, 24px);
+  padding-left: var(--_left-padding);
+  padding-right: var(--table-column-head-padding-right, 32px);
+  padding-top: var(--table-column-head-padding-top, 6px);
+  padding-bottom: var(--table-column-head-padding-bottom, 6px);
+  font-weight: $light;
+}
+
+.columnHeadSortable {
+  --_sort-arrow-width: 8px;
+  --_sort-arrow-right-margin: 12px;
+  padding-left: calc(var(--_left-padding) - var(--_sort-arrow-width) - var(--_sort-arrow-right-margin));
+}
+
+.columnHeadSortable button {
+  display: inline-grid;
+  grid-template-columns: repeat(2, auto);
+  align-items: baseline;
+  justify-content: start;
+  column-gap: var( --_sort-arrow-right-margin);
+  font-weight: $light;
+  text-align: left;
+}
+
+.columnHeadSortingApplied {
+  font-weight: $bold;
+}
+
+.sortArrow {
+  width: var(--_sort-arrow-width);
+  transform: rotate(180deg);
+  fill: $grey;
+  // display: inline-block;
+  // margin-right: var( --_sort-arrow-right-margin);
+}
+
+.sortArrowUp {
+  transform: unset;
+}
+
+.sortArrowActive {
+  fill: $blue;
+}

--- a/src/shared/components/table/ColumnHead.tsx
+++ b/src/shared/components/table/ColumnHead.tsx
@@ -19,9 +19,9 @@ import classNames from 'classnames';
 
 import SortIcon from 'static/icons/icon_arrow.svg';
 
-import styles from './ColumnHead.scss';
+import type { SortOrderWithNone } from 'src/shared/types/sort-order';
 
-type SortOrder = 'none' | 'asc' | 'desc';
+import styles from './ColumnHead.scss';
 
 type RegularColumnHeadProps = DetailedHTMLProps<
   ThHTMLAttributes<HTMLTableCellElement>,
@@ -29,8 +29,8 @@ type RegularColumnHeadProps = DetailedHTMLProps<
 >;
 
 type SortableColumnHeadProps = RegularColumnHeadProps & {
-  sortOrder: SortOrder;
-  onSortOrderChange: (order: SortOrder) => void;
+  sortOrder: SortOrderWithNone;
+  onSortOrderChange: (order: SortOrderWithNone) => void;
 };
 
 type Props = RegularColumnHeadProps | SortableColumnHeadProps;
@@ -44,7 +44,7 @@ const ColumnHead = (props: Props) => {
   const isSortingApplied = props.sortOrder !== 'none';
 
   const changeSortingOrder = () => {
-    const nextOrder: SortOrder =
+    const nextOrder: SortOrderWithNone =
       sortOrder === 'none' ? 'desc' : sortOrder === 'desc' ? 'asc' : 'none';
 
     onSortOrderChange(nextOrder);

--- a/src/shared/components/table/ColumnHead.tsx
+++ b/src/shared/components/table/ColumnHead.tsx
@@ -1,0 +1,76 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { DetailedHTMLProps, ThHTMLAttributes } from 'react';
+import classNames from 'classnames';
+
+import SortIcon from 'static/icons/icon_arrow.svg';
+
+import styles from './ColumnHead.scss';
+
+type SortOrder = 'none' | 'asc' | 'desc';
+
+type RegularColumnHeadProps = DetailedHTMLProps<
+  ThHTMLAttributes<HTMLTableCellElement>,
+  HTMLTableCellElement
+>;
+
+type SortableColumnHeadProps = RegularColumnHeadProps & {
+  sortOrder: SortOrder;
+  onSortOrderChange: (order: SortOrder) => void;
+};
+
+type Props = RegularColumnHeadProps | SortableColumnHeadProps;
+
+const ColumnHead = (props: Props) => {
+  if (!('sortOrder' in props)) {
+    return <th {...props} className={styles.columnHead} />;
+  }
+
+  const { sortOrder, onSortOrderChange, children } = props;
+  const isSortingApplied = props.sortOrder !== 'none';
+
+  const changeSortingOrder = () => {
+    const nextOrder: SortOrder =
+      sortOrder === 'none' ? 'desc' : sortOrder === 'desc' ? 'asc' : 'none';
+
+    onSortOrderChange(nextOrder);
+  };
+
+  const componentClasses = classNames(
+    styles.columnHead,
+    styles.columnHeadSortable,
+    {
+      [styles.columnHeadSortingApplied]: isSortingApplied
+    }
+  );
+
+  const sortIconClasses = classNames(styles.sortArrow, {
+    [styles.sortArrowUp]: sortOrder === 'asc',
+    [styles.sortArrowActive]: isSortingApplied
+  });
+
+  return (
+    <th className={componentClasses}>
+      <button onClick={changeSortingOrder}>
+        <SortIcon className={sortIconClasses} />
+        {children}
+      </button>
+    </th>
+  );
+};
+
+export default ColumnHead;

--- a/src/shared/components/table/Table.scss
+++ b/src/shared/components/table/Table.scss
@@ -19,7 +19,6 @@
   background-clip: padding-box;
 }
 
-// .table th,
 .table td {
   padding: var(--table-data-padding, 6px 32px 6px 24px);
 }

--- a/src/shared/components/table/Table.scss
+++ b/src/shared/components/table/Table.scss
@@ -19,9 +19,9 @@
   background-clip: padding-box;
 }
 
-.table th,
+// .table th,
 .table td {
-  padding: var(--table-data-padding, 6px 12px);
+  padding: var(--table-data-padding, 6px 32px 6px 24px);
 }
 
 .table td {

--- a/src/shared/components/table/index.ts
+++ b/src/shared/components/table/index.ts
@@ -16,3 +16,4 @@
 
 export { default as Table } from './Table';
 export { default as RowFooter } from './RowFooter';
+export { default as ColumnHead } from './ColumnHead';

--- a/src/shared/helpers/sortingHelpers.ts
+++ b/src/shared/helpers/sortingHelpers.ts
@@ -1,0 +1,65 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const sortStringAsc = (a: string | null, b: string | null) => {
+  if (a === b || (!a && !b)) {
+    return 0;
+  } else if (!a) {
+    return 1;
+  } else if (!b) {
+    return -1;
+  } else {
+    return a.toLowerCase().localeCompare(b.toLowerCase());
+  }
+};
+
+export const sortStringDesc = (a: string | null, b: string | null) => {
+  if (a === b || (!a && !b)) {
+    return 0;
+  } else if (!a) {
+    return -1;
+  } else if (!b) {
+    return 1;
+  } else {
+    return b.toLowerCase().localeCompare(a.toLowerCase());
+  }
+};
+
+// accepts elements that are either numbers or nulls
+export const sortNumberAsc = (a: number | null, b: number | null) => {
+  if (a === b) {
+    return 0;
+  } else if (a === null) {
+    return 1;
+  } else if (b === null) {
+    return -1;
+  } else {
+    return a - b;
+  }
+};
+
+// accepts elements that are either numbers or nulls
+export const sortNumberDesc = (a: number | null, b: number | null) => {
+  if (a === b) {
+    return 0;
+  } else if (a === null) {
+    return 1;
+  } else if (b === null) {
+    return -1;
+  } else {
+    return b - a;
+  }
+};

--- a/src/shared/types/sort-order.ts
+++ b/src/shared/types/sort-order.ts
@@ -1,0 +1,19 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type SortOrder = 'asc' | 'desc';
+
+export type SortOrderWithNone = SortOrder | 'none';


### PR DESCRIPTION
## Description
- Add the `ColumnHead` component to use with the `Table` component. The `ColumnHead` component can show the sort arrows if it allows sorting.
-  Added the sorting logic for genomes results table
- Enabled sticky header for the genomes table
- Updated CSS of ExternalLink component to fix its positioning along z-axis when overlaid by the sticky header 

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2205

## Deployment URL(s)
http://species-table-sorting.review.ensembl.org/new-species-selector