### PR TITLE
Add an initial, skeleton page for Variant Entity Viewer, with appropriate routing

### DIFF
--- a/src/content/app/entity-viewer/EntityViewerForGene.tsx
+++ b/src/content/app/entity-viewer/EntityViewerForGene.tsx
@@ -1,0 +1,109 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import * as urlFor from 'src/shared/helpers/urlHelper';
+
+import { useAppSelector, useAppDispatch } from 'src/store';
+import useEntityViewerIds from 'src/content/app/entity-viewer/hooks/useEntityViewerIds';
+import useEntityViewerUrlCheck from 'src/content/app/entity-viewer/hooks/useEntityViewerUrlChecks';
+
+import { getBreakpointWidth } from 'src/global/globalSelectors';
+import { getGenomeById } from 'src/shared/state/genome/genomeSelectors';
+import {
+  isEntityViewerSidebarOpen,
+  getEntityViewerSidebarModalView
+} from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors';
+
+import { deleteActiveEntityIdAndSave } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSlice';
+import { toggleSidebar } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSlice';
+
+import { StandardAppLayout } from 'src/shared/components/layout';
+import EntityViewerSidebarToolstrip from './shared/components/entity-viewer-sidebar/entity-viewer-sidebar-toolstrip/EntityViewerSidebarToolstrip';
+import EntityViewerSidebarModal from 'src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/EntityViewerSidebarModal';
+import EntityViewerTopbar from './shared/components/entity-viewer-topbar/EntityViewerTopbar';
+import GeneView from './gene-view/GeneView';
+import GeneViewSidebar from './gene-view/components/gene-view-sidebar/GeneViewSideBar';
+import GeneViewSidebarTabs from './gene-view/components/gene-view-sidebar-tabs/GeneViewSidebarTabs';
+import MissingFeatureError from 'src/shared/components/error-screen/url-errors/MissingFeatureError';
+
+const EntityViewerForGene = () => {
+  const { activeGenomeId, activeEntityId } = useEntityViewerIds();
+  const {
+    genomeIdInUrl,
+    entityIdInUrl,
+    isFetching: isVerifyingUrl,
+    isMissingEntity
+  } = useEntityViewerUrlCheck();
+  const genome = useAppSelector((state) =>
+    getGenomeById(state, activeGenomeId ?? '')
+  );
+  const isSidebarOpen = useAppSelector(isEntityViewerSidebarOpen);
+  const isSidebarModalOpen = Boolean(
+    useAppSelector(getEntityViewerSidebarModalView)
+  );
+  const viewportWidth = useAppSelector(getBreakpointWidth);
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+
+  const openEntityViewerInterstitial = () => {
+    dispatch(deleteActiveEntityIdAndSave());
+    navigate(urlFor.entityViewer({ genomeId: genomeIdInUrl }));
+  };
+
+  if (!activeGenomeId || !activeEntityId || isVerifyingUrl) {
+    return null;
+  }
+
+  if (isMissingEntity) {
+    return (
+      <MissingFeatureError
+        featureId={entityIdInUrl as string}
+        genome={genome}
+        showTopBar={true}
+        onContinue={openEntityViewerInterstitial}
+      />
+    );
+  }
+
+  return (
+    <StandardAppLayout
+      mainContent={<GeneView />}
+      topbarContent={<EntityViewerTopbar />}
+      sidebarContent={
+        <SidebarContent isSidebarModalOpen={isSidebarModalOpen} />
+      }
+      sidebarNavigation={<GeneViewSidebarTabs />}
+      sidebarToolstripContent={<EntityViewerSidebarToolstrip />}
+      isSidebarOpen={isSidebarOpen}
+      onSidebarToggle={() => dispatch(toggleSidebar())}
+      isDrawerOpen={false}
+      viewportWidth={viewportWidth}
+    />
+  );
+};
+
+const SidebarContent = (props: { isSidebarModalOpen: boolean }) => {
+  return props.isSidebarModalOpen ? (
+    <EntityViewerSidebarModal />
+  ) : (
+    <GeneViewSidebar />
+  );
+};
+
+export default EntityViewerForGene;

