### PR TITLE
Memoize the input field to prevent bugs due to re-rendering

### DIFF
--- a/src/shared/components/input/Input.tsx
+++ b/src/shared/components/input/Input.tsx
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { forwardRef, type InputHTMLAttributes, type ForwardedRef } from 'react';
+import {
+  forwardRef,
+  memo,
+  type InputHTMLAttributes,
+  type ForwardedRef
+} from 'react';
 import classNames from 'classnames';
 
 import styles from './Input.module.css';
@@ -30,4 +35,4 @@ const Input = (props: Props, ref: ForwardedRef<HTMLInputElement>) => (
   />
 );
 
-export default forwardRef(Input);
+export default memo(forwardRef(Input));


### PR DESCRIPTION
## Description
**Problem:** Search input field in in-app search component was not registering the first typed letter.

**Cause:** We add a `type="search"` attribute to the search input field, in order for it to show the clear button. This transition from question button to clear button in the `ShadedInput` component caused a re-rendering of the input field, and as a result, it cleared user's input before sending it to click handler.

**Solution:** This PR wraps the search field in React's `memo` function; such that the `Input` component does not re-render when its parent (`ShadedInput`) does.


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2557

## Deployment URL(s)
http://memoize-input-field.review.ensembl.org