### PR TITLE
Fix page metadata for Entity Viewer and Help page

### DIFF
--- a/src/content/app/entity-viewer/EntityViewer.tsx
+++ b/src/content/app/entity-viewer/EntityViewer.tsx
@@ -39,7 +39,6 @@ import {
   initializeSidebar
 } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSlice';
 
-import EntityViewerIdsContextProvider from 'src/content/app/entity-viewer/contexts/entity-viewer-ids-context/EntityViewerIdsContextProvider';
 import { StandardAppLayout } from 'src/shared/components/layout';
 import EntityViewerAppBar from './shared/components/entity-viewer-app-bar/EntityViewerAppBar';
 import EntityViewerSidebarToolstrip from './shared/components/entity-viewer-sidebar/entity-viewer-sidebar-toolstrip/EntityViewerSidebarToolstrip';
@@ -222,12 +221,4 @@ const useEntityViewerRouting = () => {
   ]);
 };
 
-const WrappedEntityViewer = () => {
-  return (
-    <EntityViewerIdsContextProvider>
-      <EntityViewer />
-    </EntityViewerIdsContextProvider>
-  );
-};
-
-export default WrappedEntityViewer;
+export default EntityViewer;

--- a/src/content/app/entity-viewer/EntityViewerPage.tsx
+++ b/src/content/app/entity-viewer/EntityViewerPage.tsx
@@ -34,6 +34,8 @@ import {
   fetchGenePageMeta
 } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
 
+import EntityViewerIdsContextProvider from 'src/content/app/entity-viewer/contexts/entity-viewer-ids-context/EntityViewerIdsContextProvider';
+
 import type { ServerFetch } from 'src/routes/routesConfig';
 import type { AppDispatch } from 'src/store';
 
@@ -142,4 +144,12 @@ export const serverFetch: ServerFetch = async (params) => {
   }
 };
 
-export default EntityViewerPage;
+const WrappedEntityViewerPage = () => {
+  return (
+    <EntityViewerIdsContextProvider>
+      <EntityViewerPage />
+    </EntityViewerIdsContextProvider>
+  );
+};
+
+export default WrappedEntityViewerPage;

--- a/src/content/app/entity-viewer/EntityViewerPage.tsx
+++ b/src/content/app/entity-viewer/EntityViewerPage.tsx
@@ -67,10 +67,10 @@ const EntityViewerPage = () => {
     }
 
     const preparedPageMeta = entityId
-      ? buildPageMetaData({
+      ? buildPageMeta({
           title: pageMeta?.title ?? defaultPageTitle
         })
-      : buildPageMetaData();
+      : buildPageMeta();
 
     dispatch(updatePageMeta(preparedPageMeta));
   }, [isLoading]);
@@ -87,7 +87,7 @@ export const serverFetch: ServerFetch = async (params) => {
 
   // If the url is just /entity-viewer, update page meta and exit
   if (!genomeIdFromUrl) {
-    dispatch(updatePageMeta(buildPageMetaData()));
+    dispatch(updatePageMeta(buildPageMeta()));
     return;
   }
 
@@ -107,7 +107,7 @@ export const serverFetch: ServerFetch = async (params) => {
 
   // If the url is just /entity-viewer/:genomeId, update page meta and exit
   if (!entityId) {
-    dispatch(updatePageMeta(buildPageMetaData()));
+    dispatch(updatePageMeta(buildPageMeta()));
     return;
   }
 
@@ -140,7 +140,7 @@ export const serverFetch: ServerFetch = async (params) => {
     const title = pageMetaQueryResult.data?.title ?? '';
     dispatch(
       updatePageMeta(
-        buildPageMetaData({
+        buildPageMeta({
           title
         })
       )
@@ -148,7 +148,7 @@ export const serverFetch: ServerFetch = async (params) => {
   }
 };
 
-const buildPageMetaData = (
+const buildPageMeta = (
   params: {
     title?: string;
     description?: string;

--- a/src/content/app/help/Help.tsx
+++ b/src/content/app/help/Help.tsx
@@ -63,7 +63,11 @@ const Help = () => {
 
   const { currentData: menu } = useGetHelpMenuQuery({ name: 'help' });
 
-  const { currentData: article, error: articleError } = useGetHelpArticleQuery(
+  const {
+    currentData: article,
+    isLoading,
+    error: articleError
+  } = useGetHelpArticleQuery(
     { pathname },
     {
       skip: isIndexPage
@@ -75,12 +79,12 @@ const Help = () => {
   let breadcrumbs: string[] = [];
 
   useEffect(() => {
-    if (!article) {
+    if (isLoading) {
       return;
     }
 
     dispatch(updatePageMeta(createHelpPageMeta({ path: pathname, article })));
-  }, [pathname, article]);
+  }, [isLoading, pathname, article]);
 
   if (menu) {
     breadcrumbs = buildBreadcrumbs(menu, { url: pathname });


### PR DESCRIPTION
## Description
**Bug:** Switching on the client side to Entity Viewer was not updating the title of the browser tab; although you could see the correct text if you refreshed the page.

https://github.com/Ensembl/ensembl-client/assets/6834224/802ae04f-00b1-4a99-b45f-6d447f60fd57

**Cause:** The code that was responsible for updating page metadata was not wrapped in the right context provider. (Although it's weird that it didn't cause a runtime error, as I would expect from [these lines](https://github.com/Ensembl/ensembl-client/blob/dev/src/content/app/entity-viewer/hooks/useEntityViewerIds.ts#L24-L28).)

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2254

## Deployment URL(s)
http://fix-ev-page-meta.review.ensembl.org


## Views affected
- Entity Viewer pages (if you switch to Entity Viewer from any other app)
- Index page of the Help & Docs app