### PR TITLE
Vep form submission

### DIFF
--- a/src/content/app/tools/vep/components/form-section/FormSection.module.css
+++ b/src/content/app/tools/vep/components/form-section/FormSection.module.css
@@ -1,7 +1,9 @@
 .container {
+  --form-section-min-height: 62px; /* declaring it as a custom property so that children of FormSection could use it */
   border-width: 1px;
   border-style: solid;
   border-color: var(--form-section-border-color, var(--color-medium-light-grey));
+  min-height: var(--form-section-min-height);
 }
 
 .container + .container {

--- a/src/content/app/tools/vep/components/vep-submit-button/VepSubmitButton.tsx
+++ b/src/content/app/tools/vep/components/vep-submit-button/VepSubmitButton.tsx
@@ -1,0 +1,90 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useAppSelector } from 'src/store';
+
+import {
+  getSelectedSpecies,
+  getVepFormParameters,
+  getVepFormInputText,
+  getVepFormInputFile,
+  getVepFormInputCommittedFlag
+} from 'src/content/app/tools/vep/state/vep-form/vepFormSelectors';
+
+import { PrimaryButton } from 'src/shared/components/button/Button';
+
+import type {
+  VEPSubmissionPayload,
+  VepSelectedSpecies
+} from 'src/content/app/tools/vep/types/vepSubmission';
+
+const VepSubmitButton = () => {
+  const selectedSpecies = useAppSelector(getSelectedSpecies);
+  const inputText = useAppSelector(getVepFormInputText);
+  const inputFile = useAppSelector(getVepFormInputFile);
+  const formParameters = useAppSelector(getVepFormParameters);
+  const isInputCommitted = useAppSelector(getVepFormInputCommittedFlag);
+
+  const canSubmit = Boolean(
+    selectedSpecies &&
+      (inputText || inputFile) &&
+      Object.keys(formParameters).length &&
+      isInputCommitted
+  );
+
+  const onSubmit = () => {
+    const payload = preparePayload({
+      species: selectedSpecies as VepSelectedSpecies,
+      inputText,
+      inputFile,
+      parameters: formParameters
+    });
+
+    console.log('payload', payload); // eslint-disable-line
+  };
+
+  return (
+    <PrimaryButton disabled={!canSubmit} onClick={onSubmit}>
+      Run
+    </PrimaryButton>
+  );
+};
+
+const preparePayload = ({
+  species,
+  inputText,
+  inputFile,
+  parameters
+}: {
+  species: VepSelectedSpecies;
+  inputText: string;
+  inputFile: File | null;
+  parameters: Record<string, unknown>;
+}): VEPSubmissionPayload => {
+  if (inputText) {
+    new File([inputText], 'input.txt', {
+      type: 'text/plain'
+    });
+  }
+
+  return {
+    genome_id: species.genome_id,
+    input_file: inputFile as File,
+    parameters: JSON.stringify(parameters)
+  };
+};
+
+export default VepSubmitButton;

--- a/src/content/app/tools/vep/components/vep-submit-button/VepSubmitButton.tsx
+++ b/src/content/app/tools/vep/components/vep-submit-button/VepSubmitButton.tsx
@@ -24,6 +24,8 @@ import {
   getVepFormInputCommittedFlag
 } from 'src/content/app/tools/vep/state/vep-form/vepFormSelectors';
 
