### PR TITLE
Update VEP results page

### DIFF
--- a/src/content/app/tools/vep/VepPageContent.tsx
+++ b/src/content/app/tools/vep/VepPageContent.tsx
@@ -60,10 +60,10 @@ const Main = () => {
       <Route index={true} element={<VepForm />} />
       <Route
         path="unviewed-submissions"
-        element={<div>List of unviewed submissions</div>}
+        element={<VepSubmissions unviewed={true} />}
       />
       <Route path="submissions">
-        <Route index={true} element={<VepSubmissions />} />
+        <Route index={true} element={<VepSubmissions unviewed={false} />} />
         <Route path=":submissionId" element={<VepSubmissionResults />} />
       </Route>
       <Route path="*" element={<NotFoundErrorScreen />} />

--- a/src/content/app/tools/vep/components/vep-submission-header/VepSubmissionHeader.module.css
+++ b/src/content/app/tools/vep/components/vep-submission-header/VepSubmissionHeader.module.css
@@ -43,7 +43,7 @@ for ListedVepSubmission, and for the VEP results
 }
 
 .labelLeft {
-  margin-right: 10px;
+  margin-right: 4px;
 }
 
 .light {

--- a/src/content/app/tools/vep/components/vep-submission-header/VepSubmissionHeader.tsx
+++ b/src/content/app/tools/vep/components/vep-submission-header/VepSubmissionHeader.tsx
@@ -19,6 +19,7 @@ import classNames from 'classnames';
 import noop from 'lodash/noop';
 
 import config from 'config';
+import * as urlFor from 'src/shared/helpers/urlHelper';
 
 import { useAppDispatch } from 'src/store';
 
@@ -67,7 +68,7 @@ const VepSubmissionHeader = (props: Props) => {
             <>
               <span className={classNames(styles.labelLeft, styles.smallLight)}>
                 Submission
-              </span>
+              </span>{' '}
               {submission.id}
             </>
           )}
@@ -114,6 +115,9 @@ const ControlButtons = (
 
   const canGetResults = submission.status === 'SUCCEEDED';
   const downloadLink = `${config.toolsApiBaseUrl}/vep/submissions/${submission.id}/download`;
+  const vepResultsLink = urlFor.vepResults({
+    submissionId: props.submission.id
+  });
 
   return (
     <div className={styles.controls}>
@@ -122,7 +126,7 @@ const ControlButtons = (
         href={downloadLink}
         disabled={isDeleting || !canGetResults}
       />
-      <ButtonLink isDisabled={isDeleting || !canGetResults} to="/">
+      <ButtonLink isDisabled={isDeleting || !canGetResults} to={vepResultsLink}>
         Results
       </ButtonLink>
     </div>

--- a/src/content/app/tools/vep/components/vep-submit-button/VepSubmitButton.tsx
+++ b/src/content/app/tools/vep/components/vep-submit-button/VepSubmitButton.tsx
@@ -71,7 +71,7 @@ const VepSubmitButton = (props: { className?: string }) => {
       onVepFormSubmission({ submissionId: submissionId as string })
     );
 
-    navigate(urlFor.vepSubmissionsList());
+    navigate(urlFor.vepUnviewedSubmissionsList());
 
     submitVepForm(payload);
   };

--- a/src/content/app/tools/vep/components/vep-top-bar/VepTopBarNavButtons.tsx
+++ b/src/content/app/tools/vep/components/vep-top-bar/VepTopBarNavButtons.tsx
@@ -34,12 +34,10 @@ const VepTopBarNavButtons = () => {
   const hasUnviewedVepSubmissions = unviewedVepSubmissions.length > 0;
   const hasViewedVepSubmissions = viewedVepSubmissions.length > 0;
 
-  // TODO: use different destinations for the two buttons (link to unviewed submissions list vs viewed submissions)
-
   return (
     <div className={styles.jobListsNavigation}>
       <ButtonLink
-        to={urlFor.vepSubmissionsList()}
+        to={urlFor.vepUnviewedSubmissionsList()}
         isDisabled={!hasUnviewedVepSubmissions}
       >
         Unviewed jobs

--- a/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
+++ b/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
@@ -142,23 +142,6 @@ const vepApiSlice = restApiSlice.injectEndpoints({
       query: ({ submission_id, page, per_page }) => ({
         url: `${config.toolsApiBaseUrl}/vep/submissions/${submission_id}/results?page=${page}&per_page=${per_page}`
       })
-      // queryFn: async ({ submission_id, page, per_page }) => {
-      //   // TODO: the query function will accept a submission id,
-      //   // and will send request to:
-      //   //
-      //   // to fetch data.
-      //   // Meanwhile, until the back-end endpoint is developed,
-      //   // this function returns hard-coded response payload.
-
-      //   const url = `${config.toolsApiBaseUrl}/vep/submissions/${submission_id}/results?page=${page}&per_page=${per_page}`;
-      //   const mockResponseModule = await import(
-      //     'tests/fixtures/vep/mockVepResults'
-      //   );
-      //   const mockResponse = mockResponseModule.default;
-      //   return {
-      //     data: mockResponse
-      //   };
-      // }
     })
   })
 });

