### PR TITLE
Scroll to gene in variant transcript consequences panel

### DIFF
--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.module.css
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.module.css
@@ -48,7 +48,6 @@
 }
 
 .transcriptId {
-  color: var(--color-blue);
   width: fit-content;
   padding-top: 8px;
 }

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.module.css
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.module.css
@@ -40,7 +40,7 @@
 
 .geneButtons {
   display: flex;
-  column-gap: 30px;
+  column-gap: 25px;
 }
 
 .transcriptLeftColumn {

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.module.css
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.module.css
@@ -22,6 +22,21 @@
   font-weight: var(--font-weight-bold);
 }
 
+.transcriptConsqTitle {
+  margin-left: 20px;
+}
+
+.scrollToGeneSection {
+  display: inline-flex;
+  column-gap: 10px;
+  margin-left: 64px;
+}
+
+.geneButtons {
+  display: flex;
+  column-gap: 40px;
+}
+
 .transcriptLeftColumn {
   padding-top: 6px;
 }
@@ -45,10 +60,6 @@
 
 .value {
   padding-left: 10px;
-}
-
-.transcriptConsqTitle {
-  margin-left: 20px;
 }
 
 .geneSection:not(:first-child) {

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.module.css
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.module.css
@@ -28,13 +28,19 @@
 
 .scrollToGeneSection {
   display: inline-flex;
+  align-items: baseline;
   column-gap: 10px;
   margin-left: 64px;
 }
 
+.scrollToLabel {
+  font-weight: var(--font-weight-light);
+  font-size: 11px;
+}
+
 .geneButtons {
   display: flex;
-  column-gap: 40px;
+  column-gap: 30px;
 }
 
 .transcriptLeftColumn {

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.tsx
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.tsx
@@ -448,7 +448,7 @@ const TranscriptConsequencesList = (props: TranscriptConsequencesListProps) => {
                 </div>
               </div>
             </div>
-            <button
+            <TextButton
               className={classNames(styles.right, styles.transcriptId)}
               onClick={() =>
                 handleTranscriptConsequenceClick(
@@ -457,7 +457,7 @@ const TranscriptConsequencesList = (props: TranscriptConsequencesListProps) => {
               }
             >
               {consequencesForSingleTranscript.stable_id}
-            </button>
+            </TextButton>
           </div>
 
           {expandedIds.has(consequencesForSingleTranscript.stable_id) ? (

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.tsx
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.tsx
@@ -179,7 +179,7 @@ const PanelHeader = (props: {
 
       {genesCount > 1 && (
         <div className={styles.scrollToGeneSection}>
-          <span className={styles.label}>Scroll to</span>
+          <span className={styles.scrollToLabel}>Scroll to</span>
           <div className={styles.geneButtons}>
             {[...Array(genesCount)].map((_, index) => (
               <TextButton key={index} onClick={() => scrollToGene(index)}>

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.tsx
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/TranscriptConsequences.tsx
@@ -38,6 +38,7 @@ import Panel from 'src/shared/components/panel/Panel';
 import TranscriptConsequenceDetails from './transcript-consequence-details/TranscriptConsequenceDetails';
 import { TranscriptQualityLabel } from 'src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel';
 import { CircleLoader } from 'src/shared/components/loader';
+import TextButton from 'src/shared/components/text-button/TextButton';
 
 import type { GeneInResponse } from '../../state/api/queries/variantTranscriptConsequencesQueries';
 
@@ -93,7 +94,9 @@ const TranscriptConsequences = (props: Props) => {
   }
 
   const { variant, transcriptConsequences, allele, geneData } = currentData;
-  const panelHeader = <PanelHeader variant={variant} />;
+  const panelHeader = (
+    <PanelHeader variant={variant} genesCount={geneData.length} />
+  );
 
   if (!transcriptConsequences) {
     return (
@@ -149,8 +152,21 @@ const TranscriptConsequences = (props: Props) => {
 
 const PanelHeader = (props: {
   variant: TranscriptConsequencesData['variant'];
+  genesCount: number;
 }) => {
-  const { variant } = props;
+  const { variant, genesCount } = props;
+
+  const scrollToGene = (geneIndex: number) => {
+    const geneSections = document.querySelectorAll(`.${styles.geneDetails}`);
+    const geneSection = geneSections[geneIndex];
+
+    if (geneSection) {
+      // this should always be the case
+      geneSection.scrollIntoView({
+        behavior: 'smooth'
+      });
+    }
+  };
 
   return (
     <div className={styles.panelHeader}>
@@ -160,6 +176,19 @@ const PanelHeader = (props: {
       <span className={styles.transcriptConsqTitle}>
         Transcript consequences
       </span>
+
+      {genesCount > 1 && (
+        <div className={styles.scrollToGeneSection}>
+          <span className={styles.label}>Scroll to</span>
+          <div className={styles.geneButtons}>
+            {[...Array(genesCount)].map((_, index) => (
+              <TextButton key={index} onClick={() => scrollToGene(index)}>
+                Gene {index + 1}
+              </TextButton>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Description
Add buttons to transcript consequences panel header that appear if there are transcripts belonging to several genes, and scroll to each of the genes.

**Also:**
- Used the `TextButton` component for the clickable transcript ids that expand and collapse the consequences for a given transcript.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2476

## Deployment URL(s)
http://ev-var-scroll-gene.review.ensembl.org

Example variants
- 1:230710778:rs2102791505?