+import { useVepFormSubmissionMutation } from 'src/content/app/tools/vep/state/vep-api/vepApiSlice';
+
 import { PrimaryButton } from 'src/shared/components/button/Button';
 
 import type {
@@ -37,6 +39,7 @@ const VepSubmitButton = () => {
   const inputFile = useAppSelector(getVepFormInputFile);
   const formParameters = useAppSelector(getVepFormParameters);
   const isInputCommitted = useAppSelector(getVepFormInputCommittedFlag);
+  const [submitVepForm] = useVepFormSubmissionMutation();
 
   const canSubmit = Boolean(
     selectedSpecies &&
@@ -53,7 +56,7 @@ const VepSubmitButton = () => {
       parameters: formParameters
     });
 
-    console.log('payload', payload); // eslint-disable-line
+    submitVepForm(payload);
   };
 
   return (
@@ -75,7 +78,7 @@ const preparePayload = ({
   parameters: Record<string, unknown>;
 }): VEPSubmissionPayload => {
   if (inputText) {
-    new File([inputText], 'input.txt', {
+    inputFile = new File([inputText], 'input.txt', {
       type: 'text/plain'
     });
   }

--- a/src/content/app/tools/vep/components/vep-top-bar/VepTopBar.module.css
+++ b/src/content/app/tools/vep/components/vep-top-bar/VepTopBar.module.css
@@ -1,6 +1,5 @@
 .grid {
   display: grid;
-  flex-grow: 1;
   align-items: center;
   grid-template-columns:
     [vep-logo] max-content

--- a/src/content/app/tools/vep/components/vep-top-bar/VepTopBar.tsx
+++ b/src/content/app/tools/vep/components/vep-top-bar/VepTopBar.tsx
@@ -16,7 +16,10 @@
 
 import { useAppSelector } from 'src/store';
 
-import { getVepFormParameters } from 'src/content/app/tools/vep/state/vep-form/vepFormSelectors';
+import {
+  getSelectedSpecies,
+  getVepFormParameters
+} from 'src/content/app/tools/vep/state/vep-form/vepFormSelectors';
 
 import { useVepFormConfigQuery } from 'src/content/app/tools/vep/state/vep-api/vepApiSlice';
 
@@ -59,12 +62,15 @@ const VepTopBar = () => {
 };
 
 const TranscriptSetSelector = () => {
+  const selectedSpecies = useAppSelector(getSelectedSpecies); // TODO: use genome id of the species to fetch the form config
   const vepFormParameters = useAppSelector(getVepFormParameters);
   const { currentData: vepFormConfig } = useVepFormConfigQuery();
 
+  const canPopulateSelect = selectedSpecies && vepFormConfig;
+
   let options: Option[] = [];
 
-  if (!vepFormConfig) {
+  if (!canPopulateSelect) {
     options = [{ label: 'Select', value: 'none' }];
   } else {
     options = vepFormConfig.parameters.transcript_set.options;
@@ -77,7 +83,7 @@ const TranscriptSetSelector = () => {
       Transcript set
       <SimpleSelect
         options={options}
-        disabled={!vepFormConfig}
+        disabled={!canPopulateSelect}
         className={styles.transcriptSetSelector}
         value={selectedValue}
       />

--- a/src/content/app/tools/vep/components/vep-top-bar/VepTopBar.tsx
+++ b/src/content/app/tools/vep/components/vep-top-bar/VepTopBar.tsx
@@ -14,11 +14,19 @@
  * limitations under the License.
  */
 
+import { useAppSelector } from 'src/store';
+
+import { getVepFormParameters } from 'src/content/app/tools/vep/state/vep-form/vepFormSelectors';
+
+import { useVepFormConfigQuery } from 'src/content/app/tools/vep/state/vep-api/vepApiSlice';
+
 import ToolsTopBar from 'src/content/app/tools/shared/components/tools-top-bar/ToolsTopBar';
-import { PrimaryButton } from 'src/shared/components/button/Button';
 import Logotype from 'static/img/brand/logotype.svg';
-import SimpleSelect from 'src/shared/components/simple-select/SimpleSelect';
+import SimpleSelect, {
+  type Option
+} from 'src/shared/components/simple-select/SimpleSelect';
 import ButtonLink from 'src/shared/components/button-link/ButtonLink';
+import VepSubmitButton from '../vep-submit-button/VepSubmitButton';
 
 import logoUrl from 'static/img/tools/vep/ensembl-vep.svg?url';
 
@@ -30,15 +38,8 @@ const VepTopBar = () => {
       <div className={styles.grid}>
         <img src={logoUrl} alt="Ensembl VEP logo" className={styles.logo} />
         <div className={styles.runAJob}>Run a job</div>
-        <div className={styles.transcriptSet}>
-          Transcript set
-          <SimpleSelect
-            options={[{ label: 'Select', value: 'none' }]}
-            disabled={true}
-            className={styles.transcriptSetSelector}
-          />
-        </div>
-        <PrimaryButton disabled={true}>Run</PrimaryButton>
+        <TranscriptSetSelector />
+        <VepSubmitButton />
         <div className={styles.vepVersion}>
           <Logotype />
           <span>Variant effect predictor </span>
@@ -54,6 +55,33 @@ const VepTopBar = () => {
         </div>
       </div>
     </ToolsTopBar>
+  );
+};
+
+const TranscriptSetSelector = () => {
+  const vepFormParameters = useAppSelector(getVepFormParameters);
+  const { currentData: vepFormConfig } = useVepFormConfigQuery();
+
+  let options: Option[] = [];
+
+  if (!vepFormConfig) {
+    options = [{ label: 'Select', value: 'none' }];
+  } else {
+    options = vepFormConfig.parameters.transcript_set.options;
+  }
+
+  const selectedValue = (vepFormParameters.transcript_set as string) ?? 'none';
+
+  return (
+    <div className={styles.transcriptSet}>
+      Transcript set
+      <SimpleSelect
+        options={options}
+        disabled={!vepFormConfig}
+        className={styles.transcriptSetSelector}
+        value={selectedValue}
+      />
+    </div>
   );
 };
 

--- a/src/content/app/tools/vep/state/vep-api/fixtures/mockVepFormConfig.ts
+++ b/src/content/app/tools/vep/state/vep-api/fixtures/mockVepFormConfig.ts
@@ -1,0 +1,48 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { VepFormConfig } from 'src/content/app/tools/vep/types/vepFormConfig';
+
+const mockVepFormConfig = {
+  parameters: {
+    transcript_set: {
+      label: 'Transcript set',
+      description: null,
+      type: 'select',
+      options: [
+        {
+          label: 'GENCODE',
+          value: 'gencode_comprehensive'
+        }
+      ],
+      default_value: 'gencode_comprehensive'
+    },
+    symbol: {
+      label: 'Gene symbol',
+      description: null,
+      type: 'boolean',
+      default_value: true
+    },
+    biotype: {
+      label: 'Transcript biotype',
+      description: null,
+      type: 'boolean',
+      default_value: true
+    }
+  }
+} satisfies VepFormConfig;
+
+export default mockVepFormConfig;

--- a/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
+++ b/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import config from 'config';
+
 import restApiSlice from 'src/shared/state/api-slices/restSlice';
 import { setDefaultParameters } from '../vep-form/vepFormSlice';
 
@@ -56,9 +58,22 @@ const vepApiSlice = restApiSlice.injectEndpoints({
       { submissionId: string },
       VEPSubmissionPayload
     >({
+      // FIXME: uncomment when the back-end endpoint is ready
+      // query: (payload) => ({
+      //   url: `${config.toolsApiBaseUrl}/vep/submission`,
+      //   method: 'POST',
+      //   body: prepareSubmissionFormData(payload)
+      // }),
+
+      // TODO: remove when the back-end endpoint is ready
       queryFn: async (payload) => {
-        // TODO: actually submit the payload when the BE endpoint is ready
-        console.log('payload', payload); // eslint-disable-line
+        const submissionUrl = `${config.toolsApiBaseUrl}/vep/submission`;
+        console.log(
+          'url',
+          submissionUrl,
+          'payload',
+          prepareSubmissionFormData(payload)
+        ); // eslint-disable-line
 
         return {
           data: { submissionId: 'fake-id' }
@@ -84,6 +99,22 @@ const vepApiSlice = restApiSlice.injectEndpoints({
     })
   })
 });
+
+/**
+ * This function transforms the JSON payload passed into vepFormSubmission function
+ * into a FormData object necessary to submit a multipart/form-data request.
+ * While vepFormSubmission could have received a FormData object as its argument in the first place,
+ * the presence of this function allows us to type-check the payload.
+ */
+const prepareSubmissionFormData = (payload: VEPSubmissionPayload) => {
+  const formData = new FormData();
+
+  for (const [key, value] of Object.entries(payload)) {
+    formData.append(key, value);
+  }
+
+  return formData;
+};
 
 export const {
   useVepFormConfigQuery,

--- a/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
+++ b/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
@@ -21,6 +21,7 @@ import { getVepFormParameters } from '../vep-form/vepFormSelectors';
 
 import type { VepResultsResponse } from 'src/content/app/tools/vep/types/vepResultsResponse';
 import type { VepFormConfig } from 'src/content/app/tools/vep/types/vepFormConfig';
+import type { VEPSubmissionPayload } from 'src/content/app/tools/vep/types/vepSubmission';
 import type { RootState } from 'src/store';
 
 const vepApiSlice = restApiSlice.injectEndpoints({
@@ -51,6 +52,19 @@ const vepApiSlice = restApiSlice.injectEndpoints({
         };
       }
     }),
+    vepFormSubmission: builder.mutation<
+      { submissionId: string },
+      VEPSubmissionPayload
+    >({
+      queryFn: async (payload) => {
+        // TODO: actually submit the payload when the BE endpoint is ready
+        console.log('payload', payload); // eslint-disable-line
+
+        return {
+          data: { submissionId: 'fake-id' }
+        };
+      }
+    }),
     vepResults: builder.query<VepResultsResponse, void>({
       queryFn: async () => {
         // TODO: the query function will accept a submission id,
@@ -71,4 +85,8 @@ const vepApiSlice = restApiSlice.injectEndpoints({
   })
 });
 
-export const { useVepFormConfigQuery, useVepResultsQuery } = vepApiSlice;
+export const {
+  useVepFormConfigQuery,
+  useVepResultsQuery,
+  useVepFormSubmissionMutation
+} = vepApiSlice;

--- a/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
+++ b/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
@@ -55,31 +55,14 @@ const vepApiSlice = restApiSlice.injectEndpoints({
       }
     }),
     vepFormSubmission: builder.mutation<
-      { submissionId: string },
+      { submission_id: string },
       VEPSubmissionPayload
     >({
-      // FIXME: uncomment when the back-end endpoint is ready
-      // query: (payload) => ({
-      //   url: `${config.toolsApiBaseUrl}/vep/submissions`,
-      //   method: 'POST',
-      //   body: prepareSubmissionFormData(payload)
-      // }),
-
-      // TODO: remove when the back-end endpoint is ready
-      queryFn: async (payload) => {
-        const submissionUrl = `${config.toolsApiBaseUrl}/vep/submissions`;
-        // eslint-disable-next-line
-        console.log(
-          'url',
-          submissionUrl,
-          'payload',
-          prepareSubmissionFormData(payload)
-        );
-
-        return {
-          data: { submissionId: 'fake-id' }
-        };
-      }
+      query: (payload) => ({
+        url: `${config.toolsApiBaseUrl}/vep/submissions`,
+        method: 'POST',
+        body: prepareSubmissionFormData(payload)
+      })
     }),
     vepResults: builder.query<VepResultsResponse, void>({
       queryFn: async () => {

--- a/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
+++ b/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
@@ -60,14 +60,14 @@ const vepApiSlice = restApiSlice.injectEndpoints({
     >({
       // FIXME: uncomment when the back-end endpoint is ready
       // query: (payload) => ({
-      //   url: `${config.toolsApiBaseUrl}/vep/submission`,
+      //   url: `${config.toolsApiBaseUrl}/vep/submissions`,
       //   method: 'POST',
       //   body: prepareSubmissionFormData(payload)
       // }),
 
       // TODO: remove when the back-end endpoint is ready
       queryFn: async (payload) => {
-        const submissionUrl = `${config.toolsApiBaseUrl}/vep/submission`;
+        const submissionUrl = `${config.toolsApiBaseUrl}/vep/submissions`;
         // eslint-disable-next-line
         console.log(
           'url',

--- a/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
+++ b/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
@@ -15,11 +15,42 @@
  */
 
 import restApiSlice from 'src/shared/state/api-slices/restSlice';
+import { setDefaultParameters } from '../vep-form/vepFormSlice';
+
+import { getVepFormParameters } from '../vep-form/vepFormSelectors';
 
 import type { VepResultsResponse } from 'src/content/app/tools/vep/types/vepResultsResponse';
+import type { VepFormConfig } from 'src/content/app/tools/vep/types/vepFormConfig';
+import type { RootState } from 'src/store';
 
 const vepApiSlice = restApiSlice.injectEndpoints({
   endpoints: (builder) => ({
+    vepFormConfig: builder.query<VepFormConfig, void>({
+      queryFn: async (_, { dispatch, getState }) => {
+        // TODO: the query function will accept a genome id,
+        // and will send request to:
+        // `${config.toolsApiBaseUrl}/vep/config?genome_id=${genomeId}`
+        // to fetch data.
+        // Meanwhile, until the back-end endpoint is developed,
+        // this function returns hard-coded response payload.
+        const mockResponseModule = await import(
+          'src/content/app/tools/vep/state/vep-api/fixtures/mockVepFormConfig'
+        );
+        const vepFormConfig = mockResponseModule.default;
+
+        const vepFormParametersInState = getVepFormParameters(
+          getState() as RootState
+        );
+
+        if (!Object.keys(vepFormParametersInState).length) {
+          dispatch(setDefaultParameters(vepFormConfig));
+        }
+
+        return {
+          data: vepFormConfig
+        };
+      }
+    }),
     vepResults: builder.query<VepResultsResponse, void>({
       queryFn: async () => {
         // TODO: the query function will accept a submission id,
@@ -40,4 +71,4 @@ const vepApiSlice = restApiSlice.injectEndpoints({
   })
 });
 
-export const { useVepResultsQuery } = vepApiSlice;
+export const { useVepFormConfigQuery, useVepResultsQuery } = vepApiSlice;

--- a/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
+++ b/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
@@ -68,12 +68,13 @@ const vepApiSlice = restApiSlice.injectEndpoints({
       // TODO: remove when the back-end endpoint is ready
       queryFn: async (payload) => {
         const submissionUrl = `${config.toolsApiBaseUrl}/vep/submission`;
+        // eslint-disable-next-line
         console.log(
           'url',
           submissionUrl,
           'payload',
           prepareSubmissionFormData(payload)
-        ); // eslint-disable-line
+        );
 
         return {
           data: { submissionId: 'fake-id' }

--- a/src/content/app/tools/vep/state/vep-form/vepFormSelectors.ts
+++ b/src/content/app/tools/vep/state/vep-form/vepFormSelectors.ts
@@ -19,6 +19,9 @@ import type { RootState } from 'src/store';
 export const getSelectedSpecies = (state: RootState) =>
   state.vep.vepForm.selectedSpecies;
 
+export const getVepSubmissionName = (state: RootState) =>
+  state.vep.vepForm.submissionName;
+
 export const getVepFormParameters = (state: RootState) =>
   state.vep.vepForm.parameters;
 

--- a/src/content/app/tools/vep/state/vep-form/vepFormSlice.ts
+++ b/src/content/app/tools/vep/state/vep-form/vepFormSlice.ts
@@ -16,16 +16,30 @@
 
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import type { CommittedItem } from 'src/content/app/species-selector/types/committedItem';
+import type {
+  VepFormConfig,
+  VepFormParameterName
+} from 'src/content/app/tools/vep/types/vepFormConfig';
+import type { VepSelectedSpecies } from 'src/content/app/tools/vep/types/vepSubmission';
 
-type VepSelectedSpecies = Omit<CommittedItem, 'isEnabled'>;
+type VepFormParameters = Partial<
+  Record<VepFormParameterName, string | boolean>
+>;
 
 export type VepFormState = {
   selectedSpecies: VepSelectedSpecies | null;
+  inputText: string;
+  inputFile: File | null; // <-- this is temporary; we should not store potentially huge files in-memory
+  isInputCommitted: boolean;
+  parameters: VepFormParameters;
 };
 
 export const initialState: VepFormState = {
-  selectedSpecies: null
+  selectedSpecies: null,
+  inputText: '',
+  inputFile: null,
+  isInputCommitted: false,
+  parameters: {}
 };
 
 const vepFormSlice = createSlice({
@@ -37,10 +51,46 @@ const vepFormSlice = createSlice({
       action: PayloadAction<{ species: VepSelectedSpecies }>
     ) => {
       state.selectedSpecies = action.payload.species;
+    },
+    // replace the whole parameters object in the state
+    setDefaultParameters: (state, action: PayloadAction<VepFormConfig>) => {
+      const defaultParameters: VepFormParameters = {};
+
+      for (const [parameterName, parameter] of Object.entries(
+        action.payload.parameters
+      )) {
+        defaultParameters[parameterName as VepFormParameterName] =
+          parameter.default_value;
+      }
+
+      state.parameters = defaultParameters;
+    },
+    // update one or more of the parameters object in the state
+    updateParameters: (state, action: PayloadAction<VepFormParameters>) => {
+      state.parameters = {
+        ...state.parameters,
+        ...action.payload
+      };
+    },
+    updateInputText: (state, action: PayloadAction<string>) => {
+      state.inputText = action.payload;
+    },
+    updateInputFile: (state, action: PayloadAction<File>) => {
+      state.inputFile = action.payload;
+    },
+    updateInputCommittedFlag: (state, action: PayloadAction<boolean>) => {
+      state.isInputCommitted = action.payload;
     }
   }
 });
 
-export const { setSelectedSpecies } = vepFormSlice.actions;
+export const {
+  setSelectedSpecies,
+  setDefaultParameters,
+  updateParameters,
+  updateInputText,
+  updateInputFile,
+  updateInputCommittedFlag
+} = vepFormSlice.actions;
 
 export default vepFormSlice.reducer;

--- a/src/content/app/tools/vep/state/vep-form/vepFormSlice.ts
+++ b/src/content/app/tools/vep/state/vep-form/vepFormSlice.ts
@@ -28,6 +28,7 @@ type VepFormParameters = Partial<
 
 export type VepFormState = {
   selectedSpecies: VepSelectedSpecies | null;
+  submissionName: string | null;
   inputText: string;
   inputFile: File | null; // <-- this is temporary; we should not store potentially huge files in-memory
   isInputCommitted: boolean;
@@ -36,6 +37,7 @@ export type VepFormState = {
 
 export const initialState: VepFormState = {
   selectedSpecies: null,
+  submissionName: null,
   inputText: '',
   inputFile: null,
   isInputCommitted: false,
@@ -72,6 +74,9 @@ const vepFormSlice = createSlice({
         ...action.payload
       };
     },
+    updateSubmissionName: (state, action: PayloadAction<string>) => {
+      state.submissionName = action.payload;
+    },
     updateInputText: (state, action: PayloadAction<string>) => {
       state.inputText = action.payload;
     },
@@ -88,6 +93,7 @@ export const {
   setSelectedSpecies,
   setDefaultParameters,
   updateParameters,
+  updateSubmissionName,
   updateInputText,
   updateInputFile,
   updateInputCommittedFlag

--- a/src/content/app/tools/vep/types/vepFormConfig.ts
+++ b/src/content/app/tools/vep/types/vepFormConfig.ts
@@ -14,19 +14,33 @@
  * limitations under the License.
  */
 
-import type { RootState } from 'src/store';
+type CommonParameterFields = {
+  label: string;
+  description: string | null;
+};
 
-export const getSelectedSpecies = (state: RootState) =>
-  state.vep.vepForm.selectedSpecies;
+type SelectParameterOption = {
+  label: string;
+  value: string;
+};
 
-export const getVepFormParameters = (state: RootState) =>
-  state.vep.vepForm.parameters;
+type SelectParameter = CommonParameterFields & {
+  type: 'select';
+  options: SelectParameterOption[];
+  default_value: string;
+};
 
-export const getVepFormInputText = (state: RootState) =>
-  state.vep.vepForm.inputText;
+type BooleanParameter = CommonParameterFields & {
+  type: 'boolean';
+  default_value: boolean;
+};
 
-export const getVepFormInputFile = (state: RootState) =>
-  state.vep.vepForm.inputFile;
+export type VepFormConfig = {
+  parameters: {
+    transcript_set: SelectParameter;
+    symbol: BooleanParameter;
+    biotype: BooleanParameter;
+  };
+};
 
-export const getVepFormInputCommittedFlag = (state: RootState) =>
-  state.vep.vepForm.isInputCommitted;
+export type VepFormParameterName = keyof VepFormConfig['parameters'];

--- a/src/content/app/tools/vep/types/vepSubmission.ts
+++ b/src/content/app/tools/vep/types/vepSubmission.ts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+import type { CommittedItem } from 'src/content/app/species-selector/types/committedItem';
+
+export type VepSelectedSpecies = Omit<CommittedItem, 'isEnabled'>;
+
 /**
  * Schema of the data that will be persisted in indexedDB.
  */

--- a/src/content/app/tools/vep/types/vepSubmission.ts
+++ b/src/content/app/tools/vep/types/vepSubmission.ts
@@ -14,19 +14,26 @@
  * limitations under the License.
  */
 
-import type { RootState } from 'src/store';
+/**
+ * Schema of the data that will be persisted in indexedDB.
+ */
+export type VEPSubmission = {
+  id: string;
+  genome_id: string; // <-- should be the whole CommittedItem rather than a string
+  input_text: string | null;
+  input_file: File | null;
+  submission_name: string | null;
+  parameters: Record<string, unknown>;
+  created_at: string;
+  submitted_at: string | null; // <-- can get the unsubmitted submission
+  status: string; // <-- a member of a closed dictionary of words
+};
 
-export const getSelectedSpecies = (state: RootState) =>
-  state.vep.vepForm.selectedSpecies;
-
-export const getVepFormParameters = (state: RootState) =>
-  state.vep.vepForm.parameters;
-
-export const getVepFormInputText = (state: RootState) =>
-  state.vep.vepForm.inputText;
-
-export const getVepFormInputFile = (state: RootState) =>
-  state.vep.vepForm.inputFile;
-
-export const getVepFormInputCommittedFlag = (state: RootState) =>
-  state.vep.vepForm.isInputCommitted;
+/**
+ * Schema of the payload submitted to the server.
+ */
+export type VEPSubmissionPayload = {
+  genome_id: string;
+  input_file: File;
+  parameters: string;
+};

--- a/src/content/app/tools/vep/views/vep-form/VepForm.module.css
+++ b/src/content/app/tools/vep/views/vep-form/VepForm.module.css
@@ -1,3 +1,15 @@
+/*
+ * The purpose of this container is to make the main area of the page scrollable.
+ * The scrollbar should be at the right edge of the page; therefore, this container has a default (100%) width.
+ */
+.outerContainer {
+  height: 100%;
+  overflow-y: auto;
+}
+
+/*
+ * This container has a max width.
+ */
 .container {
   margin-top: 22px;
   margin-left: var(--double-standard-gutter);
@@ -33,10 +45,6 @@
   grid-column: form-reset;
 }
 
-
-.formSection {
-  min-height: 62px;
-}
 
 /*
 *  TOP SECTIONS OF THE FORM

--- a/src/content/app/tools/vep/views/vep-form/VepForm.module.css
+++ b/src/content/app/tools/vep/views/vep-form/VepForm.module.css
@@ -60,8 +60,10 @@
     [section-main-content] 1fr
     [section-toggle] auto;
   column-gap: var(--column-gap);
-  align-items: center;
-  height: 62px;
+  align-items: start;
+  min-height: 62px;
+  padding-top: 26px;
+  padding-bottom: 22px;
 }
 
 .topFormSectionName {

--- a/src/content/app/tools/vep/views/vep-form/VepForm.module.css
+++ b/src/content/app/tools/vep/views/vep-form/VepForm.module.css
@@ -8,7 +8,7 @@
 }
 
 /*
- * This container has a max width.
+ * The purpose of this container is to set a max width to the form.
  */
 .container {
   margin-top: 22px;
@@ -61,7 +61,7 @@
     [section-toggle] auto;
   column-gap: var(--column-gap);
   align-items: start;
-  min-height: 62px;
+  min-height: var(--form-section-min-height);
   padding-top: 26px;
   padding-bottom: 22px;
 }

--- a/src/content/app/tools/vep/views/vep-form/VepForm.tsx
+++ b/src/content/app/tools/vep/views/vep-form/VepForm.tsx
@@ -19,6 +19,7 @@ import {
   VepSpeciesSelectorNavButton
 } from './vep-form-species-section/VepFormSpeciesSection';
 import VepFormVariantsSection from './vep-form-variants-section/VepFormVariantsSection';
+import VepFormOptionsSection from './vep-form-options-section/VepFormOptionsSection';
 import FormSection from 'src/content/app/tools/vep/components/form-section/FormSection';
 import ShadedInput from 'src/shared/components/input/ShadedInput';
 import { DeleteButtonWithLabel } from 'src/shared/components/delete-button/DeleteButton';
@@ -27,27 +28,30 @@ import styles from './VepForm.module.css';
 
 const VepForm = () => {
   return (
-    <div className={styles.container}>
-      <div className={styles.topmostAreaGrid}>
-        <div className={styles.submissionName}>
-          <label>Submission name</label>
-          <ShadedInput placeholder="Optional" />
+    <div className={styles.outerContainer}>
+      <div className={styles.container}>
+        <div className={styles.topmostAreaGrid}>
+          <div className={styles.submissionName}>
+            <label>Submission name</label>
+            <ShadedInput placeholder="Optional" />
+          </div>
+          <div className={styles.resetForm}>
+            <DeleteButtonWithLabel label="Reset" disabled={true} />
+          </div>
         </div>
-        <div className={styles.resetForm}>
-          <DeleteButtonWithLabel label="Reset" disabled={true} />
-        </div>
-      </div>
 
-      <FormSection className={styles.formSection}>
-        <div className={styles.topFormSectionRegularGrid}>
-          <div className={styles.topFormSectionName}>Species</div>
-          <VepFormSpecies className={styles.topFormSectionMain} />
-          <VepSpeciesSelectorNavButton
-            className={styles.topFormSectionToggle}
-          />
-        </div>
-      </FormSection>
-      <VepFormVariantsSection />
+        <FormSection>
+          <div className={styles.topFormSectionRegularGrid}>
+            <div className={styles.topFormSectionName}>Species</div>
+            <VepFormSpecies className={styles.topFormSectionMain} />
+            <VepSpeciesSelectorNavButton
+              className={styles.topFormSectionToggle}
+            />
+          </div>
+        </FormSection>
+        <VepFormVariantsSection />
+        <VepFormOptionsSection />
+      </div>
     </div>
   );
 };

--- a/src/content/app/tools/vep/views/vep-form/VepForm.tsx
+++ b/src/content/app/tools/vep/views/vep-form/VepForm.tsx
@@ -20,8 +20,8 @@ import {
 } from './vep-form-species-section/VepFormSpeciesSection';
 import VepFormVariantsSection from './vep-form-variants-section/VepFormVariantsSection';
 import VepFormOptionsSection from './vep-form-options-section/VepFormOptionsSection';
+import VepSubmissionName from './vep-submission-name/VepSubmissionName';
 import FormSection from 'src/content/app/tools/vep/components/form-section/FormSection';
-import ShadedInput from 'src/shared/components/input/ShadedInput';
 import { DeleteButtonWithLabel } from 'src/shared/components/delete-button/DeleteButton';
 
 import styles from './VepForm.module.css';
@@ -31,10 +31,7 @@ const VepForm = () => {
     <div className={styles.outerContainer}>
       <div className={styles.container}>
         <div className={styles.topmostAreaGrid}>
-          <div className={styles.submissionName}>
-            <label>Submission name</label>
-            <ShadedInput placeholder="Optional" />
-          </div>
+          <VepSubmissionName />
           <div className={styles.resetForm}>
             <DeleteButtonWithLabel label="Reset" disabled={true} />
           </div>

--- a/src/content/app/tools/vep/views/vep-form/vep-form-options-section/VepFormOptionsSection.module.css
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-options-section/VepFormOptionsSection.module.css
@@ -1,0 +1,43 @@
+.container {
+  margin-top: 50px;
+}
+
+.sectionTitleContainer {
+  --padding-side: 42px; /* Note that this is the same as in other VEP form sections. Perhaps this is something that should live in the FormSection component? */
+  display: flex;
+  align-items: center;
+  height: var(--form-section-min-height);
+  padding-left: var(--padding-side);
+  padding-right: var(--padding-side);
+}
+
+.disabledSectionTitle {
+  color: var(--color-medium-dark-grey);
+}
+
+
+/*
+  For consideration:
+  - The background is the same as in vep-form-variants section. What's a good way of extracting that?
+  - Not sure about the padding (is it the same as in vep-form-variants section?
+  - It is unclear from designs what the rules for the grid are (column width, gap width).
+    Should ask Andrea
+*/
+.optionsGrid {
+  --padding-side: 42px; /* same as for the title container? */
+  display: grid;
+  grid-template-columns: repeat(4, 200px);
+  column-gap: 1.5rem;
+  background-color: var(--color-light-grey);
+  padding-left: var(--padding-side);
+  padding-right: var(--padding-side);
+  padding-top: 12px;
+}
+
+.optionsContainerCollapsed {
+  padding-bottom: 12px;
+}
+
+.optionsContainerExpanded {
+  padding-bottom: 22px;
+}

--- a/src/content/app/tools/vep/views/vep-form/vep-form-options-section/VepFormOptionsSection.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-options-section/VepFormOptionsSection.tsx
@@ -1,0 +1,107 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useVepFormConfigQuery } from 'src/content/app/tools/vep/state/vep-api/vepApiSlice';
+
+import FormSection from 'src/content/app/tools/vep/components/form-section/FormSection';
+import VepFormGeneOptions from './vep-form-gene-options/VepFormGeneOptions';
+
+import styles from './VepFormOptionsSection.module.css';
+
+/**
+ * TODO:
+ * - Show a pseudo-toggle between short variants and structural variants.
+ * - Move Genes & transcripts section to its own directory?
+ * - Display options
+ *
+ * IDEAS:
+ * - Should user's file be stored in IndexedDB before submission?
+ *  - This means, VEP isn't going to be usable in FF private mode
+ *    - But it won't be usable in that mode anyway
+ *
+ * OTHER STUFF:
+ * - Make sure only the main content can scroll on the VEP form page
+ * - Change PlusButton to PlusIcon in Vep Species Selection section
+ * - Show transcript set in the top bar
+ * - Handle error message for too large file that user tries to attach
+ */
+
+const VepFormOptionsSection = () => {
+  // FIXME: remember that useVepFormConfigQuery will need a genome id when request is sent to backend for real
+  const { currentData: formConfig } = useVepFormConfigQuery();
+
+  // FIXME:
+  // - return null if there is no selected species
+  // - return null if there is no variants input
+
+  if (!formConfig) {
+    // TODO: handle the loading state?
+    return null;
+  }
+
+  return (
+    <div className={styles.container}>
+      <VepFormGeneOptions config={formConfig} />
+      <FormSection>
+        <div className={styles.sectionTitleContainer}>
+          <span className={styles.disabledSectionTitle}>
+            Protein & functional
+          </span>
+        </div>
+      </FormSection>
+      <FormSection>
+        <div className={styles.sectionTitleContainer}>
+          <span className={styles.disabledSectionTitle}>Predictions</span>
+        </div>
+      </FormSection>
+      <FormSection>
+        <div className={styles.sectionTitleContainer}>
+          <span className={styles.disabledSectionTitle}>
+            Variant population frequencies
+          </span>
+        </div>
+      </FormSection>
+      <FormSection>
+        <div className={styles.sectionTitleContainer}>
+          <span className={styles.disabledSectionTitle}>
+            Variant phenotypes
+          </span>
+        </div>
+      </FormSection>
+      <FormSection>
+        <div className={styles.sectionTitleContainer}>
+          <span className={styles.disabledSectionTitle}>Variant citations</span>
+        </div>
+      </FormSection>
+      <FormSection>
+        <div className={styles.sectionTitleContainer}>
+          <span className={styles.disabledSectionTitle}>
+            Regulatory annotation
+          </span>
+        </div>
+      </FormSection>
+      <FormSection>
+        <div className={styles.sectionTitleContainer}>
+          <span className={styles.disabledSectionTitle}>
+            Conservation & constraint
+          </span>
+        </div>
+      </FormSection>
+    </div>
+  );
+};
+
+export default VepFormOptionsSection;

--- a/src/content/app/tools/vep/views/vep-form/vep-form-options-section/VepFormOptionsSection.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-options-section/VepFormOptionsSection.tsx
@@ -25,24 +25,6 @@ import VepFormGeneOptions from './vep-form-gene-options/VepFormGeneOptions';
 
 import styles from './VepFormOptionsSection.module.css';
 
-/**
- * TODO:
- * - Show a pseudo-toggle between short variants and structural variants.
- * - Move Genes & transcripts section to its own directory?
- * - Display options
- *
- * IDEAS:
- * - Should user's file be stored in IndexedDB before submission?
- *  - This means, VEP isn't going to be usable in FF private mode
- *    - But it won't be usable in that mode anyway
- *
- * OTHER STUFF:
- * - Make sure only the main content can scroll on the VEP form page
- * - Change PlusButton to PlusIcon in Vep Species Selection section
- * - Show transcript set in the top bar
- * - Handle error message for too large file that user tries to attach
- */
-
 const VepFormOptionsSection = () => {
   const isVariantsInputCommitted = useAppSelector(getVepFormInputCommittedFlag);
 

--- a/src/content/app/tools/vep/views/vep-form/vep-form-options-section/VepFormOptionsSection.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-options-section/VepFormOptionsSection.tsx
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+import { useAppSelector } from 'src/store';
+
+import { getVepFormInputCommittedFlag } from 'src/content/app/tools/vep/state/vep-form/vepFormSelectors';
+
 import { useVepFormConfigQuery } from 'src/content/app/tools/vep/state/vep-api/vepApiSlice';
 
 import FormSection from 'src/content/app/tools/vep/components/form-section/FormSection';
@@ -40,14 +44,12 @@ import styles from './VepFormOptionsSection.module.css';
  */
 
 const VepFormOptionsSection = () => {
+  const isVariantsInputCommitted = useAppSelector(getVepFormInputCommittedFlag);
+
   // FIXME: remember that useVepFormConfigQuery will need a genome id when request is sent to backend for real
   const { currentData: formConfig } = useVepFormConfigQuery();
 
-  // FIXME:
-  // - return null if there is no selected species
-  // - return null if there is no variants input
-
-  if (!formConfig) {
+  if (!isVariantsInputCommitted || !formConfig) {
     // TODO: handle the loading state?
     return null;
   }

--- a/src/content/app/tools/vep/views/vep-form/vep-form-options-section/vep-form-gene-options/VepFormGeneOptions.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-options-section/vep-form-gene-options/VepFormGeneOptions.tsx
@@ -1,0 +1,90 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState } from 'react';
+import classNames from 'classnames';
+
+import { useAppDispatch, useAppSelector } from 'src/store';
+
+import { getVepFormParameters } from 'src/content/app/tools/vep/state/vep-form/vepFormSelectors';
+
+import { updateParameters } from 'src/content/app/tools/vep/state/vep-form/vepFormSlice';
+
+import FormSection from 'src/content/app/tools/vep/components/form-section/FormSection';
+import ShowHide from 'src/shared/components/show-hide/ShowHide';
+import Checkbox from 'src/shared/components/checkbox/Checkbox';
+
+import type {
+  VepFormConfig,
+  VepFormParameterName
+} from 'src/content/app/tools/vep/types/vepFormConfig';
+
+import commonStyles from '../VepFormOptionsSection.module.css';
+
+type Props = {
+  config: VepFormConfig;
+};
+
+const VepFormGeneOptions = (props: Props) => {
+  const { config } = props;
+  const [isGeneSectionExpanded, setIsGeneSectionExpanded] = useState(false);
+  const vepFormParameters = useAppSelector(getVepFormParameters);
+  const dispatch = useAppDispatch();
+
+  const toggleGeneSection = () => {
+    setIsGeneSectionExpanded(!isGeneSectionExpanded);
+  };
+
+  const onCheckboxChange = (parameter: VepFormParameterName) => {
+    dispatch(updateParameters({ [parameter]: !vepFormParameters[parameter] }));
+  };
+
+  const optionsContainerClasses = classNames(commonStyles.optionsGrid, {
+    [commonStyles.optionsContainerCollapsed]: !isGeneSectionExpanded,
+    [commonStyles.optionsContainerExpanded]: isGeneSectionExpanded
+  });
+
+  return (
+    <FormSection>
+      <div className={commonStyles.sectionTitleContainer}>
+        <ShowHide
+          label="Genes & transcripts"
+          isExpanded={isGeneSectionExpanded}
+          onClick={toggleGeneSection}
+        />
+      </div>
+      <div className={optionsContainerClasses}>
+        {/* show only the selected options in the collapsed view */}
+        {'symbol' in vepFormParameters && (
+          <Checkbox
+            label={config.parameters.symbol.label}
+            checked={vepFormParameters.symbol as boolean}
+            onChange={() => onCheckboxChange('symbol')}
+          />
+        )}
+        {'biotype' in vepFormParameters && (
+          <Checkbox
+            label={config.parameters.biotype.label}
+            checked={vepFormParameters.biotype as boolean}
+            onChange={() => onCheckboxChange('biotype')}
+          />
+        )}
+      </div>
+    </FormSection>
+  );
+};
+
+export default VepFormGeneOptions;

--- a/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.module.css
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.module.css
@@ -1,3 +1,7 @@
+.variantsSection {
+  --variants-raw-input-height: 142px;
+}
+
 /*
   For consideration:
   Is it worth extracting the background color and the top/bottom padding
@@ -38,7 +42,15 @@
 }
 
 .textarea {
-  --textarea-height: 142px;
+  --textarea-height: var(--variants-raw-input-height);
+}
+
+.rawVariantsTextContainer {
+  font-family: var(--font-family-monospace);
+  max-height: var(--variants-raw-input-height);
+  width: 450px;
+  overflow: auto;
+  white-space: pre;
 }
 
 .fileDropZone {

--- a/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.tsx
@@ -17,9 +17,17 @@
 import { useState, type FormEvent } from 'react';
 import classNames from 'classnames';
 
-import { useAppSelector } from 'src/store';
+import { useAppDispatch, useAppSelector } from 'src/store';
 
-import { getSelectedSpecies } from 'src/content/app/tools/vep/state/vep-form/vepFormSelectors';
+import {
+  getSelectedSpecies,
+  getVepFormInputText
+} from 'src/content/app/tools/vep/state/vep-form/vepFormSelectors';
+
+import {
+  updateInputText,
+  updateInputCommittedFlag
+} from 'src/content/app/tools/vep/state/vep-form/vepFormSlice';
 
 import FormSection from 'src/content/app/tools/vep/components/form-section/FormSection';
 import PlusButton from 'src/shared/components/plus-button/PlusButton';
@@ -37,24 +45,29 @@ import styles from './VepFormVariantsSection.module.css';
 import uploadStyles from 'src/shared/components/upload/Upload.module.css';
 
 const VepFormVariantsSection = () => {
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(true);
   const selectedSpecies = useAppSelector(getSelectedSpecies);
-  const [inputString, setInputString] = useState('');
   const [inputFile, setInputFile] = useState<File | null>(null);
+  const inputText = useAppSelector(getVepFormInputText);
+  const dispatch = useAppDispatch();
 
   const toggleExpanded = () => {
     setIsExpanded(!isExpanded);
   };
 
   const onReset = () => {
-    setInputString('');
+    dispatch(updateInputText(''));
     setInputFile(null);
+  };
+
+  const onInputTextUpdate = (text: string) => {
+    dispatch(updateInputText(text));
   };
 
   const canExpand = !!selectedSpecies;
 
   return (
-    <FormSection className={commonFormStyles.formSection}>
+    <FormSection>
       <div className={commonFormStyles.topFormSectionRegularGrid}>
         <div className={commonFormStyles.topFormSectionName}>Variants</div>
         <div className={commonFormStyles.topFormSectionMain}>
@@ -72,8 +85,8 @@ const VepFormVariantsSection = () => {
       </div>
       {isExpanded && (
         <ExpandedContents
-          inputString={inputString}
-          setInputString={setInputString}
+          inputString={inputText}
+          setInputString={onInputTextUpdate}
           inputFile={inputFile}
           setInputFile={setInputFile}
           onReset={onReset}
@@ -92,6 +105,7 @@ const ExpandedContents = (props: {
 }) => {
   const { inputString, inputFile, setInputString, setInputFile, onReset } =
     props;
+  const dispatch = useAppDispatch();
 
   const onTextareaContentChange = (event: FormEvent<HTMLTextAreaElement>) => {
     setInputString(event.currentTarget.value);
@@ -99,6 +113,10 @@ const ExpandedContents = (props: {
 
   const onFileDrop = (file: File) => {
     setInputFile(file);
+  };
+
+  const onCommitInput = () => {
+    dispatch(updateInputCommittedFlag(true));
   };
 
   const hasTextInput = !!inputString;
@@ -121,7 +139,9 @@ const ExpandedContents = (props: {
       </div>
       <div className={styles.gridColumnRight}>
         <div className={styles.inputControlButtons}>
-          <PrimaryButton disabled={!canCommitInput}>Add</PrimaryButton>
+          <PrimaryButton disabled={!canCommitInput} onClick={onCommitInput}>
+            Add
+          </PrimaryButton>
           {canCommitInput && <TextButton onClick={onReset}>Clear</TextButton>}
         </div>
       </div>

--- a/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.tsx
@@ -45,7 +45,7 @@ import styles from './VepFormVariantsSection.module.css';
 import uploadStyles from 'src/shared/components/upload/Upload.module.css';
 
 const VepFormVariantsSection = () => {
-  const [isExpanded, setIsExpanded] = useState(true);
+  const [isExpanded, setIsExpanded] = useState(false);
   const selectedSpecies = useAppSelector(getSelectedSpecies);
   const [inputFile, setInputFile] = useState<File | null>(null);
   const inputText = useAppSelector(getVepFormInputText);
@@ -67,17 +67,23 @@ const VepFormVariantsSection = () => {
   const canExpand = !!selectedSpecies;
 
   return (
-    <FormSection>
+    <FormSection className={styles.variantsSection}>
       <div className={commonFormStyles.topFormSectionRegularGrid}>
         <div className={commonFormStyles.topFormSectionName}>Variants</div>
         <div className={commonFormStyles.topFormSectionMain}>
-          <TextButton disabled={!canExpand} onClick={toggleExpanded}>
-            Add variants
-          </TextButton>
+          <MainContentCollapsed
+            isExpanded={isExpanded}
+            canExpand={canExpand}
+            inputText={inputText}
+            inputFile={inputFile}
+            toggleExpanded={toggleExpanded}
+          />
         </div>
         <div className={commonFormStyles.topFormSectionToggle}>
           {isExpanded ? (
             <CloseButtonWithLabel onClick={toggleExpanded} />
+          ) : inputText || inputFile ? (
+            <TextButton onClick={toggleExpanded}>Change</TextButton>
           ) : (
             <PlusButton disabled={!canExpand} onClick={toggleExpanded} />
           )}
@@ -89,6 +95,7 @@ const VepFormVariantsSection = () => {
           setInputString={onInputTextUpdate}
           inputFile={inputFile}
           setInputFile={setInputFile}
+          toggleExpanded={toggleExpanded}
           onReset={onReset}
         />
       )}
@@ -96,15 +103,50 @@ const VepFormVariantsSection = () => {
   );
 };
 
-const ExpandedContents = (props: {
+const MainContentCollapsed = ({
+  inputText,
+  inputFile,
+  isExpanded,
+  canExpand,
+  toggleExpanded
+}: {
+  inputText: string;
+  inputFile: File | null;
+  isExpanded: boolean;
+  canExpand: boolean;
+  toggleExpanded: () => void;
+}) => {
+  if (isExpanded || (!inputText && !inputFile)) {
+    return (
+      <TextButton disabled={!canExpand} onClick={toggleExpanded}>
+        Add variants
+      </TextButton>
+    );
+  } else if (inputText) {
+    return <div className={styles.rawVariantsTextContainer}>{inputText}</div>;
+  } else if (inputFile) {
+    return <span>{inputFile.name}</span>;
+  } else {
+    // this branch should be unreachable
+    return null;
+  }
+};
+
+const ExpandedContents = ({
+  inputString,
+  inputFile,
+  setInputString,
+  setInputFile,
+  toggleExpanded,
+  onReset
+}: {
   inputString: string;
   setInputString: (val: string) => void;
   inputFile: File | null;
   setInputFile: (file: File) => void;
+  toggleExpanded: () => void;
   onReset: () => void;
 }) => {
-  const { inputString, inputFile, setInputString, setInputFile, onReset } =
-    props;
   const dispatch = useAppDispatch();
 
   const onTextareaContentChange = (event: FormEvent<HTMLTextAreaElement>) => {
@@ -117,6 +159,7 @@ const ExpandedContents = (props: {
 
   const onCommitInput = () => {
     dispatch(updateInputCommittedFlag(true));
+    toggleExpanded();
   };
 
   const hasTextInput = !!inputString;

--- a/src/content/app/tools/vep/views/vep-form/vep-submission-name/VepSubmissionName.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-submission-name/VepSubmissionName.tsx
@@ -1,0 +1,50 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { FormEvent } from 'react';
+
+import { useAppDispatch, useAppSelector } from 'src/store';
+
+import { getVepSubmissionName } from 'src/content/app/tools/vep/state/vep-form/vepFormSelectors';
+
+import { updateSubmissionName } from 'src/content/app/tools/vep/state/vep-form/vepFormSlice';
+
+import ShadedInput from 'src/shared/components/input/ShadedInput';
+
+import commonStyles from '../VepForm.module.css';
+
+const VepSubmissionName = () => {
+  const submissionName = useAppSelector(getVepSubmissionName) ?? '';
+  const dispatch = useAppDispatch();
+
+  const onSubmissionNameChange = (event: FormEvent<HTMLInputElement>) => {
+    const newName = event.currentTarget.value;
+    dispatch(updateSubmissionName(newName));
+  };
+
+  return (
+    <div className={commonStyles.submissionName}>
+      <label>Submission name</label>
+      <ShadedInput
+        placeholder="Optional"
+        value={submissionName}
+        onChange={onSubmissionNameChange}
+      />
+    </div>
+  );
+};
+
+export default VepSubmissionName;

--- a/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.tsx
@@ -68,7 +68,7 @@ const VepResultsTable = (props: {
           <ColumnHead>Alt allele</ColumnHead>
           <ColumnHead>Genes</ColumnHead>
           <ColumnHead>Transcripts</ColumnHead>
-          <ColumnHead>Consequences</ColumnHead>
+          <ColumnHead>Predicted molecular consequence</ColumnHead>
         </tr>
       </thead>
       <tbody>

--- a/src/shared/components/show-hide/ShowHide.module.css
+++ b/src/shared/components/show-hide/ShowHide.module.css
@@ -1,6 +1,4 @@
 .showHide {
-  cursor: pointer;
-  display: inline-block;
   white-space: nowrap;
 }
 

--- a/src/shared/components/show-hide/ShowHide.tsx
+++ b/src/shared/components/show-hide/ShowHide.tsx
@@ -39,14 +39,14 @@ const ShowHide = (props: Props) => {
   const wrapperClasses = classNames(styles.showHide, props.className);
 
   return (
-    <div onClick={props.onClick} className={wrapperClasses}>
+    <button onClick={props.onClick} className={wrapperClasses}>
       {props.label && <span className={styles.label}>{props.label}</span>}
       <Chevron
         direction={props.isExpanded ? 'up' : 'down'}
         animate={true}
         className={styles.chevron}
       />
-    </div>
+    </button>
   );
 };
 


### PR DESCRIPTION
## Description
- Added initial implementation for VEP options
  - Fetching a config with VEP options
    - Currently, the config is mocked
  - Displaying checkboxes for options to include gene symbols and transcript biotypes in the analysis
  - Showing the transcript set selector with data from the config
- Enabled visibility rules around the form, and rules for form completeness
  - The options section only shows up after user's input for variants has been committed
  - If user's variants input has been committed, it shows up in the collapsed view of the variants section
  - The "Run" button that submits the form gets enabled only in presence of a selected species, user's input, and form parameters
- Enabled VEP form submission
  - According to the agreed-upon api spec, user's plain-text input is transformed into a file at submission
- Created a mock redux action to submit the VEP form. In absence of a working backend, it logs out the payload.


## Related JIRA Issue(s)
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2568

## Deployment URL(s)
http://vep-form-submission.review.ensembl.org