### PR TITLE
Show BLAST hits count for non-chromosomal top-level regions as well as for chromosomes 

### DIFF
--- a/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicRegionHeatmap.tsx
+++ b/src/content/app/tools/blast/components/blast-genomic-hits-diagram/BlastGenomicRegionHeatmap.tsx
@@ -25,10 +25,7 @@ import {
   ELEMENT_HEIGHT
 } from './blastGenomicHitsDiagramConstants';
 
-import type {
-  BlastHit,
-  BlastJobResult
-} from 'src/content/app/tools/blast/types/blastJob';
+import type { BlastHit } from 'src/content/app/tools/blast/types/blastJob';
 
 import styles from './BlastGenomicHitsDiagram.module.css';
 
@@ -38,15 +35,15 @@ type HitLocation = {
 };
 
 type Props = {
-  job: BlastJobResult;
+  hits: BlastHit[];
   width: number;
   regionName: string; // name of the genomic region (chromosome) that the heatmap is built for
   topHits?: HitLocation[];
 };
 
 const BlastGenomicRegionHeatmap = (props: Props) => {
-  const { width, job, regionName } = props;
-  const region = job.hits.find((hit) => hit.hit_acc === regionName) as BlastHit;
+  const { width, hits, regionName } = props;
+  const region = hits.find((hit) => hit.hit_acc === regionName) as BlastHit;
   const regionLength = region.hit_len;
 
   const scale = scaleLinear()

--- a/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.module.css
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.module.css
@@ -136,7 +136,3 @@
 .light {
   font-weight: var(--font-weight-light);
 }
-
-.strong {
-
-}

--- a/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.module.css
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.module.css
@@ -8,8 +8,15 @@
     'sequence-label hits-diagram species'
     'table table table';
 
-  gap: 20px;
-  padding-bottom: 20px;
+  column-gap: 20px;
+  padding-bottom: 45px;
+}
+
+.resultsSummaryRow:has(.hitLabel:not(:first-child)) {
+  grid-template-areas:
+    'sequence-label hits-diagram species'
+    'sequence-label-2 hits-diagram-2 .'
+    'table table table';
 }
 
 .resultsSummaryRow:first-of-type {
@@ -36,15 +43,25 @@
 }
 
 .hitLabel {
+  grid-area: sequence-label;
   text-align: right;
   padding-right: 20px;
 }
 