--- a/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
+++ b/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
@@ -131,22 +131,34 @@ const vepApiSlice = restApiSlice.injectEndpoints({
         };
       }
     }),
-    vepResults: builder.query<VepResultsResponse, void>({
-      queryFn: async () => {
-        // TODO: the query function will accept a submission id,
-        // and will send request to:
-        // `${config.toolsApiBaseUrl}/vep/submissions/${submissionId}/results`
-        // to fetch data.
-        // Meanwhile, until the back-end endpoint is developed,
-        // this function returns hard-coded response payload.
-        const mockResponseModule = await import(
-          'tests/fixtures/vep/mockVepResults'
-        );
-        const mockResponse = mockResponseModule.default;
-        return {
-          data: mockResponse
-        };
+    vepResults: builder.query<
+      VepResultsResponse,
+      {
+        submission_id: string;
+        page: number;
+        per_page: number;
       }
+    >({
+      query: ({ submission_id, page, per_page }) => ({
+        url: `${config.toolsApiBaseUrl}/vep/submissions/${submission_id}/results?page=${page}&per_page=${per_page}`
+      })
+      // queryFn: async ({ submission_id, page, per_page }) => {
+      //   // TODO: the query function will accept a submission id,
+      //   // and will send request to:
+      //   //
+      //   // to fetch data.
+      //   // Meanwhile, until the back-end endpoint is developed,
+      //   // this function returns hard-coded response payload.
+
+      //   const url = `${config.toolsApiBaseUrl}/vep/submissions/${submission_id}/results?page=${page}&per_page=${per_page}`;
+      //   const mockResponseModule = await import(
+      //     'tests/fixtures/vep/mockVepResults'
+      //   );
+      //   const mockResponse = mockResponseModule.default;
+      //   return {
+      //     data: mockResponse
+      //   };
+      // }
     })
   })
 });

--- a/src/content/app/tools/vep/state/vep-submissions/vepSubmissionsSelectors.ts
+++ b/src/content/app/tools/vep/state/vep-submissions/vepSubmissionsSelectors.ts
@@ -17,7 +17,10 @@
 import { createSelector } from '@reduxjs/toolkit';
 
 import type { RootState } from 'src/store';
-import type { VepSubmission } from 'src/content/app/tools/vep/types/vepSubmission';
+import type {
+  VepSubmission,
+  VepSubmissionWithoutInputFile
+} from 'src/content/app/tools/vep/types/vepSubmission';
 
 const getVepSubmissionsState = (state: RootState) => state.vep.vepSubmissions;
 
@@ -38,6 +41,14 @@ export const getViewedVepSubmissions = createSelector(
       .toSorted(sortSubmissionsChronologically);
   }
 );
+
+export const getVepSubmissionById = (
+  state: RootState,
+  submissionId: string
+): VepSubmissionWithoutInputFile | null => {
+  const vepSubmissionsState = getVepSubmissionsState(state);
+  return vepSubmissionsState[submissionId] ?? null;
+};
 
 const sortSubmissionsChronologically = (
   submission1: Pick<VepSubmission, 'createdAt'>,

--- a/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.module.css
+++ b/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.module.css
@@ -4,8 +4,8 @@
   height: 100%;
   padding-top: 20px;
   margin-left: var(--double-standard-gutter);
-  margin-right: var(--double-standard-gutter);
-  overflow: hidden;
+  margin-right: var(--standard-gutter);
+  max-width: calc(var(--vep-container-max-width) - var(--standard-gutter));
 }
 
 .resultsBox {

--- a/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.tsx
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useParams } from 'react-router';
 
