### PR TITLE
Show example VCF input for VEP if available

### DIFF
--- a/src/content/app/tools/vep/state/vep-api/queries/vepExampleVariantQuery.ts
+++ b/src/content/app/tools/vep/state/vep-api/queries/vepExampleVariantQuery.ts
@@ -1,0 +1,58 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from 'graphql-request';
+import { Pick3 } from 'ts-multipick';
+
+import type { Variant } from 'src/shared/types/variation-api/variant';
+import type { VariantAllele } from 'src/shared/types/variation-api/variantAllele';
+
+export const variantDefaultQuery = gql`
+  query VariantDetails($genomeId: String!, $variantId: String!) {
+    variant(by_id: { genome_id: $genomeId, variant_id: $variantId }) {
+      name
+      slice {
+        region {
+          name
+        }
+      }
+      alleles {
+        slice {
+          location {
+            start
+          }
+        }
+        allele_sequence
+        reference_sequence
+      }
+    }
+  }
+`;
+
+export type VepExampleVariantAllele = Pick<
+  VariantAllele,
+  'allele_sequence' | 'reference_sequence'
+> &
+  Pick3<VariantAllele, 'slice', 'location', 'start'>;
+
+export type VepExampleVariant = Pick<Variant, 'name'> &
+  Pick3<Variant, 'slice', 'region', 'name'> & {
+    alleles: VepExampleVariantAllele[];
+  };
+
+export type VepExampleVariantQueryResult = {
+  variant: VepExampleVariant;
+};

--- a/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
+++ b/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
@@ -14,12 +14,18 @@
  * limitations under the License.
  */
 
+import { request } from 'graphql-request';
+
 import config from 'config';
+
+import {
+  variantDefaultQuery,
+  type VepExampleVariantQueryResult
+} from './queries/vepExampleVariantQuery';
 
 import restApiSlice from 'src/shared/state/api-slices/restSlice';
 
 import { fetchExampleObjectsForGenome } from 'src/shared/state/genome/genomeApiSlice';
-import { fetchDefaultEntityViewerVariant } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
 
 import type { VepResultsResponse } from 'src/content/app/tools/vep/types/vepResultsResponse';
 import type { VepFormConfig } from 'src/content/app/tools/vep/types/vepFormConfig';
