### PR TITLE
Reveal previously hidden links to Species Manager and Entity Viewer for variant in prod

### DIFF
--- a/src/content/app/entity-viewer/components/example-links/ExampleLinks.tsx
+++ b/src/content/app/entity-viewer/components/example-links/ExampleLinks.tsx
@@ -18,7 +18,6 @@ import { Link } from 'react-router-dom';
 
 import * as urlHelper from 'src/shared/helpers/urlHelper';
 import { buildFocusIdForUrl } from 'src/shared/helpers/focusObjectHelpers';
-import { isEnvironment, Environment } from 'src/shared/helpers/environment';
 
 import { useExampleObjectsForGenomeQuery } from 'src/shared/state/genome/genomeApiSlice';
 import useEntityViewerIds from 'src/content/app/entity-viewer/hooks/useEntityViewerIds';
@@ -47,40 +46,31 @@ const ExampleLinks = () => {
     );
   }
 
-  const exampleLinks = (currentData ?? [])
-    .filter((exampleObject) => {
-      // TODO: remove this filter when variant view is ready for production
-      if (isEnvironment([Environment.PRODUCTION])) {
-        return exampleObject.type === 'gene';
-      } else {
-        return true;
-      }
-    })
-    .map((exampleObject) => {
-      let path = '';
+  const exampleLinks = (currentData ?? []).map((exampleObject) => {
+    let path = '';
 
-      if (exampleObject.type === 'gene') {
-        const geneUrlId = buildFocusIdForUrl({
-          type: 'gene',
-          objectId: exampleObject.id
-        });
-        path = urlHelper.entityViewer({
-          genomeId: genomeIdForUrl,
-          entityId: geneUrlId
-        });
-      } else if (exampleObject.type === 'variant') {
-        path = urlHelper.entityViewerVariant({
-          genomeId: genomeIdForUrl,
-          variantId: exampleObject.id
-        });
-      }
+    if (exampleObject.type === 'gene') {
+      const geneUrlId = buildFocusIdForUrl({
+        type: 'gene',
+        objectId: exampleObject.id
+      });
+      path = urlHelper.entityViewer({
+        genomeId: genomeIdForUrl,
+        entityId: geneUrlId
+      });
+    } else if (exampleObject.type === 'variant') {
+      path = urlHelper.entityViewerVariant({
+        genomeId: genomeIdForUrl,
+        variantId: exampleObject.id
+      });
+    }
 
-      return path ? (
-        <Link key={path} to={path}>
-          Example {exampleObject.type}
-        </Link>
-      ) : null;
-    });
+    return path ? (
+      <Link key={path} to={path}>
+        Example {exampleObject.type}
+      </Link>
+    ) : null;
+  });
 
   return <div className={styles.exampleLinks}>{exampleLinks}</div>;
 };

--- a/src/content/app/genome-browser/components/zmenu/zmenus/VariantZmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/zmenus/VariantZmenu.tsx
@@ -17,7 +17,6 @@
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import { getChrLocationStr } from 'src/content/app/genome-browser/helpers/browserHelper';
 import { buildFocusVariantId } from 'src/shared/helpers/focusObjectHelpers';
-import { isEnvironment, Environment } from 'src/shared/helpers/environment';
 
 import useGenomeBrowserIds from 'src/content/app/genome-browser/hooks/useGenomeBrowserIds';
 
@@ -84,9 +83,7 @@ const VariantZmenu = (props: Props) => {
           theme="dark"
           links={{
             genomeBrowser: { url: linkToVariantInGenomeBrowser },
-            entityViewer: !isEnvironment([Environment.PRODUCTION])
-              ? { url: linkToVariantInEntityViewer }
-              : undefined
+            entityViewer: { url: linkToVariantInEntityViewer }
           }}
           onAnyAppClick={props.onDestroy}
           className={styles.zmenuAppLinks}

--- a/src/content/app/species/state/general/speciesGeneralHelper.ts
+++ b/src/content/app/species/state/general/speciesGeneralHelper.ts
@@ -17,8 +17,6 @@
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import { formatNumber } from 'src/shared/helpers/formatters/numberFormatter';
 
-import { isEnvironment, Environment } from 'src/shared/helpers/environment';
-
 import { SpeciesStatsProps as IndividualStat } from 'src/content/app/species/components/species-stats/SpeciesStats';
 import { ExampleFocusObject } from 'src/shared/state/genome/genomeTypes';
 
@@ -619,14 +617,12 @@ const getExampleLinks = (props: {
           focus: focusId
         })
       },
-      entityViewer: !isEnvironment([Environment.PRODUCTION])
-        ? {
-            url: urlFor.entityViewerVariant({
-              genomeId: genomeIdForUrl,
-              variantId: exampleVariant.id
-            })
-          }
-        : undefined
+      entityViewer: {
+        url: urlFor.entityViewerVariant({
+          genomeId: genomeIdForUrl,
+          variantId: exampleVariant.id
+        })
+      }
     };
   }
 

--- a/src/shared/components/species-manager-indicator/SpeciesManagerIndicator.tsx
+++ b/src/shared/components/species-manager-indicator/SpeciesManagerIndicator.tsx
@@ -19,7 +19,6 @@ import { Link } from 'react-router-dom';
 import { useAppSelector } from 'src/store';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
-import { isEnvironment, Environment } from 'src/shared/helpers/environment';
 
 import { getCommittedSpecies } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors';
 
@@ -39,11 +38,6 @@ type Props =
 const SpeciesManagerIndicator = (props: Props) => {
   const { mode = 'default' } = props;
   const selectedSpecies = useAppSelector(getCommittedSpecies);
-
-  // temporarily hide on live deployments
-  if (isEnvironment([Environment.PRODUCTION])) {
-    return null;
-  }
 
   const totalSpeciesCount = selectedSpecies.length;
   const enabledSpeciesCount = selectedSpecies.filter(


### PR DESCRIPTION
## Description
While species manager and the Entity Viewer variant view were in development, links to them were hidden in the production environment. We are now at a point where we can start showing these links.

Enabled links:
- Species page: example variant link to EntityViewer
- Entity viewer: example variant link
- Link to Species Manager in the top of different pages

![image](https://github.com/Ensembl/ensembl-client/assets/6834224/d59b2826-732a-47ee-a6a4-2e3dd9cfb272)

![image](https://github.com/Ensembl/ensembl-client/assets/6834224/49cae412-07a1-4a26-909a-28c2f83a08f9)

![image](https://github.com/Ensembl/ensembl-client/assets/6834224/cad76f17-b2c1-4cc4-a23b-edd1f049a431)

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2582

## Deployment URL(s)
http://show-hidden-links-prod.review.ensembl.org (though you shouldn't see anything special on review deployment)