### PR TITLE
Add default z-menu

### DIFF
--- a/src/content/app/genome-browser/components/zmenu/Zmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/Zmenu.tsx
@@ -30,6 +30,7 @@ import { Toolbox, ToolboxPosition } from 'src/shared/components/toolbox';
 import GeneAndOneTranscriptZmenu from './zmenus/GeneAndOneTranscriptZmenu';
 import VariantZmenu from './zmenus/VariantZmenu';
 import RegulationZmenu from './zmenus/RegulationZmenu';
+import DefaultZmenu from './zmenus/DefaultZmenu';
 
 import {
   ZmenuPayloadVarietyType,
@@ -99,10 +100,10 @@ const Zmenu = (props: ZmenuProps) => {
     zmenuContent = (
       <RegulationZmenu payload={props.payload} onDestroy={destroyZmenu} />
     );
-  }
-
-  if (!zmenuContent) {
-    return null;
+  } else {
+    zmenuContent = (
+      <DefaultZmenu payload={props.payload} onDestroy={destroyZmenu} />
+    );
   }
 
   const anchorStyles = getAnchorInlineStyles(props);

--- a/src/content/app/genome-browser/components/zmenu/ZmenuContent.tsx
+++ b/src/content/app/genome-browser/components/zmenu/ZmenuContent.tsx
@@ -25,22 +25,14 @@ import useGenomeBrowserIds from 'src/content/app/genome-browser/hooks/useGenomeB
 import {
   ZmenuContentItem as ZmenuContentItemType,
   Markup,
-  ZmenuContentTranscript,
-  ZmenuContentGene,
-  ZmenuContentVariant,
-  ZmenuContentRegulation
+  ZmenuContent as ZmenuContentType
 } from 'src/content/app/genome-browser/services/genome-browser-service/types/zmenu';
 
 import styles from './Zmenu.module.css';
 
 export type ZmenuContentProps = {
-  features: (
-    | ZmenuContentTranscript
-    | ZmenuContentGene
-    | ZmenuContentVariant
-    | ZmenuContentRegulation
-  )[];
-  featureId: string;
+  features: ZmenuContentType[];
+  featureId?: string;
   destroyZmenu: () => void;
 };
 
@@ -49,7 +41,7 @@ export const ZmenuContent = (props: ZmenuContentProps) => {
 
   const renderedContent = (
     <>
-      {features.map((feature: any, index) => (
+      {features.map((feature, index) => (
         <p key={index} className={styles.zmenuContentFeature}>
           <ZmenuContentFeature
             featureId={featureId}
@@ -65,8 +57,8 @@ export const ZmenuContent = (props: ZmenuContentProps) => {
 };
 
 type ZmenuContentFeatureProps = {
-  featureId: string;
-  feature: ZmenuContentGene | ZmenuContentTranscript;
+  featureId?: string;
+  feature: ZmenuContentType;
   destroyZmenu: () => void;
 };
 export const ZmenuContentFeature = (props: ZmenuContentFeatureProps) => {
@@ -95,7 +87,7 @@ export const ZmenuContentFeature = (props: ZmenuContentFeatureProps) => {
 
 type ZmenuContentBlockProps = {
   items: ZmenuContentItemType[];
-  featureId: string;
+  featureId?: string;
   destroyZmenu: () => void;
 };
 
@@ -115,7 +107,7 @@ export const ZmenuContentBlock = (props: ZmenuContentBlockProps) => {
 };
 
 export type ZmenuContentItemProps = ZmenuContentItemType & {
-  featureId: string;
+  featureId?: string;
   destroyZmenu: () => void;
 };
 
@@ -145,7 +137,7 @@ export const ZmenuContentItem = (props: ZmenuContentItemProps) => {
 
   const itemProps = {
     className,
-    ...(isFocusable && { onClick: handleClick })
+    ...(isFocusable && featureId && { onClick: handleClick })
   };
 
   return <span {...itemProps}>{text}</span>;

--- a/src/content/app/genome-browser/components/zmenu/zmenus/DefaultZmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/zmenus/DefaultZmenu.tsx
@@ -1,0 +1,60 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import ZmenuContent from '../ZmenuContent';
+
+import type {
+  ZmenuContentDefault,
+  ZmenuPayload
+} from 'src/content/app/genome-browser/services/genome-browser-service/types/zmenu';
+
+type Props = {
+  payload: ZmenuPayload;
+  onDestroy: () => void;
+};
+
+const DefaultZmenu = (props: Props) => {
+  const { content } = props.payload;
+
+  const featureMetadata = extractFeatureMetadata(props.payload);
+
+  const featureId =
+    featureMetadata.type && featureMetadata.id
+      ? `${featureMetadata.type}:${featureMetadata.id}`
+      : undefined;
+
+  return (
+    <ZmenuContent
+      features={content}
+      featureId={featureId}
+      destroyZmenu={props.onDestroy}
+    />
+  );
+};
+
+const extractFeatureMetadata = (payload: ZmenuPayload) => {
+  const zmenuContent = payload.content[0] as ZmenuContentDefault;
+  const featureMetadata = zmenuContent.metadata;
+
+  return {
+    id: featureMetadata.id,
+    type: featureMetadata.type
+  };
+};
+
+export default DefaultZmenu;

--- a/src/content/app/genome-browser/components/zmenu/zmenus/GeneAndOneTranscriptZmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/zmenus/GeneAndOneTranscriptZmenu.tsx
@@ -61,7 +61,8 @@ const GeneAndOneTranscriptZmenu = (props: Props) => {
     gene = content.find(
       (feature) =>
         feature.metadata.type === 'gene' &&
-        feature.metadata.versioned_id === transcript?.metadata.gene_id
+        (feature.metadata as ZmenuContentGene['metadata']).versioned_id ===
+          transcript?.metadata.gene_id
     ) as ZmenuContentGene;
 
     if (gene) {

--- a/src/content/app/genome-browser/services/genome-browser-service/types/zmenu.ts
+++ b/src/content/app/genome-browser/services/genome-browser-service/types/zmenu.ts
@@ -85,6 +85,11 @@ export type ZmenuContentRegulationMetadata = {
   core_end: number; // end coordinate of the feature core
 };
 
+export type ZmenuContentOptionalMetadata = {
+  id?: string; // the payload might include some feature metadata
+  type: string;
+};
+
 export type ZmenuContentGene = {
   data: ZmenuContentLine[];
   metadata: ZmenuContentGeneMetadata;
@@ -105,11 +110,17 @@ export type ZmenuContentRegulation = {
   metadata: ZmenuContentRegulationMetadata;
 };
 
+export type ZmenuContentDefault = {
+  data: ZmenuContentLine[];
+  metadata: ZmenuContentOptionalMetadata;
+};
+
 export type ZmenuContent =
   | ZmenuContentGene
   | ZmenuContentTranscript
   | ZmenuContentVariant
-  | ZmenuContentRegulation;
+  | ZmenuContentRegulation
+  | ZmenuContentDefault;
 
 export enum ZmenuPayloadVarietyType {
   GENE_AND_ONE_TRANSCRIPT = 'gene-and-one-transcript',

--- a/src/content/app/genome-browser/services/genome-browser-service/types/zmenu.ts
+++ b/src/content/app/genome-browser/services/genome-browser-service/types/zmenu.ts
@@ -85,7 +85,7 @@ export type ZmenuContentRegulationMetadata = {
   core_end: number; // end coordinate of the feature core
 };
 
-export type ZmenuContentOptionalMetadata = {
+export type ZmenuContentMinimalMetadata = {
   id?: string; // the payload might include some feature metadata
   type: string;
 };
@@ -112,7 +112,7 @@ export type ZmenuContentRegulation = {
 
 export type ZmenuContentDefault = {
   data: ZmenuContentLine[];
-  metadata: ZmenuContentOptionalMetadata;
+  metadata: ZmenuContentMinimalMetadata;
 };
 
 export type ZmenuContent =

--- a/src/server/middleware/proxyMiddleware.ts
+++ b/src/server/middleware/proxyMiddleware.ts
@@ -32,7 +32,8 @@ const serverConfig = getConfigForServer();
  * EXAMPLE: to proxy all requests except for the genome browser backend to staging-2020,
  * while directing requests for the genome browser backend to your locally running server,
  * change the body of the createApiProxyMiddleware function as follows:
-
+ */
+const createApiProxyMiddleware = () => {
   const apiProxyMiddleware = createHttpProxyMiddleware(
     ['/api/**', '!/api/browser/**'],
     {
@@ -52,8 +53,9 @@ const serverConfig = getConfigForServer();
   });
 
   return [apiProxyMiddleware, browserProxyMiddleware];
-*/
+};
 
+/*
 const createApiProxyMiddleware = () => {
   const apiProxyMiddleware = createHttpProxyMiddleware('/api', {
     target: 'https://staging-2020.ensembl.org',
@@ -65,6 +67,7 @@ const createApiProxyMiddleware = () => {
   // (see example in the comment block above)
   return [apiProxyMiddleware];
 };
+*/
 
 const createStaticAssetsMiddleware = () => {
   // proxy all requests for static assets to the server that runs webpack dev middleware

--- a/src/server/middleware/proxyMiddleware.ts
+++ b/src/server/middleware/proxyMiddleware.ts
@@ -32,8 +32,7 @@ const serverConfig = getConfigForServer();
  * EXAMPLE: to proxy all requests except for the genome browser backend to staging-2020,
  * while directing requests for the genome browser backend to your locally running server,
  * change the body of the createApiProxyMiddleware function as follows:
- */
-const createApiProxyMiddleware = () => {
+
   const apiProxyMiddleware = createHttpProxyMiddleware(
     ['/api/**', '!/api/browser/**'],
     {
@@ -53,9 +52,8 @@ const createApiProxyMiddleware = () => {
   });
 
   return [apiProxyMiddleware, browserProxyMiddleware];
-};
+*/
 
-/*
 const createApiProxyMiddleware = () => {
   const apiProxyMiddleware = createHttpProxyMiddleware('/api', {
     target: 'https://staging-2020.ensembl.org',
@@ -67,7 +65,6 @@ const createApiProxyMiddleware = () => {
   // (see example in the comment block above)
   return [apiProxyMiddleware];
 };
-*/
 
 const createStaticAssetsMiddleware = () => {
   // proxy all requests for static assets to the server that runs webpack dev middleware


### PR DESCRIPTION
## Description
This PR adds a generic zmenu type as a fallback for drawing zmenus for any track that provides (the data for) it.

## Review app
http://compara-zmenu.review.ensembl.org

## Related JIRA Issue(s)
This zmenu type is used for many expansion node tracks (e.g. compara, repeats, simple features tracks).
Main ticket: [ENSWBSITES-2475](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2475)
Related tickets: [ENSWBSITES-2439](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2439), [ENSWBSITES-2417](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2417), [ENSWBSITES-2416](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2416)

## Views affected
Genome Browser