### PR TITLE
Bugfixes for the species page

### DIFF
--- a/src/content/app/species/state/general/speciesGeneralHelper.ts
+++ b/src/content/app/species/state/general/speciesGeneralHelper.ts
@@ -661,51 +661,50 @@ const getExampleLinks = (props: {
       (object) => object.type === 'gene'
     );
 
-    const focusId = geneExample?.id
-      ? buildFocusIdForUrl({
-          type: 'gene',
-          objectId: geneExample.id
-        })
-      : undefined;
-
-    if (focusId) {
-      exampleLinks = {
-        genomeBrowser: {
-          url: urlFor.browser({
-            genomeId: genomeIdForUrl,
-            focus: focusId
-          })
-        },
-        entityViewer: {
-          url: urlFor.entityViewer({
-            genomeId: genomeIdForUrl,
-            entityId: focusId
-          })
-        }
-      };
+    if (!geneExample) {
+      return;
     }
+
+    const focusId = buildFocusIdForUrl({
+      type: 'gene',
+      objectId: geneExample.id
+    });
+
+    exampleLinks = {
+      genomeBrowser: {
+        url: urlFor.browser({
+          genomeId: genomeIdForUrl,
+          focus: focusId
+        })
+      },
+      entityViewer: {
+        url: urlFor.entityViewer({
+          genomeId: genomeIdForUrl,
+          entityId: focusId
+        })
+      }
+    };
   } else if (section === SpeciesStatsSection.ASSEMBLY) {
     const locationExample = exampleFocusObjects.find(
       (object) => object.type === 'location'
     );
-
-    const focusId = locationExample?.id
-      ? buildFocusIdForUrl({
-          type: 'location',
-          objectId: locationExample.id
-        })
-      : undefined;
-
-    if (focusId) {
-      exampleLinks = {
-        genomeBrowser: {
-          url: urlFor.browser({
-            genomeId: genomeIdForUrl,
-            focus: focusId
-          })
-        }
-      };
+    if (!locationExample) {
+      return;
     }
+
+    const focusId = buildFocusIdForUrl({
+      type: 'location',
+      objectId: locationExample.id
+    });
+
+    exampleLinks = {
+      genomeBrowser: {
+        url: urlFor.browser({
+          genomeId: genomeIdForUrl,
+          focus: focusId
+        })
+      }
+    };
   }
 
   return exampleLinks;

--- a/src/content/app/species/state/sidebar/speciesSidebarSlice.ts
+++ b/src/content/app/species/state/sidebar/speciesSidebarSlice.ts
@@ -68,7 +68,7 @@ const speciesPageSidebarSlice = createSlice({
       }>
     ) {
       const isSidebarOpen =
-        !state[action.payload.genomeId].isSidebarOpen ?? true;
+        !state[action.payload.genomeId]?.isSidebarOpen ?? true;
       updateStateForGenome(state, action.payload.genomeId, { isSidebarOpen });
     },
 
@@ -80,11 +80,7 @@ const speciesPageSidebarSlice = createSlice({
       }>
     ) {
       const { activeGenomeId, fragment } = action.payload;
-
-      state[activeGenomeId] = {
-        ...state[activeGenomeId],
-        ...fragment
-      };
+      updateStateForGenome(state, activeGenomeId, fragment);
     }
   }
 });

