### PR TITLE
Add Variant image to Entity Viewer variant page

### DIFF
--- a/src/content/app/entity-viewer/components/example-links/ExampleLinks.module.css
+++ b/src/content/app/entity-viewer/components/example-links/ExampleLinks.module.css
@@ -1,9 +1,8 @@
 .exampleLinks {
-  margin-top: 50px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 40px;
   padding-left: 120px;
   padding-bottom: var(--global-padding-bottom);
-}
-
-.exampleLinks a {
-  margin-bottom: 30px;
 }

--- a/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
+++ b/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
@@ -175,7 +175,17 @@ const entityViewerThoasSlice = graphqlApiSlice.injectEndpoints({
         url: config.variationApiUrl,
         body: variantDefaultQuery,
         variables: params
-      })
+      }),
+      transformResponse: (response: EntityViewerVariantDefaultQueryResult) => {
+        response.variant.alleles = response.variant.alleles.map(
+          (allele, index) => ({
+            ...allele,
+            urlId: `${index}`
+          })
+        );
+
+        return response;
+      }
     })
   })
 });

--- a/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
+++ b/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
@@ -195,5 +195,6 @@ export const {
 
 export const {
   genePageMeta: fetchGenePageMeta,
-  variantPageMeta: fetchVariantPageMeta
+  variantPageMeta: fetchVariantPageMeta,
+  defaultEntityViewerVariant: fetchDefaultEntityViewerVariant
 } = entityViewerThoasSlice.endpoints;

--- a/src/content/app/entity-viewer/state/api/queries/variantDefaultQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/variantDefaultQuery.ts
@@ -97,6 +97,8 @@ type VariantDetailsAllele = Pick<
     population_frequencies: VariantDetailsAllelePopulationFrequency[];
     prediction_results: VariantDetailsAllelePredictionResult[];
     phenotype_assertions: VariantDetailsAllelePhenotypeAssertion[];
+  } & {
+    urlId: string; // a provisional field that is added during api response transformation; might be replaced by something better from Variation team later
   };
 
 type VariantDetailsAllelePopulationFrequency = Pick<

