### PR TITLE
Switch to gitlab agent

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,11 +82,13 @@ variables:
   stage: deploy
   environment:
     name: jobs/k8s-job
+
   before_script:
     - *gitlab-agent-setup-commands
     - git clone https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
     - git -C ensembl-k8s-manifests/ checkout k8s123-migration
     - cd ensembl-k8s-manifests/ensembl-client/static-assets
+
   script:
     - sed -i "s#<PROJECT_ID>#${CI_PROJECT_ID}#g" copy_job.yaml
     - sed -i "s#<JOB_ID>#${BUILD_JOB_ID}#g" copy_job.yaml
@@ -190,7 +192,7 @@ Test_N_Build:
     ENVIRONMENT: production
     API_HOST: ""
   rules:
-    - if: $CI_COMMIT_BRANCH == "switch-to-gitlab-agent" || $CI_COMMIT_BRANCH == "dev"
+    - if: $CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "dev"
 
 # Job to build static asset for internal environment
 # master branch -> Internal
@@ -227,7 +229,7 @@ Node:Live:
   variables:
     CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}-prod
   rules:
-    - if: $CI_COMMIT_BRANCH == "switch-to-gitlab-agent"
+    - if: $CI_COMMIT_BRANCH == "master"
   needs:
     - Test_N_Build
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -416,7 +416,7 @@ Dev:
     kubernetes:
       namespace: ensembl-dev
   rules:
-    - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "master"'
+    - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "switch-to-gitlab-agent"'
   needs:
     - Test_N_Build
     - Node:Live
@@ -430,7 +430,7 @@ Pub:Dev-HL:wp51:
     AGENT: ${DEV_AGENT}
     NAMESPACE: ${DEV_NS}
   rules:
-    - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "master"'
+    - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "switch-to-gitlab-agent"'
   needs:
     - Test_N_Build
     - Node:Live

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,6 +24,7 @@ variables:
 
 # The before_script commands for deployment jobs
 # that are used to set up gitlab agent
+# (will be used through yaml anchors in the jobs below)
 .gitlab-agent-setup-commands: &gitlab-agent-setup-commands
   - kubectl config use-context ${AGENT}
   - kubectl config set-context --current --namespace=${NAMESPACE}
@@ -422,7 +423,7 @@ Dev:
     - Node:Live
 
 # Publish static assets
-Pub:Dev-HL:wp51:
+Pub:Dev:
   extends: .publish_assets
   environment:
     name: development
@@ -436,7 +437,9 @@ Pub:Dev-HL:wp51:
     - Node:Live
 
 
-# Job to deploy review deployments to development environment in the new cluster in Harlow (WP51)
+# REVIEW DEPLOYMENTS (<branch_name>.review.ensembl.org)
+
+# Job to deploy Node server and a dedicated Nginx container with embedded static assets
 Review:
   extends: .deploy-review
   variables:
@@ -455,19 +458,22 @@ Review:
     - Test_N_Build:review
     - Nginx:review
     - Node:review
+
 # Clean up the review app resources
-stop_review:
+CleanUpReview:
   extends: .stop-review
   environment:
-    name: wp51-hl-development
+    name: development
     action: stop
     kubernetes:
-      namespace: ensembl-development
+      namespace: ${CI_COMMIT_REF_SLUG}
   except:
   - dev
   - master
 
-SetupReview:HL51:
+
+# Create a review deployment (runs once per new branch)
+SetupReview:
   extends: .setup-review-newk8s
   environment:
     name: development

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,6 +78,7 @@ variables:
     name: jobs/k8s-job
 
   before_script:
+    - *gitlab-agent-setup-commands
     - git clone https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
     - git -C ensembl-k8s-manifests/ checkout k8s123-migration
     - cd ensembl-k8s-manifests/ensembl-client/static-assets
@@ -271,33 +272,10 @@ Node:review:
 
 ######## DEPLOYMENT JOBS ########
 
-# Job to deploy to the staging environment (staging-2020.review.ensembl.org)
-Staging:
-  extends: .deploy
-  environment:
-    name: staging
-  rules:
-    - if: $CI_COMMIT_BRANCH == "dev"
-  needs:
-    - Test_N_Build
-    - Node:Staging
-  variables:
-    AGENT: ${STAGING_AGENT}
-    NAMESPACE: ${STAGING_NS}
 
