### PR TITLE
List all transcript consequences for a variant allele

### DIFF
--- a/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
+++ b/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
@@ -68,6 +68,10 @@ import {
   variantAlleleFrequenciesQuery,
   type VariantAlleleFrequenciesQueryResult
 } from './queries/variantAlleleFrequenciesQuery';
+import {
+  VariantTranscriptConsequencesQueryResult,
+  variantTranscriptConsequencesQuery
+} from './queries/variantTranscriptConsequenceQuery';
 
 type GeneQueryParams = { genomeId: string; geneId: string };
 type ProductQueryParams = { productId: string; genomeId: string };
@@ -210,6 +214,18 @@ const entityViewerThoasSlice = graphqlApiSlice.injectEndpoints({
       }),
       transformResponse: (response: VariantAlleleFrequenciesQueryResult) =>
         addAlleleUrlId(response)
+    }),
+    variantTranscriptConsequences: builder.query<
+      VariantTranscriptConsequencesQueryResult,
+      VariantQueryParams
+    >({
+      query: (params) => ({
+        url: config.variationApiUrl,
+        body: variantTranscriptConsequencesQuery,
+        variables: params
+      }),
+      transformResponse: (response: VariantTranscriptConsequencesQueryResult) =>
+        addAlleleUrlId(response)
     })
   })
 });
@@ -243,7 +259,8 @@ export const {
   useVariantPageMetaQuery,
   useDefaultEntityViewerVariantQuery,
   useVariantStudyPopulationsQuery,
-  useVariantAllelePopulationFrequenciesQuery
+  useVariantAllelePopulationFrequenciesQuery,
+  useVariantTranscriptConsequencesQuery
 } = entityViewerThoasSlice;
 
 export const {

--- a/src/content/app/entity-viewer/state/api/queries/variantTranscriptConsequenceQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/variantTranscriptConsequenceQuery.ts
@@ -1,0 +1,45 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from 'graphql-request';
+import type { VariantPredictedMolecularConsequence } from 'src/shared/types/variation-api/variantPredictedMolecularConsequence';
+
+export const variantTranscriptConsequencesQuery = gql`
+  query VariantTranscriptConsequence($genomeId: String!, $variantId: String!) {
+    variant(by_id: { genome_id: $genomeId, variant_id: $variantId }) {
+      alleles {
+        allele_sequence
+        predicted_molecular_consequences {
+          consequences {
+            accession_id
+          }
+          feature_stable_id
+        }
+      }
+    }
+  }
+`;
+
+type PredictedMolecularConsequence = {
+  urlId: string;
+  allele_sequence: string;
+  predicted_molecular_consequences: VariantPredictedMolecularConsequence[];
+};
+export type VariantTranscriptConsequencesQueryResult = {
+  variant: {
+    alleles: PredictedMolecularConsequence[];
+  };
+};

--- a/src/content/app/entity-viewer/state/variant-view/general/variantViewGeneralSelectors.ts
+++ b/src/content/app/entity-viewer/state/variant-view/general/variantViewGeneralSelectors.ts
@@ -41,3 +41,12 @@ export const getAlleleIdForVariant = (
   const slice = getSliceForVariant(state, genomeId, variantId);
   return slice?.alleleId;
 };
+
+export const getExpandedTranscriptConseqeuenceIds = (
+  state: RootState,
+  genomeId: string,
+  variantId: string
+) => {
+  const transcriptsSlice = getSliceForVariant(state, genomeId, variantId);
+  return transcriptsSlice?.expandedTranscriptConseqeuenceIds ?? [];
+};

--- a/src/content/app/entity-viewer/state/variant-view/general/variantViewGeneralSlice.ts
+++ b/src/content/app/entity-viewer/state/variant-view/general/variantViewGeneralSlice.ts
@@ -32,6 +32,7 @@ export type ViewName = (typeof views)[number];
 export type StateForVariant = {
   view: ViewName;
   alleleId: string | null;
+  expandedTranscriptConseqeuenceIds: string[];
 };
 
 type VariantViewGeneralState = {
@@ -51,7 +52,8 @@ const ensurePresenceOfVariantState = (
   if (!state[genomeId][variantId]) {
     state[genomeId][variantId] = {
       view: 'default',
-      alleleId: null
+      alleleId: null,
+      expandedTranscriptConseqeuenceIds: []
     };
   }
 };
@@ -83,10 +85,25 @@ const variantViewGeneralSlice = createSlice({
       const { genomeId, variantId, alleleId } = action.payload;
       ensurePresenceOfVariantState(state, genomeId, variantId);
       state[genomeId][variantId].alleleId = alleleId;
+    },
+    setExpandedTranscriptConsequenceIds(
+      state,
+      action: PayloadAction<{
+        genomeId: string;
+        variantId: string;
+        expandedTranscriptConseqeuenceIds: string[];
+      }>
+    ) {
+      const { genomeId, variantId, expandedTranscriptConseqeuenceIds } =
+        action.payload;
+      ensurePresenceOfVariantState(state, genomeId, variantId);
+      state[genomeId][variantId].expandedTranscriptConseqeuenceIds =
+        expandedTranscriptConseqeuenceIds;
     }
   }
 });
 