--- a/src/content/app/entity-viewer/EntityViewerForVariant.tsx
+++ b/src/content/app/entity-viewer/EntityViewerForVariant.tsx
@@ -1,0 +1,23 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+const EntityViewerForVariant = () => {
+  return <div>ENTITY VIEWER FOR VARIANT!</div>;
+};
+
+export default EntityViewerForVariant;

--- a/src/content/app/entity-viewer/EntityViewerForVariant.tsx
+++ b/src/content/app/entity-viewer/EntityViewerForVariant.tsx
@@ -16,8 +16,53 @@
 
 import React from 'react';
 
+import { useAppSelector, useAppDispatch } from 'src/store';
+
+import { getBreakpointWidth } from 'src/global/globalSelectors';
+import {
+  isEntityViewerSidebarOpen,
+  getEntityViewerSidebarModalView
+} from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors';
+
+import { toggleSidebar } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSlice';
+
+import { StandardAppLayout } from 'src/shared/components/layout';
+import EntityViewerSidebarToolstrip from './shared/components/entity-viewer-sidebar/entity-viewer-sidebar-toolstrip/EntityViewerSidebarToolstrip';
+import EntityViewerSidebarModal from 'src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/EntityViewerSidebarModal';
+import VariantView from './variant-view/VariantView';
+
 const EntityViewerForVariant = () => {
-  return <div>ENTITY VIEWER FOR VARIANT!</div>;
+  const isSidebarOpen = useAppSelector(isEntityViewerSidebarOpen);
+  const isSidebarModalOpen = Boolean(
+    useAppSelector(getEntityViewerSidebarModalView)
+  );
+
+  const viewportWidth = useAppSelector(getBreakpointWidth);
+  const dispatch = useAppDispatch();
+
+  return (
+    <StandardAppLayout
+      mainContent={<VariantView />}
+      topbarContent={<div>Variant summary for top bar goes here</div>}
+      sidebarContent={
+        <SidebarContent isSidebarModalOpen={isSidebarModalOpen} />
+      }
+      sidebarNavigation={null}
+      sidebarToolstripContent={<EntityViewerSidebarToolstrip />}
+      isSidebarOpen={isSidebarOpen}
+      onSidebarToggle={() => dispatch(toggleSidebar())}
+      isDrawerOpen={false}
+      viewportWidth={viewportWidth}
+    />
+  );
+};
+
+const SidebarContent = (props: { isSidebarModalOpen: boolean }) => {
+  return props.isSidebarModalOpen ? (
+    <EntityViewerSidebarModal />
+  ) : (
+    <div>Variant information for sidebar goes here</div>
+  );
 };
 
 export default EntityViewerForVariant;

--- a/src/content/app/entity-viewer/shared/page-meta/buildPageMeta.ts
+++ b/src/content/app/entity-viewer/shared/page-meta/buildPageMeta.ts
@@ -1,0 +1,37 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const defaultEntityViewerPageTitle = 'Entity viewer — Ensembl';
+
+/**
+ * NOTE: for the time being, this function for building page metadata
+ * is very simplistic; its only purpose is to set fallback values if none are provided.
+ * Later on, I expect we will want to add something like JSON schemas to the pages.
+ */
+export const buildPageMeta = (
+  params: {
+    title?: string;
+    description?: string;
+  } = {}
+) => {
+  // TODO: eventually, decide on what we want to put in the page description
+  const { title = defaultEntityViewerPageTitle, description = '' } = params;
+
+  return {
+    title,
+    description
+  };
+};

