### PR TITLE
Change method for case-insensitive substring check

### DIFF
--- a/src/content/app/species-selector/components/selectable-genomes-table/filterGenomes.ts
+++ b/src/content/app/species-selector/components/selectable-genomes-table/filterGenomes.ts
@@ -24,24 +24,31 @@ const filterGenomes = ({
   genomes: SpeciesSearchMatch[];
 }) => {
   return genomes.filter((genome) => {
-    const queryRegex = getQueryRegex(query);
-
     return (
-      genome.common_name?.match(queryRegex) ||
-      genome.scientific_name.match(queryRegex) ||
-      genome.type?.kind.match(queryRegex) ||
-      genome.type?.value.match(queryRegex) ||
-      (genome.is_reference && 'reference'.match(queryRegex)) ||
-      genome.assembly.accession_id.match(queryRegex) ||
-      genome.assembly.name.match(queryRegex) ||
-      genome.annotation_provider.match(queryRegex) ||
-      genome.annotation_method.match(queryRegex)
+      isSubstringOf(genome.common_name, query) ||
+      isSubstringOf(genome.scientific_name, query) ||
+      isSubstringOf(genome.type?.kind, query) ||
+      isSubstringOf(genome.type?.value, query) ||
+      (genome.is_reference && isSubstringOf('reference', query)) ||
+      isSubstringOf(genome.assembly.accession_id, query) ||
+      isSubstringOf(genome.assembly.name, query) ||
+      isSubstringOf(genome.assembly.name, query) ||
+      isSubstringOf(genome.annotation_provider, query) ||
+      isSubstringOf(genome.annotation_method, query)
     );
   });
 };
 
-const getQueryRegex = (query: string) => {
-  return new RegExp(query, 'i');
+const isSubstringOf = (
+  string: string | undefined | null,
+  candidateSubstring: string
+) => {
+  if (typeof string !== 'string') {
+    return false;
+  }
+  const normalizedString = string.toUpperCase();
+  const normalizedCandidateString = candidateSubstring.toUpperCase();
+  return normalizedString.includes(normalizedCandidateString);
 };
 
 export default filterGenomes;

--- a/src/content/app/species-selector/components/selectable-genomes-table/filterGenomes.ts
+++ b/src/content/app/species-selector/components/selectable-genomes-table/filterGenomes.ts
@@ -39,6 +39,10 @@ const filterGenomes = ({
   });
 };
 
+// Strings in modern javascript have a .localeCompare method
+// that can do case-insensitive string comparison;
+// but it does not check whether a string contains a substring.
+// The function below is an old an not very elegant way of checking this.
 const isSubstringOf = (
   string: string | undefined | null,
   candidateSubstring: string


### PR DESCRIPTION
## Description
**Bug:** an earlier implementation of the string comparison function for the filter field used user's input to generate a regular expression. Because no characters in user's input were escaped, this resulted in an error if a special character, such as an opening parenthesis, was entered. On the screen capture below, I am adding an opening parenthesis (`(`) after the word "human":

https://github.com/Ensembl/ensembl-client/assets/6834224/749bd858-fa6b-4d09-be35-b45cf1a6d02a

See also a Sentry error report:

![image](https://github.com/Ensembl/ensembl-client/assets/6834224/f187034a-d4d9-4fc1-b821-a154ec968cf5)


It is, of course, possible to escape all special characters in user's input by passing it through a replace function (see [example on Stack Overflow](https://stackoverflow.com/a/63772309/3925302)); but I thought it more straightforward to just do a simple string includes after normalising the two strings to the same register.

## Deployment URL(s)
http://fix-substring-check.review.ensembl.org