### PR TITLE
Use gene stable ids from transcript consequences to get lists of transcripts

### DIFF
--- a/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
+++ b/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { request } from 'graphql-request';
+
 import graphqlApiSlice from 'src/shared/state/api-slices/graphqlApiSlice';
 
 import config from 'config';
@@ -235,15 +237,46 @@ const entityViewerThoasSlice = graphqlApiSlice.injectEndpoints({
         response: VariantPredictedMolecularConsequencesResponse
       ) => addAlleleUrlId(response)
     }),
-    geneForVariantTranscriptConsequences: builder.query<
-      GeneForVariantTranscriptConsequencesResponse,
-      TranscriptQueryParams
+    genesForVariantTranscriptConsequences: builder.query<
+      { genes: GeneForVariantTranscriptConsequencesResponse['gene'][] },
+      { genomeId: string; geneIds: string[] }
     >({
-      query: (params) => ({
-        url: config.coreApiUrl,
-        body: geneForVariantTranscriptConsequencesQuery,
-        variables: params
-      })
+      queryFn: async (params) => {
+        const { genomeId, geneIds } = params;
+        const requestPromises = geneIds.map((geneId) =>
+          request<GeneForVariantTranscriptConsequencesResponse>({
+            url: config.coreApiUrl,
+            document: geneForVariantTranscriptConsequencesQuery,
+            variables: {
+              genomeId,
+              geneId
+            }
+          })
+        );
+
+        try {
+          const responses = await Promise.all(requestPromises);
+          return {
+            data: {
+              genes: responses.map(({ gene }) => gene)
+            }
+          };
+        } catch (error) {
+          return {
+            error: {
+              status: 500,
+              meta: {
+                error: 'Failed to fetch genes'
+              }
+            }
+          };
+        }
+      }
+      // query: (params) => ({
+      //   url: config.coreApiUrl,
+      //   body: geneForVariantTranscriptConsequencesQuery,
+      //   variables: params
+      // })
     }),
     transcriptForVariantTranscriptConsequences: builder.query<
       TranscriptForVariantTranscriptConsequencesResponse,
@@ -289,7 +322,7 @@ export const {
   useVariantStudyPopulationsQuery,
   useVariantAllelePopulationFrequenciesQuery,
   useVariantPredictedMolecularConsequencesQuery,
-  useGeneForVariantTranscriptConsequencesQuery,
+  useGenesForVariantTranscriptConsequencesQuery,
   useTranscriptForVariantTranscriptConsequencesQuery
 } = entityViewerThoasSlice;
 

--- a/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
+++ b/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
@@ -272,11 +272,6 @@ const entityViewerThoasSlice = graphqlApiSlice.injectEndpoints({
           };
         }
       }
-      // query: (params) => ({
-      //   url: config.coreApiUrl,
-      //   body: geneForVariantTranscriptConsequencesQuery,
-      //   variables: params
-      // })
     }),
     transcriptForVariantTranscriptConsequences: builder.query<
       TranscriptForVariantTranscriptConsequencesResponse,

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.module.css
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.module.css
@@ -55,6 +55,24 @@
   margin-top: 100px;
 }
 
+/* Draw a 2-px-thick line above the middle section of the row
+  The values in linear-gradient are copied from grid-template-columns of .row class
+*/
+.geneSection:not(:first-child)::before {
+  content: '';
+  display: block;
+  height: 2px;
+  background: linear-gradient(
+    to right,
+    transparent,
+    transparent calc(160px + 18px),
+    var(--color-orange) calc(160px + 18px),
+    var(--color-orange) calc(160px + 18px + 700px),
+    transparent calc(160px + 18px + 700px)
+  );
+  margin-bottom: 40px;
+}
+
 .transcriptsList {
   display: grid;
   grid-template-rows: auto 1fr;
@@ -83,14 +101,8 @@
   padding: 6px 0;
 }
 
-.geneSection:not(:first-child) .headerMiddleColumn {
-  border-top: 2px solid var(--color-orange);
-  padding-top: 50px;
-}
-
 .transcriptsCount {
-  align-self: end; /* to keep transcript count level with gene label when there are several genes (see padding-top: 50px in geneSection above) */
-  padding-bottom: 6px;
+  padding: 6px 0;
 }
 
 .geneDetails span {

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.module.css
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.module.css
@@ -51,16 +51,14 @@
   margin-left: 20px;
 }
 
+.geneSection:not(:first-child) {
+  margin-top: 100px;
+}
+
 .transcriptsList {
   display: grid;
   grid-template-rows: auto 1fr;
   height: 100%;
-}
-
-.content {
-  position: relative;
-  padding-top: 36px;
-  padding-bottom: var(--global-padding-bottom);
 }
 
 .row {
@@ -85,8 +83,14 @@
   padding: 6px 0;
 }
 