--- a/src/content/app/entity-viewer/shared/server-fetch/entityViewerServerFetch.ts
+++ b/src/content/app/entity-viewer/shared/server-fetch/entityViewerServerFetch.ts
@@ -1,0 +1,199 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getPathParameters } from 'src/shared/hooks/useUrlParams';
+
+import { parseFocusIdFromUrl } from 'src/shared/helpers/focusObjectHelpers';
+
+import {
+  fetchGenomeSummary,
+  isGenomeNotFoundError
+} from 'src/shared/state/genome/genomeApiSlice';
+import { updatePageMeta } from 'src/shared/state/page-meta/pageMetaSlice';
+import {
+  fetchGenePageMeta,
+  fetchVariantPageMeta
+} from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
+
+import { buildPageMeta } from '../page-meta/buildPageMeta';
+
+import type { ServerFetch } from 'src/routes/routesConfig';
+import type { AppDispatch } from 'src/store';
+
+class NotFoundError extends Error {}
+
+/**
+ * The purpose of this function is to:
+ * - Check that url parts resolve to existing genome id and entity; make the server respond with a 404 error if not.
+ * - Fetch summary data about the feature that can then be exposed as page metadata
+ */
+export const serverFetch: ServerFetch = async (params) => {
+  const { path, store } = params;
+  const dispatch: AppDispatch = store.dispatch;
+  const { genomeId: genomeIdFromUrl, entityId } = getPathParameters<
+    'genomeId' | 'entityId'
+  >(['/entity-viewer/:genomeId', '/entity-viewer/:genomeId/:entityId'], path);
+
+  // If the url is just /entity-viewer, update page meta and exit
+  if (!genomeIdFromUrl) {
+    dispatch(updatePageMeta(buildPageMeta()));
+    return;
+  }
+
+  try {
+    const genomeId = await fetchGenomeData({
+      dispatch,
+      genomeId: genomeIdFromUrl
+    });
+
+    if (!entityId) {
+      dispatch(updatePageMeta(buildPageMeta()));
+      return;
+    }
+
+    await fetchEntityData({ genomeId, entityId, dispatch });
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      return {
+        status: 404
+      };
+    } else {
+      throw new Error(); // viewRouter will pick this up and return a response with a 500 http status code
+    }
+  }
+};
+
+// the first and, sadly, unavoidable check: need to make sure that genome with given id exists
+const fetchGenomeData = async ({
+  genomeId,
+  dispatch
+}: {
+  genomeId: string;
+  dispatch: AppDispatch;
+}) => {
+  const genomeInfoResponsePromise = dispatch(
+    fetchGenomeSummary.initiate(genomeId)
+  );
+  const { data: genomeInfoData, error: genomeInfoError } =
+    await genomeInfoResponsePromise;
+
+  if (isGenomeNotFoundError(genomeInfoError)) {
+    throw new NotFoundError();
+  }
+
+  return genomeInfoData?.genome_id as string; // by this point, genomeId clearly exists
+};
+
+const fetchEntityData = async (params: {
+  genomeId: string;
+  entityId: string;
+  dispatch: AppDispatch;
+}) => {
+  const { entityId } = params;
+
+  let parsedEntityId;
+
+  try {
+    parsedEntityId = parseFocusIdFromUrl(entityId);
+  } catch {
+    throw new NotFoundError();
+  }
+
+  if (parsedEntityId.type === 'gene') {
+    return await fetchGeneData({ ...params, geneId: parsedEntityId.objectId });
+  } else if (parsedEntityId.type === 'variant') {
+    return await fetchVariantData({
+      ...params,
+      variantId: parsedEntityId.objectId
+    });
+  } else {
+    throw new NotFoundError();
+  }
+};
+
+const fetchGeneData = async ({
+  genomeId,
+  geneId,
+  dispatch
+}: {
+  genomeId: string;
+  geneId: string;
+  dispatch: AppDispatch;
+}) => {
+  const pageMetaPromise = dispatch(
+    fetchGenePageMeta.initiate({
+      genomeId,
+      geneId
+    })
+  );
+  const pageMetaQueryResult = await pageMetaPromise;
+  pageMetaPromise.unsubscribe();
+
+  if (pageMetaQueryResult?.error) {
+    if ((pageMetaQueryResult.error as any)?.meta?.data?.gene === null) {
+      // this is graphql's way of telling us that there is no such gene
+      throw new NotFoundError();
+    } else {
+      throw new Error(); // must be some other error; we will respond with a status code 500
+    }
+  } else {
+    const title = pageMetaQueryResult.data?.title;
+    dispatch(
+      updatePageMeta(
+        buildPageMeta({
+          title
+        })
+      )
+    );
+  }
+};
+
+const fetchVariantData = async ({
+  genomeId,
+  variantId,
+  dispatch
+}: {
+  genomeId: string;
+  variantId: string;
+  dispatch: AppDispatch;
+}) => {
+  const pageMetaPromise = dispatch(
+    fetchVariantPageMeta.initiate({
+      genomeId,
+      variantId
+    })
+  );
+  const pageMetaQueryResult = await pageMetaPromise;
+  pageMetaPromise.unsubscribe();
+
+  if (pageMetaQueryResult?.error) {
+    if ((pageMetaQueryResult.error as any)?.meta?.data?.variant === null) {
+      // this is graphql's way of telling us that there is no such variant
+      throw new NotFoundError();
+    } else {
+      throw new Error(); // must be some other error; we will respond with a status code 500
+    }
+  } else {
+    const title = pageMetaQueryResult.data?.title;
+    dispatch(
+      updatePageMeta(
+        buildPageMeta({
+          title
+        })
+      )
+    );
+  }
+};