-import { useAppSelector } from 'src/store';
+import { useAppSelector, useAppDispatch } from 'src/store';
 
 import { getVepSubmissionById } from 'src/content/app/tools/vep/state/vep-submissions/vepSubmissionsSelectors';
 
 import { useVepResultsQuery } from 'src/content/app/tools/vep/state/vep-api/vepApiSlice';
+import { updateSubmission } from 'src/content/app/tools/vep/state/vep-submissions/vepSubmissionsSlice';
 
 import useVepVariantTabularData, {
   type VepResultsTableRowData
@@ -57,6 +58,18 @@ const VepSubmissionResults = () => {
   const submission = useAppSelector((state) =>
     getVepSubmissionById(state, submissionId)
   );
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    if (vepResults && submission && !submission.resultsSeen) {
+      dispatch(
+        updateSubmission({
+          submissionId: submission.id,
+          fragment: { resultsSeen: true }
+        })
+      );
+    }
+  }, [submission, vepResults]);
 
   if (!vepResults) {
     return <CircleLoader />;

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-allele/VepResultsAllele.module.css
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-allele/VepResultsAllele.module.css
@@ -1,0 +1,16 @@
+.toolboxContents {
+  max-width: 450px;
+  text-align: left;
+  word-break: break-all;
+}
+
+.sequence {
+  font-family: var(--font-family-monospace);
+  line-height: 1.2;
+  user-select: text;
+}
+
+.sequenceLength {
+  font-size: 11px;
+  font-weight: var(--font-weight-light);
+}

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-allele/VepResultsAllele.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-allele/VepResultsAllele.tsx
@@ -1,0 +1,75 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState } from 'react';
+
+import useRefWithRerender from 'src/shared/hooks/useRefWithRerender';
+
+import TextButton from 'src/shared/components/text-button/TextButton';
+import { Toolbox, ToolboxPosition } from 'src/shared/components/toolbox';
+
+import styles from './VepResultsAllele.module.css';
+
+type Props = {
+  sequence: string;
+};
+
+const MAX_DISPLAY_LENGTH = 5;
+
+const AlleleSequence = ({ sequence }: Props) => {
+  const [anchorRef, setAnchorRef] = useRefWithRerender<HTMLElement>(null);
+  const [shouldShowTooltip, setShouldShowTooltip] = useState(false);
+
+  if (sequence.length <= MAX_DISPLAY_LENGTH) {
+    return sequence;
+  }
+
+  const onClick = () => {
+    setShouldShowTooltip(!shouldShowTooltip);
+  };
+
+  const onOutsideClick = () => {
+    setShouldShowTooltip(false);
+  };
+
+  const displaySequence = sequence.slice(0, MAX_DISPLAY_LENGTH) + '…';
+
+  return (
+    <div>
+      <TextButton
+        ref={setAnchorRef}
+        onClick={onClick}
+        style={{ position: 'relative' }}
+      >
+        {displaySequence}
+      </TextButton>
+      <div className={styles.sequenceLength}>{sequence.length}</div>
+      {anchorRef.current && shouldShowTooltip && (
+        <Toolbox
+          onOutsideClick={onOutsideClick}
+          anchor={anchorRef.current}
+          position={ToolboxPosition.RIGHT}
+        >
+          <div className={styles.toolboxContents}>
+            <div className={styles.sequence}>{sequence}</div>
+          </div>
+        </Toolbox>
+      )}
+    </div>
+  );
+};
+
+export default AlleleSequence;