-.headerRightColumn {
-  padding: 6px 0;
+.geneSection:not(:first-child) .headerMiddleColumn {
+  border-top: 2px solid var(--color-orange);
+  padding-top: 50px;
+}
+
+.transcriptsCount {
+  align-self: end; /* to keep transcript count level with gene label when there are several genes (see padding-top: 50px in geneSection above) */
+  padding-bottom: 6px;
 }
 
 .geneDetails span {
@@ -113,9 +117,4 @@
 
 .right {
   grid-column: 5/6;
-}
-
-
-.details {
-  width: 700px;
 }

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.tsx
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.tsx
@@ -192,7 +192,7 @@ const TranscriptConsequencesPerGene = (props: {
           </div>
         </div>
         <div className={classnames(styles.right, styles.transcriptsCount)}>
-          <span>{`${transcriptConsCount} `}</span>
+          <span>{transcriptConsCount}</span>
           <span className={styles.label}>
             {pluralise('transcript', transcriptConsCount)}
           </span>

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.tsx
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.tsx
@@ -20,8 +20,11 @@ import classnames from 'classnames';
 import { useAppSelector, useAppDispatch } from 'src/store';
 
 import { getReverseComplement } from 'src/shared/helpers/sequenceHelpers';
-import { getExpandedTranscriptConseqeuenceIds } from '../../state/variant-view/general/variantViewGeneralSelectors';
-import { setExpandedTranscriptConsequenceIds } from '../../state/variant-view/general/variantViewGeneralSlice';
+import { pluralise } from 'src/shared/helpers/formatters/pluralisationFormatter';
+import { defaultSort as defaultSortForTranscripts } from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
+
+import { getExpandedTranscriptConseqeuenceIds } from 'src/content/app/entity-viewer/state/variant-view/general/variantViewGeneralSelectors';
+import { setExpandedTranscriptConsequenceIds } from 'src/content/app/entity-viewer/state/variant-view/general/variantViewGeneralSlice';
 import { formatAlleleSequence } from '../variant-view-sidebar/overview/MainAccordion';
 
 import useTranscriptConsequencesData, {
@@ -30,6 +33,7 @@ import useTranscriptConsequencesData, {
 
 import Panel from 'src/shared/components/panel/Panel';
 import TranscriptConsequenceDetails from './transcript-consequence-details/TranscriptConsequenceDetails';
+import { TranscriptQualityLabel } from 'src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel';
 import { CircleLoader } from 'src/shared/components/loader';
 
 import styles from './TranscriptConsequences.module.css';
@@ -84,45 +88,24 @@ const TranscriptConsequences = (props: Props) => {
     );
   }
 
-  const strand = geneData.slice.strand.code;
-  const alleleSequence = allele?.allele_sequence ?? '';
-
   return (
     <Panel header={panelHeader}>
       <div className={styles.container}>
-        <div className={classnames(styles.row, styles.header)}>
-          <div className={styles.left}></div>
-          <div className={styles.middle}>
-            <div className={styles.headerMiddleColumn}>
-              <TranscriptAllele
-                referenceSequence={allele.reference_sequence}
-                alleleSequence={alleleSequence}
-                alleleType={allele.allele_type.value}
-                strand={strand}
-              />
-              <div className={styles.geneDetails}>
-                <span className={styles.label}>Gene</span>
-                {geneData.symbol && (
-                  <span className={styles.geneSymbol}>{geneData.symbol}</span>
-                )}
-                <span className={styles.geneStableId}>
-                  {geneData.stable_id}
-                </span>
-              </div>
-            </div>
-          </div>
-          <div className={classnames(styles.right, styles.headerRightColumn)}>
-            <span>{`${transcriptConsequences.length} transcripts`}</span>
-          </div>
-        </div>
-        <TranscriptConsequencesList
-          transcriptConsequences={transcriptConsequences}
-          genomeId={genomeId}
-          variantId={variantId}
-          gene={geneData}
-          variant={variant}
-          allele={allele}
-        />
+        {geneData.map((gene) => (
+          <TranscriptConsequencesPerGene
+            key={gene.stable_id}
+            genomeId={genomeId}
+            gene={gene}
+            allele={allele}
+            variantId={variantId}
+            variant={variant}
+            transcriptConsequences={transcriptConsequences.filter(
+              (cons) =>
+                cons.gene_stable_id === gene.stable_id ||
+                cons.gene_stable_id === gene.unversioned_stable_id
+            )}
+          />
+        ))}
       </div>
     </Panel>
   );
@@ -141,6 +124,88 @@ const PanelHeader = (props: {
       <span className={styles.transcriptConsqTitle}>
         Transcript consequences
       </span>
+    </div>
+  );
+};
+
+const TranscriptConsequencesPerGene = (props: {
+  genomeId: string;
+  variantId: string;
+  gene: TranscriptConsequencesData['geneData'][number];
+  variant: TranscriptConsequencesData['variant'];
+  allele: NonNullable<TranscriptConsequencesData['allele']>;
+  transcriptConsequences: NonNullable<
+    TranscriptConsequencesData['transcriptConsequences']
+  >;
+}) => {
+  const { genomeId, gene, variantId, variant, allele, transcriptConsequences } =
+    props;
+  const strand = gene.slice.strand.code;
+  const alleleSequence = allele.allele_sequence;
+
+  const transcriptConsequencesWithTranscript: Array<
+    (typeof transcriptConsequences)[number] & {
+      transcript: (typeof gene)['transcripts'][number];
+    }
+  > = [];
+
+  const sortedTranscripts = defaultSortForTranscripts(gene.transcripts);
+
+  for (const transcript of sortedTranscripts) {
+    // Currently, stable ids in transcript consequences returned by the api
+    // are unversioned; later on, they are expected to be changed to versioned ids.
+    const consequence = transcriptConsequences.find(
+      (cons) =>
+        cons.stable_id === transcript.stable_id ||
+        cons.stable_id === transcript.unversioned_stable_id
+    );
+
+    if (consequence) {
+      transcriptConsequencesWithTranscript.push({
+        ...consequence,
+        transcript
+      });
+    }
+  }
+
+  const transcriptConsCount = transcriptConsequencesWithTranscript.length;
+
+  return (
+    <div className={styles.geneSection}>
+      <div className={classnames(styles.row, styles.header)}>
+        <div className={styles.left}></div>
+        <div className={styles.middle}>
+          <div className={styles.headerMiddleColumn}>
+            <TranscriptAllele
+              referenceSequence={allele.reference_sequence}
+              alleleSequence={alleleSequence}
+              alleleType={allele.allele_type.value}
+              strand={strand}
+            />
+            <div className={styles.geneDetails}>
+              <span className={styles.label}>Gene</span>
+              {gene.symbol && (
+                <span className={styles.geneSymbol}>{gene.symbol}</span>
+              )}
+              <span className={styles.geneStableId}>{gene.stable_id}</span>
+            </div>
+          </div>
+        </div>
+        <div className={classnames(styles.right, styles.transcriptsCount)}>
+          <span>{`${transcriptConsCount} `}</span>
+          <span className={styles.label}>
+            {pluralise('transcript', transcriptConsCount)}
+          </span>
+        </div>
+      </div>
+      <TranscriptConsequencesList
+        transcriptConsequences={transcriptConsequencesWithTranscript}
+        genomeId={genomeId}
+        variantId={variantId}
+        gene={gene}
+        variant={variant}
+        allele={allele}
+      />
     </div>
   );
 };
@@ -205,10 +270,14 @@ const TranscriptAllele = ({
 type TranscriptConsequencesListProps = {
   genomeId: string;
   variantId: string;
-  transcriptConsequences: NonNullable<
-    TranscriptConsequencesData['transcriptConsequences']
+  transcriptConsequences: Array<
+    NonNullable<
+      TranscriptConsequencesData['transcriptConsequences']
+    >[number] & {
+      transcript: TranscriptConsequencesData['geneData'][number]['transcripts'][number];
+    }
   >;
-  gene: TranscriptConsequencesData['geneData'];
+  gene: TranscriptConsequencesData['geneData'][number];
   allele: NonNullable<TranscriptConsequencesData['allele']>;
   variant: TranscriptConsequencesData['variant'];
 };
@@ -249,8 +318,11 @@ const TranscriptConsequencesList = (props: TranscriptConsequencesListProps) => {
               )
             })}
           >
-            {/* <TranscriptQualityLabel metadata={props.transcript.metadata} /> */}
-            <div className={styles.transcriptLeftColumn}></div>
+            <div className={styles.transcriptLeftColumn}>
+              <TranscriptQualityLabel
+                metadata={consequencesForSingleTranscript.transcript.metadata}
+              />
+            </div>
             <div className={styles.middle}>
               <div className={styles.clickableTranscriptArea}>
                 <div className={styles.transcriptMiddleColumn}>
@@ -265,7 +337,11 @@ const TranscriptConsequencesList = (props: TranscriptConsequencesListProps) => {
                     </span>
                   </div>
                   <div>
-                    <span className={styles.label}>Transcript biotype</span>
+                    <span className={styles.label}>Transcript biotype</span>{' '}
+                    {
+                      consequencesForSingleTranscript.transcript.metadata
+                        .biotype.value
+                    }
                   </div>
                 </div>
               </div>

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-consequence-details/TranscriptConsequenceDetails.tsx
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-consequence-details/TranscriptConsequenceDetails.tsx
@@ -36,7 +36,7 @@ import styles from './TranscriptConsequenceDetails.module.css';
 type Props = {
   genomeId: string;
   transcriptId: string;
-  gene: TranscriptConsequencesData['geneData'];
+  gene: TranscriptConsequencesData['geneData'][number];
   variant: TranscriptConsequencesData['variant'];
   allele: NonNullable<TranscriptConsequencesData['allele']>;
   transcriptConsequences: PredictedMolecularConsequenceInResponse;

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-diagram/TranscriptVariantDiagram.tsx
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-diagram/TranscriptVariantDiagram.tsx
@@ -25,7 +25,7 @@ import type { TranscriptDetailsData } from '../useTranscriptDetails';
 import styles from './TranscriptVariantDiagram.module.css';
 
 type Props = {
-  gene: TranscriptConsequencesData['geneData'];
+  gene: TranscriptConsequencesData['geneData'][number];
   transcript: TranscriptDetailsData['transcriptData'];
   variant: TranscriptConsequencesData['variant'];
 };

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/useTranscriptConsequencesData.ts
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/useTranscriptConsequencesData.ts
@@ -17,7 +17,7 @@
 import {
   useDefaultEntityViewerVariantQuery,
   useVariantPredictedMolecularConsequencesQuery,
-  useGeneForVariantTranscriptConsequencesQuery
+  useGenesForVariantTranscriptConsequencesQuery
 } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
 
 type Params = {
@@ -60,19 +60,23 @@ const useTranscriptConsequencesData = (params: Params) => {
     (allele) => allele.urlId === alleleId
   )?.predicted_molecular_consequences;
 
-  const transcriptId = consequencesForAllele?.[0]?.stable_id;
+  const geneIds = new Set<string>();
+
+  consequencesForAllele?.forEach((consequence) =>
+    geneIds.add(consequence.gene_stable_id)
+  );
 
   const {
     currentData: geneData,
     isFetching: isLoadingGeneData,
     isError: isGeneDataError
-  } = useGeneForVariantTranscriptConsequencesQuery(
+  } = useGenesForVariantTranscriptConsequencesQuery(
     {
       genomeId,
-      transcriptId: transcriptId ?? ''
+      geneIds: [...geneIds]
     },
     {
-      skip: !transcriptId
+      skip: !geneIds.size
     }
   );
 
@@ -81,7 +85,7 @@ const useTranscriptConsequencesData = (params: Params) => {
       ? {
           variant: variantData.variant,
           allele: variantAllele,
-          geneData: geneData.transcript.gene,
+          geneData: geneData.genes,
           transcriptConsequences: consequencesForAllele
         }
       : null;

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/useTranscriptDetails.ts
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/useTranscriptDetails.ts
@@ -37,7 +37,7 @@ import type {
 type Params = {
   genomeId: string;
   transcriptId: string;
-  gene: TranscriptConsequencesData['geneData'];
+  gene: TranscriptConsequencesData['geneData'][number];
   variant: TranscriptConsequencesData['variant'];
   allele: NonNullable<TranscriptConsequencesData['allele']>;
 };
@@ -101,7 +101,7 @@ const useTranscriptDetails = (params: Params) => {
 const useGenomicRegionData = (params: {
   variant?: VariantDetails;
   allele?: VariantDetailsAllele;
-  gene?: GeneForVariantTranscriptConsequencesResponse['transcript']['gene'];
+  gene?: GeneForVariantTranscriptConsequencesResponse['gene'];
   transcript?: TranscriptForVariantTranscriptConsequencesResponse['transcript'];
 }) => {
   const { gene, transcript, variant, allele } = params;


### PR DESCRIPTION
## Description
Instead of reading transcript's stable id from the first predicted molecular consequence and assuming that all other transcripts are from the same gene, in this PR, we read gene stable ids, and, if there are different genes in the list of predicted molecular consequences, then we fetch all these genes.

Also, added the  `TranscriptQualityLabel` ("Ensembl canonical", etc.) to show to the left of the transcripts.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2466

## Deployment URL(s)
http://tr-cons-cds.review.ensembl.org

Examples with transcript consequences for more than one gene:
- http://tr-cons-cds.review.ensembl.org/entity-viewer/grch38/variant:1:227732439:rs1660720802?allele=0&view=transcript-consequences
- http://tr-cons-cds.review.ensembl.org/entity-viewer/grch38/variant:1:12167:rs112125468?allele=0&view=transcript-consequences