### PR TITLE
Refactor ExternalLink and ExternalReference components

### DIFF
--- a/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.module.css
+++ b/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.module.css
@@ -89,7 +89,6 @@
 
 .externalRefLink {
   font-weight: var(--font-weight-normal);
-  font-size: 12px;
 }
 
 .downloadLink {

--- a/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -176,25 +176,25 @@ export const TranscriptsListItemInfo = (
           <div className={styles.moreInfoColumn}>
             {!!transcriptNCBI && (
               <ExternalReference
-                classNames={{
-                  link: styles.externalRefLink
-                }}
-                label={'RefSeq match'}
+                label="RefSeq match"
                 to={transcriptNCBI.url}
-                linkText={transcriptNCBI.id}
                 onClick={() => handleExternalReferenceClick('RefSeq match')}
-              />
+              >
+                <span className={styles.externalRefLink}>
+                  {transcriptNCBI.id}
+                </span>
+              </ExternalReference>
             )}
             {transcriptCCDS?.url && (
               <ExternalReference
-                classNames={{
-                  link: styles.externalRefLink
-                }}
-                label={'CCDS'}
+                label="CCDS"
                 to={transcriptCCDS.url}
-                linkText={transcriptCCDS.accession_id}
                 onClick={() => handleExternalReferenceClick('CCDS')}
-              />
+              >
+                <span className={styles.externalRefLink}>
+                  {transcriptCCDS.accession_id}
+                </span>
+              </ExternalReference>
             )}
           </div>
         )}

--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.module.css
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.module.css
@@ -22,10 +22,6 @@
 }
 
 .showHide,
-.externalReferenceContainer {
+.externalReference {
   margin-bottom: 10px;
-}
-
-.externalReferenceLink {
-  font-size: 12px;
 }

--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/external-references/GeneExternalReferences.tsx
@@ -183,13 +183,11 @@ const ExternalReferencesGroup = (props: {
             : entry.description
         }
         to={entry.url}
-        linkText={entry.accession_id}
         key={key}
-        classNames={{
-          container: styles.externalReferenceContainer,
-          link: styles.externalReferenceLink
-        }}
-      />
+        className={styles.externalReference}
+      >
+        {entry.accession_id}
+      </ExternalReference>
     ) : null
   );
 
@@ -263,13 +261,11 @@ const renderExternalReferencesGroups = (
             <ExternalReference
               label={externalReferencesGroup.source.name}
               to={externalReferencesGroup.references[0].url}
-              linkText={externalReferencesGroup.references[0].accession_id}
               onClick={() => onClick(externalReferencesGroup.source.name)}
-              classNames={{
-                container: styles.externalReferenceContainer,
-                link: styles.externalReferenceLink
-              }}
-            />
+              className={styles.externalReference}
+            >
+              {externalReferencesGroup.references[0].accession_id}
+            </ExternalReference>
           ) : null
         ) : (
           <ExternalReferencesGroup

--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.module.css
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.module.css
@@ -2,12 +2,8 @@
   font-size: 13px;
 }
 
