### PR TITLE
Add Google Analytics to Species Selector

### DIFF
--- a/src/analyticsHelper.ts
+++ b/src/analyticsHelper.ts
@@ -34,7 +34,7 @@ export type AnalyticsOptions = CustomDimensionsOptions & {
   category: string;
   action: string;
   label?: string;
-  value?: number;
+  value?: string | number;
 };
 
 export type AnalyticsType = {

--- a/src/content/app/species-selector/components/genome-selector-by-species-taxonomy-id/GenomeSelectorBySpeciesTaxonomyId.tsx
+++ b/src/content/app/species-selector/components/genome-selector-by-species-taxonomy-id/GenomeSelectorBySpeciesTaxonomyId.tsx
@@ -16,12 +16,11 @@
 
 import React, { useState, useEffect } from 'react';
 
-import { useAppDispatch, useAppSelector } from 'src/store';
+import { useAppSelector } from 'src/store';
 
 import { getCommittedSpecies } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors';
 
 import { useLazyGetGenomesBySpeciesTaxonomyIdQuery } from 'src/content/app/species-selector/state/species-selector-api-slice/speciesSelectorApiSlice';
-import { commitSelectedSpeciesAndSave } from 'src/content/app/species-selector/state/species-selector-search-slice/speciesSelectorSearchSlice';
 
 import useSelectableGenomesTable from 'src/content/app/species-selector/components/selectable-genomes-table/useSelectableGenomesTable';
 
@@ -31,11 +30,14 @@ import { PrimaryButton } from 'src/shared/components/button/Button';
 import { CircleLoader } from 'src/shared/components/loader';
 import InfoPill from 'src/shared/components/info-pill/InfoPill';
 
+import type { SpeciesSearchMatch } from 'src/content/app/species-selector/types/speciesSearchMatch';
+
 import styles from './GenomeSelectorBySpeciesTaxonomyId.module.css';
 
 type Props = {
   speciesTaxonomyId: string | number;
   speciesImageUrl: string | null;
+  onSpeciesAdd: (genomes: SpeciesSearchMatch[]) => void;
 };
 
 const GenomeSelectorBySpeciesTaxonomyId = (props: Props) => {
@@ -99,10 +101,9 @@ type TopSectionProps = Props & {
 
 const TopSection = (props: TopSectionProps) => {
   const { speciesImageUrl, genomes, stagedGenomes } = props;
-  const dispatch = useAppDispatch();
 
   const onSpeciesAdd = () => {
-    dispatch(commitSelectedSpeciesAndSave(stagedGenomes));
+    props.onSpeciesAdd(stagedGenomes);
   };
 
   const selectedGenomesCount = genomes.filter(

--- a/src/content/app/species-selector/components/popular-species-list/PopularSpeciesList.tsx
+++ b/src/content/app/species-selector/components/popular-species-list/PopularSpeciesList.tsx
@@ -17,6 +17,7 @@
 import React, { useMemo } from 'react';
 
 import { useAppDispatch, useAppSelector } from 'src/store';
+import useSpeciesSelectorAnalytics from 'src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics';
 
 import { getCommittedSpecies } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors';
 
@@ -34,6 +35,7 @@ const PopularSpeciesList = () => {
   const dispatch = useAppDispatch();
   const committedItems = useAppSelector(getCommittedSpecies);
   const { currentData } = useGetPopularSpeciesQuery();
+  const { trackPopularSpeciesClick } = useSpeciesSelectorAnalytics();
 
   const committedItemsSet = useMemo(() => {
     return new Set(committedItems.map((item) => item.species_taxonomy_id));
@@ -42,6 +44,7 @@ const PopularSpeciesList = () => {
   const onPopularSpeciesButtonClick = (species: PopularSpecies) => {
     dispatch(setPopularSpecies(species));
     dispatch(setModalView('popular-species-genomes'));
+    trackPopularSpeciesClick(species);
   };
 
   return (

--- a/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx
+++ b/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx
@@ -29,7 +29,7 @@ import styles from './SpeciesSearchField.module.css';
 
 export type Props = {
   query: string;
-  onSearchSubmit: () => void;
+  onSearchSubmit: (query: string) => void | (() => void);
   canSubmit?: boolean;
   onInput?: ((event: FormEvent<HTMLInputElement>) => void) | (() => void);
 };
@@ -39,7 +39,7 @@ export const SpeciesSearchField = (props: Props) => {
 
   const onSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    props.onSearchSubmit();
+    props.onSearchSubmit(query);
   };
 
   return (

--- a/src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics.ts
+++ b/src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics.ts
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 
-import { useSelector } from 'react-redux';
-
 import analyticsTracking from 'src/services/analytics-service';
 
 import { getSpeciesAnalyticsName } from 'src/content/app/species-selector/speciesSelectorHelper';
-import { getCommittedSpecies } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors';
 
 import { AppName } from 'src/global/globalConfig';
 import type { PopularSpecies } from 'src/content/app/species-selector/types/popularSpecies';
 import type { AnalyticsOptions } from 'src/analyticsHelper';
 
 const useSpeciesSelectorAnalytics = () => {
-  const committedSpecies = useSelector(getCommittedSpecies);
-
   const trackEvent = (params: AnalyticsOptions) => {
     analyticsTracking.trackEvent({
       ...params,
@@ -54,14 +49,13 @@ const useSpeciesSelectorAnalytics = () => {
     });
   };
 
-  const trackTotalSelectedGenomesCount = (numSpeciesToCommit: number) => {
-    const alreadyCommittedSpeciesCount = committedSpecies.length;
-    const newCount = alreadyCommittedSpeciesCount + numSpeciesToCommit;
+  const trackTotalSelectedGenomesCount = (genomesCount: number) => {
+    // NOTE: genomesCount includes both already committed genomes and the newly added genomes
 
     trackEvent({
       category: 'species_selector',
       action: 'total_species_count',
-      value: newCount
+      value: genomesCount
     });
   };
 

--- a/src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics.ts
+++ b/src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics.ts
@@ -1,0 +1,87 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useSelector } from 'react-redux';
+
+import analyticsTracking from 'src/services/analytics-service';
+
+import { getSpeciesAnalyticsName } from 'src/content/app/species-selector/speciesSelectorHelper';
+import { getCommittedSpecies } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors';
+
+import { AppName } from 'src/global/globalConfig';
+import type { PopularSpecies } from 'src/content/app/species-selector/types/popularSpecies';
+import type { AnalyticsOptions } from 'src/analyticsHelper';
+
+const useSpeciesSelectorAnalytics = () => {
+  const committedSpecies = useSelector(getCommittedSpecies);
+
+  const trackEvent = (params: AnalyticsOptions) => {
+    analyticsTracking.trackEvent({
+      ...params,
+      app: AppName.SPECIES_SELECTOR
+    });
+  };
+
+  /*  Species Selector Page Events */
+  const trackSpeciesSearchQuery = (query: string) => {
+    trackEvent({
+      category: 'species_selector',
+      action: 'search',
+      value: query
+    });
+  };
+
+  const trackPopularSpeciesClick = (species: PopularSpecies) => {
+    const speciesNameForAnalytics = `${species.name} - ${species.species_taxonomy_id}`;
+
+    trackEvent({
+      category: 'popular_species',
+      action: 'preselect',
+      label: speciesNameForAnalytics
+    });
+  };
+
+  const trackTotalSelectedGenomesCount = (numSpeciesToCommit: number) => {
+    const alreadyCommittedSpeciesCount = committedSpecies.length;
+    const newCount = alreadyCommittedSpeciesCount + numSpeciesToCommit;
+
+    trackEvent({
+      category: 'species_selector',
+      action: 'total_species_count',
+      value: newCount
+    });
+  };
+
+  const trackAddedGenome = (
+    genome: Parameters<typeof getSpeciesAnalyticsName>[0]
+  ) => {
+    const nameFprAnalytics = getSpeciesAnalyticsName(genome);
+
+    trackEvent({
+      category: 'species_selector',
+      action: 'add',
+      value: nameFprAnalytics
+    });
+  };
+
+  return {
+    trackSpeciesSearchQuery,
+    trackAddedGenome,
+    trackPopularSpeciesClick,
+    trackTotalSelectedGenomesCount
+  };
+};
+export default useSpeciesSelectorAnalytics;

--- a/src/content/app/species-selector/speciesSelectorHelper.ts
+++ b/src/content/app/species-selector/speciesSelectorHelper.ts
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
+import { Pick2 } from 'ts-multipick';
+
 import type { CommittedItem } from 'src/content/app/species-selector/types/committedItem';
 
-export const getSpeciesAnalyticsName = (species: CommittedItem) => {
-  return `${species.common_name || species.scientific_name} - ${
-    species.assembly.name
-  }`;
+type GenomeDataForAnalytics = Pick<CommittedItem, 'scientific_name'> &
+  Pick2<CommittedItem, 'assembly', 'accession_id'>;
+
+export const getSpeciesAnalyticsName = (species: GenomeDataForAnalytics) => {
+  return `${species.scientific_name} - ${species.assembly.accession_id}`;
 };

--- a/src/content/app/species-selector/views/species-selector-main-view/SpeciesSelectorMainView.tsx
+++ b/src/content/app/species-selector/views/species-selector-main-view/SpeciesSelectorMainView.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 
 import { useAppDispatch } from 'src/store';
+import useSpeciesSelectorAnalytics from 'src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics';
 
 import { setModalView } from 'src/content/app/species-selector/state/species-selector-ui-slice/speciesSelectorUISlice';
 import { setPopularSpecies } from 'src/content/app/species-selector/state/species-selector-search-slice/speciesSelectorSearchSlice';
@@ -28,10 +29,12 @@ import styles from './SpeciesSelectorMainView.module.css';
 
 const SpeciesSelectorMainView = () => {
   const dispatch = useAppDispatch();
+  const { trackSpeciesSearchQuery } = useSpeciesSelectorAnalytics();
 
-  const onSearchSubmit = () => {
+  const onSearchSubmit = (query: string) => {
     dispatch(setPopularSpecies(null));
     dispatch(setModalView('species-search'));
+    trackSpeciesSearchQuery(query);
   };
 
   return (

--- a/src/content/app/species-selector/views/species-selector-results-view/SpeciesSelectorResultsView.tsx
+++ b/src/content/app/species-selector/views/species-selector-results-view/SpeciesSelectorResultsView.tsx
@@ -17,7 +17,9 @@
 import React from 'react';
 
 import { useAppDispatch, useAppSelector } from 'src/store';
+import useSpeciesSelectorAnalytics from 'src/content/app/species-selector/hooks/useSpeciesSelectorAnalytics';
 
+import { getCommittedSpecies } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors';
 import {
   getSpeciesSearchQuery,
   getSelectedPopularSpecies
@@ -55,10 +57,22 @@ const Content = (props: { onClose: () => void }) => {
   const modalView = useAppSelector(getSpeciesSelectorModalView);
   const query = useAppSelector(getSpeciesSearchQuery);
   const selectedPopularSpecies = useAppSelector(getSelectedPopularSpecies);
+  const committedSpecies = useAppSelector(getCommittedSpecies);
+
   const dispatch = useAppDispatch();
+  const { trackAddedGenome, trackTotalSelectedGenomesCount } =
+    useSpeciesSelectorAnalytics();
 
   const onSpeciesAdd = (genomes: SpeciesSearchMatch[]) => {
     dispatch(commitSelectedSpeciesAndSave(genomes));
+
+    // track which genomes were added and how many selected genomes user has as a result
+    const totalGenomesCount = committedSpecies.length + genomes.length;
+    trackTotalSelectedGenomesCount(totalGenomesCount);
+
+    for (const addedGenome of genomes) {
+      trackAddedGenome(addedGenome);
+    }
   };
 
   return modalView === 'species-search' ? (
@@ -69,6 +83,7 @@ const Content = (props: { onClose: () => void }) => {
     />
   ) : selectedPopularSpecies ? (
     <GenomeSelectorBySpeciesTaxonomyId
+      onSpeciesAdd={onSpeciesAdd}
       speciesTaxonomyId={selectedPopularSpecies.species_taxonomy_id}
       speciesImageUrl={selectedPopularSpecies.image}
     />

--- a/src/services/analytics-service.ts
+++ b/src/services/analytics-service.ts
@@ -66,7 +66,7 @@ class AnalyticsTracking {
     }
 
     if (options.value) {
-      eventParams.event_value = options.value;
+      eventParams.value = options.value;
     }
 
     if (options.species) {

--- a/src/services/google-analytics/index.ts
+++ b/src/services/google-analytics/index.ts
@@ -27,7 +27,7 @@ export type TrackEventParams = CustomDimensionsOptions & {
   event_action: string;
   event_category: string;
   event_label?: string;
-  event_value?: number;
+  value?: number | string;
 };
 
 /**

--- a/src/services/google-analytics/loadGoogleAnalytics.ts
+++ b/src/services/google-analytics/loadGoogleAnalytics.ts
@@ -58,7 +58,9 @@ const createGAShim = (trackerId: string) => {
   window.gtag('js', new Date()); // Google uses this for timing hits
 
   // It is better to disable sending pageviews automatically as it will trigger too many calls in genome browser
-  window.gtag('config', trackerId, { send_page_view: false });
+  if (trackerId) {
+    window.gtag('config', trackerId, { send_page_view: false });
+  }
 };
 
 const loadScript = (trackerId: string) => {


### PR DESCRIPTION
## Description
Adding back Google analytics to the Species Selector 😞 

- Tracking when the results table with genomes/assemblies has been shown because of a search term submission as opposed to popular species button click
- Tracking what genomes (assemblies) have been selected
- Tracking how many species lozenges the user will have after the selection (combining the number of the already present lozenges with the number of newly added)

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2390

## Deployment URL(s)
http://analytics-species-selector.review.ensembl.org