### PR TITLE
Add formatter for small numbers, and move allele table columns around

### DIFF
--- a/src/content/app/entity-viewer/variant-view/population-allele-frequencies/PopulationAlleleFrequencies.tsx
+++ b/src/content/app/entity-viewer/variant-view/population-allele-frequencies/PopulationAlleleFrequencies.tsx
@@ -17,7 +17,7 @@
 import React, { useState, useEffect } from 'react';
 import classNames from 'classnames';
 
-import { formatSmallNumber } from 'src/shared/helpers/formatters/numberFormatter';
+import { createSmallNumberFormatter } from 'src/shared/helpers/formatters/numberFormatter';
 
 import usePopulationAlleleFrequenciesData from './usePopulationAlleleFrequenciesData';
 
@@ -155,12 +155,13 @@ const GlobalFrequenciesTable = (props: {
   );
 
   const tableClasses = classNames(styles.table, styles.tablePlain);
+  const smallNumberFormatter = createSmallNumberFormatter();
 
   const diagram = alleleGlobalFreq ? (
     <CircleDiagram alleleFrequency={alleleGlobalFreq.allele_frequency} />
   ) : null;
   const formattedFreq = alleleGlobalFreq
-    ? formatSmallNumber(alleleGlobalFreq.allele_frequency)
+    ? smallNumberFormatter.format(alleleGlobalFreq.allele_frequency)
     : null;
 
   return (
@@ -181,6 +182,7 @@ const PopulationFrequenciesTable = (props: {
   currentPopulationGroup: string;
 }) => {
   const { allele, currentPopulationGroup } = props;
+  const smallNumberFormatter = createSmallNumberFormatter();
 
   const allelePopFreqs = allele.populationFrequencies;
 
@@ -206,7 +208,7 @@ const PopulationFrequenciesTable = (props: {
             <td>
               <CircleDiagram alleleFrequency={popFreq.allele_frequency} />
             </td>
-            <td>{formatSmallNumber(popFreq.allele_frequency)}</td>
+            <td>{smallNumberFormatter.format(popFreq.allele_frequency)}</td>
           </tr>
         ))}
       </tbody>

--- a/src/content/app/entity-viewer/variant-view/population-allele-frequencies/PopulationAlleleFrequencies.tsx
+++ b/src/content/app/entity-viewer/variant-view/population-allele-frequencies/PopulationAlleleFrequencies.tsx
@@ -168,8 +168,8 @@ const GlobalFrequenciesTable = (props: {
       <tbody>
         <tr>
           <td>Global</td>
-          <td>{formattedFreq}</td>
           <td>{diagram}</td>
+          <td>{formattedFreq}</td>
         </tr>
       </tbody>
     </table>

--- a/src/content/app/entity-viewer/variant-view/population-allele-frequencies/PopulationAlleleFrequencies.tsx
+++ b/src/content/app/entity-viewer/variant-view/population-allele-frequencies/PopulationAlleleFrequencies.tsx
@@ -17,6 +17,8 @@
 import React, { useState, useEffect } from 'react';
 import classNames from 'classnames';
 
+import { formatSmallNumber } from 'src/shared/helpers/formatters/numberFormatter';
+
 import usePopulationAlleleFrequenciesData from './usePopulationAlleleFrequenciesData';
 
 import Panel from 'src/shared/components/panel/Panel';
@@ -157,13 +159,16 @@ const GlobalFrequenciesTable = (props: {
   const diagram = alleleGlobalFreq ? (
     <CircleDiagram alleleFrequency={alleleGlobalFreq.allele_frequency} />
   ) : null;
+  const formattedFreq = alleleGlobalFreq
+    ? formatSmallNumber(alleleGlobalFreq.allele_frequency)
+    : null;
 
   return (
     <table className={tableClasses}>
       <tbody>
         <tr>
           <td>Global</td>
-          <td>{alleleGlobalFreq?.allele_frequency}</td>
+          <td>{formattedFreq}</td>
           <td>{diagram}</td>
         </tr>
       </tbody>
@@ -198,10 +203,10 @@ const PopulationFrequenciesTable = (props: {
         {filteredAllelePopFreqs.map((popFreq, index) => (
           <tr key={index}>
             <td>{popFreq.description}</td>
-            <td>{popFreq.allele_frequency}</td>
             <td>
               <CircleDiagram alleleFrequency={popFreq.allele_frequency} />
             </td>
+            <td>{formatSmallNumber(popFreq.allele_frequency)}</td>
           </tr>
         ))}
       </tbody>

--- a/src/shared/helpers/formatters/numberFormatter.test.ts
+++ b/src/shared/helpers/formatters/numberFormatter.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { formatNumber } from './numberFormatter';
+import { formatNumber, formatSmallNumber } from './numberFormatter';
 
 import { faker } from '@faker-js/faker';
 
@@ -136,5 +136,71 @@ describe('formatNumber', () => {
     expect(numberSplitByComma[1].length).toBe(5);
 
     expect(Number(numberSplitByComma.join(''))).toBe(randomNumber);
+  });
+});
+
+describe('formatSmallNumber', () => {
+  describe('with truncation and scientific notation', () => {
+    const commonFormattingOptions = {
+      maximumSignificantDigits: 5,
+      scientificNotation: true
+    };
+
+    test('0.999959690 is formatted as 0.99995', () => {
+      // Notice that the number is truncated rather than rounded!
+      expect(formatSmallNumber(0.99995969, commonFormattingOptions)).toBe(
+        '0.99995'
+      );
+    });
+
+    test('0.00000123 is formatted as 1.23e-6', () => {
+      expect(formatSmallNumber(0.00000123, commonFormattingOptions)).toBe(
+        '1.23e-6'
+      );
+    });
+
+    test('0.0000012395 is formatted as 1.23e-6', () => {
+      // Notice that the number got truncated rather than rounded!
+      expect(
+        formatSmallNumber(0.0000012395, {
+          ...commonFormattingOptions,
+          scientificNotation: {
+            maximumSignificantDigits: 3
+          }
+        })
+      ).toBe('1.23e-6');
+    });
+  });
+
+  describe('with scientific notation, but without truncation', () => {
+    const commonFormattingOptions = {
+      maximumSignificantDigits: 21, // this is the maximum number allowed
+      scientificNotation: true
+    };
+
+    test('0.999959690 is formatted as 0.99995969', () => {
+      // Note that the trailing zero is removed,
+      // because the Number type has no memory of its literal representation.
+      expect(formatSmallNumber(0.99995969, commonFormattingOptions)).toBe(
+        '0.99995969'
+      );
+    });
+
+    test('0.00000123 is formatted as 1.23e-6', () => {
+      expect(formatSmallNumber(0.00000123, commonFormattingOptions)).toBe(
+        '1.23e-6'
+      );
+    });
+
+    test('0.0000012395 is formatted as 1.2395e-6', () => {
+      expect(
+        formatSmallNumber(0.0000012395, {
+          ...commonFormattingOptions,
+          scientificNotation: {
+            maximumSignificantDigits: 21 // i.e. as many as possible
+          }
+        })
+      ).toBe('1.2395e-6');
+    });
   });
 });

--- a/src/shared/helpers/formatters/numberFormatter.test.ts
+++ b/src/shared/helpers/formatters/numberFormatter.test.ts
@@ -153,9 +153,17 @@ describe('formatSmallNumber', () => {
       );
     });
 
-    test('0.00000123 is formatted as 1.23e-6', () => {
-      expect(formatSmallNumber(0.00000123, commonFormattingOptions)).toBe(
-        '1.23e-6'
+    test('0.000123 is formatted as 0.000123', () => {
+      // By default, the value below which the formatter will switch to scientific notation is 0.0001
+      // Therefore, given 0.000123 as an input, the formatter should return this number unchanged
+      expect(formatSmallNumber(0.000123, commonFormattingOptions)).toBe(
+        '0.000123'
+      );
+    });
+
+    test('0.0000123 is formatted as 1.23e-5', () => {
+      expect(formatSmallNumber(0.0000123, commonFormattingOptions)).toBe(
+        '1.23e-5'
       );
     });
 

--- a/src/shared/helpers/formatters/numberFormatter.test.ts
+++ b/src/shared/helpers/formatters/numberFormatter.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { formatNumber, formatSmallNumber } from './numberFormatter';
+import { formatNumber, createSmallNumberFormatter } from './numberFormatter';
 
 import { faker } from '@faker-js/faker';
 
@@ -139,76 +139,61 @@ describe('formatNumber', () => {
   });
 });
 
-describe('formatSmallNumber', () => {
-  describe('with truncation and scientific notation', () => {
+describe('createSmallNumberFormatter', () => {
+  describe('when formatted number should be truncated, and scientific notation applied', () => {
     const commonFormattingOptions = {
-      maximumSignificantDigits: 5,
-      scientificNotation: true
+      maximumSignificantDigits: 5
     };
 
     test('0.999959690 is formatted as 0.99995', () => {
+      const formatter = createSmallNumberFormatter(commonFormattingOptions);
       // Notice that the number is truncated rather than rounded!
-      expect(formatSmallNumber(0.99995969, commonFormattingOptions)).toBe(
-        '0.99995'
-      );
+      expect(formatter.format(0.99995969)).toBe('0.99995');
     });
 
     test('0.000123 is formatted as 0.000123', () => {
+      const formatter = createSmallNumberFormatter(commonFormattingOptions);
+
       // By default, the value below which the formatter will switch to scientific notation is 0.0001
       // Therefore, given 0.000123 as an input, the formatter should return this number unchanged
-      expect(formatSmallNumber(0.000123, commonFormattingOptions)).toBe(
-        '0.000123'
-      );
+      expect(formatter.format(0.000123)).toBe('0.000123');
     });
 
     test('0.0000123 is formatted as 1.23e-5', () => {
-      expect(formatSmallNumber(0.0000123, commonFormattingOptions)).toBe(
-        '1.23e-5'
-      );
+      const formatter = createSmallNumberFormatter(commonFormattingOptions);
+      expect(formatter.format(0.0000123)).toBe('1.23e-5');
     });
 
     test('0.0000012395 is formatted as 1.23e-6', () => {
+      const formattingOptions = {
+        ...commonFormattingOptions,
+        scientificNotation: {
+          maximumSignificantDigits: 3
+        }
+      };
+      const formatter = createSmallNumberFormatter(formattingOptions);
       // Notice that the number got truncated rather than rounded!
-      expect(
-        formatSmallNumber(0.0000012395, {
-          ...commonFormattingOptions,
-          scientificNotation: {
-            maximumSignificantDigits: 3
-          }
-        })
-      ).toBe('1.23e-6');
+      expect(formatter.format(0.0000012395)).toBe('1.23e-6');
     });
   });
 
   describe('with scientific notation, but without truncation', () => {
-    const commonFormattingOptions = {
-      maximumSignificantDigits: 21, // this is the maximum number allowed
-      scientificNotation: true
-    };
-
     test('0.999959690 is formatted as 0.99995969', () => {
+      const formatter = createSmallNumberFormatter();
+
       // Note that the trailing zero is removed,
       // because the Number type has no memory of its literal representation.
-      expect(formatSmallNumber(0.99995969, commonFormattingOptions)).toBe(
-        '0.99995969'
-      );
+      expect(formatter.format(0.99995969)).toBe('0.99995969');
     });
 
     test('0.00000123 is formatted as 1.23e-6', () => {
-      expect(formatSmallNumber(0.00000123, commonFormattingOptions)).toBe(
-        '1.23e-6'
-      );
+      const formatter = createSmallNumberFormatter();
+      expect(formatter.format(0.00000123)).toBe('1.23e-6');
     });
 
     test('0.0000012395 is formatted as 1.2395e-6', () => {
-      expect(
-        formatSmallNumber(0.0000012395, {
-          ...commonFormattingOptions,
-          scientificNotation: {
-            maximumSignificantDigits: 21 // i.e. as many as possible
-          }
-        })
-      ).toBe('1.2395e-6');
+      const formatter = createSmallNumberFormatter();
+      expect(formatter.format(0.0000012395)).toBe('1.2395e-6');
     });
   });
 });

--- a/src/shared/helpers/formatters/numberFormatter.ts
+++ b/src/shared/helpers/formatters/numberFormatter.ts
@@ -30,3 +30,45 @@ export const getNumberWithoutCommas = (input: string) => {
   const inputWithoutCommas = input.replace(/,/g, '');
   return +inputWithoutCommas;
 };
+
+export const formatSmallNumber = (
+  num: number,
+  options?: Intl.NumberFormatOptions & {
+    scientificNotation?:
+      | {
+          cutoff?: number; // number below which we should format the input using scientific notation
+          maximumSignificantDigits?: number;
+        }
+      | boolean;
+  }
+) => {
+  options = options ?? {};
+  options = {
+    ...defaultSmallNumberFormatterOptions,
+    ...options
+  };
+  options.scientificNotation = options.scientificNotation ?? true; // use scientific notation unless explicitly told not to
+
+  if (options.scientificNotation) {
+    const scientificNotationConfig =
+      options.scientificNotation === true ? {} : options.scientificNotation;
+    const { cutoff = 0.00001 } = scientificNotationConfig;
+    const numAbs = Math.abs(num);
+    if (numAbs > 0 && numAbs < cutoff) {
+      options.notation = 'scientific';
+      options.maximumSignificantDigits =
+        scientificNotationConfig.maximumSignificantDigits ??
+        defaultSmallNumberFormatterOptions.maximumSignificantDigits;
+    }
+  }
+
+  const formatter = new Intl.NumberFormat('en-GB', options);
+
+  return formatter.format(num).toLocaleLowerCase();
+};
+
+// FIXME: Intl.NumberFormatOptions type doesn't seem to include "roundingMode"?
+const defaultSmallNumberFormatterOptions = {
+  maximumSignificantDigits: 21,
+  roundingMode: 'trunc'
+};

--- a/src/shared/helpers/formatters/numberFormatter.ts
+++ b/src/shared/helpers/formatters/numberFormatter.ts
@@ -52,7 +52,7 @@ export const formatSmallNumber = (
   if (options.scientificNotation) {
     const scientificNotationConfig =
       options.scientificNotation === true ? {} : options.scientificNotation;
-    const { cutoff = 0.00001 } = scientificNotationConfig;
+    const { cutoff = 0.0001 } = scientificNotationConfig;
     const numAbs = Math.abs(num);
     if (numAbs > 0 && numAbs < cutoff) {
       options.notation = 'scientific';


### PR DESCRIPTION
## Description
- Added a formatter for small numbers
- Moved variant alleles table columns around

### Note
We discussed several options for the interface of the formatter:

#### Option 1

```
const formattedNumber = formatSmallNumber(number, intlNumberFormatOptions);
```

**Advantages:** 
- Convenience

**Disadvantages:**
- `formatSmallNumber` would create a new formatter every time it is called; this is an expensive operation. In a test, creating a new formatter in a loop 1000 times took about 40-60ms; whereas creating a formatter once and then using it in a loop 1000 times took about 2ms.

#### Option 2

```
const formatter = createSmallNumberFormatter(intlNumberFormatOptions);
const formattedNumber = formatter.format(number);
```

**Advantages:** 
- Many times more performant than option 1 if iterating over an array of numbers

**Disadvantages:**
- Slightly less convenient


Eventually, we agreed on option 2.

## Related JIRA Issue(s)
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2502
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2503

## Deployment URL(s)
http://allele-freq-table.review.ensembl.org

Example variants:
- `19:474690:rs569586139`