+.hitLabel:not(:first-child) {
+  grid-area: sequence-label-2;
+}
+
 .summaryPlot {
-  grid-column: hits-diagram;
+  grid-area: hits-diagram;
+}
+
+.summaryPlot:not(:nth-child(2)) {
+  grid-area: hits-diagram-2;
 }
 
 .blastSpecies {
+  grid-area: species;
   display: inline-flex;
   align-items: baseline;
   flex-wrap: wrap;
@@ -78,6 +95,7 @@
 }
 
 .hitsTable {
+  margin-top: 20px;
   padding: 20px;
   border-top: 1px solid var(--color-grey);
   border-bottom: 1px solid var(--color-grey);

--- a/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.module.css
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.module.css
@@ -1,3 +1,5 @@
+/* stylelint-disable no-descending-specificity */
+
 .resultsSummaryRow {
   display: grid;
   grid-template-columns:
@@ -9,10 +11,13 @@
     'table table table';
 
   column-gap: 20px;
-  padding-bottom: 45px;
+  padding-bottom: 46px;
 }
 
-.resultsSummaryRow:has(.hitLabel:not(:first-child)) {
+/* Change the grid for cases when there are two pieces of information about BLAST hit counts
+ * (i.e. number of BLAST hits against chromosomes vs against other top-level regions)
+ */
+.resultsSummaryRow:has(.hitLabel ~ .hitLabel) {
   grid-template-areas:
     'sequence-label hits-diagram species'
     'sequence-label-2 hits-diagram-2 .'
@@ -21,10 +26,6 @@
 
 .resultsSummaryRow:first-of-type {
   padding-top: 24px;
-}
-
-.resultsSummaryRow:last-of-type {
-  padding-bottom: 46px;
 }
 
 .tableWrapper {
@@ -45,18 +46,26 @@
 .hitLabel {
   grid-area: sequence-label;
   text-align: right;
+  font-size: 12px;
   padding-right: 20px;
 }
 
-.hitLabel:not(:first-child) {
+/* There will only be at most two elements with .hitLabel class;
+ * but they will be separated by an element with the .summaryPlot class
+ */
+.hitLabel ~ .hitLabel {
   grid-area: sequence-label-2;
 }
 
 .summaryPlot {
   grid-area: hits-diagram;
+  font-size: 12px;
 }
 
-.summaryPlot:not(:nth-child(2)) {
+/* There will only be at most two elements with .summaryPlot class;
+ * but they will be separated by an element with the .hitLabel class
+ */
+.summaryPlot ~ .summaryPlot {
   grid-area: hits-diagram-2;
 }
 
@@ -122,4 +131,12 @@
   grid-column: failed-status;
   justify-self: end;
   color: var(--color-red);
+}
+
+.light {
+  font-weight: var(--font-weight-light);
+}
+
+.strong {
+
 }

--- a/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.module.css
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.module.css
@@ -47,6 +47,7 @@
   grid-area: sequence-label;
   text-align: right;
   font-size: 12px;
+  font-weight: var(--font-weight-bold);
   padding-right: 20px;
 }
 

--- a/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
@@ -307,7 +307,9 @@ const GenomicHitsDiagramContainer = (props: {
     <>
       <div className={styles.hitLabel}>
         <span>{chromosomeAlignmentsCount} </span>
-        <span>{pluralise('hit', chromosomeAlignmentsCount)}</span>
+        <span className={styles.light}>
+          {pluralise('hit', nonChromosomeAlignmentsCount)}
+        </span>
       </div>
       <div className={styles.summaryPlot}>
         <BlastGenomicHitsDiagram
@@ -324,10 +326,14 @@ const GenomicHitsDiagramContainer = (props: {
     <>
       <div className={styles.hitLabel}>
         <span>{nonChromosomeAlignmentsCount} </span>
-        <span>{pluralise('hit', nonChromosomeAlignmentsCount)}</span>
+        <span className={styles.light}>
+          {pluralise('hit', nonChromosomeAlignmentsCount)}
+        </span>
       </div>
       <div className={styles.summaryPlot}>
-        in {nonChromosomeHits.length} unassembled regions
+        <span className={styles.light}>in</span>
+        {` ${nonChromosomeHits.length} `}
+        <span className={styles.light}>unassembled regions</span>
       </div>
     </>
   ) : null;

--- a/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
@@ -342,7 +342,7 @@ const GenomicHitsDiagramContainer = (props: {
     return (
       <div className={styles.hitLabel}>
         <span>0 </span>
-        <span>hits</span>
+        <span className={styles.light}>hits</span>
       </div>
     );
   }

--- a/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/useGroupedBlastHits.ts
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/useGroupedBlastHits.ts
@@ -46,12 +46,6 @@ const useGroupedBlastHits = (params: {
     };
   }
 
-  /**
-   * If no chromosomeHits and no nonChromosomeHits, output 0 hits
-   * If chromosomeHits and no nonChromosomeHits, output only chromosome hits
-   * If no chromosomeHits, but some nonChromosomeHits, output only nonChromosomeHits
-   */
-
   const { chromosomeHits, nonChromosomeHits } = partitionBlastHits({
     karyotype: genomeKaryotype,
     job

--- a/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/useGroupedBlastHits.ts
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/useGroupedBlastHits.ts
@@ -1,0 +1,123 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useGenomeKaryotypeQuery } from 'src/shared/state/genome/genomeApiSlice';
+
+import type {
+  BlastJobResult,
+  BlastHit
+} from 'src/content/app/tools/blast/types/blastJob';
+import type { GenomeKaryotypeItem } from 'src/shared/state/genome/genomeTypes';
+
+/**
+ * The purpose of this hook is to be used when displaying results of a BLAST search
+ * run against the genomic DNA (i.e. the hits will be top-level genomic regions).
+ * The hook separates BLAST hits that matched chromosomes from the rest of the hits.
+ */
+const useGroupedBlastHits = (params: {
+  genomeId: string;
+  job: BlastJobResult;
+}) => {
+  const { genomeId, job } = params;
+  const {
+    currentData: genomeKaryotype,
+    isFetching,
+    isError
+  } = useGenomeKaryotypeQuery(genomeId); // the karyotype data has properly sorted top-level sequences
+
+  if (!genomeKaryotype) {
+    return {
+      currentData: undefined,
+      isFetching,
+      isError
+    };
+  }
+
+  /**
+   * If no chromosomeHits and no nonChromosomeHits, output 0 hits
+   * If chromosomeHits and no nonChromosomeHits, output only chromosome hits
+   * If no chromosomeHits, but some nonChromosomeHits, output only nonChromosomeHits
+   */
+
+  const { chromosomeHits, nonChromosomeHits } = partitionBlastHits({
+    karyotype: genomeKaryotype,
+    job
+  });
+  const topMatches = getTopMatches(chromosomeHits);
+
+  return {
+    currentData: {
+      chromosomeHits,
+      nonChromosomeHits,
+      topMatches
+    },
+    isFetching,
+    isError
+  };
+};
+
+/**
+ * Separate BLAST hits into the ones that occurred on chromosomes
+ * (as defined by whatever our apis include in the "karyotype" response),
+ * and the rest.
+ *
+ * Only the hits against chromosomes will be drawn in the diagram.
+ */
+const partitionBlastHits = ({
+  karyotype,
+  job
+}: {
+  karyotype: GenomeKaryotypeItem[];
+  job: BlastJobResult;
+}) => {
+  const chromosomeNames = new Set(karyotype.map((item) => item.name));
+  const chromosomeHits: BlastHit[] = [];
+  const nonChromosomeHits: BlastHit[] = [];
+
+  for (const hit of job.hits) {
+    if (chromosomeNames.has(hit.hit_acc)) {
+      chromosomeHits.push(hit);
+    } else {
+      nonChromosomeHits.push(hit);
+    }
+  }
+
+  return {
+    chromosomeHits,
+    nonChromosomeHits
+  };
+};
+
+/**
+ * Compact view shows regions with top five BLAST matches, according to eValue
+ * (the smaller the eValue, the better the match)
+ */
+const getTopMatches = (hits: BlastHit[]) => {
+  const sortedHsps = hits
+    .flatMap((hit) => {
+      return hit.hit_hsps.map((hit_hsp) => ({
+        start: Math.min(hit_hsp.hsp_hit_from, hit_hsp.hsp_hit_to),
+        end: Math.max(hit_hsp.hsp_hit_from, hit_hsp.hsp_hit_to),
+        eValue: hit_hsp.hsp_expect,
+        regionName: hit.hit_acc
+      }));
+    })
+    .toSorted((hitA, hitB) => hitA.eValue - hitB.eValue);
+
+  return sortedHsps.slice(0, 5);
+};
+
+export default useGroupedBlastHits;

--- a/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/useGroupedBlastHits.ts
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/useGroupedBlastHits.ts
@@ -64,11 +64,11 @@ const useGroupedBlastHits = (params: {
 };
 
 /**
- * Separate BLAST hits into the ones that occurred on chromosomes
+ * Separate BLAST hits into the ones that matched chromosomes
  * (as defined by whatever our apis include in the "karyotype" response),
- * and the rest.
+ * and the ones that matched other top-level regions.
  *
- * Only the hits against chromosomes will be drawn in the diagram.
+ * Only the hits that matched chromosomes will be drawn in the diagram.
  */
 const partitionBlastHits = ({
   karyotype,


### PR DESCRIPTION
## Description

### Problem
The BLAST results summary view, which shows hits count, was not accounting for the fact that genomes may have top-level regions that are either assembled at the chromosome level, or not (or both). As a result, the hits counter and the chromosome diagram became inconsistent with each other, e.g. as on the screenshot below (see the Indian false vampire):

![image](https://github.com/Ensembl/ensembl-client/assets/6834224/af2c3993-a495-49a5-beb9-a9a206dba5df)

### Changes introduced in this PR
This PR separates BLAST hits into those that have matched chromosomes (as reported by the `karyotype` endpoint of the metadata api) as opposed to the rest of the top-level regions. From the code perspective, the logic for doing this has been moved into the `useGroupedBlastHits` hook, along with the logic for identifying the five top matches, which previously lived in the `BlastGenomicHitsDiagram` component. The result is shown on the screenshot below:

![image](https://github.com/Ensembl/ensembl-client/assets/6834224/f255c9d9-0e6a-4652-94ca-3d5a4e02cce7)

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2310

## Deployment URL(s)
http://blast-unassembled-regions.review.ensembl.org