### PR TITLE
Fix polling in case of error response; continue status polling on startup

### DIFF
--- a/src/content/app/tools/vep/state/vep-action-listeners/vepSubmissionStatusPolling.ts
+++ b/src/content/app/tools/vep/state/vep-action-listeners/vepSubmissionStatusPolling.ts
@@ -23,7 +23,7 @@ import type { SubmissionStatus } from 'src/content/app/tools/vep/types/vepSubmis
 
 export const POLLING_INTERVAL = 15 * 1000;
 
-type PolledSubmission = {
+export type PolledSubmission = {
   id: string;
   status: SubmissionStatus;
 };
@@ -109,12 +109,14 @@ class VepSubmissionStatusPolling {
       if (response.status >= 500) {
         // try later
         this.queue.unshift(submissionId);
-      } else if (response.status === 404)
+      } else if (response.status === 404) {
         // fail submission
         this.reportSubmissionStatus({
           submissionId,
           status: 'FAILED'
         });
+      }
+      return;
     }
 
     const { status } = await response.json();

--- a/src/content/app/tools/vep/state/vep-submissions/vepSubmissionsSlice.ts
+++ b/src/content/app/tools/vep/state/vep-submissions/vepSubmissionsSlice.ts
@@ -29,7 +29,7 @@ import {
 
 import type { VepSubmissionWithoutInputFile } from 'src/content/app/tools/vep/types/vepSubmission';
 
-type VepSubmissionsState = Record<string, VepSubmissionWithoutInputFile>;
+export type VepSubmissionsState = Record<string, VepSubmissionWithoutInputFile>;
 
 export const restoreVepSubmissions = createAsyncThunk(
   'vep-submissions/restoreSubmissions',


### PR DESCRIPTION
## Description
- Fixed a status polling bug when backend responds to a status request with an error (see the added `return` statement  on line 119 of the `vepSubmissionStatusPolling.ts` file 🙂 ). Added tests to confirm that the polling continues after a server error.
- Added code to resume VEP status polling after a browser refresh.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2694

## Deployment URL(s)
http://vep-submissions-list.review.ensembl.org