### PR TITLE
Variant image fixes

### DIFF
--- a/src/content/app/entity-viewer/variant-view/VariantView.module.css
+++ b/src/content/app/entity-viewer/variant-view/VariantView.module.css
@@ -5,5 +5,6 @@
   grid-template-rows: [navigation-panel] auto [view-specific-content] 1fr;
   height: 100%;
   padding-left: var(--double-standard-gutter);
+  padding-right: var(--standard-gutter);
   overflow: auto;
 }

--- a/src/content/app/entity-viewer/variant-view/VariantView.tsx
+++ b/src/content/app/entity-viewer/variant-view/VariantView.tsx
@@ -78,6 +78,7 @@ const VariantView = () => {
           />
           <VariantImage
             genomeId={activeGenomeId}
+            genomeIdForUrl={genomeIdForUrl as string}
             variantId={variantId}
             activeAlleleId={alleleIdInUrl || ''}
             onAlleleChange={onAlleleChange}

--- a/src/content/app/entity-viewer/variant-view/variant-image/VariantImage.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-image/VariantImage.module.css
@@ -14,7 +14,6 @@
   background: repeating-linear-gradient(to bottom, var(--color-orange) 0 4px, transparent 4px 8px);
   background-size: 1px 100%;
   background-repeat: no-repeat;
-  /* background-position: 0; */
   left: calc(
     var(--chevrons-block-width) +
     calc(var(--nucleotides-offset)) * calc(16px + 1px)

--- a/src/content/app/entity-viewer/variant-view/variant-image/VariantImage.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-image/VariantImage.module.css
@@ -1,15 +1,25 @@
 .container {
   --chevrons-block-width: 165px; /* the block of right-pointing chevrons to the left of reference sequence, indicating forward strand */
   height: 100%;
-  background:
-    repeating-linear-gradient(to bottom, var(--color-orange) 0 4px, transparent 4px 8px);
+  padding-bottom: var(--global-padding-bottom);
+  position: relative;
+}
+
+.container::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: repeating-linear-gradient(to bottom, var(--color-orange) 0 4px, transparent 4px 8px);
   background-size: 1px 100%;
-  background-position: calc(
+  background-repeat: no-repeat;
+  /* background-position: 0; */
+  left: calc(
     var(--chevrons-block-width) +
     calc(var(--nucleotides-offset)) * calc(16px + 1px)
-    - 2px); /* chevron block width plus total width of letter block and spaces between them, minus a couple of pixels */
-  background-repeat: no-repeat;
-  padding-bottom: var(--global-padding-bottom);
+    - 2px);
+  z-index: 1;
 }
 
 .referenceSequenceBlock {
@@ -20,6 +30,10 @@
     'chevrons sequence sequence .'
     '. . strand-label .';
   grid-template-columns: var(--chevrons-block-width) calc(var(--nucleotides-offset) * calc(16px + 1px)) max-content auto;
+  position: sticky;
+  top: 220px;
+  background-color: var(--color-black);
+  z-index: 1;
 }
 
 
@@ -80,4 +94,9 @@
   font-size: 11px;
   justify-self: end;
   margin-top: 11px;
+}
+
+.viewIn {
+  grid-area: view-in;
+  margin-left: 32px;
 }

--- a/src/content/app/entity-viewer/variant-view/variant-image/VariantImage.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-image/VariantImage.module.css
@@ -4,7 +4,10 @@
   background:
     repeating-linear-gradient(to bottom, var(--color-orange) 0 4px, transparent 4px 8px);
   background-size: 1px 100%;
-  background-position: calc(var(--chevrons-block-width) + var(--nucleotides-offset) * 16px - 1px);
+  background-position: calc(
+    var(--chevrons-block-width) +
+    calc(var(--nucleotides-offset)) * calc(16px + 1px)
+    - 2px); /* chevron block width plus total width of letter block and spaces between them, minus a couple of pixels */
   background-repeat: no-repeat;
   padding-bottom: var(--global-padding-bottom);
 }