--- a/src/content/app/tools/vep/views/vep-submission-results/useVepVariantTabularData.ts
+++ b/src/content/app/tools/vep/views/vep-submission-results/useVepVariantTabularData.ts
@@ -92,9 +92,12 @@ const reshapeVariant = ({
       const genesMap = new Map<string, VariantAffectedGene>();
 
       if (onlyCanonicalTranscripts) {
-        transcriptConsequences = transcriptConsequences.filter(
+        const candidateTranscriptConsequences = transcriptConsequences.filter(
           (cons) => cons.is_canonical
         );
+        transcriptConsequences = candidateTranscriptConsequences.length
+          ? candidateTranscriptConsequences
+          : [transcriptConsequences[0]];
       } else {
         // make sure canonical transcripts go first
         transcriptConsequences.sort((a, b) => {

--- a/src/content/app/tools/vep/views/vep-submission-results/useVepVariantTabularData.ts
+++ b/src/content/app/tools/vep/views/vep-submission-results/useVepVariantTabularData.ts
@@ -26,9 +26,21 @@ import type {
 
 type VariantInResponse = VepResultsResponse['variants'][number];
 
+/**
+ * The UI allows the user to expand or collapse transcripts
+ * that are the part of transcript consequences of an alternative allele.
+ * Hierarchically, a transcript belongs to a gene;
+ * and both are within the scope of an alternative allele.
+ * This is reflected in the ExpandedTranscriptsPath below.
+ */
+export type ExpandedTranscriptsPath = {
+  altAllele: string;
+  geneId: string;
+};
+
 type Params = {
   variant: VariantInResponse;
-  showAllTranscripts: boolean;
+  expandedTranscriptPaths: ExpandedTranscriptsPath[];
 };
 
 /**
@@ -43,11 +55,11 @@ type Params = {
  * seems to be predicted molecular consequences of a variant allele.
  */
 const useVepVariantTabularData = (params: Params) => {
-  const { variant, showAllTranscripts } = params;
+  const { variant, expandedTranscriptPaths } = params;
 
   const tabularData = useMemo(() => {
     return getTabularData(params);
-  }, [variant, showAllTranscripts]);
+  }, [variant, expandedTranscriptPaths]);
 
   return tabularData;
 };
@@ -73,60 +85,25 @@ type ReshapedVariant = Omit<VariantInResponse, 'alternative_alleles'> & {
  */
 const reshapeVariant = ({
   variant,
-  oneTranscriptPerGene // rename to one transcript per gene
+  expandedTranscriptPaths
 }: {
   variant: VariantInResponse;
-  oneTranscriptPerGene: boolean;
+  expandedTranscriptPaths: ExpandedTranscriptsPath[];
 }) => {
   const alternativeAlleles: UpdatedAlternativeAllele[] =
     variant.alternative_alleles.map((allele) => {
-      let {
+      const { transcriptConsequences, intergenicConsequences } =
+        groupAlleleConsequencesByType(allele.predicted_molecular_consequences);
+
+      const genes = buildGeneData({
         transcriptConsequences,
-        intergenicConsequences // eslint-disable-line prefer-const
-      } = groupAlleleConsequencesByType(
-        allele.predicted_molecular_consequences
-      );
-
-      const allTranscriptConsequences = transcriptConsequences;
-
-      const genesMap = new Map<string, VariantAffectedGene>();
-
-      if (oneTranscriptPerGene) {
-        transcriptConsequences = selectSingleTranscriptConsequencePerGene(
-          transcriptConsequences
-        );
-      } else {
-        // make sure canonical transcripts go first
-        transcriptConsequences.sort((a, b) => {
-          const aScore = a.is_canonical ? 0 : 1;
-          const bScore = b.is_canonical ? 0 : 1;
-          return aScore - bScore;
-        });
-      }
-
-      for (const consequence of transcriptConsequences) {
-        const geneId = consequence.gene_stable_id;
-        const visitedGene = genesMap.get(geneId);
-
-        if (visitedGene) {
-          visitedGene.transcripts.push(consequence);
-        } else {
-          const gene: VariantAffectedGene = {
-            stable_id: geneId,
-            symbol: consequence.gene_symbol,
-            transcripts: [consequence],
-            transcriptsCount: getTotalTranscriptsCountForGene({
-              transcriptConsequences: allTranscriptConsequences,
-              geneId
-            })
-          };
-          genesMap.set(geneId, gene);
-        }
-      }
+        altAllele: allele,
+        expandedTranscriptPaths
+      });
 
       return {
         ...allele,
-        genes: [...genesMap.values()],
+        genes,
         intergenicConsequences
       };
     });
@@ -144,38 +121,58 @@ const reshapeVariant = ({
  * - A variant may not affect the canonical transcript of a gene.
  *   In that case, return an array containing the first transcript per gene
  */
-const selectSingleTranscriptConsequencePerGene = (
-  transcriptConsequences: PredictedTranscriptConsequence[]
-) => {
-  const transcriptsGeneMap = new Map<string, PredictedTranscriptConsequence>();
-
-  for (const transcriptConsequence of transcriptConsequences) {
-    const { gene_stable_id } = transcriptConsequence;
-    if (
-      !transcriptsGeneMap.get(gene_stable_id) ||
-      transcriptConsequence.is_canonical
-    ) {
-      transcriptsGeneMap.set(gene_stable_id, transcriptConsequence);
-    }
-  }
-
-  return [...transcriptsGeneMap.values()];
-};
-
-const getTotalTranscriptsCountForGene = ({
+const buildGeneData = ({
   transcriptConsequences,
-  geneId
+  expandedTranscriptPaths,
+  altAllele
 }: {
   transcriptConsequences: PredictedTranscriptConsequence[];
-  geneId: string;
+  expandedTranscriptPaths: ExpandedTranscriptsPath[];
+  altAllele: AlternativeVariantAllele;
 }) => {
-  let count = 0;
-  for (let i = 0; i < transcriptConsequences.length; i++) {
-    if (transcriptConsequences[i].gene_stable_id === geneId) {
-      count++;
+  const genesMap = new Map<string, VariantAffectedGene>();
+
+  // transform transcript paths array into a set for faster access
+  const transcriptPathAccessor = (transcriptPath: ExpandedTranscriptsPath) =>
+    `${transcriptPath.altAllele}-${transcriptPath.geneId}`;
+  const transcriptPathsSet = new Set(
+    expandedTranscriptPaths.map(transcriptPathAccessor)
+  );
+
+  // sort transcript consequences such that canonical transcripts go first
+  // (note that it is possible for a variant to not affect any of the canonical transcripts,
+  // in which case the sort shouldn't change the transcript order)
+  transcriptConsequences.sort((a, b) => {
+    const aScore = a.is_canonical ? 0 : 1;
+    const bScore = b.is_canonical ? 0 : 1;
+    return aScore - bScore;
+  });
+
+  for (const consequence of transcriptConsequences) {
+    const geneId = consequence.gene_stable_id;
+    const visitedGene = genesMap.get(geneId);
+    const shouldShowOneTranscriptPerGene = !transcriptPathsSet.has(
+      transcriptPathAccessor({ geneId, altAllele: altAllele.allele_sequence })
+    );
+
+    if (visitedGene) {
+      if (!shouldShowOneTranscriptPerGene) {
+        visitedGene.transcripts.push(consequence);
+      }
+      visitedGene.transcriptsCount++;
+    } else {
+      // after transcript consequences have been sorted, canonical transcripts, if they exist, will be first
+      const gene: VariantAffectedGene = {
+        stable_id: geneId,
+        symbol: consequence.gene_symbol,
+        transcripts: [consequence],
+        transcriptsCount: 1
+      };
+      genesMap.set(geneId, gene);
     }
   }
-  return count;
+
+  return [...genesMap.values()];
 };
 
 type ConsequenceGroups = {
@@ -208,6 +205,7 @@ export type VepResultsTableRowData = {
     | (PredictedTranscriptConsequence & {
         totalTranscriptsCount: number;
         isLastTranscript: boolean;
+        altAlleleSequence: string;
       });
   gene: {
     stableId: string;
@@ -237,15 +235,15 @@ export type VepResultsTableRowData = {
  */
 const getTabularData = ({
   variant,
-  showAllTranscripts
+  expandedTranscriptPaths
 }: {
   variant: VariantInResponse;
-  showAllTranscripts: boolean;
+  expandedTranscriptPaths: ExpandedTranscriptsPath[];
 }): VepResultsTableRowData[] => {
   const result: VepResultsTableRowData[] = [];
   const reshapedVariant = reshapeVariant({
     variant,
-    oneTranscriptPerGene: !showAllTranscripts
+    expandedTranscriptPaths
   });
 
   // First, start by creating table row data for transcript consequences of each of variant's alt alleles
@@ -259,7 +257,8 @@ const getTabularData = ({
           consequence: {
             ...transcriptConsequence,
             totalTranscriptsCount: gene.transcriptsCount,
-            isLastTranscript: i === gene.transcripts.length - 1
+            isLastTranscript: i === gene.transcripts.length - 1,
+            altAlleleSequence: altAllele.allele_sequence
           },
           gene: null,
           alternativeAllele: null,

--- a/src/content/app/tools/vep/views/vep-submissions/VepSubmissions.tsx
+++ b/src/content/app/tools/vep/views/vep-submissions/VepSubmissions.tsx
@@ -16,19 +16,30 @@
 
 import { useAppSelector } from 'src/store';
 
-import { getUnviewedVepSubmissions } from 'src/content/app/tools/vep/state/vep-submissions/vepSubmissionsSelectors';
+import {
+  getUnviewedVepSubmissions,
+  getViewedVepSubmissions
+} from 'src/content/app/tools/vep/state/vep-submissions/vepSubmissionsSelectors';
 
 import ListedVepSubmission from './listed-vep-submission/ListedVepSubmission';
 
 import styles from './VepSubmissions.module.css';
 
-const VepSubmissions = () => {
-  const unviewedVepSubmissions = useAppSelector(getUnviewedVepSubmissions);
+type Props = {
+  unviewed: boolean;
+};
+
+const VepSubmissions = (props: Props) => {
+  const isUnviewedSubmissionsList = props.unviewed;
+  const submissionsSelector = isUnviewedSubmissionsList
+    ? getUnviewedVepSubmissions
+    : getViewedVepSubmissions;
+  const vepSubmissions = useAppSelector(submissionsSelector);
 
   return (
     <div className={styles.scrollContainer}>
       <div className={styles.container}>
-        {unviewedVepSubmissions.map((submission) => (
+        {vepSubmissions.map((submission) => (
           <ListedVepSubmission key={submission.id} submission={submission} />
         ))}
       </div>

--- a/src/server/middleware/proxyMiddleware.ts
+++ b/src/server/middleware/proxyMiddleware.ts
@@ -56,7 +56,7 @@ const serverConfig = getConfigForServer();
 const createApiProxyMiddleware = () => {
   const apiProxyMiddleware = createHttpProxyMiddleware({
     pathFilter: '/api',
-    target: 'https://staging-2020.ensembl.org',
+    target: 'https://dev-2020.ensembl.org',
     changeOrigin: true,
     secure: false
   });

--- a/src/server/middleware/proxyMiddleware.ts
+++ b/src/server/middleware/proxyMiddleware.ts
@@ -56,7 +56,7 @@ const serverConfig = getConfigForServer();
 const createApiProxyMiddleware = () => {
   const apiProxyMiddleware = createHttpProxyMiddleware({
     pathFilter: '/api',
-    target: 'https://dev-2020.ensembl.org',
+    target: 'https://staging-2020.ensembl.org',
     changeOrigin: true,
     secure: false
   });

--- a/src/shared/helpers/urlHelper.ts
+++ b/src/shared/helpers/urlHelper.ts
@@ -180,6 +180,8 @@ export const vepForm = () => '/vep';
 
 export const vepSpeciesSelector = () => '/vep/species-selector';
 
+export const vepUnviewedSubmissionsList = () => '/vep/unviewed-submissions';
+
 export const vepSubmissionsList = () => '/vep/submissions';
 
 export const vepResults = ({ submissionId }: { submissionId: string }) =>

--- a/src/shared/helpers/urlHelper.ts
+++ b/src/shared/helpers/urlHelper.ts
@@ -182,6 +182,9 @@ export const vepSpeciesSelector = () => '/vep/species-selector';
 
 export const vepSubmissionsList = () => '/vep/submissions';
 
+export const vepResults = ({ submissionId }: { submissionId: string }) =>
+  `/vep/submissions/${submissionId}`;
+
 type RefgetUrlParams = {
   checksum: string;
   start?: number;


### PR DESCRIPTION
## Description
- Added VEP submissions header to the results page
- Set up links to viewed submissions vs unviewed submissions.
- When user visits the results page for a given VEP submission, mark that submission as viewed
- Make sure the expansion/collapsing of transcripts is scoped within a gene and within an alternative allele; i.e. pressing the expand/collapse button does not affect transcripts in other rows.


https://github.com/user-attachments/assets/50587fb5-8678-45af-9d60-ac298d67d583


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2705

## Deployment URL(s)
http://vep-results-page.review.ensembl.org
