### PR TITLE
Add the variants section to the VEP input form

### DIFF
--- a/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence.module.css
+++ b/src/content/app/tools/blast/components/blast-input-sequences/BlastInputSequence.module.css
@@ -27,12 +27,6 @@
   border: var(--border);
 }
 
-/* FIXME: this is a hack */
-.body [class*='defaultUpload'] {
-  width: 112px;
-  margin-left: 18px;
-}
-
 .textarea {
   font-family: var(--font-family-monospace);
   font-size: 12px;

--- a/src/content/app/tools/vep/views/vep-form/VepForm.tsx
+++ b/src/content/app/tools/vep/views/vep-form/VepForm.tsx
@@ -18,9 +18,8 @@ import {
   VepFormSpecies,
   VepSpeciesSelectorNavButton
 } from './vep-form-species-section/VepFormSpeciesSection';
+import VepFormVariantsSection from './vep-form-variants-section/VepFormVariantsSection';
 import FormSection from 'src/content/app/tools/vep/components/form-section/FormSection';
-import PlusButton from 'src/shared/components/plus-button/PlusButton';
-import TextButton from 'src/shared/components/text-button/TextButton';
 import ShadedInput from 'src/shared/components/input/ShadedInput';
 import { DeleteButtonWithLabel } from 'src/shared/components/delete-button/DeleteButton';
 
@@ -48,17 +47,7 @@ const VepForm = () => {
           />
         </div>
       </FormSection>
-      <FormSection className={styles.formSection}>
-        <div className={styles.topFormSectionRegularGrid}>
-          <div className={styles.topFormSectionName}>Variants</div>
-          <div className={styles.topFormSectionMain}>
-            <TextButton disabled={true}>Add variants</TextButton>
-          </div>
-          <div className={styles.topFormSectionToggle}>
-            <PlusButton disabled={true} />
-          </div>
-        </div>
-      </FormSection>
+      <VepFormVariantsSection />
     </div>
   );
 };

--- a/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.module.css
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.module.css
@@ -54,6 +54,12 @@
   margin-right: 50px;
 }
 
+.fileDropZoneOutline {
+  display: flex;
+  align-items: center;
+  height: 58px;
+}
+
 .alignSelfCenter {
   align-self: center;
 }

--- a/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.module.css
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.module.css
@@ -1,0 +1,59 @@
+/*
+  For consideration:
+  Is it worth extracting the background color and the top/bottom padding
+  into some subcomponent of the FormSection component,
+  and if yes, then what would it be called?
+*/
+.expandedContentGrid {
+  --column-gap: 12px;
+  display: grid;
+  grid-template-columns: [left] 120px [middle] 450px [right] auto;
+  column-gap: var(--column-gap);
+  background-color: var(--color-light-grey);
+  padding: 24px 0;
+}
+
+.gridColumnLeft {
+  grid-column: left;
+  justify-self: end;
+  text-align: right;
+}
+
+.gridColumnMiddle {
+  grid-column: middle;
+}
+
+.gridColumnRight {
+  grid-column: right;
+  justify-self: start;
+}
+
+.inputControlButtons {
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  row-gap: 24px;
+  padding-top: var(--standard-gutter);
+  padding-left: calc(var(--standard-gutter) - var(--column-gap)); /* to achieve the same distance from textarea as the width of the standard gutter */
+}
+
+.textarea {
+  --textarea-height: 142px;
+}
+
+.fileDropZone {
+  width: 100%;
+}
+
+.fileDropZoneLabel {
+  display: flex;
+  align-items: center;  
+}
+
+.fileDropZoneLabel > span {
+  margin-right: 50px;
+}
+
+.alignSelfCenter {
+  align-self: center;
+}

--- a/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.tsx
@@ -26,7 +26,8 @@ import PlusButton from 'src/shared/components/plus-button/PlusButton';
 import { PrimaryButton } from 'src/shared/components/button/Button';
 import TextButton from 'src/shared/components/text-button/TextButton';
 import Textarea from 'src/shared/components/textarea/Textarea';
