### PR TITLE
Remove thoas ingress

### DIFF
--- a/gitlab-ci-templates/.setup-review-template.yaml
+++ b/gitlab-ci-templates/.setup-review-template.yaml
@@ -41,10 +41,6 @@
     - sed -i "s#<DEPLOYMENT_ENV>#${GENOME_SEARCH_SERVICE_SLUG}#g" ensembl_genome_search_service.yaml
     - sed -i "s#<DEPLOYMENT_ENV>#${GENOME_SEARCH_SERVICE_SLUG}#g" ensembl_genome_search_ingress.yaml
     - sed -i "s#<SUB_DOMAIN>#${CI_COMMIT_REF_SLUG}#g" ensembl_genome_search_ingress.yaml     
-    # ensembl-thoas
-    - sed -i "s#<DEPLOYMENT_ENV>#${THOAS_SERVICE_SLUG}#g" ensembl_thoas_service.yaml
-    - sed -i "s#<DEPLOYMENT_ENV>#${THOAS_SERVICE_SLUG}#g" ensembl_thoas_ingress.yaml
-    - sed -i "s#<SUB_DOMAIN>#${CI_COMMIT_REF_SLUG}#g" ensembl_thoas_ingress.yaml 
     # ensembl-refget-proxy
     - sed -i "s#<DEPLOYMENT_ENV>#${REFGET_SERVICE_SLUG}#g" ensembl_refget_proxy_service.yaml
     - sed -i "s#<DEPLOYMENT_ENV>#${REFGET_SERVICE_SLUG}#g" ensembl_refget_proxy_ingress.yaml


### PR DESCRIPTION
## Description
Thoas is now being served from staging env and ingress is created in metadata-api ingress


## Deployment URL(s)
[http://table-style-updates.review.ensembl.org/api/graphql/core](http://table-style-updates.review.ensembl.org/api/graphql/core)

[http://table-style-updates.review.ensembl.org/api/graphql/compara](http://table-style-updates.review.ensembl.org/api/graphql/compara)
