### PR TITLE
Fix display of gene segments in TranscriptVariantDiagram

### DIFF
--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-diagram/TranscriptVariantDiagram.tsx
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-diagram/TranscriptVariantDiagram.tsx
@@ -68,7 +68,7 @@ const Diagram = (
 
   const scale = scaleLinear()
     .domain([1, geneLength])
-    .range([1, width])
+    .range([0, width])
     .interpolate(interpolateRound)
     .clamp(true);
 
@@ -82,10 +82,9 @@ const Diagram = (
   const transcriptWidth = width - distanceFromGeneStart - distanceToGeneEnd;
   const variantX = scale(variantRelativeStart);
 
-  const shouldRenderLeftGeneSegment =
-    transcript.slice.location.start !== geneStart;
+  const shouldRenderLeftGeneSegment = transcript.relative_location.start !== 1;
   const shouldRenderRightGeneSegment =
-    transcript.slice.location.end !== geneEnd;
+    transcript.relative_location.start !== geneLength;
 
   return (
     <svg


### PR DESCRIPTION
## Description
TranscriptVariantDiagram component was failing to draw the remainder of the gene for transcripts on the reverse strand, leaving empty space around the diagram of the transcript.

**BEFORE:**

![image](https://github.com/Ensembl/ensembl-client/assets/6834224/1d49a197-06fb-42ff-bb94-c9a2c6ade93c)

**AFTER:**

![image](https://github.com/Ensembl/ensembl-client/assets/6834224/a9200a2c-b68b-4666-b507-19262d9ae10c)


**BEFORE:**

![image](https://github.com/Ensembl/ensembl-client/assets/6834224/ad72269d-d241-42fa-86d6-c135dc1452f2)

**AFTER:**

![localhost_8080_entity-viewer_grch38_variant_2_178717100_rs1313924560](https://github.com/Ensembl/ensembl-client/assets/6834224/9fb91e32-2e78-4b62-99b2-8cc16fe11cf4)


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2461

## Deployment URL(s)
http://fix-ev-var-transcript-diagram.review.ensembl.org