### PR TITLE
Most recently added genomes should appear in the beginning of the list of species lozenges

### DIFF
--- a/src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSlice.ts
+++ b/src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSlice.ts
@@ -137,8 +137,8 @@ export const commitSelectedSpeciesAndSave = createAsyncThunk(
     const newSpeciesToCommit = prepareSelectedSpeciesForCommit(selectedSpecies);
 
     const newCommittedSpecies = [
-      ...alreadyCommittedSpecies,
-      ...newSpeciesToCommit
+      ...newSpeciesToCommit,
+      ...alreadyCommittedSpecies
     ];
 
     dispatch(updateCommittedSpecies(newCommittedSpecies));


### PR DESCRIPTION
## Description
The genome(s) selected most recently should show up in the beginning of species tabs list in the top of the page.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2572

## Deployment URL(s)
http://selected-species-tabs-order.review.ensembl.org