@@ -52,7 +55,7 @@
   grid-area: variant-name;
   margin-left: 8px; /* half the letter block width */
   display: inline-flex;
-  height: 36px;
+  height: 28px;
   align-items: flex-start;
 }
 
@@ -76,5 +79,5 @@
   font-weight: var(--font-weight-light);
   font-size: 11px;
   justify-self: end;
-  margin-top: 14px;
+  margin-top: 11px;
 }

--- a/src/content/app/entity-viewer/variant-view/variant-image/VariantImage.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-image/VariantImage.module.css
@@ -19,7 +19,7 @@
     '. reference-sequence-label variant-name view-in'
     'chevrons sequence sequence .'
     '. . strand-label .';
-  grid-template-columns: var(--chevrons-block-width) calc(var(--nucleotides-offset) * 16px) max-content auto;
+  grid-template-columns: var(--chevrons-block-width) calc(var(--nucleotides-offset) * calc(16px + 1px)) max-content auto;
 }
 
 

--- a/src/content/app/entity-viewer/variant-view/variant-image/VariantImage.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-image/VariantImage.tsx
@@ -100,6 +100,7 @@ const VariantImage = (props: Props) => {
         hasAnchorBase={hasAnchorBase}
         variantStart={variantStart}
         activeAlleleId={activeAlleleId}
+        isReferenceAlleleSelected={referenceAllele?.urlId === activeAlleleId}
         mostSevereConsequence={mostSevereConsequence}
         onAlleleClick={onAlleleChange}
       />

--- a/src/content/app/entity-viewer/variant-view/variant-image/VariantImage.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-image/VariantImage.tsx
@@ -16,10 +16,12 @@
 
 import React from 'react';
 
+import * as urlFor from 'src/shared/helpers/urlHelper';
 import {
   getReferenceAndAltAlleles,
   getMostSevereVariantConsequence
 } from 'src/shared/helpers/variantHelpers';
+import { buildFocusIdForUrl } from 'src/shared/helpers/focusObjectHelpers';
 
 import useVariantImageData from './useVariantImageData';
 
@@ -27,6 +29,7 @@ import FlankingSequence from './flanking-sequence/FlankingSequence';
 import ReferenceSequenceAllele from './reference-sequence-allele/ReferenceSequenceAllele';
 import AlternativeAlleles from './alternative-alleles/AlternativeAlleles';
 import Chevron from 'src/shared/components/chevron/Chevron';
+import ViewInApp from 'src/shared/components/view-in-app/ViewInApp';
 
 import type { VariantDetails } from 'src/content/app/entity-viewer/state/api/queries/variantDefaultQuery';
 
@@ -34,13 +37,20 @@ import styles from './VariantImage.module.css';
 
 type Props = {
   genomeId: string;
+  genomeIdForUrl: string;
   variantId: string;
   activeAlleleId: string;
   onAlleleChange: (alleleId: string) => void;
 };
 
 const VariantImage = (props: Props) => {
-  const { genomeId, variantId, activeAlleleId, onAlleleChange } = props;
+  const {
+    genomeId,
+    genomeIdForUrl,
+    variantId,
+    activeAlleleId,
+    onAlleleChange
+  } = props;
 
   const { currentData } = useVariantImageData({
     genomeId,
@@ -88,6 +98,8 @@ const VariantImage = (props: Props) => {
         regionName={regionName}
         regionLength={regionLength}
         variant={variant}
+        genomeIdForUrl={genomeIdForUrl}
+        variantId={variantId}
         referenceAllele={referenceAllele as VariantDetails['alleles'][number]}
         activeAlleleId={activeAlleleId}
         mostSevereConsequence={mostSevereConsequence}
@@ -119,6 +131,8 @@ const ReferenceSequence = (props: {
   regionName: string;
   regionLength: number;
   variant: VariantDetails;
+  genomeIdForUrl: string;
+  variantId: string;
   referenceAllele: VariantDetails['alleles'][number];
   activeAlleleId: string;
   mostSevereConsequence: string;
@@ -134,6 +148,8 @@ const ReferenceSequence = (props: {
     regionLength,
     hasAnchorBase,
     variant,
+    genomeIdForUrl,
+    variantId,
     referenceAllele,
     activeAlleleId,
     mostSevereConsequence,
@@ -179,7 +195,8 @@ const ReferenceSequence = (props: {
       <div className={styles.referenceSequence}>
         <FlankingSequence
           sequence={leftFlankingSequence}
-          hasEllipsisAtStart={hasEllipsisAtStart}
+          position="left"
+          hasEllipsis={hasEllipsisAtStart}
         />
         <ReferenceSequenceAllele
           sequence={referenceSequence}
@@ -194,9 +211,25 @@ const ReferenceSequence = (props: {
         />
         <FlankingSequence
           sequence={rightFlankingSequence}
-          hasEllipsisAtEnd={hasEllipsisAtEnd}
+          position="right"
+          hasEllipsis={hasEllipsisAtEnd}
         />
       </div>
+      <ViewInApp
+        className={styles.viewIn}
+        theme="dark"
+        links={{
+          genomeBrowser: {
+            url: urlFor.browser({
+              genomeId: genomeIdForUrl,
+              focus: buildFocusIdForUrl({
+                type: 'variant',
+                objectId: variantId
+              })
+            })
+          }
+        }}
+      />
     </div>
   );
 };

--- a/src/content/app/entity-viewer/variant-view/variant-image/alternative-allele/AlternativeAllele.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-image/alternative-allele/AlternativeAllele.module.css
@@ -1,6 +1,7 @@
 .allele {
   --sequence-block-letter-color: var(--color-black);
   justify-self: start;
+  font-size: 11px;
 }
 
 .letterBlock + .letterBlock {

--- a/src/content/app/entity-viewer/variant-view/variant-image/alternative-allele/AlternativeAllele.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-image/alternative-allele/AlternativeAllele.tsx
@@ -43,6 +43,7 @@ type Props = {
   mostSevereConsequence: string;
   hasAnchorBase: boolean;
   activeAlleleId: string;
+  isReferenceAlleleSelected: boolean;
   onClick: (alleleId: string) => void;
 };
 
@@ -54,6 +55,7 @@ const AlternativeAllele = (props: Props) => {
     variantLength,
     hasAnchorBase,
     activeAlleleId,
+    isReferenceAlleleSelected,
     mostSevereConsequence
   } = props;
   const {
@@ -88,8 +90,9 @@ const AlternativeAllele = (props: Props) => {
   }
 
   const defaultLetterColour = 'var(--color-grey)'; // this is a fallback colour that should never be displayed if everything is working correctly
-  const letterColour =
-    getVariantGroupCSSColour(mostSevereConsequence) ?? defaultLetterColour;
+  const letterColour = isReferenceAlleleSelected
+    ? 'var(--color-blue)'
+    : getVariantGroupCSSColour(mostSevereConsequence) ?? defaultLetterColour;
 
   const sequenceLetterStyle = {
     ['--sequence-block-color' as string]: letterColour
@@ -102,7 +105,9 @@ const AlternativeAllele = (props: Props) => {
       }
     : sequenceLetterStyle;
 
-  if (!isSelectedAllele) {
+  if (isReferenceAlleleSelected) {
+    sequenceLetterStyle['--sequence-block-letter-color'] = 'var(--color-white)';
+  } else if (!isSelectedAllele) {
     sequenceLetterStyle.opacity = '50%';
     lastSequenceLetterStyle.opacity = '50%';
   }

--- a/src/content/app/entity-viewer/variant-view/variant-image/alternative-alleles/AlternativeAlleles.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-image/alternative-alleles/AlternativeAlleles.module.css
@@ -1,6 +1,6 @@
 .grid {
   display: grid;
-  grid-template-columns: [left] calc(var(--nucleotides-offset) * 16px) [right] max-content;
+  grid-template-columns: [left] calc(var(--nucleotides-offset) * 16px + var(--nucleotides-offset) * 1px) [right] max-content;
   row-gap: 6px;
   margin-top: 40px;
   margin-left: var(--chevrons-block-width);

--- a/src/content/app/entity-viewer/variant-view/variant-image/alternative-alleles/AlternativeAlleles.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-image/alternative-alleles/AlternativeAlleles.tsx
@@ -29,6 +29,7 @@ type Props = {
   variantLength: number; // accounts for anchor base in appropriate variant types
   hasAnchorBase: boolean;
   activeAlleleId: string;
+  isReferenceAlleleSelected: boolean;
   mostSevereConsequence: string;
   onAlleleClick: (alleleId: string) => void;
 };
@@ -41,6 +42,7 @@ const AlternativeAlleles = (props: Props) => {
     variantLength,
     hasAnchorBase,
     activeAlleleId,
+    isReferenceAlleleSelected,
     mostSevereConsequence,
     onAlleleClick
   } = props;
@@ -82,6 +84,7 @@ const AlternativeAlleles = (props: Props) => {
             hasAnchorBase={hasAnchorBase}
             mostSevereConsequence={mostSevereConsequence}
             activeAlleleId={activeAlleleId}
+            isReferenceAlleleSelected={isReferenceAlleleSelected}
             onClick={onAlleleClick}
           />
         </Row>

--- a/src/content/app/entity-viewer/variant-view/variant-image/flanking-sequence/FlankingSequence.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-image/flanking-sequence/FlankingSequence.module.css
@@ -3,3 +3,7 @@
   --sequence-block-letter-color: var(--color-medium-light-grey);
   font-size: 11px;
 }
+
+.letter + .letter {
+  margin-left: 1px;
+}

--- a/src/content/app/entity-viewer/variant-view/variant-image/flanking-sequence/FlankingSequence.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-image/flanking-sequence/FlankingSequence.module.css
@@ -7,3 +7,7 @@
 .letter + .letter {
   margin-left: 1px;
 }
+
+.firstRightSequenceLetter {
+  margin-left: 1px;
+}

--- a/src/content/app/entity-viewer/variant-view/variant-image/flanking-sequence/FlankingSequence.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-image/flanking-sequence/FlankingSequence.tsx
@@ -25,8 +25,6 @@ type Props = {
   sequence: string;
   position: 'left' | 'right';
   hasEllipsis?: boolean;
-  // hasEllipsisAtStart?: boolean;
-  // hasEllipsisAtEnd?: boolean;
 };
 
 const FlankingSequence = (props: Props) => {

--- a/src/content/app/entity-viewer/variant-view/variant-image/flanking-sequence/FlankingSequence.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-image/flanking-sequence/FlankingSequence.tsx
@@ -15,6 +15,7 @@
  */
 
 import React from 'react';
+import classNames from 'classnames';
 
 import SequenceLetterBlock from '../sequence-letter-block/SequenceLetterBlock';
 
@@ -22,12 +23,17 @@ import styles from './FlankingSequence.module.css';
 
 type Props = {
   sequence: string;
-  hasEllipsisAtStart?: boolean;
-  hasEllipsisAtEnd?: boolean;
+  position: 'left' | 'right';
+  hasEllipsis?: boolean;
+  // hasEllipsisAtStart?: boolean;
+  // hasEllipsisAtEnd?: boolean;
 };
 
 const FlankingSequence = (props: Props) => {
-  const { sequence, hasEllipsisAtStart, hasEllipsisAtEnd } = props;
+  const { sequence, position, hasEllipsis } = props;
+
+  const hasEllipsisAtStart = hasEllipsis && position === 'left';
+  const hasEllipsisAtEnd = hasEllipsis && position === 'right';
 
   const letters = sequence.split('');
 
@@ -38,13 +44,20 @@ const FlankingSequence = (props: Props) => {
     letters[letters.length - 1] = '…';
   }
 
+  const getLetterClasses = (letterIndex: number) => {
+    return classNames(styles.letter, {
+      [styles.firstRightSequenceLetter]:
+        position === 'right' && letterIndex === 0
+    });
+  };
+
   return (
     <>
       {letters.map((letter, index) => (
         <SequenceLetterBlock
           key={index}
           letter={letter}
-          className={styles.letter}
+          className={getLetterClasses(index)}
         />
       ))}
     </>

--- a/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.module.css
@@ -3,10 +3,6 @@
   margin-left: 1px;
 }
 
-/* .letter + .letter {
-  margin-left: 1px;
-} */
-
 .referenceSequenceGap {
   display: inline-flex;
   justify-content: space-around;

--- a/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.module.css
@@ -1,10 +1,11 @@
 .letter {
   font-size: 11px;
-}
-
-.letter + .letter {
   margin-left: 1px;
 }
+
+/* .letter + .letter {
+  margin-left: 1px;
+} */
 
 .referenceSequenceGap {
   display: inline-flex;

--- a/src/content/app/entity-viewer/variant-view/variant-view-navigation-panel/VariantViewNavigationPanel.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-view-navigation-panel/VariantViewNavigationPanel.module.css
@@ -5,4 +5,9 @@
   row-gap: 32px;
   align-items: start;
   padding: 34px 0;
+  position: sticky;
+  top: 0;
+  background-color: var(--color-black);
+  border-bottom: 1px solid var(--color-orange); /* NOTE: this will only need to be enabled for the default view that shows variant image */
+  z-index: 2;
 }

--- a/src/content/app/entity-viewer/variant-view/variant-view-navigation-panel/VariantViewNavigationPanel.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-view-navigation-panel/VariantViewNavigationPanel.tsx
@@ -16,6 +16,8 @@
 
 import React from 'react';
 
+import { getReferenceAndAltAlleles } from 'src/shared/helpers/variantHelpers';
+
 import { useDefaultEntityViewerVariantQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
 
 import VariantViewTab from './variant-view-tab/VariantViewTab';
@@ -42,7 +44,7 @@ const VariantViewNavigationPanel = (props: Props) => {
     return null;
   }
 
-  const { alleleSequence } = currentData;
+  const { alleleSequence, isReferenceAlleleActive } = currentData;
 
   return (
     <div className={styles.grid}>
@@ -71,7 +73,7 @@ const VariantViewNavigationPanel = (props: Props) => {
       <VariantViewTab
         viewId="allele-frequencies"
         tabText="Allele frequency"
-        labelText={alleleSequence}
+        labelText={isReferenceAlleleActive ? 'Ref allele' : alleleSequence}
         pillContent="0"
         pressed={false}
       />
@@ -135,6 +137,7 @@ const useVariantViewNavigationData = (params: Props) => {
   }
 
   const variant = currentData.variant;
+  const { referenceAllele } = getReferenceAndAltAlleles(variant.alleles);
   const activeAllele = variant.alleles.find(
     (allele) => allele.urlId === activeAlleleId
   );
@@ -146,10 +149,12 @@ const useVariantViewNavigationData = (params: Props) => {
 
     alleleSequence = `${truncatedSequence}${ellipsis}`;
   }
+  const isReferenceAlleleActive = referenceAllele?.urlId === activeAlleleId;
 
   return {
     currentData: {
-      alleleSequence
+      alleleSequence,
+      isReferenceAlleleActive
     },
     isLoading,
     isError


### PR DESCRIPTION
## Description
- When reference allele is selected, show the words "Ref allele" rather than allele sequence under the "Allele frequency" button
- Make font size in reference sequence and in alternative allele sequences the same, so that the letters are strictly under one another. Also, include the 1px space between nucleotide letter blocks into the calculation of the left offset for the alternative alleles and for the vertical orange line
- When reference allele is selected, alternative alleles change colour to blue
- Add a horizontal orange line between navigation panel and the variant image
- Add the "View in" button with a link to genome browser
- Add appropriate scrolling behaviour: the navigation panel and the reference sequence remain in place during vertical scrolling 

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2398

## Deployment URL(s)
http://variant-image-fixes.review.ensembl.org