--- a/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
+++ b/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
@@ -51,9 +51,14 @@ import {
   geneHomologiesQuery,
   type EntityViewerGeneHomologiesQueryResult
 } from './queries/geneHomologiesQuery';
+import {
+  variantDefaultQuery,
+  type EntityViewerVariantDefaultQueryResult
+} from './queries/variantDefaultQuery';
 
 type GeneQueryParams = { genomeId: string; geneId: string };
 type ProductQueryParams = { productId: string; genomeId: string };
+type VariantQueryParams = { genomeId: string; variantId: string };
 
 const entityViewerThoasSlice = graphqlApiSlice.injectEndpoints({
   endpoints: (builder) => ({
@@ -138,6 +143,16 @@ const entityViewerThoasSlice = graphqlApiSlice.injectEndpoints({
         body: geneHomologiesQuery,
         variables: params
       })
+    }),
+    defaultEntityViewerVariant: builder.query<
+      EntityViewerVariantDefaultQueryResult,
+      VariantQueryParams
+    >({
+      query: (params) => ({
+        url: config.variationApiUrl,
+        body: variantDefaultQuery,
+        variables: params
+      })
     })
   })
 });
@@ -150,7 +165,8 @@ export const {
   useGeneExternalReferencesQuery,
   useGeneForSequenceDownloadQuery,
   useProteinDomainsQuery,
-  useEvGeneHomologyQuery
+  useEvGeneHomologyQuery,
+  useDefaultEntityViewerVariantQuery
 } = entityViewerThoasSlice;
 
 export const { genePageMeta: fetchGenePageMeta } =

--- a/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
+++ b/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
@@ -52,6 +52,11 @@ import {
   type EntityViewerGeneHomologiesQueryResult
 } from './queries/geneHomologiesQuery';
 import {
+  variantPageMetaQuery,
+  type VariantPageMetaQueryResult,
+  type VariantPageMeta
+} from './queries/variantPageMetaQuery';
+import {
   variantDefaultQuery,
   type EntityViewerVariantDefaultQueryResult
 } from './queries/variantDefaultQuery';
@@ -144,6 +149,24 @@ const entityViewerThoasSlice = graphqlApiSlice.injectEndpoints({
         variables: params
       })
     }),
+    variantPageMeta: builder.query<VariantPageMeta, VariantQueryParams>({
+      query: (params) => ({
+        url: config.variationApiUrl,
+        body: variantPageMetaQuery,
+        variables: params
+      }),
+      transformResponse(response: VariantPageMetaQueryResult) {
+        const {
+          variant: { name: variantName }
+        } = response;
+
+        const title = `Variant: ${variantName} — Ensembl`;
+
+        return {
+          title
+        };
+      }
+    }),
     defaultEntityViewerVariant: builder.query<
       EntityViewerVariantDefaultQueryResult,
       VariantQueryParams
@@ -166,8 +189,11 @@ export const {
   useGeneForSequenceDownloadQuery,
   useProteinDomainsQuery,
   useEvGeneHomologyQuery,
+  useVariantPageMetaQuery,
   useDefaultEntityViewerVariantQuery
 } = entityViewerThoasSlice;
 
-export const { genePageMeta: fetchGenePageMeta } =
-  entityViewerThoasSlice.endpoints;
+export const {
+  genePageMeta: fetchGenePageMeta,
+  variantPageMeta: fetchVariantPageMeta
+} = entityViewerThoasSlice.endpoints;

