### PR TITLE
Remove 'Chromosome' text from GB navigation bar

### DIFF
--- a/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.scss
+++ b/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.scss
@@ -26,11 +26,6 @@
   align-items: center;
 }
 
-.chrLabel {
-  font-size: 12px;
-  font-weight: $light;
-}
-
 .chrCode {
   background: $dark-grey;
   color: $white;

--- a/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.tsx
+++ b/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.tsx
@@ -44,7 +44,6 @@ export const BrowserLocationIndicator = () => {
 
   return (
     <div className={styles.browserLocationIndicator}>
-      <div className={styles.chrLabel}>Chromosome</div>
       <div className={styles.chrLocationView}>
         {activeChromosome?.is_circular ? (
           <CircularChromosomeIndicator />


### PR DESCRIPTION
## Description
This is just a one liner PR. Removed `Chromosome` text from `BrowserLocationIndicator` and the related CSS.


## Related JIRA Issue(s)
[ENSWBSITES-2312](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2312)

## Deployment URL(s)
http://remove-chromosome-text.review.ensembl.org


## Views affected
Genome browser