### PR TITLE
Update review setup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -156,17 +156,23 @@ variables:
 # Template for stopping review app - Do cleanup here 
 .stop-review:
   stage: deploy
-  image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:0.1
+  image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:latest
   variables:
     GIT_STRATEGY: none
   when: manual
   script:
-  - kubectl delete ingress ensembl-client-${CI_COMMIT_REF_SLUG}-nginx-ingress
-  - kubectl delete ingress ensembl-client-${CI_COMMIT_REF_SLUG}-node-ingress
-  - kubectl delete svc ensembl-client-${CI_COMMIT_REF_SLUG}-nginx-svc
-  - kubectl delete svc ensembl-client-${CI_COMMIT_REF_SLUG}-node-svc
-  - kubectl delete deploy ensembl-client-${CI_COMMIT_REF_SLUG}-nginx-deployment
-  - kubectl delete deploy ensembl-client-${CI_COMMIT_REF_SLUG}-node-deployment
+  - kubectl delete ingress compara-server-ingress-${CI_COMMIT_REF_SLUG}
+  - kubectl delete ingress ensembl-help-docs-ingress-${CI_COMMIT_REF_SLUG}
+  - kubectl delete ingress ensembl-in-app-search-api-ingress-${CI_COMMIT_REF_SLUG}
+  - kubectl delete ingress ensembl-thoas-ingress-${CI_COMMIT_REF_SLUG}
+  - kubectl delete ingress ensembl-tools-api-ingress-${CI_COMMIT_REF_SLUG}
+  - kubectl delete ingress ensembl-track-api-ingress-${CI_COMMIT_REF_SLUG}
+  - kubectl delete ingress genome-browser-server-${CI_COMMIT_REF_SLUG}-hi
+  - kubectl delete ingress genome-browser-server-${CI_COMMIT_REF_SLUG}-lo
+  - kubectl delete ingress metadata-api-ingress-${CI_COMMIT_REF_SLUG}
+  - kubectl delete ingress refget-proxy-ingress-${CI_COMMIT_REF_SLUG}
+  - kubectl delete ingress variation-graphql-ingress-${CI_COMMIT_REF_SLUG}
+  - kubectl delete namespace ${CI_COMMIT_REF_SLUG}
 
 Test:
   image: node:20.9.0
@@ -402,7 +408,7 @@ Pub:Dev-HL:wp51:
     - Node:Live
 
 
-# Job to deploy review deployments to development environment in the new cluster in Harlow (WP40)
+# Job to deploy review deployments to development environment in the new cluster in Harlow (WP51)
 Review:WP51:HL:
   extends: .deploy-review
   variables:
@@ -419,18 +425,17 @@ Review:WP51:HL:
     - Test_N_Build:review
     - Nginx:review
     - Node:review
-
+# Clean up the review app resources
 stop_review:
   extends: .stop-review
   environment:
-    name: review/$CI_COMMIT_REF_SLUG
+    name: wp51-hl-development
     action: stop
     kubernetes:
-      namespace: ensembl-dev
+      namespace: ensembl-development
   except:
   - dev
   - master
-  - /^nodeploy\/.*$/
 
 SetupReview:HL51:
   extends: .setup-review-newk8s

--- a/gitlab-ci-templates/.setup-review-template.yaml
+++ b/gitlab-ci-templates/.setup-review-template.yaml
@@ -5,7 +5,7 @@
   image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:latest
   before_script:
     - git clone --depth 1 --branch k8s123-migration https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
-    - kubectl create namespace ${CI_COMMIT_REF_SLUG} || true # Carry on if namespace already exists
+    - kubectl create namespace ${CI_COMMIT_REF_SLUG} # Stops here if namespace exists (cleanup required)
     
   script:
     # Setup Ingress for default backend

