### PR TITLE
Account for relaxed requirements to species stats payload – nulls allowed anywhere

### DIFF
--- a/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
+++ b/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
@@ -28,12 +28,11 @@ import {
 import { getCommittedSpeciesById } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors';
 
 import {
-  getStatsForSection,
   sectionGroupsMap,
-  speciesStatsSectionNames,
   type SpeciesStatsSection,
   type StatsSection
 } from '../../state/general/speciesGeneralHelper';
+import prepareStatistics from './prepareStatistics';
 
 import { useGetSpeciesStatisticsQuery } from 'src/content/app/species/state/api/speciesApiSlice';
 import { setActiveGenomeExpandedSections } from 'src/content/app/species/state/general/speciesGeneralSlice';
@@ -48,8 +47,6 @@ import { CircleLoader } from 'src/shared/components/loader';
 import type { RootState } from 'src/store';
 import type { LinksConfig } from 'src/shared/components/view-in-app/ViewInApp';
 import type { CommittedItem } from 'src/content/app/species-selector/types/committedItem';
-import type { SpeciesStatistics } from 'src/content/app/species/state/api/speciesApiTypes';
-import type { ExampleFocusObject } from 'src/shared/state/genome/genomeTypes';
 
 import styles from './SpeciesMainView.scss';
 
@@ -268,27 +265,6 @@ const SpeciesMainViewStats = () => {
       })}
     </div>
   );
-};
-
-const prepareStatistics = ({
-  statistics,
-  genomeIdForUrl,
-  exampleFocusObjects
-}: {
-  statistics: SpeciesStatistics;
-  genomeIdForUrl: string;
-  exampleFocusObjects: ExampleFocusObject[];
-}) => {
-  return speciesStatsSectionNames
-    .map((section) =>
-      getStatsForSection({
-        allStats: statistics,
-        genomeIdForUrl,
-        section: section as SpeciesStatsSection,
-        exampleFocusObjects
-      })
-    )
-    .filter(Boolean) as StatsSection[];
 };
 
 export default SpeciesMainViewStats;

