### PR TITLE
Switch to compara graphql api

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -22,6 +22,7 @@ export type BaseApiUrls = {
   coreApiUrl: string;
   genomeSearchBaseUrl: string;
   metadataApiBaseUrl: string;
+  comparaApiBaseUrl: string;
   docsBaseUrl: string;
   genomeBrowserBackendBaseUrl: string;
   refgetBaseUrl: string;
@@ -39,6 +40,7 @@ const defaultApiUrls: BaseApiUrls = {
   coreApiUrl: '/api/graphql/core',
   genomeSearchBaseUrl: '/api/genomesearch',
   metadataApiBaseUrl: '/api/metadata',
+  comparaApiBaseUrl: '/api/graphql/compara',
   docsBaseUrl: '/api/docs',
   genomeBrowserBackendBaseUrl: '/api/browser/data',
   refgetBaseUrl: '/api/refget',
@@ -74,6 +76,7 @@ const getBaseApiUrls = (): BaseApiUrls => {
     metadataApiBaseUrl:
       process.env.SSR_METADATA_API_URL ??
       `${defaultServerHost}${defaultApiUrls.metadataApiBaseUrl}`,
+    comparaApiBaseUrl: defaultApiUrls.comparaApiBaseUrl, // irrelevant for server-side rendering
     genomeBrowserBackendBaseUrl: defaultApiUrls.genomeBrowserBackendBaseUrl, // irrelevant for server-side rendering
     refgetBaseUrl: defaultApiUrls.refgetBaseUrl, // irrelevant for server-side rendering
     tracksApiBaseUrl: defaultApiUrls.tracksApiBaseUrl, // irrelevant for server-side rendering

--- a/src/content/app/entity-viewer/gene-view/components/gene-homology/GeneHomology.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-homology/GeneHomology.tsx
@@ -28,15 +28,15 @@ import { CircleLoader } from 'src/shared/components/loader';
 const GeneHomology = () => {
   const { activeGenomeId, parsedEntityId } = useEntityViewerIds();
 
-  const geneUnverstionedStableId = parsedEntityId?.objectId;
+  const geneUnversionedStableId = parsedEntityId?.objectId;
 
   const { currentData: geneSummaryData } = useGeneSummaryQuery(
     {
       genomeId: activeGenomeId || '',
-      geneId: geneUnverstionedStableId ?? ''
+      geneId: geneUnversionedStableId ?? ''
     },
     {
-      skip: !activeGenomeId || !geneUnverstionedStableId
+      skip: !activeGenomeId || !geneUnversionedStableId
     }
   );
 

--- a/src/content/app/entity-viewer/gene-view/components/gene-homology/GeneHomology.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-homology/GeneHomology.tsx
@@ -16,16 +16,41 @@
 
 import React from 'react';
 
-import { useEvGeneHomologyQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
+import {
+  useGeneSummaryQuery,
+  useEvGeneHomologyQuery
+} from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
+import useEntityViewerIds from 'src/content/app/entity-viewer/hooks/useEntityViewerIds';
 
 import GeneHomologyTable from './GeneHomologyTable';
 import { CircleLoader } from 'src/shared/components/loader';
 
 const GeneHomology = () => {
-  const { currentData, isFetching, isError } = useEvGeneHomologyQuery({
-    genomeId: '',
-    geneId: ''
-  });
+  const { activeGenomeId, parsedEntityId } = useEntityViewerIds();
+
+  const geneUnverstionedStableId = parsedEntityId?.objectId;
+
+  const { currentData: geneSummaryData } = useGeneSummaryQuery(
+    {
+      genomeId: activeGenomeId || '',
+      geneId: geneUnverstionedStableId ?? ''
+    },
+    {
+      skip: !activeGenomeId || !geneUnverstionedStableId
+    }
+  );
+
+  const geneStableId = geneSummaryData?.gene.stable_id;
+
+  const { currentData, isFetching, isError } = useEvGeneHomologyQuery(
+    {
+      genomeId: activeGenomeId || '',
+      geneId: geneStableId ?? ''
+    },
+    {
+      skip: !activeGenomeId || !geneStableId
+    }
+  );
 
   if (isFetching) {
     return <CircleLoader />;

--- a/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
+++ b/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
@@ -47,7 +47,10 @@ import {
   proteinDomainsQuery,
   type ProteinDomainsQueryResult
 } from './queries/proteinDomainsQuery';
-import type { MockHomologiesResponse } from 'src/content/app/entity-viewer/state/api/fixtures/mockHomologyData'; // Update the type after switch to real data
+import {
+  geneHomologiesQuery,
+  type EntityViewerGeneHomologiesQueryResult
+} from './queries/geneHomologiesQuery';
 
 type GeneQueryParams = { genomeId: string; geneId: string };
 type ProductQueryParams = { productId: string; genomeId: string };
@@ -126,16 +129,15 @@ const entityViewerThoasSlice = graphqlApiSlice.injectEndpoints({
         variables: params
       })
     }),
-    evGeneHomology: builder.query<MockHomologiesResponse, GeneQueryParams>({
-      // eslint-disable-next-line
-      queryFn: async (params) => {
-        const { default: geneHomologies } = await import(
-          'src/content/app/entity-viewer/state/api/fixtures/mockHomologyData'
-        );
-        return {
-          data: geneHomologies
-        };
-      }
+    evGeneHomology: builder.query<
+      EntityViewerGeneHomologiesQueryResult,
+      GeneQueryParams
+    >({
+      query: (params) => ({
+        url: config.comparaApiBaseUrl,
+        body: geneHomologiesQuery,
+        variables: params
+      })
     })
   })
 });

--- a/src/content/app/entity-viewer/state/api/queries/geneHomologiesQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/geneHomologiesQuery.ts
@@ -1,0 +1,72 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from 'graphql-request';
+
+import type { GeneHomology } from '../types/geneHomology';
+
+export const geneHomologiesQuery = gql`
+  query EntityViewerGeneHomologies($genomeId: String!, $geneId: String!) {
+    homologies(genome_id: $genomeId, gene_stable_id: $geneId) {
+      target_genome {
+        genome_id
+        common_name
+        scientific_name
+        assembly {
+          accession_id
+          name
+        }
+      }
+      target_gene {
+        stable_id
+        symbol
+        version
+        unversioned_stable_id
+      }
+      query_genome {
+        genome_id
+        common_name
+        scientific_name
+        assembly {
+          accession_id
+          name
+        }
+      }
+      query_gene {
+        stable_id
+        symbol
+        version
+        unversioned_stable_id
+      }
+      subtype {
+        accession_id
+        label
+        value
+        definition
+      }
+      stats {
+        query_percent_id
+        query_percent_coverage
+        target_percent_id
+        target_percent_coverage
+      }
+    }
+  }
+`;
+
+export type EntityViewerGeneHomologiesQueryResult = {
+  homologies: GeneHomology[];
+};

--- a/src/server/helpers/getConfigForClient.ts
+++ b/src/server/helpers/getConfigForClient.ts
@@ -31,7 +31,8 @@ const getBaseApiUrls = (): BaseApiUrls => {
     toolsApiBaseUrl: process.env.TOOLS_API_BASE_URL ?? '/api/tools',
     searchApiBaseUrl: process.env.TOOLS_API_BASE_URL ?? '/api/search',
     variationApiUrl:
-      process.env.VARIATION_GRAPHQL_API_URL ?? '/api/graphql/variation'
+      process.env.VARIATION_GRAPHQL_API_URL ?? '/api/graphql/variation',
+    comparaApiBaseUrl: '/api/graphql/compara'
   };
 };
 


### PR DESCRIPTION
## Description
Use the real Compara api (manually deployed to staging) to display gene homology table

This is what it looks like for mouse:

https://github.com/Ensembl/ensembl-client/assets/6834224/a07788f2-2732-4feb-ab34-d601478534cd


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2294

## Deployment URL(s)
Compara api is not deployed to review deployments. Run the branch locally.

## Views affected
Entity Viewer => Gene Relationships => Homology