### PR TITLE
Correctly update species list in the Species Manager after species deletion

### DIFF
--- a/src/content/app/species-selector/views/species-manager/useFilteredGenomes.ts
+++ b/src/content/app/species-selector/views/species-manager/useFilteredGenomes.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState, type FormEvent } from 'react';
+import { useState, useEffect, useRef, type FormEvent } from 'react';
 
 import { useAppSelector } from 'src/store';
 
@@ -25,13 +25,29 @@ import type { CommittedItem } from 'src/content/app/species-selector/types/commi
 const useFilteredGenomes = () => {
   const selectedGenomes = useAppSelector(getCommittedSpecies);
   const [filteredGenomes, setFilteredGenomes] = useState(selectedGenomes);
+  const filterStringRef = useRef('');
+
+  // If the list of selected genomes changes (e.g. a species has been deleted),
+  // this should be reflected in the list of filtered genomes
+  useEffect(() => {
+    const filterString = filterStringRef.current;
+    const filteredGenomes = applyFilter(selectedGenomes, filterString);
+    setFilteredGenomes(filteredGenomes);
+  }, [selectedGenomes]);
 
   const onFilterChange = (event: FormEvent<HTMLInputElement>) => {
     const filterString = event.currentTarget.value;
-    const filteredGenomes = selectedGenomes.filter((genome) => {
-      return doesGenomeMatchQuery(genome, filterString);
-    });
+    filterStringRef.current = filterString;
+
+    const filteredGenomes = applyFilter(selectedGenomes, filterString);
+
     setFilteredGenomes(filteredGenomes);
+  };
+
+  const applyFilter = (genomes: CommittedItem[], filter: string) => {
+    return genomes.filter((genome) => {
+      return doesGenomeMatchQuery(genome, filter);
+    });
   };
 
   return {


### PR DESCRIPTION
## Description
### Bug
- Select several species in the species selector.
- Open the species manager to see the list (table) of selected species.
- Try deleting one or more species.
- _(Bug)_ You will notice that the species you've just deleted remain in the species list. (However, if you refresh the page, you will see that they are now gone)

### Cause of the issue
The bug must have been introduced in https://github.com/Ensembl/ensembl-client/pull/1127 when I added a filter box to the species manager. Since that PR, the list of species shown in the Species Manager is actually the list of filtered genomes, which is kept in the local state in the `useFilteredGenomes` hook. That local state did not get updated if the list of selected species changed, e.g. if one or more selected species were deleted.

### Solution
I added a useEffect hook to update the filtered genomes list if selected species have been updated.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2595

## Deployment URL(s)
http://fix-species-manager-deletion.review.ensembl.org