-export const { setView, setAllele } = variantViewGeneralSlice.actions;
+export const { setView, setAllele, setExpandedTranscriptConsequenceIds } =
+  variantViewGeneralSlice.actions;
 
 export default variantViewGeneralSlice.reducer;

--- a/src/content/app/entity-viewer/variant-view/VariantView.tsx
+++ b/src/content/app/entity-viewer/variant-view/VariantView.tsx
@@ -38,6 +38,7 @@ import { useDefaultEntityViewerVariantQuery } from 'src/content/app/entity-viewe
 import VariantViewNavigationPanel from './variant-view-navigation-panel/VariantViewNavigationPanel';
 import VariantImage from './variant-image/VariantImage';
 import PopulationAlleleFrequencies from './population-allele-frequencies/PopulationAlleleFrequencies';
+import TranscriptConsequences from './transcript-consequences/TranscriptConsequences';
 
 import type { VariantAllele } from 'src/shared/types/variation-api/variantAllele';
 
@@ -122,6 +123,8 @@ const MainContent = (props: {
     return <VariantImage {...otherProps} />;
   } else if (view === 'allele-frequencies') {
     return <PopulationAlleleFrequencies {...otherProps} />;
+  } else if (view === 'transcript-consequences') {
+    return <TranscriptConsequences {...otherProps} />;
   }
 };
 

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.module.css
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.module.css
@@ -1,0 +1,112 @@
+.container {
+  padding-left: var(--double-standard-gutter);
+  margin-top: 20px;
+  padding-bottom: var(--global-padding-bottom);
+}
+
+/* Note: might need changing after Panel is refactored */
+.panelHeader {
+  padding-left: calc(var(--standard-gutter) - 10px);
+}
+
+.variantName {
+  font-weight: var(--font-weight-bold);
+}
+
+.variantType {
+  font-size: 11px;
+  font-weight: var(--font-weight-light);
+  margin: 0 10px;
+}
+
+.colonSeparator {
+  font-weight: var(--font-weight-bold);
+}
+
+.transcriptLeftColumn {
+  padding-top: 6px;
+}
+
+.transcriptId {
+  color: var(--color-blue);
+  cursor: pointer;
+  padding-top: 8px;
+}
+
+.transcriptMiddleColumn {
+  display: flex;
+  justify-content: space-between;
+  border-top: 1px solid var(--color-orange);
+  padding: 6px 0;
+}
+
+.label {
+  font-weight: var(--font-weight-light);
+}
+.value {
+  padding-left: 10px;
+}
+
+.transcriptConsqTitle {
+  margin-left: 20px;
+}
+
+.transcriptsList {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  height: 100%;
+}
+
+.content {
+  position: relative;
+  padding-top: 36px;
+  padding-bottom: var(--global-padding-bottom);
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 160px 18px 695px 27px 180px;
+  padding: 5px 0;
+  font-size: 12px;
+  position: relative;
+}
+
+.header {
+  margin-bottom: 25px;
+}
+
+.headerMiddleColumn {
+  display: flex;
+  justify-content: space-between;
+  padding: 6px 0;
+}
+
+.headerRightColumn {
+  padding: 6px 0;
+}
+
+.geneDetails span {
+  padding-left: 8px; 
+}
+
+.geneDetails .geneStableId {
+  font-weight: var(--font-weight-normal);;
+}
+
+.geneDetails .geneSymbol {
+  font-weight: var(--font-weight-bold);;
+}
+
+.left {
+  grid-column: 1/2;
+  text-align: right;
+}
+
+.middle {
+  grid-column: 3/4;
+  position: relative;
+}
+
+.right {
+  grid-column: 5/6;
+}

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.tsx
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.tsx
@@ -1,0 +1,234 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import classnames from 'classnames';
+import { useAppSelector, useAppDispatch } from 'src/store';
+
+import useTranscriptConsequencesData from './useTranscriptConsequencesData';
+
+import Panel from 'src/shared/components/panel/Panel';
+import { CircleLoader } from 'src/shared/components/loader';
+
+import { VariantPredictedMolecularConsequence } from 'src/shared/types/variation-api/variantPredictedMolecularConsequence';
+import { getExpandedTranscriptConseqeuenceIds } from '../../state/variant-view/general/variantViewGeneralSelectors';
+import { setExpandedTranscriptConsequenceIds } from '../../state/variant-view/general/variantViewGeneralSlice';
+import { formatAlleleSequence } from '../variant-view-sidebar/overview/MainAccordion';
+
+import styles from './TranscriptConsequences.module.css';
+
+type Props = {
+  genomeId: string;
+  variantId: string;
+  activeAlleleId: string;
+};
+
+type TranscriptConsequencesData = NonNullable<
+  ReturnType<typeof useTranscriptConsequencesData>['currentData']
+>;
+
+const TranscriptConsequences = (props: Props) => {
+  const { genomeId, variantId, activeAlleleId } = props;
+
+  const { currentData, isLoading } = useTranscriptConsequencesData({
+    genomeId,
+    variantId,
+    activeAlleleId
+  });
+
+  if (isLoading) {
+    const panelHeader = (
+      <div className={styles.panelHeader}>
+        <span className={styles.transcriptConsqTitle}>
+          Transcript Consequences
+        </span>
+      </div>
+    );
+
+    return (
+      <Panel header={panelHeader}>
+        <div className={styles.container}>
+          <CircleLoader />
+        </div>
+      </Panel>
+    );
+  } else if (!currentData) {
+    return null;
+  }
+
+  const { variant, transcriptConsequences, transcriptAllele } = currentData;
+  const panelHeader = <PanelHeader variant={variant} />;
+
+  if (!transcriptConsequences) {
+    return (
+      <Panel header={panelHeader}>
+        <div className={styles.container}>No data</div>
+      </Panel>
+    );
+  }
+
+  return (
+    <Panel header={panelHeader}>
+      <div className={styles.container}>
+        <div className={classnames(styles.row, styles.header)}>
+          <div className={styles.left}></div>
+          <div className={styles.middle}>
+            <div className={styles.headerMiddleColumn}>
+              <div className={styles.transcriptAllele}>
+                <span className={styles.label}>Transcript allele</span>
+                <span className={styles.value}>
+                  {formatAlleleSequence(transcriptAllele as string)}
+                </span>
+              </div>
+              <div className={styles.geneDetails}>
+                <span className={styles.label}>Gene</span>
+                <span className={styles.geneSymbol}>SYM</span>
+                <span className={styles.geneStableId}>ENSG0000000000</span>
+              </div>
+            </div>
+          </div>
+          <div className={classnames(styles.right, styles.headerRightColumn)}>
+            <span>{`${transcriptConsequences.length} transcripts`}</span>
+          </div>
+        </div>
+        <TranscriptConsquencesTable
+          transcriptConsequences={transcriptConsequences}
+          genomeId={genomeId}
+          variantId={variantId}
+        />
+      </div>
+    </Panel>
+  );
+};
+
+const PanelHeader = (props: {
+  variant: TranscriptConsequencesData['variant'];
+}) => {
+  const { variant } = props;
+
+  return (
+    <div className={styles.panelHeader}>
+      <span className={styles.variantName}>{variant.name}</span>
+      <span className={styles.variantType}>{variant.allele_type.value}</span>
+      <span className={styles.colonSeparator}>:</span>
+      <span className={styles.transcriptConsqTitle}>
+        Transcript Consequences
+      </span>
+    </div>
+  );
+};
+
+const TranscriptConsquencesTable = (props: {
+  transcriptConsequences: NonNullable<
+    TranscriptConsequencesData['transcriptConsequences']
+  >;
+  genomeId: string;
+  variantId: string;
+}) => {
+  const { transcriptConsequences, genomeId, variantId } = props;
+
+  return (
+    <TranscriptConsequencesList
+      transcriptConsequences={transcriptConsequences}
+      genomeId={genomeId}
+      variantId={variantId}
+    />
+  );
+};
+
+type TranscriptConsequencesListProps = {
+  transcriptConsequences: VariantPredictedMolecularConsequence[];
+  genomeId: string;
+  variantId: string;
+};
+
+const TranscriptConsequencesList = (props: TranscriptConsequencesListProps) => {
+  const { genomeId, variantId } = props;
+  const expandedTranscriptIds = useAppSelector((state) =>
+    getExpandedTranscriptConseqeuenceIds(state, genomeId, variantId)
+  );
+  const expandedIds = new Set<string>(expandedTranscriptIds);
+  const dispatch = useAppDispatch();
+
+  const handleTranscriptConsequenceClick = (transcriptId: string) => {
+    if (expandedIds.has(transcriptId)) {
+      expandedIds.delete(transcriptId);
+    } else {
+      expandedIds.add(transcriptId);
+    }
+
+    dispatch(
+      setExpandedTranscriptConsequenceIds({
+        genomeId,
+        variantId,
+        expandedTranscriptConseqeuenceIds: [...expandedIds.values()]
+      })
+    );
+  };
+
+  const { transcriptConsequences } = props;
+  return (
+    <div className={styles.transcriptConsequenceListView}>
+      {transcriptConsequences.map((transcript, index) => (
+        <div key={index}>
+          <div className={styles.row}>
+            {/* <TranscriptQualityLabel metadata={props.transcript.metadata} /> */}
+            <div className={styles.transcriptLeftColumn}></div>
+            <div className={styles.middle}>
+              <div className={styles.clickableTranscriptArea}>
+                <div className={styles.transcriptMiddleColumn}>
+                  <div>
+                    <span className={styles.label}>
+                      Transcript variant type
+                    </span>
+                    <span className={styles.value}>
+                      {transcript.consequences[0].accession_id}
+                    </span>
+                  </div>
+                  <div>
+                    <span className={styles.label}>Transcript biotype</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className={styles.right}
+              onClick={() =>
+                handleTranscriptConsequenceClick(transcript.feature_stable_id)
+              }
+            >
+              <div className={styles.transcriptId}>
+                {transcript.feature_stable_id}
+              </div>
+            </div>
+          </div>
+
+          {expandedTranscriptIds.includes(transcript.feature_stable_id) ? (
+            <TranscriptsConsequencesItemInfo
+              transcriptId={transcript.feature_stable_id}
+            />
+          ) : null}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const TranscriptsConsequencesItemInfo = (props: { transcriptId: string }) => (
+  <div>More info for {props.transcriptId}</div>
+);
+
+export default TranscriptConsequences;

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/useTranscriptConsequencesData.ts
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/useTranscriptConsequencesData.ts
@@ -1,0 +1,68 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  useDefaultEntityViewerVariantQuery,
+  useVariantTranscriptConsequencesQuery
+} from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
+
+type Params = {
+  genomeId: string;
+  variantId: string;
+  activeAlleleId: string;
+};
+
+const useTranscriptConsequencesData = (params: Params) => {
+  const {
+    currentData: defaultVariantData,
+    isFetching: isVariantLoading,
+    isError: isVariantError
+  } = useDefaultEntityViewerVariantQuery({
+    genomeId: params.genomeId,
+    variantId: params.variantId
+  });
+
+  const {
+    currentData: transcriptConsequencesData,
+    isFetching: areTranscriptConsequencesLoading,
+    isError: isTranscriptConsequencesError
+  } = useVariantTranscriptConsequencesQuery(params);
+
+  if (!defaultVariantData || !transcriptConsequencesData) {
+    return {
+      currentData: null,
+      isLoading: isVariantLoading || areTranscriptConsequencesLoading,
+      isError: isVariantError || isTranscriptConsequencesError
+    };
+  }
+
+  const transcriptConsData = transcriptConsequencesData.variant.alleles.find(
+    (allele) => allele.urlId === params.activeAlleleId
+  );
+
+  return {
+    currentData: {
+      variant: defaultVariantData.variant,
+      transcriptAllele: transcriptConsData?.allele_sequence,
+      transcriptConsequences:
+        transcriptConsData?.predicted_molecular_consequences
+    },
+    isLoading: false,
+    isError: false
+  };
+};
+
+export default useTranscriptConsequencesData;

--- a/src/content/app/entity-viewer/variant-view/variant-view-navigation-panel/VariantViewNavigationPanel.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-view-navigation-panel/VariantViewNavigationPanel.tsx
@@ -27,6 +27,7 @@ import {
 } from 'src/shared/helpers/variantHelpers';
 
 import { useDefaultEntityViewerVariantQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
+import useTranscriptConsequencesData from '../transcript-consequences/useTranscriptConsequencesData';
 
 import VariantViewTab from './variant-view-tab/VariantViewTab';
 
@@ -43,6 +44,12 @@ type Props = {
 const VariantViewNavigationPanel = (props: Props) => {
   const { genomeIdForUrl, variantId, activeAlleleId, view } = props;
   const { currentData } = useVariantViewNavigationData(props);
+  const { currentData: transcriptConsequenceData } =
+    useTranscriptConsequencesData(props);
+
+  const transcriptConsequenceCount =
+    transcriptConsequenceData?.transcriptConsequences?.length;
+
   const navigate = useNavigate();
 
   if (!currentData) {
@@ -73,6 +80,14 @@ const VariantViewNavigationPanel = (props: Props) => {
     navigate(url);
   };
 
+  const onTranscriptConsequencesClick = () => {
+    const url = urlFor.entityViewerVariant({
+      ...commonUrlParams,
+      view: 'transcript-consequences'
+    });
+    navigate(url);
+  };
+
   const componentClasses = classNames(styles.grid, {
     [styles.withBottomBorder]: !props.view
   });
@@ -90,9 +105,10 @@ const VariantViewNavigationPanel = (props: Props) => {
         viewId="transcript-consequences"
         tabText="Transcript consequences"
         labelText="Features"
-        pillContent="0"
-        pressed={false}
-        disabled={true}
+        pillContent={transcriptConsequenceCount}
+        disabled={transcriptConsequenceCount === 0}
+        onClick={onTranscriptConsequencesClick}
+        pressed={view === 'transcript-consequences'}
       />
       <VariantViewTab
         viewId="regulatory-consequences"

--- a/src/content/app/entity-viewer/variant-view/variant-view-sidebar/overview/MainAccordion.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-view-sidebar/overview/MainAccordion.tsx
@@ -213,7 +213,7 @@ const Allele = (props: {
   }
 };
 
-const formatAlleleSequence = (sequence: string) => {
+export const formatAlleleSequence = (sequence: string) => {
   const maxCharacters = 18;
 
   return sequence.length > maxCharacters

--- a/src/shared/types/variation-api/variantAllele.ts
+++ b/src/shared/types/variation-api/variantAllele.ts
@@ -20,6 +20,7 @@ import type { VariantPredictionResult } from './variantPredictionResult';
 import type { VariantAllelePopulationFrequency } from './variantAllelePopulationFrequency';
 import type { VariantAllelePhenotypeAssertion } from './variantAllelePhenotypeAssertion';
 import type { OntologyTermMetadata } from '../core-api/metadata';
+import type { VariantPredictedMolecularConsequence } from './variantPredictedMolecularConsequence';
 
 export type VariantAllele = {
   type: 'VariantAllele';
@@ -32,5 +33,6 @@ export type VariantAllele = {
   prediction_results: VariantPredictionResult[];
   population_frequencies: VariantAllelePopulationFrequency[];
   phenotype_assertions: VariantAllelePhenotypeAssertion[];
+  predicted_molecular_consequences: VariantPredictedMolecularConsequence[];
   citations: unknown[]; // will be an array of Publication data types submitted to CDM
 };

--- a/src/shared/types/variation-api/variantPredictedMolecularConsequence.ts
+++ b/src/shared/types/variation-api/variantPredictedMolecularConsequence.ts
@@ -1,0 +1,24 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type VariantPredictedMolecularConsequence = {
+  consequences: Consequence[];
+  feature_stable_id: string;
+};
+
+type Consequence = {
+  accession_id: string;
+};


### PR DESCRIPTION
## Description
Done in this PR:

1. Added tab header with variant info
2. List all transcript consequences as per [XD](https://xd.adobe.com/view/573e7994-6561-412f-84f0-b34c0d38761e-026d/screen/fb9c7da5-6910-4974-bbe5-27c3607a7690)
3. Added feature count (pill under the navigation tab)
4. Placeholder for expanded transcripts
5. State that remembers expanded transcripts
6. Placeholder for gene symbol and stable id (to be updated once the [new payload](https://github.com/Ensembl/ensembl-vdm-docs/pull/9/files) becomes available)

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2425

## Deployment URL(s)
http://transcript-consequence.review.ensembl.org


## Views affected
EV variant