### PR TITLE
Fix selection of focus objects if they have a dot in the name

### DIFF
--- a/src/content/app/genome-browser/components/browser-bar/BrowserBar.test.tsx
+++ b/src/content/app/genome-browser/components/browser-bar/BrowserBar.test.tsx
@@ -15,12 +15,11 @@
  */
 
 import React from 'react';
-import configureMockStore from 'redux-mock-store';
+import { configureStore } from '@reduxjs/toolkit';
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
-import thunk from 'redux-thunk';
-import set from 'lodash/fp/set';
 
+import createRootReducer from 'src/root/rootReducer';
 import { createMockBrowserState } from 'tests/fixtures/browser';
 
 import { BrowserBar } from './BrowserBar';
@@ -31,8 +30,9 @@ jest.mock(
 );
 jest.mock(
   'src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator',
-  () => () =>
+  () => () => (
     <div id="browserLocationIndicator">Browser Location Indicator</div>
+  )
 );
 jest.mock(
   'src/shared/components/feature-summary-strip/FeatureSummaryStrip',
@@ -41,12 +41,12 @@ jest.mock(
 
 const mockState = createMockBrowserState();
 
-const mockStore = configureMockStore([thunk]);
+const renderComponent = (state: any = mockState) => {
+  const store = configureStore({
+    reducer: createRootReducer(),
+    preloadedState: state
+  });
 
-let store: ReturnType<typeof mockStore>;
-
-const renderComponent = (state: typeof mockState = mockState) => {
-  store = mockStore(state);
   return render(
     <Provider store={store}>
       <BrowserBar />
@@ -72,9 +72,10 @@ describe('<BrowserBar />', () => {
     });
 
     it('does not contain FeatureSummaryStrip when focusObject is null', () => {
-      const { container } = renderComponent(
-        set('browser.focusObjects', null, mockState)
-      );
+      const updatedState = createMockBrowserState();
+      updatedState.browser.focusObjects = {} as any;
+
+      const { container } = renderComponent(updatedState);
       expect(container.querySelector('#featureSummaryStrip')).toBeFalsy();
     });
   });

--- a/src/content/app/genome-browser/hooks/useBrowserRouting.test.tsx
+++ b/src/content/app/genome-browser/hooks/useBrowserRouting.test.tsx
@@ -58,13 +58,6 @@ jest.mock(
   })
 );
 
-jest.mock(
-  'src/content/app/genome-browser/state/focus-object/focusObjectSlice',
-  () => ({
-    fetchFocusObject: jest.fn(() => ({ type: 'fetch-focus-object' }))
-  })
-);
-
 type GenomeExplainerResponse = Pick<
   BriefGenomeSummary,
   'genome_id' | 'genome_tag' | 'common_name' | 'scientific_name'
@@ -207,7 +200,9 @@ const server = setupServer(
   graphql.query('TrackPanelGene', () => {
     return HttpResponse.json({
       data: {
-        gene: true // doesn't matter, as long it's a truthy value
+        gene: {
+          stable_id: 'doesnt-matter'
+        }
       }
     });
   })

--- a/src/content/app/genome-browser/state/focus-object/focusObjectSelectors.ts
+++ b/src/content/app/genome-browser/state/focus-object/focusObjectSelectors.ts
@@ -15,7 +15,6 @@
  */
 
 import { createSelector } from '@reduxjs/toolkit';
-import get from 'lodash/get';
 
 import { buildFocusObjectId } from 'src/shared/helpers/focusObjectHelpers';
 import isGeneFocusObject from './isGeneFocusObject';
@@ -31,18 +30,13 @@ import type { RootState } from 'src/store';
 export const getFocusObjectLoadingStatus = (
   state: RootState,
   objectId: string
-): LoadingState =>
-  get(
-    state,
-    `browser.focusObjects.${objectId}.loadingStatus`,
-    LoadingState.NOT_REQUESTED
-  );
+): LoadingState => state.browser.focusObjects[objectId]?.loadingStatus ?? null;
 
 export const getFocusObjectById = (
   state: RootState,
   objectId: string
 ): FocusObject | null => {
-  return get(state, `browser.focusObjects.${objectId}.data`, null);
+  return state.browser.focusObjects[objectId]?.data ?? null;
 };
 
 export const getFocusObjectByParams = (


### PR DESCRIPTION
## Description
### Bug
On staging, visit genome browser to view an example location for a pig with an unassembled genome:

https://staging-2020.ensembl.org/genome-browser/72183a10-35d4-44b8-9b95-0355f679084b?focus=location:LUXV01009748.1:13291118-13350572&location=LUXV01009748.1:13291118-13350572

The right-hand sidebar will remain forever loading.

![image](https://github.com/Ensembl/ensembl-client/assets/6834224/85eec85d-bd01-41cd-8f55-5d6a66005875)

### Cause
The region name in this case contains a dot: `LUXV01009748.1`. The code we were using to read the focus object off redux was using lodash's `get` function, with a path to a property in an object expressed as a dot-separated string:

```
get(
    state,
    `browser.focusObjects.${objectId}.loadingStatus`,
    LoadingState.NOT_REQUESTED
  );
```

When focus object id contains dots, this results in an extra dot within the path string, and the `get` function looks at the wrong field.

### Solution
Replace the `get` function with javascript optional chaining.

## Deployment URL(s)
http://fix-focus-object-selection.review.ensembl.org/genome-browser/72183a10-35d4-44b8-9b95-0355f679084b?focus=location:LUXV01009748.1:13291118-13350572&location=LUXV01009748.1:13291118-13350572