### PR TITLE
Support nullable homologies field returned by the Compara api

### DIFF
--- a/src/content/app/entity-viewer/gene-view/components/gene-homology/GeneHomology.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-homology/GeneHomology.tsx
@@ -25,6 +25,8 @@ import useEntityViewerIds from 'src/content/app/entity-viewer/hooks/useEntityVie
 import GeneHomologyTable from './GeneHomologyTable';
 import { CircleLoader } from 'src/shared/components/loader';
 
+import type { GeneHomology as GeneHomologyType } from 'src/content/app/entity-viewer/state/api/types/geneHomology';
+
 const GeneHomology = () => {
   const { activeGenomeId, parsedEntityId } = useEntityViewerIds();
 
@@ -57,11 +59,21 @@ const GeneHomology = () => {
   } else if (isError) {
     // might be smarter, and show this message only in 404-like errors; while showing something like 'Failed to fetch homology data' otherwise
     return 'No data';
+  } else if (currentData?.homologies === null) {
+    // This means that Compara pipelines have not been run for this genome.
+    // We might want to show a more meaningful message here
+    return 'No data';
   } else if (!currentData) {
     return null; // this should not happen; but will make typescript happy
   }
 
-  return <GeneHomologyTable homologies={currentData.homologies} />;
+  // We have checked above that both currentData and currentData.homologies exist;
+  // but typescript cannot see this
+  return (
+    <GeneHomologyTable
+      homologies={currentData.homologies as GeneHomologyType[]}
+    />
+  );
 };
 
 export default GeneHomology;

--- a/src/content/app/entity-viewer/state/api/queries/geneHomologiesQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/geneHomologiesQuery.ts
@@ -67,6 +67,12 @@ export const geneHomologiesQuery = gql`
   }
 `;
 
+/**
+ * When the `homologies` field is null, it means that compara pipelines
+ * have not been run for the current genome.
+ * Note that this is different from the scenario in which the pipelines were run,
+ * but no homologies were found. In that case, the homologies field will resolve to an empty array.
+ */
 export type EntityViewerGeneHomologiesQueryResult = {
-  homologies: GeneHomology[];
+  homologies: GeneHomology[] | null;
 };


### PR DESCRIPTION
## Description
The Compara api has been updated to distinguish between the following two cases:
- The pipeline for homologies was run for a given genome, and no homologies were found. In this case, the `homologies` field in the api response will be an empty array.
- The pipeline for homologies has not been run for a given genome; thus, there are no homologies to report. In this case, the `homologies` filed in the api response will be set to `null`.

This PR updates the types and adds minor adjustments to the code to support the nullability of the `homologies` field.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2526

## Deployment URL(s)
http://nullable-homologies.review.ensembl.org (although there isn't anything interesting to see there yet)