### PR TITLE
Update browser bar

### DIFF
--- a/src/content/app/genome-browser/components/browser-bar/BrowserBar.module.css
+++ b/src/content/app/genome-browser/components/browser-bar/BrowserBar.module.css
@@ -1,15 +1,18 @@
 .browserBar {
-  display: flex;
+  display: grid;
+  grid-template-columns: [browser-reset] auto [feature-summary] 1fr [empty] 20px [location-indicator] auto; /* "empty" column plus two gaps around it should produce 60px of white space */
+  column-gap: 20px;
   width: 100%;
   align-items: center;
   position: relative;
   padding-left: 18px;
 }
 
-.browserResetWrapper {
-  margin-right: 20px;
+.featureSummaryStrip {
+  justify-self: start;
+  max-width: 100%;
 }
 
-.browserLocationIndicatorWrapper {
-  margin-left: auto;
+.browserLocationIndicator {
+  grid-column: location-indicator;
 }

--- a/src/content/app/genome-browser/components/browser-bar/BrowserBar.tsx
+++ b/src/content/app/genome-browser/components/browser-bar/BrowserBar.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useRef } from 'react';
 
 import { useAppSelector } from 'src/store';
 
@@ -31,6 +31,9 @@ export const BrowserBar = () => {
   const focusObject = useAppSelector(getBrowserActiveFocusObject);
   const isDrawerOpened = useAppSelector(getIsDrawerOpened);
 
+  const browserBarRef = useRef<HTMLDivElement>(null);
+  const featureSummaryRef = useRef<HTMLDivElement>(null);
+
   // return empty div instead of null, so that the dedicated slot in the CSS grid of StandardAppLayout
   // always contains a child DOM element
   if (!focusObject) {
@@ -38,19 +41,21 @@ export const BrowserBar = () => {
   }
 
   return (
-    <div className={styles.browserBar}>
-      <div className={styles.browserResetWrapper}>
-        <BrowserReset />
-      </div>
+    <div className={styles.browserBar} ref={browserBarRef}>
+      <BrowserReset />
       {focusObject && (
         <FeatureSummaryStrip
           focusObject={focusObject}
           isGhosted={isDrawerOpened}
+          ref={featureSummaryRef}
+          className={styles.featureSummaryStrip}
         />
       )}
-      <div className={styles.browserLocationIndicatorWrapper}>
-        <BrowserLocationIndicator />
-      </div>
+      <BrowserLocationIndicator
+        className={styles.browserLocationIndicator}
+        containerRef={browserBarRef}
+        nonOverlapElementRef={featureSummaryRef}
+      />
     </div>
   );
 };

--- a/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.module.css
+++ b/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.module.css
@@ -28,7 +28,7 @@
 }
 
 .regionName {
-  color: var(--color-grey);
+  color: var(--color-medium-dark-grey);
 }
 
 .chrSeparator {

--- a/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.module.css
+++ b/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.module.css
@@ -3,7 +3,6 @@
   align-items: center;
   white-space: nowrap;
   flex-wrap: nowrap;
-  line-height: 1;
   font-size: 14px;
 }
 
@@ -22,14 +21,14 @@
   align-items: center;
 }
 
