### PR TITLE
Add VariantSummaryStrip and add links to alleles in the sidebar

### DIFF
--- a/src/content/app/entity-viewer/EntityViewerForVariant.tsx
+++ b/src/content/app/entity-viewer/EntityViewerForVariant.tsx
@@ -31,6 +31,7 @@ import EntityViewerSidebarToolstrip from './shared/components/entity-viewer-side
 import EntityViewerSidebarModal from 'src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/EntityViewerSidebarModal';
 import VariantView from './variant-view/VariantView';
 import VariantViewSidebar from './variant-view/variant-view-sidebar/VariantViewSideBar';
+import VariantSummaryStrip from 'src/content/app/entity-viewer/variant-view/variant-summary-strip/VariantSummaryStrip';
 
 const EntityViewerForVariant = () => {
   const isSidebarOpen = useAppSelector(isEntityViewerSidebarOpen);
@@ -44,7 +45,7 @@ const EntityViewerForVariant = () => {
   return (
     <StandardAppLayout
       mainContent={<VariantView />}
-      topbarContent={<div>Variant summary for top bar goes here</div>}
+      topbarContent={<VariantSummaryStrip />}
       sidebarContent={
         <SidebarContent isSidebarModalOpen={isSidebarModalOpen} />
       }

--- a/src/content/app/entity-viewer/variant-view/variant-summary-strip/VariantSummaryStrip.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-summary-strip/VariantSummaryStrip.module.css
@@ -25,3 +25,9 @@
 .emphasized {
   font-weight: var(--font-weight-bold);
 }
+
+.variantType {
+  font-size: 12px;
+  font-weight: var(--font-weight-light);
+  margin-left: 18px;
+}

--- a/src/content/app/entity-viewer/variant-view/variant-summary-strip/VariantSummaryStrip.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-summary-strip/VariantSummaryStrip.module.css
@@ -1,0 +1,27 @@
+.outer {
+  margin-left: var(--double-standard-gutter);
+}
+
+.strip {
+  font-size: 14px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.section {
+  display: inline;
+}
+
+.section:not(:first-child) {
+  margin-left: 30px;
+}
+
+.label {
+  font-size: 12px;
+  font-weight: var(--font-weight-light);
+  margin-right: 18px;
+}
+
+.emphasized {
+  font-weight: var(--font-weight-bold);
+}

--- a/src/content/app/entity-viewer/variant-view/variant-summary-strip/VariantSummaryStrip.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-summary-strip/VariantSummaryStrip.tsx
@@ -1,0 +1,111 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { type ComponentProps } from 'react';
+import classNames from 'classnames';
+import type { Pick2 } from 'ts-multipick';
+
+import useEntityViewerIds from 'src/content/app/entity-viewer/hooks/useEntityViewerIds';
+import { useDefaultEntityViewerVariantQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
+
+import VariantConsequence from 'src/content/app/genome-browser/components/drawer/drawer-views/variant-summary/variant-consequence/VariantConsequence';
+import VariantAllelesSequences from 'src/shared/components/variant-alleles-sequences/VariantAllelesSequences';
+import VariantLocation from 'src/content/app/genome-browser/components/drawer/drawer-views/variant-summary/variant-location/VariantLocation';
+
+import type { Variant } from 'src/shared/types/variation-api/variant';
+
+import styles from './VariantSummaryStrip.module.css';
+
+/**
+ * NOTE:
+ * This component is largely a duplicate of VariantSummaryStrip from shared components.
+ * The reason this component is created is because the VariantSummaryStrip in shared components
+ * uses a graphql query from the Genome Browser app, which is completely unnecessary
+ * when we already have all the required data.
+ * Hopefully, we'll be able to either refactor the FeatureSummaryStrip in shared components,
+ * or move it into the genome browser directory so that it does not confuse developers.
+ *
+ * Note also that, in contrast to variant feature summary in genome browser,
+ * this component has variant type in it
+ */
+
+type MinimalVariant = ComponentProps<typeof VariantConsequence>['variant'] & {
+  alleles: ComponentProps<typeof VariantAllelesSequences>['alleles'];
+} & ComponentProps<typeof VariantLocation>['variant'] &
+  Pick<Variant, 'name'> &
+  Pick2<Variant, 'allele_type', 'value'>;
+type VariantSummaryStripProps = {
+  variant: MinimalVariant;
+  className?: string;
+};
+
+const VariantSummaryStripWithData = () => {
+  const { activeGenomeId, parsedEntityId } = useEntityViewerIds();
+
+  const { objectId: variantId } = parsedEntityId ?? {};
+
+  const { currentData } = useDefaultEntityViewerVariantQuery(
+    {
+      genomeId: activeGenomeId ?? '',
+      variantId: variantId ?? ''
+    },
+    {
+      skip: !activeGenomeId || !variantId
+    }
+  );
+
+  return currentData ? (
+    <VariantSummaryStrip
+      variant={currentData.variant}
+      className={styles.outer}
+    />
+  ) : null;
+};
+
+// This is a presentation component; it can be extracted into a shared component if necessary
+export const VariantSummaryStrip = (props: VariantSummaryStripProps) => {
+  const { variant, className: classNameFromProps } = props;
+
+  const mostSevereConsequence = (
+    <VariantConsequence variant={variant} withColour={false} />
+  );
+
+  const componentClasses = classNames(styles.strip, classNameFromProps);
+
+  return (
+    <div className={componentClasses}>
+      <div className={styles.section}>
+        <span className={styles.label}>Variant</span>
+        <span className={styles.emphasized}>{variant.name}</span>
+        <span>{variant.allele_type.value}</span>
+      </div>
+      {mostSevereConsequence && (
+        <div className={styles.section}>
+          <span className={styles.label}>Most severe consequence</span>
+          {mostSevereConsequence}
+        </div>
+      )}
+      <div className={styles.section}>
+        <VariantAllelesSequences alleles={variant.alleles} />
+      </div>
+      <div className={styles.section}>
+        <VariantLocation variant={variant} />
+      </div>
+    </div>
+  );
+};
+
+export default VariantSummaryStripWithData;

--- a/src/content/app/entity-viewer/variant-view/variant-summary-strip/VariantSummaryStrip.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-summary-strip/VariantSummaryStrip.tsx
@@ -90,7 +90,7 @@ export const VariantSummaryStrip = (props: VariantSummaryStripProps) => {
       <div className={styles.section}>
         <span className={styles.label}>Variant</span>
         <span className={styles.emphasized}>{variant.name}</span>
-        <span>{variant.allele_type.value}</span>
+        <span className={styles.variantType}>{variant.allele_type.value}</span>
       </div>
       {mostSevereConsequence && (
         <div className={styles.section}>

--- a/src/content/app/entity-viewer/variant-view/variant-view-navigation-panel/variant-view-tab/VariantViewTab.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-view-navigation-panel/variant-view-tab/VariantViewTab.module.css
@@ -16,7 +16,12 @@
 .bottomRow {
   padding-left: 10px; /* same as TabButton default */
   display: flex;
+  align-items: baseline;
   gap: 10px;
+}
+
+.label {
+  font-size: 12px;
 }
 
 .disabled .label {

--- a/src/content/app/entity-viewer/variant-view/variant-view-sidebar/overview/MainAccordion.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-view-sidebar/overview/MainAccordion.tsx
@@ -34,7 +34,6 @@ import type { VariantDetails } from 'src/content/app/entity-viewer/state/api/que
 
 import styles from './VariantOverview.module.css';
 
-export type AccordionSectionID = 'function' | 'other_data_sets';
 
 type Props = {
   genomeId: string;

--- a/src/content/app/entity-viewer/variant-view/variant-view-sidebar/overview/MainAccordion.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-view-sidebar/overview/MainAccordion.tsx
@@ -100,7 +100,7 @@ const MainAccordion = (props: Props) => {
 
         <AccordionItem
           className={styles.entityViewerAccordionItem}
-          uuid={'other_data_sets'}
+          uuid={'synonyms'}
         >
           <AccordionItemHeading className={styles.entityViewerAccordionHeader}>
             <AccordionItemButton

--- a/src/content/app/entity-viewer/variant-view/variant-view-sidebar/overview/MainAccordion.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-view-sidebar/overview/MainAccordion.tsx
@@ -15,7 +15,10 @@
  */
 
 import React from 'react';
+import { Link } from 'react-router-dom';
 import classNames from 'classnames';
+
+import * as urlFor from 'src/shared/helpers/urlHelper';
 
 import {
   Accordion,
@@ -26,14 +29,22 @@ import {
 } from 'src/shared/components/accordion';
 
 import { getReferenceAndAltAlleles } from 'src/shared/helpers/variantHelpers';
-import { type EntityViewerVariantDefaultQueryResult } from 'src/content/app/entity-viewer/state/api/queries/variantDefaultQuery';
+
+import type { VariantDetails } from 'src/content/app/entity-viewer/state/api/queries/variantDefaultQuery';
 
 import styles from './VariantOverview.module.css';
 
 export type AccordionSectionID = 'function' | 'other_data_sets';
 
-const MainAccordion = (props: EntityViewerVariantDefaultQueryResult) => {
-  const { variant } = props;
+type Props = {
+  genomeId: string;
+  variantId: string;
+  variant: VariantDetails;
+  activeAlleleId: string | null;
+};
+
+const MainAccordion = (props: Props) => {
+  const { genomeId, variantId, variant, activeAlleleId } = props;
   const disabledAccordionButtonClass = classNames(
     styles.entityViewerAccordionButton,
     {
@@ -60,7 +71,12 @@ const MainAccordion = (props: EntityViewerVariantDefaultQueryResult) => {
           <AccordionItemPanel
             className={styles.entityViewerAccordionItemContent}
           >
-            <Alleles alleles={variant.alleles} />
+            <Alleles
+              alleles={variant.alleles}
+              genomeId={genomeId}
+              variantId={variantId}
+              activeAlleleId={activeAlleleId}
+            />
           </AccordionItemPanel>
         </AccordionItem>
 
@@ -106,39 +122,79 @@ const MainAccordion = (props: EntityViewerVariantDefaultQueryResult) => {
   );
 };
 
-type AlleleProps = {
-  alleles: {
-    allele_sequence: string;
-    reference_sequence: string;
-    allele_type: {
-      value: string;
-    };
-  }[];
+type AllelesProps = {
+  genomeId: string;
+  variantId: string;
+  activeAlleleId: string | null;
+  alleles: VariantDetails['alleles'];
 };
-const Alleles = (props: AlleleProps) => {
-  const { referenceAllele, alternativeAlleles } = getReferenceAndAltAlleles(
-    props.alleles
-  );
+
+const Alleles = (props: AllelesProps) => {
+  const { genomeId, variantId, alleles, activeAlleleId } = props;
+  const { referenceAllele, alternativeAlleles } =
+    getReferenceAndAltAlleles(alleles);
 
   return (
     <div>
-      <div className={styles.row}>
-        <div className={styles.label}>Ref</div>
-        <div className={styles.value}>
-          {referenceAllele?.reference_sequence}
+      {referenceAllele && (
+        <div className={styles.row}>
+          <div className={styles.label}>Ref</div>
+          <div className={styles.value}>
+            <Allele
+              genomeId={genomeId}
+              variantId={variantId}
+              allele={referenceAllele}
+              activeAlleleId={activeAlleleId}
+            />
+          </div>
         </div>
-      </div>
+      )}
       <div className={styles.row}>
         <div className={styles.label}>Alt</div>
-        <div className={styles.value}>
-          {alternativeAlleles.map((allele, index) => (
-            <div key={index} className={styles.alleleSequence}>
-              {allele.allele_sequence}
-            </div>
+        <div className={styles.altAlleles}>
+          {alternativeAlleles.map((allele) => (
+            <Allele
+              key={allele.urlId}
+              genomeId={genomeId}
+              variantId={variantId}
+              allele={allele}
+              activeAlleleId={activeAlleleId}
+            />
           ))}
         </div>
       </div>
     </div>
   );
 };
+
+const Allele = (props: {
+  genomeId: string;
+  variantId: string;
+  allele: VariantDetails['alleles'][number];
+  activeAlleleId: string | null;
+}) => {
+  const { genomeId, variantId, allele, activeAlleleId } = props;
+  const formattedSequence = formatAlleleSequence(allele.allele_sequence);
+
+  if (allele.urlId === activeAlleleId) {
+    return <span>{formattedSequence}</span>;
+  } else {
+    const url = urlFor.entityViewerVariant({
+      genomeId,
+      variantId,
+      alleleId: allele.urlId
+    });
+
+    return <Link to={url}>{formattedSequence}</Link>;
+  }
+};
+
+const formatAlleleSequence = (sequence: string) => {
+  const maxCharacters = 18;
+
+  return sequence.length > maxCharacters
+    ? `${sequence.slice(0, maxCharacters - 1)}…`
+    : sequence;
+};
+
 export default MainAccordion;

--- a/src/content/app/entity-viewer/variant-view/variant-view-sidebar/overview/MainAccordion.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-view-sidebar/overview/MainAccordion.tsx
@@ -34,7 +34,6 @@ import type { VariantDetails } from 'src/content/app/entity-viewer/state/api/que
 
 import styles from './VariantOverview.module.css';
 
-
 type Props = {
   genomeId: string;
   variantId: string;
@@ -138,7 +137,7 @@ const Alleles = (props: AllelesProps) => {
       {referenceAllele && (
         <div className={styles.row}>
           <div className={styles.label}>Ref</div>
-          <div className={styles.value}>
+          <div>
             <Allele
               genomeId={genomeId}
               variantId={variantId}

--- a/src/content/app/entity-viewer/variant-view/variant-view-sidebar/overview/VariantOverview.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-view-sidebar/overview/VariantOverview.module.css
@@ -44,11 +44,9 @@
   font-weight: var(--font-weight-bold);
 }
 
-.alleleSequence {
-  max-width: 18ch;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
+.altAlleles {
+  display: flex;
+  flex-direction: column;
 }
 
 

--- a/src/content/app/entity-viewer/variant-view/variant-view-sidebar/overview/VariantOverview.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-view-sidebar/overview/VariantOverview.tsx
@@ -32,7 +32,8 @@ import ExternalLink from 'src/shared/components/external-link/ExternalLink';
 import styles from './VariantOverview.module.css';
 
 const VariantOverview = () => {
-  const { activeGenomeId, parsedEntityId } = useEntityViewerIds();
+  const { activeGenomeId, genomeIdForUrl, parsedEntityId } =
+    useEntityViewerIds();
   const { search: urlQuery } = useLocation();
 
   const alleleIdInUrl = new URLSearchParams(urlQuery).get('allele');
@@ -53,7 +54,7 @@ const VariantOverview = () => {
     return <div>Loading...</div>;
   }
 
-  if (!activeGenomeId || !variantId || !currentData?.variant) {
+  if (!genomeIdForUrl || !variantId || !currentData?.variant) {
     return <div>No data to display</div>;
   }
 
@@ -115,7 +116,7 @@ const VariantOverview = () => {
       </section>
 
       <MainAccordion
-        genomeId={activeGenomeId}
+        genomeId={genomeIdForUrl}
         variantId={variantId}
         variant={variant}
         activeAlleleId={alleleIdInUrl}

--- a/src/content/app/entity-viewer/variant-view/variant-view-sidebar/overview/VariantOverview.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-view-sidebar/overview/VariantOverview.tsx
@@ -15,6 +15,7 @@
  */
 
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 
 import useEntityViewerIds from 'src/content/app/entity-viewer/hooks/useEntityViewerIds';
 import { useDefaultEntityViewerVariantQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
@@ -32,6 +33,9 @@ import styles from './VariantOverview.module.css';
 
 const VariantOverview = () => {
   const { activeGenomeId, parsedEntityId } = useEntityViewerIds();
+  const { search: urlQuery } = useLocation();
+
+  const alleleIdInUrl = new URLSearchParams(urlQuery).get('allele');
 
   const { objectId: variantId } = parsedEntityId ?? {};
 
@@ -49,7 +53,7 @@ const VariantOverview = () => {
     return <div>Loading...</div>;
   }
 
-  if (!currentData?.variant) {
+  if (!activeGenomeId || !variantId || !currentData?.variant) {
     return <div>No data to display</div>;
   }
 
@@ -110,7 +114,12 @@ const VariantOverview = () => {
         </div>
       </section>
 
-      <MainAccordion variant={variant} />
+      <MainAccordion
+        genomeId={activeGenomeId}
+        variantId={variantId}
+        variant={variant}
+        activeAlleleId={alleleIdInUrl}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Description
- Add the `VariantSummaryStrip` component to the top bar of EntityViewer
- Make the alleles listed in the sidebar into links that switch the currently active allele

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2385

## Deployment URL(s)
http://ev-variant-top.review.ensembl.org