### PR TITLE
Fix ternary operator issue

### DIFF
--- a/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.tsx
+++ b/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelector.tsx
@@ -120,7 +120,7 @@ const BlastSpeciesSelector = (
         onClose={onClose}
       />
 
-      {currentData?.matches.length && (
+      {currentData?.matches.length ? (
         <div className={styles.tableContainer}>
           <SpeciesSearchResultsTable
             results={deferredGenomes}
@@ -134,7 +134,7 @@ const BlastSpeciesSelector = (
             onSpeciesSelectToggle={onGenomeStageToggle}
           />
         </div>
-      )}
+      ) : null}
     </div>
   );
 };


### PR DESCRIPTION
## Description
Removes the extra 0 displayed when a species search in blast returns no results

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2370

## Deployment URL(s)
http://zero-search.review.ensembl.org


## Views affected
Blast species search