-.chrCode {
-  background: var(--color-dark-grey);
-  color: var(--color-white);
+.regionNameContainer {
   display: inline-block;
-  font-weight: var(--font-weight-bold);
-  margin: 0 0.5em;
-  padding: 5px;
-  text-align: center;
+  position: relative;
+  margin-right: 0.5em;
+}
+
+.regionName {
+  color: var(--color-grey);
 }
 
 .chrSeparator {
@@ -39,4 +38,19 @@
 .chrRegion {
   color: var(--color-dark-grey);
   display: inline-block;
+}
+
+.probeAnchor {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: calc(14px * 1.5); /* font size of the element times the line height */
+}
+
+.probe {
+  position: absolute;
+  top: 0;
+  right: 0;
+  color: red;
+  visibility: hidden;
 }

--- a/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.test.tsx
+++ b/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.test.tsx
@@ -127,7 +127,7 @@ describe('BrowserLocationIndicator', () => {
     it('displays chromosome name', async () => {
       const { container } = renderBrowserLocationIndicator();
       await waitFor(() => {
-        const renderedName = container.querySelector('.chrCode');
+        const renderedName = container.querySelector('.regionName');
         expect(renderedName?.textContent).toBe(humanChromosomeName);
       });
     });

--- a/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.tsx
+++ b/src/content/app/genome-browser/components/browser-location-indicator/BrowserLocationIndicator.tsx
@@ -34,7 +34,10 @@ type Props = {
 };
 
 export const BrowserLocationIndicator = (props: Props) => {
-  const [shouldShowRegionName, setShouldShowRegionName] = useState(false);
+  const shouldCheckProximity = props.containerRef && props.nonOverlapElementRef;
+  const [shouldShowRegionName, setShouldShowRegionName] = useState(
+    !shouldCheckProximity
+  ); // start with false if component needs to figure out how close it is to its neightbor on the left
   const actualChrLocation = useAppSelector(getActualChrLocation);
   const activeGenomeId = useAppSelector(getBrowserActiveGenomeId) as string;
 
@@ -70,7 +73,7 @@ export const BrowserLocationIndicator = (props: Props) => {
               <span className={styles.regionName}>{regionName}</span>
             )}
             {props.nonOverlapElementRef && props.containerRef && (
-              <ElementWidthSensor
+              <ProximitySensor
                 regionName={regionName}
                 containerRef={props.containerRef}
                 nonOverlapElementRef={props.nonOverlapElementRef}
@@ -90,7 +93,7 @@ export const BrowserLocationIndicator = (props: Props) => {
   );
 };
 
-const ElementWidthSensor = ({
+const ProximitySensor = ({
   regionName,
   containerRef,
   nonOverlapElementRef,

--- a/src/shared/components/feature-summary-strip/FeatureSummaryStrip.module.css
+++ b/src/shared/components/feature-summary-strip/FeatureSummaryStrip.module.css
@@ -1,19 +1,17 @@
-.featureSummaryStripWrapper {
-  flex-grow: 1;
-}
-
 .featureSummaryStrip {
   font-size: 14px;
-  display: flex;
-  align-items: center;
   white-space: nowrap;
   flex-wrap: nowrap;
-  line-height: 1;
   overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.featureSummaryStrip > div:not(:last-child) {
-  margin-right: 30px;
+.section {
+  display: inline;
+}
+
+.section:not(:first-child) {
+  margin-left: 30px;
 }
 
 .featureSummaryStripGhosted {

--- a/src/shared/components/feature-summary-strip/FeatureSummaryStrip.test.tsx
+++ b/src/shared/components/feature-summary-strip/FeatureSummaryStrip.test.tsx
@@ -24,10 +24,14 @@ import {
 
 import { createFocusObject } from 'tests/fixtures/focus-object';
 
-jest.mock('../feature-summary-strip', () => ({
-  GeneSummaryStrip: () => <div>Gene Summary Strip</div>,
-  LocationSummaryStrip: () => <div>Location Summary Strip</div>
-}));
+jest.mock('./GeneSummaryStrip', () => {
+  const { forwardRef } = jest.requireActual('react');
+  return forwardRef(() => <div>Gene Summary Strip</div>);
+});
+jest.mock('./LocationSummaryStrip', () => {
+  const { forwardRef } = jest.requireActual('react');
+  return forwardRef(() => <div>Location Summary Strip</div>);
+});
 
 describe('<FeatureSummaryStrip />', () => {
   const defaultProps = {

--- a/src/shared/components/feature-summary-strip/FeatureSummaryStrip.tsx
+++ b/src/shared/components/feature-summary-strip/FeatureSummaryStrip.tsx
@@ -16,11 +16,9 @@
 
 import React, { forwardRef, type ForwardedRef } from 'react';
 
-import {
-  GeneSummaryStrip,
-  LocationSummaryStrip,
-  VariantSummaryStrip
-} from '../feature-summary-strip';
+import GeneSummaryStrip from './GeneSummaryStrip';
+import LocationSummaryStrip from './LocationSummaryStrip';
+import VariantSummaryStrip from './VariantSummaryStrip';
 
 import type { FocusObject } from 'src/shared/types/focus-object/focusObjectTypes';
 

--- a/src/shared/components/feature-summary-strip/FeatureSummaryStrip.tsx
+++ b/src/shared/components/feature-summary-strip/FeatureSummaryStrip.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { forwardRef, type ForwardedRef } from 'react';
 
 import {
   GeneSummaryStrip,
@@ -26,26 +26,47 @@ import type { FocusObject } from 'src/shared/types/focus-object/focusObjectTypes
 
 export type FeatureSummaryStripProps = {
   focusObject: FocusObject;
+  className?: string;
   isGhosted?: boolean;
 };
 
-export const FeatureSummaryStrip = (props: FeatureSummaryStripProps) => {
+export const FeatureSummaryStrip = (
+  props: FeatureSummaryStripProps,
+  ref: ForwardedRef<HTMLDivElement>
+) => {
   const { focusObject, isGhosted } = props;
 
   switch (focusObject.type) {
     case 'gene':
-      return <GeneSummaryStrip gene={focusObject} isGhosted={isGhosted} />;
+      return (
+        <GeneSummaryStrip
+          gene={focusObject}
+          isGhosted={isGhosted}
+          ref={ref}
+          className={props.className}
+        />
+      );
     case 'location':
       return (
-        <LocationSummaryStrip location={focusObject} isGhosted={isGhosted} />
+        <LocationSummaryStrip
+          location={focusObject}
+          isGhosted={isGhosted}
+          ref={ref}
+          className={props.className}
+        />
       );
     case 'variant':
       return (
-        <VariantSummaryStrip variant={focusObject} isGhosted={isGhosted} />
+        <VariantSummaryStrip
+          variant={focusObject}
+          isGhosted={isGhosted}
+          ref={ref}
+          className={props.className}
+        />
       );
     default:
       return null;
   }
 };
 
-export default FeatureSummaryStrip;
+export default forwardRef(FeatureSummaryStrip);

--- a/src/shared/components/feature-summary-strip/LocationSummaryStrip.tsx
+++ b/src/shared/components/feature-summary-strip/LocationSummaryStrip.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { forwardRef, type ForwardedRef } from 'react';
 import classNames from 'classnames';
 
 import { getFormattedLocation } from 'src/shared/helpers/formatters/regionFormatter';
@@ -26,14 +26,19 @@ import { FocusLocation } from 'src/shared/types/focus-object/focusObjectTypes';
 type Props = {
   location: FocusLocation;
   isGhosted?: boolean;
+  className?: string;
 };
 
-const LocationSummaryStrip = ({ location, isGhosted }: Props) => {
-  const stripClasses = classNames(styles.featureSummaryStrip, {
+const LocationSummaryStrip = (
+  props: Props,
+  ref: ForwardedRef<HTMLDivElement>
+) => {
+  const { location, isGhosted } = props;
+  const stripClasses = classNames(styles.featureSummaryStrip, props.className, {
     [styles.featureSummaryStripGhosted]: isGhosted
   });
   return (
-    <div className={stripClasses}>
+    <div className={stripClasses} ref={ref}>
       <span className={styles.featureSummaryStripLabel}>Location:</span>
       <span className={styles.featureDisplayName}>
         {getFormattedLocation(location.location)}
@@ -42,4 +47,4 @@ const LocationSummaryStrip = ({ location, isGhosted }: Props) => {
   );
 };
 
-export default LocationSummaryStrip;
+export default forwardRef(LocationSummaryStrip);


### PR DESCRIPTION
## Description

**Before**
- During client-side navigation, the code would fire that would hide some sections of the feature information in the browser bar
- On refresh, that code did not fire, and the text contents of the feature summary strip overflowed the available space, and pushed the sidebar tabs to the right:

https://github.com/Ensembl/ensembl-client/assets/6834224/e0664d63-4935-4fbd-8a53-791542667a8f

**After**
- Feature summary text always shows all sections; and is truncated if it does not fit in the available space
- The display of the region name depends on whether there is sufficient space to render it into
- There should always be 60px between BrowserLocationIndicator component and FeatureSummaryStrip component


https://github.com/Ensembl/ensembl-client/assets/6834224/e3097640-b49d-496e-9c2e-30de90853595

Couldn't think of how to achieve this through CSS alone; so done by adding an invisible copy of the region name (see the `ProximitySensor` component), which checks how close it is to the FeatureSummaryStrip when the BrowserBar resizes. Checked the performance, and found it to be tolerable.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1965

## Deployment URL(s)
http://update-browser-bar.review.ensembl.org