@@ -74,18 +80,19 @@ const vepApiSlice = restApiSlice.injectEndpoints({
           throw new Error(); // FIXME
         }
 
-        const { data: exampleVariantData } = await dispatch(
-          fetchDefaultEntityViewerVariant.initiate(
-            { genomeId, variantId: exampleVariant.id },
-            { subscribe: false }
-          )
-        );
+        const { variant } = await request<VepExampleVariantQueryResult>({
+          url: config.variationApiUrl,
+          document: variantDefaultQuery,
+          variables: {
+            genomeId,
+            variantId: exampleVariant.id
+          }
+        });
 
-        if (!exampleVariantData) {
+        if (!variant) {
           throw new Error(); // FIXME
         }
 
-        const { variant } = exampleVariantData;
         const firstAltAllele = variant.alleles[0];
         const regionName = variant.slice.region.name;
         const start = firstAltAllele.slice.location.start;

--- a/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.module.css
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.module.css
@@ -21,10 +21,6 @@
   grid-column: left;
   justify-self: end;
   text-align: right;
-  display: flex;
-  flex-direction: column;
-  align-items: end;
-  row-gap: 0.4em;
   font-size: 11px;
 }
 
@@ -36,6 +32,14 @@
   grid-column: right;
   justify-self: start;
   padding-left: calc(var(--standard-gutter) - var(--column-gap)); /* to achieve the same distance from textarea as the width of the standard gutter */
+}
+
+.exampleInputsContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: end;
+  row-gap: 0.4em;
+  padding-top: 25px;
 }
 
 .inputControlButtons {

--- a/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.module.css
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.module.css
@@ -21,6 +21,11 @@
   grid-column: left;
   justify-self: end;
   text-align: right;
+  display: flex;
+  flex-direction: column;
+  align-items: end;
+  row-gap: 0.4em;
+  font-size: 11px;
 }
 
 .gridColumnMiddle {
@@ -96,4 +101,8 @@
 
 .alignSelfCenter {
   align-self: center;
+}
+
+.labelThin {
+  font-weight: var(--font-weight-light);
 }

--- a/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.tsx
@@ -55,6 +55,13 @@ const VepFormVariantsSection = () => {
   const inputFileName = useAppSelector(getVepFormInputFileName);
   const dispatch = useAppDispatch();
 
+  const { currentData: exampleInputs } = useVepFormExampleInputQuery(
+    { genomeId: selectedSpecies?.genome_id ?? '' },
+    {
+      skip: !selectedSpecies?.genome_id
+    }
+  );
+
   useEffect(() => {
     // if the input form is reset (and thus the selected species is deleted)
     // when this section is expanded,
@@ -108,10 +115,10 @@ const VepFormVariantsSection = () => {
       </div>
       {isExpanded && (
         <ExpandedContents
-          genomeId={selectedSpecies?.genome_id ?? ''}
           inputString={inputText}
           setInputString={onInputTextUpdate}
           inputFileName={inputFileName}
+          exampleInputs={exampleInputs}
           setInputFile={onInputFileUpdate}
           toggleExpanded={toggleExpanded}
           onReset={onReset}
@@ -151,30 +158,26 @@ const MainContentCollapsed = ({
 };
 
 const ExpandedContents = ({
-  genomeId,
   inputString,
   inputFileName,
+  exampleInputs,
   setInputString,
   setInputFile,
   toggleExpanded,
   onReset
 }: {
-  genomeId: string;
   inputString: string | null;
   setInputString: (val: string) => void;
   inputFileName: string | null;
   setInputFile: (file: File) => void;
+  exampleInputs?: {
+    vcfString?: string;
+  };
   toggleExpanded: () => void;
   onReset: () => void;
 }) => {
   const [oversizedFileName, setOversizedFileName] = useState<string | null>(
     null
-  );
-  const { currentData: exampleInputs } = useVepFormExampleInputQuery(
-    { genomeId },
-    {
-      skip: !genomeId
-    }
   );
   const dispatch = useAppDispatch();
 

--- a/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.tsx
@@ -214,7 +214,7 @@ const ExpandedContents = ({
     <div className={styles.expandedContentGrid}>
       <div className={styles.gridColumnLeft}>
         {exampleInputs && (
-          <>
+          <div className={styles.exampleInputsContainer}>
             <span className={styles.labelThin}>Example data</span>
             {exampleInputs.vcfString && (
               <ExampleVariantInput
@@ -224,7 +224,7 @@ const ExpandedContents = ({
                 VCF
               </ExampleVariantInput>
             )}
-          </>
+          </div>
         )}
       </div>
       <div className={styles.gridColumnMiddle}>

--- a/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState, useEffect, type FormEvent } from 'react';
+import { useState, useEffect, type FormEvent, type ReactNode } from 'react';
 import classNames from 'classnames';
 
 import { useAppDispatch, useAppSelector } from 'src/store';
@@ -31,6 +31,7 @@ import {
   clearVariantsInput,
   updateInputCommittedFlag
 } from 'src/content/app/tools/vep/state/vep-form/vepFormSlice';
+import { useVepFormExampleInputQuery } from 'src/content/app/tools/vep/state/vep-api/vepApiSlice';
 
 import FormSection from 'src/content/app/tools/vep/components/form-section/FormSection';
 import PlusButton from 'src/shared/components/plus-button/PlusButton';
@@ -107,6 +108,7 @@ const VepFormVariantsSection = () => {
       </div>
       {isExpanded && (
         <ExpandedContents
+          genomeId={selectedSpecies?.genome_id ?? ''}
           inputString={inputText}
           setInputString={onInputTextUpdate}
           inputFileName={inputFileName}
@@ -149,6 +151,7 @@ const MainContentCollapsed = ({
 };
 
 const ExpandedContents = ({
+  genomeId,
   inputString,
   inputFileName,
   setInputString,
@@ -156,6 +159,7 @@ const ExpandedContents = ({
   toggleExpanded,
   onReset
 }: {
+  genomeId: string;
   inputString: string | null;
   setInputString: (val: string) => void;
   inputFileName: string | null;
@@ -165,6 +169,12 @@ const ExpandedContents = ({
 }) => {
   const [oversizedFileName, setOversizedFileName] = useState<string | null>(
     null
+  );
+  const { currentData: exampleInputs } = useVepFormExampleInputQuery(
+    { genomeId },
+    {
+      skip: !genomeId
+    }
   );
   const dispatch = useAppDispatch();
 
@@ -202,7 +212,21 @@ const ExpandedContents = ({
 
   return (
     <div className={styles.expandedContentGrid}>
-      <div className={styles.gridColumnLeft}>Example data</div>
+      <div className={styles.gridColumnLeft}>
+        {exampleInputs && (
+          <>
+            <span className={styles.labelThin}>Example data</span>
+            {exampleInputs.vcfString && (
+              <ExampleVariantInput
+                input={exampleInputs.vcfString}
+                onClick={setInputString}
+              >
+                VCF
+              </ExampleVariantInput>
+            )}
+          </>
+        )}
+      </div>
       <div className={styles.gridColumnMiddle}>
         <Textarea
           className={styles.textarea}
@@ -279,6 +303,18 @@ const MaxUploadSize = (props: { isError: boolean }) => {
       </span>
     </div>
   );
+};
+
+const ExampleVariantInput = (props: {
+  input: string;
+  onClick: (input: string) => void;
+  children: ReactNode;
+}) => {
+  const onClick = () => {
+    props.onClick(props.input);
+  };
+
+  return <TextButton onClick={onClick}>{props.children}</TextButton>;
 };
 
 const isBelowMaxFileSize = (file: File) => {


### PR DESCRIPTION
## Description
When a species is selected for VEP analysis:
  - Request example focus objects for the genome, and check if the genome has an example variant
  - If example variant is provided, query the variation api to get data necessary for generation of an example VCF string

If example variant is available for genome, display the "Example data VCF" element to the left of the textarea for manual input of user data (see [XD](https://xd.adobe.com/view/2e253ea8-6bd8-4efa-ad39-dc65f9eb01bd-7b76/screen/95805eb0-0207-4467-a965-c773a98a5bbd))

If user clicks on the blue "VCF" text, populate the textarea with the VCF representation of the example variant

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2699

## Deployment URL(s)
http://vep-example-input.review.ensembl.org