-Pub:Staging:WP40:HL:
-  extends: .publish_assets
-  environment:
-    name: wp40-hl-staging
-    kubernetes:
-      namespace: ensembl-stage
-  rules:
-    - if: $CI_COMMIT_BRANCH == "dev"
-  needs:
-    - Test_N_Build
-    - Node:Staging
+# DEPLOYMENT TO THE LIVE (PRODUCTION) ENVIRONMENT (beta.ensembl.org)
 
-# Job to deploy to live (aka production) environment (beta.ensembl.org)
+# Deploy the Node server
 Live:
   extends: .deploy
   variables:
@@ -312,12 +290,14 @@ Live:
     - Test_N_Build
     - Node:Live
 
-Pub:Live-HL:wp40:
+# Publish static assets
+Pub:Live:
   extends: .publish_assets
   environment:
-    name: wp40-hl-prod
-    kubernetes:
-      namespace: ensembl-prod
+    name: production
+  variables:
+    AGENT: ${PROD_AGENT}
+    NAMESPACE: ${PROD_NS}
   rules:
     - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "master"'
   needs:
@@ -325,7 +305,9 @@ Pub:Live-HL:wp40:
     - Node:Live
 
 
-# Fallback deployment for the live (production) deployment: beta.ensembl.org (Hinxton)
+# DEPLOYMENT TO THE LIVE (PRODUCTION) FALLBACK ENVIRONMENT (beta.ensembl.org, running in Hinxton)
+
+# Deploy the Node server
 LiveFallback:
   extends: .deploy
   variables:
@@ -341,19 +323,55 @@ LiveFallback:
     - Test_N_Build
     - Node:Live
 
-Pub::WP41:Live-HX:
+# Publish static assets
+Pub::LiveFallback:
   extends: .publish_assets
   environment:
-    name: wp41-hx-prod
-    kubernetes:
-      namespace: ensembl-prod
+    name: fallback
+  variables:
+    AGENT: ${FALLBACK_AGENT}
+    NAMESPACE: ${FALLBACK_NS}
   rules:
     - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "master"'
   needs:
     - Test_N_Build
     - Node:Live
 
-# Internal deployment: internal-2020.ensembl.org
+
+# DEPLOYMENT TO THE STAGING ENVIRONMENT (staging-2020.ensembl.org)
+
+# Deploy the Node server
+Staging:
+  extends: .deploy
+  environment:
+    name: staging
+  rules:
+    - if: $CI_COMMIT_BRANCH == "dev"
+  needs:
+    - Test_N_Build
+    - Node:Staging
+  variables:
+    AGENT: ${STAGING_AGENT}
+    NAMESPACE: ${STAGING_NS}
+
+# Publish static assets
+Pub:Staging:
+  extends: .publish_assets
+  environment:
+    name: staging
+  variables:
+    AGENT: ${STAGING_AGENT}
+    NAMESPACE: ${STAGING_NS}
+  rules:
+    - if: $CI_COMMIT_BRANCH == "dev"
+  needs:
+    - Test_N_Build
+    - Node:Staging
+
+
+# DEPLOYMENT TO THE INTERNAL ENVIRONMENT (internal-2020.ensembl.org)
+
+# Deploy the Node server
 Internal:
   extends: .deploy
   variables:
@@ -369,19 +387,24 @@ Internal:
     - Test_N_Build:internal
     - Node:Internal
 
-Pub:Internal::WP40:HL:
+# Publish static assets
+Pub:Internal:
   extends: .publish_assets
   environment:
-    name: wp40-hl-internal
-    kubernetes:
-      namespace: ensembl-internal
+    name: internal
+  variables:
+    AGENT: ${INTERNAL_AGENT}
+    NAMESPACE: ${INTERNAL_NS}
   rules:
     - if: $CI_COMMIT_BRANCH == "master"
   needs:
     - Test_N_Build:internal
     - Node:Internal
 
-# Development deployment: dev-2020.ensembl.org
+
+# DEPLOYMENT TO THE DEVELOPMENT ENVIRONMENT (dev-2020.ensembl.org)
+
+# Deploy the Node server
 Dev:
   extends: .deploy
   variables:
@@ -398,12 +421,14 @@ Dev:
     - Test_N_Build
     - Node:Live
 
+# Publish static assets
 Pub:Dev-HL:wp51:
   extends: .publish_assets
   environment:
-    name: wp51-hl-development
-    kubernetes:
-      namespace: ensembl-dev
+    name: development
+  variables:
+    AGENT: ${DEV_AGENT}
+    NAMESPACE: ${DEV_NS}
   rules:
     - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "master"'
   needs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,12 @@ variables:
   ENVIRONMENT: production
   DOCKER_TLS_CERTDIR: ""
 
