### PR TITLE
Add CDS diagram to transcript consequences view

### DIFF
--- a/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
+++ b/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
@@ -231,20 +231,9 @@ const entityViewerThoasSlice = graphqlApiSlice.injectEndpoints({
         body: variantPredictedMolecularConsequencesQuery,
         variables: params
       }),
-      transformResponse: (response: VariantPredictedMolecularConsequencesResponse) => {
-        // Adapt to the api error by copying values from consequence.accession_id to consequence.value
-        // TODO: remove when the api is fix
-        for (const allele of response.variant.alleles ) {
-          for ( const predicted_consequence of allele.predicted_molecular_consequences ) {
-            for ( const cons of predicted_consequence.consequences) {
-              cons.value = (cons as any).accession_id;
-            }
-          }
-
-        }
-        return addAlleleUrlId(response);
-      }
-
+      transformResponse: (
+        response: VariantPredictedMolecularConsequencesResponse
+      ) => addAlleleUrlId(response)
     }),
     geneForVariantTranscriptConsequences: builder.query<
       GeneForVariantTranscriptConsequencesResponse,
@@ -265,7 +254,7 @@ const entityViewerThoasSlice = graphqlApiSlice.injectEndpoints({
         body: transcriptForVariantTranscriptConsequencesQuery,
         variables: params
       })
-    }),
+    })
   })
 });
 

--- a/src/content/app/entity-viewer/state/api/queries/variantPredictedMolecularConsequencesQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/variantPredictedMolecularConsequencesQuery.ts
@@ -1,29 +1,79 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { gql } from 'graphql-request';
 
-import type { VariantPredictedMolecularConsequence } from 'src/shared/types/variation-api/variantPredictedMolecularConsequence';
+import type {
+  VariantPredictedMolecularConsequence,
+  VariantRelativeLocation
+} from 'src/shared/types/variation-api/variantPredictedMolecularConsequence';
 
+const variantRelativeLocationFragment = gql`
+  fragment RelativeLocationFields on VariantRelativeLocation {
+    start
+    end
+    length
+    ref_sequence
+    alt_sequence
+  }
+`;
 
-// FIXME: the string value of the consequence for a given allele in a given transcript
-// is currently erronously returned in the `accession_id` field of the consequence structure.
-// It should be changed from `accession_id` to `value` very soon.
-// Once that is done, delete the accession_id field from the query.
 export const variantPredictedMolecularConsequencesQuery = gql`
-  query VariantPredictedMolecularConsequences($genomeId: String!, $variantId: String!) {
+  query VariantPredictedMolecularConsequences(
+    $genomeId: String!
+    $variantId: String!
+  ) {
     variant(by_id: { genome_id: $genomeId, variant_id: $variantId }) {
       alleles {
         predicted_molecular_consequences {
-          feature_stable_id
+          stable_id
+          gene_stable_id
+          gene_symbol
+          cdna_location {
+            ...RelativeLocationFields
+          }
+          cds_location {
+            ...RelativeLocationFields
+          }
+          protein_location {
+            ...RelativeLocationFields
+          }
           consequences {
-            accession_id
             value
           }
         }
       }
     }
   }
+  ${variantRelativeLocationFragment}
 `;
 
-type PredictedMolecularConsequenceInResponse = Pick<VariantPredictedMolecularConsequence, 'feature_stable_id' | 'consequences'>;
+type VariantRelativeLocationInResponse = Omit<
+  VariantRelativeLocation,
+  'percentage_overlap'
+>;
+
+export type PredictedMolecularConsequenceInResponse = Pick<
+  VariantPredictedMolecularConsequence,
+  'stable_id' | 'gene_stable_id' | 'gene_symbol' | 'consequences'
+> & {
+  cdna_location: VariantRelativeLocationInResponse | null;
+  cds_location: VariantRelativeLocationInResponse | null;
+  protein_location: VariantRelativeLocationInResponse | null;
+};
 
 type VariantAlleleInResponse = {
   urlId: string;
@@ -35,5 +85,5 @@ type VariantInResponse = {
 };
 
 export type VariantPredictedMolecularConsequencesResponse = {
-  variant: VariantInResponse
+  variant: VariantInResponse;
 };

--- a/src/content/app/entity-viewer/state/api/queries/variantTranscriptConsequencesQueries.ts
+++ b/src/content/app/entity-viewer/state/api/queries/variantTranscriptConsequencesQueries.ts
@@ -76,6 +76,7 @@ export const transcriptForVariantTranscriptConsequencesQuery = gql`
         length
       }
       spliced_exons {
+        index
         relative_location {
           start
           end
@@ -86,6 +87,7 @@ export const transcriptForVariantTranscriptConsequencesQuery = gql`
         cds {
           relative_start
           relative_end
+          nucleotide_length
         }
       }
     }
@@ -98,11 +100,15 @@ type GeneInResponse = Pick<FullGene, 'stable_id' | 'symbol'> &
   Pick4<FullGene, 'slice', 'region', 'sequence', 'checksum'> &
   Pick3<FullGene, 'slice', 'strand', 'code'>;
 
-type SplicedExonInTranscript = Pick2<
+type SplicedExonInTranscript = Pick<
   FullTranscript['spliced_exons'][number],
