### PR TITLE
Update code generating help for species statistics

### DIFF
--- a/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
+++ b/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
@@ -77,7 +77,7 @@ type ContentProps = {
 const getCollapsedContent = (props: ContentProps) => {
   const { species, statsSection } = props;
   const { summaryStats, section, exampleLinks } = statsSection;
-  const { title, helpText, exampleLinkText } = sectionGroupsMap[section];
+  const { title, exampleLinkText } = sectionGroupsMap[section];
 
   const onExampleLinkClick = () => {
     props.trackSpeciesPageExampleLink(species, exampleLinkText as string);
@@ -97,9 +97,9 @@ const getCollapsedContent = (props: ContentProps) => {
                     {summaryStat.primaryValue}
                   </span>
                   <span className={styles.unit}>{summaryStat.primaryUnit}</span>
-                  {helpText && (
+                  {summaryStat.helpText && (
                     <span className={styles.questionButton}>
-                      <QuestionButton helpText={helpText} />
+                      <QuestionButton helpText={summaryStat.helpText} />
                     </span>
                   )}
                 </div>


### PR DESCRIPTION
## Description
Show the species name agains compara coverage statistic has been calculated, in the tooltip on the Species page.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2288

## Deployment URL(s)
http://compara-stats-help.review.ensembl.org