### PR TITLE
move Copy link above the vcf string

### DIFF
--- a/src/shared/components/variant-vcf/VariantVCF.tsx
+++ b/src/shared/components/variant-vcf/VariantVCF.tsx
@@ -52,6 +52,7 @@ const VariantVCF = (props: Props) => {
 
   return (
     <div className={componentClasses}>
+      {props.withCopy && <Copy value={vcfSequenceParts.vcfString} />}
       <span className={styles.vcfString}>
         <span>{vcfSequenceParts.regionName}</span>
         <span>{vcfSequenceParts.startCoordinate}</span>
@@ -59,7 +60,6 @@ const VariantVCF = (props: Props) => {
         <span>{vcfSequenceParts.referenceAlleleSequence}</span>
         <span>{vcfSequenceParts.alternativeAlleleSequences.join(',')}</span>
       </span>
-      {props.withCopy && <Copy value={vcfSequenceParts.vcfString} />}
     </div>
   );
 };


### PR DESCRIPTION
## Description

Copy link when the vcf strings are long go beyond the screen below and become hidden at the bottom.
Moved it above the vcf string as in the updated xd
I updated the VariantVCF component itself so that this change affects everywhere we show vcf strings (Confirmed with Andrea)

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2401

## Deployment URL(s)
http://move-copy-link.review.ensembl.org


## Views affected
Variant EV, GB drawer