### PR TITLE
Update formatting for CADD and MAF scores in Entity Viewer and Genome Browser

### DIFF
--- a/src/content/app/genome-browser/components/drawer/drawer-views/variant-summary/VariantSummary.module.css
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/variant-summary/VariantSummary.module.css
@@ -47,6 +47,15 @@ For the reference (from Andrea)
   font-weight: var(--font-weight-light);
 }
 
+/* space between a score and the sequence of the respective allele */
+.alleleSequenceOffset {
+  margin-left: 8px;
+}
+
+.wrappableSequence {
+  word-break: break-all;
+}
+
 .withSpaceLeft {
   margin-left: 12px;
 }
@@ -62,7 +71,6 @@ For the reference (from Andrea)
 
 .caddScore {
   display: block;
-  word-break: break-all;
 }
 
 .phenotypeAssociations {

--- a/src/content/app/genome-browser/components/drawer/drawer-views/variant-summary/VariantSummary.module.css
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/variant-summary/VariantSummary.module.css
@@ -60,6 +60,11 @@ For the reference (from Andrea)
   max-width: 60ch;
 }
 
+.caddScore {
+  display: block;
+  word-break: break-all;
+}
+
 .phenotypeAssociations {
   margin-top: 15px;
   margin-bottom: 30px;

--- a/src/content/app/genome-browser/components/drawer/drawer-views/variant-summary/VariantSummary.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/variant-summary/VariantSummary.tsx
@@ -230,7 +230,11 @@ export const CADDScores = (props: {
 }) => {
   const caddScoreString = props.data
     .map((data) => `${data.score} (${data.sequence})`)
-    .join(', ');
+    .map((content) => (
+      <span className={styles.caddScore} key={content}>
+        {content}
+      </span>
+    ));
 
   return <span>{caddScoreString}</span>;
 };

--- a/src/content/app/genome-browser/components/drawer/drawer-views/variant-summary/VariantSummary.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/variant-summary/VariantSummary.tsx
@@ -115,8 +115,16 @@ const VariantSummary = (props: Props) => {
         <div className={classNames(styles.row, styles.newRowGroup)}>
           <div className={styles.label}>MAF</div>
           <div className={styles.value}>
-            {preparedSummaryData.minorAlleleFrequency.frequency} (
-            {preparedSummaryData.minorAlleleFrequency.sequence})
+            {preparedSummaryData.minorAlleleFrequency.frequency}
+            <span
+              className={classNames(
+                styles.light,
+                styles.wrappableSequence,
+                styles.alleleSequenceOffset
+              )}
+            >
+              {preparedSummaryData.minorAlleleFrequency.sequence}
+            </span>
           </div>
         </div>
       )}
@@ -228,15 +236,22 @@ export const VariantDB = (props: {
 export const CADDScores = (props: {
   data: { sequence: string; score: number }[];
 }) => {
-  const caddScoreString = props.data
-    .map((data) => `${data.score} (${data.sequence})`)
-    .map((content) => (
-      <span className={styles.caddScore} key={content}>
-        {content}
+  const caddScores = props.data.map((data) => (
+    <div className={styles.caddScore} key={data.sequence}>
+      <span>{data.score}</span>{' '}
+      <span
+        className={classNames(
+          styles.light,
+          styles.wrappableSequence,
+          styles.alleleSequenceOffset
+        )}
+      >
+        {data.sequence}
       </span>
-    ));
+    </div>
+  ));
 
-  return <span>{caddScoreString}</span>;
+  return <div>{caddScores}</div>;
 };
 
 // FIXME: links should be grouped by sources. Does ExternalReference component do this?


### PR DESCRIPTION
## Description
- In a variant with multiple alleles, put CADD score for each of the alleles on its own line
- Instead of putting the allele sequence next to the score in parenthesis, apply a light-weight font to it
- Make the same style changes (no parenthesis around allele sequence; light-weight font for the sequence) for the MAF score 

### Genome browser

**Before:**

![before](https://github.com/Ensembl/ensembl-client/assets/6834224/a77efb3c-06b1-4578-a782-2ddc8f1b6a20)


**After:**

![after](https://github.com/Ensembl/ensembl-client/assets/6834224/85bdf756-999c-4024-b8ee-bb496dbe08f6)


### Entity Viewer

**Before:**

https://github.com/Ensembl/ensembl-client/assets/6834224/79daee75-51e6-4a02-9dd8-c1eb9dd5ba30


**After (no extra scroll in the sidebar):**


https://github.com/Ensembl/ensembl-client/assets/6834224/5995c658-9f8d-46f8-aa71-9bc1b88e4797

## Jira ticket
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2541

## Deployment URL(s)
http://cadd-scores-formatting.review.ensembl.org

Example variant: `8:29401799:rs61644085`