--- a/src/content/app/entity-viewer/state/api/queries/variantDefaultQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/variantDefaultQuery.ts
@@ -32,6 +32,7 @@ export const variantDefaultQuery = gql`
         location {
           start
           end
+          length
         }
         region {
           name
@@ -121,7 +122,7 @@ type VariantDetailsAllelePredictionResult = Pick<
   Pick2<VariantAllele['prediction_results'][number], 'analysis_method', 'tool'>;
 
 export type VariantDetails = Pick<Variant, 'name'> &
-  Pick3<Variant, 'slice', 'location', 'start' | 'end'> &
+  Pick3<Variant, 'slice', 'location', 'start' | 'end' | 'length'> &
   Pick3<Variant, 'slice', 'region', 'name'> &
   Pick2<Variant, 'allele_type', 'value'> &
   Pick2<Variant, 'primary_source', 'url'> &

--- a/src/content/app/entity-viewer/variant-view/VariantView.module.css
+++ b/src/content/app/entity-viewer/variant-view/VariantView.module.css
@@ -4,4 +4,6 @@
   display: grid;
   grid-template-rows: [navigation-panel] auto [view-specific-content] 1fr;
   height: 100%;
+  padding-left: var(--double-standard-gutter);
+  overflow: auto;
 }

--- a/src/content/app/entity-viewer/variant-view/VariantView.tsx
+++ b/src/content/app/entity-viewer/variant-view/VariantView.tsx
@@ -21,6 +21,8 @@ import useEntityViewerIds from 'src/content/app/entity-viewer/hooks/useEntityVie
 
 import { useDefaultEntityViewerVariantQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
 
+import VariantImage from './variant-image/VariantImage';
+
 import type { VariantAllele } from 'src/shared/types/variation-api/variantAllele';
 
 import styles from './VariantView.module.css';
@@ -51,13 +53,21 @@ const VariantView = () => {
 
   return (
     <div className={styles.container}>
-      {variantData && (
+      {activeGenomeId && variantId && variantData && (
         <>
-          <div style={{ height: '200px', textAlign: 'center' }}>
+          <div
+            style={{
+              height: '200px',
+              position: 'sticky',
+              top: '0',
+              backgroundColor: 'var(--color-black)',
+              textAlign: 'center'
+            }}
+          >
             Placeholder for navigation panel for variant {variantData.name}
           </div>
-          <div style={{ textAlign: 'center' }}>
-            Placeholder for the image for variant {variantData.name}
+          <div>
+            <VariantImage genomeId={activeGenomeId} variantId={variantId} />
           </div>
         </>
       )}
@@ -65,6 +75,7 @@ const VariantView = () => {
   );
 };
 
+// A hook for choosing an allele
 const useDefaultAlternativeAllele = (params: {
   genomeId?: string;
   variantId?: string;

--- a/src/content/app/entity-viewer/variant-view/VariantView.tsx
+++ b/src/content/app/entity-viewer/variant-view/VariantView.tsx
@@ -30,7 +30,7 @@ import type { VariantAllele } from 'src/shared/types/variation-api/variantAllele
 import styles from './VariantView.module.css';
 
 const VariantView = () => {
-  const { activeGenomeId, genomeIdForUrl, entityIdForUrl, parsedEntityId } =
+  const { activeGenomeId, genomeIdForUrl, parsedEntityId } =
     useEntityViewerIds();
   const navigate = useNavigate();
   const { search: urlQuery } = useLocation();
@@ -52,7 +52,7 @@ const VariantView = () => {
 
   useDefaultAlternativeAllele({
     genomeId: genomeIdForUrl,
-    variantId: entityIdForUrl,
+    variantId,
     alleleIdInUrl,
     variant: variantData
   });

--- a/src/content/app/entity-viewer/variant-view/VariantView.tsx
+++ b/src/content/app/entity-viewer/variant-view/VariantView.tsx
@@ -23,6 +23,7 @@ import useEntityViewerIds from 'src/content/app/entity-viewer/hooks/useEntityVie
 
 import { useDefaultEntityViewerVariantQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
 
+import VariantViewNavigationPanel from './variant-view-navigation-panel/VariantViewNavigationPanel';
 import VariantImage from './variant-image/VariantImage';
 
 import type { VariantAllele } from 'src/shared/types/variation-api/variantAllele';
@@ -70,25 +71,17 @@ const VariantView = () => {
     <div className={styles.container}>
       {activeGenomeId && variantId && variantData && (
         <>
-          <div
-            style={{
-              height: '200px',
-              position: 'sticky',
-              top: '0',
-              backgroundColor: 'var(--color-black)',
-              textAlign: 'center'
-            }}
-          >
-            Placeholder for navigation panel for variant {variantData.name}
-          </div>
-          <div>
-            <VariantImage
-              genomeId={activeGenomeId}
-              variantId={variantId}
-              activeAlleleId={alleleIdInUrl || ''}
-              onAlleleChange={onAlleleChange}
-            />
-          </div>
+          <VariantViewNavigationPanel
+            genomeId={activeGenomeId}
+            variantId={variantId}
+            activeAlleleId={alleleIdInUrl || ''}
+          />
+          <VariantImage
+            genomeId={activeGenomeId}
+            variantId={variantId}
+            activeAlleleId={alleleIdInUrl || ''}
+            onAlleleChange={onAlleleChange}
+          />
         </>
       )}
     </div>

--- a/src/content/app/entity-viewer/variant-view/variant-image/VariantImage.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-image/VariantImage.module.css
@@ -1,0 +1,80 @@
+.container {
+  --chevrons-block-width: 165px; /* the block of right-pointing chevrons to the left of reference sequence, indicating forward strand */
+  height: 100%;
+  background:
+    repeating-linear-gradient(to bottom, var(--color-orange) 0 4px, transparent 4px 8px);
+  background-size: 1px 100%;
+  background-position: calc(var(--chevrons-block-width) + var(--nucleotides-offset) * 16px - 1px);
+  background-repeat: no-repeat;
+  padding-bottom: var(--global-padding-bottom);
+}
+
+.referenceSequenceBlock {
+  display: grid;
+  grid-template-areas:
+    '. . variant-start .'
+    '. reference-sequence-label variant-name view-in'
+    'chevrons sequence sequence .'
+    '. . strand-label .';
+  grid-template-columns: var(--chevrons-block-width) calc(var(--nucleotides-offset) * 16px) max-content auto;
+}
+
+
+.chevrons {
+  --chevron-fill: #485967;
+  grid-area: chevrons;
+  align-self: center;
+  display: inline-flex;
+  justify-content: space-between;
+  width: var(--chevrons-block-width);
+  padding-right: 24px;
+}
+
+.variantStartLabel {
+  grid-area: variant-start;
+  display: inline-flex;
+  height: 36px;
+  align-items: flex-start;
+  margin-top: 30px;
+  font-size: 11px;
+  font-family: var(--font-family-monospace);
+  margin-left: 8px; /* half the letter block width */
+}
+
+.referenceSequenceLabel {
+  grid-area: reference-sequence-label;
+  line-height: 1;
+  font-weight: var(--font-weight-light);
+  font-size: 11px;
+}
+
+.variantInfo {
+  grid-area: variant-name;
+  margin-left: 8px; /* half the letter block width */
+  display: inline-flex;
+  height: 36px;
+  align-items: flex-start;
+}
+
+.variantName {
+  font-weight: var(--font-weight-bold);
+  font-size: 12px;
+  padding-right: 12px;
+}
+
+.variantType {
+  font-weight: var(--font-weight-light);
+  font-size: 11px;
+}
+
+.referenceSequence {
+  grid-area: sequence;
+}
+
+.strandLabel {
+  grid-area: strand-label;
+  font-weight: var(--font-weight-light);
+  font-size: 11px;
+  justify-self: end;
+  margin-top: 14px;
+}

--- a/src/content/app/entity-viewer/variant-view/variant-image/VariantImage.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-image/VariantImage.tsx
@@ -1,0 +1,178 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import useVariantImageData from './useVariantImageData';
+
+import FlankingSequence from './flanking-sequence/FlankingSequence';
+import ReferenceSequenceAllele from './reference-sequence-allele/ReferenceSequenceAllele';
+import AlternativeAlleles from './alternative-alleles/AlternativeAlleles';
+import Chevron from 'src/shared/components/chevron/Chevron';
+
+import type { VariantDetails } from 'src/content/app/entity-viewer/state/api/queries/variantDefaultQuery';
+
+import styles from './VariantImage.module.css';
+
+type Props = {
+  genomeId: string;
+  variantId: string;
+};
+
+const VariantImage = (props: Props) => {
+  const { genomeId, variantId } = props;
+  const { currentData } = useVariantImageData({
+    genomeId,
+    variantId
+  });
+
+  if (!currentData) {
+    return null;
+  }
+
+  const {
+    referenceSequence,
+    variant,
+    regionLength,
+    regionName,
+    regionSliceStart,
+    regionSliceEnd,
+    variantStart, // accounts for anchor base in appropriate variant types
+    variantEnd,
+    variantLength, // accounts for anchor base in appropriate variant types
+    hasAnchorBase
+  } = currentData;
+
+  const distanceToVariantStart = variantStart - regionSliceStart;
+
+  const containerStyles = {
+    ['--nucleotides-offset' as string]: `${distanceToVariantStart}`
+  };
+
+  return (
+    <div className={styles.container} style={containerStyles}>
+      <ReferenceSequence
+        referenceSequence={referenceSequence}
+        regionSliceStart={regionSliceStart}
+        regionSliceEnd={regionSliceEnd}
+        variantStart={variantStart}
+        variantEnd={variantEnd}
+        variantLength={variantLength}
+        hasAnchorBase={hasAnchorBase}
+        regionName={regionName}
+        regionLength={regionLength}
+        variant={variant}
+      />
+      <AlternativeAlleles
+        variant={variant}
+        variantLength={variantLength}
+        regionSliceStart={regionSliceStart}
+        hasAnchorBase={hasAnchorBase}
+        variantStart={variantStart}
+      />
+    </div>
+  );
+};
+
+const ReferenceSequence = (props: {
+  referenceSequence: string;
+  regionSliceStart: number;
+  regionSliceEnd: number;
+  variantStart: number;
+  variantEnd: number;
+  variantLength: number;
+  hasAnchorBase: boolean;
+  regionName: string;
+  regionLength: number;
+  variant: VariantDetails;
+}) => {
+  const {
+    referenceSequence,
+    regionSliceStart,
+    regionSliceEnd,
+    variantStart, // accounts for anchor base in appropriate variant types
+    variantLength, // accounts for anchor base in appropriate variant types
+    regionName,
+    regionLength,
+    hasAnchorBase,
+    variant
+  } = props;
+
+  const {
+    name: variantName,
+    allele_type: { value: variantType },
+    slice: {
+      location: { start: variantLocationStart }
+    }
+  } = variant;
+
+  const distanceToVariantStart = variantStart - regionSliceStart;
+  const leftFlankingSequence = referenceSequence.slice(
+    0,
+    distanceToVariantStart
+  );
+  const hasEllipsisAtStart = regionSliceStart > 1;
+
+  const rightFlankingSequence = referenceSequence.slice(
+    distanceToVariantStart + variantLength
+  );
+  const hasEllipsisAtEnd = regionSliceEnd < regionLength;
+
+  return (
+    <div className={styles.referenceSequenceBlock}>
+      <div className={styles.variantStartLabel}>
+        {`${regionName}:${variantLocationStart}`}
+      </div>
+      <div className={styles.referenceSequenceLabel}>Reference sequence</div>
+      <div className={styles.variantInfo}>
+        <div>
+          <span className={styles.variantName}>{variantName}</span>
+          <span className={styles.variantType}>{variantType}</span>
+        </div>
+      </div>
+      <div className={styles.strandLabel}>forward strand</div>
+      <ForwardStrandChevrons />
+      <div className={styles.referenceSequence}>
+        <FlankingSequence
+          sequence={leftFlankingSequence}
+          hasEllipsisAtStart={hasEllipsisAtStart}
+        />
+        <ReferenceSequenceAllele
+          sequence={referenceSequence}
+          regionSliceStart={regionSliceStart}
+          variantStart={variantStart}
+          variantLength={variantLength}
+          variantType={variantType}
+          hasAnchorBase={hasAnchorBase}
+        />
+        <FlankingSequence
+          sequence={rightFlankingSequence}
+          hasEllipsisAtEnd={hasEllipsisAtEnd}
+        />
+      </div>
+    </div>
+  );
+};
+
+const ForwardStrandChevrons = () => {
+  const chevrons = [...Array(5)].map((_, index) => (
+    <Chevron key={index} direction="right" />
+  ));
+
+  return <div className={styles.chevrons}>{chevrons}</div>;
+};
+
+export default VariantImage;

--- a/src/content/app/entity-viewer/variant-view/variant-image/VariantImage.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-image/VariantImage.tsx
@@ -16,6 +16,11 @@
 
 import React from 'react';
 
+import {
+  getReferenceAndAltAlleles,
+  getMostSevereVariantConsequence
+} from 'src/shared/helpers/variantHelpers';
+
 import useVariantImageData from './useVariantImageData';
 
 import FlankingSequence from './flanking-sequence/FlankingSequence';
@@ -30,10 +35,13 @@ import styles from './VariantImage.module.css';
 type Props = {
   genomeId: string;
   variantId: string;
+  activeAlleleId: string;
+  onAlleleChange: (alleleId: string) => void;
 };
 
 const VariantImage = (props: Props) => {
-  const { genomeId, variantId } = props;
+  const { genomeId, variantId, activeAlleleId, onAlleleChange } = props;
+
   const { currentData } = useVariantImageData({
     genomeId,
     variantId
@@ -56,6 +64,11 @@ const VariantImage = (props: Props) => {
     hasAnchorBase
   } = currentData;
 
+  const { referenceAllele, alternativeAlleles } = getReferenceAndAltAlleles(
+    variant.alleles
+  );
+  const mostSevereConsequence = getMostSevereVariantConsequence(variant);
+
   const distanceToVariantStart = variantStart - regionSliceStart;
 
   const containerStyles = {
@@ -75,13 +88,20 @@ const VariantImage = (props: Props) => {
         regionName={regionName}
         regionLength={regionLength}
         variant={variant}
+        referenceAllele={referenceAllele as VariantDetails['alleles'][number]}
+        activeAlleleId={activeAlleleId}
+        mostSevereConsequence={mostSevereConsequence}
+        onAlleleClick={() => onAlleleChange(referenceAllele?.urlId || '')}
       />
       <AlternativeAlleles
-        variant={variant}
+        alleles={alternativeAlleles}
         variantLength={variantLength}
         regionSliceStart={regionSliceStart}
         hasAnchorBase={hasAnchorBase}
         variantStart={variantStart}
+        activeAlleleId={activeAlleleId}
+        mostSevereConsequence={mostSevereConsequence}
+        onAlleleClick={onAlleleChange}
       />
     </div>
   );
@@ -98,6 +118,10 @@ const ReferenceSequence = (props: {
   regionName: string;
   regionLength: number;
   variant: VariantDetails;
+  referenceAllele: VariantDetails['alleles'][number];
+  activeAlleleId: string;
+  mostSevereConsequence: string;
+  onAlleleClick: () => void;
 }) => {
   const {
     referenceSequence,
@@ -108,7 +132,11 @@ const ReferenceSequence = (props: {
     regionName,
     regionLength,
     hasAnchorBase,
-    variant
+    variant,
+    referenceAllele,
+    activeAlleleId,
+    mostSevereConsequence,
+    onAlleleClick
   } = props;
 
   const {
@@ -118,6 +146,8 @@ const ReferenceSequence = (props: {
       location: { start: variantLocationStart }
     }
   } = variant;
+
+  const isSelectedAllele = referenceAllele.urlId === activeAlleleId;
 
   const distanceToVariantStart = variantStart - regionSliceStart;
   const leftFlankingSequence = referenceSequence.slice(
@@ -156,7 +186,10 @@ const ReferenceSequence = (props: {
           variantStart={variantStart}
           variantLength={variantLength}
           variantType={variantType}
+          mostSevereConsequence={mostSevereConsequence}
           hasAnchorBase={hasAnchorBase}
+          isSelectedAllele={isSelectedAllele}
+          onClick={onAlleleClick}
         />
         <FlankingSequence
           sequence={rightFlankingSequence}

--- a/src/content/app/entity-viewer/variant-view/variant-image/alternative-allele/AlternativeAllele.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-image/alternative-allele/AlternativeAllele.module.css
@@ -1,0 +1,8 @@
+.allele {
+  --sequence-block-letter-color: var(--color-black);
+  justify-self: start;
+}
+
+.letterBlock + .letterBlock {
+  margin-left: 1px;
+}

--- a/src/content/app/entity-viewer/variant-view/variant-image/alternative-allele/AlternativeAllele.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-image/alternative-allele/AlternativeAllele.tsx
@@ -16,6 +16,11 @@
 
 import React from 'react';
 
+import {
+  DISPLAYED_REFERENCE_SEQUENCE_LENGTH,
+  MAX_REFERENCE_ALLELE_DISPLAY_LENGTH
+} from '../variantImageConstants';
+
 import SequenceLetterBlock from '../sequence-letter-block/SequenceLetterBlock';
 
 import variantGroups from 'src/content/app/genome-browser/constants/variantGroups';
@@ -48,14 +53,12 @@ const AlternativeAllele = (props: Props) => {
     sequence = sequence.slice(1); // exclude the first (anchor) base of the allele
   }
 
-  const maxReferenceSequenceLength = 41; // FIXME: import this as a constant from another file
-
   // Maximum alt allele display length is dynamic, and depends on where the variant starts
-  // Alt alleles are allowed to exceed the length of the remaining reference sequence (after variant start)
-  // by five nucleotides
+  // Alt alleles are allowed to exceed the length of the remaining reference sequence
+  // (to the right of variant start) by five nucleotides
   const distanceToVariantStart = variantStart - regionSliceStart;
   const maxAlternativeAlleleLength =
-    maxReferenceSequenceLength - distanceToVariantStart + 5;
+    DISPLAYED_REFERENCE_SEQUENCE_LENGTH - distanceToVariantStart + 5;
 
   const sequenceLetters = sequence
     .split('')
@@ -84,7 +87,6 @@ const AlternativeAllele = (props: Props) => {
     : sequenceLetterStyle;
 
   if (alleleType === 'deletion') {
-    // for deletion, do not count the first (anchor) base of the reference sequence
     return (
       <Deletion
         variantLength={variantLength}
@@ -116,9 +118,8 @@ const Deletion = (props: {
   letterStyle: Record<string, string>;
 }) => {
   const { variantLength, letterStyle } = props;
-  const maxReferenceAlleleDisplayLength = 21; // FIXME: use imported constant
 
-  if (variantLength <= maxReferenceAlleleDisplayLength) {
+  if (variantLength <= MAX_REFERENCE_ALLELE_DISPLAY_LENGTH) {
     const letterBlocks = [...Array(variantLength)].map((_, index) => (
       <SequenceLetterBlock
         key={index}

--- a/src/content/app/entity-viewer/variant-view/variant-image/alternative-allele/AlternativeAllele.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-image/alternative-allele/AlternativeAllele.tsx
@@ -1,0 +1,194 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import SequenceLetterBlock from '../sequence-letter-block/SequenceLetterBlock';
+
+import variantGroups from 'src/content/app/genome-browser/constants/variantGroups';
+
+import styles from './AlternativeAllele.module.css';
+
+type Props = {
+  regionSliceStart: number;
+  variantStart: number; // accounts for anchor base in appropriate variant types
+  variantLength: number; // length of reference allele; accounts for anchor base in appropriate variant types
+  alleleType: string;
+  sequence: string;
+  mostSevereConsequence: string;
+  hasAnchorBase: boolean;
+  // onClick: () => void;
+};
+
+const AlternativeAllele = (props: Props) => {
+  const {
+    variantStart,
+    regionSliceStart,
+    alleleType,
+    variantLength,
+    hasAnchorBase,
+    mostSevereConsequence
+  } = props;
+  let { sequence } = props;
+
+  if (hasAnchorBase) {
+    sequence = sequence.slice(1); // exclude the first (anchor) base of the allele
+  }
+
+  const maxReferenceSequenceLength = 41; // FIXME: import this as a constant from another file
+
+  // Maximum alt allele display length is dynamic, and depends on where the variant starts
+  // Alt alleles are allowed to exceed the length of the remaining reference sequence (after variant start)
+  // by five nucleotides
+  const distanceToVariantStart = variantStart - regionSliceStart;
+  const maxAlternativeAlleleLength =
+    maxReferenceSequenceLength - distanceToVariantStart + 5;
+
+  const sequenceLetters = sequence
+    .split('')
+    .slice(0, maxAlternativeAlleleLength);
+  const shouldShowEllipsis = sequence.length > maxAlternativeAlleleLength;
+
+  if (shouldShowEllipsis) {
+    sequenceLetters[sequenceLetters.length - 1] = '…';
+  }
+
+  const colourId = colourToIdMap.get(mostSevereConsequence);
+  const defaultLetterColour = 'var(--color-grey)'; // this is a fallback colour that should never be displayed if everything is working correctly
+  const letterColour = colourId
+    ? colours.get(colourId) ?? defaultLetterColour
+    : defaultLetterColour;
+
+  const sequenceLetterStyle = {
+    ['--sequence-block-color' as string]: letterColour
+  };
+  // if the sequence should end in ellipsis, make the letter block transparent
+  const lastSequenceLetterStyle = shouldShowEllipsis
+    ? {
+        ['--sequence-block-color' as string]: 'transparent',
+        ['--sequence-block-letter-color' as string]: letterColour
+      }
+    : sequenceLetterStyle;
+
+  if (alleleType === 'deletion') {
+    // for deletion, do not count the first (anchor) base of the reference sequence
+    return (
+      <Deletion
+        variantLength={variantLength}
+        letterStyle={sequenceLetterStyle}
+      />
+    );
+  } else {
+    return (
+      <button className={styles.allele}>
+        {sequenceLetters.map((letter, index) => (
+          <SequenceLetterBlock
+            key={index}
+            letter={letter}
+            style={
+              index === sequenceLetters.length - 1
+                ? lastSequenceLetterStyle
+                : sequenceLetterStyle
+            }
+            className={styles.letterBlock}
+          />
+        ))}
+      </button>
+    );
+  }
+};
+
+const Deletion = (props: {
+  variantLength: number; // length of the reference allele, including the "anchor" nucleotide
+  letterStyle: Record<string, string>;
+}) => {
+  const { variantLength, letterStyle } = props;
+  const maxReferenceAlleleDisplayLength = 21; // FIXME: use imported constant
+
+  if (variantLength <= maxReferenceAlleleDisplayLength) {
+    const letterBlocks = [...Array(variantLength)].map((_, index) => (
+      <SequenceLetterBlock
+        key={index}
+        letter="-"
+        style={letterStyle}
+        className={styles.letterBlock}
+      />
+    ));
+    return <button className={styles.allele}>{letterBlocks}</button>;
+  } else {
+    const flankingBlocksCount = 8;
+    const blocksGapCount = 5;
+
+    const gapLetterStyle: Record<string, string> = {
+      '--sequence-block-letter-color': letterStyle['--sequence-block-color'],
+      '--sequence-block-color': 'transparent'
+    };
+
+    const sequenceLeft = Array(flankingBlocksCount).fill('-').join('');
+    const sequenceMid = Array(blocksGapCount).fill('-').join('');
+    const sequenceRight = Array(flankingBlocksCount).fill('-').join('');
+
+    return (
+      <button className={styles.allele}>
+        <Sequence sequence={sequenceLeft} letterStyle={letterStyle} />
+        <Sequence sequence={sequenceMid} letterStyle={gapLetterStyle} />
+        <Sequence sequence={sequenceRight} letterStyle={letterStyle} />
+      </button>
+    );
+  }
+};
+
+const Sequence = (props: {
+  sequence: string;
+  letterStyle: Record<string, string>;
+}) => {
+  return props.sequence
+    .split('')
+    .map((letter, index) => (
+      <SequenceLetterBlock
+        key={index}
+        letter={letter}
+        style={props.letterStyle}
+        className={styles.letterBlock}
+      />
+    ));
+};
+
+const colours = new Map([
+  [1, 'var(--color-dark-pink)'],
+  [2, 'var(--color-dark-yellow)'],
+  [3, 'var(--color-lime)'],
+  [4, 'var(--color-teal)'],
+  [5, 'var(--color-duckegg-blue)']
+]);
+
+// FIXME: copied the lines below from VariantColour component.
+// Should move this to a common file
+const buildColourToIdMap = () => {
+  const colourMap = new Map<string, number>();
+
+  for (const group of variantGroups) {
+    for (const variantType of group.variant_types) {
+      colourMap.set(variantType.label, group.id);
+    }
+  }
+
+  return colourMap;
+};
+
+const colourToIdMap = buildColourToIdMap();
+
+export default AlternativeAllele;

--- a/src/content/app/entity-viewer/variant-view/variant-image/alternative-alleles/AlternativeAlleles.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-image/alternative-alleles/AlternativeAlleles.module.css
@@ -1,0 +1,24 @@
+.grid {
+  display: grid;
+  grid-template-columns: [left] calc(var(--nucleotides-offset) * 16px) [right] max-content;
+  row-gap: 6px;
+  margin-top: 40px;
+  margin-left: var(--chevrons-block-width);
+}
+
+.left {
+  grid-column: left;
+  display: flex;
+  justify-content: flex-end;
+  padding-right: 12px;
+  gap: 12px;
+}
+
+.label {
+  font-size: 11px;
+  font-weight: var(--font-weight-light);
+}
+
+.alleleLength {
+  font-size: 11px;
+}

--- a/src/content/app/entity-viewer/variant-view/variant-image/alternative-alleles/AlternativeAlleles.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-image/alternative-alleles/AlternativeAlleles.tsx
@@ -16,8 +16,6 @@
 
 import React, { type ReactNode } from 'react';
 
-import { getReferenceAndAltAlleles } from 'src/shared/helpers/variantHelpers';
-
 import AlternativeAllele from '../alternative-allele/AlternativeAllele';
 
 import type { VariantDetails } from 'src/content/app/entity-viewer/state/api/queries/variantDefaultQuery';
@@ -25,31 +23,29 @@ import type { VariantDetails } from 'src/content/app/entity-viewer/state/api/que
 import styles from './AlternativeAlleles.module.css';
 
 type Props = {
-  variant: VariantDetails;
+  alleles: VariantDetails['alleles']; // a list of alternative alleles to render
   regionSliceStart: number;
   variantStart: number; // accounts for anchor base in appropriate variant types
   variantLength: number; // accounts for anchor base in appropriate variant types
   hasAnchorBase: boolean;
-  // onClick: () => void;
+  activeAlleleId: string;
+  mostSevereConsequence: string;
+  onAlleleClick: (alleleId: string) => void;
 };
 
 const AlternativeAlleles = (props: Props) => {
   const {
-    variant,
+    alleles,
     regionSliceStart,
     variantStart,
     variantLength,
-    hasAnchorBase
+    hasAnchorBase,
+    activeAlleleId,
+    mostSevereConsequence,
+    onAlleleClick
   } = props;
 
-  const { alternativeAlleles } = getReferenceAndAltAlleles(variant.alleles);
-
   const offsetInNucleotides = variantStart - regionSliceStart;
-
-  // there should always be a valid most severe consequence;
-  // but in case there isn't, fall back to a bogus string
-  const mostSevereConsequence =
-    getMostSevereVariantConsequence(variant) || 'unknown';
 
   const getAlleleLength = (sequenceLength: number, alleleType: string) => {
     if (alleleType === 'deletion') {
@@ -68,7 +64,7 @@ const AlternativeAlleles = (props: Props) => {
 
   return (
     <div className={styles.grid} style={gridStyles}>
-      {alternativeAlleles.map((allele, index) => (
+      {alleles.map((allele, index) => (
         <Row
           key={index}
           index={index}
@@ -79,13 +75,14 @@ const AlternativeAlleles = (props: Props) => {
         >
           <AlternativeAllele
             key={index}
-            alleleType={allele.allele_type.value}
-            sequence={allele.allele_sequence}
+            allele={allele}
             regionSliceStart={regionSliceStart}
             variantStart={variantStart}
             variantLength={variantLength}
             hasAnchorBase={hasAnchorBase}
             mostSevereConsequence={mostSevereConsequence}
+            activeAlleleId={activeAlleleId}
+            onClick={onAlleleClick}
           />
         </Row>
       ))}
@@ -110,26 +107,6 @@ const Row = (props: {
       {children}
     </>
   );
-};
-
-// FIXME: this is copied from VariantConsequence file; should move into a common file
-const getMostSevereVariantConsequence = <
-  T extends {
-    analysis_method: {
-      tool: string;
-    };
-    result: string | null;
-  }
->({
-  prediction_results: predictionResults
-}: {
-  prediction_results: T[];
-}) => {
-  const consequencePrediction = predictionResults.find(
-    ({ analysis_method }) => analysis_method.tool === 'Ensembl VEP'
-  );
-
-  return consequencePrediction?.result;
 };
 
 export default AlternativeAlleles;

--- a/src/content/app/entity-viewer/variant-view/variant-image/alternative-alleles/AlternativeAlleles.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-image/alternative-alleles/AlternativeAlleles.tsx
@@ -1,0 +1,135 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { type ReactNode } from 'react';
+
+import { getReferenceAndAltAlleles } from 'src/shared/helpers/variantHelpers';
+
+import AlternativeAllele from '../alternative-allele/AlternativeAllele';
+
+import type { VariantDetails } from 'src/content/app/entity-viewer/state/api/queries/variantDefaultQuery';
+
+import styles from './AlternativeAlleles.module.css';
+
+type Props = {
+  variant: VariantDetails;
+  regionSliceStart: number;
+  variantStart: number; // accounts for anchor base in appropriate variant types
+  variantLength: number; // accounts for anchor base in appropriate variant types
+  hasAnchorBase: boolean;
+  // onClick: () => void;
+};
+
+const AlternativeAlleles = (props: Props) => {
+  const {
+    variant,
+    regionSliceStart,
+    variantStart,
+    variantLength,
+    hasAnchorBase
+  } = props;
+
+  const { alternativeAlleles } = getReferenceAndAltAlleles(variant.alleles);
+
+  const offsetInNucleotides = variantStart - regionSliceStart;
+
+  // there should always be a valid most severe consequence;
+  // but in case there isn't, fall back to a bogus string
+  const mostSevereConsequence =
+    getMostSevereVariantConsequence(variant) || 'unknown';
+
+  const getAlleleLength = (sequenceLength: number, alleleType: string) => {
+    if (alleleType === 'deletion') {
+      return 0;
+    } else if (alleleType === 'insertion' || alleleType === 'indel') {
+      return sequenceLength - 1; // subtract the first nucleotide, which is the anchor base
+    } else {
+      return sequenceLength;
+    }
+  };
+
+  // FIXME: can this only be on the parent container?
+  const gridStyles = {
+    ['--nucleotides-offset' as string]: `${offsetInNucleotides}`
+  };
+
+  return (
+    <div className={styles.grid} style={gridStyles}>
+      {alternativeAlleles.map((allele, index) => (
+        <Row
+          key={index}
+          index={index}
+          alleleLength={getAlleleLength(
+            allele.allele_sequence.length,
+            allele.allele_type.value
+          )}
+        >
+          <AlternativeAllele
+            key={index}
+            alleleType={allele.allele_type.value}
+            sequence={allele.allele_sequence}
+            regionSliceStart={regionSliceStart}
+            variantStart={variantStart}
+            variantLength={variantLength}
+            hasAnchorBase={hasAnchorBase}
+            mostSevereConsequence={mostSevereConsequence}
+          />
+        </Row>
+      ))}
+    </div>
+  );
+};
+
+const Row = (props: {
+  index: number;
+  alleleLength: number;
+  children: ReactNode;
+}) => {
+  const { index, alleleLength, children } = props;
+  return (
+    <>
+      <div className={styles.left}>
+        {index === 0 && (
+          <span className={styles.label}>Alternative alleles</span>
+        )}
+        <span className={styles.alleleLength}>{alleleLength}</span>
+      </div>
+      {children}
+    </>
+  );
+};
+
+// FIXME: this is copied from VariantConsequence file; should move into a common file
+const getMostSevereVariantConsequence = <
+  T extends {
+    analysis_method: {
+      tool: string;
+    };
+    result: string | null;
+  }
+>({
+  prediction_results: predictionResults
+}: {
+  prediction_results: T[];
+}) => {
+  const consequencePrediction = predictionResults.find(
+    ({ analysis_method }) => analysis_method.tool === 'Ensembl VEP'
+  );
+
+  return consequencePrediction?.result;
+};
+
+export default AlternativeAlleles;

--- a/src/content/app/entity-viewer/variant-view/variant-image/flanking-sequence/FlankingSequence.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-image/flanking-sequence/FlankingSequence.module.css
@@ -1,0 +1,5 @@
+.letter {
+  --sequence-block-color: transparent;
+  --sequence-block-letter-color: var(--color-medium-light-grey);
+  font-size: 11px;
+}

--- a/src/content/app/entity-viewer/variant-view/variant-image/flanking-sequence/FlankingSequence.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-image/flanking-sequence/FlankingSequence.tsx
@@ -1,0 +1,54 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import SequenceLetterBlock from '../sequence-letter-block/SequenceLetterBlock';
+
+import styles from './FlankingSequence.module.css';
+
+type Props = {
+  sequence: string;
+  hasEllipsisAtStart?: boolean;
+  hasEllipsisAtEnd?: boolean;
+};
+
+const FlankingSequence = (props: Props) => {
+  const { sequence, hasEllipsisAtStart, hasEllipsisAtEnd } = props;
+
+  const letters = sequence.split('');
+
+  if (hasEllipsisAtStart) {
+    letters[0] = '…';
+  }
+  if (hasEllipsisAtEnd) {
+    letters[letters.length - 1] = '…';
+  }
+
+  return (
+    <>
+      {letters.map((letter, index) => (
+        <SequenceLetterBlock
+          key={index}
+          letter={letter}
+          className={styles.letter}
+        />
+      ))}
+    </>
+  );
+};
+
+export default FlankingSequence;

--- a/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.module.css
@@ -1,0 +1,17 @@
+.letter {
+  --sequence-block-color: var(--color-blue);
+  --sequence-block-letter-color: var(--color-white);
+  font-size: 11px;
+}
+
+.letter + .letter {
+  margin-left: 1px;
+}
+
+.referenceSequenceGap {
+  display: inline-flex;
+  justify-content: space-around;
+  color: var(--color-white);
+  width: calc(5 * 16px + 5 * 1px); /* where 16px is width of a sequence letter block, and 1px is the gap width */
+  font-size: 11px;
+}

--- a/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.module.css
@@ -1,6 +1,4 @@
 .letter {
-  --sequence-block-color: var(--color-blue);
-  --sequence-block-letter-color: var(--color-white);
   font-size: 11px;
 }
 

--- a/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.tsx
@@ -17,7 +17,10 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { MAX_REFERENCE_ALLELE_DISPLAY_LENGTH } from '../variantImageConstants';
+import {
+  MAX_REFERENCE_ALLELE_DISPLAY_LENGTH,
+  MIN_FLANKING_SEQUENCE_LENGTH
+} from '../variantImageConstants';
 
 import { getVariantGroupCSSColour } from 'src/shared/helpers/variantHelpers';
 
@@ -112,11 +115,17 @@ const ReferenceSequenceAllele = (props: Props) => {
     const twoDotBlocks = [...Array(2)].map((_, index) => (
       <SequenceLetterBlock
         key={index}
-        letter={'.'}
+        letter="."
         className={letterBlockClasses}
+        style={sequenceLetterStyle}
       />
     ));
-    const missingSequenceLength = sequence.length - 20;
+
+    const visibleLetterBlocksCount = 16; // for the reference allele, image shows 8 letter blocks on either side of the gap
+    const missingSequenceLength =
+      sequence.length -
+      2 * MIN_FLANKING_SEQUENCE_LENGTH -
+      visibleLetterBlocksCount;
     const gap = <ReferenceSequenceGap gapLength={missingSequenceLength} />;
 
     return (
@@ -132,11 +141,14 @@ const ReferenceSequenceAllele = (props: Props) => {
 };
 
 const ReferenceSequenceGap = (props: { gapLength: number }) => {
+  const dotsCount = 4;
+  const remainingGap = props.gapLength - dotsCount;
+
   return (
     <div className={styles.referenceSequenceGap}>
       <span>.</span>
       <span>.</span>
-      <span>{props.gapLength}</span>
+      <span>{remainingGap}</span>
       <span>.</span>
       <span>.</span>
     </div>

--- a/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.tsx
@@ -1,0 +1,125 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import classNames from 'classnames';
+
+import SequenceLetterBlock from '../sequence-letter-block/SequenceLetterBlock';
+
+import styles from './ReferenceSequenceAllele.module.css';
+
+type Props = {
+  sequence: string;
+  regionSliceStart: number;
+  variantStart: number; // accounts for anchor base in appropriate variant types
+  variantLength: number; // accounts for anchor base in appropriate variant types
+  variantType: string;
+  hasAnchorBase: boolean;
+  // onClick
+  // isActiveAllele
+};
+
+const ReferenceSequenceAllele = (props: Props) => {
+  const {
+    sequence,
+    regionSliceStart,
+    variantStart,
+    variantLength,
+    variantType
+  } = props;
+
+  if (variantType === 'insertion') {
+    return null;
+  }
+
+  const maxVariantDisplayLength = 21; // FIXME: use imported constant
+
+  const shouldDisplayGap = variantLength > maxVariantDisplayLength;
+
+  const letterBlockClasses = classNames(styles.letter);
+
+  const sequenceSliceStart = variantStart - regionSliceStart;
+  const letters = sequence
+    .slice(sequenceSliceStart, sequenceSliceStart + variantLength)
+    .split('');
+
+  if (!shouldDisplayGap) {
+    return (
+      <button>
+        {letters.map((letter, index) => (
+          <SequenceLetterBlock
+            key={index}
+            letter={letter}
+            className={letterBlockClasses}
+          />
+        ))}
+      </button>
+    );
+  } else {
+    // show six nucleotides on both sides
+    const lettersLeft = letters
+      .slice(0, 6)
+      .map((letter, index) => (
+        <SequenceLetterBlock
+          key={index}
+          letter={letter}
+          className={letterBlockClasses}
+        />
+      ));
+    const lettersRight = letters
+      .slice(letters.length - 6)
+      .map((letter, index) => (
+        <SequenceLetterBlock
+          key={index}
+          letter={letter}
+          className={letterBlockClasses}
+        />
+      ));
+    const twoDotBlocks = [...Array(2)].map((_, index) => (
+      <SequenceLetterBlock
+        key={index}
+        letter={'.'}
+        className={letterBlockClasses}
+      />
+    ));
+    const missingSequenceLength = sequence.length - 20;
+    const gap = <ReferenceSequenceGap gapLength={missingSequenceLength} />;
+
+    return (
+      <button>
+        {lettersLeft}
+        {twoDotBlocks}
+        {gap}
+        {twoDotBlocks}
+        {lettersRight}
+      </button>
+    );
+  }
+};
+
+const ReferenceSequenceGap = (props: { gapLength: number }) => {
+  return (
+    <div className={styles.referenceSequenceGap}>
+      <span>.</span>
+      <span>.</span>
+      <span>{props.gapLength}</span>
+      <span>.</span>
+      <span>.</span>
+    </div>
+  );
+};
+
+export default ReferenceSequenceAllele;

--- a/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.tsx
@@ -17,6 +17,8 @@
 import React from 'react';
 import classNames from 'classnames';
 
+import { MAX_REFERENCE_ALLELE_DISPLAY_LENGTH } from '../variantImageConstants';
+
 import SequenceLetterBlock from '../sequence-letter-block/SequenceLetterBlock';
 
 import styles from './ReferenceSequenceAllele.module.css';
@@ -45,9 +47,7 @@ const ReferenceSequenceAllele = (props: Props) => {
     return null;
   }
 
-  const maxVariantDisplayLength = 21; // FIXME: use imported constant
-
-  const shouldDisplayGap = variantLength > maxVariantDisplayLength;
+  const shouldDisplayGap = variantLength > MAX_REFERENCE_ALLELE_DISPLAY_LENGTH;
 
   const letterBlockClasses = classNames(styles.letter);
 

--- a/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.tsx
@@ -19,6 +19,8 @@ import classNames from 'classnames';
 
 import { MAX_REFERENCE_ALLELE_DISPLAY_LENGTH } from '../variantImageConstants';
 
+import { getVariantGroupCSSColour } from 'src/shared/helpers/variantHelpers';
+
 import SequenceLetterBlock from '../sequence-letter-block/SequenceLetterBlock';
 
 import styles from './ReferenceSequenceAllele.module.css';
@@ -29,9 +31,10 @@ type Props = {
   variantStart: number; // accounts for anchor base in appropriate variant types
   variantLength: number; // accounts for anchor base in appropriate variant types
   variantType: string;
+  mostSevereConsequence: string;
   hasAnchorBase: boolean;
-  // onClick
-  // isActiveAllele
+  isSelectedAllele: boolean;
+  onClick: () => void;
 };
 
 const ReferenceSequenceAllele = (props: Props) => {
@@ -40,7 +43,10 @@ const ReferenceSequenceAllele = (props: Props) => {
     regionSliceStart,
     variantStart,
     variantLength,
-    variantType
+    variantType,
+    mostSevereConsequence,
+    isSelectedAllele,
+    onClick
   } = props;
 
   if (variantType === 'insertion') {
@@ -56,14 +62,27 @@ const ReferenceSequenceAllele = (props: Props) => {
     .slice(sequenceSliceStart, sequenceSliceStart + variantLength)
     .split('');
 
+  const defaultLetterColour = 'var(--color-grey)'; // this is a fallback colour that should never be displayed if everything is working correctly
+  const letterBlockColour = isSelectedAllele
+    ? getVariantGroupCSSColour(mostSevereConsequence) ?? defaultLetterColour
+    : 'var(--color-blue)';
+  const letterColour = isSelectedAllele
+    ? 'var(--color-black)'
+    : 'var(--color-white)';
+  const sequenceLetterStyle: Record<string, string> = {
+    '--sequence-block-color': letterBlockColour,
+    '--sequence-block-letter-color': letterColour
+  };
+
   if (!shouldDisplayGap) {
     return (
-      <button>
+      <button onClick={onClick} disabled={isSelectedAllele}>
         {letters.map((letter, index) => (
           <SequenceLetterBlock
             key={index}
             letter={letter}
             className={letterBlockClasses}
+            style={sequenceLetterStyle}
           />
         ))}
       </button>
@@ -77,6 +96,7 @@ const ReferenceSequenceAllele = (props: Props) => {
           key={index}
           letter={letter}
           className={letterBlockClasses}
+          style={sequenceLetterStyle}
         />
       ));
     const lettersRight = letters
@@ -86,6 +106,7 @@ const ReferenceSequenceAllele = (props: Props) => {
           key={index}
           letter={letter}
           className={letterBlockClasses}
+          style={sequenceLetterStyle}
         />
       ));
     const twoDotBlocks = [...Array(2)].map((_, index) => (
@@ -99,7 +120,7 @@ const ReferenceSequenceAllele = (props: Props) => {
     const gap = <ReferenceSequenceGap gapLength={missingSequenceLength} />;
 
     return (
-      <button>
+      <button onClick={onClick} disabled={isSelectedAllele}>
         {lettersLeft}
         {twoDotBlocks}
         {gap}

--- a/src/content/app/entity-viewer/variant-view/variant-image/sequence-letter-block/SequenceLetterBlock.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-image/sequence-letter-block/SequenceLetterBlock.module.css
@@ -1,0 +1,10 @@
+.block {
+  display: inline-flex;
+  height: 16px;
+  width: 16px;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--sequence-block-color, black);
+  color: var(--sequence-block-letter-color, white);
+  font-family: var(--font-family-monospace);
+}

--- a/src/content/app/entity-viewer/variant-view/variant-image/sequence-letter-block/SequenceLetterBlock.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-image/sequence-letter-block/SequenceLetterBlock.tsx
@@ -1,0 +1,39 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { type HTMLAttributes } from 'react';
+import classNames from 'classnames';
+
+import styles from './SequenceLetterBlock.module.css';
+
+type Props = HTMLAttributes<HTMLSpanElement> & {
+  letter: string;
+  className?: string;
+};
+
+const SequenceLetterBlock = (props: Props) => {
+  const { letter, className, ...otherProps } = props;
+
+  const componentClasses = classNames(styles.block, className);
+
+  return (
+    <span className={componentClasses} {...otherProps}>
+      {letter}
+    </span>
+  );
+};
+
+export default SequenceLetterBlock;

--- a/src/content/app/entity-viewer/variant-view/variant-image/useVariantImageData.test.ts
+++ b/src/content/app/entity-viewer/variant-view/variant-image/useVariantImageData.test.ts
@@ -1,0 +1,204 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { calculateSliceStart, calculateSliceEnd } from './useVariantImageData';
+
+describe('calculateSliceStart', () => {
+  describe('very short variants', () => {
+    test('for a variant with a length of 1 nucleotide', () => {
+      const sliceStart = calculateSliceStart({
+        variantStart: 101,
+        variantLength: 1
+      });
+
+      expect(sliceStart).toBe(81); // in 1-based coord system
+    });
+
+    test('for a variant with a length of 2 nucleotides', () => {
+      const sliceStart = calculateSliceStart({
+        variantStart: 101,
+        variantLength: 2
+      });
+
+      expect(sliceStart).toBe(81); // in 1-based coord system
+    });
+
+    test('for a variant with a length of 3 nucleotides', () => {
+      const sliceStart = calculateSliceStart({
+        variantStart: 100,
+        variantLength: 3
+      });
+
+      expect(sliceStart).toBe(81); // in 1-based coord system
+    });
+
+    test('for variant near region start', () => {
+      const sliceStart = calculateSliceStart({
+        variantStart: 3,
+        variantLength: 3
+      });
+
+      expect(sliceStart).toBe(1); // in 1-based coord system
+    });
+  });
+
+  describe('close to max display length without truncation', () => {
+    test('for a 20-nucleotide-long variant', () => {
+      const sliceStart = calculateSliceStart({
+        variantStart: 92,
+        variantLength: 20
+      });
+
+      expect(sliceStart).toBe(81); // in 1-based coord system
+    });
+
+    test('for a 21-nucleotide-long variant', () => {
+      const sliceStart = calculateSliceStart({
+        variantStart: 91,
+        variantLength: 21
+      });
+
+      expect(sliceStart).toBe(81); // in 1-based coord system
+    });
+  });
+
+  describe('variants longer than max display length', () => {
+    // NOTE: it should not matter how long the variant is;
+    // the start of the ref sequence is always 10 nucleotides before
+
+    test('for a 22-nucleotide-long variant', () => {
+      const sliceStart = calculateSliceStart({
+        variantStart: 91,
+        variantLength: 22
+      });
+
+      expect(sliceStart).toBe(81); // in 1-based coord system
+    });
+
+    test('for a 200-nucleotide-long variant', () => {
+      const sliceStart = calculateSliceStart({
+        variantStart: 91,
+        variantLength: 200
+      });
+
+      expect(sliceStart).toBe(81); // in 1-based coord system
+    });
+
+    test('for a 200-nucleotide-long variant near region start', () => {
+      const sliceStart = calculateSliceStart({
+        variantStart: 5,
+        variantLength: 200
+      });
+
+      expect(sliceStart).toBe(1); // never drop below the first nucleotide
+    });
+  });
+});
+
+describe('calculateSliceEnd', () => {
+  describe('very short variants', () => {
+    test('for a 1-nucleotide-long variant', () => {
+      const sliceEnd = calculateSliceEnd({
+        variantEnd: 101,
+        variantLength: 1,
+        regionLength: 1_000_000 // irrelevantly long
+      });
+
+      expect(sliceEnd).toBe(121); // in 1-based coord system
+    });
+
+    test('for a 2-nucleotide-long variant', () => {
+      // variant spans positions 101-102
+      const sliceEnd = calculateSliceEnd({
+        variantEnd: 102,
+        variantLength: 2,
+        regionLength: 1_000_000 // irrelevantly long
+      });
+
+      expect(sliceEnd).toBe(121); // in 1-based coord system
+    });
+
+    test('for a 3-nucleotide-long variant', () => {
+      // variant spans positions 100-102
+      const sliceEnd = calculateSliceEnd({
+        variantEnd: 102,
+        variantLength: 3,
+        regionLength: 1_000_000 // irrelevantly long
+      });
+
+      expect(sliceEnd).toBe(121); // in 1-based coord system
+    });
+  });
+
+  describe('close to max display length without truncation', () => {
+    test('for a 20-nucleotide-long variant', () => {
+      // variant spans positions 92-111
+      const sliceEnd = calculateSliceEnd({
+        variantEnd: 111,
+        variantLength: 20,
+        regionLength: 1_000_000 // irrelevantly long
+      });
+
+      expect(sliceEnd).toBe(121); // in 1-based coord system
+    });
+
+    test('for a 21-nucleotide-long variant', () => {
+      // variant spans positions 91-111
+      const sliceEnd = calculateSliceEnd({
+        variantEnd: 111,
+        variantLength: 21,
+        regionLength: 1_000_000 // irrelevantly long
+      });
+
+      expect(sliceEnd).toBe(121); // in 1-based coord system
+    });
+  });
+
+  describe('variants longer than max display length', () => {
+    test('for a 22-nucleotide-long variant', () => {
+      // variant spans positions 91-112
+      const sliceEnd = calculateSliceEnd({
+        variantEnd: 112,
+        variantLength: 22,
+        regionLength: 1_000_000 // irrelevantly long
+      });
+
+      expect(sliceEnd).toBe(122); // in 1-based coord system
+    });
+
+    test('for a 200-nucleotide-long variant', () => {
+      // variant spans positions 91-290
+      const sliceEnd = calculateSliceEnd({
+        variantEnd: 290,
+        variantLength: 200,
+        regionLength: 1_000_000 // irrelevantly long
+      });
+
+      expect(sliceEnd).toBe(300); // in 1-based coord system
+    });
+
+    test('for a 200-nucleotide-long variant near region end', () => {
+      // variant spans positions 91-290
+      const sliceEnd = calculateSliceEnd({
+        variantEnd: 290,
+        variantLength: 200,
+        regionLength: 295 // irrelevantly long
+      });
+
+      expect(sliceEnd).toBe(295); // in 1-based coord system
+    });
+  });
+});

--- a/src/content/app/entity-viewer/variant-view/variant-image/useVariantImageData.ts
+++ b/src/content/app/entity-viewer/variant-view/variant-image/useVariantImageData.ts
@@ -16,7 +16,11 @@
 
 import type { Pick2 } from 'ts-multipick';
 
-import { DISPLAYED_REFERENCE_SEQUENCE_LENGTH } from './variantImageConstants';
+import {
+  DISPLAYED_REFERENCE_SEQUENCE_LENGTH,
+  MAX_REFERENCE_ALLELE_DISPLAY_LENGTH,
+  MIN_FLANKING_SEQUENCE_LENGTH
+} from './variantImageConstants';
 
 import { useDefaultEntityViewerVariantQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
 import { useRegionChecksumQuery } from 'src/shared/state/region/regionApiSlice';
@@ -211,12 +215,9 @@ export const calculateSliceStart = (params: {
   const displaySequenceMidpoint = Math.ceil(
     DISPLAYED_REFERENCE_SEQUENCE_LENGTH / 2
   );
-  const minFlankingSequenceLength = 10;
-  const maxDisplayedVariantLength =
-    DISPLAYED_REFERENCE_SEQUENCE_LENGTH - 2 * minFlankingSequenceLength;
 
-  if (variantLength > maxDisplayedVariantLength) {
-    return Math.max(variantStart - minFlankingSequenceLength, 1);
+  if (variantLength > MAX_REFERENCE_ALLELE_DISPLAY_LENGTH) {
+    return Math.max(variantStart - MIN_FLANKING_SEQUENCE_LENGTH, 1);
   } else {
     const distanceToStart =
       variantLength % 2
@@ -234,17 +235,14 @@ export const calculateSliceEnd = (params: {
 }) => {
   const { variantEnd, variantLength, regionLength } = params;
 
-  const minFlankingSequenceLength = 10; // NOTE: think of ellipses
-  const maxDisplayedVariantLength =
-    DISPLAYED_REFERENCE_SEQUENCE_LENGTH - 2 * minFlankingSequenceLength;
-
-  if (variantLength > maxDisplayedVariantLength) {
-    return Math.min(variantEnd + minFlankingSequenceLength, regionLength);
+  if (variantLength > MAX_REFERENCE_ALLELE_DISPLAY_LENGTH) {
+    return Math.min(variantEnd + MIN_FLANKING_SEQUENCE_LENGTH, regionLength);
   } else {
     const distanceToFlankingSequence =
-      Math.floor(maxDisplayedVariantLength / 2) - Math.floor(variantLength / 2);
+      Math.floor(MAX_REFERENCE_ALLELE_DISPLAY_LENGTH / 2) -
+      Math.floor(variantLength / 2);
     return Math.min(
-      variantEnd + distanceToFlankingSequence + minFlankingSequenceLength,
+      variantEnd + distanceToFlankingSequence + MIN_FLANKING_SEQUENCE_LENGTH,
       regionLength
     );
   }

--- a/src/content/app/entity-viewer/variant-view/variant-image/useVariantImageData.ts
+++ b/src/content/app/entity-viewer/variant-view/variant-image/useVariantImageData.ts
@@ -1,0 +1,267 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Pick2 } from 'ts-multipick';
+
+import { useDefaultEntityViewerVariantQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
+import { useRegionChecksumQuery } from 'src/shared/state/region/regionApiSlice';
+import { useRefgetSequenceQuery } from 'src/shared/state/api-slices/refgetSlice';
+
+import type { VariantPredictionResult } from 'src/shared/types/variation-api/variantPredictionResult';
+import type { EntityViewerVariantDefaultQueryResult } from 'src/content/app/entity-viewer/state/api/queries/variantDefaultQuery';
+
+export type ReferenceSequenceForVariantData = {
+  referenceSequence: string;
+  variant: EntityViewerVariantDefaultQueryResult['variant'];
+  variantAlleleType: string;
+  hasAnchorBase: boolean;
+  variantStart: number;
+  variantEnd: number;
+  variantLength: number;
+  regionName: string;
+  regionLength: number;
+  regionSliceStart: number;
+  regionSliceEnd: number;
+};
+
+/**
+ * NOTE on the "anchor base".
+ * For some variant types, such as insertions and deletions (and, by extension, indels),
+ * the first nucleotide in the variant sequence reported by the api is treated as an "anchor base",
+ * i.e. the same nucleotide as in the reference sequence.
+ * Since the actual sequence alteration happens after the anchor base,
+ * we want to treat this nucleotide as just part of the reference sequence,
+ * and not highlight it on the image, as we highlight the nucleotides of the actual variant.
+ */
+
+const useVariantImageData = (params: {
+  genomeId: string;
+  variantId: string;
+}): {
+  currentData?: ReferenceSequenceForVariantData;
+  isLoading: boolean;
+  isError: boolean;
+} => {
+  const { genomeId } = params;
+  const {
+    currentData: variantData,
+    isLoading: isVariantRegionDataLoading,
+    isError: isVariantRegionDataError
+  } = useVariantRegionInformation(params);
+  const hasAnchorBase = variantData?.hasAnchorBase ?? false;
+  const regionName = variantData?.regionName ?? '';
+  let variantStart = variantData?.start ?? 0;
+  if (hasAnchorBase) {
+    // see note about the anchor base above
+    variantStart += 1;
+  }
+  const variantEnd = variantData?.end ?? 0;
+  const variantLength = variantData?.variantLength ?? 0;
+
+  const {
+    currentData: regionChecksumData,
+    isLoading: isRegionChecksumDataLoading,
+    isError: isRegionChecksumDataError
+  } = useRegionChecksumData({ genomeId, regionName });
+
+  const regionLength = regionChecksumData?.region.length ?? 0;
+  const regionChecksum = regionChecksumData?.region.sequence.checksum;
+
+  const sliceStart = regionChecksumData
+    ? calculateSliceStart({
+        variantStart,
+        variantLength
+      })
+    : 0;
+  const sliceEnd = regionChecksumData
+    ? calculateSliceEnd({
+        variantEnd,
+        variantLength,
+        regionLength
+      })
+    : 0;
+
+  const {
+    currentData: referenceSequence,
+    isLoading,
+    isError
+  } = useRefgetSequenceQuery(
+    {
+      checksum: regionChecksum ?? '',
+      start: sliceStart - 1, // translate to 0-based coordinate system that refget uses
+      end: sliceEnd
+    },
+    {
+      skip: !regionChecksum
+    }
+  );
+
+  const variantAlleleType = variantData!.variantAlleleType;
+
+  return {
+    currentData: referenceSequence
+      ? {
+          variantAlleleType,
+          variant: variantData!.variant,
+          referenceSequence,
+          hasAnchorBase,
+          variantStart,
+          variantEnd,
+          variantLength,
+          regionName,
+          regionLength,
+          regionSliceStart: sliceStart,
+          regionSliceEnd: sliceEnd
+        }
+      : undefined,
+    isLoading:
+      isLoading || isRegionChecksumDataLoading || isVariantRegionDataLoading,
+    isError: isError || isRegionChecksumDataError || isVariantRegionDataError
+  };
+};
+
+const useVariantRegionInformation = (params: {
+  genomeId: string;
+  variantId: string;
+}) => {
+  const { currentData, isLoading, isError } =
+    useDefaultEntityViewerVariantQuery(params);
+
+  if (!currentData) {
+    return {
+      currentData: null,
+      isLoading,
+      isError
+    };
+  }
+  const { variant } = currentData;
+  const {
+    slice: {
+      region: { name: regionName },
+      location: { start, end }
+    },
+    allele_type: { value: alleleType }
+  } = variant;
+
+  // there should always be data about most severe consequence;
+  // but adding a bogus fallback string just in case, and to appease typescript
+  const mostSevereVariantConsequence =
+    getMostSevereVariantConsequence(currentData.variant) || 'unknown';
+
+  // see note about the anchor base above
+  const hasAnchorBase = ['insertion', 'deletion', 'indel'].includes(alleleType);
+  let {
+    slice: {
+      location: { length: variantLength }
+    }
+  } = variant;
+  if (hasAnchorBase) {
+    // for insertions, api already reports variant length as 0; no need to go to negative numbers
+    variantLength = Math.max(variantLength - 1, 0);
+  }
+
+  return {
+    currentData: {
+      variant,
+      variantAlleleType: alleleType,
+      mostSevereVariantConsequence,
+      hasAnchorBase,
+      regionName,
+      start,
+      end,
+      variantLength
+    },
+    isLoading: false,
+    isError: false
+  };
+};
+
+const useRegionChecksumData = (params: {
+  genomeId: string;
+  regionName?: string;
+}) => {
+  const { genomeId, regionName = '' } = params;
+
+  return useRegionChecksumQuery(
+    { genomeId, regionName },
+    { skip: !regionName }
+  );
+};
+
+export const calculateSliceStart = (params: {
+  variantStart: number;
+  variantLength: number;
+}) => {
+  const { variantStart, variantLength } = params;
+  const maxDisplayedSequenceLength = 41;
+  const displaySequenceMidpoint = Math.ceil(maxDisplayedSequenceLength / 2);
+  const minFlankingSequenceLength = 10;
+  const maxDisplayedVariantLength =
+    maxDisplayedSequenceLength - 2 * minFlankingSequenceLength;
+
+  if (variantLength > maxDisplayedVariantLength) {
+    return Math.max(variantStart - minFlankingSequenceLength, 1);
+  } else {
+    const distanceToStart =
+      variantLength % 2
+        ? displaySequenceMidpoint - Math.floor(variantLength / 2) - 1 // for odd numbers
+        : displaySequenceMidpoint - Math.floor(variantLength / 2); // for even numbers
+
+    return Math.max(variantStart - distanceToStart, 1);
+  }
+};
+
+export const calculateSliceEnd = (params: {
+  variantEnd: number;
+  variantLength: number;
+  regionLength: number;
+}) => {
+  const { variantEnd, variantLength, regionLength } = params;
+
+  const maxDisplayedSequenceLength = 41;
+  const minFlankingSequenceLength = 10; // NOTE: think of ellipses
+  const maxDisplayedVariantLength =
+    maxDisplayedSequenceLength - 2 * minFlankingSequenceLength;
+
+  if (variantLength > maxDisplayedVariantLength) {
+    return Math.min(variantEnd + minFlankingSequenceLength, regionLength);
+  } else {
+    const distanceToFlankingSequence =
+      Math.floor(maxDisplayedVariantLength / 2) - Math.floor(variantLength / 2);
+    return Math.min(
+      variantEnd + distanceToFlankingSequence + minFlankingSequenceLength,
+      regionLength
+    );
+  }
+};
+
+type MostSevereConsequenceParams = Pick<VariantPredictionResult, 'result'> &
+  Pick2<VariantPredictionResult, 'analysis_method', 'tool'>;
+
+// FIXME: copied this from a genome browser file; should extract into a common file
+const getMostSevereVariantConsequence = ({
+  prediction_results: predictionResults
+}: {
+  prediction_results: MostSevereConsequenceParams[];
+}) => {
+  const consequencePrediction = predictionResults.find(
+    ({ analysis_method }) => analysis_method.tool === 'Ensembl VEP'
+  );
+
+  return consequencePrediction?.result;
+};
+
+export default useVariantImageData;

--- a/src/content/app/entity-viewer/variant-view/variant-image/useVariantImageData.ts
+++ b/src/content/app/entity-viewer/variant-view/variant-image/useVariantImageData.ts
@@ -16,6 +16,8 @@
 
 import type { Pick2 } from 'ts-multipick';
 
+import { DISPLAYED_REFERENCE_SEQUENCE_LENGTH } from './variantImageConstants';
+
 import { useDefaultEntityViewerVariantQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
 import { useRegionChecksumQuery } from 'src/shared/state/region/regionApiSlice';
 import { useRefgetSequenceQuery } from 'src/shared/state/api-slices/refgetSlice';
@@ -206,11 +208,12 @@ export const calculateSliceStart = (params: {
   variantLength: number;
 }) => {
   const { variantStart, variantLength } = params;
-  const maxDisplayedSequenceLength = 41;
-  const displaySequenceMidpoint = Math.ceil(maxDisplayedSequenceLength / 2);
+  const displaySequenceMidpoint = Math.ceil(
+    DISPLAYED_REFERENCE_SEQUENCE_LENGTH / 2
+  );
   const minFlankingSequenceLength = 10;
   const maxDisplayedVariantLength =
-    maxDisplayedSequenceLength - 2 * minFlankingSequenceLength;
+    DISPLAYED_REFERENCE_SEQUENCE_LENGTH - 2 * minFlankingSequenceLength;
 
   if (variantLength > maxDisplayedVariantLength) {
     return Math.max(variantStart - minFlankingSequenceLength, 1);
@@ -231,10 +234,9 @@ export const calculateSliceEnd = (params: {
 }) => {
   const { variantEnd, variantLength, regionLength } = params;
 
-  const maxDisplayedSequenceLength = 41;
   const minFlankingSequenceLength = 10; // NOTE: think of ellipses
   const maxDisplayedVariantLength =
-    maxDisplayedSequenceLength - 2 * minFlankingSequenceLength;
+    DISPLAYED_REFERENCE_SEQUENCE_LENGTH - 2 * minFlankingSequenceLength;
 
   if (variantLength > maxDisplayedVariantLength) {
     return Math.min(variantEnd + minFlankingSequenceLength, regionLength);

--- a/src/content/app/entity-viewer/variant-view/variant-image/variantImageConstants.ts
+++ b/src/content/app/entity-viewer/variant-view/variant-image/variantImageConstants.ts
@@ -18,3 +18,8 @@ export const DISPLAYED_REFERENCE_SEQUENCE_LENGTH = 41;
 
 // the maximum number of letter blocks allocated to reference allele
 export const MAX_REFERENCE_ALLELE_DISPLAY_LENGTH = 21;
+
+// min 10 nucleotides should be visible on either side of the reference allele
+export const MIN_FLANKING_SEQUENCE_LENGTH =
+  (DISPLAYED_REFERENCE_SEQUENCE_LENGTH - MAX_REFERENCE_ALLELE_DISPLAY_LENGTH) /
+  2;

--- a/src/content/app/entity-viewer/variant-view/variant-image/variantImageConstants.ts
+++ b/src/content/app/entity-viewer/variant-view/variant-image/variantImageConstants.ts
@@ -1,0 +1,20 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const DISPLAYED_REFERENCE_SEQUENCE_LENGTH = 41;
+
+// the maximum number of letter blocks allocated to reference allele
+export const MAX_REFERENCE_ALLELE_DISPLAY_LENGTH = 21;

--- a/src/content/app/entity-viewer/variant-view/variant-view-navigation-panel/VariantViewNavigationPanel.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-view-navigation-panel/VariantViewNavigationPanel.module.css
@@ -1,0 +1,8 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(5, 210px);
+  column-gap: 10px;
+  row-gap: 32px;
+  align-items: start;
+  padding: 34px 0;
+}

--- a/src/content/app/entity-viewer/variant-view/variant-view-navigation-panel/VariantViewNavigationPanel.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-view-navigation-panel/VariantViewNavigationPanel.tsx
@@ -1,0 +1,159 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { useDefaultEntityViewerVariantQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
+
+import VariantViewTab from './variant-view-tab/VariantViewTab';
+
+import styles from './VariantViewNavigationPanel.module.css';
+
+/**
+ * TODO:
+ * - Update styles of tab elements
+ * - Update styles of info pill
+ * - Use alt allele data for allele frequency
+ */
+
+type Props = {
+  genomeId: string;
+  variantId: string;
+  activeAlleleId: string;
+};
+
+const VariantViewNavigationPanel = (props: Props) => {
+  const { currentData } = useVariantViewNavigationData(props);
+
+  if (!currentData) {
+    return null;
+  }
+
+  const { alleleSequence } = currentData;
+
+  return (
+    <div className={styles.grid}>
+      <VariantViewTab
+        viewId="default"
+        tabText="Variant name"
+        labelText="Protein altering variant"
+        pressed={true}
+      />
+      <VariantViewTab
+        viewId="transcript-consequences"
+        tabText="Transcript consequences"
+        labelText="Features"
+        pillContent="0"
+        pressed={false}
+        disabled={true}
+      />
+      <VariantViewTab
+        viewId="regulatory-consequences"
+        tabText="Regulatory consequences"
+        labelText="Features"
+        pillContent="0"
+        pressed={false}
+        disabled={true}
+      />
+      <VariantViewTab
+        viewId="allele-frequencies"
+        tabText="Allele frequency"
+        labelText={alleleSequence}
+        pillContent="0"
+        pressed={false}
+      />
+      <VariantViewTab
+        viewId="genes"
+        tabText="Genes"
+        labelText="Features"
+        pillContent="0"
+        pressed={false}
+        disabled={true}
+      />
+      <VariantViewTab
+        viewId="variant-phenotypes"
+        tabText="Variant phenotypes"
+        labelText="Associations"
+        pillContent="0"
+        pressed={false}
+        disabled={true}
+      />
+      <VariantViewTab
+        viewId="gene-phenotypes"
+        tabText="Gene phenotypes"
+        labelText="Associations"
+        pillContent="0"
+        pressed={false}
+        disabled={true}
+      />
+      <VariantViewTab
+        viewId="publications"
+        tabText="Citations"
+        labelText="Publications"
+        pillContent="0"
+        pressed={false}
+        disabled={true}
+      />
+      <VariantViewTab
+        viewId="compara"
+        tabText="Comparative genomic context"
+        pressed={false}
+        unavailable={true}
+      />
+    </div>
+  );
+};
+
+const useVariantViewNavigationData = (params: Props) => {
+  const { genomeId, variantId, activeAlleleId } = params;
+
+  const { currentData, isLoading, isError } =
+    useDefaultEntityViewerVariantQuery({
+      genomeId,
+      variantId
+    });
+
+  if (!currentData) {
+    return {
+      currentData: null,
+      isLoading,
+      isError
+    };
+  }
+
+  const variant = currentData.variant;
+  const activeAllele = variant.alleles.find(
+    (allele) => allele.urlId === activeAlleleId
+  );
+
+  let alleleSequence = activeAllele?.allele_sequence ?? '';
+  if (alleleSequence.length > 18) {
+    const truncatedSequence = alleleSequence.slice(0, 17);
+    const ellipsis = '…';
+
+    alleleSequence = `${truncatedSequence}${ellipsis}`;
+  }
+
+  return {
+    currentData: {
+      alleleSequence
+    },
+    isLoading,
+    isError
+  };
+};
+
+export default VariantViewNavigationPanel;

--- a/src/content/app/entity-viewer/variant-view/variant-view-navigation-panel/variant-view-tab/VariantViewTab.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-view-navigation-panel/variant-view-tab/VariantViewTab.module.css
@@ -1,0 +1,36 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.tab {
+  width: 210px;
+}
+
+.unavailable {
+  --tab-button-color: #374148;
+  --tab-button-text-color: var(--color-dark-grey);
+}
+
+.bottomRow {
+  padding-left: 10px; /* same as TabButton default */
+  display: flex;
+  gap: 10px;
+}
+
+.disabled .label {
+  font-weight: var(--font-weight-light);
+  color: var(--color-grey);
+}
+
+.pill {
+  --info-pill-color: transparent;
+  --info-pill-border-color: var(--color-dark-grey);
+  --info-pill-padding: 0 10px;
+  --info-pill-font-size: 11px;
+}
+
+.disabled .pill {
+  --info-pill-text-color: var(--color-medium-dark-grey);
+}

--- a/src/content/app/entity-viewer/variant-view/variant-view-navigation-panel/variant-view-tab/VariantViewTab.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-view-navigation-panel/variant-view-tab/VariantViewTab.tsx
@@ -1,0 +1,89 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import classNames from 'classnames';
+
+import TabButton from 'src/shared/components/tab-button/TabButton';
+import InfoPill from 'src/shared/components/info-pill/InfoPill';
+
+import styles from './VariantViewTab.module.css';
+
+type Props = {
+  viewId: string;
+  tabText: string;
+  labelText?: string;
+  pillContent?: string | number;
+  onClick?: (viewId: string) => void;
+  pressed: boolean;
+  disabled?: boolean;
+  unavailable?: boolean; // temporary marker for a tab whose content won't be available for a long time
+};
+
+const VariantViewTab = (props: Props) => {
+  const { viewId, tabText, pressed, disabled, unavailable } = props;
+
+  const onClick = () => {
+    props.onClick?.(viewId);
+  };
+
+  if (unavailable) {
+    const tabClasses = classNames(styles.tab, styles.unavailable);
+
+    return (
+      <TabButton pressed={false} disabled className={tabClasses}>
+        {tabText}
+      </TabButton>
+    );
+  }
+
+  const componentClasses = classNames(styles.container, {
+    [styles.disabled]: disabled
+  });
+
+  return (
+    <div className={componentClasses}>
+      <TabButton
+        className={styles.tab}
+        pressed={pressed}
+        disabled={disabled}
+        onClick={onClick}
+      >
+        {tabText}
+      </TabButton>
+      <BottomRow {...props} />
+    </div>
+  );
+};
+
+const BottomRow = (props: Props) => {
+  const { labelText, pillContent } = props;
+
+  if (!labelText && !pillContent) {
+    return null;
+  }
+
+  return (
+    <div className={styles.bottomRow}>
+      {labelText && <span className={styles.label}>{labelText}</span>}
+      {pillContent && (
+        <InfoPill className={styles.pill}>{pillContent}</InfoPill>
+      )}
+    </div>
+  );
+};
+
+export default VariantViewTab;

--- a/src/content/app/genome-browser/components/zmenu/zmenus/VariantZmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/zmenus/VariantZmenu.tsx
@@ -19,6 +19,7 @@ import React from 'react';
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import { getChrLocationStr } from 'src/content/app/genome-browser/helpers/browserHelper';
 import { buildFocusVariantId } from 'src/shared/helpers/focusObjectHelpers';
+import { isEnvironment, Environment } from 'src/shared/helpers/environment';
 
 import useGenomeBrowserIds from 'src/content/app/genome-browser/hooks/useGenomeBrowserIds';
 
@@ -68,6 +69,11 @@ const VariantZmenu = (props: Props) => {
     location: locationForVariant
   });
 
+  const linkToVariantInEntityViewer = urlFor.entityViewerVariant({
+    genomeId: genomeIdForUrl,
+    variantId: variantId
+  });
+
   return (
     <>
       <ZmenuContent
@@ -78,7 +84,12 @@ const VariantZmenu = (props: Props) => {
       <div className={styles.zmenuLinksGrid}>
         <ViewInApp
           theme="dark"
-          links={{ genomeBrowser: { url: linkToVariantInGenomeBrowser } }}
+          links={{
+            genomeBrowser: { url: linkToVariantInGenomeBrowser },
+            entityViewer: !isEnvironment([Environment.PRODUCTION])
+              ? { url: linkToVariantInEntityViewer }
+              : undefined
+          }}
           onAnyAppClick={props.onDestroy}
           className={styles.zmenuAppLinks}
         />

--- a/src/content/app/species/state/general/speciesGeneralHelper.ts
+++ b/src/content/app/species/state/general/speciesGeneralHelper.ts
@@ -17,6 +17,8 @@
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import { formatNumber } from 'src/shared/helpers/formatters/numberFormatter';
 
+import { isEnvironment, Environment } from 'src/shared/helpers/environment';
+
 import { SpeciesStatsProps as IndividualStat } from 'src/content/app/species/components/species-stats/SpeciesStats';
 import { ExampleFocusObject } from 'src/shared/state/genome/genomeTypes';
 
@@ -616,7 +618,15 @@ const getExampleLinks = (props: {
           genomeId: genomeIdForUrl,
           focus: focusId
         })
-      }
+      },
+      entityViewer: !isEnvironment([Environment.PRODUCTION])
+        ? {
+            url: urlFor.entityViewerVariant({
+              genomeId: genomeIdForUrl,
+              variantId: exampleVariant.id
+            })
+          }
+        : undefined
     };
   }
 

--- a/src/shared/components/feature-summary-strip/FeatureSummaryStrip.module.css
+++ b/src/shared/components/feature-summary-strip/FeatureSummaryStrip.module.css
@@ -24,12 +24,9 @@
 }
 
 .featureSummaryStripLabel {
-  margin-right: 18px;
-}
-
-.featureSummaryStripLabel {
   font-size: 12px;
   font-weight: var(--font-weight-light);
+  margin-right: 18px;
 }
 
 .featureNameEmphasized {

--- a/src/shared/components/info-pill/InfoPill.module.css
+++ b/src/shared/components/info-pill/InfoPill.module.css
@@ -1,9 +1,17 @@
 .infoPill {
-  background: var(--info-pill-color, var(--color-black));
+  --_pill-bg-color:  var(--info-pill-color, var(--color-black));
+  --_pill-border-color: var(--info-pill-border-color, var(--_pill-bg-color));
+  display: inline-flex;
+  align-items: center;
+  background-color: var(--_pill-bg-color);
+  border-color: var(--_pill-border-color);
   color: var(--info-pill-text-color, var(--color-white));
   font-size: var(--info-pill-font-size, 12px);
   font-weight: var(--info-pill-font-weight, var(--font-weight-bold));
-  padding: var(--info-pill-padding, 2px 8px);
+  padding: var(--info-pill-padding, 0 8px);
   border-radius: var(--info-pill-border-radius, 14px);
+  border-width: 1px;
+  border-style: solid;
+  line-height: 1;
   white-space: nowrap;
 }

--- a/src/shared/components/info-pill/InfoPill.tsx
+++ b/src/shared/components/info-pill/InfoPill.tsx
@@ -14,16 +14,23 @@
  * limitations under the License.
  */
 
-import React, { type ReactNode } from 'react';
+import React, { type HTMLAttributes } from 'react';
+import classNames from 'classnames';
 
 import styles from './InfoPill.module.css';
 
-type Props = {
-  children: ReactNode;
-};
+type Props = HTMLAttributes<HTMLSpanElement>;
 
 const InfoPill = (props: Props) => {
-  return <span className={styles.infoPill}>{props.children}</span>;
+  const { className: classNameFromProps, children, ...otherProps } = props;
+
+  const componentClasses = classNames(styles.infoPill, classNameFromProps);
+
+  return (
+    <span className={componentClasses} {...otherProps}>
+      {children}
+    </span>
+  );
 };
 
 export default InfoPill;

--- a/src/shared/components/tab-button/TabButton.module.css
+++ b/src/shared/components/tab-button/TabButton.module.css
@@ -1,0 +1,24 @@
+.button {
+  --_button-bg-color: var(--tab-button-color, var(--color-blue));
+  --_button-border-color: var(--tab-button-border-color, var(--_button-bg-color));
+  display: inline-flex;
+  align-items: center;
+  background-color: var(--_button-bg-color);
+  border-color: var(--_button-border-color);
+  border-width: 1px;
+  border-style: solid;
+  color: var(--tab-button-text-color, var(--color-white));
+  padding: var(--tab-button-padding, 0 10px);
+  font-weight: var(--font-weight-bold);
+  min-height: 28px;
+}
+
+.pressed {
+  --_button-bg-color: var(--tab-button-color, transparent);
+  --_button-border-color: var(--tab-button-border-color, var(--color-blue));
+}
+
+.button:disabled:not(.pressed) {
+  --_button-bg-color: var(--tab-button-color, #485967);
+  color: var(--tab-button-text-color, var(--color-grey));
+}

--- a/src/shared/components/tab-button/TabButton.tsx
+++ b/src/shared/components/tab-button/TabButton.tsx
@@ -1,0 +1,63 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, {
+  type DetailedHTMLProps,
+  type ButtonHTMLAttributes
+} from 'react';
+import classNames from 'classnames';
+
+import styles from './TabButton.module.css';
+
+type Props = DetailedHTMLProps<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  HTMLButtonElement
+> & {
+  pressed: boolean;
+};
+
+/**
+ * This component will likely only be used for navigation.
+ * In contrast to our regular buttons, which are immediately released,
+ * this one stays pressed when clicked.
+ */
+
+const TabButton = (props: Props) => {
+  const {
+    pressed,
+    disabled,
+    className: classNameFromProps,
+    ...otherProps
+  } = props;
+
+  const buttonClasses = classNames(
+    styles.button,
+    {
+      [styles.pressed]: pressed
+    },
+    classNameFromProps
+  );
+
+  return (
+    <button
+      className={buttonClasses}
+      disabled={pressed || disabled}
+      {...otherProps}
+    />
+  );
+};
+
+export default TabButton;

--- a/src/shared/helpers/urlHelper.ts
+++ b/src/shared/helpers/urlHelper.ts
@@ -99,11 +99,16 @@ export const entityViewerVariant = (params?: {
   const genomeId = params?.genomeId || '';
   const variantId = params?.variantId || '';
   let path = '/entity-viewer';
+
+  const variantIdForUrl = variantId.startsWith('variant:')
+    ? variantId
+    : `variant:${variantId}`;
+
   if (genomeId) {
     path += `/${genomeId}`;
   }
   if (variantId) {
-    path += `/variant:${variantId}`;
+    path += `/${variantIdForUrl}`;
   }
   const urlSearchParams = new URLSearchParams('');
   if (params?.alleleId) {

--- a/src/shared/helpers/urlHelper.ts
+++ b/src/shared/helpers/urlHelper.ts
@@ -87,6 +87,34 @@ export const entityViewer = (params?: EntityViewerUrlParams) => {
   return query ? `${path}?${query}` : path;
 };
 
+export const entityViewerVariant = (params?: {
+  genomeId?: string | null;
+  variantId?: string | null;
+  alleleId?: string | null;
+}) => {
+  if (!params?.genomeId && params?.variantId) {
+    // this should never happen
+    throw 'Invalid parameters combination for Entity Viewer variant url';
+  }
+  const genomeId = params?.genomeId || '';
+  const variantId = params?.variantId || '';
+  let path = '/entity-viewer';
+  if (genomeId) {
+    path += `/${genomeId}`;
+  }
+  if (variantId) {
+    path += `/variant:${variantId}`;
+  }
+  const urlSearchParams = new URLSearchParams('');
+  if (params?.alleleId) {
+    urlSearchParams.append('allele', params.alleleId);
+  }
+
+  const query = urlSearchParams.toString();
+
+  return query ? `${path}?${query}` : path;
+};
+
 export const blastForm = () => '/blast';
 
 export const blastUnviewedSubmissions = () => '/blast/unviewed-submissions';

--- a/src/shared/state/region/queries/regionChecksumQuery.ts
+++ b/src/shared/state/region/queries/regionChecksumQuery.ts
@@ -1,0 +1,40 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from 'graphql-request';
+import type { Pick2 } from 'ts-multipick';
+
+import type { Region } from 'src/shared/types/core-api/slice';
+
+export const regionChecksumQuery = gql`
+  query RegionChecksum($genomeId: String!, $regionName: String!) {
+    region(by_name: { genome_id: $genomeId, name: $regionName }) {
+      name
+      length
+      topology
+      sequence {
+        checksum
+      }
+    }
+  }
+`;
+
+type RegionInResponse = Pick<Region, 'name' | 'length' | 'topology'> &
+  Pick2<Region, 'sequence', 'checksum'>;
+
+export type RegionChecksumQueryResult = {
+  region: RegionInResponse;
+};

--- a/src/shared/state/region/regionApiSlice.ts
+++ b/src/shared/state/region/regionApiSlice.ts
@@ -1,0 +1,47 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import graphqlApiSlice from 'src/shared/state/api-slices/graphqlApiSlice';
+
+import config from 'config';
+
+import {
+  regionChecksumQuery,
+  type RegionChecksumQueryResult
+} from './queries/regionChecksumQuery';
+
+type RegionQueryParams = {
+  genomeId: string;
+  regionName: string;
+};
+
+// A shared endpoint for fetching region checksum by region name
+
+const regionApiSlice = graphqlApiSlice.injectEndpoints({
+  endpoints: (builder) => ({
+    regionChecksum: builder.query<RegionChecksumQueryResult, RegionQueryParams>(
+      {
+        query: (params) => ({
+          url: config.coreApiUrl,
+          body: regionChecksumQuery,
+          variables: params
+        })
+      }
+    )
+  })
+});
+
+export const { useRegionChecksumQuery } = regionApiSlice;

--- a/src/styles/design-tokens.css
+++ b/src/styles/design-tokens.css
@@ -12,7 +12,7 @@
   --color-light-blue: #33adff;
   --color-ice-blue: #e5f5ff;
   --color-teal: #327C89;
-  --color-duckegg-blue: #96D0C9;
+  --color-duckegg-blue: #96d0c9;
   --color-neon-blue: #8ef4f8;
 
   --color-light-grey: #f1f2f4;
@@ -22,7 +22,7 @@
   --color-dark-grey: #6f8190;
 
   --color-red: #d90000;
-  --color-dark-pink: #e685ae;
+  --color-dark-pink: #eb768a;
   --color-purple: #ca81ff;
 
   --color-orange: #ff9900;

--- a/stories/shared-components/tab-button/TabButton.stories.module.css
+++ b/stories/shared-components/tab-button/TabButton.stories.module.css
@@ -1,0 +1,14 @@
+.container {
+  padding: 3rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.containerDark {
+  background-color: var(--color-black);
+}
+
+.button {
+  width: 210px;
+}

--- a/stories/shared-components/tab-button/TabButton.stories.tsx
+++ b/stories/shared-components/tab-button/TabButton.stories.tsx
@@ -1,0 +1,49 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import classNames from 'classnames';
+
+import TabButton from 'src/shared/components/tab-button/TabButton';
+
+import styles from './TabButton.stories.module.css';
+
+const TabButtonStory = () => {
+  const containerClasses = classNames(styles.container, styles.containerDark);
+
+  return (
+    <div className={containerClasses}>
+      <TabButton pressed={false} className={styles.button}>
+        Default
+      </TabButton>
+      <TabButton pressed={true} className={styles.button}>
+        Pressed
+      </TabButton>
+      <TabButton pressed={false} disabled className={styles.button}>
+        Disabled
+      </TabButton>
+    </div>
+  );
+};
+
+export const DefaultTabButtonStory = {
+  name: 'default',
+  render: () => <TabButtonStory />
+};
+
+export default {
+  title: 'Components/Shared Components/TabButton'
+};


### PR DESCRIPTION
## Description
Adding variant image to the main EntityViewer view for variant. Clicking on an allele in the image changes the selected allele by updating the url.

**Note:** the nuances for some variant types, such as insertions, deletions, and indels. Alternative alleles of those variants, as reported by the variation API, will have sequences that start with the "anchor base", i.e. the nucleotide from the reference sequence that is immediately to the left of the altered sequence.

For example, for insertion, this is the diagram of what the api reports (i've coloured the anchor base green):

<img src="https://github.com/Ensembl/ensembl-client/assets/6834224/da98846e-f23d-4fa6-ad73-ff073d7cc664" width="600" />

whereas this is how we should draw this (ignoring the first nucleotide of alt allele):

<img src="https://github.com/Ensembl/ensembl-client/assets/6834224/2d8a3bb1-4f59-4bad-a3f1-0e9c14325050" width="600" />

The similar consideration applies to deletions and indels.


### NOTE
See also PR https://github.com/Ensembl/ensembl-client/pull/1077, whose branch has been created from the current branch, and which, as a result, has been merged into this PR

### TODO in subsequent PR(s)
- add the "View in" button
- complex scrolling pattern (keep the reference sequence with the variant while scrolling)


## Related JIRA Issue(s)
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2382
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2381

## Deployment URL(s)
http://ev-variant-image.review.ensembl.org

**NOTE:** refget on review deployments is half-broken and cannot fetch various human chromosomes. Please test locally.

**Example variants:**
- **SNV:** http://ev-variant-image.review.ensembl.org/entity-viewer/grch38/variant:8:26293803:rs1313451503
- **SNV:** variant:1:230710048:rs699
- **substitution:** variant:1:230710043:rs141900991 (refget can't fetch chrom 1 on review deployments)
- **deletion:** variant:16:89919802:rs1555623833
- **long insertion:** variant:21:45988497:rs4647797
- **indel:** variant:1:230710046:rs878890662
- **indel, 2 alleles:** variant:21:45988303:rs1413726367