### PR TITLE
Update `types` field in track category payload to `type` field

### DIFF
--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
@@ -78,8 +78,7 @@ export const TrackPanelList = () => {
   };
 
   const currentTrackCategories = genomeTrackCategories?.filter(
-    (category: GenomeTrackCategory) =>
-      category.types.includes(selectedTrackPanelTab)
+    (category: GenomeTrackCategory) => category.type === selectedTrackPanelTab
   );
 
   const trackCategoryIds =

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-tabs/TrackPanelTabs.test.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-tabs/TrackPanelTabs.test.tsx
@@ -50,7 +50,7 @@ const mockTrackCategories = {
     {
       label: 'Genes & transcripts',
       track_category_id: 'genes-transcripts',
-      types: ['Genomic'],
+      type: 'Genomic',
       track_list: [
         {
           track_id: 'gene-pc-fwd',

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-tabs/TrackPanelTabs.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-tabs/TrackPanelTabs.tsx
@@ -60,7 +60,7 @@ export const TrackPanelTabs = () => {
   const hasTracksInCategory = (trackSet: TrackSet) => {
     return genomeTrackCategories?.reduce((hasTracks, category) => {
       return (
-        (category.types.includes(trackSet) && category.track_list.length > 0) ||
+        (category.type === trackSet && category.track_list.length > 0) ||
         hasTracks
       );
     }, false);

--- a/src/content/app/genome-browser/state/types/tracks.ts
+++ b/src/content/app/genome-browser/state/types/tracks.ts
@@ -59,5 +59,5 @@ export type GenomeTrackCategory = {
   label: string;
   track_category_id: string;
   track_list: GenomicTrack[];
-  type: TrackSet; // shows which groups of tracks this category belongs to
+  type: TrackSet;
 };

--- a/src/content/app/genome-browser/state/types/tracks.ts
+++ b/src/content/app/genome-browser/state/types/tracks.ts
@@ -59,5 +59,5 @@ export type GenomeTrackCategory = {
   label: string;
   track_category_id: string;
   track_list: GenomicTrack[];
-  types: TrackSet[]; // shows which groups of tracks this category belongs to
+  type: TrackSet; // shows which groups of tracks this category belongs to
 };

--- a/tests/fixtures/genomes.ts
+++ b/tests/fixtures/genomes.ts
@@ -28,19 +28,19 @@ export const createGenomeCategories = (): GenomeTrackCategory[] => [
     label: faker.lorem.words() as string,
     track_category_id: faker.lorem.words(),
     track_list: [createTrack()],
-    types: [TrackSet.GENOMIC]
+    type: TrackSet.GENOMIC
   },
   {
     label: faker.lorem.words(),
     track_category_id: faker.lorem.words(),
     track_list: [createTrack()],
-    types: [TrackSet.VARIATION]
+    type: TrackSet.VARIATION
   },
   {
     label: faker.lorem.words(),
     track_category_id: faker.lorem.words(),
     track_list: [],
-    types: [TrackSet.REGULATION]
+    type: TrackSet.REGULATION
   }
 ];
 


### PR DESCRIPTION
## Description
The payload in track_categories endpoint of the track api has been updated. See [Slack](https://genomes-ebi.slack.com/archives/C01QD9623KK/p1698956984094639).

This PR is to support that change.

## Deployment URL(s)
http://submit-tracks.review.ensembl.org
