### PR TITLE
Update browser checks

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -20,7 +20,6 @@ import { hostWithProtocol as defaultServerHost } from 'src/server/constants';
 
 export type BaseApiUrls = {
   coreApiUrl: string;
-  genomeSearchBaseUrl: string;
   metadataApiBaseUrl: string;
   comparaApiBaseUrl: string;
   docsBaseUrl: string;
@@ -38,7 +37,6 @@ export type PublicKeys = {
 
 const defaultApiUrls: BaseApiUrls = {
   coreApiUrl: '/api/graphql/core',
-  genomeSearchBaseUrl: '/api/genomesearch',
   metadataApiBaseUrl: '/api/metadata',
   comparaApiBaseUrl: '/api/graphql/compara',
   docsBaseUrl: '/api/docs',
@@ -64,9 +62,6 @@ const getBaseApiUrls = (): BaseApiUrls => {
     coreApiUrl:
       process.env.SSR_CORE_API_BASE_URL ??
       `${defaultServerHost}${defaultApiUrls.coreApiUrl}`,
-    genomeSearchBaseUrl:
-      process.env.SSR_GENOME_SEARCH_BASE_URL ??
-      `${defaultServerHost}${defaultApiUrls.genomeSearchBaseUrl}`,
     docsBaseUrl:
       process.env.SSR_DOCS_BASE_URL ??
       `${defaultServerHost}${defaultApiUrls.docsBaseUrl}`,

--- a/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.test.tsx
+++ b/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.test.tsx
@@ -43,7 +43,7 @@ const mockBacteriumKaryotype = [
   { is_circular: true, name: bacterialChromosomeName }
 ];
 
-const mockGenomeSearchApi = 'http://metadata-api';
+const mockMetadataApiUrl = 'http://metadata-api';
 
 jest.mock('config', () => ({
   metadataApiBaseUrl: 'http://metadata-api'
@@ -55,18 +55,15 @@ jest.mock(
 );
 
 const server = setupServer(
-  http.get(
-    `${mockGenomeSearchApi}/genome/:genomeId/karyotype`,
-    ({ params }) => {
-      const { genomeId } = params;
+  http.get(`${mockMetadataApiUrl}/genome/:genomeId/karyotype`, ({ params }) => {
+    const { genomeId } = params;
 
-      if (genomeId === 'human') {
-        return HttpResponse.json(mockHumanKaryotype);
-      } else if (genomeId === 'ecoli') {
-        return HttpResponse.json(mockBacteriumKaryotype);
-      }
+    if (genomeId === 'human') {
+      return HttpResponse.json(mockHumanKaryotype);
+    } else if (genomeId === 'ecoli') {
+      return HttpResponse.json(mockBacteriumKaryotype);
     }
-  )
+  })
 );
 
 const initialReduxState = {

--- a/src/server/helpers/getConfigForClient.ts
+++ b/src/server/helpers/getConfigForClient.ts
@@ -20,8 +20,6 @@ import type { BaseApiUrls } from 'config';
 const getBaseApiUrls = (): BaseApiUrls => {
   return {
     coreApiUrl: process.env.BROWSER_CORE_API_BASE_URL ?? '/api/graphql/core',
-    genomeSearchBaseUrl:
-      process.env.BROWSER_GENOME_SEARCH_BASE_URL ?? '/api/genomesearch',
     metadataApiBaseUrl: process.env.METADATA_API_BASE_URL ?? '/api/metadata',
     docsBaseUrl: process.env.BROWSER_DOCS_BASE_URL ?? '/api/docs',
     refgetBaseUrl: process.env.REFGET_BASE_URL ?? '/api/refget',

--- a/src/shared/helpers/browserSupport.ts
+++ b/src/shared/helpers/browserSupport.ts
@@ -19,18 +19,16 @@
   so no need to check for ES6 support
 */
 
-// Safari versions older than 14 don't have addEventListener on MediaQueryList
-const hasOutdatedMediaQueryList = () => {
-  return (
-    !('MediaQueryList' in window) || !EventTarget.isPrototypeOf(MediaQueryList)
-  );
+// BigInt64Array was added to Safari in version 15 (released in Sep 2021); it is required by genome browser code
+const lacksBigInt64Array = () => {
+  return !('BigInt64Array' in window);
 };
 
 const hasNoAbortController = () => {
   return !('AbortController' in window);
 };
 
-const browserChecks = [hasOutdatedMediaQueryList, hasNoAbortController];
+const browserChecks = [lacksBigInt64Array, hasNoAbortController];
 
 const ensureBrowserSupport = () => {
   if (browserChecks.some((check) => check())) {


### PR DESCRIPTION
## Description
- Updated the browser support checker to check that user's browser engine has `BigInt64Array`. `BigInt64Array` is needed by the genome browser (whatever wasm/js glue it gets compiled into). The last of the major browsers to have added its support was Safari, in version 15, i.e. in September 2021 (see [link](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt64Array#browser_compatibility)).
After this check, the previous check that was `MediaQueryList` inherited from `EventTarget` became redundant — that check was testing that Safari was [at least on version 14](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList#browser_compatibility), whereas the new check makes sure that Safari is at least on version 15.
- Also, removed references to the genome search api from our configs. We are no longer using that api on the client.


### Without the check

![No BigInt64Array in Safari 14 1 (default in BigSur)](https://github.com/Ensembl/ensembl-client/assets/6834224/ec203e9f-a42a-4d3e-9bdd-105914c2123d)


## Related JIRA Issue(s)
None

## Deployment URL(s)
http://update-browser-checks.review.ensembl.org, but you won't see any detectable changes.