### PR TITLE
Use url helper to create refget urls in refget api slice

### DIFF
--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/useTranscriptDetails.ts
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/useTranscriptDetails.ts
@@ -178,7 +178,7 @@ const useGenomicRegionData = (params: {
   } = useRefgetSequenceQuery(
     {
       checksum: regionChecksum ?? '',
-      start: genomicSliceStart - 1, // translate to 0-based coordinate system that refget uses
+      start: genomicSliceStart,
       end: genomicSliceEnd
     },
     {
@@ -270,7 +270,7 @@ const useProteinData = (params: {
   } = useRefgetSequenceQuery(
     {
       checksum: proteinChecksum ?? '',
-      start: proteinSliceCoordinates.proteinSliceStart - 1, // FIXME: undo the (- 1) after useRefgetSequenceQuery hook is updated to use urlFor.refget
+      start: proteinSliceCoordinates.proteinSliceStart,
       end: proteinSliceCoordinates.proteinSliceEnd
     },
     {

--- a/src/content/app/entity-viewer/variant-view/variant-image/useVariantImageData.ts
+++ b/src/content/app/entity-viewer/variant-view/variant-image/useVariantImageData.ts
@@ -107,7 +107,7 @@ const useVariantImageData = (params: {
   } = useRefgetSequenceQuery(
     {
       checksum: regionChecksum ?? '',
-      start: sliceStart - 1, // translate to 0-based coordinate system that refget uses
+      start: sliceStart,
       end: sliceEnd
     },
     {

--- a/src/shared/state/api-slices/refgetSlice.ts
+++ b/src/shared/state/api-slices/refgetSlice.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import config from 'config';
+import * as urlFor from 'src/shared/helpers/urlHelper';
 
 import restApiSlice from 'src/shared/state/api-slices/restSlice';
 
@@ -24,7 +24,7 @@ import { Strand } from 'src/shared/types/core-api/strand';
 
 export type SequenceQueryParams = {
   checksum: string;
-  start?: number;
+  start?: number; // In Ensembl (1-based) coordinate system!
   end?: number;
   strand?: Strand;
 };
@@ -33,23 +33,9 @@ const refgetApiSlice = restApiSlice.injectEndpoints({
   endpoints: (builder) => ({
     refgetSequence: builder.query<string, SequenceQueryParams>({
       query: (params) => {
-        const { checksum, start, end } = params;
-        const queryParameters = new URLSearchParams();
-        if (start) {
-          queryParameters.set('start', `${start}`);
-        }
-        if (end) {
-          queryParameters.set('end', `${end}`);
-        }
-
-        const queryString = [...queryParameters].length
-          ? `?${queryParameters.toString()}`
-          : '';
-
-        // FIXME:
-        // Use urlFor.refget helper. !!!Remember that urlFor.refget helper accepts start in Ensembl coordinates
+        const refgetUrl = urlFor.refget(params);
         return {
-          url: `${config.refgetBaseUrl}/sequence/${checksum}${queryString}`,
+          url: refgetUrl,
           responseHandler: 'text'
         };
       },


### PR DESCRIPTION
## Description
**Background:** Refget uses a 0-based coordinate system for genomic features; whereas Ensembl apis are using a 1-based coordinate system. It is very easy to forget to convert between these two coordinate systems. Currently, in our codebase, the `refget` function in `urlHelper` expects to receive the start coordinate in Ensembl coordinate system, and subtracts 1 from it. The `useRefgetSequenceQuery` hook exported from `refgetApiSlice` generates a refget url independently, and does not subtract 1 from the start coordinate.

This, in fact, has already caused bugs. Consider any gene, e.g. PPP2R2A, the example gene for human grch38, and look at the beginning of its sequence in the genome browser. Notice that it starts with AGG

<img width="1053" alt="image" src="https://github.com/Ensembl/ensembl-client/assets/6834224/7637bb8c-2227-47c7-9de9-979ee333f2ca">

Now, check its sequence in the genome browser drawer, and you will notice that it starts with GGC. This is because the sequence was fetched with the `useRefgetSequenceQuery` hook without correcting for the difference between the 0-base and the 1-base coordinate systems of Refget and Ensembl:

<img width="858" alt="image" src="https://github.com/Ensembl/ensembl-client/assets/6834224/b9b5ca59-f66c-4b9d-a345-416f4210e237">
 

### Scope of this PR
It seems that the less confusing option is to keep using Ensembl-based coordinates throughout our codebase, and only convert the start coordinate from 1-based to 0-based coordinate system in `urlHelper`'s `refget` function. Therefore, this PR makes the `useRefgetSequenceQuery` hook call `urlHelper` to generate refget url.

**After the fix:**

Notice that PPP2R2A genomic sequence in the genome browser drawer now starts with AGG, same as in the genome browser itself.

<img width="552" alt="image" src="https://github.com/Ensembl/ensembl-client/assets/6834224/4a213738-89b5-4080-bb48-d7894bbedcc8">


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2515

## Deployment URL(s)
http://fix-refget-slice.review.ensembl.org


## Views affected
- Genome browser
- Entity viewer (variant view)