### PR TITLE
Vep form bugfixes and improvements

### DIFF
--- a/src/content/app/tools/vep/components/vep-app-bar/VepAppBar.tsx
+++ b/src/content/app/tools/vep/components/vep-app-bar/VepAppBar.tsx
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
+import { useMatch } from 'react-router';
+
 import { useAppDispatch, useAppSelector } from 'src/store';
+
+import * as urlFor from 'src/shared/helpers/urlHelper';
 
 import { getEnabledCommittedSpecies } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors';
 import { getSelectedSpecies as getSelectedSpeciesForVep } from 'src/content/app/tools/vep/state/vep-form/vepFormSelectors';
@@ -40,11 +44,14 @@ const VepAppBar = () => {
 };
 
 const SpeciesTabs = () => {
+  const vepFormPath = urlFor.vepForm();
+  const isVepFormView = useMatch({ path: vepFormPath, end: true });
   const speciesList = useAppSelector(getEnabledCommittedSpecies);
   const speciesSelectedForVep = useAppSelector(getSelectedSpeciesForVep);
   const dispatch = useAppDispatch();
 
   const hasSelectedSpeciesForVep = !!speciesSelectedForVep;
+  const shouldEnableSpeciesTabs = isVepFormView && !hasSelectedSpeciesForVep;
 
   const onSpeciesSelect = (species: CommittedItem) => {
     dispatch(setSelectedSpecies({ species }));
@@ -55,7 +62,7 @@ const SpeciesTabs = () => {
       key={species.genome_id}
       species={species}
       onClick={onSpeciesSelect}
-      disabled={hasSelectedSpeciesForVep}
+      disabled={!shouldEnableSpeciesTabs}
     />
   ));
 

--- a/src/content/app/tools/vep/components/vep-app-bar/VepAppBar.tsx
+++ b/src/content/app/tools/vep/components/vep-app-bar/VepAppBar.tsx
@@ -14,14 +14,20 @@
  * limitations under the License.
  */
 
-import { useAppSelector } from 'src/store';
+import { useAppDispatch, useAppSelector } from 'src/store';
+
 import { getEnabledCommittedSpecies } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors';
+import { getSelectedSpecies as getSelectedSpeciesForVep } from 'src/content/app/tools/vep/state/vep-form/vepFormSelectors';
+
+import { setSelectedSpecies } from 'src/content/app/tools/vep/state/vep-form/vepFormSlice';
 
 import AppBar, { AppName } from 'src/shared/components/app-bar/AppBar';
 import SpeciesManagerIndicator from 'src/shared/components/species-manager-indicator/SpeciesManagerIndicator';
 import { SelectedSpecies } from 'src/shared/components/selected-species';
 import SpeciesTabsSlider from 'src/shared/components/species-tabs-slider/SpeciesTabsSlider';
 import { AppName as AppNameText } from 'src/global/globalConfig';
+
+import type { CommittedItem } from 'src/content/app/species-selector/types/committedItem';
 
 const VepAppBar = () => {
   return (
@@ -35,12 +41,21 @@ const VepAppBar = () => {
 
 const SpeciesTabs = () => {
   const speciesList = useAppSelector(getEnabledCommittedSpecies);
+  const speciesSelectedForVep = useAppSelector(getSelectedSpeciesForVep);
+  const dispatch = useAppDispatch();
+
+  const hasSelectedSpeciesForVep = !!speciesSelectedForVep;
+
+  const onSpeciesSelect = (species: CommittedItem) => {
+    dispatch(setSelectedSpecies({ species }));
+  };
 
   const speciesTabs = speciesList.map((species) => (
     <SelectedSpecies
       key={species.genome_id}
       species={species}
-      disabled={true}
+      onClick={onSpeciesSelect}
+      disabled={hasSelectedSpeciesForVep}
     />
   ));
 

--- a/src/content/app/tools/vep/components/vep-top-bar/VepTopBar.tsx
+++ b/src/content/app/tools/vep/components/vep-top-bar/VepTopBar.tsx
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import noop from 'lodash/noop';
+
 import { useAppSelector } from 'src/store';
 
 import {
@@ -62,9 +64,16 @@ const VepTopBar = () => {
 };
 
 const TranscriptSetSelector = () => {
-  const selectedSpecies = useAppSelector(getSelectedSpecies); // TODO: use genome id of the species to fetch the form config
+  const selectedSpecies = useAppSelector(getSelectedSpecies);
   const vepFormParameters = useAppSelector(getVepFormParameters);
-  const { currentData: vepFormConfig } = useVepFormConfigQuery();
+  const { currentData: vepFormConfig } = useVepFormConfigQuery(
+    {
+      genome_id: selectedSpecies?.genome_id ?? ''
+    },
+    {
+      skip: !selectedSpecies
+    }
+  );
 
   const canPopulateSelect = selectedSpecies && vepFormConfig;
 
@@ -86,6 +95,7 @@ const TranscriptSetSelector = () => {
         disabled={!canPopulateSelect}
         className={styles.transcriptSetSelector}
         value={selectedValue}
+        onChange={noop}
       />
     </div>
   );

--- a/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
+++ b/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
@@ -17,19 +17,16 @@
 import config from 'config';
 
 import restApiSlice from 'src/shared/state/api-slices/restSlice';
-import { setDefaultParameters } from '../vep-form/vepFormSlice';
-
-import { getVepFormParameters } from '../vep-form/vepFormSelectors';
 
 import type { VepResultsResponse } from 'src/content/app/tools/vep/types/vepResultsResponse';
 import type { VepFormConfig } from 'src/content/app/tools/vep/types/vepFormConfig';
 import type { VEPSubmissionPayload } from 'src/content/app/tools/vep/types/vepSubmission';
-import type { RootState } from 'src/store';
 
 const vepApiSlice = restApiSlice.injectEndpoints({
   endpoints: (builder) => ({
-    vepFormConfig: builder.query<VepFormConfig, void>({
-      queryFn: async (_, { dispatch, getState }) => {
+    vepFormConfig: builder.query<VepFormConfig, { genome_id: string }>({
+      // eslint-disable-next-line
+      queryFn: async (params) => {
         // TODO: the query function will accept a genome id,
         // and will send request to:
         // `${config.toolsApiBaseUrl}/vep/config?genome_id=${genomeId}`
@@ -41,13 +38,10 @@ const vepApiSlice = restApiSlice.injectEndpoints({
         );
         const vepFormConfig = mockResponseModule.default;
 
-        const vepFormParametersInState = getVepFormParameters(
-          getState() as RootState
-        );
-
-        if (!Object.keys(vepFormParametersInState).length) {
-          dispatch(setDefaultParameters(vepFormConfig));
-        }
+        // simulate network delay
+        await new Promise((resolve) => {
+          setTimeout(resolve, 200);
+        });
 
         return {
           data: vepFormConfig

--- a/src/content/app/tools/vep/state/vep-form/vepFormSlice.ts
+++ b/src/content/app/tools/vep/state/vep-form/vepFormSlice.ts
@@ -52,7 +52,11 @@ const vepFormSlice = createSlice({
       state,
       action: PayloadAction<{ species: VepSelectedSpecies }>
     ) => {
+      // NOTE: selecting a new species means that form parameters,
+      // whose values might remain from previously selected species,
+      // should be reset
       state.selectedSpecies = action.payload.species;
+      state.parameters = {};
     },
     // replace the whole parameters object in the state
     setDefaultParameters: (state, action: PayloadAction<VepFormConfig>) => {

--- a/src/content/app/tools/vep/state/vep-form/vepFormSlice.ts
+++ b/src/content/app/tools/vep/state/vep-form/vepFormSlice.ts
@@ -80,7 +80,7 @@ const vepFormSlice = createSlice({
     updateInputText: (state, action: PayloadAction<string>) => {
       state.inputText = action.payload;
     },
-    updateInputFile: (state, action: PayloadAction<File>) => {
+    updateInputFile: (state, action: PayloadAction<File | null>) => {
       state.inputFile = action.payload;
     },
     updateInputCommittedFlag: (state, action: PayloadAction<boolean>) => {

--- a/src/content/app/tools/vep/state/vep-form/vepFormSlice.ts
+++ b/src/content/app/tools/vep/state/vep-form/vepFormSlice.ts
@@ -85,6 +85,9 @@ const vepFormSlice = createSlice({
     },
     updateInputCommittedFlag: (state, action: PayloadAction<boolean>) => {
       state.isInputCommitted = action.payload;
+    },
+    resetForm: () => {
+      return initialState;
     }
   }
 });
@@ -96,7 +99,8 @@ export const {
   updateSubmissionName,
   updateInputText,
   updateInputFile,
-  updateInputCommittedFlag
+  updateInputCommittedFlag,
+  resetForm
 } = vepFormSlice.actions;
 
 export default vepFormSlice.reducer;

--- a/src/content/app/tools/vep/views/vep-form/VepForm.module.css
+++ b/src/content/app/tools/vep/views/vep-form/VepForm.module.css
@@ -21,9 +21,9 @@
 *  THE TOPMOST AREA, ABOVE OTHER FORM SECTIONS
 */
 .topmostAreaGrid {
-  --padding-side: 42px;
+  --padding-side: 40px;
   display: grid;
-  grid-template-columns: [submission-name-field] 1fr [form-reset] max-content;
+  grid-template-columns: [submission-name-field] 400px [form-reset] 1fr;
   align-items: end;
   padding-left: var(--padding-side);
   padding-right: var(--padding-side);
@@ -32,7 +32,6 @@
 
 .submissionName {
   grid-column: submission-name-field;
-  justify-self: start;
   display: flex;
   align-items: center;
   column-gap: 12px;
@@ -43,6 +42,7 @@
 
 .resetForm {
   grid-column: form-reset;
+  justify-self: end;
 }
 
 
@@ -53,7 +53,7 @@
 /* Grid to use to display the regular content of the section, i.e. not the expanded content */
 .topFormSectionRegularGrid {
   --column-gap: 20px;
-  --padding-side: 42px;
+  --padding-side: 40px;
   display: grid;
   grid-template-columns:
     [section-name] calc(152px - var(--column-gap))

--- a/src/content/app/tools/vep/views/vep-form/VepForm.tsx
+++ b/src/content/app/tools/vep/views/vep-form/VepForm.tsx
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import useVepFormConfig from './useVepFormConfig';
+
 import {
   VepFormSpecies,
   VepSpeciesSelectorNavButton
@@ -27,6 +29,8 @@ import VepFormResetButton from './vep-form-reset-button/VepFormResetButton';
 import styles from './VepForm.module.css';
 
 const VepForm = () => {
+  useVepFormConfig();
+
   return (
     <div className={styles.outerContainer}>
       <div className={styles.container}>

--- a/src/content/app/tools/vep/views/vep-form/VepForm.tsx
+++ b/src/content/app/tools/vep/views/vep-form/VepForm.tsx
@@ -22,7 +22,7 @@ import VepFormVariantsSection from './vep-form-variants-section/VepFormVariantsS
 import VepFormOptionsSection from './vep-form-options-section/VepFormOptionsSection';
 import VepSubmissionName from './vep-submission-name/VepSubmissionName';
 import FormSection from 'src/content/app/tools/vep/components/form-section/FormSection';
-import { DeleteButtonWithLabel } from 'src/shared/components/delete-button/DeleteButton';
+import VepFormResetButton from './vep-form-reset-button/VepFormResetButton';
 
 import styles from './VepForm.module.css';
 
@@ -32,9 +32,7 @@ const VepForm = () => {
       <div className={styles.container}>
         <div className={styles.topmostAreaGrid}>
           <VepSubmissionName />
-          <div className={styles.resetForm}>
-            <DeleteButtonWithLabel label="Reset" disabled={true} />
-          </div>
+          <VepFormResetButton className={styles.resetForm} />
         </div>
 
         <FormSection>

--- a/src/content/app/tools/vep/views/vep-form/useVepFormConfig.ts
+++ b/src/content/app/tools/vep/views/vep-form/useVepFormConfig.ts
@@ -1,0 +1,79 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect } from 'react';
+
+import { useAppDispatch, useAppSelector } from 'src/store';
+
+import {
+  getSelectedSpecies,
+  getVepFormParameters
+} from 'src/content/app/tools/vep/state/vep-form//vepFormSelectors';
+
+import { useVepFormConfigQuery } from 'src/content/app/tools/vep/state/vep-api/vepApiSlice';
+import { setDefaultParameters } from 'src/content/app/tools/vep/state/vep-form/vepFormSlice';
+
+/**
+ * The purpose of this hook is to request VEP form config with user options
+ * every time the selected species changes; and to update VEP form parameters
+ * with the default values from the config.
+ *
+ * Consider the following scenarios:
+ * 1. Component mounts for the first time. User selects a species.
+ *    VEP form config needs to be fetched.
+ * 2. After selecting a species, user decides to change the species.
+ *    A different VEP form config needs to be fetched.
+ * 3. User starts filling in the form triggering the fetching of a VEP form config;
+ *    then resets the form, and starts filling it again for the same species.
+ *    A new request for the config will not be sent, because the previous request
+ *    will have still been cached; but it is necessary to set up
+ *    default form parameters from the config.
+ * 4. User starts filling in the form, switches to a different app,
+ *    then comes back. No need to fetch a new VEP form config.
+ */
+
+const useVepFormConfig = () => {
+  const selectedSpecies = useAppSelector(getSelectedSpecies);
+  const vepFormParameters = useAppSelector(getVepFormParameters);
+  const selectedGenomeId = selectedSpecies?.genome_id;
+  const areFormParametersEmpty = isObjectEmpty(vepFormParameters);
+  const { currentData: vepFormConfig } = useVepFormConfigQuery(
+    {
+      genome_id: selectedGenomeId ?? ''
+    },
+    {
+      skip: !selectedGenomeId || !areFormParametersEmpty
+    }
+  );
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    // NOTE: When the user changes the selected species,
+    // form parameters are cleared out (see vepFormSlice),
+    // which will trigger the dispatch below.
+    if (!vepFormConfig || !areFormParametersEmpty) {
+      return;
+    }
+
+    dispatch(setDefaultParameters(vepFormConfig));
+  }, [vepFormConfig, areFormParametersEmpty]);
+};
+
+const isObjectEmpty = (obj: Record<string, unknown>) => {
+  return Object.keys(obj).length === 0;
+};
+
+export default useVepFormConfig;

--- a/src/content/app/tools/vep/views/vep-form/vep-form-options-section/VepFormOptionsSection.module.css
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-options-section/VepFormOptionsSection.module.css
@@ -2,8 +2,13 @@
   margin-top: 50px;
 }
 
+.sectionHeader {
+  margin-bottom: 24px;
+  padding-left: 40px;
+}
+
 .sectionTitleContainer {
-  --padding-side: 42px; /* Note that this is the same as in other VEP form sections. Perhaps this is something that should live in the FormSection component? */
+  --padding-side: 40px; /* Note that this is the same as in other VEP form sections. Perhaps this is something that should live in the FormSection component? */
   display: flex;
   align-items: center;
   height: var(--form-section-min-height);

--- a/src/content/app/tools/vep/views/vep-form/vep-form-options-section/VepFormOptionsSection.module.css
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-options-section/VepFormOptionsSection.module.css
@@ -3,6 +3,10 @@
 }
 
 .sectionHeader {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 60px;
+  align-items: center;
   margin-bottom: 24px;
   padding-left: 40px;
 }
@@ -37,6 +41,10 @@
   padding-left: var(--padding-side);
   padding-right: var(--padding-side);
   padding-top: 12px;
+}
+
+.optionsGrid:empty {
+  display: none;
 }
 
 .optionsContainerCollapsed {

--- a/src/content/app/tools/vep/views/vep-form/vep-form-options-section/VepFormOptionsSection.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-options-section/VepFormOptionsSection.tsx
@@ -36,8 +36,14 @@ const VepFormOptionsSection = () => {
     return null;
   }
 
+  // FIXME: just for development; remember to remove
+  // if (!formConfig) {
+  //   return null;
+  // }
+
   return (
     <div className={styles.container}>
+      <SectionHeader />
       <VepFormGeneOptions config={formConfig} />
       <FormSection>
         <div className={styles.sectionTitleContainer}>
@@ -86,6 +92,10 @@ const VepFormOptionsSection = () => {
       </FormSection>
     </div>
   );
+};
+
+const SectionHeader = () => {
+  return <div className={styles.sectionHeader}>Job options</div>;
 };
 
 export default VepFormOptionsSection;

--- a/src/content/app/tools/vep/views/vep-form/vep-form-options-section/VepFormOptionsSection.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-options-section/VepFormOptionsSection.tsx
@@ -22,6 +22,10 @@ import { useVepFormConfigQuery } from 'src/content/app/tools/vep/state/vep-api/v
 
 import FormSection from 'src/content/app/tools/vep/components/form-section/FormSection';
 import VepFormGeneOptions from './vep-form-gene-options/VepFormGeneOptions';
+import {
+  PseudoRadioButton,
+  PseudoRadioButtonGroup
+} from 'src/shared/components/pseudo-radio-button';
 
 import styles from './VepFormOptionsSection.module.css';
 
@@ -35,11 +39,6 @@ const VepFormOptionsSection = () => {
     // TODO: handle the loading state?
     return null;
   }
-
-  // FIXME: just for development; remember to remove
-  // if (!formConfig) {
-  //   return null;
-  // }
 
   return (
     <div className={styles.container}>
@@ -95,7 +94,15 @@ const VepFormOptionsSection = () => {
 };
 
 const SectionHeader = () => {
-  return <div className={styles.sectionHeader}>Job options</div>;
+  return (
+    <div className={styles.sectionHeader}>
+      <span>Job options</span>
+      <PseudoRadioButtonGroup>
+        <PseudoRadioButton label="Short variants" />
+        <PseudoRadioButton label="Structural variants" disabled={true} />
+      </PseudoRadioButtonGroup>
+    </div>
+  );
 };
 
 export default VepFormOptionsSection;

--- a/src/content/app/tools/vep/views/vep-form/vep-form-options-section/VepFormOptionsSection.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-options-section/VepFormOptionsSection.tsx
@@ -16,7 +16,10 @@
 
 import { useAppSelector } from 'src/store';
 
-import { getVepFormInputCommittedFlag } from 'src/content/app/tools/vep/state/vep-form/vepFormSelectors';
+import {
+  getSelectedSpecies,
+  getVepFormInputCommittedFlag
+} from 'src/content/app/tools/vep/state/vep-form/vepFormSelectors';
 
 import { useVepFormConfigQuery } from 'src/content/app/tools/vep/state/vep-api/vepApiSlice';
 
@@ -26,17 +29,33 @@ import {
   PseudoRadioButton,
   PseudoRadioButtonGroup
 } from 'src/shared/components/pseudo-radio-button';
+import { CircleLoader } from 'src/shared/components/loader';
 
 import styles from './VepFormOptionsSection.module.css';
 
 const VepFormOptionsSection = () => {
+  const selectedSpecies = useAppSelector(getSelectedSpecies);
   const isVariantsInputCommitted = useAppSelector(getVepFormInputCommittedFlag);
 
-  // FIXME: remember that useVepFormConfigQuery will need a genome id when request is sent to backend for real
-  const { currentData: formConfig } = useVepFormConfigQuery();
+  const { currentData: formConfig, isFetching } = useVepFormConfigQuery(
+    {
+      genome_id: selectedSpecies?.genome_id ?? ''
+    },
+    {
+      skip: !selectedSpecies
+    }
+  );
+
+  if (isFetching) {
+    return (
+      <div className={styles.container}>
+        <CircleLoader />
+      </div>
+    );
+  }
 
   if (!isVariantsInputCommitted || !formConfig) {
-    // TODO: handle the loading state?
+    // TODO: should we handle the error state somehow?
     return null;
   }
 

--- a/src/content/app/tools/vep/views/vep-form/vep-form-options-section/VepFormOptionsSection.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-options-section/VepFormOptionsSection.tsx
@@ -46,7 +46,7 @@ const VepFormOptionsSection = () => {
     }
   );
 
-  if (isFetching) {
+  if (isFetching && isVariantsInputCommitted) {
     return (
       <div className={styles.container}>
         <CircleLoader />

--- a/src/content/app/tools/vep/views/vep-form/vep-form-options-section/vep-form-gene-options/VepFormGeneOptions.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-options-section/vep-form-gene-options/VepFormGeneOptions.tsx
@@ -68,7 +68,7 @@ const VepFormGeneOptions = (props: Props) => {
       </div>
       <div className={optionsContainerClasses}>
         {/* show only the selected options in the collapsed view */}
-        {'symbol' in vepFormParameters && (
+        {'symbol' in vepFormParameters && isGeneSectionExpanded && (
           <Checkbox
             label={config.parameters.symbol.label}
             checked={vepFormParameters.symbol as boolean}

--- a/src/content/app/tools/vep/views/vep-form/vep-form-options-section/vep-form-gene-options/VepFormGeneOptions.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-options-section/vep-form-gene-options/VepFormGeneOptions.tsx
@@ -52,6 +52,14 @@ const VepFormGeneOptions = (props: Props) => {
     dispatch(updateParameters({ [parameter]: !vepFormParameters[parameter] }));
   };
 
+  const shouldShowOptionCheckbox = (optionName: VepFormParameterName) => {
+    if (isGeneSectionExpanded) {
+      return optionName in vepFormParameters;
+    } else {
+      return optionName in vepFormParameters && vepFormParameters[optionName];
+    }
+  };
+
   const optionsContainerClasses = classNames(commonStyles.optionsGrid, {
     [commonStyles.optionsContainerCollapsed]: !isGeneSectionExpanded,
     [commonStyles.optionsContainerExpanded]: isGeneSectionExpanded
@@ -68,14 +76,14 @@ const VepFormGeneOptions = (props: Props) => {
       </div>
       <div className={optionsContainerClasses}>
         {/* show only the selected options in the collapsed view */}
-        {'symbol' in vepFormParameters && isGeneSectionExpanded && (
+        {shouldShowOptionCheckbox('symbol') && (
           <Checkbox
             label={config.parameters.symbol.label}
             checked={vepFormParameters.symbol as boolean}
             onChange={() => onCheckboxChange('symbol')}
           />
         )}
-        {'biotype' in vepFormParameters && (
+        {shouldShowOptionCheckbox('biotype') && (
           <Checkbox
             label={config.parameters.biotype.label}
             checked={vepFormParameters.biotype as boolean}

--- a/src/content/app/tools/vep/views/vep-form/vep-form-reset-button/VepFormResetButton.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-reset-button/VepFormResetButton.tsx
@@ -1,0 +1,54 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useAppDispatch, useAppSelector } from 'src/store';
+
+import { getSelectedSpecies } from 'src/content/app/tools/vep/state/vep-form/vepFormSelectors';
+
+import { resetForm } from 'src/content/app/tools/vep/state/vep-form/vepFormSlice';
+
+import { DeleteButtonWithLabel } from 'src/shared/components/delete-button/DeleteButton';
+
+type Props = {
+  className?: string;
+};
+
+/**
+ * A selected species is the minimal necessary data of the VEP form that should enable the reset button.
+ * Since no other data can be added until a species has been selected, it is also unnecessary
+ * to check for the presence for any other data when enabling the button.
+ */
+const VepFormResetButton = (props: Props) => {
+  const selectedSpecies = useAppSelector(getSelectedSpecies);
+  const dispatch = useAppDispatch();
+
+  const shouldEnableReset = Boolean(selectedSpecies);
+
+  const onReset = () => {
+    dispatch(resetForm());
+  };
+
+  return (
+    <DeleteButtonWithLabel
+      label="Reset"
+      onClick={onReset}
+      disabled={!shouldEnableReset}
+      className={props.className}
+    />
+  );
+};
+
+export default VepFormResetButton;

--- a/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.module.css
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.module.css
@@ -30,6 +30,7 @@
 .gridColumnRight {
   grid-column: right;
   justify-self: start;
+  padding-left: calc(var(--standard-gutter) - var(--column-gap)); /* to achieve the same distance from textarea as the width of the standard gutter */
 }
 
 .inputControlButtons {
@@ -38,7 +39,6 @@
   align-items: start;
   row-gap: 24px;
   padding-top: var(--standard-gutter);
-  padding-left: calc(var(--standard-gutter) - var(--column-gap)); /* to achieve the same distance from textarea as the width of the standard gutter */
 }
 
 .textarea {
@@ -72,6 +72,26 @@
   display: flex;
   align-items: center;
   height: 58px;
+}
+
+.maxUploadSize {
+  display: flex;
+  flex-direction: column;
+  font-weight: var(--font-weight-light);
+  margin-top: 26px;
+}
+
+.maxUploadSizeNumber {
+  font-weight: initial;
+}
+
+.maxUploadSizeError {
+  color: var(--color-red);
+}
+
+.invisible {
+  visibility: hidden;
+  pointer-events: none;
 }
 
 .alignSelfCenter {

--- a/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.module.css
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.module.css
@@ -43,6 +43,8 @@
 
 .textarea {
   --textarea-height: var(--variants-raw-input-height);
+  font-family: var(--font-family-monospace);
+  line-height: var(--body-line-height);
 }
 
 .rawVariantsTextContainer {

--- a/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.tsx
@@ -21,11 +21,13 @@ import { useAppDispatch, useAppSelector } from 'src/store';
 
 import {
   getSelectedSpecies,
-  getVepFormInputText
+  getVepFormInputText,
+  getVepFormInputFile
 } from 'src/content/app/tools/vep/state/vep-form/vepFormSelectors';
 
 import {
   updateInputText,
+  updateInputFile,
   updateInputCommittedFlag
 } from 'src/content/app/tools/vep/state/vep-form/vepFormSlice';
 
@@ -47,8 +49,8 @@ import uploadStyles from 'src/shared/components/upload/Upload.module.css';
 const VepFormVariantsSection = () => {
   const [isExpanded, setIsExpanded] = useState(false);
   const selectedSpecies = useAppSelector(getSelectedSpecies);
-  const [inputFile, setInputFile] = useState<File | null>(null);
   const inputText = useAppSelector(getVepFormInputText);
+  const inputFile = useAppSelector(getVepFormInputFile);
   const dispatch = useAppDispatch();
 
   const toggleExpanded = () => {
@@ -57,11 +59,15 @@ const VepFormVariantsSection = () => {
 
   const onReset = () => {
     dispatch(updateInputText(''));
-    setInputFile(null);
+    dispatch(updateInputFile(null));
   };
 
   const onInputTextUpdate = (text: string) => {
     dispatch(updateInputText(text));
+  };
+
+  const onInputFileUpdate = (file: File) => {
+    dispatch(updateInputFile(file));
   };
 
   const canExpand = !!selectedSpecies;
@@ -94,7 +100,7 @@ const VepFormVariantsSection = () => {
           inputString={inputText}
           setInputString={onInputTextUpdate}
           inputFile={inputFile}
-          setInputFile={setInputFile}
+          setInputFile={onInputFileUpdate}
           toggleExpanded={toggleExpanded}
           onReset={onReset}
         />

--- a/src/shared/components/pseudo-radio-button/PseudoRadioButton.module.css
+++ b/src/shared/components/pseudo-radio-button/PseudoRadioButton.module.css
@@ -1,0 +1,12 @@
+.pseudoRadioGroup {
+  --radio-label-font-weight: var(--font-weight-normal);
+  display: flex;
+  column-gap: 2rem;
+  margin-left: var(--inner-block-offset-left);
+}
+
+.pseudoRadioDisabled > * {
+  --radio-background-color: var(--color-light-grey);
+  --radio-label-font-weight: var(--font-weight-light);
+  cursor: default !important; /* yes, !important is terrible; but this is just a dummy component; no parent will need to override this */
+}

--- a/src/shared/components/pseudo-radio-button/PseudoRadioButton.module.css
+++ b/src/shared/components/pseudo-radio-button/PseudoRadioButton.module.css
@@ -1,12 +1,8 @@
-.pseudoRadioGroup {
-  --radio-label-font-weight: var(--font-weight-normal);
-  display: flex;
-  column-gap: 2rem;
-  margin-left: var(--inner-block-offset-left);
+.pseudoRadioButton > * {
+  cursor: default !important; /* yes, !important is a bad smell; but this is just a dummy component; and no parent will need to override this */
 }
 
 .pseudoRadioDisabled > * {
   --radio-background-color: var(--color-light-grey);
   --radio-label-font-weight: var(--font-weight-light);
-  cursor: default !important; /* yes, !important is terrible; but this is just a dummy component; no parent will need to override this */
 }

--- a/src/shared/components/pseudo-radio-button/PseudoRadioButton.tsx
+++ b/src/shared/components/pseudo-radio-button/PseudoRadioButton.tsx
@@ -21,7 +21,7 @@ import styles from './PseudoRadioButton.module.css';
 
 type Props = {
   label: string;
-  disabled: boolean;
+  disabled?: boolean;
 };
 
 /**
@@ -30,9 +30,13 @@ type Props = {
  * will actually do something useful.
  */
 const PseudoRadioButton = (props: Props) => {
-  const componentClasses = classNames(radioStyles.radioGroupItem, {
-    [styles.pseudoRadioDisabled]: props.disabled
-  });
+  const componentClasses = classNames(
+    radioStyles.radioGroupItem,
+    styles.pseudoRadioButton,
+    {
+      [styles.pseudoRadioDisabled]: props.disabled
+    }
+  );
   const radioClasses = classNames(radioStyles.radio, {
     [radioStyles.radioChecked]: !props.disabled
   });
@@ -40,7 +44,7 @@ const PseudoRadioButton = (props: Props) => {
   return (
     <div className={componentClasses}>
       <span className={classNames(radioClasses)} />
-      <span className={radioStyles.label}>Only species in list</span>
+      <span className={radioStyles.label}>{props.label}</span>
     </div>
   );
 };

--- a/src/shared/components/pseudo-radio-button/PseudoRadioButton.tsx
+++ b/src/shared/components/pseudo-radio-button/PseudoRadioButton.tsx
@@ -1,0 +1,48 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classNames from 'classnames';
+
+import radioStyles from 'src/shared/components/radio-group/RadioGroup.module.css';
+import styles from './PseudoRadioButton.module.css';
+
+type Props = {
+  label: string;
+  disabled: boolean;
+};
+
+/**
+ * This component looks like a radio button; but is purely decorative.
+ * Its purpose is to show to user what the UI will look like when the radio buttons
+ * will actually do something useful.
+ */
+const PseudoRadioButton = (props: Props) => {
+  const componentClasses = classNames(radioStyles.radioGroupItem, {
+    [styles.pseudoRadioDisabled]: props.disabled
+  });
+  const radioClasses = classNames(radioStyles.radio, {
+    [radioStyles.radioChecked]: !props.disabled
+  });
+
+  return (
+    <div className={componentClasses}>
+      <span className={classNames(radioClasses)} />
+      <span className={radioStyles.label}>Only species in list</span>
+    </div>
+  );
+};
+
+export default PseudoRadioButton;

--- a/src/shared/components/pseudo-radio-button/PseudoRadioButtonGroup.module.css
+++ b/src/shared/components/pseudo-radio-button/PseudoRadioButtonGroup.module.css
@@ -1,0 +1,6 @@
+.container {
+  --radio-label-font-weight: var(--font-weight-normal);
+  display: flex;
+  column-gap: var(--pseudo-radio-buttons-column-gap, 34px);
+  /* margin-left: var(--inner-block-offset-left); */
+}

--- a/src/shared/components/pseudo-radio-button/PseudoRadioButtonGroup.module.css
+++ b/src/shared/components/pseudo-radio-button/PseudoRadioButtonGroup.module.css
@@ -2,5 +2,4 @@
   --radio-label-font-weight: var(--font-weight-normal);
   display: flex;
   column-gap: var(--pseudo-radio-buttons-column-gap, 34px);
-  /* margin-left: var(--inner-block-offset-left); */
 }

--- a/src/shared/components/pseudo-radio-button/PseudoRadioButtonGroup.tsx
+++ b/src/shared/components/pseudo-radio-button/PseudoRadioButtonGroup.tsx
@@ -1,0 +1,39 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classNames from 'classnames';
+import type { ReactNode } from 'react';
+
+import styles from './PseudoRadioButtonGroup.module.css';
+
+type Props = {
+  children: ReactNode;
+  className?: string;
+};
+
+/**
+ * This is just a simple container with some style presets.
+ * There has not yet been any designs in which the pseudo-radio buttons are positioned vertically;
+ * so the only thing this container will do currently is position its children horizontally
+ */
+
+const PseudoRadioButtonGroup = (props: Props) => {
+  const componentClasses = classNames(styles.container, props.className);
+
+  return <div className={componentClasses}>{props.children}</div>;
+};
+
+export default PseudoRadioButtonGroup;

--- a/src/shared/components/pseudo-radio-button/index.ts
+++ b/src/shared/components/pseudo-radio-button/index.ts
@@ -1,0 +1,18 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default as PseudoRadioButton } from './PseudoRadioButton';
+export { default as PseudoRadioButtonGroup } from './PseudoRadioButtonGroup';

--- a/src/shared/components/textarea/Textarea.module.css
+++ b/src/shared/components/textarea/Textarea.module.css
@@ -2,7 +2,10 @@
   border-color: var(--textarea-border-color, var(--color-grey));
   border-width: var(--textarea-border-width, 1px);
   border-style: var(--textarea-border-style, solid);
-  padding: 7px;
+  padding-left: var(--textarea-padding-left, 15px);
+  padding-right: var(--textarea-padding-right, 15px);
+  padding-top: var(--textarea-padding-top, 7px);
+  padding-bottom: var(--textarea-padding-bottom, 7px);
   width: 100%;
   height: var(--textarea-height, 85px); /* To display 5 lines of text */
 }
@@ -24,6 +27,5 @@
 .shadedTextarea {
   --textarea-border-style: none;
   box-shadow: var(--form-field-shadow);
-  padding: 7px 15px;
   border: none;
 }


### PR DESCRIPTION
## Description
This PR contains various small improvements and bugfixes for VEP form

**Bugfixes**
- Enable the form submit ("Run") button after a file is attached

**Improvements**
- Select a species by clicking on a species lozenge
- Show pseudo-radiobuttons (Short variants / Structural variants) at the top of the options section
- Hide the unchecked form options (i.e. gene symbol or biotype) from the collapsed section view
- Clear the form upon pressing the Reset button
- Show an error message when the attached file is too large (over 250MB)
- Disable species lozenges on any VEP screen other than the initial VEP form
- Make sure that when the selected species changes, VEP form config is fetched again

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2652

## Deployment URL(s)
http://vep-form-submission.review.ensembl.org