### PR TITLE
Update the UI for finding a gene

### DIFF
--- a/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -106,7 +106,7 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
 
   const isFilterPanelOpen = useAppSelector(getFilterPanelOpen);
   const sortingRule = useAppSelector(getSortingRule);
-  const filters = useAppSelector(getFilters);
+  const filters = useAppSelector(getFilters); // A problem with this selector (not memoized?
   const dispatch = useAppDispatch();
   const { search } = useLocation();
   const { trackFiltersPanelOpen } = useEntityViewerAnalytics();

--- a/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -106,7 +106,7 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
 
   const isFilterPanelOpen = useAppSelector(getFilterPanelOpen);
   const sortingRule = useAppSelector(getSortingRule);
-  const filters = useAppSelector(getFilters); // A problem with this selector (not memoized?
+  const filters = useAppSelector(getFilters);
   const dispatch = useAppDispatch();
   const { search } = useLocation();
   const { trackFiltersPanelOpen } = useEntityViewerAnalytics();

--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.module.css
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.module.css
@@ -85,18 +85,6 @@
   padding: 15px;
 }
 
-
-.findAGene {
-  color: var(--color-blue);
-  cursor: pointer;
+.geneSearchButton {
   margin: 30px 0 20px;
-  display: inline-flex;
-  align-items: center;
-  column-gap: 12px;
-  font-size: 12px;
-}
-
-.findAGene svg {
-  fill: var(--color-blue);
-  width: 13px;
 }

--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
@@ -24,7 +24,7 @@ import { useAppDispatch } from 'src/store';
 import GenePublications from '../publications/GenePublications';
 import MainAccordion from './MainAccordion';
 import ExternalReference from 'src/shared/components/external-reference/ExternalReference';
-import SearchIcon from 'static/icons/icon_search.svg';
+import GeneSearchButton from 'src/shared/components/gene-search-button/GeneSearchButton';
 
 import {
   openSidebarModal,
@@ -130,10 +130,10 @@ const GeneOverview = () => {
 
       <section>
         <div className={styles.sectionContent}>
-          <div className={styles.findAGene} onClick={openSearch}>
-            <span>Find a gene</span>
-            <SearchIcon />
-          </div>
+          <GeneSearchButton
+            className={styles.geneSearchButton}
+            onClick={openSearch}
+          />
         </div>
       </section>
 

--- a/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/EntityViewerSidebarModal.tsx
+++ b/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/EntityViewerSidebarModal.tsx
@@ -41,7 +41,7 @@ const entityViewerSidebarModals: Record<
 };
 
 const entityViewerSidebarModalTitles = {
-  [SidebarModalView.SEARCH]: 'Search',
+  [SidebarModalView.SEARCH]: 'Search this species',
   [SidebarModalView.BOOKMARKS]: 'Previously viewed',
   [SidebarModalView.DOWNLOAD]: 'Download'
 };

--- a/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerSearch.tsx
+++ b/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerSearch.tsx
@@ -14,12 +14,21 @@
  * limitations under the License.
  */
 
+import { useAppDispatch } from 'src/store';
+
 import useEntityViewerIds from 'src/content/app/entity-viewer/hooks/useEntityViewerIds';
+
+import { closeSidebarModal } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSlice';
 
 import InAppSearch from 'src/shared/components/in-app-search/InAppSearch';
 
 const EntityViewerSidebarSearch = () => {
   const { activeGenomeId, genomeIdForUrl } = useEntityViewerIds();
+  const dispatch = useAppDispatch();
+
+  const onSearchMatchNavigation = () => {
+    dispatch(closeSidebarModal());
+  };
 
   return (
     <section>
@@ -30,6 +39,7 @@ const EntityViewerSidebarSearch = () => {
             genomeId={activeGenomeId}
             genomeIdForUrl={genomeIdForUrl as string}
             mode="sidebar"
+            onMatchNavigation={onSearchMatchNavigation}
           />
         )}
       </div>

--- a/src/content/app/genome-browser/components/browser-sidebar-modal/BrowserSidebarModal.tsx
+++ b/src/content/app/genome-browser/components/browser-sidebar-modal/BrowserSidebarModal.tsx
@@ -46,7 +46,7 @@ const browserSidebarModals: Record<string, ReturnType<typeof lazy>> = {
 };
 
 export const browserSidebarModalTitles: { [key: string]: string } = {
-  [BrowserSidebarModalView.SEARCH]: 'Search',
+  [BrowserSidebarModalView.SEARCH]: 'Search this species',
   [BrowserSidebarModalView.BOOKMARKS]: 'Previously viewed',
   [BrowserSidebarModalView.SHARE]: 'Share',
   [BrowserSidebarModalView.DOWNLOAD]: 'Download',

--- a/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/SearchModal.tsx
+++ b/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/SearchModal.tsx
@@ -14,19 +14,26 @@
  * limitations under the License.
  */
 
-import { useSelector } from 'react-redux';
+import { useAppDispatch, useAppSelector } from 'src/store';
 
 import useGenomeBrowserIds from 'src/content/app/genome-browser/hooks/useGenomeBrowserIds';
 import useGenomeBrowserAnalytics from 'src/content/app/genome-browser/hooks/useGenomeBrowserAnalytics';
 
 import { getBrowserActiveGenomeId } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
 
+import { closeBrowserSidebarModal } from 'src/content/app/genome-browser/state/browser-sidebar-modal/browserSidebarModalSlice';
+
 import InAppSearch from 'src/shared/components/in-app-search/InAppSearch';
 
 const SearchModal = () => {
-  const activeGenomeId = useSelector(getBrowserActiveGenomeId);
+  const activeGenomeId = useAppSelector(getBrowserActiveGenomeId);
   const { genomeIdForUrl } = useGenomeBrowserIds();
   const { trackSidebarSearch } = useGenomeBrowserAnalytics();
+  const dispatch = useAppDispatch();
+
+  const onSearchMatchNavigation = () => {
+    dispatch(closeBrowserSidebarModal());
+  };
 
   return (
     <section className="searchModal">
@@ -38,6 +45,7 @@ const SearchModal = () => {
             genomeIdForUrl={genomeIdForUrl as string}
             mode="sidebar"
             onSearchSubmit={trackSidebarSearch}
+            onMatchNavigation={onSearchMatchNavigation}
           />
         )}
       </div>

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.module.css
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.module.css
@@ -69,16 +69,16 @@
   column-gap: 30px;
 }
 
-.modalLinksWrapper svg {
-  fill: var(--color-blue);
-  width: 13px;
-  margin-left: 10px;
-}
-
 .modalLink {
   display: inline-flex;
   font-size: 12px;
   align-items: center;
   color: var(--color-blue);
   cursor: pointer;
+}
+
+.modalLink svg {
+  fill: var(--color-blue);
+  width: 13px;
+  margin-left: 10px;
 }

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.test.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.test.tsx
@@ -135,11 +135,9 @@ describe('<TrackPanelList />', () => {
     });
 
     it('opens the relevant modal when modal link is clicked', async () => {
-      const { container, store } = renderComponent();
+      const { store, getByText } = renderComponent();
 
-      const geneSearchLink = container.querySelector(
-        '.modalLink:nth-child(1)'
-      ) as HTMLElement;
+      const geneSearchLink = getByText('Find a gene');
 
       await userEvent.click(geneSearchLink);
 
@@ -148,9 +146,7 @@ describe('<TrackPanelList />', () => {
         BrowserSidebarModalView.SEARCH
       );
 
-      const navigateLocationLink = container.querySelector(
-        '.modalLink:nth-child(2)'
-      ) as HTMLElement;
+      const navigateLocationLink = getByText('Change location');
 
       await userEvent.click(navigateLocationLink);
 

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
@@ -41,12 +41,11 @@ import {
   AccordionItemButton,
   AccordionItemPanel
 } from 'src/shared/components/accordion';
-
 import { TrackSet } from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
 import TrackPanelVariantGroupLegend from './track-panel-items/TrackPanelVariantGroupLegend';
 import TrackPanelRegulationLegend from './track-panel-items/TrackPanelRegulationLegend';
+import GeneSearchButton from 'src/shared/components/gene-search-button/GeneSearchButton';
 
-import SearchIcon from 'static/icons/icon_search.svg';
 import ResetIcon from 'static/icons/icon_reset.svg';
 
 import type { GenomeTrackCategory } from 'src/content/app/genome-browser/state/types/tracks';
@@ -90,14 +89,11 @@ export const TrackPanelList = () => {
     <div className={styles.trackPanelList}>
       <FocusObject focusObject={activeFocusObject} />
       <div className={styles.modalLinksWrapper}>
-        <div className={styles.modalLink} onClick={openSearch}>
-          <span>Find a gene</span>
-          <SearchIcon />
-        </div>
-        <div className={styles.modalLink} onClick={openNavigateModal}>
+        <GeneSearchButton onClick={openSearch} />
+        <button className={styles.modalLink} onClick={openNavigateModal}>
           <span>Change location</span>
           <ResetIcon />
-        </div>
+        </button>
       </div>
 
       <div className={styles.accordionContainer}>

--- a/src/content/app/species-selector/components/genome-selector-by-search-query/GenomeSelectorBySearchQuery.module.css
+++ b/src/content/app/species-selector/components/genome-selector-by-search-query/GenomeSelectorBySearchQuery.module.css
@@ -2,6 +2,7 @@
   height: 100%;
   display: grid;
   grid-template-rows: auto auto 1fr;
+  padding-top: 12px;
   padding-left: var(--global-padding-left);
 }
 

--- a/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.module.css
+++ b/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.module.css
@@ -2,7 +2,7 @@
   display: grid;
   grid-template-columns: auto minmax(max-content, 1fr);
   align-items: center;
-  column-gap: 46px;
+  column-gap: 4px;
 }
 
 .aside {

--- a/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.module.css
+++ b/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.module.css
@@ -1,6 +1,6 @@
 .grid {
   display: grid;
-  grid-template-columns: 1fr max-content;
+  grid-template-columns: auto minmax(max-content, 1fr);
   align-items: center;
   column-gap: 46px;
 }

--- a/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
+++ b/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
@@ -87,9 +87,11 @@ const AppBarMainContent = (props: { selectedSpecies: CommittedItem[] }) => {
       <SelectedSpeciesList selectedSpecies={props.selectedSpecies} />
       <div className={styles.aside}>
         {geneSearchButton}
-        <span className={styles.selectTabMessage}>
-          Select a tab to see a Species home page
-        </span>
+        {!isInGeneSearchMode && (
+          <span className={styles.selectTabMessage}>
+            Select a tab to see a Species home page
+          </span>
+        )}
       </div>
     </div>
   );

--- a/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
+++ b/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
@@ -21,6 +21,7 @@ import { useAppSelector } from 'src/store';
 import * as urlFor from 'src/shared/helpers/urlHelper';
 
 import { getCommittedSpecies } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors';
+import { getQuery as readStoredGeneQuery } from 'src/content/app/species-selector/state/species-selector-gene-search-slice/speciesSelectorGeneSearchSelectors';
 
 import AppBar, { AppName } from 'src/shared/components/app-bar/AppBar';
 import SpeciesManagerIndicator from 'src/shared/components/species-manager-indicator/SpeciesManagerIndicator';
@@ -62,12 +63,13 @@ export const SpeciesSelectorAppBar = () => {
 };
 
 const AppBarMainContent = (props: { selectedSpecies: CommittedItem[] }) => {
+  const storedGeneSearchQuery = useAppSelector(readStoredGeneQuery);
   const navigate = useNavigate();
   const location = useLocation();
   const isInGeneSearchMode = location.pathname.includes('/search/gene');
 
   const onGeneSearchOpen = () => {
-    navigate(urlFor.speciesSelectorGeneSearch());
+    navigate(urlFor.speciesSelectorGeneSearch(storedGeneSearchQuery));
   };
 
   const onGeneSearchClose = () => {

--- a/src/content/app/species-selector/state/species-selector-gene-search-slice/speciesSelectorGeneSearchSelectors.ts
+++ b/src/content/app/species-selector/state/species-selector-gene-search-slice/speciesSelectorGeneSearchSelectors.ts
@@ -14,12 +14,8 @@
  * limitations under the License.
  */
 
-import { combineReducers } from '@reduxjs/toolkit';
+import type { RootState } from 'src/store';
 
-import speciesSelectorGeneralReducer from './species-selector-general-slice/speciesSelectorGeneralSlice';
-import speciesSelectorGeneSearchReducer from './species-selector-gene-search-slice/speciesSelectorGeneSearchSlice';
-
-export default combineReducers({
-  general: speciesSelectorGeneralReducer,
-  geneSearch: speciesSelectorGeneSearchReducer
-});
+export const getQuery = (state: RootState) => {
+  return state.speciesSelector.geneSearch.query;
+};

--- a/src/content/app/species-selector/state/species-selector-gene-search-slice/speciesSelectorGeneSearchSlice.ts
+++ b/src/content/app/species-selector/state/species-selector-gene-search-slice/speciesSelectorGeneSearchSlice.ts
@@ -14,12 +14,29 @@
  * limitations under the License.
  */
 
-import { combineReducers } from '@reduxjs/toolkit';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
-import speciesSelectorGeneralReducer from './species-selector-general-slice/speciesSelectorGeneralSlice';
-import speciesSelectorGeneSearchReducer from './species-selector-gene-search-slice/speciesSelectorGeneSearchSlice';
+type SpeciesSelectorGeneSearchState = {
+  query: string;
+};
 
-export default combineReducers({
-  general: speciesSelectorGeneralReducer,
-  geneSearch: speciesSelectorGeneSearchReducer
+const initialState: SpeciesSelectorGeneSearchState = {
+  query: ''
+};
+
+const speciesSelectorGeneSearchSlice = createSlice({
+  name: 'species-selector-gene-search',
+  initialState,
+  reducers: {
+    setQuery: (state, action: PayloadAction<string>) => {
+      state.query = action.payload;
+    }
+  },
+  selectors: {
+    getQuery: (state) => state.query
+  }
 });
+
+export const { setQuery } = speciesSelectorGeneSearchSlice.actions;
+
+export default speciesSelectorGeneSearchSlice.reducer;

--- a/src/content/app/species-selector/views/species-selector-gene-search-view/SpeciesSelectorGeneSearchView.tsx
+++ b/src/content/app/species-selector/views/species-selector-gene-search-view/SpeciesSelectorGeneSearchView.tsx
@@ -14,18 +14,42 @@
  * limitations under the License.
  */
 
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+import { useAppDispatch } from 'src/store';
+
+import { setQuery as storeGeneQuery } from 'src/content/app/species-selector/state/species-selector-gene-search-slice/speciesSelectorGeneSearchSlice';
 
 import GeneSearchPanel from 'src/shared/components/gene-search-panel/GeneSearchPanel';
 
 const SpeciesSelectorGeneSearchView = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+
+  const queryFromParams = searchParams.get('query') ?? '';
 
   const onClose = () => {
     navigate(-1);
   };
 
-  return <GeneSearchPanel onClose={onClose} />;
+  const onSearchSubmit = (query: string) => {
+    updateSearchParams(query);
+    dispatch(storeGeneQuery(query));
+  };
+
+  const updateSearchParams = (query: string) => {
+    searchParams.set('query', query);
+    setSearchParams(searchParams, { replace: true });
+  };
+
+  return (
+    <GeneSearchPanel
+      query={queryFromParams}
+      onSearchSubmit={onSearchSubmit}
+      onClose={onClose}
+    />
+  );
 };
 
 export default SpeciesSelectorGeneSearchView;

--- a/src/content/app/species/SpeciesPage.module.css
+++ b/src/content/app/species/SpeciesPage.module.css
@@ -10,15 +10,15 @@
   align-items: center;
   line-height: 1;
   max-width: 1380px;
-  /* padding-left: 30px; */
-  padding-right: 20px;
+  padding-left: 30px;
 }
 
 .closeButton {
-  margin-left: var(--double-standard-gutter);
+  /* margin-left: var(--double-standard-gutter); */
 }
 
 .addSpeciesButton {
   --add-button-icon-color: var(--color-green);
   --add-button-label-color: var(--color-black);
+  padding-right: 35px;
 }

--- a/src/content/app/species/SpeciesPage.module.css
+++ b/src/content/app/species/SpeciesPage.module.css
@@ -9,19 +9,16 @@
   grid-template-columns: 1fr auto;
   align-items: center;
   line-height: 1;
-  padding-left: 30px;
+  max-width: 1380px;
+  /* padding-left: 30px; */
   padding-right: 20px;
 }
 
-.topbarLeft {
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-  justify-self: start;
+.closeButton {
+  margin-left: var(--double-standard-gutter);
 }
 
-.pageTitle {
-  color: var(--color-blue);
-  font-weight: var(--font-weight-bold);
-  margin-left: 17px;
+.addSpeciesButton {
+  --add-button-icon-color: var(--color-green);
+  --add-button-label-color: var(--color-black);
 }

--- a/src/content/app/species/SpeciesPageContent.tsx
+++ b/src/content/app/species/SpeciesPageContent.tsx
@@ -38,10 +38,11 @@ import SpeciesAppBar from './components/species-app-bar/SpeciesAppBar';
 import SpeciesPageSidebar from './components/species-page-sidebar/SpeciesPageSidebar';
 import { StandardAppLayout } from 'src/shared/components/layout';
 import SpeciesMainView from 'src/content/app/species/components/species-main-view/SpeciesMainView';
-import Chevron from 'src/shared/components/chevron/Chevron';
 import MissingGenomeError from 'src/shared/components/error-screen/url-errors/MissingGenomeError';
 import SpeciesSidebarModal from './components/species-sidebar-modal/SpeciesSidebarModal';
 import SpeciesSidebarToolstrip from './components/species-sidebar-toolstrip/SpeciesSidebarToolstrip';
+import AddButton from 'src/shared/components/add-button/AddButton';
+import { CloseButtonWithLabel } from 'src/shared/components/close-button/CloseButton';
 
 import { BreakpointWidth } from 'src/global/globalConfig';
 import type { CommittedItem } from 'src/content/app/species-selector/types/committedItem';
@@ -144,10 +145,16 @@ const TopBar = () => {
 
   return (
     <div className={styles.topbar}>
-      <div className={styles.topbarLeft} onClick={returnToSpeciesSelector}>
-        <Chevron direction="left" animate={false} />
-        <span className={styles.pageTitle}>Find a Species</span>
-      </div>
+      <CloseButtonWithLabel
+        className={styles.closeButton}
+        onClick={returnToSpeciesSelector}
+      />
+      <AddButton
+        onClick={returnToSpeciesSelector}
+        className={styles.addSpeciesButton}
+      >
+        Add a species
+      </AddButton>
     </div>
   );
 };

--- a/src/content/app/species/components/species-page-sidebar/SpeciesPageSidebar.module.css
+++ b/src/content/app/species/components/species-page-sidebar/SpeciesPageSidebar.module.css
@@ -59,6 +59,10 @@
   font-weight: var(--font-weight-bold);
 }
 
+.topSectionButtonsContainer {
+  margin: 36px 0;
+}
+
 .getFilesSection {
   margin-top: 40px;
 }

--- a/src/content/app/species/components/species-page-sidebar/SpeciesPageSidebar.tsx
+++ b/src/content/app/species/components/species-page-sidebar/SpeciesPageSidebar.tsx
@@ -26,6 +26,7 @@ import { updateSpeciesSidebarModalForGenome } from 'src/content/app/species/stat
 import Sidebar from 'src/shared/components/layout/sidebar/Sidebar';
 import ExternalReference from 'src/shared/components/external-reference/ExternalReference';
 import ExternalLink from 'src/shared/components/external-link/ExternalLink';
+import GeneSearchButton from 'src/shared/components/gene-search-button/GeneSearchButton';
 
 import DownloadIcon from 'static/icons/icon_download.svg';
 
@@ -40,6 +41,17 @@ type Props = {
 
 const SpeciesPageSidebar = (props: Props) => {
   const { data } = props;
+  const activeGenomeId = useAppSelector(getActiveGenomeId) as string;
+  const dispatch = useAppDispatch();
+
+  const onGeneSearchClick = () => {
+    dispatch(
+      updateSpeciesSidebarModalForGenome({
+        activeGenomeId,
+        fragment: { sidebarModalView: SpeciesSidebarModalView.SEARCH }
+      })
+    );
+  };
 
   return (
     <Sidebar>
@@ -55,9 +67,11 @@ const SpeciesPageSidebar = (props: Props) => {
           </div>
           <SpeciesType {...data} />
         </div>
-      </section>
 
-      {/*  There will be buttons to find a gene here */}
+        <div className={styles.topSectionButtonsContainer}>
+          <GeneSearchButton onClick={onGeneSearchClick} />
+        </div>
+      </section>
 
       <div className={styles.sectionHead}>Assembly</div>
       <section className={styles.section}>

--- a/src/content/app/species/components/species-sidebar-modal/SpeciesSidebarModal.tsx
+++ b/src/content/app/species/components/species-sidebar-modal/SpeciesSidebarModal.tsx
@@ -38,7 +38,7 @@ const speciesSidebarModals: Record<string, ReturnType<typeof lazy>> = {
 };
 
 export const speciesSidebarModalTitles: { [key: string]: string } = {
-  [SpeciesSidebarModalView.SEARCH]: 'Search',
+  [SpeciesSidebarModalView.SEARCH]: 'Search this species',
   [SpeciesSidebarModalView.BOOKMARKS]: 'Previously viewed',
   [SpeciesSidebarModalView.SHARE]: 'Share',
   [SpeciesSidebarModalView.DOWNLOAD]: 'Download'

--- a/src/content/app/species/components/species-sidebar-modal/modal-views/SpeciesSidebarSearch.tsx
+++ b/src/content/app/species/components/species-sidebar-modal/modal-views/SpeciesSidebarSearch.tsx
@@ -14,18 +14,34 @@
  * limitations under the License.
  */
 
-import { useSelector } from 'react-redux';
+import { useAppDispatch, useAppSelector } from 'src/store';
 
 import { useUrlParams } from 'src/shared/hooks/useUrlParams';
 
 import { getActiveGenomeId } from 'src/content/app/species/state/general/speciesGeneralSelectors';
 
+import { updateSpeciesSidebarModalForGenome } from 'src/content/app/species/state/sidebar/speciesSidebarSlice';
+
 import InAppSearch from 'src/shared/components/in-app-search/InAppSearch';
 
 const SpeciesSidebarSearch = () => {
-  const activeGenomeId = useSelector(getActiveGenomeId);
+  const activeGenomeId = useAppSelector(getActiveGenomeId);
   const { genomeId: genomeIdForUrl } =
     useUrlParams<'genomeId'>('/species/:genomeId');
+  const dispatch = useAppDispatch();
+
+  const onSearchMatchNavigation = () => {
+    if (!activeGenomeId) {
+      return; // should not happen
+    }
+
+    dispatch(
+      updateSpeciesSidebarModalForGenome({
+        activeGenomeId,
+        fragment: { sidebarModalView: null }
+      })
+    );
+  };
 
   return (
     <section className="searchModal">
@@ -36,6 +52,7 @@ const SpeciesSidebarSearch = () => {
             genomeId={activeGenomeId}
             genomeIdForUrl={genomeIdForUrl as string}
             mode="sidebar"
+            onMatchNavigation={onSearchMatchNavigation}
           />
         )}
       </div>

--- a/src/content/app/species/components/species-title-area/SpeciesTitleArea.module.css
+++ b/src/content/app/species/components/species-title-area/SpeciesTitleArea.module.css
@@ -46,6 +46,7 @@
   grid-area: assembly-count;
   column-gap: 12px;
   flex-wrap: nowrap;
+  margin-left: 20px;
 }
 
 .assembliesLink {
@@ -61,18 +62,14 @@
   grid-area: remove;
   justify-self: end;
   white-space: nowrap;
+  padding-right: 35px;
 }
 
 .speciesRemoveMessage {
   grid-area: remove-message;
   justify-content: end;
   margin-bottom: 20px;
-}
-
-.remove {
-  grid-area: remove;
-  align-self: start;
-  white-space: nowrap;
+  padding-right: 35px;
 }
 
 @container species-page-title-area (min-width: 761px) {
@@ -81,66 +78,38 @@
     grid-template-areas:
       'icon species-name assembly-count usage-toggle remove'
       '. remove-message remove-message remove-message remove-message';
-    grid-template-columns: 60px fit-content(60%) 1fr minmax(auto, 284px) auto;
+    grid-template-columns: 60px auto minmax(180px, 1fr) minmax(auto, 284px) auto;
     grid-template-rows: 80px auto;
   }
 
-  .speciesToggle {
-    padding-left: 25px;
+  .grid:not(:has(.assemblyCountWrapper)) {
+    grid-template-areas:
+      'icon species-name usage-toggle remove'
+      '. remove-message remove-message remove-message';
+    grid-template-columns: 60px minmax(auto, 1fr) minmax(auto, 284px) auto;
   }
 }
 
 
-@container species-page-title-area (min-width: 641px) and (max-width: 760px) {
+@container species-page-title-area (max-width: 830px) {
   .grid {
     grid-template-areas:
-      'icon species-name assembly-count usage-toggle remove'
-      '. remove-message remove-message remove-message .';
-    grid-template-columns: 60px min-content auto 1fr;
-    grid-template-rows: 80px auto auto;
-    margin-bottom: 20px;
-  }
-
-  .speciesNameWrapper {
-    min-height: 60px;
-    display: flex;
-    align-items: center;
-  }
-
-  .assemblyName {
-    padding-top: 3px;
-    white-space: nowrap;
-  }
-
-  .speciesToggle {
-    padding: 0;
-  }
-
-  /* .speciesRemove {
-    white-space: normal;
-  } */
-
-  .speciesRemoveMessage {
-    grid-area: remove-message;
-    justify-content: start;
-  }
-}
-
-@container species-page-title-area (max-width: 640px) {
-  .grid {
-    grid-template-areas:
-      'icon species-name assembly-count .'
-      '. usage-toggle remove .'
-      '. remove-message remove-message .';
-    grid-template-columns: 60px 150px 1fr;
-    grid-template-rows: 80px 0 auto 40px;
+      'icon species-name assembly-count'
+      '. usage-toggle remove'
+      '. remove-message remove-message';
+    grid-template-columns: 60px auto minmax(min-content, 1fr);
+    grid-template-rows: minmax(80px, auto) auto auto;
     grid-row-gap: 10px;
     margin-bottom: 20px;
   }
 
+  .assemblyCountWrapper {
+    margin-left: 20px;
+  }
 
   .speciesRemoveMessage {
     margin-top: 20px;
+    margin-bottom: 0;
     justify-content: start;
   }
 

--- a/src/content/app/species/components/species-title-area/SpeciesTitleArea.module.css
+++ b/src/content/app/species/components/species-title-area/SpeciesTitleArea.module.css
@@ -9,14 +9,14 @@
   align-items: center;
   grid-column-gap: 20px;
   padding-right: 20px;
+  justify-content: start;
 }
 
 .speciesIcon {
   grid-area: icon;
-  width: 60px;
-  height: 60px;
+  width: 57px;
+  height: 57px;
   border: 1px solid var(--color-blue);
-  padding: 6px;
 }
 
 .speciesIcon img {
@@ -44,7 +44,8 @@
   align-items: center;
   display: inline-flex;
   grid-area: assembly-count;
-  justify-content: space-around;
+  column-gap: 12px;
+  flex-wrap: nowrap;
 }
 
 .assembliesLink {
@@ -60,13 +61,6 @@
   grid-area: remove;
   justify-self: end;
   white-space: nowrap;
-}
-
-.disabledRemoveButton {
-  background-color: var(--color-grey);
-  color: var(--color-white);
-  border: 1px solid var(--color-grey);
-  cursor: default;
 }
 
 .speciesRemoveMessage {
@@ -87,7 +81,7 @@
     grid-template-areas:
       'icon species-name assembly-count usage-toggle remove'
       '. remove-message remove-message remove-message remove-message';
-    grid-template-columns: 60px fit-content(60%) 110px minmax(200px, 680px) auto 1fr;
+    grid-template-columns: 60px fit-content(60%) 1fr minmax(auto, 284px) auto;
     grid-template-rows: 80px auto;
   }
 
@@ -122,9 +116,9 @@
     padding: 0;
   }
 
-  .speciesRemove {
+  /* .speciesRemove {
     white-space: normal;
-  }
+  } */
 
   .speciesRemoveMessage {
     grid-area: remove-message;

--- a/src/content/app/species/components/species-title-area/SpeciesTitleArea.module.css
+++ b/src/content/app/species/components/species-title-area/SpeciesTitleArea.module.css
@@ -75,21 +75,6 @@
   margin-bottom: 20px;
 }
 
-.geneSearchWrapper {
-  grid-area: search;
-  color: var(--color-blue);
-  cursor: pointer;
-  display: inline-flex;
-  column-gap: 12px;
-  white-space: nowrap;
-  justify-self: start;
-}
-
-.geneSearchWrapper svg {
-  fill: var(--color-blue);
-  width: 13px;
-}
-
 .remove {
   grid-area: remove;
   align-self: start;
@@ -100,8 +85,8 @@
   .grid {
     display: grid;
     grid-template-areas:
-      'icon species-name assembly-count usage-toggle search remove'
-      '. remove-message remove-message remove-message remove-message remove-message';
+      'icon species-name assembly-count usage-toggle remove'
+      '. remove-message remove-message remove-message remove-message';
     grid-template-columns: 60px fit-content(60%) 110px minmax(200px, 680px) auto 1fr;
     grid-template-rows: 80px auto;
   }
@@ -116,8 +101,7 @@
   .grid {
     grid-template-areas:
       'icon species-name assembly-count usage-toggle remove'
-      '. remove-message remove-message remove-message .'
-      '. search . . .';
+      '. remove-message remove-message remove-message .';
     grid-template-columns: 60px min-content auto 1fr;
     grid-template-rows: 80px auto auto;
     margin-bottom: 20px;
@@ -146,12 +130,6 @@
     grid-area: remove-message;
     justify-content: start;
   }
-
-  .geneSearchWrapper {
-    grid-area: search;
-    margin: 0;
-  }
-
 }
 
 @container species-page-title-area (max-width: 640px) {
@@ -159,8 +137,7 @@
     grid-template-areas:
       'icon species-name assembly-count .'
       '. usage-toggle remove .'
-      '. remove-message remove-message .'
-      '. search . .';
+      '. remove-message remove-message .';
     grid-template-columns: 60px 150px 1fr;
     grid-template-rows: 80px 0 auto 40px;
     grid-row-gap: 10px;

--- a/src/content/app/species/components/species-title-area/SpeciesTitleArea.tsx
+++ b/src/content/app/species/components/species-title-area/SpeciesTitleArea.tsx
@@ -29,17 +29,12 @@ import { SecondaryButton } from 'src/shared/components/button/Button';
 import DeletionConfirmation from 'src/shared/components/deletion-confirmation/DeletionConfirmation';
 import SpeciesUsageToggle from './species-usage-toggle/SpeciesUsageToggle';
 import InfoPill from 'src/shared/components/info-pill/InfoPill';
-import SearchIcon from 'static/icons/icon_search.svg';
 
 import { getCommittedSpeciesById } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors';
 import { getActiveGenomeId } from 'src/content/app/species/state/general/speciesGeneralSelectors';
 import { useGetPopularSpeciesQuery } from 'src/content/app/species-selector/state/species-selector-api-slice/speciesSelectorApiSlice';
 import { useSpeciesDetailsQuery } from 'src/content/app/species/state/api/speciesApiSlice';
 
-import {
-  SpeciesSidebarModalView,
-  updateSpeciesSidebarModalForGenome
-} from 'src/content/app/species/state/sidebar/speciesSidebarSlice';
 import { deleteSpeciesAndSave } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSlice';
 
 import type { RootState } from 'src/store';
@@ -91,15 +86,6 @@ const SpeciesTitleArea = () => {
     return null;
   }
 
-  const openSearch = () => {
-    dispatch(
-      updateSpeciesSidebarModalForGenome({
-        activeGenomeId,
-        fragment: { sidebarModalView: SpeciesSidebarModalView.SEARCH }
-      })
-    );
-  };
-
   const navigateToAssemblies = () => {
     navigate(
       urlFor.speciesSelectorSearch({
@@ -143,10 +129,6 @@ const SpeciesTitleArea = () => {
         )}
         <div className={styles.speciesToggle}>
           <SpeciesUsageToggle />
-        </div>
-        <div className={styles.geneSearchWrapper} onClick={openSearch}>
-          <span>Find a gene</span>
-          <SearchIcon />
         </div>
         <div className={styles.speciesRemove}>
           <SecondaryButton

--- a/src/content/app/species/components/species-title-area/SpeciesTitleArea.tsx
+++ b/src/content/app/species/components/species-title-area/SpeciesTitleArea.tsx
@@ -25,15 +25,15 @@ import { getDisplayName } from 'src/shared/components/selected-species/selectedS
 
 import useSpeciesAnalytics from 'src/content/app/species/hooks/useSpeciesAnalytics';
 
-import { SecondaryButton } from 'src/shared/components/button/Button';
-import DeletionConfirmation from 'src/shared/components/deletion-confirmation/DeletionConfirmation';
-import SpeciesUsageToggle from './species-usage-toggle/SpeciesUsageToggle';
-import InfoPill from 'src/shared/components/info-pill/InfoPill';
-
 import { getCommittedSpeciesById } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors';
 import { getActiveGenomeId } from 'src/content/app/species/state/general/speciesGeneralSelectors';
 import { useGetPopularSpeciesQuery } from 'src/content/app/species-selector/state/species-selector-api-slice/speciesSelectorApiSlice';
 import { useSpeciesDetailsQuery } from 'src/content/app/species/state/api/speciesApiSlice';
+
+import DeletionConfirmation from 'src/shared/components/deletion-confirmation/DeletionConfirmation';
+import SpeciesUsageToggle from './species-usage-toggle/SpeciesUsageToggle';
+import InfoPill from 'src/shared/components/info-pill/InfoPill';
+import { DeleteButtonWithLabel } from 'src/shared/components/delete-button/DeleteButton';
 
 import { deleteSpeciesAndSave } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSlice';
 
@@ -131,15 +131,14 @@ const SpeciesTitleArea = () => {
           <SpeciesUsageToggle />
         </div>
         <div className={styles.speciesRemove}>
-          <SecondaryButton
+          <DeleteButtonWithLabel
+            label="Remove from list"
             onClick={toggleRemovalDialog}
             disabled={isRemoving}
             className={classNames({
               [styles.disabledRemoveButton]: isRemoving
             })}
-          >
-            Remove species
-          </SecondaryButton>
+          />
         </div>
         {isRemoving && (
           <DeletionConfirmation

--- a/src/shared/components/delete-button/DeleteButton.module.css
+++ b/src/shared/components/delete-button/DeleteButton.module.css
@@ -17,7 +17,7 @@
 .deleteButtonWithLabel {
   --_label-font-size: var(--delete-button-label-font-size, 11px);
   --_label-font-weight: var(--delete-button-label-font-weight, var(--font-weight-light));
-  --_button-to-label-gap: var(--delete-button-to-label-gap, 18px);
+  --_button-to-label-gap: var(--delete-button-to-label-gap, 10px);
   display: flex;
   align-items: flex-end;
   column-gap: var(--_button-to-label-gap);

--- a/src/shared/components/delete-button/DeleteButton.module.css
+++ b/src/shared/components/delete-button/DeleteButton.module.css
@@ -1,14 +1,26 @@
 .deleteButton {
-  background: transparent;
-  border: none;
+  /* background: transparent;
+  border: none; */
   height: var(--delete-button-size, 18px);
   width: var(--delete-button-size, 18px);
+  fill: var(--delete-button-color, var(--color-blue));
 }
 
-.deleteButton svg {
-  fill: var(--delete-button-background, var(--color-blue));
-}
+/* .deleteButton {
+
+} */
 
 .deleteButtonDisabled {
-  --delete-button-background: var(--color-grey);
+  --delete-button-color: var(--color-grey);
+}
+
+.deleteButtonWithLabel {
+  --_label-font-size: var(--delete-button-label-font-size, 11px);
+  --_label-font-weight: var(--delete-button-label-font-weight, var(--font-weight-light));
+  --_button-to-label-gap: var(--delete-button-to-label-gap, 18px);
+  display: flex;
+  align-items: flex-end;
+  column-gap: var(--_button-to-label-gap);
+  font-size: var(--_label-font-size);
+  font-weight: var(--_label-font-weight);
 }

--- a/src/shared/components/delete-button/DeleteButton.module.css
+++ b/src/shared/components/delete-button/DeleteButton.module.css
@@ -1,14 +1,8 @@
 .deleteButton {
-  /* background: transparent;
-  border: none; */
   height: var(--delete-button-size, 18px);
   width: var(--delete-button-size, 18px);
   fill: var(--delete-button-color, var(--color-blue));
 }
-
-/* .deleteButton {
-
-} */
 
 .deleteButtonDisabled {
   --delete-button-color: var(--color-grey);

--- a/src/shared/components/delete-button/DeleteButton.tsx
+++ b/src/shared/components/delete-button/DeleteButton.tsx
@@ -26,17 +26,69 @@ type Props = Omit<HTMLAttributes<HTMLButtonElement>, 'children'> & {
 };
 
 const DeleteButton = (props: Props, ref: ForwardedRef<HTMLButtonElement>) => {
-  const { className, ...otherProps } = props;
-
-  const elementClasses = classNames(
-    styles.deleteButton,
-    { [styles.deleteButtonDisabled]: props.disabled },
-    className
-  );
+  const iconClasses = classNames(styles.deleteButton, {
+    [styles.deleteButtonDisabled]: props.disabled
+  });
 
   return (
-    <button {...otherProps} ref={ref} className={elementClasses}>
-      <TrashcanIcon />
+    <button {...props} ref={ref}>
+      <TrashcanIcon className={iconClasses} />
+    </button>
+  );
+};
+
+/**
+ * Design mock-ups are showing a common pattern of a delete button
+ * accompanied by a short label typically to the left of the button.
+ * Both the label and the button are clickable.
+ * This component captures this simple arrangement.
+ * For anything more complicated, please use constituent components separately.
+ */
+export const DeleteButtonWithLabel = (
+  props: Props & {
+    label?: string;
+    labelPosition?: 'left' | 'right';
+  }
+) => {
+  const {
+    label = 'Remove',
+    labelPosition = 'left',
+    onClick,
+    className: classNameFromProps,
+    ...otherProps
+  } = props;
+
+  const componentClasses = classNames(
+    styles.deleteButtonWithLabel,
+    classNameFromProps
+  );
+
+  const iconClasses = classNames(styles.deleteButton, {
+    [styles.deleteButtonDisabled]: props.disabled
+  });
+  const deleteIcon = <TrashcanIcon className={iconClasses} />;
+
+  const buttonContent =
+    labelPosition === 'left' ? (
+      <>
+        <span>{label}</span>
+        {deleteIcon}
+      </>
+    ) : (
+      <>
+        {deleteIcon}
+        <span>{label}</span>
+      </>
+    );
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={componentClasses}
+      {...otherProps}
+    >
+      {buttonContent}
     </button>
   );
 };

--- a/src/shared/components/gene-search-button/GeneSearchButton.module.css
+++ b/src/shared/components/gene-search-button/GeneSearchButton.module.css
@@ -20,11 +20,6 @@
   border-radius: 5px;
 }
 
-.closeIcon {
-  fill: var(--color-blue);
-  height: 16px;
-}
-
 .searchIcon {
   fill: var(--color-white);
   height: 14px;

--- a/src/shared/components/gene-search-button/GeneSearchButton.tsx
+++ b/src/shared/components/gene-search-button/GeneSearchButton.tsx
@@ -14,18 +14,23 @@
  * limitations under the License.
  */
 
+import classNames from 'classnames';
+
 import SearchIcon from 'static/icons/icon_search.svg';
 
 import styles from './GeneSearchButton.module.css';
 
 type Props = {
   onClick: () => void;
+  className?: string;
 };
 
 const GeneSearchButton = (props: Props) => {
+  const componentClasses = classNames(styles.geneSearchButton, props.className);
+
   return (
-    <button onClick={props.onClick} className={styles.geneSearchButton}>
-      <span>Find a Gene</span>
+    <button onClick={props.onClick} className={componentClasses}>
+      <span>Find a gene</span>
       <span className={styles.searchIconWrapper}>
         <SearchIcon className={styles.searchIcon} />
       </span>

--- a/src/shared/components/gene-search-button/GeneSearchCloseButton.tsx
+++ b/src/shared/components/gene-search-button/GeneSearchCloseButton.tsx
@@ -14,21 +14,14 @@
  * limitations under the License.
  */
 
-import CloseIcon from 'static/icons/icon_close.svg';
-
-import styles from './GeneSearchButton.module.css';
+import { CloseButtonWithLabel } from 'src/shared/components/close-button/CloseButton';
 
 type Props = {
   onClick: () => void;
 };
 
 const GeneSearchButton = (props: Props) => {
-  return (
-    <button onClick={props.onClick} className={styles.geneSearchButton}>
-      <CloseIcon className={styles.closeIcon} />
-      <span>Find a Gene</span>
-    </button>
-  );
+  return <CloseButtonWithLabel onClick={props.onClick} />;
 };
 
 export default GeneSearchButton;

--- a/src/shared/components/gene-search-panel/GeneSearchPanel.module.css
+++ b/src/shared/components/gene-search-panel/GeneSearchPanel.module.css
@@ -7,6 +7,7 @@
 }
 
 .main {
+  --inner-block-offset-left: 25px;
   height: 100%;
   display: grid;
   grid-template-rows: [search-form] auto [search-results] 1fr;
@@ -21,7 +22,7 @@
     "search-field submit-button"
     "search-scope .";
   grid-template-columns: 485px min-content;
-  column-gap: 1rem;
+  column-gap: 46px;
   row-gap: 10px;
   align-items: center;
 }
@@ -61,6 +62,7 @@
   text-align: left;
   box-shadow: inset 0 -1px 0 var(--table-head-border-color, var(--color-blue)); /* same as in Table.module.css */
   padding: 0 0.5rem 0.4rem 1rem;
+  font-size: 12px;
   font-weight: var(--font-weight-light);
 }
 
@@ -107,12 +109,34 @@
   --pointer-box-padding: 12px 20px;
 }
 
+.noResults {
+  display: flex;
+  flex-direction: column;
+  row-gap: 20px;
+  margin-left: var(--inner-block-offset-left);
+  margin-top: 2rem;
+}
+
+.noResults p {
+  margin: 0;
+}
+
+:where(.noResults p:first-child) {
+  font-size: 12px;
+  font-weight: var(--font-weight-light);
+}
+
+
+.warning {
+  color: var(--color-red);
+}
+
 /* FIXME: remove the pseudo-radio elements when we replace them with real radio buttons */
 .pseudoRadioGroup {
   --radio-label-font-weight: var(--font-weight-normal);
   display: flex;
   column-gap: 2rem;
-  margin-left: 25px;
+  margin-left: var(--inner-block-offset-left);
 }
 
 .pseudoRadioDisabled > * {

--- a/src/shared/components/gene-search-panel/GeneSearchPanel.module.css
+++ b/src/shared/components/gene-search-panel/GeneSearchPanel.module.css
@@ -1,13 +1,8 @@
-.panel {
-  height: 100%;
-  background-color: var(--color-light-grey);
-  padding: 65px 0 var(--global-padding-bottom) var(--global-padding-left); /* TODO: the 65px on top looks like it is something repeatable between components? */
-  position: relative;
-  overflow: hidden;
-}
-
 .main {
   --inner-block-offset-left: 25px;
+  padding-bottom: var(--global-padding-bottom);
+  padding-left: var(--global-padding-left);
+  padding-top: 12px;
   height: 100%;
   display: grid;
   grid-template-rows: [search-form] auto [search-results] 1fr;

--- a/src/shared/components/gene-search-panel/GeneSearchPanel.module.css
+++ b/src/shared/components/gene-search-panel/GeneSearchPanel.module.css
@@ -121,11 +121,11 @@
   margin: 0;
 }
 
+/* Using the :where selector to drop selector specificity, so that it does not compete with .speciesCount class */
 :where(.noResults p:first-child) {
   font-size: 12px;
   font-weight: var(--font-weight-light);
 }
-
 
 .warning {
   color: var(--color-red);

--- a/src/shared/components/gene-search-panel/GeneSearchPanel.tsx
+++ b/src/shared/components/gene-search-panel/GeneSearchPanel.tsx
@@ -129,6 +129,11 @@ const GeneSearchForm = (props: {
     }
   }, [props.query]);
 
+  // NOTE: future versions of React will stop passing null to ref callbacks; so update function signature when this happens
+  const focusInput = (input: HTMLInputElement | null) => {
+    input && input.focus();
+  };
+
   const onFormSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setShouldDisableSubmit(true);
@@ -152,6 +157,7 @@ const GeneSearchForm = (props: {
           value={searchInput || ''}
           help="Find a gene using a stable ID (versioned or un-versioned), symbol or synonym"
           type="search"
+          ref={focusInput}
         />
         <PrimaryButton
           type="submit"

--- a/src/shared/components/gene-search-panel/GeneSearchPanel.tsx
+++ b/src/shared/components/gene-search-panel/GeneSearchPanel.tsx
@@ -19,8 +19,7 @@ import {
   useRef,
   useEffect,
   type FormEvent,
-  type ChangeEvent,
-  type ReactNode
+  type ChangeEvent
 } from 'react';
 import classNames from 'classnames';
 
@@ -35,11 +34,11 @@ import { getCommittedSpecies } from 'src/content/app/species-selector/state/spec
 
 import ShadedInput from 'src/shared/components/input/ShadedInput';
 import { PrimaryButton } from 'src/shared/components/button/Button';
-import CloseButton from 'src/shared/components/close-button/CloseButton';
 import ViewInApp from 'src/shared/components/view-in-app/ViewInApp';
 import PointerBox, {
   Position as PointerBoxPosition
 } from 'src/shared/components/pointer-box/PointerBox';
+import ModalView from 'src/shared/components/modal-view/ModalView';
 
 import type { CommittedItem } from 'src/content/app/species-selector/types/committedItem';
 import type { SearchResults } from 'src/shared/types/search-api/search-results';
@@ -57,23 +56,9 @@ type Props = {
 
 const GeneSearchPanel = (props: Props) => {
   return (
-    <Panel {...props}>
+    <ModalView {...props}>
       <Main {...props} />
-    </Panel>
-  );
-};
-
-/**
- * This component will likely be extracted into its own shared component.
- * Its responsibility is to create a 100%-high grey div with a close button and space for children
- * I am not sure what its name is going to be. "Panel" is taken (not that it's a very descriptive name anyway).
- */
-const Panel = (props: { onClose: () => void; children: ReactNode }) => {
-  return (
-    <div className={styles.panel}>
-      {props.children}
-      <CloseButton className={styles.closeButton} onClick={props.onClose} />
-    </div>
+    </ModalView>
   );
 };
 
@@ -121,7 +106,7 @@ const GeneSearchForm = (props: {
   query: string;
 }) => {
   const [searchInput, setSearchInput] = useState(props.query);
-  const [shouldDisableSubmit, setShouldDisableSubmit] = useState(false);
+  const [shouldDisableSubmit, setShouldDisableSubmit] = useState(true);
 
   useEffect(() => {
     if (props.query !== searchInput) {
@@ -142,8 +127,9 @@ const GeneSearchForm = (props: {
   };
 
   const onQueryChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setSearchInput(event.target.value);
-    setShouldDisableSubmit(false);
+    const newQuery = event.target.value;
+    setSearchInput(newQuery);
+    setShouldDisableSubmit(!newQuery);
   };
 
   return (

--- a/src/shared/components/help-article/HelpArticle.module.css
+++ b/src/shared/components/help-article/HelpArticle.module.css
@@ -3,6 +3,8 @@
   defined in helpArticleVariables.module.css
 */
 
+/* stylelint-disable no-descending-specificity */
+
 .textArticle {
   --text-column-width: 450px;
   height: 100%;

--- a/src/shared/components/in-app-search/InAppSearch.tsx
+++ b/src/shared/components/in-app-search/InAppSearch.tsx
@@ -54,6 +54,7 @@ export type Props = {
   genomeIdForUrl: string; // this should be a temporary measure; it should be returned by search api
   mode: InAppSearchMode;
   onSearchSubmit?: (query: string) => void;
+  onMatchNavigation?: () => void; // currently, there are no requirements to this callback to pass any data
 };
 
 const InAppSearch = (props: Props) => {
@@ -152,6 +153,7 @@ const InAppSearch = (props: Props) => {
             app={app}
             mode={mode}
             genomeIdForUrl={genomeIdForUrl}
+            onMatchNavigation={props.onMatchNavigation}
           />
         )
       )}

--- a/src/shared/components/in-app-search/InAppSearch.tsx
+++ b/src/shared/components/in-app-search/InAppSearch.tsx
@@ -54,7 +54,7 @@ export type Props = {
   genomeIdForUrl: string; // this should be a temporary measure; it should be returned by search api
   mode: InAppSearchMode;
   onSearchSubmit?: (query: string) => void;
-  onMatchNavigation?: () => void; // currently, there are no requirements to this callback to pass any data
+  onMatchNavigation?: () => void; // currently, there are no requirements for this callback to receive any data
 };
 
 const InAppSearch = (props: Props) => {

--- a/src/shared/components/in-app-search/InAppSearchMatches.tsx
+++ b/src/shared/components/in-app-search/InAppSearchMatches.tsx
@@ -47,6 +47,7 @@ type InAppSearchMatchesProps = SearchResults & {
   app: AppName;
   mode: InAppSearchMode;
   genomeIdForUrl: string; // TODO: remove this when backend starts including this id in the response
+  onMatchNavigation?: () => void; // currently, there are no requirements for data to be passed in this callback
 };
 
 const InAppSearchMatches = (props: InAppSearchMatchesProps) => {
@@ -60,6 +61,7 @@ const InAppSearchMatches = (props: InAppSearchMatchesProps) => {
           mode={props.mode}
           genomeIdForUrl={props.genomeIdForUrl}
           position={index + 1}
+          onMatchNavigation={props.onMatchNavigation}
         />
       ))}
     </div>
@@ -72,6 +74,7 @@ type InAppSearchMatchProps = {
   mode: InAppSearchMode;
   genomeIdForUrl: string;
   position: number;
+  onMatchNavigation?: () => void;
 };
 
 const InAppSearchMatch = (props: InAppSearchMatchProps) => {
@@ -112,6 +115,7 @@ const InAppSearchMatch = (props: InAppSearchMatchProps) => {
     }
 
     setShouldShowTooltip(!shouldShowTooltip);
+    props.onMatchNavigation?.();
   };
 
   const hideTooltip = () => setShouldShowTooltip(false);

--- a/src/shared/components/modal-view/ModalView.module.css
+++ b/src/shared/components/modal-view/ModalView.module.css
@@ -5,7 +5,7 @@
   position: relative; 
   height: 100%;
   background-color: var(--color-light-grey);
-  padding-right: calc(var(--standard-gutter) + var(--close-button-size));
+  padding-right: calc(var(--standard-gutter) + var(--close-button-size) + 10px);
   padding-top: var(--close-button-margin-top);
   overflow: auto;
 }

--- a/src/shared/components/species-tabs-wrapper/SpeciesTabsWrapper.module.css
+++ b/src/shared/components/species-tabs-wrapper/SpeciesTabsWrapper.module.css
@@ -1,6 +1,6 @@
 .grid {
   display: grid;
-  grid-template-columns: 1fr max-content;
+  grid-template-columns: auto minmax(max-content, 1fr);
   column-gap: 30px;
   align-items: center;
 }

--- a/stories/shared-components/delete-button/DeleteButton.stories.tsx
+++ b/stories/shared-components/delete-button/DeleteButton.stories.tsx
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-import DeleteButton from 'src/shared/components/delete-button/DeleteButton';
+import DeleteButton, {
+  DeleteButtonWithLabel
+} from 'src/shared/components/delete-button/DeleteButton';
 
 export default {
   title: 'Components/Shared Components/Delete button'
@@ -28,4 +30,9 @@ export const DefaultDeleteButtonStory = {
 export const DisabledDeleteButtonStory = {
   name: 'disabled',
   render: () => <DeleteButton disabled={true} />
+};
+
+export const DeleteButtonWithLabelStory = {
+  name: 'with label',
+  render: () => <DeleteButtonWithLabel />
 };


### PR DESCRIPTION
## Description
- Species Selector
  - Updated the close state of the "Find a gene" button (it now uses a close button with the label "Close")
  - Added a help button and a clear button to the search field
  - Disable the "Go" button on search submit (until text changes)
  - Store search query in redux, such that the closing of the panel will not clear existing search results
- Species page
  - Move the "find a gene" button from the title area to the sidebar
  - Changed title of the search modal from "Search" to "Search this species"
  - Updated some UI elements (Close button, Add a species button, Delete button) 
  - Fixed styles of the title area
- Genome Browser (sidebar and search modal)
  - Use GeneSearchButton component for consistency
  - Search modal title changed from "Search" to "Search this species"
  - Click on the view gene button in sidebar tooltip in the search modal should close the modal
- Entity Viewer (sidebar and search modal)
  - Use GeneSearchButton component for consistency
  - Click on the view gene button in sidebar tooltip in the search modal should close the modal
  - Search modal title changed from "Search" to "Search this species"

### Updates to the species pages

**Before:**
![image](https://github.com/Ensembl/ensembl-client/assets/6834224/cbc0c705-c2e3-403e-90a2-f78436b229da)

**After:**
![image](https://github.com/Ensembl/ensembl-client/assets/6834224/ea80edcf-2a25-4b56-977d-3e7abac2e830)


## Related JIRA Issue(s)
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2524
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1641

## Deployment URL(s)
http://find-gene-ui-updates.review.ensembl.org