### PR TITLE
Make species selector button clickable

### DIFF
--- a/src/header/launchbar/LaunchbarButton.tsx
+++ b/src/header/launchbar/LaunchbarButton.tsx
@@ -33,7 +33,7 @@ export type LaunchbarButtonProps = {
   icon: FunctionComponent<unknown>;
   enabled?: boolean;
   isActive?: boolean;
-  isClickable?: boolean | false;
+  isClickableWhenActive?: boolean;
 };
 
 const LaunchbarButton: FunctionComponent<LaunchbarButtonProps> = (
@@ -55,7 +55,7 @@ const LaunchbarButton: FunctionComponent<LaunchbarButtonProps> = (
     />
   );
 
-  return (isButtonEnabled && !isActive) || props.isClickable ? (
+  return (isButtonEnabled && !isActive) || props.isClickableWhenActive ? (
     <NavLink
       className={styles.launchbarButtonWrapperLink}
       to={props.path}
@@ -69,7 +69,11 @@ const LaunchbarButton: FunctionComponent<LaunchbarButtonProps> = (
 };
 
 const LaunchbarButtonContent = memo(
-  (props: Required<Omit<LaunchbarButtonProps, 'path' | 'isClickable'>>) => {
+  (
+    props: Required<
+      Omit<LaunchbarButtonProps, 'path' | 'isClickableWhenActive'>
+    >
+  ) => {
     const [hoverRef, isHovered] = useHover<HTMLDivElement>();
     const elementClasses = classNames(styles.launchbarButton, {
       [styles.launchbarButtonSelected]: props.isActive,

--- a/src/header/launchbar/LaunchbarButton.tsx
+++ b/src/header/launchbar/LaunchbarButton.tsx
@@ -33,6 +33,7 @@ export type LaunchbarButtonProps = {
   icon: FunctionComponent<unknown>;
   enabled?: boolean;
   isActive?: boolean;
+  isClickable?: boolean | false;
 };
 
 const LaunchbarButton: FunctionComponent<LaunchbarButtonProps> = (
@@ -54,7 +55,7 @@ const LaunchbarButton: FunctionComponent<LaunchbarButtonProps> = (
     />
   );
 
-  return isButtonEnabled && !isActive ? (
+  return (isButtonEnabled && !isActive) || props.isClickable ? (
     <NavLink
       className={styles.launchbarButtonWrapperLink}
       to={props.path}
@@ -68,7 +69,7 @@ const LaunchbarButton: FunctionComponent<LaunchbarButtonProps> = (
 };
 
 const LaunchbarButtonContent = memo(
-  (props: Required<Omit<LaunchbarButtonProps, 'path'>>) => {
+  (props: Required<Omit<LaunchbarButtonProps, 'path' | 'isClickable'>>) => {
     const [hoverRef, isHovered] = useHover<HTMLDivElement>();
     const elementClasses = classNames(styles.launchbarButton, {
       [styles.launchbarButtonSelected]: props.isActive,

--- a/src/header/launchbar/SpeciesSelectorLaunchbarButton.tsx
+++ b/src/header/launchbar/SpeciesSelectorLaunchbarButton.tsx
@@ -41,6 +41,7 @@ const SpeciesSelectorLaunchbarButton = () => {
       icon={SpeciesSelectorIcon}
       enabled={true}
       isActive={['species', 'species-selector'].includes(firstPathnamePart)}
+      isClickable={true}
     />
   );
 };

--- a/src/header/launchbar/SpeciesSelectorLaunchbarButton.tsx
+++ b/src/header/launchbar/SpeciesSelectorLaunchbarButton.tsx
@@ -41,7 +41,7 @@ const SpeciesSelectorLaunchbarButton = () => {
       icon={SpeciesSelectorIcon}
       enabled={true}
       isActive={['species', 'species-selector'].includes(firstPathnamePart)}
-      isClickable={true}
+      isClickableWhenActive={true}
     />
   );
 };


### PR DESCRIPTION
## Description
Species selector button needs to be clickable (always) from different pages - manage, search and homepage.
Leave it active (black), but clickable.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2531

## Deployment URL(s)
http://enable-species-selector-button.review.ensembl.org


## Views affected
Species selector