+# The before_script commands for deployment jobs
+# that are used to set up gitlab agent
+.gitlab-agent-setup-commands: &gitlab-agent-setup-commands
+  - kubectl config use-context ${AGENT}
+  - kubectl config set-context --current --namespace=${NAMESPACE}
+
 # Template to build static assets
 .build-static:
   stage: test_build_static
@@ -107,12 +113,6 @@ variables:
     - docker push ${CONTAINER_NODE_IMAGE}
     - docker rmi ${CONTAINER_NODE_IMAGE}
     - docker logout $CI_REGISTRY
-
-# The before_script commands for deployment jobs
-# that are used to set up gitlab agent
-.gitlab-agent-setup-commands: &gitlab-agent-setup-commands
-  - kubectl config use-context ${AGENT}
-  - kubectl config set-context --current --namespace=${NAMESPACE}
 
 # Template for deployment to the new kubernetes cluster
 # For live deployment, it does not need to deploy a static assets container

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,26 +70,8 @@ variables:
     - docker rmi ${CONTAINER_IMAGE}
     - docker logout $CI_REGISTRY
 
-.publish_assets:
-  image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:latest
-  stage: deploy
-  environment:
-    name: jobs/k8s-job
-
-  before_script:
-    - git clone https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
-    - git -C ensembl-k8s-manifests/ checkout wp-k8s
-    - cd ensembl-k8s-manifests
-
-  script:
-    - sed -i "s#<PROJECT_ID>#${CI_PROJECT_ID}#g" static_assets_copy_job.yaml
-    - sed -i "s#<JOB_ID>#${BUILD_JOB_ID}#g" static_assets_copy_job.yaml
-    - kustomize edit set namesuffix -- -${CI_PROJECT_ID}-${BUILD_JOB_ID}
-    - kubectl apply -k .
-
 # Template for publishing static assets for the new kubernetes cluster
-# Will need updating after the migration is completed (see the name of the template, name of the ensembl-k8s-manifests branch)
-.publish_assets-newcluster:
+.publish_assets:
   image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:latest
   stage: deploy
   environment:
@@ -125,12 +107,20 @@ variables:
     - docker rmi ${CONTAINER_NODE_IMAGE}
     - docker logout $CI_REGISTRY
 
+# The before_script commands for deployment jobs
+# that are used to set up gitlab agent
+.gitlab-agent-setup-commands: &gitlab-agent-setup-commands
+  - kubectl config use-context ${AGENT}
+  - kubectl config set-context --current --namespace=${NAMESPACE}
+
 # Template for deployment to the new kubernetes cluster
 # For live deployment, it does not need to deploy a static assets container
 # Will need updating after the migration is completed (the name of the template, name of the ensembl-k8s-manifests branch)
-.deploy-newcluster:
+.deploy:
   stage: deploy
   image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:latest
+  before_script:
+    - *gitlab-agent-setup-commands
   script:
     - git clone https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
     - git -C ensembl-k8s-manifests/ checkout k8s123-migration
@@ -142,6 +132,8 @@ variables:
 .deploy-review:
   stage: deploy
   image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:latest
+  before_script:
+    - *gitlab-agent-setup-commands
   script:
   - git clone https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
   - git -C ensembl-k8s-manifests/ checkout k8s123-migration
@@ -278,19 +270,23 @@ Node:review:
 
 
 ######## DEPLOYMENT JOBS ########
-# Job to deploy to staging environment on the new cluster (WP40-HL k8s cluster)
-Staging:WP40:HL:
-  extends: .deploy-newcluster
+
+# Job to deploy to the staging environment (staging-2020.review.ensembl.org)
+Staging:
+  extends: .deploy
   environment:
-    name: wp40-hl-staging
+    name: staging
   rules:
     - if: $CI_COMMIT_BRANCH == "dev"
   needs:
     - Test_N_Build
     - Node:Staging
+  variables:
+    AGENT: ${STAGING_AGENT}
+    NAMESPACE: ${STAGING_NS}
 
 Pub:Staging:WP40:HL:
-  extends: .publish_assets-newcluster
+  extends: .publish_assets
   environment:
     name: wp40-hl-staging
     kubernetes:
@@ -301,13 +297,15 @@ Pub:Staging:WP40:HL:
     - Test_N_Build
     - Node:Staging
 
