### PR TITLE
Memoise a couple of selectors for the geneViewTranscripts slice

### DIFF
--- a/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors.ts
+++ b/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { createSelector } from '@reduxjs/toolkit';
+
 import {
   getEntityViewerActiveGenomeId,
   getEntityViewerActiveEntityId
@@ -26,18 +28,19 @@ import {
   SortingRule
 } from './geneViewTranscriptsSlice';
 
-const getSliceForGene = (
-  state: RootState
-): TranscriptsStatePerGene | undefined => {
-  const activeGenomeId = getEntityViewerActiveGenomeId(state);
-  const activeEntityId = getEntityViewerActiveEntityId(state);
-  if (!activeGenomeId || !activeEntityId) {
-    return;
+const getSliceForGene = createSelector(
+  [
+    getEntityViewerActiveGenomeId,
+    getEntityViewerActiveEntityId,
+    (state: RootState) => state
+  ],
+  (genomeId, entityId, state): TranscriptsStatePerGene | undefined => {
+    if (!genomeId || !entityId) {
+      return;
+    }
+    return state.entityViewer.geneView.transcripts[genomeId]?.[entityId];
   }
-  return state.entityViewer.geneView.transcripts[activeGenomeId]?.[
-    activeEntityId
-  ];
-};
+);
 
 export const getExpandedTranscriptIds = (state: RootState): string[] => {
   const transcriptsSlice = getSliceForGene(state);
@@ -58,10 +61,12 @@ export const getExpandedTranscriptMoreInfoIds = (
   return transcriptsSlice?.expandedMoreInfoIds ?? [];
 };
 
-export const getFilters = (state: RootState): Filters => {
-  const transcriptsSlice = getSliceForGene(state);
-  return transcriptsSlice?.filters ?? {};
-};
+export const getFilters = createSelector(
+  [getSliceForGene],
+  (transcriptsSlice): Filters => {
+    return transcriptsSlice?.filters ?? {};
+  }
+);
 
 export const getSortingRule = (state: RootState): SortingRule => {
   const transcriptsSlice = getSliceForGene(state);


### PR DESCRIPTION
## Description
I noticed that navigation `gene` -> `variant` -> `gene` in Entity Viewer will show up the following warning in dev tools:

```
Selector getFilters returned a different result when called with the same parameters. This can lead to unnecessary rerenders.
Selectors that return a new reference (such as an object or an array) should be memoized
```

<img width="1397" alt="image" src="https://github.com/Ensembl/ensembl-client/assets/6834224/108662be-879e-4c2c-aab7-2d35790cd6e0">

The problem selector that the warning was pointing at was the `getFilters` selector (called in GeneView.tsx, line 109); so I added memoization for it.

**Before:**
https://github.com/Ensembl/ensembl-client/assets/6834224/a4ce2164-8b31-4c00-83cf-fc7a453c54e6

**After (no warnings):**
https://github.com/Ensembl/ensembl-client/assets/6834224/a85b44cd-7b8e-48d5-9e60-6f186bc4a483


## Deployment URL(s)
http://memoize-selector.review.ensembl.org