--- a/src/content/app/entity-viewer/state/api/queries/variantDefaultQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/variantDefaultQuery.ts
@@ -1,0 +1,139 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from 'graphql-request';
+import { Pick2, Pick3 } from 'ts-multipick';
+
+import type { Variant } from 'src/shared/types/variation-api/variant';
+import type { VariantAllele } from 'src/shared/types/variation-api/variantAllele';
+
+export const variantDefaultQuery = gql`
+  query VariantDetails($genomeId: String!, $variantId: String!) {
+    variant(by_id: { genome_id: $genomeId, variant_id: $variantId }) {
+      name
+      alternative_names {
+        name
+        url
+      }
+      slice {
+        location {
+          start
+          end
+        }
+        region {
+          name
+        }
+      }
+      allele_type {
+        value
+      }
+      primary_source {
+        url
+        source {
+          name
+          release
+        }
+      }
+      prediction_results {
+        score
+        result
+        analysis_method {
+          tool
+        }
+      }
+      alleles {
+        name
+        allele_type {
+          value
+        }
+        slice {
+          location {
+            start
+            end
+          }
+        }
+        allele_sequence
+        reference_sequence
+        phenotype_assertions {
+          feature
+        }
+        prediction_results {
+          score
+          result
+          analysis_method {
+            tool
+          }
+        }
+        population_frequencies {
+          is_minor_allele
+          is_hpmaf
+          allele_frequency
+        }
+      }
+    }
+  }
+`;
+
+type VariantDetailsAllele = Pick<
+  VariantAllele,
+  'name' | 'allele_sequence' | 'reference_sequence'
+> &
+  Pick2<VariantAllele, 'allele_type', 'value'> &
+  Pick3<VariantAllele, 'slice', 'location', 'start' | 'end'> & {
+    population_frequencies: VariantDetailsAllelePopulationFrequency[];
+    prediction_results: VariantDetailsAllelePredictionResult[];
+    phenotype_assertions: VariantDetailsAllelePhenotypeAssertion[];
+  };
+
+type VariantDetailsAllelePopulationFrequency = Pick<
+  VariantAllele['population_frequencies'][number],
+  'is_minor_allele' | 'is_hpmaf' | 'allele_frequency'
+>;
+
+type VariantDetailsAllelePhenotypeAssertion = Pick<
+  VariantAllele['phenotype_assertions'][number],
+  'feature'
+>; // it doesn't really matter what we request; the point is to check whether the array of assertions will be empty
+
+type VariantDetailsPredictionResult = Pick<
+  Variant['prediction_results'][number],
+  'result' | 'score'
+> &
+  Pick2<Variant['prediction_results'][number], 'analysis_method', 'tool'>;
+
+type VariantDetailsAllelePredictionResult = Pick<
+  VariantAllele['prediction_results'][number],
+  'result' | 'score'
+> &
+  Pick2<VariantAllele['prediction_results'][number], 'analysis_method', 'tool'>;
+
+export type VariantDetails = Pick<Variant, 'name'> &
+  Pick3<Variant, 'slice', 'location', 'start' | 'end'> &
+  Pick3<Variant, 'slice', 'region', 'name'> &
+  Pick2<Variant, 'allele_type', 'value'> &
+  Pick2<Variant, 'primary_source', 'url'> &
+  Pick3<Variant, 'primary_source', 'source', 'name' | 'release'> & {
+    alternative_names: Pick<
+      Variant['alternative_names'][number],
+      'name' | 'url'
+    >[];
+    prediction_results: VariantDetailsPredictionResult[];
+    alleles: VariantDetailsAllele[];
+  };
+
+export type EntityViewerVariantDefaultQueryResult = {
+  variant: VariantDetails;
+};

--- a/src/content/app/entity-viewer/state/api/queries/variantPageMetaQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/variantPageMetaQuery.ts
@@ -1,0 +1,40 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from 'graphql-request';
+
+export const variantPageMetaQuery = gql`
+  query VariantDetails($genomeId: String!, $variantId: String!) {
+    variant(by_id: { genome_id: $genomeId, variant_id: $variantId }) {
+      name
+    }
+  }
+`;
+
+export type VariantPageMetaQueryResult = {
+  variant: {
+    name: string;
+  };
+};
+
+/**
+ * TODO in the future:
+ * - Add information for page description meta tag
+ */
+
+export type VariantPageMeta = {
+  title: string;
+};