-# Job to deploy to live environment in the new kubernetes cluster (wp40)
-Live:wp40:HL:
-  extends: .deploy-newcluster
+# Job to deploy to live (aka production) environment (beta.ensembl.org)
+Live:
+  extends: .deploy
   variables:
     CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}-prod
+    AGENT: ${PROD_AGENT}
+    NAMESPACE: ${PROD_NS}
   environment:
-    name: wp40-hl-prod
+    name: production
   rules:
     - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "master"'
   needs:
@@ -315,7 +313,7 @@ Live:wp40:HL:
     - Node:Live
 
 Pub:Live-HL:wp40:
-  extends: .publish_assets-newcluster
+  extends: .publish_assets
   environment:
     name: wp40-hl-prod
     kubernetes:
@@ -327,14 +325,16 @@ Pub:Live-HL:wp40:
     - Node:Live
 
 
-# Job to deploy a production fallback to the new kubernetes cluster in Hinxton (WP41)
-Live:WP41:HX:
-  extends: .deploy-newcluster
+# Fallback deployment for the live (production) deployment: beta.ensembl.org (Hinxton)
+LiveFallback:
+  extends: .deploy
   variables:
     CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:nginx-${CI_COMMIT_SHORT_SHA}-prod
     CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}-prod
+    AGENT: ${FALLBACK_AGENT}
+    NAMESPACE: ${FALLBACK_NS}
   environment:
-    name: wp41-hx-prod
+    name: fallback
   rules:
     - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "master"'
   needs:
@@ -342,7 +342,7 @@ Live:WP41:HX:
     - Node:Live
 
 Pub::WP41:Live-HX:
-  extends: .publish_assets-newcluster
+  extends: .publish_assets
   environment:
     name: wp41-hx-prod
     kubernetes:
@@ -353,14 +353,16 @@ Pub::WP41:Live-HX:
     - Test_N_Build
     - Node:Live
 
-# Job to deploy to internal environment in the new cluster in Harlow (WP40)
-Internal:WP40:HL:
-  extends: .deploy-newcluster
+# Internal deployment: internal-2020.ensembl.org
+Internal:
+  extends: .deploy
   variables:
     CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:nginx-${CI_COMMIT_SHORT_SHA}-internal
     CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}-internal
+    AGENT: ${INTERNAL_AGENT}
+    NAMESPACE: ${INTERNAL_NS}
   environment:
-    name: wp40-hl-internal
+    name: internal
   rules:
     - if: $CI_COMMIT_BRANCH == "master"
   needs:
@@ -368,7 +370,7 @@ Internal:WP40:HL:
     - Node:Internal
 
 Pub:Internal::WP40:HL:
-  extends: .publish_assets-newcluster
+  extends: .publish_assets
   environment:
     name: wp40-hl-internal
     kubernetes:
@@ -379,14 +381,15 @@ Pub:Internal::WP40:HL:
     - Test_N_Build:internal
     - Node:Internal
 
-# Job to deploy to Dev environment in the new kubernetes cluster (wp51)
-# This deployment is for dev-2020.ensembl.org and same as production environment
-Dev:wp51:HL:
-  extends: .deploy-newcluster
+# Development deployment: dev-2020.ensembl.org
+Dev:
+  extends: .deploy
   variables:
     CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}-prod
+    AGENT: ${DEV_AGENT}
+    NAMESPACE: ${DEV_NS}
   environment:
-    name: wp51-hl-development
+    name: development
     kubernetes:
       namespace: ensembl-dev
   rules:
@@ -396,7 +399,7 @@ Dev:wp51:HL:
     - Node:Live
 
 Pub:Dev-HL:wp51:
-  extends: .publish_assets-newcluster
+  extends: .publish_assets
   environment:
     name: wp51-hl-development
     kubernetes:
@@ -414,8 +417,10 @@ Review:WP51:HL:
   variables:
     CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:nginx-${CI_COMMIT_SHORT_SHA}-${CI_COMMIT_REF_SLUG}
     CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}-${CI_COMMIT_REF_SLUG}
+    AGENT: ${DEV_AGENT}
+    NAMESPACE: ${DEV_NS}
   environment:
-    name: wp51-hl-development
+    name: development
     url: http://$CI_COMMIT_REF_SLUG.review.ensembl.org
     kubernetes:
       namespace: ${CI_COMMIT_REF_SLUG}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -416,7 +416,7 @@ Dev:
     kubernetes:
       namespace: ensembl-dev
   rules:
