### PR TITLE
Show colour values in colour cards in Storybook

### DIFF
--- a/stories/design-primitives/colours/ColourCard.tsx
+++ b/stories/design-primitives/colours/ColourCard.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FunctionComponent } from 'react';
+import { useState, useEffect } from 'react';
 
 import styles from './ColourCard.module.css';
 
@@ -23,7 +23,21 @@ type Props = {
   variableName: string;
 };
 
-const ColourCard: FunctionComponent<Props> = (props) => {
+const ColourCard = (props: Props) => {
+  const [color, setColor] = useState<string | null>(null);
+
+  useEffect(() => {
+    // read back from the DOM the color value
+    // encoded by the color name custom property
+    const rootElement = document.querySelector('html') as HTMLElement;
+    const color = getComputedStyle(rootElement)
+      .getPropertyValue(props.variableName)
+      .trim();
+    if (color) {
+      setColor(color);
+    }
+  }, []);
+
   return (
     <div className={styles.colourCard}>
       <div
@@ -33,6 +47,7 @@ const ColourCard: FunctionComponent<Props> = (props) => {
       <div className={styles.colourInfo}>
         <div className={styles.colourName}>{props.name}</div>
         <div>{props.variableName}</div>
+        {!!color && <div>{color}</div>}
       </div>
     </div>
   );


### PR DESCRIPTION
## Description
During migration from SCSS to CSS, I removed the colour values (the actual hexadecimal colour codes) from the colour cards in Storybook, because, when we still used SCSS, the colour values were imported into javascript via a non-standard SCSS export; and there were no analogs for it in CSS.

It turns out Andrea looks at our Storybook for the list of colours used on the website and wants the colour values back.

This PR reads the values of the custom properties from the root DOM element on which they are registered, and displays them in the cards.

**Before:**

![image](https://github.com/Ensembl/ensembl-client/assets/6834224/7f1a9abe-4bef-4259-8aca-abfeadb20cf2)

**After:**

![image](https://github.com/Ensembl/ensembl-client/assets/6834224/21ea3309-7901-4cba-88b6-eb5f5952cb39)
