### PR TITLE
Move logic for reshaping VEP results tabular data into a hook

### DIFF
--- a/src/content/app/tools/vep/state/vep-api/fixtures/mockVepResults.ts
+++ b/src/content/app/tools/vep/state/vep-api/fixtures/mockVepResults.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { VEPResultsResponse } from 'src/content/app/tools/vep/types/vepResultsResponse';
+import type { VepResultsResponse } from 'src/content/app/tools/vep/types/vepResultsResponse';
 
 const mockVepResults = {
   metadata: {
@@ -4503,6 +4503,6 @@ const mockVepResults = {
       ]
     }
   ]
-} satisfies VEPResultsResponse;
+} satisfies VepResultsResponse;
 
 export default mockVepResults;

--- a/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
+++ b/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
@@ -16,11 +16,11 @@
 
 import restApiSlice from 'src/shared/state/api-slices/restSlice';
 
-import type { VEPResultsResponse } from 'src/content/app/tools/vep/types/vepResultsResponse';
+import type { VepResultsResponse } from 'src/content/app/tools/vep/types/vepResultsResponse';
 
 const vepApiSlice = restApiSlice.injectEndpoints({
   endpoints: (builder) => ({
-    vepResults: builder.query<VEPResultsResponse, void>({
+    vepResults: builder.query<VepResultsResponse, void>({
       queryFn: async () => {
         // TODO: the query function will accept a submission id,
         // and will send request to:

--- a/src/content/app/tools/vep/types/vepResultsResponse.ts
+++ b/src/content/app/tools/vep/types/vepResultsResponse.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-export type VEPResultsResponse = {
-  metadata: VEPResultsResponseMetadata;
+export type VepResultsResponse = {
+  metadata: VepResultsResponseMetadata;
   variants: Variant[];
 };
 
-export type VEPResultsResponseMetadata = {
+export type VepResultsResponseMetadata = {
   pagination: {
     page: number;
     per_page: number;
@@ -46,11 +46,13 @@ export type ReferenceVariantAllele = {
 export type AlternativeVariantAllele = {
   allele_sequence: string;
   allele_type: string;
-  predicted_molecular_consequences: Array<
-    PredictedTranscriptConsequence | PredictedIntergenicConsequence
-  >;
-  representative_population_allele_frequency?: number | null;
+  predicted_molecular_consequences: PredictedMolecularConsequence[];
+  representative_population_allele_frequency?: number | null; // FIXME: remove? not part of VEP Phase 1
 };
+
+export type PredictedMolecularConsequence =
+  | PredictedTranscriptConsequence
+  | PredictedIntergenicConsequence;
 
 export type PredictedTranscriptConsequence = {
   feature_type: 'transcript';

--- a/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.module.css
+++ b/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.module.css
@@ -35,6 +35,17 @@
   max-width: 100px;
 }
 
+.expandButton {
+  display: flex;
+  align-items: center;
+  column-gap: 1rem;
+  margin-top: 12px;
+}
+
+.collapseButton {
+  margin-top: 24px;
+}
+
 .smallLight {
   font-size: 11px;
   font-weight: var(--font-weight-light);

--- a/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.module.css
+++ b/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.module.css
@@ -38,7 +38,7 @@
 .expandButton {
   display: flex;
   align-items: center;
-  column-gap: 1rem;
+  column-gap: 1ch;
   margin-top: 12px;
 }
 

--- a/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.tsx
@@ -16,16 +16,16 @@
 
 import { useVepResultsQuery } from 'src/content/app/tools/vep/state/vep-api/vepApiSlice';
 
+import useVepVariantTabularData, {
+  type VepResultsTableRowData
+} from './useVepVariantTabularData';
+
 import { Table, ColumnHead } from 'src/shared/components/table';
 import VariantConsequence from 'src/shared/components/variant-consequence/VariantConsequence';
 import VepResultsGene from './components/vep-results-gene/VepResultsGene';
 import VepResultsLocation from './components/vep-results-location/VepResultsLocation';
 
-import type {
-  VEPResultsResponse,
-  AlternativeVariantAllele,
-  PredictedTranscriptConsequence
-} from 'src/content/app/tools/vep/types/vepResultsResponse';
+import type { VepResultsResponse } from 'src/content/app/tools/vep/types/vepResultsResponse';
 
 import styles from './VepSubmissionResults.module.css';
 
@@ -33,9 +33,7 @@ import styles from './VepSubmissionResults.module.css';
  * TODO:
  * - Add unique id to variants after they are requested (to use for keys)
  * - Enable expansion/collapsing of transcripts of a given gene
- * - Show intergenic variants as predicted consequences alongside transcript consequences
  * - Consider pagination (should it be part of url?)
- * - Make the table scrollable
  */
 
 const VepSubmissionResults = () => {
@@ -53,7 +51,7 @@ const VepSubmissionResults = () => {
 };
 
 const VepResultsTable = (props: {
-  variants: VEPResultsResponse['variants'];
+  variants: VepResultsResponse['variants'];
 }) => {
   const { variants } = props;
 
@@ -81,73 +79,90 @@ const VepResultsTable = (props: {
 };
 
 const VariantRow = (props: {
-  variant: VEPResultsResponse['variants'][number];
+  variant: VepResultsResponse['variants'][number];
 }) => {
-  // group transcript consequences by gene
-  // const variant = updateVariant(props.variant);
+  const tabularData = useVepVariantTabularData({
+    variant: props.variant,
+    showAllTranscripts: true
+  });
 
-  const transcriptConsequencesForTable = getTranscriptConsequences(
-    props.variant
-  );
-
-  return transcriptConsequencesForTable.map((cons, index) => (
+  return tabularData.map((row, index) => (
     <tr key={index}>
-      {cons.variant && (
+      {row.variant && (
         <>
           <td
-            rowSpan={
-              cons.variant.rowspan > 1 ? cons.variant.rowspan : undefined
-            }
+            rowSpan={row.variant.rowspan > 1 ? row.variant.rowspan : undefined}
           >
-            <VariantName variant={cons.variant} />
+            <VariantName variant={row.variant} />
           </td>
           <td
-            rowSpan={
-              cons.variant.rowspan > 1 ? cons.variant.rowspan : undefined
-            }
+            rowSpan={row.variant.rowspan > 1 ? row.variant.rowspan : undefined}
           >
-            {cons.variant.referenceAllele}
+            {row.variant.referenceAllele}
           </td>
           <td
-            rowSpan={
-              cons.variant.rowspan > 1 ? cons.variant.rowspan : undefined
-            }
+            rowSpan={row.variant.rowspan > 1 ? row.variant.rowspan : undefined}
           >
             <VepResultsLocation
               genomeId="grch38"
-              location={cons.variant.location}
+              location={row.variant.location}
             />
           </td>
         </>
       )}
-      {cons.alternativeAllele && (
+      {row.alternativeAllele && (
         <td
           rowSpan={
-            cons.alternativeAllele.rowspan > 1
-              ? cons.alternativeAllele.rowspan
+            row.alternativeAllele.rowspan > 1
+              ? row.alternativeAllele.rowspan
               : undefined
           }
         >
-          {cons.alternativeAllele.allele_sequence}
+          {row.alternativeAllele.allele_sequence}
         </td>
       )}
-      {cons.gene && (
-        <td rowSpan={cons.gene.rowspan > 1 ? cons.gene.rowspan : undefined}>
-          <VepResultsGene {...cons.gene} genomeId="grch38" />
-        </td>
-      )}
+      <GeneTableCell row={row} />
+      <TranscriptTableCell row={row} />
       <td>
-        <VariantTranscript transcript={cons} />
-      </td>
-      <td>
-        <VariantConsequences consequences={cons.consequences} />
+        <VariantConsequences consequences={row.consequence.consequences} />
       </td>
     </tr>
   ));
 };
 
+const GeneTableCell = (props: { row: VepResultsTableRowData }) => {
+  const { row } = props;
+
+  if (row.gene) {
+    return (
+      <td rowSpan={row.gene.rowspan > 1 ? row.gene.rowspan : undefined}>
+        <VepResultsGene {...row.gene} genomeId="grch38" />
+      </td>
+    );
+  } else if (row.consequence.feature_type === null) {
+    // for an intergenic consequence, render an empty cell
+    return <td />;
+  } else {
+    return null;
+  }
+};
+
+const TranscriptTableCell = (props: { row: VepResultsTableRowData }) => {
+  const { row } = props;
+
+  if (row.consequence.feature_type === 'transcript') {
+    return (
+      <td>
+        <VariantTranscript transcript={row.consequence} />
+      </td>
+    );
+  } else {
+    return <td />;
+  }
+};
+
 const VariantName = (props: {
-  variant: NonNullable<TranscriptConsequenceForTable['variant']>;
+  variant: NonNullable<VepResultsTableRowData['variant']>;
 }) => {
   return (
     <>
@@ -177,174 +192,6 @@ const VariantConsequences = ({ consequences }: { consequences: string[] }) => {
       <VariantConsequence consequence={consequence} />
     </div>
   ));
-};
-
-type VariantAffectedGene = {
-  stable_id: string;
-  symbol: string | null;
-  transcripts: PredictedTranscriptConsequence[];
-};
-
-type UpdatedAlternativeAllele = AlternativeVariantAllele & {
-  genes: VariantAffectedGene[];
-};
-
-const updateVariant = (variant: VEPResultsResponse['variants'][number]) => {
-  const alternativeAlleles: UpdatedAlternativeAllele[] =
-    variant.alternative_alleles.map((allele) => {
-      const genesMap = new Map<string, VariantAffectedGene>();
-      // NOTE: typescript 5.5 should be able to infer the PredictedTranscriptConsequence type on its own
-      const transcriptConsequences =
-        allele.predicted_molecular_consequences.filter(
-          (cons) => cons.feature_type === 'transcript'
-        ) as PredictedTranscriptConsequence[];
-
-      // make sure canonical transcripts go first
-      transcriptConsequences.sort((a, b) => {
-        const aScore = a.is_canonical ? 0 : 1;
-        const bScore = b.is_canonical ? 0 : 1;
-        return aScore - bScore;
-      });
-
-      for (const consequence of transcriptConsequences) {
-        const geneId = consequence.gene_stable_id;
-        const storedGene = genesMap.get(geneId);
-
-        if (storedGene) {
-          storedGene.transcripts.push(consequence);
-        } else {
-          const gene: VariantAffectedGene = {
-            stable_id: geneId,
-            symbol: consequence.gene_symbol,
-            transcripts: [consequence]
-          };
-          genesMap.set(geneId, gene);
-        }
-      }
-
-      return {
-        ...allele,
-        genes: [...genesMap.values()]
-      };
-    });
-
-  return {
-    ...variant,
-    alternative_alleles: alternativeAlleles
-  };
-};
-
-type TranscriptConsequenceForTable = PredictedTranscriptConsequence & {
-  gene: {
-    stableId: string;
-    symbol: string | null;
-    strand: 'forward' | 'reverse';
-    rowspan: number;
-  } | null;
-  alternativeAllele: {
-    allele_sequence: string;
-    rowspan: number;
-  } | null;
-  variant: {
-    name: string;
-    referenceAllele: string;
-    allele_type: string;
-    location: {
-      region_name: string;
-      start: number;
-    };
-    rowspan: number;
-  } | null;
-};
-
-/**
- * The data fetched from the api is shaped in a logical way,
- * where top-level items are variants, each of which has an array of alt alleles,
- * each of which has an array of predicted consequences...
- * In order to represent this data in a table, it has to be inverted
- * to become an array of elements associated with a single row.
- * The most appropriate candidate for such data seems to be a predicted molecular consequence
- * of a variant allele.
- */
-const getTranscriptConsequences = (
-  variant: VEPResultsResponse['variants'][number]
-): TranscriptConsequenceForTable[] => {
-  const result: TranscriptConsequenceForTable[] = [];
-  const updatedVariant = updateVariant(variant);
-
-  for (const altAllele of updatedVariant.alternative_alleles) {
-    // FIXME: should not just throw away all other consequences
-    // also, manual type casting will be unnecessary in typescript 5.5
-
-    for (let geneIndex = 0; geneIndex < altAllele.genes.length; geneIndex++) {
-      const gene = altAllele.genes[geneIndex];
-
-      for (let i = 0; i < gene.transcripts.length; i++) {
-        const transcriptConsequence = gene.transcripts[i];
-        const consequenceForTable: TranscriptConsequenceForTable = {
-          ...transcriptConsequence,
-          gene: null,
-          alternativeAllele: null,
-          variant: null
-        };
-        if (!result.length) {
-          consequenceForTable.variant = {
-            name: variant.name,
-            allele_type: variant.allele_type,
-            referenceAllele: variant.reference_allele.allele_sequence,
-            location: variant.location,
-            rowspan: getTotalRowsForVariant(updatedVariant)
-          };
-        }
-        if (geneIndex === 0 && i === 0) {
-          consequenceForTable.alternativeAllele = {
-            allele_sequence: altAllele.allele_sequence,
-            rowspan: getTotalRowsForAltAllele(altAllele)
-          };
-        }
-        if (i === 0) {
-          consequenceForTable.gene = {
-            stableId: gene.stable_id,
-            symbol: gene.symbol,
-            strand: transcriptConsequence.strand,
-            rowspan: Math.max(gene.transcripts.length, 1)
-          };
-        }
-
-        result.push(consequenceForTable);
-      }
-    }
-  }
-
-  return result;
-};
-
-const getTotalRowsForVariant = (variant: ReturnType<typeof updateVariant>) => {
-  let count = 0;
-
-  for (const altAllele of variant.alternative_alleles) {
-    for (const gene of altAllele.genes) {
-      for (let i = 0; i < gene.transcripts.length; i++) {
-        count++;
-      }
-    }
-  }
-
-  return Math.max(count, 1);
-};
-
-const getTotalRowsForAltAllele = (
-  allele: ReturnType<typeof updateVariant>['alternative_alleles'][number]
-) => {
-  let count = 0;
-
-  for (const gene of allele.genes) {
-    for (let i = 0; i < gene.transcripts.length; i++) {
-      count++;
-    }
-  }
-
-  return Math.max(count, 1);
 };
 
 export default VepSubmissionResults;

--- a/src/content/app/tools/vep/views/vep-submission-results/useVepVariantTabularData.ts
+++ b/src/content/app/tools/vep/views/vep-submission-results/useVepVariantTabularData.ts
@@ -26,12 +26,6 @@ import type {
 
 type VariantInResponse = VepResultsResponse['variants'][number];
 
-/**
- * TODO:
- * - Be able to expand/collapse transcripts
- * - Be able to show intergenic variants
- */
-
 type Params = {
   variant: VariantInResponse;
   showAllTranscripts: boolean;
@@ -46,7 +40,7 @@ type Params = {
  * The data is transformed into an array in which any given element
  * is associated with a single table row.
  * The most appropriate candidate for row-level elements
- * seem to be predicted molecular consequences of a variant allele.
+ * seems to be predicted molecular consequences of a variant allele.
  */
 const useVepVariantTabularData = (params: Params) => {
   const { variant, showAllTranscripts } = params;

--- a/src/content/app/tools/vep/views/vep-submission-results/useVepVariantTabularData.ts
+++ b/src/content/app/tools/vep/views/vep-submission-results/useVepVariantTabularData.ts
@@ -312,7 +312,9 @@ const getTabularData = ({
   return result;
 };
 
-// FIXME! Consider that transcripts can be collapsed
+// Note: the number of transcripts in variant->alternative_allele->gene
+// will depend on whether the list of transcripts is collapsed or expanded
+// (see how transcripts are filtered out in the reshapeVariant function)
 const getTotalRowsForVariant = (variant: ReshapedVariant) => {
   let count = 0;
 
@@ -330,7 +332,9 @@ const getTotalRowsForVariant = (variant: ReshapedVariant) => {
   return Math.max(count, 1);
 };
 
-// FIXME! Consider that transcripts can be collapsed
+// Note: the number of transcripts in allele->gene
+// will depend on whether the list of transcripts is collapsed or expanded
+// (see how transcripts are filtered out in the reshapeVariant function)
 const getTotalRowsForAltAllele = (allele: UpdatedAlternativeAllele) => {
   let count = 0;
 

--- a/src/content/app/tools/vep/views/vep-submission-results/useVepVariantTabularData.ts
+++ b/src/content/app/tools/vep/views/vep-submission-results/useVepVariantTabularData.ts
@@ -1,0 +1,315 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo } from 'react';
+
+import type {
+  VepResultsResponse,
+  AlternativeVariantAllele,
+  PredictedMolecularConsequence,
+  PredictedTranscriptConsequence,
+  PredictedIntergenicConsequence
+} from 'src/content/app/tools/vep/types/vepResultsResponse';
+
+type VariantInResponse = VepResultsResponse['variants'][number];
+
+/**
+ * TODO:
+ * - Be able to expand/collapse transcripts
+ * - Be able to show intergenic variants
+ */
+
+type Params = {
+  variant: VariantInResponse;
+  showAllTranscripts: boolean;
+};
+
+/**
+ * The data fetched from the api is shaped hierarchically,
+ * where top-level items are variants, each of which has an array of alt alleles,
+ * each of which has an array of predicted consequences...
+ *
+ * The purpose of this hook is to reshape the data such as to represent a table.
+ * The data is transformed into an array in which any given element
+ * is associated with a single table row.
+ * The most appropriate candidate for row-level elements
+ * seem to be predicted molecular consequences of a variant allele.
+ */
+const useVepVariantTabularData = (params: Params) => {
+  const { variant, showAllTranscripts } = params;
+
+  const tabularData = useMemo(() => {
+    return getTabularData(params);
+  }, [variant, showAllTranscripts]);
+
+  return tabularData;
+};
+
+type VariantAffectedGene = {
+  stable_id: string;
+  symbol: string | null;
+  transcripts: PredictedTranscriptConsequence[];
+};
+
+type UpdatedAlternativeAllele = AlternativeVariantAllele & {
+  genes: VariantAffectedGene[];
+  intergenicConsequences: PredictedIntergenicConsequence[];
+};
+
+type ReshapedVariant = Omit<VariantInResponse, 'alternative_alleles'> & {
+  alternative_alleles: UpdatedAlternativeAllele[];
+};
+
+/**
+ * - Group transcripts belonging to the same gene, and extract gene information
+ */
+const reshapeVariant = ({
+  variant,
+  onlyCanonicalTranscripts
+}: {
+  variant: VariantInResponse;
+  onlyCanonicalTranscripts: boolean;
+}) => {
+  const alternativeAlleles: UpdatedAlternativeAllele[] =
+    variant.alternative_alleles.map((allele) => {
+      let {
+        transcriptConsequences,
+        intergenicConsequences // eslint-disable-line prefer-const
+      } = groupAlleleConsequencesByType(
+        allele.predicted_molecular_consequences
+      );
+
+      const genesMap = new Map<string, VariantAffectedGene>();
+
+      if (onlyCanonicalTranscripts) {
+        transcriptConsequences = transcriptConsequences.filter(
+          (cons) => cons.is_canonical
+        );
+      } else {
+        // make sure canonical transcripts go first
+        transcriptConsequences.sort((a, b) => {
+          const aScore = a.is_canonical ? 0 : 1;
+          const bScore = b.is_canonical ? 0 : 1;
+          return aScore - bScore;
+        });
+      }
+
+      for (const consequence of transcriptConsequences) {
+        const geneId = consequence.gene_stable_id;
+        const visitedGene = genesMap.get(geneId);
+
+        if (visitedGene) {
+          visitedGene.transcripts.push(consequence);
+        } else {
+          const gene: VariantAffectedGene = {
+            stable_id: geneId,
+            symbol: consequence.gene_symbol,
+            transcripts: [consequence]
+          };
+          genesMap.set(geneId, gene);
+        }
+      }
+
+      return {
+        ...allele,
+        genes: [...genesMap.values()],
+        intergenicConsequences
+      };
+    });
+
+  return {
+    ...variant,
+    alternative_alleles: alternativeAlleles
+  };
+};
+
+type ConsequenceGroups = {
+  transcriptConsequences: PredictedTranscriptConsequence[];
+  intergenicConsequences: PredictedIntergenicConsequence[];
+};
+
+const groupAlleleConsequencesByType = (
+  consequences: PredictedMolecularConsequence[]
+) => {
+  const consequenceGroups: ConsequenceGroups = {
+    transcriptConsequences: [],
+    intergenicConsequences: []
+  };
+
+  for (const consequence of consequences) {
+    if (consequence.feature_type === 'transcript') {
+      consequenceGroups.transcriptConsequences.push(consequence);
+    } else if (consequence.feature_type === null) {
+      consequenceGroups.intergenicConsequences.push(consequence);
+    }
+  }
+
+  return consequenceGroups;
+};
+
+export type VepResultsTableRowData = {
+  consequence: PredictedMolecularConsequence;
+  gene: {
+    stableId: string;
+    symbol: string | null;
+    strand: 'forward' | 'reverse';
+    rowspan: number;
+  } | null;
+  alternativeAllele: {
+    allele_sequence: string;
+    rowspan: number;
+  } | null;
+  variant: {
+    name: string;
+    referenceAllele: string;
+    allele_type: string;
+    location: {
+      region_name: string;
+      start: number;
+    };
+    rowspan: number;
+  } | null;
+};
+
+/**
+ * NOTE: this function will need updating after regulatory features are added
+ */
+const getTabularData = ({
+  variant,
+  showAllTranscripts
+}: {
+  variant: VariantInResponse;
+  showAllTranscripts: boolean;
+}): VepResultsTableRowData[] => {
+  const result: VepResultsTableRowData[] = [];
+  const reshapedVariant = reshapeVariant({
+    variant,
+    onlyCanonicalTranscripts: !showAllTranscripts
+  });
+
+  // First, start by creating table row data for transcript consequences of each of variant's alt alleles
+  for (const altAllele of reshapedVariant.alternative_alleles) {
+    for (let geneIndex = 0; geneIndex < altAllele.genes.length; geneIndex++) {
+      const gene = altAllele.genes[geneIndex];
+
+      for (let i = 0; i < gene.transcripts.length; i++) {
+        const transcriptConsequence = gene.transcripts[i];
+        const tableRowData: VepResultsTableRowData = {
+          consequence: transcriptConsequence,
+          gene: null,
+          alternativeAllele: null,
+          variant: null
+        };
+        if (!result.length) {
+          tableRowData.variant = {
+            name: variant.name,
+            allele_type: variant.allele_type,
+            referenceAllele: variant.reference_allele.allele_sequence,
+            location: variant.location,
+            rowspan: getTotalRowsForVariant(reshapedVariant)
+          };
+        }
+        if (geneIndex === 0 && i === 0) {
+          tableRowData.alternativeAllele = {
+            allele_sequence: altAllele.allele_sequence,
+            rowspan: getTotalRowsForAltAllele(altAllele)
+          };
+        }
+        if (i === 0) {
+          tableRowData.gene = {
+            stableId: gene.stable_id,
+            symbol: gene.symbol,
+            strand: transcriptConsequence.strand,
+            rowspan: Math.max(gene.transcripts.length, 1)
+          };
+        }
+
+        result.push(tableRowData);
+      }
+    }
+
+    // Run the loop for intergenic consequences after the loop for transcript consequences
+    // Note: unless something went very wrong, it should be impossible for an alt allele
+    // to have both transcript consequences and intergenic consequences at the same time.
+    for (let i = 0; i < altAllele.intergenicConsequences.length; i++) {
+      const intergenicConsequence = altAllele.intergenicConsequences[i];
+
+      const tableRowData: VepResultsTableRowData = {
+        consequence: intergenicConsequence,
+        gene: null,
+        alternativeAllele: null,
+        variant: null
+      };
+
+      if (i === 0) {
+        const variantForRow = {
+          name: variant.name,
+          allele_type: variant.allele_type,
+          referenceAllele: variant.reference_allele.allele_sequence,
+          location: variant.location,
+          rowspan: getTotalRowsForVariant(reshapedVariant)
+        };
+        const altAlleleForRow = {
+          allele_sequence: altAllele.allele_sequence,
+          rowspan: getTotalRowsForAltAllele(altAllele)
+        };
+
+        tableRowData.variant = variantForRow;
+        tableRowData.alternativeAllele = altAlleleForRow;
+      }
+
+      result.push(tableRowData);
+    }
+  }
+
+  return result;
+};
+
+// FIXME! Consider that transcripts can be collapsed
+const getTotalRowsForVariant = (variant: ReshapedVariant) => {
+  let count = 0;
+
+  for (const altAllele of variant.alternative_alleles) {
+    for (const gene of altAllele.genes) {
+      for (let i = 0; i < gene.transcripts.length; i++) {
+        count++;
+      }
+    }
+    for (let i = 0; i < altAllele.intergenicConsequences.length; i++) {
+      count++;
+    }
+  }
+
+  return Math.max(count, 1);
+};
+
+// FIXME! Consider that transcripts can be collapsed
+const getTotalRowsForAltAllele = (allele: UpdatedAlternativeAllele) => {
+  let count = 0;
+
+  for (const gene of allele.genes) {
+    for (let i = 0; i < gene.transcripts.length; i++) {
+      count++;
+    }
+  }
+  for (let i = 0; i < allele.intergenicConsequences.length; i++) {
+    count++;
+  }
+
+  return Math.max(count, 1);
+};
+
+export default useVepVariantTabularData;

--- a/src/shared/components/pill/Pill.module.css
+++ b/src/shared/components/pill/Pill.module.css
@@ -1,0 +1,9 @@
+.pill {
+  background: var(--pill-color, var(--color-blue));
+  color: var(--pill-text-color, var(--color-white));
+  font-size: var(--pill-font-size, 12px);
+  font-weight: var(--pill-font-weight, var(--font-weight-bold));
+  padding: var(--pill-padding, 2px 8px);
+  border-radius: var(--pill-border-radius, 14px);
+  white-space: nowrap;
+}

--- a/src/shared/components/pill/Pill.tsx
+++ b/src/shared/components/pill/Pill.tsx
@@ -1,0 +1,42 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { type ComponentProps } from 'react';
+import classNames from 'classnames';
+
+import styles from './Pill.module.css';
+
+/**
+ * Visually, this component is indistinguishable from PillButton.
+ * Its default background color is also blue, as is the default colour of our clickable elements.
+ * Yet, on its own, this element does not respond to clicks.
+ *
+ * The purpose of this element is to be included into a parent button
+ * when there is also a label next to the pill;
+ * and according to the design, both the pill and the label should be clickable
+ */
+
+type Props = ComponentProps<'span'>;
+
+const Pill = (props: Props) => {
+  const { className, ...otherProps } = props;
+
+  const pillClasses = classNames(styles.pill, className);
+
+  return <span className={pillClasses} {...otherProps} />;
+};
+
+export default Pill;


### PR DESCRIPTION
## Description
- Show intergenic variants in the table
- Collapse / expand transcripts


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2617

## Deployment URL(s)
http://vep-results-table-2.review.ensembl.org

The table can be accessed at the /vep/submissions/:id path. Since there are no real submission ids yet, any string will do. For example: http://vep-results-table.review.ensembl.org/vep/submissions/1