--- a/src/content/app/entity-viewer/variant-view/VariantView.module.css
+++ b/src/content/app/entity-viewer/variant-view/VariantView.module.css
@@ -1,0 +1,7 @@
+.container {
+  color: var(--color-white);
+  background-color: var(--color-black);
+  display: grid;
+  grid-template-rows: [navigation-panel] auto [view-specific-content] 1fr;
+  height: 100%;
+}

--- a/src/content/app/entity-viewer/variant-view/VariantView.tsx
+++ b/src/content/app/entity-viewer/variant-view/VariantView.tsx
@@ -13,3 +13,46 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import React from 'react';
+
+import useEntityViewerIds from 'src/content/app/entity-viewer/hooks/useEntityViewerIds';
+
+import { useDefaultEntityViewerVariantQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
+
+import styles from './VariantView.module.css';
+
+const VariantView = () => {
+  const { activeGenomeId, parsedEntityId } = useEntityViewerIds();
+
+  const { objectId: variantId } = parsedEntityId ?? {};
+
+  const { currentData } = useDefaultEntityViewerVariantQuery(
+    {
+      genomeId: activeGenomeId ?? '',
+      variantId: variantId ?? ''
+    },
+    {
+      skip: !activeGenomeId || !variantId
+    }
+  );
+
+  const variantData = currentData?.variant;
+
+  return (
+    <div className={styles.container}>
+      {variantData && (
+        <>
+          <div style={{ height: '200px', textAlign: 'center' }}>
+            Placeholder for navigation panel for variant {variantData.name}
+          </div>
+          <div style={{ textAlign: 'center' }}>
+            Placeholder for the image for variant {variantData.name}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default VariantView;

--- a/src/content/app/entity-viewer/variant-view/VariantView.tsx
+++ b/src/content/app/entity-viewer/variant-view/VariantView.tsx
@@ -1,0 +1,15 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/src/content/app/genome-browser/state/api/genomeBrowserApiSlice.ts
+++ b/src/content/app/genome-browser/state/api/genomeBrowserApiSlice.ts
@@ -43,7 +43,7 @@ import type { TrackPanelGene } from '../types/track-panel-gene';
 type GeneQueryParams = { genomeId: string; geneId: string };
 type TranscriptQueryParams = { genomeId: string; transcriptId: string };
 type RegionQueryParams = { genomeId: string; regionName: string };
-type VariantQueryParams = { genomeId: string; variantId: string }; // it isn't quite clear yet what exactly the variant id should be; just an rsID is insufficient
+type VariantQueryParams = { genomeId: string; variantId: string };
 
 const genomeBrowserApiSlice = graphqlApiSlice.injectEndpoints({
   endpoints: (builder) => ({


### PR DESCRIPTION
## Description
- Added a new view for the Entity Viewer that will evolve into a view for variants
- This should unlock further work on the Variant view of Entity Viewer
- So far, the view is mostly empty. There are a couple of placeholders with inline styles. Don't be offended by the inline styles of the placeholders — they will soon go away.
- The screen also sends a query to get some variant information. I have copy-pasted it from the Genome Browser app. We will adjust this query later as needed. To prove that the query works, I am outputting the variant name
- Updated server-side fetch code for EntityViewer pages — split it into the fetching of gene data vs fetching of variant data
- Picking an allele (first alternative) and adding it as a url parameter

I put the top-level `EntityViewerForVariant.tsx` file at the top level of the entity-viewer directory, and am putting the files specific to the variant view of EntityViewer in the `variant-view` directory, like so:

```
├── EntityViewer.module.css
├── EntityViewer.tsx
├── EntityViewerForGene.tsx
├── EntityViewerForVariant.tsx
├── EntityViewerPage.tsx
├── gene-view
│   ├── GeneView.module.css
│   ├── GeneView.tsx
│   ├── components
│   ├── constants
│   └── hooks
└── variant-view
    ├── VariantView.module.css
    └── VariantView.tsx
```

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2378

## Deployment URL(s)
http://variant-ev-routing.review.ensembl.org/entity-viewer/grch38/variant:1:230710048:rs699