-.externalRefContainer {
+.externalReference {
   margin-top: 6px;
-}
-
-.externalRefLink {
-  font-size: 12px;
 }
 
 .sectionHead {

--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.test.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.test.tsx
@@ -132,15 +132,15 @@ describe('<GeneOverview />', () => {
     });
 
     it('renders all data correctly', () => {
-      const { container, queryByTestId } = render(<GeneOverview />);
+      const { container, queryByTestId, queryByText } = render(
+        <GeneOverview />
+      );
 
       const geneSymbolElement = container.querySelector('.geneSymbol');
       const stableIdElement = queryByTestId('stableId');
       const geneNameElement = container.querySelector('.geneName');
       const synonymsElement = container.querySelector('.synonyms');
-      const xrefElement = container.querySelector(
-        '.externalLinkContainer .link'
-      );
+      const xrefElement = queryByText(metadata.name.accession_id);
       const biotypeValueElement = container.querySelector('.biotypeValue');
 
       // child components
@@ -149,7 +149,7 @@ describe('<GeneOverview />', () => {
       expect(geneSymbolElement?.textContent).toMatch(geneSymbol);
       expect(stableIdElement?.textContent).toMatch(stableId);
       expect(geneNameElement?.textContent).toMatch(geneName);
-      expect(xrefElement?.textContent).toMatch(metadata.name.accession_id);
+      expect(xrefElement).toBeTruthy();
       expect(synonymsElement?.textContent).toMatch(
         alternativeSymbols.join(', ')
       );

--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
@@ -97,14 +97,12 @@ const GeneOverview = () => {
           <div className={styles.geneName}>{getGeneName(gene.name)}</div>
           {geneNameMetadata?.accession_id && geneNameMetadata?.url && (
             <ExternalReference
-              classNames={{
-                container: styles.externalRefContainer,
-                link: styles.externalRefLink
-              }}
+              className={styles.externalReference}
               to={geneNameMetadata.url}
-              linkText={geneNameMetadata.accession_id}
               onClick={trackLink}
-            />
+            >
+              {geneNameMetadata.accession_id}
+            </ExternalReference>
           )}
         </div>
       </section>

--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/publications/GenePublications.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/publications/GenePublications.tsx
@@ -53,13 +53,7 @@ const GenePublications = (props: Props) => {
       <div className={geneOverviewStyles.sectionHead}>Publications</div>
 
       <div className={geneOverviewStyles.sectionContent}>
-        <ExternalReference
-          to={linkToEuroPMC}
-          linkText="Europe PMC"
-          classNames={{
-            link: geneOverviewStyles.externalRefLink
-          }}
-        />
+        <ExternalReference to={linkToEuroPMC}>Europe PMC</ExternalReference>
       </div>
     </section>
   );

--- a/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.tsx
@@ -316,7 +316,7 @@ const ProteinDomainInfoTooltip = (props: {
               <span className={styles.tooltipFieldLabel}>
                 {domainInfo.resourceName}
               </span>
-              <ExternalLink linkText={domainInfo.name} to={domainInfo.url} />
+              <ExternalLink to={domainInfo.url}>{domainInfo.name}</ExternalLink>
             </div>
           )}
           {domainInfo.closestDataProviderName &&
@@ -326,10 +326,9 @@ const ProteinDomainInfoTooltip = (props: {
                 <span className={styles.tooltipFieldLabel}>
                   {domainInfo.closestDataProviderName}
                 </span>
-                <ExternalLink
-                  linkText={domainInfo.accessionIdInClosestDataProvider}
-                  to={domainInfo.urlForClosestDataProvider}
-                />
+                <ExternalLink to={domainInfo.urlForClosestDataProvider}>
+                  {domainInfo.accessionIdInClosestDataProvider}
+                </ExternalLink>
               </div>
             )}
           <div className={styles.tooltipRow}>

--- a/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.module.css
+++ b/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.module.css
@@ -28,13 +28,9 @@
   grid-column: download;
 }
 
-.externalRefContainer {
+.externalReference {
   font-weight: var(--font-weight-normal);
   margin-right: 16px;
-}
-
-.externalRefLink {
-  font-size: 12px;
 }
 
 .proteinFeaturesCountWrapper {

--- a/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.test.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.test.tsx
@@ -104,9 +104,11 @@ describe('<ProteinsListItemInfo /', () => {
 
         expect(getByText(props.xrefs[1].accession_id)).toBeTruthy();
         expect(getAllByText(props.source)).toHaveLength(4);
-        expect(
-          container.querySelectorAll('.externalLinkContainer')
-        ).toHaveLength(4);
+
+        for (const xrefData of tremblXrefs) {
+          const link = getByText(xrefData.accession_id);
+          expect(link).toBeTruthy();
+        }
       });
     });
   });

--- a/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
@@ -226,15 +226,13 @@ const ProteinExternalReference = (props: ProteinExternalReferenceProps) => {
   return (
     <div className={styles.proteinExternalReference}>
       <ExternalReference
-        classNames={{
-          container: styles.externalRefContainer,
-          link: styles.externalRefLink
-        }}
+        className={styles.externalReference}
         label={props.source}
         to={url}
-        linkText={props.accessionId}
         onClick={onClick}
-      />
+      >
+        {props.accessionId}
+      </ExternalReference>
     </div>
   );
 };

--- a/src/content/app/entity-viewer/variant-view/variant-view-sidebar/overview/VariantOverview.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-view-sidebar/overview/VariantOverview.tsx
@@ -102,10 +102,9 @@ const VariantOverview = () => {
         <div className={styles.externalLink}>
           {currentVariantType &&
             (currentVariantType.url ? (
-              <ExternalLink
-                to={currentVariantType.url}
-                linkText={currentVariantType.so_accession_id}
-              />
+              <ExternalLink to={currentVariantType.url}>
+                {currentVariantType.so_accession_id}
+              </ExternalLink>
             ) : (
               <span>{currentVariantType.so_accession_id}</span>
             ))}

--- a/src/content/app/genome-browser/components/drawer/drawer-views/gene-summary/GeneSummary.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/gene-summary/GeneSummary.tsx
@@ -174,10 +174,11 @@ const GeneSummary = () => {
           {getGeneName(gene.name)}
           {geneNameMetadata?.accession_id && geneNameMetadata?.url && (
             <ExternalReference
-              classNames={{ container: styles.marginTop }}
+              className={styles.marginTop}
               to={geneNameMetadata.url}
-              linkText={geneNameMetadata.accession_id}
-            />
+            >
+              {geneNameMetadata.accession_id}
+            </ExternalReference>
           )}
         </div>
       </div>

--- a/src/content/app/genome-browser/components/drawer/drawer-views/track-details/TrackDetails.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/track-details/TrackDetails.tsx
@@ -85,7 +85,7 @@ const TrackDetails = (props: Props) => {
         <div key={source.name} className={styles.standardLabelValue}>
           <div className={styles.value}>
             {source.url ? (
-              <ExternalLink to={source.url} linkText={source.name} />
+              <ExternalLink to={source.url}>{source.name}</ExternalLink>
             ) : (
               <span>{source.name}</span>
             )}

--- a/src/content/app/genome-browser/components/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/transcript-summary/TranscriptSummary.tsx
@@ -254,10 +254,11 @@ const TranscriptSummary = (props: Props) => {
             )}
             {uniprotXref?.url && (
               <ExternalReference
-                label={'UniProtKB/Swiss-Prot'}
+                label="UniProtKB/Swiss-Prot"
                 to={uniprotXref.url}
-                linkText={uniprotXref.accession_id}
-              />
+              >
+                {uniprotXref.accession_id}
+              </ExternalReference>
             )}
           </div>
         </div>
@@ -266,12 +267,9 @@ const TranscriptSummary = (props: Props) => {
       {ccdsXref?.url && (
         <div className={`${styles.row} ${styles.spaceAbove}`}>
           <div className={styles.value}>
-            <ExternalReference
-              classNames={{ label: styles.lightText }}
-              label={'CCDS'}
-              to={ccdsXref.url}
-              linkText={ccdsXref.accession_id}
-            />
+            <ExternalReference label="CCDS" to={ccdsXref.url}>
+              {ccdsXref.accession_id}
+            </ExternalReference>
           </div>
         </div>
       )}

--- a/src/content/app/genome-browser/components/drawer/drawer-views/variant-group-legend/VariantGroupLegend.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/variant-group-legend/VariantGroupLegend.tsx
@@ -71,10 +71,9 @@ const VariantGroupLegend = (props: Props) => {
                 <td className={styles.variantTypeLabel}>{variantType.label}</td>
                 <td className={styles.value}>
                   {variantType.url ? (
-                    <ExternalLink
-                      to={variantType.url}
-                      linkText={variantType.so_accession_id}
-                    />
+                    <ExternalLink to={variantType.url}>
+                      {variantType.so_accession_id}
+                    </ExternalLink>
                   ) : (
                     <span>{variantType.so_accession_id}</span>
                   )}

--- a/src/content/app/genome-browser/components/drawer/drawer-views/variant-summary/VariantSummary.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/variant-summary/VariantSummary.tsx
@@ -207,10 +207,9 @@ export const VariantDB = (props: {
     dbElement = <span>{primary_source.source.name}</span>;
   } else {
     dbElement = (
-      <ExternalLink
-        to={primary_source.url}
-        linkText={primary_source.source.name}
-      />
+      <ExternalLink to={primary_source.url}>
+        {primary_source.source.name}
+      </ExternalLink>
     );
   }
 
@@ -240,11 +239,9 @@ const VariantSynonyms = (props: { variant: VariantQueryResult['variant'] }) => {
     (reference, index) => {
       if (reference.url) {
         return (
-          <ExternalLink
-            key={index}
-            to={reference.url}
-            linkText={reference.name}
-          />
+          <ExternalLink key={index} to={reference.url}>
+            {reference.name}
+          </ExternalLink>
         );
       } else {
         return <span key={index}>{reference.name}</span>;

--- a/src/content/app/species-selector/components/species-search-results-table/SpeciesSearchResultsTable.tsx
+++ b/src/content/app/species-selector/components/species-search-results-table/SpeciesSearchResultsTable.tsx
@@ -171,10 +171,9 @@ const SpeciesSearchResultsTable = (props: Props) => {
             <td className={styles.assemblyName}>{searchMatch.assembly.name}</td>
             <td>
               {!shouldDisableRow(searchMatch, canAddToStaged) ? (
-                <ExternalLink
-                  to={searchMatch.assembly.url}
-                  linkText={searchMatch.assembly.accession_id}
-                />
+                <ExternalLink to={searchMatch.assembly.url}>
+                  {searchMatch.assembly.accession_id}
+                </ExternalLink>
               ) : (
                 <DisabledExternalLink>
                   {searchMatch.assembly.accession_id}

--- a/src/content/app/species/components/species-page-sidebar/SpeciesPageSidebar.tsx
+++ b/src/content/app/species/components/species-page-sidebar/SpeciesPageSidebar.tsx
@@ -54,11 +54,9 @@ const SpeciesPageSidebar = (props: Props) => {
         <div className={styles.fieldsGroup}>
           <div className={styles.assemblyName}>{data.assembly.name}</div>
           <div className={styles.assemblySource}>
-            <ExternalReference
-              label="INSDC"
-              linkText={data.assembly.accession_id}
-              to={data.assembly.url}
-            />
+            <ExternalReference label="INSDC" to={data.assembly.url}>
+              {data.assembly.accession_id}
+            </ExternalReference>
           </div>
         </div>
 

--- a/src/shared/components/communication-framework/contact-us/ContactUs.tsx
+++ b/src/shared/components/communication-framework/contact-us/ContactUs.tsx
@@ -116,19 +116,17 @@ const ContactUs = () => {
         <p> We have two public mailing lists: </p>
         <dl>
           <dt>
-            <ExternalLink
-              linkText="announce"
-              to="https://lists.ensembl.org/mailman/listinfo/announce_ensembl.org"
-            />
+            <ExternalLink to="https://lists.ensembl.org/mailman/listinfo/announce_ensembl.org">
+              announce
+            </ExternalLink>
           </dt>
           <dd>
             a low-traffic list for release announcements and web status updates
           </dd>
           <dt>
-            <ExternalLink
-              linkText="dev"
-              to="https://lists.ensembl.org/mailman/listinfo/dev_ensembl.org"
-            />
+            <ExternalLink to="https://lists.ensembl.org/mailman/listinfo/dev_ensembl.org">
+              dev
+            </ExternalLink>
           </dt>
           <dd>
             programming help from the Ensembl development team and other Ensembl

--- a/src/shared/components/external-link/ExternalLink.module.css
+++ b/src/shared/components/external-link/ExternalLink.module.css
@@ -1,16 +1,16 @@
-.externalLinkContainer {
+.container {
   display: inline-grid;
   grid-template-columns:  [icon] auto [link] auto;
-  column-gap: 5px;
+  column-gap: var(--external-link-icon-offset, 5px);
   align-items: baseline;
 }
 
 .icon {
   display: inline-block;
-  fill: var(--color-orange);
+  fill: var(--external-link-icon-offset, var(--color-orange));
   grid-column: icon;
-  height: 12px;
-  width: 12px;
+  height: var(--external-link-icon-size, 12px);
+  aspect-ratio: 1;
 }
 
 .link {

--- a/src/shared/components/external-link/ExternalLink.module.css
+++ b/src/shared/components/external-link/ExternalLink.module.css
@@ -1,12 +1,15 @@
-.container {
+/* .container {
   display: inline-grid;
   grid-template-columns:  [icon] auto [link] auto;
   column-gap: var(--external-link-icon-offset, 5px);
   align-items: baseline;
-}
+} */
 
 .icon {
+  position: relative;
+  bottom: -1px;
   display: inline-block;
+  margin-right: var(--external-link-icon-offset, 5px);
   fill: var(--external-link-icon-offset, var(--color-orange));
   grid-column: icon;
   height: var(--external-link-icon-size, 12px);

--- a/src/shared/components/external-link/ExternalLink.module.css
+++ b/src/shared/components/external-link/ExternalLink.module.css
@@ -4,12 +4,11 @@
   display: inline-block;
   margin-right: var(--external-link-icon-offset, 5px);
   fill: var(--external-link-icon-offset, var(--color-orange));
-  grid-column: icon;
   height: var(--external-link-icon-size, 12px);
   aspect-ratio: 1;
 }
 
 .link {
   display: inline-block;
-  font-size: 12px; /* seems to be Andrea's default for external links; can be overridden by child styles */
+  font-size: 12px; /* seems to be Andrea's default for external links; can be overridden by wrapping the child in a span with its own styles */
 }

--- a/src/shared/components/external-link/ExternalLink.module.css
+++ b/src/shared/components/external-link/ExternalLink.module.css
@@ -15,4 +15,5 @@
 
 .link {
   display: inline-block;
+  font-size: 12px; /* seems to be Andrea's default for external links; can be overridden by child styles */
 }

--- a/src/shared/components/external-link/ExternalLink.module.css
+++ b/src/shared/components/external-link/ExternalLink.module.css
@@ -1,10 +1,3 @@
-/* .container {
-  display: inline-grid;
-  grid-template-columns:  [icon] auto [link] auto;
-  column-gap: var(--external-link-icon-offset, 5px);
-  align-items: baseline;
-} */
-
 .icon {
   position: relative;
   bottom: -1px;

--- a/src/shared/components/external-link/ExternalLink.test.tsx
+++ b/src/shared/components/external-link/ExternalLink.test.tsx
@@ -18,35 +18,20 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { faker } from '@faker-js/faker';
 
-import ExternalLink, { ExternalLinkProps } from './ExternalLink';
-
-const defaultProps: ExternalLinkProps = {
-  linkText: faker.lorem.words(),
-  to: faker.internet.url(),
-  classNames: {
-    icon: faker.lorem.word(),
-    link: faker.lorem.word()
-  }
-};
+import ExternalLink from './ExternalLink';
 
 describe('<ExternalLink />', () => {
-  const renderExternalLink = () => render(<ExternalLink {...defaultProps} />);
-  it('renders without error', () => {
-    const { container } = renderExternalLink();
-    expect(() => container).not.toThrow();
-  });
+  it('applies the passed in className', () => {
+    const className = faker.lorem.word();
 
-  it('applies the passed in classNames', () => {
-    const { container } = renderExternalLink();
-
-    expect(
-      container
-        .querySelector(`svg`)
-        ?.classList.contains(defaultProps.classNames?.icon as string)
-    ).toBeTruthy();
+    const { container } = render(
+      <ExternalLink className={className} to={faker.internet.url()}>
+        Hello world
+      </ExternalLink>
+    );
 
     expect(
-      container.querySelector(`.link.${defaultProps.classNames?.link}`)
-    ).toBeTruthy();
+      (container.firstChild as HTMLElement).classList.contains(className)
+    ).toBe(true);
   });
 });

--- a/src/shared/components/external-link/ExternalLink.tsx
+++ b/src/shared/components/external-link/ExternalLink.tsx
@@ -29,21 +29,19 @@ export type ExternalLinkProps = {
 };
 
 const ExternalLink = (props: ExternalLinkProps) => {
-  const componentClasses = classNames(styles.container, props.className);
+  const componentClasses = classNames(styles.link, props.className);
 
   return (
-    <span className={componentClasses}>
+    <a
+      className={componentClasses}
+      href={props.to}
+      target="_blank"
+      rel="nofollow noreferrer"
+      onClick={props.onClick}
+    >
       <LinkIcon className={styles.icon} />
-      <a
-        className={styles.link}
-        href={props.to}
-        target="_blank"
-        rel="nofollow noreferrer"
-        onClick={props.onClick}
-      >
-        {props.children}
-      </a>
-    </span>
+      {props.children}
+    </a>
   );
 };
 

--- a/src/shared/components/external-link/ExternalLink.tsx
+++ b/src/shared/components/external-link/ExternalLink.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { type ReactNode } from 'react';
 import classNames from 'classnames';
 
 import LinkIcon from 'static/icons/icon_xlink.svg';
@@ -23,30 +23,25 @@ import styles from './ExternalLink.module.css';
 
 export type ExternalLinkProps = {
   to: string;
-  linkText: string;
-  classNames?: {
-    icon?: string;
-    link?: string;
-  };
+  children: ReactNode;
+  className?: string;
   onClick?: () => void;
 };
 
 const ExternalLink = (props: ExternalLinkProps) => {
-  const iconClass = classNames(styles.icon, props.classNames?.icon);
-
-  const linkClass = classNames(styles.link, props.classNames?.link);
+  const componentClasses = classNames(styles.container, props.className);
 
   return (
-    <span className={styles.externalLinkContainer}>
-      <LinkIcon className={iconClass} />
+    <span className={componentClasses}>
+      <LinkIcon className={styles.icon} />
       <a
-        className={linkClass}
+        className={styles.link}
         href={props.to}
         target="_blank"
         rel="nofollow noreferrer"
         onClick={props.onClick}
       >
-        {props.linkText}
+        {props.children}
       </a>
     </span>
   );

--- a/src/shared/components/external-reference/ExternalReference.module.css
+++ b/src/shared/components/external-reference/ExternalReference.module.css
@@ -3,11 +3,6 @@
   font-weight: var(--font-weight-light);
 }
 
-.xrefText {
-  font-weight: var(--font-weight-light);
-  margin-left: 7px;
-}
-
 .noLink {
   margin-left: 5px;
 }

--- a/src/shared/components/external-reference/ExternalReference.test.tsx
+++ b/src/shared/components/external-reference/ExternalReference.test.tsx
@@ -18,75 +18,59 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { faker } from '@faker-js/faker';
 
-import ExternalReference, { ExternalReferenceProps } from './ExternalReference';
+import ExternalReference from './ExternalReference';
 
-const defaultProps: ExternalReferenceProps = {
-  label: faker.lorem.word(),
-  linkText: faker.lorem.word(),
-  to: faker.internet.url(),
-  classNames: {
-    container: faker.lorem.word(),
-    label: faker.lorem.word(),
-    icon: faker.lorem.word(),
-    link: faker.lorem.word()
-  }
-};
+const link = faker.internet.url();
 
 describe('<ExternalReference />', () => {
-  const renderExternalReference = (
-    props: Partial<ExternalReferenceProps> = {}
-  ) => render(<ExternalReference {...defaultProps} {...props} />);
-
   beforeEach(() => {
     jest.resetAllMocks();
   });
 
-  it('renders without error', () => {
-    const { container } = renderExternalReference();
-    expect(() => container).not.toThrow();
+  it('renders a link with a label', () => {
+    const labelText = 'I am label';
+    const linkText = 'Hello world';
+    const className = faker.lorem.word();
+
+    const { container, getByText } = render(
+      <ExternalReference label={labelText} to={link} className={className}>
+        {linkText}
+      </ExternalReference>
+    );
+
+    const labelElement = getByText(labelText);
+    const linkElement = getByText(linkText);
+
+    expect(labelElement).toBeTruthy();
+    expect(linkElement.tagName).toBe('A');
+
+    expect(
+      (container.firstChild as HTMLElement).classList.contains(className)
+    ).toBe(true);
   });
 
-  it('hides label container div when there is no label', () => {
-    const { container } = renderExternalReference({ label: undefined });
+  it('renders a link without a label', () => {
+    const linkText = 'Hello world';
+
+    const { container, getByText } = render(
+      <ExternalReference to={link}>{linkText}</ExternalReference>
+    );
+
+    const linkElement = getByText(linkText);
 
     expect(container.querySelector('.label')).toBeFalsy();
+    expect(linkElement.tagName).toBe('A');
   });
 
-  it('applies the passed in classNames', () => {
-    const { container } = renderExternalReference();
+  it('renders reference in a span if no link was provided', () => {
+    const linkText = 'Hello world';
 
-    expect(
-      container.querySelector(`.${defaultProps.classNames?.container}`)
-    ).toBeTruthy();
-
-    expect(
-      container
-        .querySelector('.label')
-        ?.classList.contains(defaultProps.classNames?.label as string)
-    ).toBeTruthy();
-
-    expect(
-      container
-        .querySelector(`.externalLinkContainer svg`)
-        ?.classList.contains(defaultProps.classNames?.icon as string)
-    ).toBeTruthy();
-
-    expect(
-      container.querySelector(
-        `.externalLinkContainer .${defaultProps.classNames?.link}`
-      )
-    ).toBeTruthy();
-  });
-
-  it('does not display ExternalLink component when there is no link', () => {
-    const { container } = renderExternalReference({ to: undefined });
-
-    expect(container.querySelector(`.externalLinkContainer`)).toBeFalsy();
-
-    expect(container.querySelector(`.noLink`)).toBeTruthy();
-
-    expect(container.querySelector(`.noLink`)?.textContent).toBe(
-      defaultProps.linkText
+    const { getByText } = render(
+      <ExternalReference>{linkText}</ExternalReference>
     );
+
+    const linkElement = getByText(linkText);
+
+    expect(linkElement.tagName).toBe('SPAN');
   });
 });

--- a/src/shared/components/external-reference/ExternalReference.tsx
+++ b/src/shared/components/external-reference/ExternalReference.tsx
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import React from 'react';
-import classNames from 'classnames';
+import React, { type ReactNode } from 'react';
 
 import ExternalLink from '../external-link/ExternalLink';
 
@@ -23,43 +22,26 @@ import styles from './ExternalReference.module.css';
 
 export type ExternalReferenceProps = {
   label?: string | null;
-  to: string;
-  linkText: string;
-  classNames?: {
-    container?: string;
-    label?: string;
-    icon?: string;
-    link?: string;
-  };
+  to?: string;
+  className?: string;
+  children: ReactNode;
   onClick?: () => void;
 };
 
 const ExternalReference = (props: ExternalReferenceProps) => {
-  const containerClass = classNames(props.classNames?.container);
-  const containerProps = containerClass
-    ? {
-        className: containerClass
-      }
-    : {};
-
-  const labelClass = classNames(styles.label, props.classNames?.label);
-
   return (
-    <div {...containerProps} data-test-id="external reference container">
-      {!!props.label && <span className={labelClass}>{props.label}</span>}
+    <div
+      className={props.className}
+      data-test-id="external reference container"
+    >
+      {!!props.label && <span className={styles.label}>{props.label}</span>}
 
       {props.to ? (
-        <ExternalLink
-          to={props.to}
-          linkText={props.linkText}
-          classNames={{
-            icon: props.classNames?.icon,
-            link: props.classNames?.link
-          }}
-          onClick={props.onClick}
-        />
+        <ExternalLink to={props.to} onClick={props.onClick}>
+          {props.children}
+        </ExternalLink>
       ) : (
-        <span className={styles.noLink}>{props.linkText}</span>
+        <span className={styles.noLink}>{props.children}</span>
       )}
     </div>
   );

--- a/stories/shared-components/external-link/ExternalLink.stories.tsx
+++ b/stories/shared-components/external-link/ExternalLink.stories.tsx
@@ -20,14 +20,17 @@ import ExternalLink from 'src/shared/components/external-link/ExternalLink';
 
 import styles from './ExternalLink.stories.module.css';
 
-export default {
-  title: 'Components/Shared Components/ExternalLink'
-};
-
-export const DefaultExternalLink = () => (
+const DefaultExternalLink = () => (
   <div className={styles.wrapper}>
-    <ExternalLink linkText={'LinkText'} to={''} />
+    <ExternalLink to="#">LinkText</ExternalLink>
   </div>
 );
 
-DefaultExternalLink.storyName = 'default';
+export const DefaultExternalLinkStory = {
+  name: 'default',
+  render: () => <DefaultExternalLink />
+};
+
+export default {
+  title: 'Components/Shared Components/ExternalLink'
+};

--- a/stories/shared-components/external-reference/ExternalReference.stories.module.css
+++ b/stories/shared-components/external-reference/ExternalReference.stories.module.css
@@ -1,3 +1,3 @@
-.wrapper {
-  padding: 40px;
+.externalReference {
+  margin: 40px;
 }

--- a/stories/shared-components/external-reference/ExternalReference.stories.tsx
+++ b/stories/shared-components/external-reference/ExternalReference.stories.tsx
@@ -20,27 +20,43 @@ import ExternalReference from 'src/shared/components/external-reference/External
 
 import styles from './ExternalReference.stories.module.css';
 
+const DefaultExternalReference = () => (
+  <ExternalReference
+    label={'Source name'}
+    to="#"
+    className={styles.externalReference}
+  >
+    Link Text
+  </ExternalReference>
+);
+
+const WithoutLabel = () => (
+  <ExternalReference to="#" className={styles.externalReference}>
+    Link Text
+  </ExternalReference>
+);
+
+const WithoutLink = () => (
+  <ExternalReference label={'Source name'} className={styles.externalReference}>
+    Link Text
+  </ExternalReference>
+);
+
+export const DefaultExternalReferenceStory = {
+  name: 'default',
+  render: () => <DefaultExternalReference />
+};
+
+export const WithoutLabelExternalReferenceStory = {
+  name: 'without label',
+  render: () => <WithoutLabel />
+};
+
+export const WithoutLinkExternalReferenceStory = {
+  name: 'without link',
+  render: () => <WithoutLink />
+};
+
 export default {
   title: 'Components/Shared Components/ExternalReference'
 };
-
-export const DefaultExternalReference = () => (
-  <ExternalReference
-    label={'Source name'}
-    linkText={'LinkText'}
-    to={''}
-    classNames={{ container: styles.wrapper }}
-  />
-);
-
-DefaultExternalReference.storyName = 'default';
-
-export const WithoutLabel = () => (
-  <ExternalReference
-    linkText={'LinkText'}
-    to={''}
-    classNames={{ container: styles.wrapper }}
-  />
-);
-
-WithoutLabel.storyName = 'without label';


### PR DESCRIPTION
## Description
Both the `ExternalLink` component and the `ExternalReference` component use our old and error-prone way of styling through the `classNames` prop. This PR refactors them so that:
- Instead of passing the link content through the `linkText` property, it is passed as a regular component child
- Relevant styleable properties are exposed through CSS custom properties.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2408

## Deployment URL(s)
http://ext-link-refactor.review.ensembl.org
