### PR TITLE
Update blast hits diagram label

### DIFF
--- a/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicHitsDiagramLegend.tsx
+++ b/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicHitsDiagramLegend.tsx
@@ -27,7 +27,9 @@ const BlastGenomicHitsDiagramLegend = () => {
   return (
     <div className={styles.diagramLegend}>
       <Image />
-      <span className={styles.diagramLegendLabel}>Top 5 hits by E-value</span>
+      <span className={styles.diagramLegendLabel}>
+        Top 5 hits by E-value - chromosomes only
+      </span>
     </div>
   );
 };


### PR DESCRIPTION
## Description
Make blast diagram label more meaningful e.g. for non chromosomal regions blast where the results image shows a blank line

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2334

## Deployment URL(s)
http://blast-label.review.ensembl.org


## Views affected
Blast