--- a/src/content/app/species/state/sidebar/speciesSidebarSlice.ts
+++ b/src/content/app/species/state/sidebar/speciesSidebarSlice.ts
@@ -15,8 +15,6 @@
  */
 
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
-import get from 'lodash/get';
-import merge from 'lodash/merge';
 
 export enum SpeciesSidebarModalView {
   SEARCH = 'search',
@@ -44,10 +42,11 @@ const initialState: SpeciesPageSidebarState = {};
 const updateStateForGenome = (
   state: SpeciesPageSidebarState,
   genomeId: string,
-  fragment: Partial<StateForGenome>
+  fragment: Partial<StateForGenome> = {}
 ) => {
-  const stateForGenome = get(state, genomeId, initialStateForGenome);
-  const updatedStateForGenome = merge({}, stateForGenome, fragment);
+  const stateForGenome =
+    state[genomeId] ?? structuredClone(initialStateForGenome);
+  const updatedStateForGenome = { ...stateForGenome, ...fragment };
   state[genomeId] = updatedStateForGenome;
 };
 
@@ -67,9 +66,10 @@ const speciesPageSidebarSlice = createSlice({
         genomeId: string;
       }>
     ) {
-      const isSidebarOpen =
-        !state[action.payload.genomeId]?.isSidebarOpen ?? true;
-      updateStateForGenome(state, action.payload.genomeId, { isSidebarOpen });
+      const { genomeId } = action.payload;
+      updateStateForGenome(state, genomeId); // make sure that there is a state associated with current genome id
+      state[action.payload.genomeId].isSidebarOpen =
+        !state[action.payload.genomeId].isSidebarOpen;
     },
 
     updateSpeciesSidebarModalForGenome(

--- a/src/shared/components/expandable-section/ExpandableSection.test.tsx
+++ b/src/shared/components/expandable-section/ExpandableSection.test.tsx
@@ -26,7 +26,7 @@ const expandedContent = faker.lorem.paragraph();
 const collapsedContent = faker.lorem.paragraph();
 const mockOnToggle = jest.fn();
 
-const defaultProps: ExpandableSectionProps = {
+const defaultProps = {
   expandedContent,
   collapsedContent,
   isExpanded: true,
@@ -36,69 +36,59 @@ const defaultProps: ExpandableSectionProps = {
     expanded: faker.lorem.slug(),
     collapsed: faker.lorem.slug()
   }
-};
+} satisfies ExpandableSectionProps;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
 
 describe('<ExpandableSection />', () => {
-  const renderExpandableSection = (
-    props: Partial<ExpandableSectionProps> = {}
-  ) => render(<ExpandableSection {...defaultProps} {...props} />);
-
-  let container: any;
-
-  beforeEach(() => {
-    jest.resetAllMocks();
-    container = renderExpandableSection().container;
-  });
-
-  it('renders without error', () => {
-    expect(() => container).not.toThrow();
-  });
-
   it('hides the expanded content when isExpanded is false', () => {
-    container = renderExpandableSection({
-      isExpanded: false
-    }).container;
-    expect(container.querySelectorAll('.expandedContent')).toHaveLength(0);
-    expect(container.querySelectorAll('.collapsedContent')).toHaveLength(1);
+    const { container } = render(
+      <ExpandableSection {...defaultProps} isExpanded={false} />
+    );
+    expect(container.textContent).toBe(collapsedContent);
   });
 
   it('shows the expanded content when isExpanded is true', () => {
-    expect(container.querySelectorAll('.expandedContent')).toHaveLength(1);
-    expect(container.querySelectorAll('.collapsedContent')).toHaveLength(0);
+    // isExpanded property is true in defaultProps above
+    const { container } = render(<ExpandableSection {...defaultProps} />);
+    expect(container.textContent).toBe(expandedContent);
   });
 
   it('calls onToggle prop when collapsing or expanding', async () => {
-    await userEvent.click(container.querySelector('.toggle'));
+    const { container, rerender } = render(
+      <ExpandableSection {...defaultProps} />
+    );
+    await userEvent.click(container.querySelector('.toggle') as HTMLElement);
     expect(mockOnToggle).toBeCalledWith(false);
 
-    container = renderExpandableSection({
-      isExpanded: false
-    }).container;
+    rerender(<ExpandableSection {...defaultProps} isExpanded={false} />);
 
-    await userEvent.click(container.querySelector('.toggle'));
+    await userEvent.click(container.querySelector('.toggle') as HTMLElement);
     expect(mockOnToggle).toBeCalledWith(true);
   });
 
   it('applies the passed in classNames', () => {
+    const { container, rerender } = render(
+      <ExpandableSection {...defaultProps} />
+    );
     expect(
       container
         .querySelector('.expandableSection')
-        .classList.contains(defaultProps.classNames?.wrapper)
+        ?.classList.contains(defaultProps.classNames.wrapper)
     ).toBeTruthy();
 
     expect(
       container
         .querySelector('.expandedContent')
-        .classList.contains(defaultProps.classNames?.expanded)
+        ?.classList.contains(defaultProps.classNames?.expanded)
     ).toBeTruthy();
 
-    container = renderExpandableSection({
-      isExpanded: false
-    }).container;
+    rerender(<ExpandableSection {...defaultProps} isExpanded={false} />);
+
     expect(
-      container
-        .querySelector('.collapsedContent')
-        .classList.contains(defaultProps.classNames?.collapsed)
+      container.querySelector(`.${defaultProps.classNames.collapsed}`)
     ).toBeTruthy();
   });
 });

--- a/src/shared/components/expandable-section/ExpandableSection.tsx
+++ b/src/shared/components/expandable-section/ExpandableSection.tsx
@@ -53,10 +53,7 @@ const ExpandableSection = (props: ExpandableSectionProps) => {
     props.classNames?.expanded
   );
 
-  const collapsedContentClassNames = classNames(
-    styles.collapsedContent,
-    props.classNames?.collapsed
-  );
+  const collapsedContentClassNames = props.classNames?.collapsed;
 
   const toggleExpanded = () => {
     props.onToggle && props.onToggle(!isExpanded);


### PR DESCRIPTION
## Description

### Bug 1
If the example features metadata endpoint does not return example objects; the "Example gene" or "Example location" links were still visible; but because they did not have any associated example object data, the "View in app" tooltip was empty, and looked broken:

![image](https://github.com/Ensembl/ensembl-client/assets/6834224/8e2b62c6-16bd-439b-b0b8-83c1d1fdf493)

### Bug 2
Open the species page, then click on the chevron closing the sidebar. This produces an error because state[genome_id] is undefined at that point.

Screenshot from Sentry:

![image](https://github.com/Ensembl/ensembl-client/assets/6834224/0286eae8-876a-4b74-8328-26d1a8539d3f)


## Deployment URL(s)
http://species-page-fixes.review.ensembl.org