-import FiledropZone from 'src/shared/components/upload/FileDropZone';
+import FileDropZone from 'src/shared/components/upload/FileDropZone';
+import FileDropZoneOutline from 'src/shared/components/upload/FileDropZoneOutline';
 import { CloseButtonWithLabel } from 'src/shared/components/close-button/CloseButton';
 
 import UploadIcon from 'static/icons/icon_upload.svg';
@@ -35,20 +36,8 @@ import commonFormStyles from '../VepForm.module.css';
 import styles from './VepFormVariantsSection.module.css';
 import uploadStyles from 'src/shared/components/upload/Upload.module.css';
 
-/**
- * TODO:
- * - Enable the "Add variants" and the plus button if species is selected
- * - Pressing the button should show the grey-backgrounded contents of the section
- *   - The open/closed state should probably be stored in redux
- * - Show textarea and the file upload button
- * - Initially, the Add button should be disabled
- * - If text entered into the textarea, hide file upload button
- * - If file uploaded, disable the textarea
- * - If either text entered into textarea or file uploaded, enable the Add button, and show the Clear button under it
- */
-
 const VepFormVariantsSection = () => {
-  const [isExpanded, setIsExpanded] = useState(true); // FIXME: initialize to false
+  const [isExpanded, setIsExpanded] = useState(true);
   const selectedSpecies = useAppSelector(getSelectedSpecies);
   const [inputString, setInputString] = useState('');
   const [inputFile, setInputFile] = useState<File | null>(null);
@@ -147,9 +136,18 @@ const ExpandedContents = (props: {
             or
           </div>
           <div className={styles.gridColumnMiddle}>
-            <FiledropZone className={styles.fileDropZone} onUpload={onFileDrop}>
-              <FileDropZoneLabel />
-            </FiledropZone>
+            {!inputFile ? (
+              <FileDropZone
+                className={styles.fileDropZone}
+                onUpload={onFileDrop}
+              >
+                <FileDropZoneLabel />
+              </FileDropZone>
+            ) : (
+              <FileDropZoneOutline className={styles.fileDropZoneOutline}>
+                {inputFile.name}
+              </FileDropZoneOutline>
+            )}
           </div>
         </>
       )}

--- a/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.tsx
@@ -37,7 +37,7 @@ import styles from './VepFormVariantsSection.module.css';
 import uploadStyles from 'src/shared/components/upload/Upload.module.css';
 
 const VepFormVariantsSection = () => {
-  const [isExpanded, setIsExpanded] = useState(true);
+  const [isExpanded, setIsExpanded] = useState(false);
   const selectedSpecies = useAppSelector(getSelectedSpecies);
   const [inputString, setInputString] = useState('');
   const [inputFile, setInputFile] = useState<File | null>(null);

--- a/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.tsx
@@ -1,0 +1,169 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, type FormEvent } from 'react';
+import classNames from 'classnames';
+
+import { useAppSelector } from 'src/store';
+
+import { getSelectedSpecies } from 'src/content/app/tools/vep/state/vep-form/vepFormSelectors';
+
+import FormSection from 'src/content/app/tools/vep/components/form-section/FormSection';
+import PlusButton from 'src/shared/components/plus-button/PlusButton';
+import { PrimaryButton } from 'src/shared/components/button/Button';
+import TextButton from 'src/shared/components/text-button/TextButton';
+import Textarea from 'src/shared/components/textarea/Textarea';
+import FiledropZone from 'src/shared/components/upload/FileDropZone';
+import { CloseButtonWithLabel } from 'src/shared/components/close-button/CloseButton';
+
+import UploadIcon from 'static/icons/icon_upload.svg';
+
+import commonFormStyles from '../VepForm.module.css';
+import styles from './VepFormVariantsSection.module.css';
+import uploadStyles from 'src/shared/components/upload/Upload.module.css';
+
+/**
+ * TODO:
+ * - Enable the "Add variants" and the plus button if species is selected
+ * - Pressing the button should show the grey-backgrounded contents of the section
+ *   - The open/closed state should probably be stored in redux
+ * - Show textarea and the file upload button
+ * - Initially, the Add button should be disabled
+ * - If text entered into the textarea, hide file upload button
+ * - If file uploaded, disable the textarea
+ * - If either text entered into textarea or file uploaded, enable the Add button, and show the Clear button under it
+ */
+
+const VepFormVariantsSection = () => {
+  const [isExpanded, setIsExpanded] = useState(true); // FIXME: initialize to false
+  const selectedSpecies = useAppSelector(getSelectedSpecies);
+  const [inputString, setInputString] = useState('');
+  const [inputFile, setInputFile] = useState<File | null>(null);
+
+  const toggleExpanded = () => {
+    setIsExpanded(!isExpanded);
+  };
+
+  const onReset = () => {
+    setInputString('');
+    setInputFile(null);
+  };
+
+  const canExpand = !!selectedSpecies;
+
+  return (
+    <FormSection className={commonFormStyles.formSection}>
+      <div className={commonFormStyles.topFormSectionRegularGrid}>
+        <div className={commonFormStyles.topFormSectionName}>Variants</div>
+        <div className={commonFormStyles.topFormSectionMain}>
+          <TextButton disabled={!canExpand} onClick={toggleExpanded}>
+            Add variants
+          </TextButton>
+        </div>
+        <div className={commonFormStyles.topFormSectionToggle}>
+          {isExpanded ? (
+            <CloseButtonWithLabel onClick={toggleExpanded} />
+          ) : (
+            <PlusButton disabled={!canExpand} onClick={toggleExpanded} />
+          )}
+        </div>
+      </div>
+      {isExpanded && (
+        <ExpandedContents
+          inputString={inputString}
+          setInputString={setInputString}
+          inputFile={inputFile}
+          setInputFile={setInputFile}
+          onReset={onReset}
+        />
+      )}
+    </FormSection>
+  );
+};
+
+const ExpandedContents = (props: {
+  inputString: string;
+  setInputString: (val: string) => void;
+  inputFile: File | null;
+  setInputFile: (file: File) => void;
+  onReset: () => void;
+}) => {
+  const { inputString, inputFile, setInputString, setInputFile, onReset } =
+    props;
+
+  const onTextareaContentChange = (event: FormEvent<HTMLTextAreaElement>) => {
+    setInputString(event.currentTarget.value);
+  };
+
+  const onFileDrop = (file: File) => {
+    setInputFile(file);
+  };
+
+  const hasTextInput = !!inputString;
+  const hasFileInput = !!inputFile;
+  const shouldDisableTextInput = hasFileInput;
+  const shouldDisableFileInput = hasTextInput;
+  const canCommitInput = hasTextInput || hasFileInput;
+
+  return (
+    <div className={styles.expandedContentGrid}>
+      <div className={styles.gridColumnLeft}>Example data</div>
+      <div className={styles.gridColumnMiddle}>
+        <Textarea
+          className={styles.textarea}
+          value={inputString}
+          onChange={onTextareaContentChange}
+          placeholder="Paste data"
+          disabled={shouldDisableTextInput}
+        />
+      </div>
+      <div className={styles.gridColumnRight}>
+        <div className={styles.inputControlButtons}>
+          <PrimaryButton disabled={!canCommitInput}>Add</PrimaryButton>
+          {canCommitInput && <TextButton onClick={onReset}>Clear</TextButton>}
+        </div>
+      </div>
+      {!shouldDisableFileInput && (
+        <>
+          <div
+            className={classNames(
+              styles.gridColumnLeft,
+              styles.alignSelfCenter
+            )}
+          >
+            or
+          </div>
+          <div className={styles.gridColumnMiddle}>
+            <FiledropZone className={styles.fileDropZone} onUpload={onFileDrop}>
+              <FileDropZoneLabel />
+            </FiledropZone>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+const FileDropZoneLabel = () => {
+  return (
+    <div className={styles.fileDropZoneLabel}>
+      <span>Click or drag a VCF here</span>
+      <UploadIcon className={uploadStyles.uploadIcon} />
+    </div>
+  );
+};
+
+export default VepFormVariantsSection;

--- a/src/shared/components/upload/FileDropZone.module.css
+++ b/src/shared/components/upload/FileDropZone.module.css
@@ -1,5 +1,5 @@
 .fileDropZone {
-  display: inline-block; /* not sure whether block or inline-block is more appropriate */
+  display: block; /* not sure whether block or inline-block is more appropriate */
   padding-top: var(--drop-zone-padding-top, 12px);
   padding-bottom: var(--drop-zone-padding-bottom, 12px);
   padding-left: var(--drop-zone-padding-left, 20px);

--- a/src/shared/components/upload/FileDropZone.module.css
+++ b/src/shared/components/upload/FileDropZone.module.css
@@ -1,0 +1,35 @@
+.fileDropZone {
+  display: inline-block; /* not sure whether block or inline-block is more appropriate */
+  padding-top: var(--drop-zone-padding-top, 12px);
+  padding-bottom: var(--drop-zone-padding-bottom, 12px);
+  padding-left: var(--drop-zone-padding-left, 20px);
+  padding-right: var(--drop-zone-padding-right, 20px);
+  border: 1px dashed var(--color-blue);
+  background-color: var(--drop-zone-bg-color, var(--color-white));
+  color: var(--color-blue);
+  cursor: pointer;
+  transition: color 0.4s, border-color 0.4s, background-color 0.4s;
+}
+
+.fileDropZone:focus-visible {
+  background-color: red;
+}
+
+.disabled {
+  border: 1px dashed var(--color-grey);
+  color: var(--color-grey);
+  pointer-events: none;
+}
+
+.draggedOver {
+  background-color: var(--drop-zone-dragover-bg-color, var(--highlighted-upload-button-background));
+}
+
+.fileInput {
+  opacity: 0;
+  overflow: hidden;
+  position: absolute;
+  z-index: -1;
+  height: 1px;
+  width: 1px;
+}

--- a/src/shared/components/upload/FileDropZone.test.tsx
+++ b/src/shared/components/upload/FileDropZone.test.tsx
@@ -16,7 +16,7 @@
 
 import { render, fireEvent, act, waitFor } from '@testing-library/react';
 import noop from 'lodash/noop';
-import Upload from './Upload';
+import FileDropZone from './FileDropZone';
 
 import type { FileTransformedToString } from './types';
 
@@ -35,19 +35,19 @@ describe('Upload', () => {
 
   describe('rendering', () => {
     it('renders an input of type file', () => {
-      const { container } = render(<Upload onUpload={noop} />);
+      const { container } = render(<FileDropZone onUpload={noop} />);
       expect(container.querySelectorAll('input[type="file"]')).toHaveLength(1);
     });
 
-    it('allows upload of only a single file by default', () => {
-      const { container } = render(<Upload onUpload={noop} />);
+    it('accepts only a single file by default', () => {
+      const { container } = render(<FileDropZone onUpload={noop} />);
       const input = container.querySelector('input');
       expect(input?.hasAttribute('multiple')).toBe(false);
     });
 
-    it('allows upload of multiple files', () => {
+    it('can accept multiple files', () => {
       const { container } = render(
-        <Upload onUpload={noop} allowMultiple={true} />
+        <FileDropZone onUpload={noop} allowMultiple={true} />
       );
       const input = container.querySelector('input');
       expect(input?.hasAttribute('multiple')).toBe(true);
@@ -58,7 +58,7 @@ describe('Upload', () => {
     const onUpload = jest.fn();
 
     it('uploads a single file', () => {
-      const { container } = render(<Upload onUpload={onUpload} />);
+      const { container } = render(<FileDropZone onUpload={onUpload} />);
 
       fireEvent.change(container.querySelector('input') as HTMLElement, {
         target: { files: [file1] }
@@ -71,7 +71,7 @@ describe('Upload', () => {
 
     it('uploads multiple files', () => {
       const { container } = render(
-        <Upload onUpload={onUpload} allowMultiple={true} />
+        <FileDropZone onUpload={onUpload} allowMultiple={true} />
       );
 
       fireEvent.change(container.querySelector('input') as HTMLElement, {
@@ -94,7 +94,7 @@ describe('Upload', () => {
         (textFromFile = result.content as string);
 
       const { container } = render(
-        <Upload onUpload={onUpload} transformTo="text" />
+        <FileDropZone onUpload={onUpload} transformTo="text" />
       );
 
       await act(async () => {
@@ -114,7 +114,11 @@ describe('Upload', () => {
         (textFromFile = results.map((result) => result.content).join(' '));
 
       const { container } = render(
-        <Upload onUpload={onUpload} allowMultiple={true} transformTo="text" />
+        <FileDropZone
+          onUpload={onUpload}
+          allowMultiple={true}
+          transformTo="text"
+        />
       );
 
       await act(async () => {
@@ -140,21 +144,21 @@ describe('Upload', () => {
     };
     const onUpload = jest.fn();
 
-    it('changes drop zone class when a file is dragged over', () => {
-      const { container } = render(<Upload onUpload={onUpload} />);
+    it('changes styles when a file is dragged over', () => {
+      const { container } = render(<FileDropZone onUpload={onUpload} />);
       const label = container.querySelector('label') as HTMLElement;
 
       fireEvent.dragEnter(label, mockDragEvent);
 
-      expect(label.classList.contains('uploadDragOver')).toBe(true);
+      expect(label.classList.contains('draggedOver')).toBe(true);
 
       fireEvent.dragLeave(label, mockDragEvent);
 
-      expect(label.classList.contains('uploadDragOver')).toBe(false);
+      expect(label.classList.contains('draggedOver')).toBe(false);
     });
 
     it('uploads a single file', () => {
-      const { container } = render(<Upload onUpload={onUpload} />);
+      const { container } = render(<FileDropZone onUpload={onUpload} />);
       const label = container.querySelector('label') as HTMLElement;
 
       fireEvent.drop(label, mockDragEvent);
@@ -166,7 +170,7 @@ describe('Upload', () => {
 
     it('uploads multiple files', () => {
       const { container } = render(
-        <Upload allowMultiple={true} onUpload={onUpload} />
+        <FileDropZone allowMultiple={true} onUpload={onUpload} />
       );
       const label = container.querySelector('label') as HTMLElement;
 

--- a/src/shared/components/upload/FileDropZone.tsx
+++ b/src/shared/components/upload/FileDropZone.tsx
@@ -1,0 +1,93 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useRef, type ChangeEvent, type ReactNode } from 'react';
+import classNames from 'classnames';
+
+import useFileDrop from './hooks/useFileDrop';
+import { transformFiles, transformFile } from './helpers/uploadHelpers';
+
+import type { FileUploadParams, Options, Result } from './types';
+
+import styles from './FileDropZone.module.css';
+
+/**
+ * Compare:
+ * - Drag-and-drop upload container component of IBM's Carbon design system
+ *   https://web-components.carbondesignsystem.com/?path=/story/components-file-uploader--drag-and-drop-upload-container-example-application
+ *
+ */
+
+export type FiledropZoneProps<T extends Options> = FileUploadParams<T> & {
+  name?: string; // Could be useful if the filedrop zone were inside a form submitted without help of javascript (unlikely)
+  disabled?: boolean;
+  className?: string;
+  children?: ReactNode;
+};
+
+const FiledropZone = <T extends Options>(props: FiledropZoneProps<T>) => {
+  const { allowMultiple, transformTo } = props;
+  const { ref, isDraggedOver } = useFileDrop(props);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleSelectedFiles = async (event: ChangeEvent<HTMLInputElement>) => {
+    const files = [...(event.target.files as FileList)];
+
+    if (transformTo) {
+      const result = allowMultiple
+        ? await transformFiles(files, transformTo)
+        : await transformFile(files[0], transformTo);
+      props.onUpload(result as Result<T>);
+    } else if (allowMultiple) {
+      props.onUpload([...files] as Result<T>);
+    } else {
+      props.onUpload(files[0] as Result<T>);
+    }
+
+    clearInput();
+  };
+
+  const clearInput = () => {
+    const inputElement = inputRef.current;
+    if (inputElement) {
+      inputElement.value = '';
+    }
+  };
+
+  const dropAreaClasses = classNames(
+    styles.fileDropZone,
+    { [styles.disabled]: props.disabled },
+    { [styles.draggedOver]: isDraggedOver },
+    props.className
+  );
+
+  return (
+    <label ref={ref} className={dropAreaClasses}>
+      <input
+        type="file"
+        ref={inputRef}
+        name={props.name}
+        className={styles.fileInput}
+        onChange={(e) => handleSelectedFiles(e)}
+        multiple={props.allowMultiple}
+        disabled={props.disabled}
+      />
+      {props.children}
+    </label>
+  );
+};
+
+export default FiledropZone;

--- a/src/shared/components/upload/FileDropZoneOutline.module.css
+++ b/src/shared/components/upload/FileDropZoneOutline.module.css
@@ -1,0 +1,8 @@
+.container {
+  padding-top: var(--drop-zone-outline-padding-top, 12px);
+  padding-bottom: var(--drop-zone-outline-padding-bottom, 12px);
+  padding-left: var(--drop-zone-outline-padding-left, 20px);
+  padding-right: var(--drop-zone-outline-padding-right, 20px);
+  border: 1px dashed var(--color-blue);
+  background-color: var(--drop-zone-bg-color, var(--color-white));
+}

--- a/src/shared/components/upload/FileDropZoneOutline.tsx
+++ b/src/shared/components/upload/FileDropZoneOutline.tsx
@@ -1,0 +1,38 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classNames from 'classnames';
+import type { ReactNode } from 'react';
+
+import styles from './FileDropZoneOutline.module.css';
+
+/**
+ * This component has a certain visual resemplance to the FileDropZone,
+ * and is used to display the names of files that have been appended via FileDropZone
+ */
+
+type Props = {
+  children: ReactNode;
+  className?: string;
+};
+
+const FileDropZoneOutline = (props: Props) => {
+  const componentClasses = classNames(styles.container, props.className);
+
+  return <div className={componentClasses}>{props.children}</div>;
+};
+
+export default FileDropZoneOutline;

--- a/src/shared/components/upload/FileDropZoneOutline.tsx
+++ b/src/shared/components/upload/FileDropZoneOutline.tsx
@@ -20,7 +20,7 @@ import type { ReactNode } from 'react';
 import styles from './FileDropZoneOutline.module.css';
 
 /**
- * This component has a certain visual resemplance to the FileDropZone,
+ * This component has a certain visual resemblance to the FileDropZone,
  * and is used to display the names of files that have been appended via FileDropZone
  */
 

--- a/src/shared/components/upload/Upload.module.css
+++ b/src/shared/components/upload/Upload.module.css
@@ -1,17 +1,24 @@
+/**
+Variables that need checking across the codebase:
+
+--drop-zone-height
+--drop-zone-width
+--drop-zone-bg-color
+--highlighted-upload-button-background
+
+*/
+
 .upload {
-  display: inline-flex;
+  height: var(--drop-zone-height, var(--upload-button-taller-height));
+  width: var(--drop-zone-width, 200px);
+}
+
+.label {
+  display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: var(--drop-zone-height, var(--upload-button-taller-height));
-  width: var(--drop-zone-width, 200px);
-  background-color: var(--drop-zone-bg-color, var(--color-white));
-  position: relative;
-  border: 1px dashed var(--color-blue);
-  color: var(--color-blue);
-  cursor: pointer;
-  user-select: none;
-  transition: color 0.4s, border-color 0.4s, background-color 0.4s;
+  height: 100%;
 }
 
 .uploadIcon {
@@ -20,40 +27,11 @@
   fill: var(--color-blue);
 }
 
-/* this will prevent dragenter and dragleave events emitted by children of the drop area
-  (although it doesn't remove the need for a javascript solution when other components are used as drop areas) */
-.upload > * {
-  pointer-events: none;
-}
-
-.uploadDragOver {
-  background-color: var(--drop-zone-bg-color, var(--highlighted-upload-button-background));
-}
-
-.uploadDisabled {
-  border: 1px dashed var(--color-grey);
-  color: var(--color-grey);
-  pointer-events: none;
-}
-
-.uploadDisabled .uploadIcon {
+.disabled .uploadIcon {
   fill: var(--color-grey);
 }
 
-.fileInput {
-  opacity: 0;
-  overflow: hidden;
-  position: absolute;
-  z-index: -1;
-  height: 1px;
-  width: 1px;
-}
-
-.defaultUpload:focus-within {
-  background: 1px dashed var(--color-black);
-}
-
-.label {
+.labelText {
   width: var(--upload-label-width, var(--upload-button-two-line-label-width));
   font-size: 12px; /* TODO: make customizable? */
   text-align: center;

--- a/src/shared/components/upload/Upload.module.css
+++ b/src/shared/components/upload/Upload.module.css
@@ -6,9 +6,6 @@ Variables that need checking across the codebase:
 --drop-zone-bg-color
 --highlighted-upload-button-background
 
-Remove
-.body [class*='defaultUpload']
-
 */
 
 .upload {

--- a/src/shared/components/upload/Upload.module.css
+++ b/src/shared/components/upload/Upload.module.css
@@ -6,6 +6,9 @@ Variables that need checking across the codebase:
 --drop-zone-bg-color
 --highlighted-upload-button-background
 
+Remove
+.body [class*='defaultUpload']
+
 */
 
 .upload {

--- a/src/shared/components/upload/Upload.tsx
+++ b/src/shared/components/upload/Upload.tsx
@@ -14,75 +14,48 @@
  * limitations under the License.
  */
 
-import { useRef, type ChangeEvent } from 'react';
 import classNames from 'classnames';
 
-import useFileDrop from './hooks/useFileDrop';
-import { transformFiles, transformFile } from './helpers/uploadHelpers';
-
+import FiledropZone, { type FiledropZoneProps } from './FileDropZone';
 import UploadIcon from 'static/icons/icon_upload.svg';
 
-import type { FileUploadParams, Options, Result } from './types';
+import type { FileUploadParams, Options } from './types';
 
 import styles from './Upload.module.css';
 
 export type UploadProps<T extends Options> = FileUploadParams<T> & {
-  name?: string; // FIXME: do we really need this?
-  label?: string;
+  name?: string; // Could be useful if the filedrop zone were inside a form submitted without help of javascript (unlikely)
   disabled?: boolean;
+  label?: string;
+  className?: string;
 };
 
 const defaultLabel = 'Click or drag a file here to upload';
 
+/**
+ * NOTE:
+ * This component puts an upload icon with the default or slightly customizable label text
+ * inside of the FileDropZone.
+ * If you need more flexibility for your upload button, use FileDropZone directly to create it.
+ */
+
 const Upload = <T extends Options>(props: UploadProps<T>) => {
-  const { allowMultiple, transformTo } = props;
-  const { ref, isDraggedOver } = useFileDrop(props);
-  const inputRef = useRef<HTMLInputElement | null>(null);
-
-  const handleSelectedFiles = async (event: ChangeEvent<HTMLInputElement>) => {
-    const files = [...(event.target.files as FileList)];
-
-    if (transformTo) {
-      const result = allowMultiple
-        ? await transformFiles(files, transformTo)
-        : await transformFile(files[0], transformTo);
-      props.onUpload(result as Result<T>);
-    } else if (allowMultiple) {
-      props.onUpload([...files] as Result<T>);
-    } else {
-      props.onUpload(files[0] as Result<T>);
-    }
-
-    clearInput();
-  };
-
-  const clearInput = () => {
-    const inputElement = inputRef.current;
-    if (inputElement) {
-      inputElement.value = '';
-    }
-  };
-
-  const dropAreaClasses = classNames(
+  const componentClasses = classNames(
     styles.upload,
-    { [styles.uploadDisabled]: props.disabled },
-    { [styles.uploadDragOver]: isDraggedOver }
+    { [styles.disabled]: props.disabled },
+    props.className
   );
 
   return (
-    <label ref={ref} className={dropAreaClasses}>
-      <span className={styles.label}>{props.label || defaultLabel}</span>
-      <UploadIcon className={styles.uploadIcon} />
-      <input
-        type="file"
-        ref={inputRef}
-        name={props.name}
-        className={styles.fileInput}
-        onChange={(e) => handleSelectedFiles(e)}
-        multiple={props.allowMultiple}
-      />
-      {props.label}
-    </label>
+    <FiledropZone
+      {...(props as FiledropZoneProps<T>)}
+      className={componentClasses}
+    >
+      <div className={styles.label}>
+        <span className={styles.labelText}>{props.label || defaultLabel}</span>
+        <UploadIcon className={styles.uploadIcon} />
+      </div>
+    </FiledropZone>
   );
 };
 

--- a/stories/shared-components/upload/FileDropZone.stories.module.css
+++ b/stories/shared-components/upload/FileDropZone.stories.module.css
@@ -1,0 +1,3 @@
+.container {
+  width: 450px;
+}

--- a/stories/shared-components/upload/FileDropZone.stories.tsx
+++ b/stories/shared-components/upload/FileDropZone.stories.tsx
@@ -14,21 +14,36 @@
  * limitations under the License.
  */
 
-import noop from 'lodash/noop';
+import { action } from '@storybook/addon-actions';
 
 import useDisabledDocumentDragover from 'src/root/useDisabledDocumentDragover';
 
 import FiledropZone from 'src/shared/components/upload/FileDropZone';
 
-const FileDropZoneContainer = () => {
+import styles from './FileDropZone.stories.module.css';
+
+type DefaultArgs = {
+  onChange: (...args: any) => void;
+};
+
+const FileDropZoneContainer = (props: DefaultArgs) => {
   useDisabledDocumentDragover();
 
-  return <FiledropZone onUpload={noop}>Hello?</FiledropZone>;
+  return (
+    <div className={styles.container}>
+      <FiledropZone onUpload={props.onChange}>
+        Click me or drop a file on me
+      </FiledropZone>
+    </div>
+  );
 };
 
 export const FileDropZoneStory = {
   name: 'default',
-  render: () => <FileDropZoneContainer />
+  render: (args: DefaultArgs) => <FileDropZoneContainer {...args} />,
+  args: {
+    onChange: action('uploaded')
+  }
 };
 
 export default {

--- a/stories/shared-components/upload/FileDropZone.stories.tsx
+++ b/stories/shared-components/upload/FileDropZone.stories.tsx
@@ -1,0 +1,36 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import noop from 'lodash/noop';
+
+import useDisabledDocumentDragover from 'src/root/useDisabledDocumentDragover';
+
+import FiledropZone from 'src/shared/components/upload/FileDropZone';
+
+const FileDropZoneContainer = () => {
+  useDisabledDocumentDragover();
+
+  return <FiledropZone onUpload={noop}>Hello?</FiledropZone>;
+};
+
+export const FileDropZoneStory = {
+  name: 'default',
+  render: () => <FileDropZoneContainer />
+};
+
+export default {
+  title: 'Components/Shared Components/FileDropZone'
+};


### PR DESCRIPTION
## Description
- Added a VepFormVariantsSection component, which encapsulates the logic that allows user to paste variants or append a file with variants
- The section starts as collapsed and disabled. It needs a selected species to become enabled.
- The "Add variants" button and the plus button of the section can toggle its expanded/collapsed state
- If text is pasted in the textared, the file drop zone is hidden. If a file is appended, the textarea gets disabled.
- If either text is entered into textarea or a file is appended, the Add button is enabled, and the Clear button appears under it

### NOTE
The design of the VEP form has introduced a different shape of the upload button — you can see that it is both shorter than what we used previously, and has a label that looks differently (single line; the icon on the same line):

![Upload button](https://github.com/Ensembl/ensembl-client/assets/6834224/542e86d2-8ccf-4171-b59d-7b3190f6543d)

To achieve this, I split our Upload component into two parts — the `FileDropZone` component that does the heavy work, and the `Upload` component that retains the previous shape of the button for default use cases.


### TODO (in separate PRs)
- Some (or all) aspects of the state of this section, which are currently stored in component's own state will need to be moved to redux
- Show an outline on the FileDropZone component when user focuses on it using keyboard
- Fetch example variant for a genome, and put its vcf representation in the textarea when user clicks on the vcf example button

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2593

## Deployment URL(s)
http://vep-user-input.review.ensembl.org