### PR TITLE
Query variant summary statistics to use with navigation buttons in Entity Viewer

### DIFF
--- a/src/content/app/entity-viewer/state/api/queries/variantDefaultQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/variantDefaultQuery.ts
@@ -55,6 +55,9 @@ export const variantDefaultQuery = gql`
           tool
         }
       }
+      ensembl_website_display_data {
+        count_citations
+      }
       alleles {
         name
         allele_type {
@@ -86,6 +89,14 @@ export const variantDefaultQuery = gql`
           is_hpmaf
           allele_frequency
         }
+        ensembl_website_display_data {
+          count_transcript_consequences
+          count_overlapped_genes
+          count_regulatory_consequences
+          count_variant_phenotypes
+          count_gene_phenotypes
+          representative_population_allele_frequency
+        }
       }
     }
   }
@@ -93,7 +104,10 @@ export const variantDefaultQuery = gql`
 
 export type VariantDetailsAllele = Pick<
   VariantAllele,
-  'name' | 'allele_sequence' | 'reference_sequence'
+  | 'name'
+  | 'allele_sequence'
+  | 'reference_sequence'
+  | 'ensembl_website_display_data'
 > &
   Pick2<VariantAllele, 'allele_type', 'value'> &
   Pick3<VariantAllele, 'slice', 'location', 'start' | 'end'> & {
@@ -126,7 +140,10 @@ type VariantDetailsAllelePredictionResult = Pick<
 > &
   Pick2<VariantAllele['prediction_results'][number], 'analysis_method', 'tool'>;
 
-export type VariantDetails = Pick<Variant, 'name'> &
+export type VariantDetails = Pick<
+  Variant,
+  'name' | 'ensembl_website_display_data'
+> &
   Pick3<Variant, 'slice', 'location', 'start' | 'end' | 'length'> &
   Pick3<Variant, 'slice', 'region', 'name'> &
   Pick3<Variant, 'slice', 'strand', 'code'> &

--- a/src/content/app/entity-viewer/variant-view/variant-view-navigation-panel/VariantViewNavigationPanel.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-view-navigation-panel/VariantViewNavigationPanel.tsx
@@ -31,10 +31,7 @@ import { useDefaultEntityViewerVariantQuery } from 'src/content/app/entity-viewe
 import VariantViewTab from './variant-view-tab/VariantViewTab';
 
 import type { ViewName } from 'src/content/app/entity-viewer/state/variant-view/general/variantViewGeneralSlice';
-import type {
-  VariantDetails,
-  VariantDetailsAllele
-} from 'src/content/app/entity-viewer/state/api/queries/variantDefaultQuery';
+import type { VariantDetails } from 'src/content/app/entity-viewer/state/api/queries/variantDefaultQuery';
 
 import styles from './VariantViewNavigationPanel.module.css';
 
@@ -196,7 +193,7 @@ const useVariantViewNavigationData = (params: Props) => {
   const isReferenceAlleleActive = referenceAllele?.urlId === activeAlleleId;
   const variantStatistics = getVariantStatistics({
     variant,
-    allele: activeAllele as VariantDetailsAllele
+    allele: activeAllele
   });
 
   return {
@@ -216,22 +213,31 @@ const getVariantStatistics = ({
   allele
 }: {
   variant: VariantDetails;
-  allele: VariantDetails['alleles'][number];
+  allele?: VariantDetails['alleles'][number];
 }) => {
   const variantLevelStatistics = variant.ensembl_website_display_data;
-  const alleleLevelStatistics = allele.ensembl_website_display_data;
+  const alleleLevelStatistics = allele?.ensembl_website_display_data;
 
   return {
-    transcriptConsequencesCount:
-      alleleLevelStatistics.count_transcript_consequences,
-    regulatoryConsequencesCount:
-      alleleLevelStatistics.count_regulatory_consequences,
-    overlappedGenesCount: alleleLevelStatistics.count_overlapped_genes,
-    variantPhenotypesCount: alleleLevelStatistics.count_variant_phenotypes,
-    genePhenotypesCount: alleleLevelStatistics.count_gene_phenotypes,
+    transcriptConsequencesCount: alleleLevelStatistics
+      ? alleleLevelStatistics.count_transcript_consequences
+      : 0,
+    regulatoryConsequencesCount: alleleLevelStatistics
+      ? alleleLevelStatistics.count_regulatory_consequences
+      : 0,
+    overlappedGenesCount: alleleLevelStatistics
+      ? alleleLevelStatistics.count_overlapped_genes
+      : 0,
+    variantPhenotypesCount: alleleLevelStatistics
+      ? alleleLevelStatistics.count_variant_phenotypes
+      : 0,
+    genePhenotypesCount: alleleLevelStatistics
+      ? alleleLevelStatistics.count_gene_phenotypes
+      : 0,
     citationsCount: variantLevelStatistics.count_citations,
-    representativeAlleleFrequency:
-      alleleLevelStatistics.representative_population_allele_frequency
+    representativeAlleleFrequency: alleleLevelStatistics
+      ? alleleLevelStatistics.representative_population_allele_frequency
+      : null
   };
 };
 

--- a/src/content/app/entity-viewer/variant-view/variant-view-navigation-panel/variant-view-tab/VariantViewTab.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-view-navigation-panel/variant-view-tab/VariantViewTab.module.css
@@ -14,7 +14,7 @@
 }
 
 .bottomRow {
-  padding-left: 10px; /* same as TabButton default */
+  padding: 0 10px; /* same as TabButton default */
   display: flex;
   align-items: baseline;
   gap: 10px;

--- a/src/content/app/entity-viewer/variant-view/variant-view-navigation-panel/variant-view-tab/VariantViewTab.module.css
+++ b/src/content/app/entity-viewer/variant-view/variant-view-navigation-panel/variant-view-tab/VariantViewTab.module.css
@@ -21,7 +21,12 @@
 }
 
 .label {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
   font-size: 12px;
+  flex-shrink: 1;
 }
 
 .disabled .label {

--- a/src/content/app/entity-viewer/variant-view/variant-view-navigation-panel/variant-view-tab/VariantViewTab.tsx
+++ b/src/content/app/entity-viewer/variant-view/variant-view-navigation-panel/variant-view-tab/VariantViewTab.tsx
@@ -71,14 +71,14 @@ const VariantViewTab = (props: Props) => {
 const BottomRow = (props: Props) => {
   const { labelText, pillContent } = props;
 
-  if (!labelText && !pillContent) {
+  if (!labelText && pillContent === undefined) {
     return null;
   }
 
   return (
     <div className={styles.bottomRow}>
       {labelText && <span className={styles.label}>{labelText}</span>}
-      {pillContent && (
+      {pillContent !== undefined && (
         <InfoPill className={styles.pill}>{pillContent}</InfoPill>
       )}
     </div>

--- a/src/shared/types/variation-api/variant.ts
+++ b/src/shared/types/variation-api/variant.ts
@@ -19,6 +19,7 @@ import type { ExternalReference } from '../core-api/externalReference';
 import type { OntologyTermMetadata } from '../core-api/metadata';
 import type { VariantPredictionResult } from './variantPredictionResult';
 import type { VariantAllele } from './variantAllele';
+import type { VariantSummaryStatistics } from './variantSummaryStatistics';
 
 export type Variant = {
   type: 'Variant';
@@ -29,4 +30,5 @@ export type Variant = {
   primary_source: ExternalReference;
   prediction_results: VariantPredictionResult[];
   alleles: VariantAllele[];
+  ensembl_website_display_data: VariantSummaryStatistics;
 };

--- a/src/shared/types/variation-api/variantAllele.ts
+++ b/src/shared/types/variation-api/variantAllele.ts
@@ -21,6 +21,7 @@ import type { VariantAllelePopulationFrequency } from './variantAllelePopulation
 import type { VariantAllelePhenotypeAssertion } from './variantAllelePhenotypeAssertion';
 import type { VariantPredictedMolecularConsequence } from './variantPredictedMolecularConsequence';
 import type { OntologyTermMetadata } from '../core-api/metadata';
+import type { VariantAlleleSummaryStatistics } from './variantSummaryStatistics';
 
 export type VariantAllele = {
   type: 'VariantAllele';
@@ -35,4 +36,5 @@ export type VariantAllele = {
   phenotype_assertions: VariantAllelePhenotypeAssertion[];
   predicted_molecular_consequences: VariantPredictedMolecularConsequence[];
   citations: unknown[]; // will be an array of Publication data types submitted to CDM
+  ensembl_website_display_data: VariantAlleleSummaryStatistics;
 };

--- a/src/shared/types/variation-api/variantSummaryStatistics.ts
+++ b/src/shared/types/variation-api/variantSummaryStatistics.ts
@@ -16,17 +16,17 @@
 
 /**
  * NOTE:
- * You will notice that the types described here
- * sit in the `ensembl_website_display_data` field
+ * You will notice that the data described by the types declared below
+ * sits in the `ensembl_website_display_data` field
  * of both the Variant type and the VariantAllele type.
  *
- * The reason for this is because the Variation team did not consider
- * the data in these types to be central to their data model, and
- * wanted to deprioritise is for other possible consumers of the variation api.
+ * The reason for this is that the Variation team preferred to deprioritise
+ * this data for other possible consumers of the variation api by indicating
+ * that it only serves the needs of the website.
  *
- * Meanwhile, in the web context, having a field called `ensembl_website_display_data`
- * is pretty meaningless; which is why I am calling the data inside of that field
- * variant summary statistics.
+ * Meanwhile, in the web context, having a type called EnsemblWebsiteDisplayData
+ * is pretty meaningless; which is why, for the purposes of this codebase,
+ * the types are named VariantSummaryStatistics and VariantAlleleSummaryStatistics.
  */
 
 export type VariantSummaryStatistics = {

--- a/src/shared/types/variation-api/variantSummaryStatistics.ts
+++ b/src/shared/types/variation-api/variantSummaryStatistics.ts
@@ -1,0 +1,43 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * NOTE:
+ * You will notice that the types described here
+ * sit in the `ensembl_website_display_data` field
+ * of both the Variant type and the VariantAllele type.
+ *
+ * The reason for this is because the Variation team did not consider
+ * the data in these types to be central to their data model, and
+ * wanted to deprioritise is for other possible consumers of the variation api.
+ *
+ * Meanwhile, in the web context, having a field called `ensembl_website_display_data`
+ * is pretty meaningless; which is why I am calling the data inside of that field
+ * variant summary statistics.
+ */
+
+export type VariantSummaryStatistics = {
+  count_citations: number;
+};
+
+export type VariantAlleleSummaryStatistics = {
+  count_transcript_consequences: number;
+  count_overlapped_genes: number;
+  count_regulatory_consequences: number;
+  count_variant_phenotypes: number;
+  count_gene_phenotypes: number;
+  representative_population_allele_frequency: number | null;
+};

--- a/src/shared/types/variation-api/variantSummaryStatistics.ts
+++ b/src/shared/types/variation-api/variantSummaryStatistics.ts
@@ -39,5 +39,5 @@ export type VariantAlleleSummaryStatistics = {
   count_regulatory_consequences: number;
   count_variant_phenotypes: number;
   count_gene_phenotypes: number;
-  representative_population_allele_frequency: number | null;
+  representative_population_allele_frequency: number | null; // global population allele frequency according to one of the studies
 };


### PR DESCRIPTION
## Description
Request summary statistics for a variant and its alleles, and show it under navigation buttons in the Entity Viewer view for variant.

## Related JIRA Issue(s)
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2433
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2543

## Deployment URL(s)
http://variant-summary-stats.review.ensembl.org

### Examples
- **rs699:** - http://variant-summary-stats.review.ensembl.org/entity-viewer/grch38/variant:1:230710048:rs699
- **rs1276937775** —  http://variant-summary-stats.review.ensembl.org/entity-viewer/grch38/variant:14:91244701:rs1276937775 (notice the low allele frequency requiring scientific notation)
- **rs878853003** — http://variant-summary-stats.review.ensembl.org/entity-viewer/grch38/variant:MT:8527:rs878853003 (allele frequencies unknown)
- **rs4647797** – http://variant-summary-stats.review.ensembl.org/entity-viewer/grch38/variant:21:45988497:rs4647797 (need to truncate the sequence under allele frequencies, next to the "unknown" pill)