### PR TITLE
Add common name upper-casing to endpoints that fetch genome data

### DIFF
--- a/src/content/app/species-selector/state/species-selector-api-slice/speciesSelectorApiSlice.ts
+++ b/src/content/app/species-selector/state/species-selector-api-slice/speciesSelectorApiSlice.ts
@@ -17,6 +17,7 @@
 import upperFirst from 'lodash/upperFirst';
 
 import restApiSlice from 'src/shared/state/api-slices/restSlice';
+import { formatGenomeData } from 'src/shared/state/genome/genomeApiSlice';
 
 import config from 'config';
 
@@ -46,12 +47,7 @@ export type GenomesSearchBySpeciesTaxonomyIdRequestParams = {
 // either because of the temporal dead zone that occurs otherwise (though typescript doesn't complain)
 // or due to some bundler nonsense
 const transformGenomesSearchResponse = (response: SpeciesSearchResponse) => {
-  response.matches.forEach((match) => {
-    match.common_name = match.common_name
-      ? upperFirst(match.common_name)
-      : match.common_name;
-  });
-
+  response.matches = response.matches.map(formatGenomeData);
   return response;
 };
 

--- a/src/content/app/species/components/species-page-sidebar/SpeciesPageSidebar.tsx
+++ b/src/content/app/species/components/species-page-sidebar/SpeciesPageSidebar.tsx
@@ -107,7 +107,7 @@ const SpeciesType = (props: GenomeInfo) => {
 
   const typeTextElement = type ? (
     <span>
-      {upperFirst(type.kind)}-{type.value}
+      {upperFirst(type.kind)} - {type.value}
     </span>
   ) : null;
 

--- a/src/content/app/species/state/api/speciesApiSlice.ts
+++ b/src/content/app/species/state/api/speciesApiSlice.ts
@@ -26,7 +26,10 @@ import {
 
 import { getGenomeIdForUrl } from 'src/shared/state/genome/genomeSelectors';
 
-import { fetchExampleObjectsForGenome } from 'src/shared/state/genome/genomeApiSlice';
+import {
+  fetchExampleObjectsForGenome,
+  formatGenomeData
+} from 'src/shared/state/genome/genomeApiSlice';
 import restApiSlice from 'src/shared/state/api-slices/restSlice';
 
 import type { RootState } from 'src/store';
@@ -98,7 +101,8 @@ const speciesApiSlice = restApiSlice.injectEndpoints({
     speciesDetails: builder.query<GenomeInfo, string>({
       query: (genomeId) => ({
         url: `${config.metadataApiBaseUrl}/genome/${genomeId}/details`
-      })
+      }),
+      transformResponse: (response: GenomeInfo) => formatGenomeData(response)
     })
   })
 });

--- a/src/shared/state/genome/genomeApiSlice.ts
+++ b/src/shared/state/genome/genomeApiSlice.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import upperFirst from 'lodash/upperFirst';
+
 import type { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import type { SerializedError } from '@reduxjs/toolkit';
 
@@ -26,13 +28,27 @@ import type {
   ExampleFocusObject
 } from './genomeTypes';
 
+type GenomeFieldsForFormatting = {
+  common_name: string | null;
+};
+export const formatGenomeData = <T extends GenomeFieldsForFormatting>(
+  genome: T
+): T => {
+  if (genome.common_name) {
+    genome.common_name = upperFirst(genome.common_name);
+  }
+  return genome;
+};
+
 const genomeApiSlice = restApiSlice.injectEndpoints({
   endpoints: (builder) => ({
     // query intended to discover whether a string available to the client is a genome id or a genome tag
     genomeSummaryByGenomeSlug: builder.query<BriefGenomeSummary, string>({
       query: (slug) => ({
         url: `${config.metadataApiBaseUrl}/genome/${slug}/explain`
-      })
+      }),
+      transformResponse: (response: BriefGenomeSummary) =>
+        formatGenomeData(response)
     }),
     genomeKaryotype: builder.query<GenomeKaryotypeItem[], string>({
       query: (genomeId) => ({


### PR DESCRIPTION
## Description
While we had code in place that was capitalising the first letter of species common name in species search api endpoint and popular species api endpoint, it was still possible to get a lower-cased species common name from genome details endpoint, and from the url explainer endpoint. Also, notice the missing space around the hyphen that separates the kind of the species type (e.g. "Breed") from the name of that type (e.g. "Hereford"):

![image](https://github.com/Ensembl/ensembl-client/assets/6834224/df06fe76-4793-4505-bfac-a4b65ec054c1)

After the fixes:

![localhost_8080_species_4106e9ef-1bb1-4ca4-974c-8de8875b8456 (1)](https://github.com/Ensembl/ensembl-client/assets/6834224/d75e73f0-7cb6-4b41-9a25-177251ee5cda)

## Deployment URL(s)
http://fix-species-formatting.review.ensembl.org