--- a/gitlab-ci-templates/.setup-review-template.yaml
+++ b/gitlab-ci-templates/.setup-review-template.yaml
@@ -14,12 +14,6 @@
     - cp review-setup/*.yaml ./
     - kustomize edit set namesuffix -- -${CI_COMMIT_REF_SLUG}
     - kubectl apply -k .
-    
-    # Deploy nginx & node
-    - echo "NGINX & NODE"
-    - mv kustomization-ensembl-client.yaml kustomization.yaml
-    - kustomize edit set namespace ${CI_COMMIT_REF_SLUG}
-    - kubectl apply -k .
 
     # Setup Ingress for default Genome Browser
     - echo "GENOME-BROWSER HI"
@@ -31,9 +25,15 @@
     - cp genome-browser/review/lo/*.yaml ./
     - kustomize edit set namesuffix -- -${CI_COMMIT_REF_SLUG}
     - kubectl apply -k .
+    
+    # Deploy nginx & node to review namespace
+    - echo "NGINX & NODE"
+    - mv kustomization-ensembl-client.yaml kustomization.yaml
+    - kustomize edit set namespace ${CI_COMMIT_REF_SLUG}
+    - kubectl apply -k .
 
-    # Setup ebi dockerhub credentials (for non-default backend deployments)
-    - kubectl create secret docker-registry ensemblweb-pull-secret --docker-server=${GITLAB_REGISTRY_URL} --docker-username=${WEB_PULL_DOCKER_USER} --docker-password=${WEB_PULL_DOCKER_SECRET} --docker-email=${WEB_PULL_DOCKER_EMAIL} || true
+    # Setup ebi dockerhub credentials in review ns (for non-default backend deployments)
+    - kubectl -n ${CI_COMMIT_REF_SLUG} create secret docker-registry ensemblweb-pull-secret --docker-server=${GITLAB_REGISTRY_URL} --docker-username=${WEB_PULL_DOCKER_USER} --docker-password=${WEB_PULL_DOCKER_SECRET} --docker-email=${WEB_PULL_DOCKER_EMAIL} || true
 
   after_script:
     - cd ../../

--- a/gitlab-ci-templates/.setup-review-template.yaml
+++ b/gitlab-ci-templates/.setup-review-template.yaml
@@ -13,24 +13,24 @@
     - sed -i "s#<HOST>#${CI_COMMIT_REF_SLUG}.review.ensembl.org#g" review-setup/ingress-host.patch.yaml
     - cp review-setup/*.yaml ./
     - kustomize edit set namesuffix -- -${CI_COMMIT_REF_SLUG}
-    - kubectl -k apply .
+    - kubectl apply -k .
     
     # Deploy nginx & node
     - echo "NGINX & NODE"
     - mv kustomization-ensembl-client.yaml kustomization.yaml
     - kustomize edit set namespace ${CI_COMMIT_REF_SLUG}
-    - kubectl -k apply .
+    - kubectl apply -k .
 
     # Setup Ingress for default Genome Browser
     - echo "GENOME-BROWSER HI"
     - cp genome-browser/review/hi/*.yaml ./
     - kustomize edit set namesuffix -- -${CI_COMMIT_REF_SLUG}
-    - kubectl -k apply .
+    - kubectl apply -k .
 
     - echo "GENOME-BROWSER LO"
     - cp genome-browser/review/lo/*.yaml ./
     - kustomize edit set namesuffix -- -${CI_COMMIT_REF_SLUG}
-    - kubectl -k apply .
+    - kubectl apply -k .
 
     # Setup ebi dockerhub credentials (for non-default backend deployments)
     - kubectl create secret docker-registry ensemblweb-pull-secret --docker-server=${GITLAB_REGISTRY_URL} --docker-username=${WEB_PULL_DOCKER_USER} --docker-password=${WEB_PULL_DOCKER_SECRET} --docker-email=${WEB_PULL_DOCKER_EMAIL} || true

--- a/gitlab-ci-templates/.setup-review-template.yaml
+++ b/gitlab-ci-templates/.setup-review-template.yaml
@@ -5,7 +5,7 @@
   image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:latest
   before_script:
     - git clone --depth 1 --branch k8s123-migration https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
-    - kubectl create namespace ${CI_COMMIT_REF_SLUG} --dry-run=client -o yaml | kubectl apply -f -
+    - kubectl create namespace ${CI_COMMIT_REF_SLUG} || true # Carry on if namespace already exists
     
   script:
     # Setup Ingress for default backend
@@ -13,24 +13,27 @@
     - sed -i "s#<HOST>#${CI_COMMIT_REF_SLUG}.review.ensembl.org#g" review-setup/ingress-host.patch.yaml
     - cp review-setup/*.yaml ./
     - kustomize edit set namesuffix -- -${CI_COMMIT_REF_SLUG}
-    - kustomize build ./ | kubectl apply -f -
+    - kubectl -k apply .
     
     # Deploy nginx & node
     - echo "NGINX & NODE"
     - mv kustomization-ensembl-client.yaml kustomization.yaml
     - kustomize edit set namespace ${CI_COMMIT_REF_SLUG}
-    - kustomize build ./ | kubectl apply -f -
+    - kubectl -k apply .
 
-    # Setup Ingress for Genome Browser
+    # Setup Ingress for default Genome Browser
     - echo "GENOME-BROWSER HI"
     - cp genome-browser/review/hi/*.yaml ./
     - kustomize edit set namesuffix -- -${CI_COMMIT_REF_SLUG}
-    - kustomize build ./ | kubectl apply -f -
+    - kubectl -k apply .
 
     - echo "GENOME-BROWSER LO"
     - cp genome-browser/review/lo/*.yaml ./
     - kustomize edit set namesuffix -- -${CI_COMMIT_REF_SLUG}
-    - kustomize build ./ | kubectl apply -f -
+    - kubectl -k apply .
+
+    # Setup ebi dockerhub credentials (for non-default backend deployments)
+    - kubectl create secret docker-registry ensemblweb-pull-secret --docker-server=${GITLAB_REGISTRY_URL} --docker-username=${WEB_PULL_DOCKER_USER} --docker-password=${WEB_PULL_DOCKER_SECRET} --docker-email=${WEB_PULL_DOCKER_EMAIL} || true
 
   after_script:
     - cd ../../

--- a/gitlab-ci-templates/.setup-review-template.yaml
+++ b/gitlab-ci-templates/.setup-review-template.yaml
@@ -5,7 +5,7 @@
   image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:latest
   before_script:
     - git clone --depth 1 --branch k8s123-migration https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
-    - kubectl create namespace ${CI_COMMIT_REF_SLUG} # Stops here if namespace exists (cleanup required)
+    - kubectl create namespace ${CI_COMMIT_REF_SLUG} || true # Carry on even if namespace already exists
     
   script:
     # Setup Ingress for default backend


### PR DESCRIPTION
## Description
This PR 
- Adds image pull secret to the review setup job in ensembl-client CI/CD pipelline.
The secret includes the dockerhub credentials needed to deploy (non-default) backends to the review namespace.
- Updates `stop_review` job for cleaning up review app resources


## Related JIRA Issue(s)
[ENSWBSITES-2460](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2460)

## Deployment URL(s)
Example review app (uses custom genome browser): http://deploy-review-nkhdev.review.ensembl.org