--- a/src/content/app/species/components/species-main-view/prepareStatistics.ts
+++ b/src/content/app/species/components/species-main-view/prepareStatistics.ts
@@ -1,0 +1,235 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  getStatsForSection,
+  speciesStatsSectionNames,
+  type SpeciesStatsSection,
+  type StatsSection
+} from '../../state/general/speciesGeneralHelper';
+
+import type { SpeciesStatistics } from 'src/content/app/species/state/api/speciesApiTypes';
+import type { ExampleFocusObject } from 'src/shared/state/genome/genomeTypes';
+
+/**
+ * RULES FOR THE CLIENT FOR DISPLAYING STATISTICS IN THE EXPANDABLE SECTIONS
+ *
+ * - For assembly_stats: anything can be null except for chromosomes.
+ *   If chromosomes are null, all fields in the section should be null.
+ * - For coding_stats: anything can be null except for coding_genes.
+ *   If coding_genes is null, all fields in the section should be null
+ * - For non_coding_stats: anything can be null except for non_coding_genes.
+ *   If non_coding_genes is null, all fields in the section should be null
+ * - For pseudogene_stats, anything can be null except for pseudogenes.
+ *   If pseudogenes field is null, all fields in the section should be null
+ * - For variation_stats, anything can be null except for short_variants.
+ *   If short_variants is null, all fields in the section should be null
+ * - For homology_stats, both coverage and coverage_explanation
+ *   should at the same time be either null or non-null
+ * - For regulation_stats, anything can be null
+ */
+const curateSpeciesStatistics = (
+  speciesStats: SpeciesStatistics
+): SpeciesStatistics => {
+  return {
+    assembly_stats: curateAssemblyStatistics(speciesStats.assembly_stats),
+    coding_stats: curateCodingGeneStatistics(speciesStats.coding_stats),
+    non_coding_stats: curateNonCodingGeneStatistics(
+      speciesStats.non_coding_stats
+    ),
+    pseudogene_stats: curatePseudogeneStatistics(speciesStats.pseudogene_stats),
+    homology_stats: curateHomologyStats(speciesStats.homology_stats),
+    variation_stats: curateVariationStats(speciesStats.variation_stats),
+    regulation_stats: curateRegulationStats(
+      speciesStats.regulation_stats
+    ) as SpeciesStatistics['regulation_stats'] // this is a white lie; we are excluding unnecessary fields from regulation stats here
+  };
+};
+
+/**
+ * Make sure that if the chromosomes field happens to be set to null,
+ * then there is no other field in the assembly statistics section that has data
+ */
+const curateAssemblyStatistics = (
+  assemblyStats: SpeciesStatistics['assembly_stats']
+) => {
+  const chromosomeStats = assemblyStats.chromosomes;
+
+  if (chromosomeStats !== null) {
+    return assemblyStats;
+  }
+
+  const emptyStats = { ...assemblyStats };
+
+  for (const key of Object.keys(emptyStats)) {
+    emptyStats[key as keyof typeof emptyStats] = null;
+  }
+
+  return emptyStats;
+};
+
+/**
+ * Make sure that if the coding_genes field happens to be set to null,
+ * then there is no other field in the coding_stats section that has data
+ */
+const curateCodingGeneStatistics = (
+  codingStats: SpeciesStatistics['coding_stats']
+) => {
+  const codingGenesCount = codingStats['coding_genes'];
+
+  if (codingGenesCount !== null) {
+    return codingStats;
+  }
+
+  const emptyStats = { ...codingStats };
+
+  for (const key of Object.keys(emptyStats)) {
+    emptyStats[key as keyof typeof emptyStats] = null;
+  }
+
+  return emptyStats;
+};
+
+/**
+ * Make sure that if the non_coding_genes field happens to be set to null,
+ * then there is no other field in the non_coding_stats section that has data
+ */
+const curateNonCodingGeneStatistics = (
+  nonCodingStats: SpeciesStatistics['non_coding_stats']
+) => {
+  const nonCodingGenesCount = nonCodingStats['non_coding_genes'];
+
+  if (nonCodingGenesCount !== null) {
+    return nonCodingStats;
+  }
+
+  const emptyStats = { ...nonCodingStats };
+
+  for (const key of Object.keys(emptyStats)) {
+    emptyStats[key as keyof typeof emptyStats] = null;
+  }
+
+  return emptyStats;
+};
+
+/**
+ * Make sure that if the non_coding_genes field happens to be set to null,
+ * then there is no other field in the non_coding_stats section that has data
+ */
+const curatePseudogeneStatistics = (
+  pseudogeneStats: SpeciesStatistics['pseudogene_stats']
+) => {
+  const pseudogenesCount = pseudogeneStats['pseudogenes'];
+
+  if (pseudogenesCount !== null) {
+    return pseudogeneStats;
+  }
+
+  const emptyStats = { ...pseudogeneStats };
+
+  for (const key of Object.keys(emptyStats)) {
+    emptyStats[key as keyof typeof emptyStats] = null;
+  }
+
+  return emptyStats;
+};
+
+/**
+ * Make sure that both the coverage field and the reference_species_name field
+ * are either null or non-null together
+ */
+const curateHomologyStats = (
+  homologyStats: SpeciesStatistics['homology_stats']
+) => {
+  const isCoveragePresent = homologyStats['coverage'] !== null;
+  const isReferenceSpeciesNamePresent =
+    homologyStats['reference_species_name'] !== null;
+
+  const isDataOk =
+    (isCoveragePresent && isReferenceSpeciesNamePresent) ||
+    (!isCoveragePresent && !isReferenceSpeciesNamePresent);
+
+  if (isDataOk) {
+    return homologyStats;
+  }
+
+  const emptyStats = { ...homologyStats };
+
+  for (const key of Object.keys(emptyStats)) {
+    emptyStats[key as keyof typeof emptyStats] = null;
+  }
+
+  return emptyStats;
+};
+
+/**
+ * Make sure that if the short_variants field happens to be set to null,
+ * then there is no other field in the variation_stats section that has data
+ */
+const curateVariationStats = (
+  variationStats: SpeciesStatistics['variation_stats']
+) => {
+  const hasShortVariants = variationStats['short_variants'] !== null;
+
+  if (hasShortVariants) {
+    return variationStats;
+  }
+
+  const emptyStats = { ...variationStats };
+
+  for (const key of Object.keys(emptyStats)) {
+    emptyStats[key as keyof typeof emptyStats] = null;
+  }
+
+  return emptyStats;
+};
+
+/**
+ * Only leave the fields that are intended for display on the species page
+ */
+const curateRegulationStats = (
+  regulationStats: SpeciesStatistics['regulation_stats']
+) => {
+  return {
+    enhancers: regulationStats.enhancers,
+    promoters: regulationStats.promoters
+  };
+};
+
+const prepareStatistics = ({
+  statistics,
+  genomeIdForUrl,
+  exampleFocusObjects
+}: {
+  statistics: SpeciesStatistics;
+  genomeIdForUrl: string;
+  exampleFocusObjects: ExampleFocusObject[];
+}) => {
+  statistics = curateSpeciesStatistics(statistics);
+
+  return speciesStatsSectionNames
+    .map((section) =>
+      getStatsForSection({
+        allStats: statistics,
+        genomeIdForUrl,
+        section: section as SpeciesStatsSection,
+        exampleFocusObjects
+      })
+    )
+    .filter(Boolean) as StatsSection[];
+};
+
+export default prepareStatistics;

