### PR TITLE
Fix offset insertions

### DIFF
--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-genomic-sequence/TranscriptVariantGenomicSequence.tsx
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-genomic-sequence/TranscriptVariantGenomicSequence.tsx
@@ -333,9 +333,6 @@ const calculateLeftOffset = ({
  * more of its nucleotides are to the left than to the right of the midline.
  */
 const getVariantLeftHalfLength = (sequence: string) => {
-  if (!sequence.length) {
-    return 0;
-  }
   return Math.floor(sequence.length / 2) + 1;
 };
 

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/useTranscriptDetails.ts
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/useTranscriptDetails.ts
@@ -139,6 +139,12 @@ const useGenomicRegionData = (params: {
     variantLength = 0;
   }
 
+  // the reason we are calculating variant end instead of just reading it from the api response
+  // is because the api gives conflicting data for insertions (where end = start + 1, but length = 0)
+  const variantEnd = variantLength
+    ? variantStart + variantLength - 1
+    : variantStart;
+
   // distances to slice start and slice end are calculated for the forward strand
   const distanceToSliceStart = getDistanceToSliceStart({
     variantStart: variantStart,
@@ -153,15 +159,15 @@ const useGenomicRegionData = (params: {
     strand: strand ?? 'forward'
   });
   const distanceToTranscriptStart = getDistanceToTranscriptStart({
-    variantStart: variantStart,
-    variantEnd: variantStart + variantLength ?? 0,
+    variantStart,
+    variantEnd,
     transcriptStart: transcriptStart ?? 0,
     transcriptEnd: transcriptEnd ?? 0,
     strand: strand ?? 'forward'
   });
   const distanceToTranscriptEnd = getDistanceToTranscriptEnd({
-    variantStart: variantStart,
-    variantEnd: variantStart + variantLength ?? 0,
+    variantStart,
+    variantEnd,
     transcriptStart: transcriptStart ?? 0,
     transcriptEnd: transcriptEnd ?? 0,
     strand: strand ?? 'forward'


### PR DESCRIPTION
## Description
- Removed the one-base left offset of genomic sequences for transcript consequences for insertions
- Updated calculations of variant end, which should fix the label showing variant location within a transcript

## Related JIRA Issue(s)
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2520
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2478

## Deployment URL(s)
http://fix-offset-insertions.review.ensembl.org

### Example urls
- Removal of the 1-base left offset in insertions
  - the offset exists on staging (resulting in wrapping of the genomic sequence in transcript consequences section): [link](https://staging-2020.ensembl.org/entity-viewer/grch38/variant:21:45988497:rs4647797?allele=0&view=transcript-consequences)
  - the offset is removed in this PR, and the genomic sequence does not wrap ([link](http://fix-offset-insertions.review.ensembl.org/entity-viewer/grch38/variant:21:45988497:rs4647797?allele=0&view=transcript-consequences))
- 0 in variant location in transcript
  - location incorrectly reported as `0 - 10` in transcript `ENST00000428120` on staging ([link](https://staging-2020.ensembl.org/entity-viewer/grch38/variant:1:2194730:rs1297037078?allele=0&view=transcript-consequences))
  - location is reported as `1 - 11` for transcript `ENST00000428120` in this PR ([link](http://fix-offset-insertions.review.ensembl.org/entity-viewer/grch38/variant:1:2194730:rs1297037078?allele=0&view=transcript-consequences))