-    - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "switch-to-gitlab-agent"'
+    - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "master"'
   needs:
     - Test_N_Build
     - Node:Live
@@ -430,7 +430,7 @@ Pub:Dev-HL:wp51:
     AGENT: ${DEV_AGENT}
     NAMESPACE: ${DEV_NS}
   rules:
-    - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "switch-to-gitlab-agent"'
+    - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "master"'
   needs:
     - Test_N_Build
     - Node:Live

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -445,7 +445,10 @@ stop_review:
 SetupReview:HL51:
   extends: .setup-review-newk8s
   environment:
-    name: wp51-hl-development
+    name: development
+  variables:
+    AGENT: ${DEV_AGENT}
+    NAMESPACE: ${CI_COMMIT_REF_SLUG}
   rules:
     - if: $CI_PIPELINE_SOURCE == "push" && 
           $CI_COMMIT_BEFORE_SHA == "0000000000000000000000000000000000000000" && 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,13 +82,11 @@ variables:
   stage: deploy
   environment:
     name: jobs/k8s-job
-
   before_script:
     - *gitlab-agent-setup-commands
     - git clone https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
     - git -C ensembl-k8s-manifests/ checkout k8s123-migration
     - cd ensembl-k8s-manifests/ensembl-client/static-assets
-
   script:
     - sed -i "s#<PROJECT_ID>#${CI_PROJECT_ID}#g" copy_job.yaml
     - sed -i "s#<JOB_ID>#${BUILD_JOB_ID}#g" copy_job.yaml
@@ -192,7 +190,7 @@ Test_N_Build:
     ENVIRONMENT: production
     API_HOST: ""
   rules:
-    - if: $CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "dev"
+    - if: $CI_COMMIT_BRANCH == "switch-to-gitlab-agent" || $CI_COMMIT_BRANCH == "dev"
 
 # Job to build static asset for internal environment
 # master branch -> Internal
@@ -229,7 +227,7 @@ Node:Live:
   variables:
     CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}-prod
   rules:
-    - if: $CI_COMMIT_BRANCH == "master"
+    - if: $CI_COMMIT_BRANCH == "switch-to-gitlab-agent"
   needs:
     - Test_N_Build
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -412,13 +412,13 @@ Pub:Dev-HL:wp51:
 
 
 # Job to deploy review deployments to development environment in the new cluster in Harlow (WP51)
-Review:WP51:HL:
+Review:
   extends: .deploy-review
   variables:
     CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:nginx-${CI_COMMIT_SHORT_SHA}-${CI_COMMIT_REF_SLUG}
     CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}-${CI_COMMIT_REF_SLUG}
     AGENT: ${DEV_AGENT}
-    NAMESPACE: ${DEV_NS}
+    NAMESPACE: ${CI_COMMIT_REF_SLUG}
   environment:
     name: development
     url: http://$CI_COMMIT_REF_SLUG.review.ensembl.org

--- a/gitlab-ci-templates/.setup-review-template.yaml
+++ b/gitlab-ci-templates/.setup-review-template.yaml
@@ -4,6 +4,8 @@
   stage: setup
   image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:latest
   before_script:
+    - kubectl config use-context ${AGENT}
+    - kubectl config set-context --current --namespace=${NAMESPACE}
     - git clone --depth 1 --branch k8s123-migration https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
     - kubectl create namespace ${CI_COMMIT_REF_SLUG} || true # Carry on even if namespace already exists
     

--- a/gitlab-ci-templates/.setup-review-template.yaml
+++ b/gitlab-ci-templates/.setup-review-template.yaml
@@ -5,9 +5,9 @@
   image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:latest
   before_script:
     - kubectl config use-context ${AGENT}
-    - kubectl config set-context --current --namespace=${NAMESPACE}
     - git clone --depth 1 --branch k8s123-migration https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
-    - kubectl create namespace ${CI_COMMIT_REF_SLUG} || true # Carry on even if namespace already exists
+    - kubectl create namespace ${NAMESPACE} || true # Carry on even if namespace already exists
+    - kubectl config set-context --current --namespace=${NAMESPACE}
     
   script:
     # Setup Ingress for default backend


### PR DESCRIPTION
## Description
Updated `.gitlab-ci.yml` to use gitlab agent for deployments.

**NOTE:** tested assets publishing in [this CI/CD run](https://gitlab.ebi.ac.uk/ensembl-web/ensembl-client/-/pipelines/505537); seems to work.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2492

## Deployment URL(s)
http://switch-to-gitlab-agent.review.ensembl.org