--- a/src/content/app/species/state/api/speciesApiTypes.ts
+++ b/src/content/app/species/state/api/speciesApiTypes.ts
@@ -15,87 +15,88 @@
  */
 
 type AssemblyStatistics = {
-  contig_n50: number;
-  total_genome_length: number;
-  total_coding_sequence_length: number;
-  total_gap_length: number;
-  spanned_gaps: number;
-  chromosomes: number;
-  toplevel_sequences: number;
-  component_sequences: number;
-  gc_percentage: number;
+  contig_n50: number | null;
+  total_genome_length: number | null;
+  total_coding_sequence_length: number | null;
+  total_gap_length: number | null;
+  spanned_gaps: number | null;
+  chromosomes: number | null;
+  toplevel_sequences: number | null;
+  component_sequences: number | null;
+  gc_percentage: number | null;
 };
 
 type CodingGeneStatistics = {
-  coding_genes: number;
-  average_genomic_span: number;
-  average_sequence_length: number;
-  average_cds_length: number;
-  shortest_gene_length: number;
-  longest_gene_length: number;
-  total_transcripts: number;
-  coding_transcripts: number;
-  transcripts_per_gene: number;
-  coding_transcripts_per_gene: number;
-  total_exons: number;
-  total_coding_exons: number;
-  average_exon_length: number;
-  average_coding_exon_length: number;
-  average_exons_per_transcript: number;
-  average_coding_exons_per_coding_transcript: number;
-  total_introns: number;
-  average_intron_length: number;
+  coding_genes: number | null;
+  average_genomic_span: number | null;
+  average_sequence_length: number | null;
+  average_cds_length: number | null;
+  shortest_gene_length: number | null;
+  longest_gene_length: number | null;
+  total_transcripts: number | null;
+  coding_transcripts: number | null;
+  transcripts_per_gene: number | null;
+  coding_transcripts_per_gene: number | null;
+  total_exons: number | null;
+  total_coding_exons: number | null;
+  average_exon_length: number | null;
+  average_coding_exon_length: number | null;
+  average_exons_per_transcript: number | null;
+  average_coding_exons_per_coding_transcript: number | null;
+  total_introns: number | null;
+  average_intron_length: number | null;
 };
 
 type NonCodingGeneStatistics = {
-  non_coding_genes: number;
-  small_non_coding_genes: number;
-  long_non_coding_genes: number;
-  misc_non_coding_genes: number;
-  average_genomic_span: number;
-  average_sequence_length: number;
-  shortest_gene_length: number;
-  longest_gene_length: number;
-  total_transcripts: number;
-  transcripts_per_gene: number;
-  total_exons: number;
-  average_exon_length: number;
-  average_exons_per_transcript: number;
-  total_introns: number;
-  average_intron_length: number;
+  non_coding_genes: number | null;
+  small_non_coding_genes: number | null;
+  long_non_coding_genes: number | null;
+  misc_non_coding_genes: number | null;
+  average_genomic_span: number | null;
+  average_sequence_length: number | null;
+  shortest_gene_length: number | null;
+  longest_gene_length: number | null;
+  total_transcripts: number | null;
+  transcripts_per_gene: number | null;
+  total_exons: number | null;
+  average_exon_length: number | null;
+  average_exons_per_transcript: number | null;
+  total_introns: number | null;
+  average_intron_length: number | null;
 };
 
 type PseudogeneStatistics = {
-  pseudogenes: number;
-  average_genomic_span: number;
-  average_sequence_length: number;
-  shortest_gene_length: number;
-  longest_gene_length: number;
-  total_transcripts: number;
-  transcripts_per_gene: number;
-  total_exons: number;
-  average_exon_length: number;
-  average_exons_per_transcript: number;
-  total_introns: number;
-  average_intron_length: number;
+  pseudogenes: number | null;
+  average_genomic_span: number | null;
+  average_sequence_length: number | null;
+  shortest_gene_length: number | null;
+  longest_gene_length: number | null;
+  total_transcripts: number | null;
+  transcripts_per_gene: number | null;
+  total_exons: number | null;
+  average_exon_length: number | null;
+  average_exons_per_transcript: number | null;
+  total_introns: number | null;
+  average_intron_length: number | null;
 };
 
 type HomologyStatistics = {
-  coverage: number;
+  coverage: number | null;
+  reference_species_name: string | null;
 };
 
 type VariationStatistics = {
-  short_variants: number;
-  structural_variants: number;
-  short_variants_with_phenotype_assertions: number;
-  short_variants_with_publications: number;
-  short_variants_frequency_studies: number;
-  structural_variants_with_phenotype_assertions: number;
+  short_variants: number | null;
+  structural_variants: number | null;
+  short_variants_with_phenotype_assertions: number | null;
+  short_variants_with_publications: number | null;
+  short_variants_frequency_studies: number | null;
+  structural_variants_with_phenotype_assertions: number | null;
 };
 
 export type RegulationStatistics = {
-  enhancers: number;
-  promoters: number;
+  enhancers: number | null;
+  promoters: number | null;
   ctcf_count: number | null;
   tfbs_count: number | null;
   open_chromatin_count: number | null;

--- a/src/content/app/species/state/general/speciesGeneralHelper.ts
+++ b/src/content/app/species/state/general/speciesGeneralHelper.ts
@@ -616,8 +616,9 @@ export const getStatsForSection = (props: {
 
   if (!data) {
     return {
-      section
-    } as StatsSection;
+      section,
+      groups: []
+    };
   }
 
   const filteredData: {
@@ -651,7 +652,7 @@ export const getStatsForSection = (props: {
           })
         : undefined;
     })
-    .filter(Boolean);
+    .filter(Boolean) as IndividualStat[] | undefined;
 
   const exampleLinks = exampleLinkText
     ? getExampleLinks({
@@ -668,8 +669,9 @@ export const getStatsForSection = (props: {
     return {
       section,
       summaryStats,
-      exampleLinks
-    } as StatsSection;
+      exampleLinks,
+      groups: []
+    };
   }
 
   const processedGroups = groups.map((group) => {


### PR DESCRIPTION
## Description
- Adding some sanity checks on the client after anything in species stats has been allowed to be nullable (see [ENSWBSITES-2323](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2323))
- Removed regulatory statistics that do not need to be shown on the species page, but whose presence makes the client enable the expandability of the regulation section.

**Before:**
 
![image](https://github.com/Ensembl/ensembl-client/assets/6834224/f9501982-7f61-40ad-8752-aced045f9645)


**After:**

![image](https://github.com/Ensembl/ensembl-client/assets/6834224/c22685ec-b012-4b0b-a920-546ffd28d991)


## Related JIRA Issue(s)
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2309

## Deployment URL(s)
http://relaxed-stats.review.ensembl.org