### PR TITLE
Entity viewer updates for long allele sequences

### DIFF
--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-genomic-sequence/TranscriptVariantGenomicSequence.module.css
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-genomic-sequence/TranscriptVariantGenomicSequence.module.css
@@ -45,23 +45,21 @@
   margin-left: 1px;
 }
 
-/* creating a basic CSS triangle: https://front-end.social/@css/111861629372809662 */
-.altAlleleArrow {
+.referenceAlleleSequenceLength {
+  font-family: var(--font-family-monospace);
+  font-size: 10px;
+}
+
+.referenceAlleleSequenceLabel {
+  font-size: 10px;
+  font-weight: var(--font-weight-light);
+}
+
+.arrow {
   position: absolute;
   left: 50%;
   top: 4px;
   transform: translateX(-50%);
-  width: 9px;
-  aspect-ratio: 1.5;
-  background-color: var(--color-orange);
-}
-
-.altAlleleArrowUp {
-  clip-path: polygon(50% 0, 100% 100%, 0 100%); /* this is what creates the triangle */
-}
-
-.altAlleleArrowDown {
-  clip-path: polygon(0 0, 50% 100%, 100% 0); /* this is what creates the triangle */
 }
 
 .altAlleleSequenceLength {

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-genomic-sequence/TranscriptVariantGenomicSequence.module.css
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-genomic-sequence/TranscriptVariantGenomicSequence.module.css
@@ -6,7 +6,6 @@
   --sequence-block-color: transparent;
   --sequence-block-letter-color: var(--color-black);
   font-size: 11px;
-  font-weight: var(--font-weight-semibold);
 }
 
 .letterFlankingSequence {
@@ -15,6 +14,10 @@
 
 .letter + .letter {
   margin-left: 1px;
+}
+
+.refAlleleLetter {
+  font-weight: var(--font-weight-semibold);
 }
 
 .ellipsis {
@@ -39,6 +42,7 @@
 .altAlleleLetter {
   --sequence-block-color: var(--color-dark-grey);
   --sequence-block-letter-color: var(--color-white);
+  font-weight: var(--font-weight-semibold);
 }
 
 .altAlleleLetter + .altAlleleLetter {

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-genomic-sequence/TranscriptVariantGenomicSequence.tsx
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-genomic-sequence/TranscriptVariantGenomicSequence.tsx
@@ -205,11 +205,13 @@ const ReferenceAlleleSequence = ({ sequence }: { sequence: string }) => {
 };
 
 const ReferenceAlleleLetterBlocks = ({ letters }: { letters: string[] }) => {
+  const letterClasses = classNames(styles.letter, styles.refAlleleLetter);
+
   return letters.map((letter, index) => (
     <SequenceLetterBlock
       letter={letter}
       key={index}
-      className={styles.letter}
+      className={letterClasses}
     />
   ));
 };

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-protein/TranscriptVariantProtein.module.css
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-protein/TranscriptVariantProtein.module.css
@@ -5,11 +5,11 @@
 .letter {
   --sequence-block-color: transparent;
   font-size: 11px;
-  font-weight: var(--font-weight-semibold);
 }
 
 .letterReferenceAllele {
   --sequence-block-letter-color: var(--color-black);
+  font-weight: var(--font-weight-semibold);
 }
 
 .letterFlankingSequence {

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-protein/TranscriptVariantProtein.module.css
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-protein/TranscriptVariantProtein.module.css
@@ -74,23 +74,9 @@
   font-weight: var(--font-weight-light);
 }
 
-/* FIXME: remove the classes for alt allele arrow
-   after extracting it into a dedicated component
-*/
-.altAlleleArrow {
+.arrow {
   position: absolute;
   left: 50%;
-  top: -11px; /* positioning styles should be passed to the arrow */
+  top: -11px;
   transform: translateX(-50%);
-  width: 9px;
-  aspect-ratio: 1.5;
-  background-color: var(--color-orange);
-}
-
-.altAlleleArrowUp {
-  clip-path: polygon(50% 0, 100% 100%, 0 100%); /* this is what creates the triangle */
-}
-
-.altAlleleArrowDown {
-  clip-path: polygon(0 0, 50% 100%, 100% 0); /* this is what creates the triangle */
 }

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-protein/TranscriptVariantProtein.tsx
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-protein/TranscriptVariantProtein.tsx
@@ -23,6 +23,7 @@ import {
 } from '../../variant-image/variantImageConstants';
 
 import SequenceLetterBlock from 'src/content/app/entity-viewer/variant-view/variant-image/sequence-letter-block/SequenceLetterBlock';
+import VariantAlleleDirection from '../variant-allele-direction/VariantAlleleDirection';
 
 import type { PredictedMolecularConsequenceInResponse } from 'src/content/app/entity-viewer/state/api/queries/variantPredictedMolecularConsequencesQuery';
 
@@ -282,7 +283,10 @@ const ProteinImpact = (props: Props) => {
 
   return (
     <div className={styles.changedSequenceContainer} style={componentStyles}>
-      <AltAlleleArrow direction={isInframeInsertion ? 'up' : 'down'} />
+      <VariantAlleleDirection
+        direction={isInframeInsertion ? 'up' : 'down'}
+        className={styles.arrow}
+      />
       <span className={styles.proteinImpactLabel}>Protein impact</span>
       {changedSequence}
       {modificationTypeLabel && (
@@ -292,16 +296,6 @@ const ProteinImpact = (props: Props) => {
       )}
     </div>
   );
-};
-
-// FIXME: extract in a reusable component
-const AltAlleleArrow = ({ direction }: { direction: 'up' | 'down' }) => {
-  const arrowDirectionClassName =
-    direction === 'up' ? styles.altAlleleArrowUp : styles.altAlleleArrowDown;
-
-  const classes = classNames(styles.altAlleleArrow, arrowDirectionClassName);
-
-  return <div className={classes} />;
 };
 
 const getSequenceOffsetLeft = (params: {

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/variant-allele-direction/VariantAlleleDirection.module.css
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/variant-allele-direction/VariantAlleleDirection.module.css
@@ -1,0 +1,19 @@
+.arrow {
+  width: 9px;
+  aspect-ratio: 1.5;
+  background-color: var(--color-orange);
+}
+
+/* creating a basic CSS triangle: https://front-end.social/@css/111861629372809662 */
+.up {
+  clip-path: polygon(50% 0, 100% 100%, 0 100%); /* this is what creates the triangle pointing up */
+}
+
+.down {
+  clip-path: polygon(0 0, 50% 100%, 100% 0); /* this is what creates the triangle pointing down */
+}
+
+/* wrapper for cases when the component displays both an up-pointing and a down-pointing arrow */
+.container {
+  display: inline-flex;
+}

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/variant-allele-direction/VariantAlleleDirection.tsx
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/variant-allele-direction/VariantAlleleDirection.tsx
@@ -1,0 +1,65 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import classNames from 'classnames';
+
+import styles from './VariantAlleleDirection.module.css';
+
+/**
+ * This purpose of this component is to indicate whether the elements of a sequence
+ * are replaced (e.g. nucleotides in an SNV or in a substitution),
+ * removed (e.g. nucleotides or amino acids in a deletion),
+ * or inserted.
+ *
+ * It does so by displaying an orange arrow pointing upwards or downwards,
+ * or by displaying both the upwards and downwards pointing arrows together.
+ */
+
+type Props = {
+  direction: 'up' | 'down' | 'both';
+  className?: string;
+};
+
+const VariantAlleleDirection = (props: Props) => {
+  const { direction } = props;
+
+  if (direction === 'up' || direction === 'down') {
+    const componentClasses = classNames(
+      styles.arrow,
+      {
+        [styles.up]: direction === 'up',
+        [styles.down]: direction === 'down'
+      },
+      props.className
+    );
+    return <span className={componentClasses} />;
+  } else {
+    // the direction is "both"
+    const upArrowClasses = classNames(styles.arrow, styles.up);
+    const downArrowClasses = classNames(styles.arrow, styles.down);
+    const containerClasses = classNames(styles.container, props.className);
+
+    return (
+      <span className={containerClasses}>
+        <span className={downArrowClasses} />
+        <span className={upArrowClasses} />
+      </span>
+    );
+  }
+};
+
+export default VariantAlleleDirection;

--- a/src/content/app/entity-viewer/variant-view/variant-image/VariantImage.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-image/VariantImage.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
+import { formatNumber } from 'src/shared/helpers/formatters/numberFormatter';
 import {
   getReferenceAndAltAlleles,
   getMostSevereVariantConsequence
@@ -181,7 +182,7 @@ const ReferenceSequence = (props: {
   return (
     <div className={styles.referenceSequenceBlock}>
       <div className={styles.variantStartLabel}>
-        {`${regionName}:${variantLocationStart}`}
+        {`${regionName}:${formatNumber(variantLocationStart)}`}
       </div>
       <div className={styles.referenceSequenceLabel}>Reference sequence</div>
       <div className={styles.variantInfo}>

--- a/src/content/app/entity-viewer/variant-view/variant-image/alternative-allele/AlternativeAllele.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-image/alternative-allele/AlternativeAllele.module.css
@@ -2,6 +2,7 @@
   --sequence-block-letter-color: var(--color-black);
   justify-self: start;
   font-size: 11px;
+  font-weight: var(--font-weight-semibold);
 }
 
 .letterBlock + .letterBlock {

--- a/src/content/app/entity-viewer/variant-view/variant-image/alternative-allele/AlternativeAllele.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-image/alternative-allele/AlternativeAllele.tsx
@@ -35,6 +35,13 @@ type AlleleData = {
   urlId: string;
 };
 
+/**
+ * TODO:
+ * - only expand sequence if there are up to five nucleotides remaining
+ * - replace dashes with dots
+ *
+ */
+
 type Props = {
   regionSliceStart: number;
   variantStart: number; // accounts for anchor base in appropriate variant types
@@ -177,7 +184,7 @@ const Deletion = (props: {
     };
 
     const sequenceLeft = Array(flankingBlocksCount).fill('-').join('');
-    const sequenceMid = Array(blocksGapCount).fill('-').join('');
+    const sequenceMid = Array(blocksGapCount).fill('.').join('');
     const sequenceRight = Array(flankingBlocksCount).fill('-').join('');
 
     return (

--- a/src/content/app/entity-viewer/variant-view/variant-image/alternative-allele/AlternativeAllele.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-image/alternative-allele/AlternativeAllele.tsx
@@ -35,13 +35,6 @@ type AlleleData = {
   urlId: string;
 };
 
-/**
- * TODO:
- * - only expand sequence if there are up to five nucleotides remaining
- * - replace dashes with dots
- *
- */
-
 type Props = {
   regionSliceStart: number;
   variantStart: number; // accounts for anchor base in appropriate variant types
@@ -80,21 +73,11 @@ const AlternativeAllele = (props: Props) => {
     sequence = sequence.slice(1); // exclude the first (anchor) base of the allele
   }
 
-  // Maximum alt allele display length is dynamic, and depends on where the variant starts
-  // Alt alleles are allowed to exceed the length of the remaining reference sequence
-  // (to the right of variant start) by five nucleotides
-  const distanceToVariantStart = variantStart - regionSliceStart;
-  const maxAlternativeAlleleLength =
-    DISPLAYED_REFERENCE_SEQUENCE_LENGTH - distanceToVariantStart + 5;
-
-  const sequenceLetters = sequence
-    .split('')
-    .slice(0, maxAlternativeAlleleLength);
-  const shouldShowEllipsis = sequence.length > maxAlternativeAlleleLength;
-
-  if (shouldShowEllipsis) {
-    sequenceLetters[sequenceLetters.length - 1] = '…';
-  }
+  const { sequenceLetters, shouldShowEllipsis } = getAltAlleleSequenceLetters({
+    variantStart,
+    regionSliceStart,
+    sequence
+  });
 
   const defaultLetterColour = 'var(--color-grey)'; // this is a fallback colour that should never be displayed if everything is working correctly
   const letterColour = isReferenceAlleleSelected
@@ -108,7 +91,8 @@ const AlternativeAllele = (props: Props) => {
   const lastSequenceLetterStyle = shouldShowEllipsis
     ? {
         ['--sequence-block-color' as string]: 'transparent',
-        ['--sequence-block-letter-color' as string]: letterColour
+        ['--sequence-block-letter-color' as string]: letterColour,
+        letterSpacing: '-3px'
       }
     : sequenceLetterStyle;
 
@@ -150,6 +134,55 @@ const AlternativeAllele = (props: Props) => {
       </button>
     );
   }
+};
+
+/**
+ * Rules for how many letters of the alternative allele sequence to display,
+ * according to design:
+ * - Alternative allele sequence is allowed to extend past the end of the reference sequence
+ *   by five nucleotides.
+ * - However, this "extra five nucleotides" rule only applies to the alternative alleles
+ *   whose whole sequence can fit into this space.
+ * - If the alternative allele's sequence is longer than the distance to the end of the
+ *   reference sequence + 5 nucleotides, then it should be truncated at the same point
+ *   where the reference sequence is truncated (i.e. the space for 5 extra nucleotides is not added)
+ */
+const getAltAlleleSequenceLetters = ({
+  variantStart,
+  regionSliceStart,
+  sequence
+}: {
+  variantStart: number;
+  regionSliceStart: number;
+  sequence: string;
+}) => {
+  // The start of the alternative allele has to be aligned with the start of the reference allele.
+  // This means that the maximum alt allele display length is dynamic,
+  // and depends on the distance between the variant start and the region slice start
+  const distanceToVariantStart = variantStart - regionSliceStart;
+  const distanceToRefSequenceEnd =
+    DISPLAYED_REFERENCE_SEQUENCE_LENGTH - distanceToVariantStart;
+
+  // Alt allele's sequence length is allowed to extend by 5 nucleotides
+  // past the reference sequence; but only if the alt allele's sequence can fully fit into this space
+  const displayedSequenceLength =
+    sequence.length <= distanceToRefSequenceEnd + 5
+      ? sequence.length
+      : distanceToRefSequenceEnd;
+
+  const sequenceLetters = sequence.split('').slice(0, displayedSequenceLength);
+
+  const shouldShowEllipsis = sequence.length > displayedSequenceLength;
+
+  if (shouldShowEllipsis) {
+    // according to design requirements, using three individual dots instead of a single ellipsis character (…)
+    sequenceLetters[sequenceLetters.length - 1] = '...';
+  }
+
+  return {
+    sequenceLetters,
+    shouldShowEllipsis
+  };
 };
 
 const Deletion = (props: {

--- a/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.module.css
@@ -3,10 +3,44 @@
   margin-left: 1px;
 }
 
+.referenceAllele {
+  position: relative;
+}
+
 .referenceSequenceGap {
   display: inline-flex;
   justify-content: space-around;
   color: var(--color-white);
   width: calc(5 * 16px + 5 * 1px); /* where 16px is width of a sequence letter block, and 1px is the gap width */
   font-size: 11px;
+}
+
+.lengthMeasure {
+  position: absolute;
+  bottom: -26px; /* to align with the center of the strand label */
+  left: 0;
+  right: 0;
+  text-align: center;
+  /* background-color: white; */
+  background:
+    /* var(--color-dark-grey); */ /* middle grey line */
+    linear-gradient(var(--color-dark-grey), var(--color-dark-grey)),
+    linear-gradient(transparent 20%, var(--color-dark-grey) 20%, var(--color-dark-grey) 80%, transparent 80%, transparent 100%),
+    linear-gradient(transparent 20%, var(--color-dark-grey) 20%, var(--color-dark-grey) 80%, transparent 80%, transparent 100%);
+  background-size:
+    100% 1px,
+    1px 100%,
+    1px 100%;
+  background-position:
+    1px 50%,
+    1px, 100%,
+    100% 0;
+  background-repeat: no-repeat;
+}
+
+.lengthMeasure > span {
+  color: white;
+  background-color: var(--color-black);
+  font-size: 11px;
+  padding: 0 10px;
 }

--- a/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.module.css
@@ -7,6 +7,10 @@
   position: relative;
 }
 
+.referenceAllele .letter {
+  font-weight: var(--font-weight-semibold);
+}
+
 .referenceSequenceGap {
   display: inline-flex;
   justify-content: space-around;

--- a/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.module.css
@@ -21,9 +21,7 @@
   left: 0;
   right: 0;
   text-align: center;
-  /* background-color: white; */
   background:
-    /* var(--color-dark-grey); */ /* middle grey line */
     linear-gradient(var(--color-dark-grey), var(--color-dark-grey)),
     linear-gradient(transparent 20%, var(--color-dark-grey) 20%, var(--color-dark-grey) 80%, transparent 80%, transparent 100%),
     linear-gradient(transparent 20%, var(--color-dark-grey) 20%, var(--color-dark-grey) 80%, transparent 80%, transparent 100%);

--- a/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.tsx
@@ -79,7 +79,11 @@ const ReferenceSequenceAllele = (props: Props) => {
 
   if (!shouldDisplayGap) {
     return (
-      <button onClick={onClick} disabled={isSelectedAllele}>
+      <button
+        onClick={onClick}
+        className={styles.referenceAllele}
+        disabled={isSelectedAllele}
+      >
         {letters.map((letter, index) => (
           <SequenceLetterBlock
             key={index}

--- a/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-image/reference-sequence-allele/ReferenceSequenceAllele.tsx
@@ -19,7 +19,7 @@ import classNames from 'classnames';
 
 import {
   MAX_REFERENCE_ALLELE_DISPLAY_LENGTH,
-  MIN_FLANKING_SEQUENCE_LENGTH
+  REFERENCE_ALLELE_GAP_LENGTH
 } from '../variantImageConstants';
 
 import { getVariantGroupCSSColour } from 'src/shared/helpers/variantHelpers';
@@ -91,9 +91,13 @@ const ReferenceSequenceAllele = (props: Props) => {
       </button>
     );
   } else {
-    // show six nucleotides on both sides
+    // the total number of displayed nucleotides is 21 - 5 = 16
+    const numDisplayedNucleotides =
+      MAX_REFERENCE_ALLELE_DISPLAY_LENGTH - REFERENCE_ALLELE_GAP_LENGTH;
+    const numHalfDisplayedNucleotides = numDisplayedNucleotides / 2;
+
     const lettersLeft = letters
-      .slice(0, 6)
+      .slice(0, numHalfDisplayedNucleotides)
       .map((letter, index) => (
         <SequenceLetterBlock
           key={index}
@@ -103,7 +107,7 @@ const ReferenceSequenceAllele = (props: Props) => {
         />
       ));
     const lettersRight = letters
-      .slice(letters.length - 6)
+      .slice(letters.length - numHalfDisplayedNucleotides)
       .map((letter, index) => (
         <SequenceLetterBlock
           key={index}
@@ -112,45 +116,42 @@ const ReferenceSequenceAllele = (props: Props) => {
           style={sequenceLetterStyle}
         />
       ));
-    const twoDotBlocks = [...Array(2)].map((_, index) => (
-      <SequenceLetterBlock
-        key={index}
-        letter="."
-        className={letterBlockClasses}
-        style={sequenceLetterStyle}
-      />
-    ));
-
-    const visibleLetterBlocksCount = 16; // for the reference allele, image shows 8 letter blocks on either side of the gap
-    const missingSequenceLength =
-      sequence.length -
-      2 * MIN_FLANKING_SEQUENCE_LENGTH -
-      visibleLetterBlocksCount;
-    const gap = <ReferenceSequenceGap gapLength={missingSequenceLength} />;
 
     return (
-      <button onClick={onClick} disabled={isSelectedAllele}>
+      <button
+        className={styles.referenceAllele}
+        onClick={onClick}
+        disabled={isSelectedAllele}
+      >
         {lettersLeft}
-        {twoDotBlocks}
-        {gap}
-        {twoDotBlocks}
+        <ReferenceSequenceGap />
         {lettersRight}
+        <SequenceLengthMeasure length={letters.length} />
       </button>
     );
   }
 };
 
-const ReferenceSequenceGap = (props: { gapLength: number }) => {
-  const dotsCount = 4;
-  const remainingGap = props.gapLength - dotsCount;
+const ReferenceSequenceGap = () => {
+  const dotsCount = REFERENCE_ALLELE_GAP_LENGTH;
 
   return (
     <div className={styles.referenceSequenceGap}>
-      <span>.</span>
-      <span>.</span>
-      <span>{remainingGap}</span>
-      <span>.</span>
-      <span>.</span>
+      {[...Array(dotsCount)].map((_, index) => (
+        <span key={index}>.</span>
+      ))}
+    </div>
+  );
+};
+
+// a ruler-like element that is displayed under a long sequence of the reference allele,
+// and shows its length
+const SequenceLengthMeasure = (props: {
+  length: number; // total length of the reference allele sequence
+}) => {
+  return (
+    <div className={styles.lengthMeasure}>
+      <span>{props.length}</span>
     </div>
   );
 };

--- a/src/content/app/entity-viewer/variant-view/variant-image/variantImageConstants.ts
+++ b/src/content/app/entity-viewer/variant-view/variant-image/variantImageConstants.ts
@@ -23,3 +23,7 @@ export const MAX_REFERENCE_ALLELE_DISPLAY_LENGTH = 21;
 export const MIN_FLANKING_SEQUENCE_LENGTH =
   (DISPLAYED_REFERENCE_SEQUENCE_LENGTH - MAX_REFERENCE_ALLELE_DISPLAY_LENGTH) /
   2;
+
+// if reference allele sequence is longer than the maximum display length,
+// a gap is drawn in the middle of the sequence
+export const REFERENCE_ALLELE_GAP_LENGTH = 5;


### PR DESCRIPTION
## Description
- Update the variant image in the main view of Entity Viewer variant page
  - If reference allele sequence is longer than what can fit into the available space, display a ruler-like element showing the length of the reference allele sequence ([XD](https://xd.adobe.com/view/573e7994-6561-412f-84f0-b34c0d38761e-026d/screen/289f159f-fd6c-455f-9c0b-835113098ea1?fullscreen))
  - Alternative alleles should not use the extra five-nucleotide space to the right of the reference sequence, if the sequence of this alternative allele cannot fit into the available space anyway. In this case, the alternative allele should be visually truncated at the same point as the reference allele is
- Update the genomic sequence in variant transcript consequences view
  - For long reference alleles, display the label `<number of nucleotides in ref allele> altered` (similar to what we do for protein sequence in this view) (see [XD](https://xd.adobe.com/view/573e7994-6561-412f-84f0-b34c0d38761e-026d/screen/10ccfa72-1b43-45b9-ba89-87beca014c43?fullscreen))
  - For indels, show both an upwards-pointing and a downwards-pointing orange arrow (see [XD](https://xd.adobe.com/view/e7d7f772-1cc2-4159-993e-e852d0d3c530-b284/))

## Related JIRA Issue(s)
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2455
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2494

## Deployment URL(s)
http://long-var-gap-numbers.review.ensembl.org