### PR TITLE
Switch to the new example features endpoint

### DIFF
--- a/src/content/app/genome-browser/state/focus-object/focusObjectSelectors.ts
+++ b/src/content/app/genome-browser/state/focus-object/focusObjectSelectors.ts
@@ -20,9 +20,6 @@ import get from 'lodash/get';
 import { buildFocusObjectId } from 'src/shared/helpers/focusObjectHelpers';
 import isGeneFocusObject from './isGeneFocusObject';
 
-import { getGenomeExampleFocusObjects } from 'src/shared/state/genome/genomeSelectors';
-import { getBrowserActiveGenomeId } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
-
 import { LoadingState } from 'src/shared/types/loading-state';
 import type {
   FocusObject,
@@ -54,36 +51,6 @@ export const getFocusObjectByParams = (
 ): FocusObject | null => {
   const focusObjectId = buildFocusObjectId(params);
   return getFocusObjectById(state, focusObjectId);
-};
-
-export const getExampleFocusObjects = (state: RootState): FocusObject[] => {
-  const activeGenomeId = getBrowserActiveGenomeId(state);
-  if (!activeGenomeId) {
-    return [];
-  }
-  const exampleObjects = getGenomeExampleFocusObjects(state, activeGenomeId);
-  return exampleObjects
-    .map(({ id, type }) => {
-      const focusObjectId = buildFocusObjectId({
-        genomeId: activeGenomeId,
-        type,
-        objectId: id
-      });
-      return state.browser.focusObjects[focusObjectId]?.data;
-    })
-    .filter(Boolean) as FocusObject[]; // make sure there are no undefineds in the returned array;
-};
-
-export const getExampleGenes = (state: RootState): FocusObject[] => {
-  return getExampleFocusObjects(state).filter(
-    (entity) => entity.type === 'gene'
-  );
-};
-
-export const getExampleLocations = (state: RootState): FocusObject[] => {
-  return getExampleFocusObjects(state).filter(
-    (entity) => entity.type === 'location'
-  );
 };
 
 export const getFocusGene = (

--- a/src/shared/state/genome/genomeApiSlice.ts
+++ b/src/shared/state/genome/genomeApiSlice.ts
@@ -20,7 +20,11 @@ import type { SerializedError } from '@reduxjs/toolkit';
 import config from 'config';
 import restApiSlice from 'src/shared/state/api-slices/restSlice';
 
-import type { GenomeInfo, GenomeKaryotypeItem } from './genomeTypes';
+import type {
+  GenomeInfo,
+  GenomeKaryotypeItem,
+  ExampleFocusObject
+} from './genomeTypes';
 
 type GenomeInfoResponse = {
   genomeId: string;
@@ -62,13 +66,25 @@ const genomeApiSlice = restApiSlice.injectEndpoints({
       query: (genomeId) => ({
         url: `${config.metadataApiBaseUrl}/genome/${genomeId}/karyotype`
       })
+    }),
+    exampleObjectsForGenome: builder.query<ExampleFocusObject[], string>({
+      query: (genomeId) => ({
+        url: `${config.metadataApiBaseUrl}/genome/${genomeId}/example_objects`
+      })
     })
   })
 });
 
-export const { useGenomeInfoQuery, useGenomeKaryotypeQuery } = genomeApiSlice;
+export const {
+  useGenomeInfoQuery,
+  useGenomeKaryotypeQuery,
+  useExampleObjectsForGenomeQuery
+} = genomeApiSlice;
 
-export const { genomeInfo: fetchGenomeInfo } = genomeApiSlice.endpoints;
+export const {
+  genomeInfo: fetchGenomeInfo,
+  exampleObjectsForGenome: fetchExampleObjectsForGenome
+} = genomeApiSlice.endpoints;
 
 export const isGenomeNotFoundError = (
   error?: SerializedError | FetchBaseQueryError

--- a/src/shared/state/genome/genomeSelectors.ts
+++ b/src/shared/state/genome/genomeSelectors.ts
@@ -53,14 +53,3 @@ export const getGenomeIdForUrl = (
   const genome = getGenomeById(state, genomeId);
   return genome?.genome_tag ?? genome?.genome_id;
 };
-
-export const getGenomeExampleFocusObjects = (
-  state: RootState,
-  genomeId: string | null
-) => {
-  const emptyObjects: never[] = [];
-  if (!genomeId) {
-    return emptyObjects;
-  }
-  return state.genome.genomes[genomeId]?.example_objects || emptyObjects;
-};


### PR DESCRIPTION
## Description
Switch the client to the new endpoint for fetching example objects.

Supports https://github.com/Ensembl/ensembl-web-metadata-api/pull/25

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2223

## Deployment URL(s)
http://example-features-endpoint.review.ensembl.org — although at the time of creating this PR, the examples endpoint is not available on review deployments.

## Views affected
- Species page
- Genome browser interstitial
- Entity viewer interstitial