### PR TITLE
Bring back outlines for focusable elements

### DIFF
--- a/src/shared/components/communication-framework/ConversationIcon.scss
+++ b/src/shared/components/communication-framework/ConversationIcon.scss
@@ -4,10 +4,9 @@
   width: 40px;
 }
 
-.conversationIconWrapper {
+.communicationPanelToggle {
   display: flex;
   gap: 16px;
   align-items: center;
-  cursor: pointer;
   color: $blue;
 }

--- a/src/shared/components/communication-framework/ConversationIcon.tsx
+++ b/src/shared/components/communication-framework/ConversationIcon.tsx
@@ -31,7 +31,7 @@ type Props = {
 
 const ConversationIcon = (props: Props) => {
   const dispatch = useDispatch();
-  const elementRef = useRef<HTMLDivElement | null>(null);
+  const elementRef = useRef<HTMLButtonElement | null>(null);
 
   const onClick = () => {
     dispatch(toggleCommunicationPanel());
@@ -54,14 +54,14 @@ const ConversationIcon = (props: Props) => {
   return (
     <>
       <CommunicationPanel />
-      <div
-        className={styles.conversationIconWrapper}
+      <button
+        className={styles.communicationPanelToggle}
         onClick={onClick}
         ref={elementRef}
       >
         {props.withLabel && 'Contact us'}
         <ConversationImageIcon className={styles.conversationIcon} />
-      </div>
+      </button>
     </>
   );
 };

--- a/src/shared/components/help-popup/HelpPopupButton.scss
+++ b/src/shared/components/help-popup/HelpPopupButton.scss
@@ -3,7 +3,6 @@
 .wrapper {
   display: inline-flex;
   align-items: center;
-  cursor: pointer;
 }
 
 .label {

--- a/src/shared/components/help-popup/HelpPopupButton.tsx
+++ b/src/shared/components/help-popup/HelpPopupButton.tsx
@@ -33,7 +33,7 @@ type Props = {
 const HelpPopupButton = (props: Props) => {
   const { label: labelText = 'Help', slug } = props;
   const [shouldShowModal, setShouldShowModal] = useState(false);
-  const elementRef = useRef<HTMLDivElement | null>(null);
+  const elementRef = useRef<HTMLButtonElement | null>(null);
 
   const openModal = () => {
     setShouldShowModal(true);
@@ -61,12 +61,12 @@ const HelpPopupButton = (props: Props) => {
 
   return (
     <>
-      <div className={styles.wrapper} onClick={openModal} ref={elementRef}>
+      <button className={styles.wrapper} onClick={openModal} ref={elementRef}>
         <span className={labelClasses}>{labelText}</span>
         <div className={styles.button}>
           <HelpIcon className={styles.icon} />
         </div>
-      </div>
+      </button>
       {shouldShowModal && (
         <Modal classNames={{ body: styles.helpPopup }} onClose={closeModal}>
           <HelpPopupBody slug={slug} />

--- a/src/styles/_normalize.scss
+++ b/src/styles/_normalize.scss
@@ -16,10 +16,6 @@ html {
   -webkit-tap-highlight-color: transparent; // disable blue highlight colour that can otherwise be seen upon tapping an element with cursor: pointer in mobile browser
 }
 
-*:focus {
-  outline: none;
-}
-
 body {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
## Description
- Undo the CSS rule that was hiding of the outline of focused links and buttons. It should thus be possible to use the Tab key to navigate between focusable elements, and see the outline of the focused element. This is the first step towards better keyboard accessibility.
- Changed a couple of buttons (`ConversationIcon` and `HelpPopupButton`) that were written as `div`s to a more appropriate html `button` element. This makes them focusable by default.


https://github.com/Ensembl/ensembl-client/assets/6834224/a01f38ff-2cb8-4978-bd23-a436ad24c81e



## Related JIRA Issue(s)
None

## Deployment URL(s)
http://bring-back-outlines.review.ensembl.org