### PR TITLE
Do not include anchor base in visual representation of indels in genomic sequence

### DIFF
--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/useTranscriptDetails.ts
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/useTranscriptDetails.ts
@@ -129,7 +129,7 @@ const useGenomicRegionData = (params: {
   const transcriptEnd = transcript?.slice.location.end;
   const strand = gene?.slice.strand.code;
 
-  if (alleleType === 'deletion') {
+  if (alleleType === 'deletion' || alleleType === 'indel') {
     variantStart += 1;
     variantLength -= 1;
   } else if (alleleType === 'insertion') {
@@ -191,7 +191,7 @@ const useGenomicRegionData = (params: {
       ? alleleSequence
       : getReverseComplement(alleleSequence);
 
-  if (alleleType === 'insertion') {
+  if (alleleType === 'insertion' || alleleType === 'indel') {
     // strip off the anchor base
     alleleSequence =
       strand === 'forward'


### PR DESCRIPTION
## Description

### Problem

Code wasn't accounting for the "anchor" base in indels in variant locations reported by the variation api. The variation api includes the "anchor" base, such that the change from reference allele to alternative allele is described as in VCF (e.g. CCA → CT, where the first letter C is the "anchor" that is not involved in the variant itself).

In genome browser, we are excluding the "anchor" base from the visual representation of insertions, deletions, and indels. We do the same in the main variant image on Entity Viewer variant page. But in the transcript consequences view, the genomic sequence was still showing the anchor base.

The fix is to adjust coordinates for the reference allele, and remove the first nucleotide (or the last nucleotide when transcript is on the reverse strand) from alternative allele.

**Before fix:**

![image](https://github.com/Ensembl/ensembl-client/assets/6834224/bcb1df13-021b-45cd-a6c0-4a281cbbc8dc)


**After fix:**

![image](https://github.com/Ensembl/ensembl-client/assets/6834224/e3fc887e-574d-4512-a02c-730bb5515d7a)


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2532

## Deployment URL(s)
http://fix-genomic-seq-indel.review.ensembl.org

**Example url:** http://fix-genomic-seq-indel.review.ensembl.org/entity-viewer/grch38/variant:1:230710046:rs878890662?allele=0&view=transcript-consequences