### PR TITLE
Enable download of VEP submissions

### DIFF
--- a/src/content/app/tools/vep/components/vep-submission-header/VepSubmissionHeader.tsx
+++ b/src/content/app/tools/vep/components/vep-submission-header/VepSubmissionHeader.tsx
@@ -18,6 +18,8 @@ import { useState } from 'react';
 import classNames from 'classnames';
 import noop from 'lodash/noop';
 
+import config from 'config';
+
 import { useAppDispatch } from 'src/store';
 
 import { getFormattedDateTime } from 'src/shared/helpers/formatters/dateFormatter';
@@ -33,7 +35,7 @@ import { PrimaryButton } from 'src/shared/components/button/Button';
 import TextButton from 'src/shared/components/text-button/TextButton';
 import ButtonLink from 'src/shared/components/button-link/ButtonLink';
 import DeleteButton from 'src/shared/components/delete-button/DeleteButton';
-import DownloadButton from 'src/shared/components/download-button/DownloadButton';
+import DownloadLink from 'src/shared/components/download-button/DownloadLink';
 
 import styles from './VepSubmissionHeader.module.css';
 
@@ -111,11 +113,15 @@ const ControlButtons = (
   const { submission, isDeleting, onDelete } = props;
 
   const canGetResults = submission.status === 'SUCCEEDED';
+  const downloadLink = `${config.toolsApiBaseUrl}/vep/submissions/${submission.id}/download`;
 
   return (
     <div className={styles.controls}>
       <DeleteButton onClick={onDelete} disabled={isDeleting} />
-      <DownloadButton onClick={noop} disabled={isDeleting || !canGetResults} />
+      <DownloadLink
+        href={downloadLink}
+        disabled={isDeleting || !canGetResults}
+      />
       <ButtonLink isDisabled={isDeleting || !canGetResults} to="/">
         Results
       </ButtonLink>

--- a/src/server/middleware/proxyMiddleware.ts
+++ b/src/server/middleware/proxyMiddleware.ts
@@ -56,7 +56,7 @@ const serverConfig = getConfigForServer();
 const createApiProxyMiddleware = () => {
   const apiProxyMiddleware = createHttpProxyMiddleware({
     pathFilter: '/api',
-    target: 'https://staging-2020.ensembl.org',
+    target: 'https://dev-2020.ensembl.org',
     changeOrigin: true,
     secure: false
   });

--- a/src/server/middleware/proxyMiddleware.ts
+++ b/src/server/middleware/proxyMiddleware.ts
@@ -56,7 +56,7 @@ const serverConfig = getConfigForServer();
 const createApiProxyMiddleware = () => {
   const apiProxyMiddleware = createHttpProxyMiddleware({
     pathFilter: '/api',
-    target: 'https://dev-2020.ensembl.org',
+    target: 'https://staging-2020.ensembl.org',
     changeOrigin: true,
     secure: false
   });

--- a/src/shared/components/download-button/DownloadButton.module.css
+++ b/src/shared/components/download-button/DownloadButton.module.css
@@ -1,8 +1,9 @@
 .downloadButton {
   --_download-button-size: var(--download-button-size, 18px);
   background-color: var(--download-button-background, var(--color-blue));
-  border: none;
-  outline: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   height: var(--_download-button-size);
   width: var(--_download-button-size);
 }

--- a/src/shared/components/download-button/DownloadLink.tsx
+++ b/src/shared/components/download-button/DownloadLink.tsx
@@ -1,0 +1,66 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classNames from 'classnames';
+import type { AnchorHTMLAttributes } from 'react';
+
+import DownloadIcon from 'static/icons/icon_download.svg';
+
+import styles from './DownloadButton.module.css';
+
+/**
+ * This component looks like the DonwloadButton component;
+ * but creates an html `a` element instead of an html `button` element.
+ * Use it when the server responds with a file, and no extra client-side logic is required.
+ */
+
+type Props = AnchorHTMLAttributes<HTMLAnchorElement> & {
+  disabled?: boolean;
+};
+
+const DownloadLink = (props: Props) => {
+  const { disabled, className: classNameFromProps, ...otherProps } = props;
+
+  const componentClasses = classNames(
+    styles.downloadButton,
+    {
+      [styles.downloadButtonDisabled]: disabled
+    },
+    classNameFromProps
+  );
+
+  // TODO: update the below after migration to React 19.
+  // React 19 will update type definitions of HTMLAnchorElement to allow inert: boolean.
+  // For react versions below 19, typescript will complain about the `inert` attribute;
+  // and the componentProps object below (as well as the empty string value) is an attempt to trick typescript.
+  // IMPORTANT: in React 19, inert="" will be treated as false instead of true;
+  // so we will need to change the below during migration.
+  // (see https://github.com/facebook/react/issues/17157#issuecomment-2003750544)
+  const componentProps = {
+    className: componentClasses,
+    download: true,
+    inert: disabled ? '' : undefined,
+    ...otherProps
+  };
+
+  return (
+    <a {...componentProps}>
+      <DownloadIcon />
+    </a>
+  );
+};
+
+export default DownloadLink;


### PR DESCRIPTION
## Description
A VEP submission file is downloaded by directly sending a request to a back-end endpoint `/api/tools/vep/submissions/:submission_id/download`. Thus instead of a button with javascript logic, it should be sufficient to just use an html anchor tag.

Changes made in this PR:
- A `DownloadLink` component is added. Visually, the component looks identical to the DownloadButton, and therefore reuses its styles. I put the `DownloadLink.tsx` file inside of the `DownloadButton` directory. Don't know if that was a good idea or not.
- Added the `DownloadLink` component to each submission component of the submissions list.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2686

## Deployment URL(s)
http://vep-submission-download.review.ensembl.org