### PR TITLE
Species manager updates

### DIFF
--- a/src/content/app/species-selector/components/species-lozenge-display-selector/SpeciesLozengeDisplaySelector.module.css
+++ b/src/content/app/species-selector/components/species-lozenge-display-selector/SpeciesLozengeDisplaySelector.module.css
@@ -1,3 +1,4 @@
 .label {
+  font-weight: var(--font-weight-light);
   padding-right: 10px;
 }

--- a/src/content/app/species-selector/views/species-manager/SpeciesManager.module.css
+++ b/src/content/app/species-selector/views/species-manager/SpeciesManager.module.css
@@ -8,9 +8,8 @@
 
 .mainContentTop {
   display: flex;
-  justify-content: space-between;
   align-items: flex-start;
-  max-width: calc(100vw - 130px);
+  column-gap: 90px;
 }
 
 .addSpeciesButton {
@@ -21,17 +20,13 @@
 .mainContentTopRight {
   display: flex;
   column-gap: var(--double-standard-gutter);
+  justify-content: space-between;
+  flex-grow: 1;
 }
 
 .filterFieldWrapper {
   display: flex;
   align-items: center;
-}
-
-.labelText {
-  font-weight: var(--font-weight-light);
-  padding-right: 10px;
-  white-space: nowrap;
 }
 
 .genomesTableContainer {

--- a/src/content/app/species-selector/views/species-manager/SpeciesManager.module.css
+++ b/src/content/app/species-selector/views/species-manager/SpeciesManager.module.css
@@ -1,5 +1,12 @@
 .container {
   display: grid;
   grid-template-rows: minmax(60px, auto) 1fr;
+  height: 100%;
   padding-left: var(--double-standard-gutter);
+}
+
+.genomesTableContainer {
+  height: 100%;
+  overflow: auto;
+  padding-bottom: var(--global-padding-bottom);
 }

--- a/src/content/app/species-selector/views/species-manager/SpeciesManager.module.css
+++ b/src/content/app/species-selector/views/species-manager/SpeciesManager.module.css
@@ -31,10 +31,22 @@
   align-items: center;
 }
 
-.genomesTableContainer {
+/* A vertically scrollable container, with a right padding
+   that puts some space between the table of genomes and the vertical scrollbar
+*/
+.genomesTableContainerOuter {
   height: 100%;
-  overflow: auto;
+  overflow-y: auto;
   padding-bottom: var(--global-padding-bottom);
   max-width: calc(100vw - 90px);
   padding-right: 20px;
+}
+
+/* A horizontally scrollable container.
+   It complements the .genomesTableContainerOuter such that
+   none of the table content can be seen crossing behind the right sticky columns
+   and into the right padding of the outer container.
+*/
+.genomesTableContainerInner {
+  overflow-x: auto;
 }

--- a/src/content/app/species-selector/views/species-manager/SpeciesManager.module.css
+++ b/src/content/app/species-selector/views/species-manager/SpeciesManager.module.css
@@ -1,12 +1,43 @@
 .container {
   display: grid;
+  grid-template-columns: max-content;
   grid-template-rows: minmax(60px, auto) 1fr;
   height: 100%;
   padding-left: var(--double-standard-gutter);
+}
+
+.mainContentTop {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  max-width: calc(100vw - 130px);
+}
+
+.addSpeciesButton {
+  --add-button-icon-color: var(--color-green);
+  --add-button-label-color: var(--color-black);
+}
+
+.mainContentTopRight {
+  display: flex;
+  column-gap: var(--double-standard-gutter);
+}
+
+.filterFieldWrapper {
+  display: flex;
+  align-items: center;
+}
+
+.labelText {
+  font-weight: var(--font-weight-light);
+  padding-right: 10px;
+  white-space: nowrap;
 }
 
 .genomesTableContainer {
   height: 100%;
   overflow: auto;
   padding-bottom: var(--global-padding-bottom);
+  max-width: calc(100vw - 90px);
+  padding-right: 20px;
 }

--- a/src/content/app/species-selector/views/species-manager/SpeciesManager.module.css
+++ b/src/content/app/species-selector/views/species-manager/SpeciesManager.module.css
@@ -15,6 +15,8 @@
 .addSpeciesButton {
   --add-button-icon-color: var(--color-green);
   --add-button-label-color: var(--color-black);
+  position: sticky;
+  right: calc(16px + 45px); /* 16px is the diameter of the close button; and 45px is minimum allowed distance between add button and close button */
 }
 
 .mainContentTopRight {

--- a/src/content/app/species-selector/views/species-manager/SpeciesManager.tsx
+++ b/src/content/app/species-selector/views/species-manager/SpeciesManager.tsx
@@ -68,8 +68,10 @@ const MainContentTop = (props: {
       <SpeciesLozengeDisplaySelector />
       <div className={styles.mainContentTopRight}>
         <label className={styles.filterFieldWrapper}>
-          <span className={styles.labelText}>Find in list</span>
-          <ShadedInput onChange={props.onFilterChange} />
+          <ShadedInput
+            onChange={props.onFilterChange}
+            placeholder="Find in list"
+          />
         </label>
         <AddButton
           onClick={onAddSpeciesClick}

--- a/src/content/app/species-selector/views/species-manager/SpeciesManager.tsx
+++ b/src/content/app/species-selector/views/species-manager/SpeciesManager.tsx
@@ -15,16 +15,25 @@
  */
 
 import { useNavigate } from 'react-router-dom';
+import type { FormEvent } from 'react';
+
+import * as urlFor from 'src/shared/helpers/urlHelper';
+
+import useFilteredGenomes from './useFilteredGenomes';
 
 import ModalView from 'src/shared/components/modal-view/ModalView';
 
 import SelectedGenomesTable from './selected-genomes-table/SelectedGenomesTable';
 import SpeciesLozengeDisplaySelector from 'src/content/app/species-selector/components/species-lozenge-display-selector/SpeciesLozengeDisplaySelector';
+import AddButton from 'src/shared/components/add-button/AddButton';
+import ShadedInput from 'src/shared/components/input/ShadedInput';
 
 import styles from './SpeciesManager.module.css';
 
 const SpeciesManager = () => {
   const navigate = useNavigate();
+  const { allSelectedGenomes, filteredGenomes, onFilterChange } =
+    useFilteredGenomes();
 
   const onClose = () => {
     navigate(-1);
@@ -33,14 +42,43 @@ const SpeciesManager = () => {
   return (
     <ModalView onClose={onClose}>
       <div className={styles.container}>
-        <div>
-          <SpeciesLozengeDisplaySelector />
-        </div>
+        <MainContentTop onFilterChange={onFilterChange} />
         <div className={styles.genomesTableContainer}>
-          <SelectedGenomesTable />
+          <SelectedGenomesTable
+            allSelectedGenomes={allSelectedGenomes}
+            filteredGenomes={filteredGenomes}
+          />
         </div>
       </div>
     </ModalView>
+  );
+};
+
+const MainContentTop = (props: {
+  onFilterChange: (event: FormEvent<HTMLInputElement>) => void;
+}) => {
+  const navigate = useNavigate();
+
+  const onAddSpeciesClick = () => {
+    navigate(urlFor.speciesSelector());
+  };
+
+  return (
+    <div className={styles.mainContentTop}>
+      <SpeciesLozengeDisplaySelector />
+      <div className={styles.mainContentTopRight}>
+        <label className={styles.filterFieldWrapper}>
+          <span className={styles.labelText}>Find in list</span>
+          <ShadedInput onChange={props.onFilterChange} />
+        </label>
+        <AddButton
+          onClick={onAddSpeciesClick}
+          className={styles.addSpeciesButton}
+        >
+          Add a species
+        </AddButton>
+      </div>
+    </div>
   );
 };
 

--- a/src/content/app/species-selector/views/species-manager/SpeciesManager.tsx
+++ b/src/content/app/species-selector/views/species-manager/SpeciesManager.tsx
@@ -43,11 +43,13 @@ const SpeciesManager = () => {
     <ModalView onClose={onClose}>
       <div className={styles.container}>
         <MainContentTop onFilterChange={onFilterChange} />
-        <div className={styles.genomesTableContainer}>
-          <SelectedGenomesTable
-            allSelectedGenomes={allSelectedGenomes}
-            filteredGenomes={filteredGenomes}
-          />
+        <div className={styles.genomesTableContainerOuter}>
+          <div className={styles.genomesTableContainerInner}>
+            <SelectedGenomesTable
+              allSelectedGenomes={allSelectedGenomes}
+              filteredGenomes={filteredGenomes}
+            />
+          </div>
         </div>
       </div>
     </ModalView>

--- a/src/content/app/species-selector/views/species-manager/SpeciesManager.tsx
+++ b/src/content/app/species-selector/views/species-manager/SpeciesManager.tsx
@@ -36,7 +36,7 @@ const SpeciesManager = () => {
         <div>
           <SpeciesLozengeDisplaySelector />
         </div>
-        <div>
+        <div className={styles.genomesTableContainer}>
           <SelectedGenomesTable />
         </div>
       </div>

--- a/src/content/app/species-selector/views/species-manager/selected-genomes-table/SelectedGenomesTable.module.css
+++ b/src/content/app/species-selector/views/species-manager/selected-genomes-table/SelectedGenomesTable.module.css
@@ -1,18 +1,42 @@
 .table {
   --table-background: var(--color-light-grey);
-  table-layout: fixed;
-  /* width: 100%; */
 }
 
 .table th {
   white-space: nowrap;
 }
 
+/* the first column contains just the home icon; no need for a regular wide padding */
+.table th:nth-child(1),
+.table td:nth-child(1) {
+  --table-column-head-padding-right: 10px;
+  --table-column-head-padding-left: 10px;
+  --table-cell-padding-left: 0;
+  --table-cell-padding-right: 0;
+}
+
+/* two last columns contain only narrow icons; no need for a regular wide padding */
 .table th:nth-child(7),
 .table th:nth-child(8),
 .table td:nth-child(7),
 .table td:nth-child(8) {
+  --table-column-head-padding-right: 10px;
+  --table-column-head-padding-left: 10px;
+  --table-cell-padding-left: 0;
+  --table-cell-padding-right: 0;
+  position: sticky;
   background-color: var(--color-light-grey);
+}
+
+/* the second to last column should have a right offset that is equal to the width of the last column */
+.table th:nth-child(7),
+.table td:nth-child(7) {
+  right: 78px;
+}
+
+.table th:nth-child(8),
+.table td:nth-child(8) {
+  right: 0;
 }
 
 .disabledRow {

--- a/src/content/app/species-selector/views/species-manager/selected-genomes-table/SelectedGenomesTable.module.css
+++ b/src/content/app/species-selector/views/species-manager/selected-genomes-table/SelectedGenomesTable.module.css
@@ -1,5 +1,18 @@
 .table {
   --table-background: var(--color-light-grey);
+  table-layout: fixed;
+  /* width: 100%; */
+}
+
+.table th {
+  white-space: nowrap;
+}
+
+.table th:nth-child(7),
+.table th:nth-child(8),
+.table td:nth-child(7),
+.table td:nth-child(8) {
+  background-color: var(--color-light-grey);
 }
 
 .disabledRow {

--- a/src/content/app/species-selector/views/species-manager/selected-genomes-table/SelectedGenomesTable.tsx
+++ b/src/content/app/species-selector/views/species-manager/selected-genomes-table/SelectedGenomesTable.tsx
@@ -202,6 +202,16 @@ const SelectedGenomesTable = () => {
     reduxDispatch(toggleSpeciesUseAndSave(genome.genome_id));
   };
 
+  const floatRightStyles = {
+    position: 'sticky',
+    right: '0'
+  } as const;
+
+  const floatRightStyles2 = {
+    position: 'sticky',
+    right: '113px'
+  } as const;
+
   return (
     <Table stickyHeader={true} className={styles.table}>
       <thead>
@@ -212,8 +222,8 @@ const SelectedGenomesTable = () => {
           <ColumnHead>Type</ColumnHead>
           <ColumnHead>Assembly</ColumnHead>
           <ColumnHead>Assembly accession</ColumnHead>
-          <ColumnHead>Remove from list</ColumnHead>
-          <ColumnHead>Use in apps</ColumnHead>
+          <ColumnHead style={floatRightStyles2}>Remove from list</ColumnHead>
+          <ColumnHead style={floatRightStyles}>Use in apps</ColumnHead>
         </tr>
       </thead>
       <tbody>
@@ -247,7 +257,7 @@ const SelectedGenomesTable = () => {
               <td>
                 <AssemblyAccessionId {...species} />
               </td>
-              <td className={styles.alignCenter}>
+              <td className={styles.alignCenter} style={floatRightStyles2}>
                 <DeleteButtonOrCheckbox
                   species={species}
                   isInDeletionMode={isInDeletionMode}
@@ -259,7 +269,7 @@ const SelectedGenomesTable = () => {
                   )}
                 />
               </td>
-              <td className={styles.alignCenter}>
+              <td className={styles.alignCenter} style={floatRightStyles}>
                 <SlideToggle
                   className={styles.toggle}
                   isOn={species.isEnabled}

--- a/src/content/app/species-selector/views/species-manager/selected-genomes-table/SelectedGenomesTable.tsx
+++ b/src/content/app/species-selector/views/species-manager/selected-genomes-table/SelectedGenomesTable.tsx
@@ -17,11 +17,9 @@
 import { Fragment, useReducer } from 'react';
 import { Link } from 'react-router-dom';
 
-import { useAppSelector, useAppDispatch } from 'src/store';
+import { useAppDispatch } from 'src/store';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
-
-import { getCommittedSpecies } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors';
 
 import { deleteSpeciesAndSave } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSlice';
 import { toggleSpeciesUseAndSave } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSlice';
@@ -128,8 +126,11 @@ const reducer = (
   }
 };
 
-const SelectedGenomesTable = () => {
-  const selectedSpecies = useAppSelector(getCommittedSpecies);
+const SelectedGenomesTable = (props: {
+  allSelectedGenomes: CommittedItem[];
+  filteredGenomes: CommittedItem[];
+}) => {
+  const { allSelectedGenomes, filteredGenomes } = props;
   const [tableState, tableDispatch] = useReducer(reducer, initialState);
   const reduxDispatch = useAppDispatch();
 
@@ -138,7 +139,7 @@ const SelectedGenomesTable = () => {
     tableState.deletionModeSettings?.genomeIds ?? []
   );
 
-  if (!selectedSpecies.length) {
+  if (!allSelectedGenomes.length) {
     return <div>You have not selected any species</div>;
   }
 
@@ -222,62 +223,62 @@ const SelectedGenomesTable = () => {
         </tr>
       </thead>
       <tbody>
-        {selectedSpecies.map((species) => (
-          <Fragment key={species.genome_id}>
+        {filteredGenomes.map((genome) => (
+          <Fragment key={genome.genome_id}>
             <tr
-              key={species.genome_id}
+              key={genome.genome_id}
               className={isInDeletionMode ? styles.disabledRow : undefined}
             >
               <td className={styles.alignCenter}>
-                <Link to={getLinkToSpeciesPage(species)}>
+                <Link to={getLinkToSpeciesPage(genome)}>
                   <HomeIcon
                     className={styles.homeIcon}
                     role="img"
-                    aria-label={getSpeciesLinkAriaLabel(species)}
+                    aria-label={getSpeciesLinkAriaLabel(genome)}
                   />
                 </Link>
               </td>
               <td>
-                <CommonName {...species} />
+                <CommonName {...genome} />
               </td>
               <td>
-                <ScientificName {...species} />
+                <ScientificName {...genome} />
               </td>
               <td>
-                <SpeciesType {...species} />
+                <SpeciesType {...genome} />
               </td>
               <td>
-                <AssemblyName {...species} />
+                <AssemblyName {...genome} />
               </td>
               <td>
-                <AssemblyAccessionId {...species} />
+                <AssemblyAccessionId {...genome} />
               </td>
               <td className={styles.alignCenter}>
                 <DeleteButtonOrCheckbox
-                  species={species}
+                  species={genome}
                   isInDeletionMode={isInDeletionMode}
                   enterDeletionMode={enterDeletionMode}
                   addGenomeToDeleteList={addGenomeToDeleteList}
                   removeGenomeFromDeleteList={removeGenomeFromDeleteList}
                   isMarkedForDeletion={genomeIdsForDeletion.has(
-                    species.genome_id
+                    genome.genome_id
                   )}
                 />
               </td>
               <td className={styles.alignCenter}>
                 <SlideToggle
                   className={styles.toggle}
-                  isOn={species.isEnabled}
-                  onChange={() => toggleGenomeUse(species)}
+                  isOn={genome.isEnabled}
+                  onChange={() => toggleGenomeUse(genome)}
                   disabled={isInDeletionMode}
                 />
               </td>
             </tr>
             {isInDeletionMode &&
               tableState.deletionModeSettings?.initialGenomeId ===
-                species.genome_id && (
+                genome.genome_id && (
                 <ConfirmDeletion
-                  species={species}
+                  species={genome}
                   onDelete={deleteGenomes}
                   onCancel={exitDeletionMode}
                 />

--- a/src/content/app/species-selector/views/species-manager/selected-genomes-table/SelectedGenomesTable.tsx
+++ b/src/content/app/species-selector/views/species-manager/selected-genomes-table/SelectedGenomesTable.tsx
@@ -186,6 +186,11 @@ const SelectedGenomesTable = () => {
       type: 'update-deletion-list',
       genomeIds: updatedList
     });
+    if (!updatedList.length) {
+      tableDispatch({
+        type: 'exit-deletion-mode'
+      });
+    }
   };
 
   const deleteGenomes = () => {
@@ -202,16 +207,6 @@ const SelectedGenomesTable = () => {
     reduxDispatch(toggleSpeciesUseAndSave(genome.genome_id));
   };
 
-  const floatRightStyles = {
-    position: 'sticky',
-    right: '0'
-  } as const;
-
-  const floatRightStyles2 = {
-    position: 'sticky',
-    right: '113px'
-  } as const;
-
   return (
     <Table stickyHeader={true} className={styles.table}>
       <thead>
@@ -222,8 +217,8 @@ const SelectedGenomesTable = () => {
           <ColumnHead>Type</ColumnHead>
           <ColumnHead>Assembly</ColumnHead>
           <ColumnHead>Assembly accession</ColumnHead>
-          <ColumnHead style={floatRightStyles2}>Remove from list</ColumnHead>
-          <ColumnHead style={floatRightStyles}>Use in apps</ColumnHead>
+          <ColumnHead>Remove from list</ColumnHead>
+          <ColumnHead>Use in apps</ColumnHead>
         </tr>
       </thead>
       <tbody>
@@ -257,7 +252,7 @@ const SelectedGenomesTable = () => {
               <td>
                 <AssemblyAccessionId {...species} />
               </td>
-              <td className={styles.alignCenter} style={floatRightStyles2}>
+              <td className={styles.alignCenter}>
                 <DeleteButtonOrCheckbox
                   species={species}
                   isInDeletionMode={isInDeletionMode}
@@ -269,7 +264,7 @@ const SelectedGenomesTable = () => {
                   )}
                 />
               </td>
-              <td className={styles.alignCenter} style={floatRightStyles}>
+              <td className={styles.alignCenter}>
                 <SlideToggle
                   className={styles.toggle}
                   isOn={species.isEnabled}
@@ -283,7 +278,6 @@ const SelectedGenomesTable = () => {
                 species.genome_id && (
                 <ConfirmDeletion
                   species={species}
-                  tableColumnsCount={8}
                   onDelete={deleteGenomes}
                   onCancel={exitDeletionMode}
                 />
@@ -333,13 +327,13 @@ const DeleteButtonOrCheckbox = ({
  */
 const ConfirmDeletion = (props: {
   species: CommittedItem;
-  tableColumnsCount: number; // this will be different depending on whether showing all columns or is hiding some
   onDelete: (species: CommittedItem) => void;
   onCancel: () => void;
 }) => {
   // this row will use the two rightmost columns of the table,
   // but will merge all the columns to the left
-  const cpanColumnsCount = props.tableColumnsCount - 2;
+  const tableColumnsCount = 8;
+  const spanColumnsCount = tableColumnsCount - 2;
 
   const onDelete = () => {
     props.onDelete(props.species);
@@ -347,7 +341,7 @@ const ConfirmDeletion = (props: {
 
   return (
     <tr className={styles.removalRow}>
-      <td colSpan={cpanColumnsCount}>
+      <td colSpan={spanColumnsCount}>
         <div className={styles.removalRowContent}>
           <span className={styles.removalWarning}>{removalWarning}</span>
           <PrimaryButton onClick={onDelete}>Remove</PrimaryButton>

--- a/src/content/app/species-selector/views/species-manager/useFilteredGenomes.ts
+++ b/src/content/app/species-selector/views/species-manager/useFilteredGenomes.ts
@@ -1,0 +1,63 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, type FormEvent } from 'react';
+
+import { useAppSelector } from 'src/store';
+
+import { getCommittedSpecies } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors';
+
+import type { CommittedItem } from 'src/content/app/species-selector/types/committedItem';
+
+const useFilteredGenomes = () => {
+  const selectedGenomes = useAppSelector(getCommittedSpecies);
+  const [filteredGenomes, setFilteredGenomes] = useState(selectedGenomes);
+
+  const onFilterChange = (event: FormEvent<HTMLInputElement>) => {
+    const filterString = event.currentTarget.value;
+    const filteredGenomes = selectedGenomes.filter((genome) => {
+      return doesGenomeMatchQuery(genome, filterString);
+    });
+    setFilteredGenomes(filteredGenomes);
+  };
+
+  return {
+    allSelectedGenomes: selectedGenomes,
+    filteredGenomes,
+    onFilterChange
+  };
+};
+
+const doesGenomeMatchQuery = (genome: CommittedItem, query: string) => {
+  const fields = [
+    genome.common_name,
+    genome.scientific_name,
+    genome.assembly.name,
+    genome.assembly.accession_id,
+    genome.type?.kind,
+    genome.type?.value
+  ].filter(Boolean) as string[];
+
+  for (const field of fields) {
+    if (field.toLocaleLowerCase().includes(query.toLocaleLowerCase())) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+export default useFilteredGenomes;

--- a/src/shared/components/add-button/AddButton.module.css
+++ b/src/shared/components/add-button/AddButton.module.css
@@ -1,15 +1,18 @@
 .button {
+  --_plus-icon-color: var(--add-button-icon-color, var(--color-blue));
+  --_plus-icon-diameter: var(--add-button-icon-size, 22px);
   display: inline-grid;
   grid-template-columns: [label] auto [icon] auto;
   align-items: center;
-  column-gap: 14px;
-  color: var(--color-blue);
+  column-gap: 10px;
+  color: var(--add-button-label-color, var(--color-blue));
+  white-space: nowrap;
 }
 
 .button svg {
-  height: var(--plus-icon-size, 22px);
-  width: var(--plus-icon-size, 22px);
-  fill: var(--color-blue);
+  height: var(--_plus-icon-diameter);
+  width: var(--_plus-icon-diameter);
+  fill: var(--_plus-icon-color);
 }
 
 .button:disabled {

--- a/src/shared/components/table/Table.module.css
+++ b/src/shared/components/table/Table.module.css
@@ -8,6 +8,7 @@
   position: sticky;
   top: 0;
   background-color: var(--table-head-background, var(--_table-background));
+  z-index: 1;
 }
 
 .table th {

--- a/src/shared/components/upload/hooks/useFileDrop.ts
+++ b/src/shared/components/upload/hooks/useFileDrop.ts
@@ -76,6 +76,8 @@ const useFileDrop = <O extends Options>(params: FileUploadParams<O>) => {
     }
   };
 
+  // FIXME: starting from React 19, callback refs return a cleanup function
+  // whereas at some point thereafter, React will stop passing null to the ref function
   const ref = useCallback((element: HTMLElement | null) => {
     if (element === null) {
       // a function ref is called with null when a component that it is referencing unmounts


### PR DESCRIPTION
## Description
- Two right columns of the selected genomes table in species manager stick to the right edge of the table when the table scrolls horizontally on small screens
- Removal of ticks from all checkboxes in the genome deletion mode makes the table exit the deletion mode
- Added a text field to filter the species shown in the table; as well as an "Add a species" button that takes user to the species selector home page. 
- Fixed the orange icon of external references in genome search matches table

## Related JIRA Issue(s)
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2510
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2535

## Deployment URL(s)
http://species-manager-updates.review.ensembl.org