### PR TITLE
Fix expansion/collapsing of transcripts in the focus gene track of genome browser

### DIFF
--- a/src/content/app/genome-browser/hooks/useFocusTrack.ts
+++ b/src/content/app/genome-browser/hooks/useFocusTrack.ts
@@ -179,7 +179,10 @@ const useFocusGene = (params: UseFocusGeneParams) => {
     const lozengeClicksSubscription = genomeBrowserService.subscribe(
       'hotspot',
       (message: HotspotMessage) => {
-        if (isLozengeClickMessage(message.payload)) {
+        if (
+          isLozengeClickMessage(message.payload) &&
+          isFocusGeneLozenge(message.payload)
+        ) {
           onLozengeClick();
         }
       }
@@ -385,5 +388,8 @@ const isLozengeClickMessage = (payload: {
 }): payload is TranscriptsLozengePayload => {
   return payload.variety[0].type === 'lozenge';
 };
+
+const isFocusGeneLozenge = (payload: TranscriptsLozengePayload) =>
+  payload.content[0].focus;
 
 export default useFocusTrack;


### PR DESCRIPTION
## Description
**Bug:** if you click on the "show all transcripts" lozenge under a gene in non-focus track, the gene in the focus track also expands/collapses its transcripts:

https://github.com/user-attachments/assets/ff22a0d0-242e-479c-b335-3294a89acf21



## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2306

## Deployment URL(s)
http://fix-gb-transcript-expansion.review.ensembl.org