-  'relative_location',
-  'start' | 'end' | 'length'
->;
+  'index'
+> &
+  Pick2<
+    FullTranscript['spliced_exons'][number],
+    'relative_location',
+    'start' | 'end' | 'length'
+  >;
 type ProductGeneratingContextInTranscript = {
   cds: {
     relative_start: NonNullable<
@@ -111,6 +117,9 @@ type ProductGeneratingContextInTranscript = {
     relative_end: NonNullable<
       FullProductGeneratingContext['cds']
     >['relative_end'];
+    nucleotide_length: NonNullable<
+      FullProductGeneratingContext['cds']
+    >['nucleotide_length'];
   } | null;
 };
 

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.tsx
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.tsx
@@ -240,12 +240,12 @@ const TranscriptConsequencesList = (props: TranscriptConsequencesListProps) => {
   const { transcriptConsequences } = props;
   return (
     <div className={styles.transcriptConsequenceListView}>
-      {transcriptConsequences.map((transcript, index) => (
+      {transcriptConsequences.map((consequencesForSingleTranscript, index) => (
         <div key={index}>
           <div
             className={classnames(styles.row, {
               [styles.rowExpanded]: expandedIds.has(
-                transcript.feature_stable_id
+                consequencesForSingleTranscript.stable_id
               )
             })}
           >
@@ -259,7 +259,7 @@ const TranscriptConsequencesList = (props: TranscriptConsequencesListProps) => {
                       Transcript variant type
                     </span>
                     <span className={styles.value}>
-                      {transcript.consequences
+                      {consequencesForSingleTranscript.consequences
                         .map(({ value }) => value)
                         .join(', ')}
                     </span>
@@ -273,22 +273,25 @@ const TranscriptConsequencesList = (props: TranscriptConsequencesListProps) => {
             <div
               className={styles.right}
               onClick={() =>
-                handleTranscriptConsequenceClick(transcript.feature_stable_id)
+                handleTranscriptConsequenceClick(
+                  consequencesForSingleTranscript.stable_id
+                )
               }
             >
               <div className={styles.transcriptId}>
-                {transcript.feature_stable_id}
+                {consequencesForSingleTranscript.stable_id}
               </div>
             </div>
           </div>
 
-          {expandedIds.has(transcript.feature_stable_id) ? (
+          {expandedIds.has(consequencesForSingleTranscript.stable_id) ? (
             <TranscriptConsequenceDetails
               genomeId={genomeId}
-              transcriptId={transcript.feature_stable_id}
+              transcriptId={consequencesForSingleTranscript.stable_id}
               gene={gene}
               allele={allele}
               variant={variant}
+              transcriptConsequences={consequencesForSingleTranscript}
             />
           ) : null}
         </div>

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-consequence-details/TranscriptConsequenceDetails.tsx
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-consequence-details/TranscriptConsequenceDetails.tsx
@@ -183,18 +183,37 @@ const CDSSection = (props: {
     >;
   };
 }) => {
-  const { exons, cds } = props;
+  const { exons, cds, allele } = props;
 
+  // NOTE: instead of using the function below that tries to calculate exon locations in CDS,
+  // the api should report this to the client.
   const exonsWithinCDS = addRelativeLocationInCDSToExons({
     exons,
     cds
   }).filter((exon) => Boolean(exon.relative_location_in_cds));
 
+  const variantStartInCDS = allele.relativeLocation.start;
+  const variantEndInCDS = allele.relativeLocation.end;
+  const singleVariantCoord = variantStartInCDS || (variantEndInCDS as number); // we are promised that there will always be either a start or an end
+
+  const variantLocationString =
+    allele.type === 'insertion'
+      ? formatNumber(variantStartInCDS as number)
+      : variantStartInCDS && variantEndInCDS
+        ? `${formatNumber(variantStartInCDS)} - ${formatNumber(variantEndInCDS)}`
+        : formatNumber(singleVariantCoord);
+
   return (
     <>
       <div className={commonStyles.row}>
         <div className={commonStyles.left}>CDS</div>
-        <div className={commonStyles.middle}>Position in CDS</div>
+        <div className={commonStyles.middle}>
+          <span className={styles.smallLight}>Position in CDS</span>{' '}
+          <span className={styles.small}>{variantLocationString}</span>{' '}
+          <span className={styles.smallLight}>
+            of {formatNumber(cds.nucleotide_length)}
+          </span>
+        </div>
       </div>
 
       <div className={commonStyles.row}>

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-consequence-details/TranscriptConsequenceDetails.tsx
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-consequence-details/TranscriptConsequenceDetails.tsx
@@ -196,12 +196,21 @@ const CDSSection = (props: {
   const variantEndInCDS = allele.relativeLocation.end;
   const singleVariantCoord = variantStartInCDS || (variantEndInCDS as number); // we are promised that there will always be either a start or an end
 
-  const variantLocationString =
-    allele.type === 'insertion'
-      ? formatNumber(variantStartInCDS as number)
-      : variantStartInCDS && variantEndInCDS
-        ? `${formatNumber(variantStartInCDS)} - ${formatNumber(variantEndInCDS)}`
-        : formatNumber(singleVariantCoord);
+  let variantLocationString: string;
+
+  if (allele.type === 'insertion') {
+    // just show the start coordinate for an insertion; it should be available
+    variantLocationString = formatNumber(variantStartInCDS as number);
+  } else if (variantStartInCDS === variantEndInCDS) {
+    // start and end shouldn't both be null; which means that they both are the same number
+    variantLocationString = formatNumber(variantStartInCDS as number);
+  } else if (variantStartInCDS && variantEndInCDS) {
+    // both start and end are present, and are different from each other
+    variantLocationString = `${formatNumber(variantStartInCDS)} - ${formatNumber(variantEndInCDS)}`;
+  } else {
+    // one of the coordinates is unknown; show the known one
+    variantLocationString = formatNumber(singleVariantCoord);
+  }
 
   return (
     <>

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-cds/TranscriptVariantCDS.module.css
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-cds/TranscriptVariantCDS.module.css
@@ -1,0 +1,15 @@
+.exonBlock {
+  fill: var(--color-grey);
+}
+
+.exonBlockArrow {
+  fill: color-mix(in srgb, var(--color-white) 50%, transparent);
+}
+
+.label {
+  font-weight: var(--font-weight-light);
+}
+
+.labelBold {
+  font-weight: initial;
+}

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-cds/TranscriptVariantCDS.tsx
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-cds/TranscriptVariantCDS.tsx
@@ -1,0 +1,340 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import type { Pick2 } from 'ts-multipick';
+import { scaleLinear, interpolateRound, ScaleLinear } from 'd3';
+
+import { measureText } from 'src/shared/helpers/textHelpers';
+
+import ChevronDown from 'static/icons/icon_chevron.svg';
+
+import type { SplicedExon } from 'src/shared/types/core-api/exon';
+import type { FullCDS } from 'src/shared/types/core-api/cds';
+import type { VariantRelativeLocation } from 'src/shared/types/variation-api/variantPredictedMolecularConsequence';
+import type { ExonWithRelativeLocationInCDS } from 'src/shared/helpers/exon-helpers/exonHelpers';
+
+import styles from './TranscriptVariantCDS.module.css';
+
+type ExonFields = Pick<SplicedExon, 'index'> &
+  Pick2<SplicedExon, 'relative_location', 'start' | 'end'>;
+type CDSFields = Pick<
+  FullCDS,
+  'relative_start' | 'relative_end' | 'nucleotide_length'
+>;
+type VariantRelativeLocationFields = Pick<
+  VariantRelativeLocation,
+  'start' | 'end'
+>;
+
+/**
+ * Specs
+ * - Exon
+ *  - height: 12px
+ *  - color: $grey
+ * - White space to the right of exon: 1px
+ *
+ * - Min exon width: 2px
+ * - Min exon width with arrow: 18px
+ *  - Arrow:
+ *    - height: 9px
+ *    - color: $white, opacity: 50%
+ *
+ * - Line representing the variant:
+ *  - height: 18px
+ *  - width: 2px
+ *  - color: $black
+ *  - centered vertically relative to exon block
+ *
+ */
+
+type Props = {
+  exons: Array<ExonFields & ExonWithRelativeLocationInCDS>;
+  cds: CDSFields;
+  allele: {
+    type: string;
+    relativeLocation: VariantRelativeLocationFields;
+  };
+};
+
+const MIN_EXON_BLOCK_WIDTH = 2;
+const EXON_MARGIN_WIDTH = 1;
+const EXON_BLOCK_HEIGHT = 12;
+const MIN_EXON_BLOCK_WITH_ARROW_WIDTH = 18;
+const VARIANT_MARKER_HEIGHT = 18;
+const VATIANT_MARKER_WIDTH = 2;
+const DIAGRAM_HEIGHT = 42;
+
+const EXON_BLOCK_OFFSET_TOP = (VARIANT_MARKER_HEIGHT - EXON_BLOCK_HEIGHT) / 2;
+
+const TranscriptVariantCDS = (props: Props) => {
+  const { exons, allele, cds } = props;
+  const width = 700;
+
+  const scale = scaleLinear()
+    .domain([1, cds.nucleotide_length])
+    .range([1, width])
+    .interpolate(interpolateRound)
+    .clamp(true);
+
+  const exonsWithWidths = getExonWidths({
+    exons,
+    containerWidth: width,
+    scale
+  });
+
+  return (
+    <svg
+      width={width}
+      height={DIAGRAM_HEIGHT}
+      viewBox={`0 0 ${width} ${DIAGRAM_HEIGHT}`}
+      overflow="visible"
+    >
+      <Exons exons={exonsWithWidths} />
+      <VariantMark
+        exons={exonsWithWidths}
+        allele={allele}
+        scale={scale}
+        containerWidth={width}
+      />
+    </svg>
+  );
+};
+
+const Exons = (props: { exons: Array<{ width: number }> }) => {
+  let x = 0;
+
+  const exonBlocks = props.exons.map((exon, index) => {
+    const width = exon.width;
+    const currentX = x;
+    x += width + EXON_MARGIN_WIDTH;
+
+    return <ExonBlock key={index} x={currentX} width={width} />;
+  });
+
+  return <g>{exonBlocks}</g>;
+};
+
+const ExonBlock = (props: { x: number; width: number }) => {
+  const { x, width } = props;
+  const desiredArrowHeight = 9;
+
+  if (width >= MIN_EXON_BLOCK_WITH_ARROW_WIDTH) {
+    // FIXME: instead of desiredArrowHeight, i.e. the width of the chevron, subtract half the true height of the chevron
+    const arrowX = x + width / 2 - desiredArrowHeight;
+
+    // for each arrow, define the rotation origin to be exactly in the middle of the arrow
+    const rotateOriginX = arrowX + desiredArrowHeight / 2;
+    const rotateOriginY = EXON_BLOCK_OFFSET_TOP + EXON_BLOCK_HEIGHT / 2;
+
+    return (
+      <>
+        <rect
+          className={styles.exonBlock}
+          x={x}
+          y={EXON_BLOCK_OFFSET_TOP}
+          width={width}
+          height={EXON_BLOCK_HEIGHT}
+        />
+        {/* 
+          Wrapping ChevronDown in a group element,
+          because browsers have not yet implemented transform attribute on svg element itself;
+          and therefore, we cannot rotate the chevron directly
+          (https://stackoverflow.com/a/50416852/3925302)
+        */}
+        <g transform={`rotate(-90 ${rotateOriginX} ${rotateOriginY})`}>
+          <ChevronDown
+            className={styles.exonBlockArrow}
+            x={arrowX}
+            y={EXON_BLOCK_OFFSET_TOP + EXON_BLOCK_HEIGHT / 2}
+            width={desiredArrowHeight}
+            height="5.625"
+          />
+        </g>
+      </>
+    );
+  } else {
+    return <rect x={x} width={width} height={EXON_BLOCK_HEIGHT} />;
+  }
+};
+
+const VariantMark = (props: {
+  exons: ReturnType<typeof getExonWidths>;
+  allele: Props['allele'];
+  scale: ScaleLinear<number, number>;
+  containerWidth: number;
+}) => {
+  const { allele, scale } = props;
+
+  const variantPosition =
+    allele.relativeLocation.start || allele.relativeLocation.end;
+
+  if (!variantPosition) {
+    // This shouldn't happen. If we are here, our CDS diagram is useless, because we can't project the variant onto the CDS
+    return null;
+  }
+
+  const x = scale(variantPosition);
+
+  return (
+    <>
+      <rect x={x} width={VATIANT_MARKER_WIDTH} height={VARIANT_MARKER_HEIGHT} />
+      <VariantMarkLabel {...props} markX={x} />
+    </>
+  );
+};
+
+const VariantMarkLabel = (props: {
+  exons: ReturnType<typeof getExonWidths>;
+  allele: Props['allele'];
+  markX: number; // the x-coordinate for positioning the variant mark
+  containerWidth: number;
+  scale: ScaleLinear<number, number>;
+}) => {
+  const { allele, exons, markX, containerWidth } = props;
+
+  const totalCodingExonsCount = exons.length;
+  const variantPosition = (allele.relativeLocation.start ||
+    allele.relativeLocation.end) as number;
+
+  let affectedExonNumber = 1;
+
+  for (let i = 0; i < exons.length; i++) {
+    const exon = exons[i];
+    const exonStart = exon.relative_location_in_cds!.start;
+    const exonEnd = exon.relative_location_in_cds!.end;
+
+    if (variantPosition >= exonStart && variantPosition <= exonEnd) {
+      affectedExonNumber = i + 1;
+      break;
+    }
+  }
+
+  const labelText = `Coding exon ${affectedExonNumber} of ${totalCodingExonsCount}`;
+  const labelFont = '11px Lato';
+
+  const { width: predictedLabelWidth } = measureText({
+    text: labelText,
+    font: labelFont
+  });
+
+  let labelX = markX;
+  let textAnchor = 'middle';
+
+  if (predictedLabelWidth / 2 > labelX) {
+    labelX = 0;
+    textAnchor = 'start';
+  } else if (labelX + predictedLabelWidth / 2 > containerWidth) {
+    labelX = containerWidth;
+    textAnchor = 'end';
+  }
+
+  return (
+    <text
+      className={styles.label}
+      textAnchor={textAnchor}
+      x={labelX}
+      y="30"
+      fontSize={11}
+    >
+      Coding exon{' '}
+      <tspan className={styles.labelBold}>{affectedExonNumber}</tspan> of{' '}
+      {exons.length}
+    </text>
+  );
+};
+
+// const WidthContainer = (props: { children: React.ReactNode }) => {
+//   const [containerWidth, setContainerWidth] = useState(0);
+//   const containerRef = useRef<HTMLDivElement | null>(null);
+
+//   useLayoutEffect(() => {
+//     const measuredContainerWidth =
+//       containerRef.current?.getBoundingClientRect().width ?? 0;
+//     setContainerWidth(measuredContainerWidth);
+//   }, []);
+
+//   return (
+//     <div ref={containerRef}>
+//       { !!containerWidth && props.children }
+//     </div>
+//   );
+// };
+
+const getExonWidths = (params: {
+  exons: Props['exons'];
+  containerWidth: number;
+  scale: ScaleLinear<number, number>;
+}) => {
+  const { exons, scale, containerWidth } = params;
+
+  const exonBlocks = exons.map((exon) => ({
+    ...exon,
+    width: scale(exon.relative_location_in_cds!.length) - EXON_MARGIN_WIDTH
+  }));
+
+  return adjustExonWidths({ exonBlocks, containerWidth });
+};
+
+const adjustExonWidths = <T extends { index: number; width: number }>(params: {
+  exonBlocks: Array<T>;
+  containerWidth: number;
+}) => {
+  const { exonBlocks, containerWidth } = params;
+  const maxExonBlocksCount =
+    containerWidth / (EXON_MARGIN_WIDTH + MIN_EXON_BLOCK_WIDTH);
+
+  if (maxExonBlocksCount <= exonBlocks.length) {
+    return exonBlocks.slice(0, maxExonBlocksCount).map((exon) => ({
+      ...exon,
+      width: MIN_EXON_BLOCK_WIDTH
+    }));
+  }
+
+  // sort by width, shortest to longest
+  exonBlocks.sort((exonA, exonB) => exonA.width - exonB.width);
+
+  let currentShrinkableExonIndex = exonBlocks.length - 1;
+
+  for (const exon of exonBlocks) {
+    if (exon.width < MIN_EXON_BLOCK_WIDTH) {
+      const extraWidth = MIN_EXON_BLOCK_WIDTH - exon.width;
+      let donorExonBlock = exonBlocks[currentShrinkableExonIndex];
+
+      if (donorExonBlock.width! > MIN_EXON_BLOCK_WIDTH) {
+        currentShrinkableExonIndex = exonBlocks.length - 1;
+        donorExonBlock = exonBlocks[currentShrinkableExonIndex];
+      }
+
+      if (donorExonBlock.width > MIN_EXON_BLOCK_WIDTH) {
+        donorExonBlock.width -= extraWidth;
+        exon.width += extraWidth;
+        currentShrinkableExonIndex -= 1;
+      } else {
+        // After the previous if-clause we would expect the donor exon block's to be wider than the minimum width
+        // But if, for whatever reason, it is not, it means that something has gone wrong, and we better skip any further adjustments
+        break;
+      }
+    }
+  }
+
+  // sort by index
+  exonBlocks.sort((exonA, exonB) => exonA.index - exonB.index);
+
+  return exonBlocks;
+};
+
+export default TranscriptVariantCDS;

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-cds/TranscriptVariantCDS.tsx
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-cds/TranscriptVariantCDS.tsx
@@ -47,27 +47,6 @@ type VariantRelativeLocationFields = Pick<
  * It should be api's responsibility to tell the client how exons are arranged along a CDS.
  */
 
-/**
- * Specs
- * - Exon
- *  - height: 12px
- *  - color: $grey
- * - White space to the right of exon: 1px
- *
- * - Min exon width: 2px
- * - Min exon width with arrow: 18px
- *  - Arrow:
- *    - height: 9px
- *    - color: $white, opacity: 50%
- *
- * - Line representing the variant:
- *  - height: 18px
- *  - width: 2px
- *  - color: $black
- *  - centered vertically relative to exon block
- *
- */
-
 type Props = {
   exons: Array<ExonFields & ExonWithRelativeLocationInCDS>;
   cds: CDSFields;
@@ -77,6 +56,7 @@ type Props = {
   };
 };
 
+const DIAGRAM_WIDTH = 700;
 const MIN_EXON_BLOCK_WIDTH = 2;
 const EXON_MARGIN_WIDTH = 1;
 const EXON_BLOCK_HEIGHT = 12;
@@ -90,25 +70,24 @@ const EXON_BLOCK_OFFSET_TOP = (VARIANT_MARKER_HEIGHT - EXON_BLOCK_HEIGHT) / 2;
 
 const TranscriptVariantCDS = (props: Props) => {
   const { exons, allele, cds } = props;
-  const width = 700;
 
   const scale = scaleLinear()
     .domain([1, cds.nucleotide_length])
-    .range([0, width])
+    .range([0, DIAGRAM_WIDTH])
     .interpolate(interpolateRound)
     .clamp(true);
 
   const exonsWithWidths = getExonWidths({
     exons,
-    containerWidth: width,
+    containerWidth: DIAGRAM_WIDTH,
     scale
   });
 
   return (
     <svg
-      width={width}
+      width={DIAGRAM_WIDTH}
       height={DIAGRAM_HEIGHT}
-      viewBox={`0 0 ${width} ${DIAGRAM_HEIGHT}`}
+      viewBox={`0 0 ${DIAGRAM_WIDTH} ${DIAGRAM_HEIGHT}`}
       overflow="visible"
     >
       <Exons exons={exonsWithWidths} />
@@ -116,7 +95,7 @@ const TranscriptVariantCDS = (props: Props) => {
         exons={exonsWithWidths}
         allele={allele}
         scale={scale}
-        containerWidth={width}
+        containerWidth={DIAGRAM_WIDTH}
       />
     </svg>
   );
@@ -274,23 +253,6 @@ const VariantMarkLabel = (props: {
     </text>
   );
 };
-
-// const WidthContainer = (props: { children: React.ReactNode }) => {
-//   const [containerWidth, setContainerWidth] = useState(0);
-//   const containerRef = useRef<HTMLDivElement | null>(null);
-
-//   useLayoutEffect(() => {
-//     const measuredContainerWidth =
-//       containerRef.current?.getBoundingClientRect().width ?? 0;
-//     setContainerWidth(measuredContainerWidth);
-//   }, []);
-
-//   return (
-//     <div ref={containerRef}>
-//       { !!containerWidth && props.children }
-//     </div>
-//   );
-// };
 
 const getExonWidths = (params: {
   exons: Props['exons'];

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-cds/TranscriptVariantCDS.tsx
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-cds/TranscriptVariantCDS.tsx
@@ -84,6 +84,7 @@ const MIN_EXON_BLOCK_WITH_ARROW_WIDTH = 18;
 const VARIANT_MARKER_HEIGHT = 18;
 const VATIANT_MARKER_WIDTH = 2;
 const DIAGRAM_HEIGHT = 42;
+const EXON_TO_LABEL_DISTANCE = 12; // distance between the bottom of exon blocks and the top of the label under the variant mark
 
 const EXON_BLOCK_OFFSET_TOP = (VARIANT_MARKER_HEIGHT - EXON_BLOCK_HEIGHT) / 2;
 
@@ -236,6 +237,9 @@ const VariantMarkLabel = (props: {
 
   const labelText = `Coding exon ${affectedExonNumber} of ${totalCodingExonsCount}`;
   const labelFont = '11px Lato';
+  const labelFontSize = 11;
+  const labelY =
+    EXON_BLOCK_HEIGHT + EXON_BLOCK_OFFSET_TOP + EXON_TO_LABEL_DISTANCE;
 
   const { width: predictedLabelWidth } = measureText({
     text: labelText,
@@ -255,15 +259,18 @@ const VariantMarkLabel = (props: {
 
   return (
     <text
+      alignmentBaseline="hanging"
       className={styles.label}
       textAnchor={textAnchor}
       x={labelX}
-      y="30"
-      fontSize={11}
+      y={labelY}
+      fontSize={labelFontSize}
     >
       Coding exon{' '}
-      <tspan className={styles.labelBold}>{affectedExonNumber}</tspan> of{' '}
-      {exons.length}
+      <tspan className={styles.labelBold} alignmentBaseline="hanging">
+        {affectedExonNumber}
+      </tspan>{' '}
+      of {exons.length}
     </text>
   );
 };

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-cds/TranscriptVariantCDS.tsx
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-cds/TranscriptVariantCDS.tsx
@@ -41,6 +41,13 @@ type VariantRelativeLocationFields = Pick<
 >;
 
 /**
+ * WARNING!
+ * This component is using spliced exons from the core api to draw a CDS diagram.
+ * This will fail to work if we ever get cases of trans-splicing.
+ * It should be api's responsibility to tell the client how exons are arranged along a CDS.
+ */
+
+/**
  * Specs
  * - Exon
  *  - height: 12px
@@ -86,7 +93,7 @@ const TranscriptVariantCDS = (props: Props) => {
 
   const scale = scaleLinear()
     .domain([1, cds.nucleotide_length])
-    .range([1, width])
+    .range([0, width])
     .interpolate(interpolateRound)
     .clamp(true);
 
@@ -132,6 +139,16 @@ const ExonBlock = (props: { x: number; width: number }) => {
   const { x, width } = props;
   const desiredArrowHeight = 9;
 
+  const exonRectangle = (
+    <rect
+      className={styles.exonBlock}
+      x={x}
+      y={EXON_BLOCK_OFFSET_TOP}
+      width={width}
+      height={EXON_BLOCK_HEIGHT}
+    />
+  );
+
   if (width >= MIN_EXON_BLOCK_WITH_ARROW_WIDTH) {
     // FIXME: instead of desiredArrowHeight, i.e. the width of the chevron, subtract half the true height of the chevron
     const arrowX = x + width / 2 - desiredArrowHeight;
@@ -142,13 +159,7 @@ const ExonBlock = (props: { x: number; width: number }) => {
 
     return (
       <>
-        <rect
-          className={styles.exonBlock}
-          x={x}
-          y={EXON_BLOCK_OFFSET_TOP}
-          width={width}
-          height={EXON_BLOCK_HEIGHT}
-        />
+        {exonRectangle}
         {/* 
           Wrapping ChevronDown in a group element,
           because browsers have not yet implemented transform attribute on svg element itself;
@@ -167,7 +178,7 @@ const ExonBlock = (props: { x: number; width: number }) => {
       </>
     );
   } else {
-    return <rect x={x} width={width} height={EXON_BLOCK_HEIGHT} />;
+    return exonRectangle;
   }
 };
 

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-cds/TranscriptVariantCDS.tsx
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-cds/TranscriptVariantCDS.tsx
@@ -117,7 +117,11 @@ const Exons = (props: { exons: Array<{ width: number }> }) => {
 
 const ExonBlock = (props: { x: number; width: number }) => {
   const { x, width } = props;
-  const desiredArrowHeight = 9;
+  const initialChevronWidth = 32; // <-- from the viewBox attribute of the svg image, in which the chevron is pointing down
+  const initialChevronHeight = 20; // <-- from the viewBox attribute of the svg image, in which the chevron is pointing down
+  const targetChevronWidth = 9; // <-- before rotating the chevron 90°; after the rotation this will become its height
+  const targetChevronHeight =
+    initialChevronHeight * (targetChevronWidth / initialChevronWidth);
 
   const exonRectangle = (
     <rect
@@ -130,11 +134,10 @@ const ExonBlock = (props: { x: number; width: number }) => {
   );
 
   if (width >= MIN_EXON_BLOCK_WITH_ARROW_WIDTH) {
-    // FIXME: instead of desiredArrowHeight, i.e. the width of the chevron, subtract half the true height of the chevron
-    const arrowX = x + width / 2 - desiredArrowHeight;
+    const arrowX = x + width / 2 - targetChevronWidth;
 
     // for each arrow, define the rotation origin to be exactly in the middle of the arrow
-    const rotateOriginX = arrowX + desiredArrowHeight / 2;
+    const rotateOriginX = arrowX + targetChevronWidth / 2;
     const rotateOriginY = EXON_BLOCK_OFFSET_TOP + EXON_BLOCK_HEIGHT / 2;
 
     return (
@@ -151,8 +154,8 @@ const ExonBlock = (props: { x: number; width: number }) => {
             className={styles.exonBlockArrow}
             x={arrowX}
             y={EXON_BLOCK_OFFSET_TOP + EXON_BLOCK_HEIGHT / 2}
-            width={desiredArrowHeight}
-            height="5.625"
+            width={targetChevronWidth}
+            height={targetChevronHeight}
           />
         </g>
       </>

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/useTranscriptConsequencesData.ts
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/useTranscriptConsequencesData.ts
@@ -60,7 +60,7 @@ const useTranscriptConsequencesData = (params: Params) => {
     (allele) => allele.urlId === alleleId
   )?.predicted_molecular_consequences;
 
-  const transcriptId = consequencesForAllele?.[0]?.feature_stable_id;
+  const transcriptId = consequencesForAllele?.[0]?.stable_id;
 
   const {
     currentData: geneData,

--- a/src/shared/helpers/exon-helpers/exonHelpers.test.ts
+++ b/src/shared/helpers/exon-helpers/exonHelpers.test.ts
@@ -1,0 +1,71 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { addRelativeLocationInCDSToExons } from './exonHelpers';
+
+import * as example1 from './fixtures/exons-cds-data-1';
+import * as example2 from './fixtures/exons-cds-data-2';
+import * as example3 from './fixtures/exons-cds-data-3';
+import * as example4 from './fixtures/exons-cds-data-4';
+
+describe('addRelativeLocationInCDSToExons', () => {
+  test('transcript with a single exon and no UTRs ', () => {
+    const result = addRelativeLocationInCDSToExons({
+      exons: example1.exons,
+      cds: example1.cds
+    });
+
+    expect(result).toEqual(example1.exonsWithRelativeLocationInCDS);
+  });
+
+  test('transcript with a single exon, and both UTRs ', () => {
+    // in this case an exon is longer than a CDS
+    const result = addRelativeLocationInCDSToExons({
+      exons: example2.exons,
+      cds: example2.cds
+    });
+
+    expect(result).toEqual(example2.exonsWithRelativeLocationInCDS);
+  });
+
+  test('transcript with two exons, and both UTRs', () => {
+    const result = addRelativeLocationInCDSToExons({
+      exons: example3.exons,
+      cds: example3.cds
+    });
+
+    expect(result).toEqual(example3.exonsWithRelativeLocationInCDS);
+  });
+
+  test('transcript with multiple exons', () => {
+    const result = addRelativeLocationInCDSToExons({
+      exons: example4.exons,
+      cds: example4.cds
+    });
+
+    const totalLength = result.reduce((acc, exon) => {
+      if (!exon.relative_location_in_cds) {
+        return acc;
+      } else {
+        return acc + exon.relative_location_in_cds.length;
+      }
+    }, 0);
+
+    expect(totalLength).toBe(example4.cds.nucleotide_length);
+
+    expect(result).toEqual(example4.exonsWithRelativeLocationInCDS);
+  });
+});

--- a/src/shared/helpers/exon-helpers/exonHelpers.ts
+++ b/src/shared/helpers/exon-helpers/exonHelpers.ts
@@ -1,0 +1,172 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Pick2 } from 'ts-multipick';
+import type { SplicedExon } from 'src/shared/types/core-api/exon';
+import type { FullCDS } from 'src/shared/types/core-api/cds';
+
+type MinimumExonFields = Pick2<
+  SplicedExon,
+  'relative_location',
+  'start' | 'end'
+>;
+type MinimumCDSFields = Pick<FullCDS, 'relative_start' | 'relative_end'>;
+
+export type ExonWithRelativeLocationInCDS = {
+  relative_location_in_cds: {
+    start: number;
+    end: number;
+    length: number;
+  } | null;
+};
+
+/**
+ * WARNING: the function below assumes that all exons are from the same transcript.
+ * It will not work properly in cases of trans-splicing.
+ */
+export const addRelativeLocationInCDSToExons = <
+  E extends MinimumExonFields,
+  C extends MinimumCDSFields
+>(params: {
+  exons: E[];
+  cds: C;
+}): Array<E & ExonWithRelativeLocationInCDS> => {
+  const cds = params.cds;
+  const exons = structuredClone(params.exons);
+
+  let lastPositionInCDS = 1;
+
+  for (const exon of exons) {
+    if (doesExonIncludeCDS({ exon, cds })) {
+      // the transcript consists of a single exon, and includes UTRs
+      const relativeStart = 1;
+      const overlappingLength = cds.relative_end - cds.relative_start + 1;
+      const relativeEnd = relativeStart + overlappingLength - 1;
+
+      (exon as E & ExonWithRelativeLocationInCDS).relative_location_in_cds = {
+        start: relativeStart,
+        end: relativeEnd,
+        length: overlappingLength
+      };
+    } else if (!isWithinCDS({ exon, cds })) {
+      (exon as E & ExonWithRelativeLocationInCDS).relative_location_in_cds =
+        null;
+    } else if (
+      !isExonStartWithinCDS({ exon, cds }) &&
+      isExonEndWithinCDS({ exon, cds })
+    ) {
+      // first exon in CDS
+      const relativeStart = 1;
+      const remainingExonLength =
+        exon.relative_location.end - cds.relative_start + 1;
+      const relativeEnd = relativeStart + remainingExonLength - 1;
+
+      (exon as E & ExonWithRelativeLocationInCDS).relative_location_in_cds = {
+        start: relativeStart,
+        end: relativeEnd,
+        length: remainingExonLength
+      };
+
+      lastPositionInCDS = relativeEnd;
+    } else if (
+      isExonStartWithinCDS({ exon, cds }) &&
+      !isExonEndWithinCDS({ exon, cds })
+    ) {
+      // last exon in CDS
+      const relativeStart = lastPositionInCDS;
+      const remainingExonLength =
+        cds.relative_end - exon.relative_location.start + 1;
+      const relativeEnd = relativeStart + remainingExonLength - 1;
+
+      (exon as E & ExonWithRelativeLocationInCDS).relative_location_in_cds = {
+        start: relativeStart,
+        end: relativeEnd,
+        length: remainingExonLength
+      };
+    } else {
+      // exon fully within CDS
+      const relativeStart = lastPositionInCDS;
+      const exonLength =
+        exon.relative_location.end - exon.relative_location.start + 1;
+      const relativeEnd = relativeStart + exonLength - 1;
+
+      (exon as E & ExonWithRelativeLocationInCDS).relative_location_in_cds = {
+        start: relativeStart,
+        end: relativeEnd,
+        length: exonLength
+      };
+
+      lastPositionInCDS = relativeEnd;
+    }
+  }
+
+  return exons as Array<E & ExonWithRelativeLocationInCDS>;
+};
+
+const doesExonIncludeCDS = <
+  E extends MinimumExonFields,
+  C extends MinimumCDSFields
+>(params: {
+  exon: E;
+  cds: C;
+}) => {
+  const { exon, cds } = params;
+
+  return (
+    cds.relative_start >= exon.relative_location.start &&
+    cds.relative_end <= exon.relative_location.end
+  );
+};
+
+const isWithinCDS = <
+  E extends MinimumExonFields,
+  C extends MinimumCDSFields
+>(params: {
+  exon: E;
+  cds: C;
+}) => {
+  return isExonStartWithinCDS(params) || isExonEndWithinCDS(params);
+};
+
+const isExonStartWithinCDS = <
+  E extends MinimumExonFields,
+  C extends MinimumCDSFields
+>(params: {
+  exon: E;
+  cds: C;
+}) => {
+  const { exon, cds } = params;
+
+  return (
+    exon.relative_location.start >= cds.relative_start &&
+    exon.relative_location.start < cds.relative_end
+  );
+};
+
+const isExonEndWithinCDS = <
+  E extends MinimumExonFields,
+  C extends MinimumCDSFields
+>(params: {
+  exon: E;
+  cds: C;
+}) => {
+  const { exon, cds } = params;
+
+  return (
+    exon.relative_location.end > cds.relative_start &&
+    exon.relative_location.end <= cds.relative_end
+  );
+};

--- a/src/shared/helpers/exon-helpers/fixtures/exons-cds-data-1.ts
+++ b/src/shared/helpers/exon-helpers/fixtures/exons-cds-data-1.ts
@@ -1,0 +1,47 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Simplest example: a protein-coding transcript containing a single exon,
+ * with no UTRs.
+ *
+ * This doesn't seem to exist in human; so using an E.coli gene b2992 as an example
+ */
+
+export const exons = [
+  {
+    index: 1,
+    relative_location: {
+      start: 1,
+      end: 489
+    }
+  }
+];
+
+export const cds = {
+  relative_start: 1,
+  relative_end: 489,
+  nucleotide_length: 489
+};
+
+// The expected result
+export const exonsWithRelativeLocationInCDS = [
+  {
+    index: 1,
+    relative_location: { start: 1, end: 489 },
+    relative_location_in_cds: { start: 1, end: 489, length: 489 }
+  }
+];

--- a/src/shared/helpers/exon-helpers/fixtures/exons-cds-data-2.ts
+++ b/src/shared/helpers/exon-helpers/fixtures/exons-cds-data-2.ts
@@ -1,0 +1,46 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A simple example: a transcript of a human gene (ENSG00000151846.9),
+ * with a transcript consisting of a single exon, with a 5' and a 3' UTR
+ */
+
+// transcript ENST00000281589.5
+export const exons = [
+  {
+    index: 1,
+    relative_location: {
+      start: 1,
+      end: 3119
+    }
+  }
+];
+
+export const cds = {
+  relative_start: 64,
+  relative_end: 1959,
+  nucleotide_length: 1896
+};
+
+// The expected result
+export const exonsWithRelativeLocationInCDS = [
+  {
+    index: 1,
+    relative_location: { start: 1, end: 3119 },
+    relative_location_in_cds: { start: 1, end: 1896, length: 1896 }
+  }
+];

--- a/src/shared/helpers/exon-helpers/fixtures/exons-cds-data-3.ts
+++ b/src/shared/helpers/exon-helpers/fixtures/exons-cds-data-3.ts
@@ -1,0 +1,57 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A transcript of a human gene, with two exons, both have UTRs
+ */
+
+// Exons of transcript ENST00000381033.5
+export const exons = [
+  {
+    index: 1,
+    relative_location: {
+      start: 1,
+      end: 545
+    }
+  },
+  {
+    index: 2,
+    relative_location: {
+      start: 4257,
+      end: 6314
+    }
+  }
+];
+
+export const cds = {
+  relative_start: 140,
+  relative_end: 4702,
+  nucleotide_length: 852
+};
+
+// The expected result
+export const exonsWithRelativeLocationInCDS = [
+  {
+    index: 1,
+    relative_location: { start: 1, end: 545 },
+    relative_location_in_cds: { start: 1, end: 406, length: 406 }
+  },
+  {
+    index: 2,
+    relative_location: { start: 4257, end: 6314 },
+    relative_location_in_cds: { start: 406, end: 851, length: 446 }
+  }
+];

--- a/src/shared/helpers/exon-helpers/fixtures/exons-cds-data-4.ts
+++ b/src/shared/helpers/exon-helpers/fixtures/exons-cds-data-4.ts
@@ -1,0 +1,379 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Exons of transcript ENST00000665585.2.
+// It is a protein-coding transcript with a bunch of exons that are outside the coding sequence
+export const exons = [
+  {
+    index: 1,
+    relative_location: {
+      start: 1,
+      end: 160
+    }
+  },
+  {
+    index: 2,
+    relative_location: {
+      start: 915,
+      end: 1020
+    }
+  },
+  {
+    index: 3,
+    relative_location: {
+      start: 3570,
+      end: 3818
+    }
+  },
+  {
+    index: 4,
+    relative_location: {
+      start: 9569,
+      end: 9677
+    }
+  },
+  {
+    index: 5,
+    relative_location: {
+      start: 10594,
+      end: 10643
+    }
+  },
+  {
+    index: 6,
+    relative_location: {
+      start: 10735,
+      end: 10775
+    }
+  },
+  {
+    index: 7,
+    relative_location: {
+      start: 10992,
+      end: 11106
+    }
+  },
+  {
+    index: 8,
+    relative_location: {
+      start: 13936,
+      end: 13985
+    }
+  },
+  {
+    index: 9,
+    relative_location: {
+      start: 15412,
+      end: 15523
+    }
+  },
+  {
+    index: 10,
+    relative_location: {
+      start: 16765,
+      end: 17880
+    }
+  },
+  {
+    index: 11,
+    relative_location: {
+      start: 20758,
+      end: 25689
+    }
+  },
+  {
+    index: 12,
+    relative_location: {
+      start: 29051,
+      end: 29146
+    }
+  },
+  {
+    index: 13,
+    relative_location: {
+      start: 31320,
+      end: 31389
+    }
+  },
+  {
+    index: 14,
+    relative_location: {
+      start: 39354,
+      end: 39781
+    }
+  },
+  {
+    index: 15,
+    relative_location: {
+      start: 40921,
+      end: 41102
+    }
+  },
+  {
+    index: 16,
+    relative_location: {
+      start: 42235,
+      end: 42422
+    }
+  },
+  {
+    index: 17,
+    relative_location: {
+      start: 47016,
+      end: 47186
+    }
+  },
+  {
+    index: 18,
+    relative_location: {
+      start: 47672,
+      end: 48026
+    }
+  },
+  {
+    index: 19,
+    relative_location: {
+      start: 54895,
+      end: 55050
+    }
+  },
+  {
+    index: 20,
+    relative_location: {
+      start: 55449,
+      end: 55593
+    }
+  },
+  {
+    index: 21,
+    relative_location: {
+      start: 59455,
+      end: 59703
+    }
+  },
+  {
+    index: 22,
+    relative_location: {
+      start: 59836,
+      end: 59899
+    }
+  },
+  {
+    index: 23,
+    relative_location: {
+      start: 61163,
+      end: 61284
+    }
+  },
+  {
+    index: 24,
+    relative_location: {
+      start: 63810,
+      end: 64008
+    }
+  },
+  {
+    index: 25,
+    relative_location: {
+      start: 64243,
+      end: 64406
+    }
+  },
+  {
+    index: 26,
+    relative_location: {
+      start: 64500,
+      end: 64638
+    }
+  },
+  {
+    index: 27,
+    relative_location: {
+      start: 79182,
+      end: 79426
+    }
+  },
+  {
+    index: 28,
+    relative_location: {
+      start: 81391,
+      end: 81537
+    }
+  },
+  {
+    index: 29,
+    relative_location: {
+      start: 82655,
+      end: 83411
+    }
+  }
+];
+
+// CDS of transcript ENST00000665585.2. Its nucleotide length is 8751
+export const cds = {
+  relative_start: 954,
+  relative_end: 59573,
+  nucleotide_length: 8751
+};
+
+// The expected result
+export const exonsWithRelativeLocationInCDS = [
+  {
+    index: 1,
+    relative_location: { start: 1, end: 160 },
+    relative_location_in_cds: null
+  },
+  {
+    index: 2,
+    relative_location: { start: 915, end: 1020 },
+    relative_location_in_cds: { start: 1, end: 67, length: 67 }
+  },
+  {
+    index: 3,
+    relative_location: { start: 3570, end: 3818 },
+    relative_location_in_cds: { start: 67, end: 315, length: 249 }
+  },
+  {
+    index: 4,
+    relative_location: { start: 9569, end: 9677 },
+    relative_location_in_cds: { start: 315, end: 423, length: 109 }
+  },
+  {
+    index: 5,
+    relative_location: { start: 10594, end: 10643 },
+    relative_location_in_cds: { start: 423, end: 472, length: 50 }
+  },
+  {
+    index: 6,
+    relative_location: { start: 10735, end: 10775 },
+    relative_location_in_cds: { start: 472, end: 512, length: 41 }
+  },
+  {
+    index: 7,
+    relative_location: { start: 10992, end: 11106 },
+    relative_location_in_cds: { start: 512, end: 626, length: 115 }
+  },
+  {
+    index: 8,
+    relative_location: { start: 13936, end: 13985 },
+    relative_location_in_cds: { start: 626, end: 675, length: 50 }
+  },
+  {
+    index: 9,
+    relative_location: { start: 15412, end: 15523 },
+    relative_location_in_cds: { start: 675, end: 786, length: 112 }
+  },
+  {
+    index: 10,
+    relative_location: { start: 16765, end: 17880 },
+    relative_location_in_cds: { start: 786, end: 1901, length: 1116 }
+  },
+  {
+    index: 11,
+    relative_location: { start: 20758, end: 25689 },
+    relative_location_in_cds: { start: 1901, end: 6832, length: 4932 }
+  },
+  {
+    index: 12,
+    relative_location: { start: 29051, end: 29146 },
+    relative_location_in_cds: { start: 6832, end: 6927, length: 96 }
+  },
+  {
+    index: 13,
+    relative_location: { start: 31320, end: 31389 },
+    relative_location_in_cds: { start: 6927, end: 6996, length: 70 }
+  },
+  {
+    index: 14,
+    relative_location: { start: 39354, end: 39781 },
+    relative_location_in_cds: { start: 6996, end: 7423, length: 428 }
+  },
+  {
+    index: 15,
+    relative_location: { start: 40921, end: 41102 },
+    relative_location_in_cds: { start: 7423, end: 7604, length: 182 }
+  },
+  {
+    index: 16,
+    relative_location: { start: 42235, end: 42422 },
+    relative_location_in_cds: { start: 7604, end: 7791, length: 188 }
+  },
+  {
+    index: 17,
+    relative_location: { start: 47016, end: 47186 },
+    relative_location_in_cds: { start: 7791, end: 7961, length: 171 }
+  },
+  {
+    index: 18,
+    relative_location: { start: 47672, end: 48026 },
+    relative_location_in_cds: { start: 7961, end: 8315, length: 355 }
+  },
+  {
+    index: 19,
+    relative_location: { start: 54895, end: 55050 },
+    relative_location_in_cds: { start: 8315, end: 8470, length: 156 }
+  },
+  {
+    index: 20,
+    relative_location: { start: 55449, end: 55593 },
+    relative_location_in_cds: { start: 8470, end: 8614, length: 145 }
+  },
+  {
+    index: 21,
+    relative_location: { start: 59455, end: 59703 },
+    relative_location_in_cds: { start: 8614, end: 8732, length: 119 }
+  },
+  {
+    index: 22,
+    relative_location: { start: 59836, end: 59899 },
+    relative_location_in_cds: null
+  },
+  {
+    index: 23,
+    relative_location: { start: 61163, end: 61284 },
+    relative_location_in_cds: null
+  },
+  {
+    index: 24,
+    relative_location: { start: 63810, end: 64008 },
+    relative_location_in_cds: null
+  },
+  {
+    index: 25,
+    relative_location: { start: 64243, end: 64406 },
+    relative_location_in_cds: null
+  },
+  {
+    index: 26,
+    relative_location: { start: 64500, end: 64638 },
+    relative_location_in_cds: null
+  },
+  {
+    index: 27,
+    relative_location: { start: 79182, end: 79426 },
+    relative_location_in_cds: null
+  },
+  {
+    index: 28,
+    relative_location: { start: 81391, end: 81537 },
+    relative_location_in_cds: null
+  },
+  {
+    index: 29,
+    relative_location: { start: 82655, end: 83411 },
+    relative_location_in_cds: null
+  }
+];

--- a/src/shared/types/variation-api/variantPredictedMolecularConsequence.ts
+++ b/src/shared/types/variation-api/variantPredictedMolecularConsequence.ts
@@ -14,9 +14,33 @@
  * limitations under the License.
  */
 
+// NOTE: currently, VariantPredictedMolecularConsequence represents an affected transcript.
+// This is why it has such fields as gene_stable_id, protein_stable_id, cdna_location, cds_location, etc.
 export type VariantPredictedMolecularConsequence = {
-  feature_stable_id: string; // NOTE: this will soon be changed to stable_id
+  stable_id: string;
+  gene_stable_id: string;
+  gene_symbol: string;
+  protein_stable_id: string | null;
+  transcript_biotype: string;
+  cdna_location: VariantRelativeLocation | null;
+  cds_location: VariantRelativeLocation | null;
+  protein_location: VariantRelativeLocation | null;
   consequences: AlleleConsequence[];
+};
+
+/**
+ * If one end of the variant, in the genomic sequence, is in an exon,
+ * and the other is in an intron, then one of the coordinates (either start or end)
+ * cannot be projected onto cDNA or CDS. As a result, the length of the variant cannot
+ * be determined, and neither can its reference or alternate sequence.
+ */
+export type VariantRelativeLocation = {
+  start: number | null;
+  end: number | null;
+  length: number | null;
+  percentage_overlap: number | null;
+  ref_sequence: string | null;
+  alt_sequence: string | null;
 };
 
 type AlleleConsequence = {

--- a/src/shared/types/variation-api/variantPredictedMolecularConsequence.ts
+++ b/src/shared/types/variation-api/variantPredictedMolecularConsequence.ts
@@ -16,6 +16,7 @@
 
 // NOTE: currently, VariantPredictedMolecularConsequence represents an affected transcript.
 // This is why it has such fields as gene_stable_id, protein_stable_id, cdna_location, cds_location, etc.
+// It is quite possible that in the future this will have to be reviewed, with consequences for other feature types added
 export type VariantPredictedMolecularConsequence = {
   stable_id: string;
   gene_stable_id: string;


### PR DESCRIPTION
## Description
This PR add CDS diagram to the transcript consequences view.

**NOTE:** Because the diagram requires the display of exons within a CDS, this PR attempts to calculates exon locations within the CDS using relative locations both of spliced exons to transcript and of CDS to transcript. Notice that both these locations are relative to a single transcript, which means that if we ever get examples of true trans-splicing (in which exons from different genes can combine together to produce a product), then they will not show up properly. We should be getting exon locations relative to cDNA and to CDS from an api; but currently aren't. 

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2432

## Deployment URL(s)
http://tr-cons-cds.review.ensembl.org