### PR TITLE
Use new location validation endpoint from metadata api (replacement of region validation)

### DIFF
--- a/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/navigate-modal/LocationNavigation.tsx
+++ b/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/navigate-modal/LocationNavigation.tsx
@@ -104,12 +104,12 @@ const LocationNavigation = () => {
 
     try {
       const validatedLocation = await validateGenomicLocation({
-        regionInput: newLocation,
+        location: newLocation,
         genomeId: activeGenomeId
       });
       onValidationSuccess(validatedLocation);
     } catch (error) {
-      if (error && typeof error === 'object' && 'region_id' in error) {
+      if (error && typeof error === 'object' && 'location' in error) {
         onValidationError();
       }
     }
@@ -170,12 +170,12 @@ const LocationNavigation = () => {
     validatedLocation: LocationValidationResponse
   ) => {
     resetForm();
-    const { region_id } = validatedLocation;
+    const { location } = validatedLocation;
 
     navigate(
       urlFor.browser({
         genomeId: genomeIdForUrl,
-        focus: `location:${region_id}`
+        focus: `location:${location}`
       }),
       {
         replace: true

--- a/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/navigate-modal/RegionNavigation.tsx
+++ b/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/navigate-modal/RegionNavigation.tsx
@@ -96,7 +96,7 @@ const RegionNavigation = () => {
 
     try {
       const validatedLocation = await validateGenomicLocation({
-        regionInput: getLocationForSubmission(),
+        location: getLocationForSubmission(),
         genomeId: activeGenomeId
       });
       if (regionName !== validatedLocation.region?.region_name) {
@@ -106,7 +106,7 @@ const RegionNavigation = () => {
         onValidationSuccess(validatedLocation);
       }
     } catch (error) {
-      if (error && typeof error === 'object' && 'region_id' in error) {
+      if (error && typeof error === 'object' && 'location' in error) {
         onValidationError();
       }
     }

--- a/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/navigate-modal/tests/LocationNavigation.test.tsx
+++ b/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/navigate-modal/tests/LocationNavigation.test.tsx
@@ -47,7 +47,7 @@ const generateKaryotype = () =>
 const mockKaryotype = generateKaryotype();
 
 jest.mock('config', () => ({
-  genomeSearchBaseUrl: 'http://location-validation-api' // need to provide absolute urls to the fetch running in Node
+  metadataApiBaseUrl: 'http://location-validation-api' // need to provide absolute urls to the fetch running in Node
 }));
 jest.mock('src/shared/state/genome/genomeApiSlice', () => {
   const originalModule = jest.requireActual(
@@ -265,7 +265,7 @@ describe('<LocationNavigation />', () => {
     it('displays the wrong location error', async () => {
       server.use(
         rest.get(
-          'http://location-validation-api/genome/region/validate',
+          'http://location-validation-api/validate_location',
           (_, res, ctx) => {
             return res.once(ctx.json(invalidLocationResponse));
           }

--- a/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/navigate-modal/tests/RegionNavigation.test.tsx
+++ b/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/navigate-modal/tests/RegionNavigation.test.tsx
@@ -43,7 +43,7 @@ const mockKaryotype = generateKaryotype();
 const mockChangeBrowserLocation = jest.fn();
 
 jest.mock('config', () => ({
-  genomeSearchBaseUrl: 'http://location-validation-api' // need to provide absolute urls to the fetch running in Node
+  metadataApiBaseUrl: 'http://location-validation-api' // need to provide absolute urls to the fetch running in Node
 }));
 jest.mock('src/shared/state/genome/genomeApiSlice', () => {
   const originalModule = jest.requireActual(
@@ -269,7 +269,7 @@ describe('<RegionNavigation />', () => {
     it('displays the wrong location error', async () => {
       server.use(
         rest.get(
-          'http://location-validation-api/genome/region/validate',
+          'http://location-validation-api/validate_location',
           (_, res, ctx) => {
             return res.once(ctx.json(invalidLocationResponse));
           }
@@ -382,7 +382,7 @@ describe('<RegionNavigation />', () => {
     it('displays the wrong location error', async () => {
       server.use(
         rest.get(
-          'http://location-validation-api/genome/region/validate',
+          'http://location-validation-api/validate_location',
           (_, res, ctx) => {
             return res.once(ctx.json(invalidLocationResponse));
           }

--- a/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/navigate-modal/tests/mockValidationServer.ts
+++ b/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/navigate-modal/tests/mockValidationServer.ts
@@ -17,6 +17,8 @@
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 
+import type { LocationValidationResponse } from 'src/content/app/genome-browser/helpers/browserHelper';
+
 const validRegionName = '2';
 const invalidRegionName = '30';
 const startCoordinate = 100;
@@ -28,39 +30,32 @@ export const invalidLocationInput = `${invalidRegionName}:${startCoordinate}-${e
 export const getMockServer = () =>
   setupServer(
     rest.get(
-      'http://location-validation-api/genome/region/validate',
+      'http://location-validation-api/validate_location',
       (req, res, ctx) => {
-        const region = req.url.searchParams.get('region');
-        if (region === validLocationInput) {
+        const location = req.url.searchParams.get('location');
+        if (location === validLocationInput) {
           return res(ctx.json(validLocationResponse));
-        } else if (region === invalidLocationInput) {
+        } else if (location === invalidLocationInput) {
           return res(ctx.json(invalidLocationResponse));
         }
       }
     )
   );
 
-const validLocationResponse = {
+const validLocationResponse: LocationValidationResponse = {
   end: {
     error_code: null,
     error_message: null,
     is_valid: true,
     value: endCoordinate
   },
-  genome_id: {
-    error_code: null,
-    error_message: null,
-    is_valid: true,
-    value: 'a7335667-93e7-11ec-a39d-005056b38ce3'
-  },
   region: {
     error_code: null,
     error_message: null,
     is_valid: true,
-    region_code: 'chromosome',
     region_name: validRegionName
   },
-  region_id: `${validRegionName}:${startCoordinate}-${endCoordinate}`,
+  location: `${validRegionName}:${startCoordinate}-${endCoordinate}`,
   start: {
     error_code: null,
     error_message: null,
@@ -69,27 +64,20 @@ const validLocationResponse = {
   }
 };
 
-export const invalidLocationResponse = {
+export const invalidLocationResponse: LocationValidationResponse = {
   end: {
     error_code: null,
     error_message: null,
     is_valid: false,
     value: endCoordinate
   },
-  genome_id: {
-    error_code: null,
-    error_message: null,
-    is_valid: true,
-    value: 'a7335667-93e7-11ec-a39d-005056b38ce3'
-  },
   region: {
     error_code: null,
     error_message: 'Could not find region 30',
     is_valid: false,
-    region_code: null,
     region_name: '30'
   },
-  region_id: null,
+  location: null,
   start: {
     error_code: null,
     error_message: null,

--- a/src/content/app/genome-browser/helpers/browserHelper.ts
+++ b/src/content/app/genome-browser/helpers/browserHelper.ts
@@ -91,24 +91,22 @@ export type ValueValidationResult = LocationValidationCommonFields & {
 };
 
 export type RegionValidationResult = LocationValidationCommonFields & {
-  region_code: string;
   region_name: string;
 };
 
 export type LocationValidationResponse = Partial<{
   end: ValueValidationResult;
-  genome_id: ValueValidationResult;
-  region_id: string | null;
+  location: string | null; // location being null means that it failed validation
   region: RegionValidationResult;
   start: ValueValidationResult;
 }>;
 
 export const validateGenomicLocation = async (params: {
-  regionInput: string;
+  location: string;
   genomeId: string;
 }) => {
-  const { regionInput, genomeId } = params;
-  const url = `${config.genomeSearchBaseUrl}/genome/region/validate?genome_id=${genomeId}&region=${regionInput}`;
+  const { location, genomeId } = params;
+  const url = `${config.metadataApiBaseUrl}/validate_location?genome_id=${genomeId}&location=${location}`;
 
   let response: LocationValidationResponse;
 
@@ -128,7 +126,7 @@ export const validateGenomicLocation = async (params: {
     }
   }
 
-  if (response.region_id === null) {
+  if (response.location === null) {
     // the backend service thinks that the submitted location is invalid
     throw response;
   }

--- a/tests/fixtures/browser.ts
+++ b/tests/fixtures/browser.ts
@@ -135,20 +135,13 @@ export const createRegionValidationInfo = (): LocationValidationResponse => {
       is_valid: true,
       value: randomValue
     },
-    genome_id: {
-      error_code: null,
-      error_message: null,
-      is_valid: true,
-      value: faker.lorem.words()
-    },
     region: {
       error_code: null,
       error_message: null,
       is_valid: true,
-      region_code: faker.lorem.words(),
       region_name: faker.lorem.words()
     },
-    region_id: faker.lorem.words(),
+    location: faker.lorem.words(),
     start: {
       error_code: null,
       error_message: null,


### PR DESCRIPTION
## Description
To validate genome browser location, migrate from the `validate_region` endpoint of the old genome search api to the `validate_location` endpoint of metadata api (see https://github.com/Ensembl/ensembl-web-metadata-api/pull/22).

The schema of the response has been updated to use our new naming conventions (location instead of region).

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2216

## Deployment URL(s)
http://use-new-endpoints.review.ensembl.org
_(it's working there; but all backends were very very slow when I checked; may be worth checking locally)_