### PR TITLE
Update the Copy button and the VariantVCF component

### DIFF
--- a/src/content/app/entity-viewer/variant-view/variant-view-sidebar/overview/VariantOverview.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-view-sidebar/overview/VariantOverview.module.css
@@ -23,6 +23,7 @@
 
 .labelValueWrapper {
   display: flex;
+  align-items: baseline;
   margin-top: 8px;
 }
 

--- a/src/shared/components/copy/Copy.module.css
+++ b/src/shared/components/copy/Copy.module.css
@@ -1,6 +1,5 @@
 .copyLozenge {
   display: inline-flex;
-  height: 18px;
   width: 68px;
   align-items: center;
 }

--- a/src/shared/components/copy/Copy.module.css
+++ b/src/shared/components/copy/Copy.module.css
@@ -1,13 +1,37 @@
 .copyLozenge {
   display: inline-flex;
   height: 18px;
-  padding: 0 14px;
+  width: 68px;
   align-items: center;
+}
+
+/* 
+  Considering that when the copy button is pressed, it shows
+  a lozenge that is wider than the initial text "Copy"
+  (the lozenge text says "Copied", and the lozenge itself
+  has padding left and right), below are three alignment classes
+  to position the initial label ("Copy") within the space taken by the lozenge.
+
+  The label "Copy" can be aligned to the left of the lozenge space,
+  or to its right, or to the middle.
+  Notice that the text "Copied" is always middle-aligned
+*/
+
+.alignLeft {
+  justify-content: flex-start;
+}
+
+.alignMiddle {
   justify-content: center;
+}
+
+.alignRight {
+  justify-content: flex-end;
 }
 
 .copy {
   color: var(--color-blue);
+  line-height: inherit;
 }
 
 .copyLozengeCopied {

--- a/src/shared/components/copy/Copy.tsx
+++ b/src/shared/components/copy/Copy.tsx
@@ -19,10 +19,13 @@ import classNames from 'classnames';
 
 import styles from './Copy.module.css';
 
+type Alignment = 'left' | 'middle' | 'right';
+
 type Props = {
   value: string;
   onCopy?: () => void;
   className?: string;
+  align?: Alignment; // by default, the component aligns the text "Copy" to middle
 };
 
 const Copy = (props: Props) => {
@@ -52,6 +55,9 @@ const Copy = (props: Props) => {
   const componentStyles = classNames(
     styles.copyLozenge,
     {
+      [styles.alignLeft]: props.align === 'left' && !copied,
+      [styles.alignMiddle]: props.align === 'middle' || !props.align || copied,
+      [styles.alignRight]: props.align === 'right' && !copied,
       [styles.copyLozengeCopied]: copied
     },
     props.className

--- a/src/shared/components/variant-vcf/VariantVCF.module.css
+++ b/src/shared/components/variant-vcf/VariantVCF.module.css
@@ -1,7 +1,6 @@
 .container {
   display: flex;
-  flex-wrap: wrap;
-  column-gap: 2ch;
+  flex-direction: column;
   row-gap: 1ch;
 }
 

--- a/src/shared/components/variant-vcf/VariantVCF.tsx
+++ b/src/shared/components/variant-vcf/VariantVCF.tsx
@@ -52,7 +52,9 @@ const VariantVCF = (props: Props) => {
 
   return (
     <div className={componentClasses}>
-      {props.withCopy && <Copy value={vcfSequenceParts.vcfString} />}
+      {props.withCopy && (
+        <Copy value={vcfSequenceParts.vcfString} align="left" />
+      )}
       <span className={styles.vcfString}>
         <span>{vcfSequenceParts.regionName}</span>
         <span>{vcfSequenceParts.startCoordinate}</span>

--- a/stories/shared-components/copy/Copy.stories.module.css
+++ b/stories/shared-components/copy/Copy.stories.module.css
@@ -1,0 +1,13 @@
+.section:not(:first-child) {
+  margin-top: 3rem;
+}
+
+.frame {
+  border: 1px dashed var(--color-medium-light-grey);
+  width: fit-content;
+}
+
+.inFrameContainer {
+  display: flex;
+  column-gap: 0.6rem;
+}

--- a/stories/shared-components/copy/Copy.stories.tsx
+++ b/stories/shared-components/copy/Copy.stories.tsx
@@ -1,0 +1,66 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import Copy from 'src/shared/components/copy/Copy';
+
+import styles from './Copy.stories.module.css';
+
+const textToCopy = 'Hello world!';
+
+const DefaultCopyButtonStory = () => (
+  <>
+    <section className={styles.section}>
+      <p>Middle alignment of the "Copy" label (default)</p>
+      <div className={styles.frame}>
+        <div className={styles.inFrameContainer}>
+          <Copy value={textToCopy} />
+          <span>Some text to the right</span>
+        </div>
+      </div>
+    </section>
+
+    <section className={styles.section}>
+      <p>Left alignment of the "Copy" label</p>
+      <div className={styles.frame}>
+        <div className={styles.inFrameContainer}>
+          <Copy value={textToCopy} align="left" />
+          <span>Some text to the right</span>
+        </div>
+      </div>
+    </section>
+
+    <section className={styles.section}>
+      <p>Right alignment of the "Copy" label</p>
+      <div className={styles.frame}>
+        <div className={styles.inFrameContainer}>
+          <span>Some text to the left</span>
+          <Copy value={textToCopy} align="right" />
+        </div>
+      </div>
+    </section>
+  </>
+);
+
+export const DefaultExternalLinkStory = {
+  name: 'default',
+  render: () => <DefaultCopyButtonStory />
+};
+
+export default {
+  title: 'Components/Shared Components/Copy'
+};


### PR DESCRIPTION
## Description
- Add a new property to the Copy button, so that it could align the text saying "Copy" to the left, middle, or right of the reserved space, and not push the surrounding elements to the side when the button is pressed (all because when we click the "Copy" button, a "Copied" lozenge appears, which is wider than the initial label 🤦 )
- Following Andrea's instructions, made the VariantVCF component always start a new line after the "Copy" button. Don't know what impact this is going to have for us later on.
- Added the Copy button to Storybook

https://github.com/Ensembl/ensembl-client/assets/6834224/30504737-c9d7-4dee-9fad-a30d3a3e8744


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2424

## Deployment URL(s)
http://copy-button.review.ensembl.org

_(NOTE: You won't see the copy button on review deployments because the copy functionality does not work over http. Please check locally.)_