### PR TITLE
Remove trailing comma after species type on species page

### DIFF
--- a/src/content/app/species/components/species-page-sidebar/SpeciesPageSidebar.tsx
+++ b/src/content/app/species/components/species-page-sidebar/SpeciesPageSidebar.tsx
@@ -126,7 +126,7 @@ const SpeciesType = (props: GenomeInfo) => {
       <span className={styles.label}>Type</span>
       <span>
         {typeTextElement}
-        {referenceTextElement ? ', ' : ''}
+        {typeTextElement && referenceTextElement ? ', ' : ''}
         {referenceTextElement}
       </span>
     </div>

--- a/src/content/app/species/components/species-page-sidebar/SpeciesPageSidebar.tsx
+++ b/src/content/app/species/components/species-page-sidebar/SpeciesPageSidebar.tsx
@@ -126,7 +126,7 @@ const SpeciesType = (props: GenomeInfo) => {
       <span className={styles.label}>Type</span>
       <span>
         {typeTextElement}
-        {typeTextElement ? ', ' : ''}
+        {referenceTextElement ? ', ' : ''}
         {referenceTextElement}
       </span>
     </div>


### PR DESCRIPTION
## Description
A rogue comma was showing up in Species Selector after the type information (we use this comma to separate the type information from whether the species is reference)

**Before:**
![image](https://github.com/Ensembl/ensembl-client/assets/6834224/684da4c4-9eb0-4821-a871-d82f3595b4f5)

**After:**
![image](https://github.com/Ensembl/ensembl-client/assets/6834224/f745113e-1497-4c28-93fb-6012c6811afc)


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2358

## Deployment URL(s)
http://species-type-remove-comma.review.ensembl.org

### Examples
- http://species-type-remove-comma.review.ensembl.org/species/grch38 — reference human
- http://species-type-remove-comma.review.ensembl.org/species/3d5ca882-670d-4d17-85dc-15185738c40a — non-reference human, with population information
- http://species-type-remove-comma.review.ensembl.org/species/grcm39 — reference mouse that also has a type