### PR TITLE
Vep species selector

### DIFF
--- a/src/content/app/tools/vep/VepPageContent.module.css
+++ b/src/content/app/tools/vep/VepPageContent.module.css
@@ -1,0 +1,4 @@
+.grid {
+  display: grid;
+  grid-template-rows: auto auto 1fr;
+}

--- a/src/content/app/tools/vep/VepPageContent.tsx
+++ b/src/content/app/tools/vep/VepPageContent.tsx
@@ -19,12 +19,16 @@ import { Route, Routes } from 'react-router-dom';
 import VepAppBar from './components/vep-app-bar/VepAppBar';
 import VepTopBar from './components/vep-top-bar/VepTopBar';
 import VepForm from './views/vep-form/VepForm';
+import VepSpeciesSelector from './views/vep-species-selector/VepSpeciesSelector';
 import { NotFoundErrorScreen } from 'src/shared/components/error-screen';
+
+import styles from './VepPageContent.module.css';
 
 const VepPageContent = () => {
   return (
-    <div>
+    <div className={styles.grid}>
       <VepAppBar />
+      <VepTopBar />
       <Main />
     </div>
   );
@@ -32,25 +36,25 @@ const VepPageContent = () => {
 
 const Main = () => {
   return (
-    <div>
-      <VepTopBar />
-
-      <Routes>
-        <Route index={true} element={<VepForm />} />
+    <Routes>
+      <Route index={true} element={<VepForm />} />
+      <Route
+        path="species-selector"
+        element={<VepSpeciesSelector />}
+      />
+      <Route
+        path="unviewed-submissions"
+        element={<div>List of unviewed submissions</div>}
+      />
+      <Route path="submissions">
+        <Route index={true} element={<div>List of viewed submissions</div>} />
         <Route
-          path="unviewed-submissions"
-          element={<div>List of unviewed submissions</div>}
+          path=":submissionId"
+          element={<div>Results of a single VEP analysis</div>}
         />
-        <Route path="submissions">
-          <Route index={true} element={<div>List of viewed submissions</div>} />
-          <Route
-            path=":submissionId"
-            element={<div>Results of a single VEP analysis</div>}
-          />
-        </Route>
-        <Route path="*" element={<NotFoundErrorScreen />} />
-      </Routes>
-    </div>
+      </Route>
+      <Route path="*" element={<NotFoundErrorScreen />} />
+    </Routes>
   );
 };
 

--- a/src/content/app/tools/vep/state/vep-form/vepFormSelectors.ts
+++ b/src/content/app/tools/vep/state/vep-form/vepFormSelectors.ts
@@ -1,0 +1,20 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { RootState } from 'src/store';
+
+export const getSelectedSpecies = (state: RootState) =>
+  state.vep.vepForm.selectedSpecies;

--- a/src/content/app/tools/vep/state/vep-form/vepFormSlice.ts
+++ b/src/content/app/tools/vep/state/vep-form/vepFormSlice.ts
@@ -1,0 +1,46 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import type { CommittedItem } from 'src/content/app/species-selector/types/committedItem';
+
+type VepSelectedSpecies = Omit<CommittedItem, 'isEnabled'>;
+
+export type VepFormState = {
+  selectedSpecies: VepSelectedSpecies | null;
+};
+
+export const initialState: VepFormState = {
+  selectedSpecies: null
+};
+
+const vepFormSlice = createSlice({
+  name: 'vep-form',
+  initialState,
+  reducers: {
+    setSelectedSpecies: (
+      state,
+      action: PayloadAction<{ species: VepSelectedSpecies }>
+    ) => {
+      state.selectedSpecies = action.payload.species;
+    }
+  }
+});
+
+export const { setSelectedSpecies } = vepFormSlice.actions;
+
+export default vepFormSlice.reducer;

--- a/src/content/app/tools/vep/state/vepReducer.ts
+++ b/src/content/app/tools/vep/state/vepReducer.ts
@@ -1,0 +1,23 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { combineReducers } from 'redux';
+
+import vepFormReducer from './vep-form/vepFormSlice';
+
+export default combineReducers({
+  vepForm: vepFormReducer
+});

--- a/src/content/app/tools/vep/views/vep-form/VepForm.tsx
+++ b/src/content/app/tools/vep/views/vep-form/VepForm.tsx
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+import { Link } from 'react-router-dom';
+
+import * as urlFor from 'src/shared/helpers/urlHelper';
+
 import FormSection from 'src/content/app/tools/vep/components/form-section/FormSection';
 import PlusButton from 'src/shared/components/plus-button/PlusButton';
 import TextButton from 'src/shared/components/text-button/TextButton';
@@ -39,11 +43,13 @@ const VepForm = () => {
         <div className={styles.topFormSectionRegularGrid}>
           <div className={styles.topFormSectionName}>Species</div>
           <div className={styles.topFormSectionMain}>
-            <TextButton>Select a species / assembly</TextButton>
+            <Link to={urlFor.vepSpeciesSelector()}>
+              Select a species / assembly
+            </Link>
           </div>
-          <div className={styles.topFormSectionToggle}>
+          <Link to={urlFor.vepSpeciesSelector()} className={styles.topFormSectionToggle}>
             <PlusButton />
-          </div>
+          </Link>
         </div>
       </FormSection>
       <FormSection className={styles.formSection}>

--- a/src/content/app/tools/vep/views/vep-form/VepForm.tsx
+++ b/src/content/app/tools/vep/views/vep-form/VepForm.tsx
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { Link } from 'react-router-dom';
-
-import * as urlFor from 'src/shared/helpers/urlHelper';
-
+import {
+  VepFormSpecies,
+  VepSpeciesSelectorNavButton
+} from './vep-form-species-section/VepFormSpeciesSection';
 import FormSection from 'src/content/app/tools/vep/components/form-section/FormSection';
 import PlusButton from 'src/shared/components/plus-button/PlusButton';
 import TextButton from 'src/shared/components/text-button/TextButton';
@@ -42,14 +42,10 @@ const VepForm = () => {
       <FormSection className={styles.formSection}>
         <div className={styles.topFormSectionRegularGrid}>
           <div className={styles.topFormSectionName}>Species</div>
-          <div className={styles.topFormSectionMain}>
-            <Link to={urlFor.vepSpeciesSelector()}>
-              Select a species / assembly
-            </Link>
-          </div>
-          <Link to={urlFor.vepSpeciesSelector()} className={styles.topFormSectionToggle}>
-            <PlusButton />
-          </Link>
+          <VepFormSpecies className={styles.topFormSectionMain} />
+          <VepSpeciesSelectorNavButton
+            className={styles.topFormSectionToggle}
+          />
         </div>
       </FormSection>
       <FormSection className={styles.formSection}>

--- a/src/content/app/tools/vep/views/vep-form/vep-form-species-section/VepFormSpeciesSection.module.css
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-species-section/VepFormSpeciesSection.module.css
@@ -1,0 +1,3 @@
+.commonName {
+  font-weight: var(--font-weight-bold);
+}

--- a/src/content/app/tools/vep/views/vep-form/vep-form-species-section/VepFormSpeciesSection.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-species-section/VepFormSpeciesSection.tsx
@@ -1,0 +1,71 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Link } from 'react-router-dom';
+
+import * as urlFor from 'src/shared/helpers/urlHelper';
+
+import { useAppSelector } from 'src/store';
+
+import { getSelectedSpecies } from 'src/content/app/tools/vep/state/vep-form/vepFormSelectors';
+
+import {
+  ScientificName,
+  AssemblyName
+} from 'src/shared/components/species-name-parts';
+import PlusButton from 'src/shared/components/plus-button/PlusButton';
+import TextButton from 'src/shared/components/text-button/TextButton';
+
+import styles from './VepFormSpeciesSection.module.css';
+
+/**
+ * TODO: Consider the following
+ * The component below displays a species label after a species has been selected for VEP analysis.
+ *   - Is this going to be a recurring pattern of displaying species info outside of tables?
+ *   - Does it need to show the type information for the selected assembly (is reference, population)?
+ *   - Does it need to consider user's selection of species info display (as chosen in species manager)
+ * The answer may justify exxtracting this into a reusable component.
+ */
+
+const vepSpeciesSelectorUrl = urlFor.vepSpeciesSelector();
+
+export const VepFormSpecies = (props: { className?: string }) => {
+  const selectedSpecies = useAppSelector(getSelectedSpecies);
+
+  if (!selectedSpecies) {
+    return <Link to={vepSpeciesSelectorUrl}>Select a species / assembly</Link>;
+  }
+
+  return (
+    <div className={props.className}>
+      {selectedSpecies.common_name && (
+        <span className={styles.commonName}>{selectedSpecies.common_name}</span>
+      )}
+      {!selectedSpecies.common_name && <ScientificName {...selectedSpecies} />}{' '}
+      <AssemblyName {...selectedSpecies} />
+    </div>
+  );
+};
+
+export const VepSpeciesSelectorNavButton = (props: { className?: string }) => {
+  const selectedSpecies = useAppSelector(getSelectedSpecies);
+
+  return (
+    <Link to={vepSpeciesSelectorUrl} className={props.className}>
+      {!selectedSpecies ? <PlusButton /> : <TextButton>Change</TextButton>}
+    </Link>
+  );
+};

--- a/src/content/app/tools/vep/views/vep-species-selector/VepSpeciesSelector.module.css
+++ b/src/content/app/tools/vep/views/vep-species-selector/VepSpeciesSelector.module.css
@@ -9,3 +9,21 @@
   overflow: auto;
   padding-bottom: var(--global-padding-bottom);
 }
+
+/* Question to consider: is the top section of a species selector
+   a sufficiently stable and repeatable component
+   to be extracted into a shared component?
+   Note: so far, the top section in vep species selector
+   does not have a filter element in the design.
+   We will see if we will need to bring it in.
+*/
+.topSection {
+  display: flex;
+  flex-direction: column;
+  row-gap: 32px;
+}
+
+.loader {
+  margin-top: 40px;
+  margin-left: 60px;
+}

--- a/src/content/app/tools/vep/views/vep-species-selector/VepSpeciesSelector.module.css
+++ b/src/content/app/tools/vep/views/vep-species-selector/VepSpeciesSelector.module.css
@@ -1,0 +1,11 @@
+.grid {
+  display: grid;
+  grid-template-rows: auto auto 1fr;
+  margin-left: var(--global-padding-left);
+  height: 100%;
+}
+
+.tableContainer {
+  overflow: auto;
+  padding-bottom: var(--global-padding-bottom);
+}

--- a/src/content/app/tools/vep/views/vep-species-selector/VepSpeciesSelector.tsx
+++ b/src/content/app/tools/vep/views/vep-species-selector/VepSpeciesSelector.tsx
@@ -1,0 +1,214 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, useDeferredValue, type FormEvent } from 'react';
+import { useNavigate } from 'react-router';
+
+import { useLazyGetSpeciesSearchResultsQuery } from 'src/content/app/species-selector/state/species-selector-api-slice/speciesSelectorApiSlice';
+
+import useSelectableGenomesTable from 'src/content/app/species-selector/components/selectable-genomes-table/useSelectableGenomesTable';
+
+import AddSpecies from 'src/content/app/species-selector/components/species-search-field/AddSpecies';
+import { SpeciesSearchField } from 'src/content/app/species-selector/components/species-search-field/SpeciesSearchField';
+import SpeciesSearchResultsSummary from 'src/content/app/species-selector/components/species-search-results-summary/SpeciesSearchResultsSummary';
+import SpeciesSearchResultsTable from 'src/content/app/species-selector/components/species-search-results-table/SpeciesSearchResultsTable';
+import ModalView from 'src/shared/components/modal-view/ModalView';
+import { CircleLoader } from 'src/shared/components/loader';
+
+import type { SpeciesSearchResponse } from 'src/content/app/species-selector/state/species-selector-api-slice/speciesSelectorApiSlice';
+import type { SpeciesSearchMatch } from 'src/content/app/species-selector/types/speciesSearchMatch';
+
+import styles from './VepSpeciesSelector.module.css';
+
+type Props = {
+  // selectedSpecies: Array<{ genome_id: string }>;
+  // onSpeciesAdd: (genomes: SpeciesSearchMatch[]) => void;
+  // onClose: () => void;
+};
+
+/**
+ * NOTE
+ * This component is similar to BLAST species selector, with the following notable differences
+ * - It only allows user to select a single genome
+ * - The view might have a list of popular species if/when we figure out where to get it from
+ */
+
+
+/**
+ * TODO:
+ * - Store selected species in redux state
+ * - Display species information in the form
+ * - Possibly, enable the "Add variants" box after species is selected
+ */
+
+
+const VepSpeciesSelector = (
+  props: Props
+) => {
+  // const { selectedSpecies } = props;
+  const [searchQuery, setSearchQuery] = useState('');
+  const [canSubmitSearch, setCanSubmitSearch] = useState(false);
+  const [searchTrigger, result] = useLazyGetSpeciesSearchResultsQuery();
+  const { currentData, isLoading, isError } = result;
+  const navigate = useNavigate();
+
+  const {
+    genomes,
+    stagedGenomes,
+    isTableExpanded,
+    onTableExpandToggle,
+    onGenomeStageToggle,
+    sortRule,
+    changeSortRule
+  } = useSelectableGenomesTable({
+    genomes: currentData?.matches ?? [],
+    selectedGenomes: [],
+  });
+
+  const deferredGenomes = useDeferredValue(genomes);
+
+  const onSearchInput = (event: FormEvent<HTMLInputElement>) => {
+    setSearchQuery(event.currentTarget.value);
+    if (!canSubmitSearch) {
+      setCanSubmitSearch(true);
+    }
+  };
+
+  const onSpeciesAdd = () => {
+    console.log({ stagedGenomes });
+    // props.onSpeciesAdd(stagedGenomes);
+  };
+
+  const onSearchSubmit = () => {
+    searchTrigger({ query: searchQuery });
+    setCanSubmitSearch(false);
+  };
+
+  const onClose = () => {
+    navigate(-1);
+  };
+
+  return (
+    <ModalView onClose={onClose}>
+      <div className={styles.grid}>
+        <TopSection
+          query={searchQuery}
+          isLoading={isLoading}
+          isError={isError}
+          searchResults={currentData}
+          canAddGenomes={stagedGenomes.length > 0}
+          canSubmitSearch={canSubmitSearch}
+          onSearchSubmit={onSearchSubmit}
+          onSearchInput={onSearchInput}
+          onGenomesAdd={onSpeciesAdd}
+          onClose={onClose}
+        />
+
+        {currentData?.matches.length ? (
+          <div className={styles.tableContainer}>
+            <SpeciesSearchResultsTable
+              results={deferredGenomes}
+              isExpanded={isTableExpanded}
+              maxStagedGenomesNumber={1}
+              sortRule={sortRule}
+              onSortRuleChange={changeSortRule}
+              onTableExpandToggle={onTableExpandToggle}
+              onSpeciesSelectToggle={onGenomeStageToggle}
+            />
+          </div>
+        ) : null}
+      </div>
+    </ModalView>
+  );
+};
+
+type TopSectionProps = {
+  query: string;
+  isLoading: boolean;
+  isError: boolean;
+  searchResults?: SpeciesSearchResponse;
+  canAddGenomes: boolean;
+  canSubmitSearch: boolean;
+  onSearchSubmit: () => void;
+  onSearchInput: (event: FormEvent<HTMLInputElement>) => void;
+  onGenomesAdd: () => void;
+  onClose: () => void;
+};
+
+const TopSection = (props: TopSectionProps) => {
+  if (props.isError) {
+    return <div>An unexpected error happened during search.</div>;
+  }
+
+  if (props.isLoading) {
+    return (
+      <>
+        <AddSpecies
+          query={props.query}
+          canAdd={false}
+          onAdd={props.onGenomesAdd}
+          onClose={props.onClose}
+        />
+        <CircleLoader className={styles.loader} />
+      </>
+    );
+  }
+
+  // search returned some results
+  if (props.searchResults?.matches.length) {
+    return (
+      <section className={styles.topSection}>
+        <div className={styles.searchFieldWrapper}>
+          <AddSpecies
+            query={props.query}
+            canAdd={props.canAddGenomes}
+            onAdd={props.onGenomesAdd}
+            onClose={props.onClose}
+          />
+        </div>
+        <div className={styles.resultsSummaryWrapper}>
+          <SpeciesSearchResultsSummary searchResults={props.searchResults} />
+        </div>
+      </section>
+    );
+  }
+
+  // search returned no results
+  if (!props.searchResults || props.searchResults?.matches.length === 0) {
+    return (
+      <section className={styles.topSection}>
+        <div className={styles.searchFieldWrapper}>
+          <SpeciesSearchField
+            query={props.query}
+            onInput={props.onSearchInput}
+            canSubmit={props.canSubmitSearch}
+            onSearchSubmit={props.onSearchSubmit}
+          />
+        </div>
+        {props.searchResults && (
+          <div className={styles.resultsSummaryWrapper}>
+            <SpeciesSearchResultsSummary searchResults={props.searchResults} />
+          </div>
+        )}
+      </section>
+    );
+  }
+
+  // this shouldn't happen
+  return null;
+};
+
+export default VepSpeciesSelector;

--- a/src/content/app/tools/vep/views/vep-species-selector/VepSpeciesSelector.tsx
+++ b/src/content/app/tools/vep/views/vep-species-selector/VepSpeciesSelector.tsx
@@ -17,7 +17,10 @@
 import { useState, useDeferredValue, type FormEvent } from 'react';
 import { useNavigate } from 'react-router';
 
+import { useAppDispatch } from 'src/store';
+
 import { useLazyGetSpeciesSearchResultsQuery } from 'src/content/app/species-selector/state/species-selector-api-slice/speciesSelectorApiSlice';
+import { setSelectedSpecies } from 'src/content/app/tools/vep/state/vep-form/vepFormSlice';
 
 import useSelectableGenomesTable from 'src/content/app/species-selector/components/selectable-genomes-table/useSelectableGenomesTable';
 
@@ -29,15 +32,8 @@ import ModalView from 'src/shared/components/modal-view/ModalView';
 import { CircleLoader } from 'src/shared/components/loader';
 
 import type { SpeciesSearchResponse } from 'src/content/app/species-selector/state/species-selector-api-slice/speciesSelectorApiSlice';
-import type { SpeciesSearchMatch } from 'src/content/app/species-selector/types/speciesSearchMatch';
 
 import styles from './VepSpeciesSelector.module.css';
-
-type Props = {
-  // selectedSpecies: Array<{ genome_id: string }>;
-  // onSpeciesAdd: (genomes: SpeciesSearchMatch[]) => void;
-  // onClose: () => void;
-};
 
 /**
  * NOTE
@@ -46,7 +42,6 @@ type Props = {
  * - The view might have a list of popular species if/when we figure out where to get it from
  */
 
-
 /**
  * TODO:
  * - Store selected species in redux state
@@ -54,16 +49,13 @@ type Props = {
  * - Possibly, enable the "Add variants" box after species is selected
  */
 
-
-const VepSpeciesSelector = (
-  props: Props
-) => {
-  // const { selectedSpecies } = props;
+const VepSpeciesSelector = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [canSubmitSearch, setCanSubmitSearch] = useState(false);
   const [searchTrigger, result] = useLazyGetSpeciesSearchResultsQuery();
   const { currentData, isLoading, isError } = result;
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
 
   const {
     genomes,
@@ -75,7 +67,7 @@ const VepSpeciesSelector = (
     changeSortRule
   } = useSelectableGenomesTable({
     genomes: currentData?.matches ?? [],
-    selectedGenomes: [],
+    selectedGenomes: []
   });
 
   const deferredGenomes = useDeferredValue(genomes);
@@ -88,8 +80,10 @@ const VepSpeciesSelector = (
   };
 
   const onSpeciesAdd = () => {
-    console.log({ stagedGenomes });
-    // props.onSpeciesAdd(stagedGenomes);
+    const selectedGenome = stagedGenomes[0]; // user can select only one genome VEP analysis at a time
+
+    dispatch(setSelectedSpecies({ species: selectedGenome }));
+    onClose();
   };
 
   const onSearchSubmit = () => {
@@ -189,8 +183,8 @@ const TopSection = (props: TopSectionProps) => {
   // search returned no results
   if (!props.searchResults || props.searchResults?.matches.length === 0) {
     return (
-      <section className={styles.topSection}>
-        <div className={styles.searchFieldWrapper}>
+      <section>
+        <div>
           <SpeciesSearchField
             query={props.query}
             onInput={props.onSearchInput}
@@ -199,7 +193,7 @@ const TopSection = (props: TopSectionProps) => {
           />
         </div>
         {props.searchResults && (
-          <div className={styles.resultsSummaryWrapper}>
+          <div>
             <SpeciesSearchResultsSummary searchResults={props.searchResults} />
           </div>
         )}

--- a/src/content/app/tools/vep/views/vep-species-selector/VepSpeciesSelector.tsx
+++ b/src/content/app/tools/vep/views/vep-species-selector/VepSpeciesSelector.tsx
@@ -42,13 +42,6 @@ import styles from './VepSpeciesSelector.module.css';
  * - The view might have a list of popular species if/when we figure out where to get it from
  */
 
-/**
- * TODO:
- * - Store selected species in redux state
- * - Display species information in the form
- * - Possibly, enable the "Add variants" box after species is selected
- */
-
 const VepSpeciesSelector = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [canSubmitSearch, setCanSubmitSearch] = useState(false);

--- a/src/root/rootReducer.ts
+++ b/src/root/rootReducer.ts
@@ -26,6 +26,7 @@ import speciesSelector from 'src/content/app/species-selector/state/speciesSelec
 import entityViewer from 'src/content/app/entity-viewer/state/entityViewerReducer';
 import speciesPage from 'src/content/app/species/state/index';
 import blast from 'src/content/app/tools/blast/state/blastReducer';
+import vep from 'src/content/app/tools/vep/state/vepReducer';
 
 import graphqlApiSlice from 'src/shared/state/api-slices/graphqlApiSlice';
 import restApiSlice from 'src/shared/state/api-slices/restSlice';
@@ -42,6 +43,7 @@ const createRootReducer = () =>
     speciesPage,
     entityViewer,
     blast,
+    vep,
     [graphqlApiSlice.reducerPath]: graphqlApiSlice.reducer,
     [restApiSlice.reducerPath]: restApiSlice.reducer
   });

--- a/src/shared/helpers/urlHelper.ts
+++ b/src/shared/helpers/urlHelper.ts
@@ -176,6 +176,12 @@ export const blastSubmissionsList = () => '/blast/submissions';
 export const blastSubmission = (submissionId: string) =>
   `/blast/submissions/${submissionId}`;
 
+export const vepForm = () => '/vep';
+
+export const vepSpeciesSelector = () => '/vep/species-selector';
+
+
+
 type RefgetUrlParams = {
   checksum: string;
   start?: number;


### PR DESCRIPTION
## Description
Add a species selector screen to the VEP form

- The species selector screen has its own route
- Only one genome can be selected at a time
- Added a redux slice for vep form state, which currently only has a "selectedSpecies" field. Selecting a species adds it to the slice


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2592

## Deployment URL(s)
http://vep-species-selector.review.ensembl.org