### PR TITLE
Add notifications support to CommunicationPanel

### DIFF
--- a/src/content/app/about/About.tsx
+++ b/src/content/app/about/About.tsx
@@ -41,7 +41,7 @@ import {
 import HelpMenu from 'src/content/app/help/components/help-menu/HelpMenu';
 import Breadcrumbs from 'src/shared/components/breadcrumbs/Breadcrumbs';
 import { CircleLoader } from 'src/shared/components/loader';
-import ConversationIcon from 'src/shared/components/communication-framework/ConversationIcon';
+import CommunicationPanelButton from 'src/shared/components/communication-framework/CommunicationPanelButton';
 import { NotFoundErrorScreen } from 'src/shared/components/error-screen';
 import SocialMediaLinks from 'src/shared/components/social-media-links/SocialMediaLinks';
 
@@ -120,7 +120,7 @@ const AppBar = () => {
     <div className={styles.appBar}>
       About Ensembl
       <div className={styles.conversationIcon}>
-        <ConversationIcon withLabel={true} />
+        <CommunicationPanelButton withLabel={true} />
       </div>
     </div>
   );

--- a/src/content/app/help/Help.tsx
+++ b/src/content/app/help/Help.tsx
@@ -30,7 +30,7 @@ import { isMissingResourceError } from 'src/shared/state/api-slices/restSlice';
 import { createHelpPageMeta } from './helpers/helpPageMetaHelpers';
 import { isHelpIndexRoute } from './helpers/isHelpIndexRoute';
 
-import ConversationIcon from 'src/shared/components/communication-framework/ConversationIcon';
+import CommunicationPanelButton from 'src/shared/components/communication-framework/CommunicationPanelButton';
 import HelpMenu from './components/help-menu/HelpMenu';
 import HelpLanding from './components/help-landing/HelpLanding';
 import {
@@ -126,7 +126,7 @@ const AppBar = () => {
     <div className={styles.appBar}>
       Help
       <div className={styles.conversationIcon}>
-        <ConversationIcon withLabel={true} />
+        <CommunicationPanelButton withLabel={true} />
       </div>
     </div>
   );

--- a/src/content/app/tools/blast/components/blast-app-bar/BlastAppBar.test.tsx
+++ b/src/content/app/tools/blast/components/blast-app-bar/BlastAppBar.test.tsx
@@ -16,23 +16,20 @@
 
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router';
-import { configureStore, combineReducers } from '@reduxjs/toolkit';
+import { configureStore } from '@reduxjs/toolkit';
 import { render, getByText } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';
 
-import blastFormReducer, {
-  initialState as initialBlastFormState
-} from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
+import createRootReducer from 'src/root/rootReducer';
 
-import speciesSelectorReducer from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSlice';
-import blastGeneralReducer from 'src/content/app/tools/blast/state/general/blastGeneralSlice';
+import { initialState as initialBlastFormState } from 'src/content/app/tools/blast/state/blast-form/blastFormSlice';
 
 import BlastAppBar from './BlastAppBar';
 
 jest.mock(
-  'src/shared/components/communication-framework/ConversationIcon',
-  () => () => <div>ConversationIcon</div>
+  'src/shared/components/communication-framework/CommunicationPanelButton',
+  () => () => <div>CommunicationPanelButton</div>
 );
 
 jest.mock(
@@ -68,16 +65,8 @@ const initialState = {
   }
 };
 
-const rootReducer = combineReducers({
-  blast: combineReducers({
-    blastForm: blastFormReducer,
-    blastGeneral: blastGeneralReducer
-  }),
-  speciesSelector: speciesSelectorReducer
-});
-
 const store = configureStore({
-  reducer: rootReducer,
+  reducer: createRootReducer(),
   preloadedState: initialState as any
 });
 

--- a/src/content/home/Home.tsx
+++ b/src/content/home/Home.tsx
@@ -19,7 +19,7 @@ import { Link } from 'react-router-dom';
 import useHomeAnalytics from 'src/content/home/hooks/useHomeAnalytics';
 
 import { HelpPopupButton } from 'src/shared/components/help-popup';
-import ConversationIcon from 'src/shared/components/communication-framework/ConversationIcon';
+import CommunicationPanelButton from 'src/shared/components/communication-framework/CommunicationPanelButton';
 import {
   GenomeBrowserIcon,
   SpeciesSelectorIcon,
@@ -120,7 +120,7 @@ const Home = () => {
               labelClass={styles.helpLabel}
             />
             <div className={styles.conversationIcon}>
-              <ConversationIcon />
+              <CommunicationPanelButton />
             </div>
           </div>
         </div>

--- a/src/services/indexeddb-service.ts
+++ b/src/services/indexeddb-service.ts
@@ -23,6 +23,7 @@ import { GB_FOCUS_OBJECTS_STORE_NAME } from 'src/content/app/genome-browser/serv
 import { BLAST_SUBMISSIONS_STORE_NAME } from 'src/content/app/tools/blast/services/blastStorageServiceConstants';
 import { VEP_SUBMISSIONS_STORE_NAME } from 'src/content/app/tools/vep/services/vepStorageServiceConstants';
 import { PREVIOUSLY_VIEWED_OBJECTS_STORE_NAME } from 'src/shared/services/previouslyViewedObjectsStorageConstants';
+import { NOTIFICATIONS_STORE_NAME } from 'src/shared/services/notificationsStorageConstants';
 
 const DB_NAME = 'ensembl-website';
 const DB_VERSION = 5;
@@ -48,6 +49,9 @@ const getDbPromise = () => {
       }
       if (!db.objectStoreNames.contains(PREVIOUSLY_VIEWED_OBJECTS_STORE_NAME)) {
         db.createObjectStore(PREVIOUSLY_VIEWED_OBJECTS_STORE_NAME);
+      }
+      if (!db.objectStoreNames.contains(NOTIFICATIONS_STORE_NAME)) {
+        db.createObjectStore(NOTIFICATIONS_STORE_NAME);
       }
       if (!db.objectStoreNames.contains(GB_TRACK_SETTINGS_STORE_NAME)) {
         const trackSettingsObjectStore = db.createObjectStore(

--- a/src/services/indexeddb-service.ts
+++ b/src/services/indexeddb-service.ts
@@ -26,7 +26,7 @@ import { PREVIOUSLY_VIEWED_OBJECTS_STORE_NAME } from 'src/shared/services/previo
 import { NOTIFICATIONS_STORE_NAME } from 'src/shared/services/notificationsStorageConstants';
 
 const DB_NAME = 'ensembl-website';
-const DB_VERSION = 5;
+const DB_VERSION = 6;
 
 const getDbPromise = () => {
   return openDB(DB_NAME, DB_VERSION, {

--- a/src/shared/components/app-bar/AppBar.tsx
+++ b/src/shared/components/app-bar/AppBar.tsx
@@ -16,7 +16,7 @@
 
 import type { ReactNode } from 'react';
 
-import ConversationIcon from 'src/shared/components/communication-framework/ConversationIcon';
+import CommunicationPanelButton from 'src/shared/components/communication-framework/CommunicationPanelButton';
 
 import styles from './AppBar.module.css';
 
@@ -39,7 +39,7 @@ export const AppBar = (props: AppBarProps) => (
     <div className={styles.appBarAside}>
       {props.aside}
       <div className={styles.conversationIcon}>
-        <ConversationIcon />
+        <CommunicationPanelButton />
       </div>
     </div>
   </section>

--- a/src/shared/components/communication-framework/CommunicationPanel.module.css
+++ b/src/shared/components/communication-framework/CommunicationPanel.module.css
@@ -19,10 +19,6 @@
 .panel {
   position: relative;
   display: grid;
-  grid-template-areas:
-          'conversation tabs close'
-          '. main main';
-  grid-template-columns: 67px 1fr 46px;
   grid-template-rows: auto 1fr;
   max-height: calc(100vh - 110px - 5vh);
   height: auto;
@@ -38,15 +34,25 @@
 }
 
 .panelHeader {
-  margin-bottom: 20px;
+  display: grid;
+  grid-template-columns: [conversation-icon] 90px [tabs] 1fr [close] 46px;
+  align-items: center;
 }
 
-.panelTabs {
-  grid-area: tabs;
+.conversationIcon {
+  justify-self: center;
+}
+
+.headerNav {
+  grid-column: tabs;
   display: flex;
   align-items: center;
-  gap: 30px;
-  margin-left: 28px;
+  column-gap: 30px;
+  font-size: 12px;
+}
+
+.headerNav .tabActive {
+  --text-button-disabled-color: var(--color-black);
 }
 
 .panelTabs .tab {
@@ -58,25 +64,15 @@
 }
 
 .panelBody {
-  grid-area: main;
   padding-top: 30px;
-  padding-left: 28px;
+  padding-left: 90px;
+  padding-right: 46px;
   overflow: auto;
   height: 100%;
 }
 
 .panelCloseButton {
-  grid-area: close;
-  align-self: center;
-  margin-bottom: 3px;
-}
-
-.conversationIcon {
-  grid-area: conversation;
-  width: 40px;
-  align-self: center;
-  justify-self: right;
-  cursor: pointer;
+  grid-column: close;
 }
 
 .overlay {

--- a/src/shared/components/communication-framework/CommunicationPanelButton.module.css
+++ b/src/shared/components/communication-framework/CommunicationPanelButton.module.css
@@ -1,0 +1,10 @@
+.conversationIcon {
+  width: 40px;
+}
+
+.communicationPanelButton {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  color: var(--color-blue);
+}

--- a/src/shared/components/communication-framework/CommunicationPanelButton.tsx
+++ b/src/shared/components/communication-framework/CommunicationPanelButton.tsx
@@ -1,0 +1,92 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useRef } from 'react';
+
+import { useAppDispatch, useAppSelector } from 'src/store';
+
+import useNotifications from './hooks/useNotifications';
+
+import { isCommunicationPanelOpen } from 'src/shared/state/communication/communicationSelector';
+
+import { openCommunicationPanel } from 'src/shared/state/communication/communicationSlice';
+
+import CommunicationPanel from 'src/shared/components/communication-framework/CommunicationPanel';
+
+import ConversationIcon from './ConversationIcon';
+
+import styles from './CommunicationPanelButton.module.css';
+
+type Props = {
+  withLabel?: boolean;
+};
+
+const CommunicationPanelButton = (props: Props) => {
+  const elementRef = useRef<HTMLButtonElement | null>(null);
+  const { notifications, markNotificationAsSeen, dismissNotification } =
+    useNotifications();
+  const showCommunicationPanel = useAppSelector(isCommunicationPanelOpen);
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    // automatically open communication panel if there is an important notification
+    if (notifications.some((notification) => notification.important)) {
+      dispatch(openCommunicationPanel());
+    }
+  }, [notifications]);
+
+  const onClick = () => {
+    dispatch(openCommunicationPanel());
+    trackButtonClick();
+  };
+
+  // dispatches an event that the conversation button has been clicked; used for analytics purposes
+  const trackButtonClick = () => {
+    const event = new CustomEvent('analytics', {
+      detail: {
+        category: 'communication_panel',
+        action: 'opened'
+      },
+      bubbles: true
+    });
+
+    elementRef.current?.dispatchEvent(event);
+  };
+
+  return (
+    <>
+      {showCommunicationPanel && (
+        <CommunicationPanel
+          notifications={notifications}
+          onNotificationSeen={markNotificationAsSeen}
+          onNotificationDismissed={dismissNotification}
+        />
+      )}
+      <button
+        className={styles.communicationPanelButton}
+        onClick={onClick}
+        ref={elementRef}
+      >
+        {props.withLabel && 'Contact us'}
+        <ConversationIcon
+          notification={notifications.length ? 'green' : undefined}
+        />
+      </button>
+    </>
+  );
+};
+
+export default CommunicationPanelButton;

--- a/src/shared/components/communication-framework/ConversationIcon.module.css
+++ b/src/shared/components/communication-framework/ConversationIcon.module.css
@@ -1,10 +1,28 @@
-.conversationIcon {
+.conversationIconWrapper {
+  display: inline-flex; /* using inline-flex to avoid extra white space inside if display: inline-block */
+  position: relative;
   width: 40px;
+  aspect-ratio: 32/22; /* same as the viewport of the svg icon */
 }
 
-.communicationPanelToggle {
-  display: flex;
-  gap: 16px;
-  align-items: center;
-  color: var(--color-blue);
+.conversationIcon {
+  width: 100%;
+  height: 100%;
+}
+
+
+/* The notification circle is similar one in LaunchbarButton; but note that the transform is different */
+
+.notification {
+  border-radius: 10px;
+  height: var(--conversation-icon-notification-size, 18px);
+  width: var(--conversation-icon-notification-size, 18px);
+  position: absolute;
+  top: 0;
+  right: 0;
+  transform: translate(40%, -40%);
+}
+
+.notificationGreen {
+  background-color: var(--color-green);
 }

--- a/src/shared/components/communication-framework/ConversationIcon.tsx
+++ b/src/shared/components/communication-framework/ConversationIcon.tsx
@@ -14,55 +14,35 @@
  * limitations under the License.
  */
 
-import { useRef } from 'react';
-import { useDispatch } from 'react-redux';
-
-import { toggleCommunicationPanel } from 'src/shared/state/communication/communicationSlice';
-
-import CommunicationPanel from 'src/shared/components/communication-framework/CommunicationPanel';
+import classNames from 'classnames';
 
 import ConversationImageIcon from 'static/icons/icon_conversation.svg';
 
 import styles from './ConversationIcon.module.css';
 
+type Notification = 'green';
+
 type Props = {
-  withLabel?: boolean;
+  notification?: Notification;
+  className?: string;
 };
 
 const ConversationIcon = (props: Props) => {
-  const dispatch = useDispatch();
-  const elementRef = useRef<HTMLButtonElement | null>(null);
+  const componentClasses = classNames(
+    styles.conversationIconWrapper,
+    props.className
+  );
 
-  const onClick = () => {
-    dispatch(toggleCommunicationPanel());
-    trackButtonClick();
-  };
-
-  // dispatches an event that the conversation button has been clicked; used for analytics purposes
-  const trackButtonClick = () => {
-    const event = new CustomEvent('analytics', {
-      detail: {
-        category: 'communication_panel',
-        action: 'opened'
-      },
-      bubbles: true
-    });
-
-    elementRef.current?.dispatchEvent(event);
-  };
+  const notificationClasses = classNames(
+    styles.notification,
+    styles.notificationGreen
+  );
 
   return (
-    <>
-      <CommunicationPanel />
-      <button
-        className={styles.communicationPanelToggle}
-        onClick={onClick}
-        ref={elementRef}
-      >
-        {props.withLabel && 'Contact us'}
-        <ConversationImageIcon className={styles.conversationIcon} />
-      </button>
-    </>
+    <div className={componentClasses}>
+      <ConversationImageIcon className={styles.conversationIcon} />
+      {props.notification && <span className={notificationClasses} />}
+    </div>
   );
 };
 

--- a/src/shared/components/communication-framework/hooks/useNotifications.ts
+++ b/src/shared/components/communication-framework/hooks/useNotifications.ts
@@ -1,0 +1,147 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, useEffect } from 'react';
+
+import {
+  saveNotification,
+  getAllNotifications
+} from 'src/shared/services/notificationsStorageService';
+
+/**
+ * Suppose the client somehow (via hard-coding at first) receives a list of notifications
+ * of the following shape:
+ *
+ * {
+ *   id: string;
+ *   important: boolean;
+ * }
+ *
+ * Probably in the future, they will also have a `body` field containing an html string.
+ *
+ * We will need to store the client-side status of the notifications
+ * (e.g. which of them user has seen/dismissed); probably by storing information about them
+ * in IndexedDB. For example, the stored notification data may have the following shape:
+ *
+ * {
+ *   id: string;
+ *   seen: boolean;
+ *   dismissed: boolean;
+ *   savedAt: Date;
+ * }
+ *
+ * Designs are currently suggesting that there should be a difference between
+ * just having seen a notification (in which case it remains visible in the communication panel,
+ * although it should no longer cause the panel to automatically open), and dismissing it entirely
+ * (in which case it is no longer visible anywhere in the UI).
+ *
+ * New notifications will need to show up in the UI. The purpose of this hook
+ * is to prepare data for that.
+ */
+
+// Consider: does it need a date?
+export type IncomingNotification = {
+  id: string;
+  important: boolean;
+};
+
+const useNotifications = () => {
+  const [notifications, setNotifications] = useState<IncomingNotification[]>(
+    []
+  );
+
+  useEffect(() => {
+    // - look up saved notifications in indexedDB
+    // - perhaps also delete outdated notifications from IndexedDB
+    //   (e.g. those whose ids are no longer among incoming notifications)?
+
+    getAllNotifications().then((storedNotifications) => {
+      // if notifications have already been set (double run of useEffect with strict mode in dev),
+      // then there is nothing else to do
+      if (notifications.length) {
+        return;
+      }
+
+      const selectedNotifications: IncomingNotification[] = [];
+
+      for (const incomingNotification of incomingNotifications) {
+        const storedNotification = storedNotifications.find(
+          (notification) => notification.id === incomingNotification.id
+        );
+        if (!storedNotification) {
+          selectedNotifications.push(incomingNotification);
+        } else if (storedNotification.dismissed) {
+          continue;
+        } else {
+          selectedNotifications.push({
+            ...incomingNotification,
+            important: false
+          });
+        }
+      }
+
+      // sort important messages first
+      selectedNotifications.sort(
+        (a, b) => Number(b.important) - Number(a.important)
+      );
+
+      setNotifications(selectedNotifications);
+    });
+  }, []);
+
+  const markNotificationAsSeen = async (id: string) => {
+    // store / update notification data in IndexedDB
+    await saveNotification({
+      id,
+      seen: true,
+      dismissed: false,
+      savedAt: Date.now()
+    });
+  };
+
+  const dismissNotification = async (id: string) => {
+    await saveNotification({
+      id,
+      seen: true,
+      dismissed: true,
+      savedAt: Date.now()
+    });
+
+    removeNotificationFromState(id);
+  };
+
+  const removeNotificationFromState = (id: string) => {
+    setNotifications((notifications) =>
+      notifications.filter((notification) => notification.id !== id)
+    );
+  };
+
+  return {
+    notifications,
+    markNotificationAsSeen,
+    dismissNotification
+  };
+};
+
+// Hard-coded list of notifications
+const incomingNotifications: IncomingNotification[] = [
+  {
+    id: 'beta-intro-rapid-retirement',
+    important: true
+  }
+];
+
+export default useNotifications;

--- a/src/shared/components/communication-framework/notifications/Notification.module.css
+++ b/src/shared/components/communication-framework/notifications/Notification.module.css
@@ -1,3 +1,4 @@
 .container {
   max-width: 450px; /* same as paragraph width in help&docs */
+  min-height: 570px; /* same as for contact us form */
 }

--- a/src/shared/components/communication-framework/notifications/Notification.module.css
+++ b/src/shared/components/communication-framework/notifications/Notification.module.css
@@ -1,0 +1,3 @@
+.container {
+  max-width: 450px; /* same as paragraph width in help&docs */
+}

--- a/src/shared/components/communication-framework/notifications/Notification.tsx
+++ b/src/shared/components/communication-framework/notifications/Notification.tsx
@@ -1,0 +1,63 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect } from 'react';
+
+import BetaIntroRapidRetirement from './beta-intro-rapid-retirement/BetaIntroRapidRetirement';
+
+import type { IncomingNotification } from '../hooks/useNotifications';
+
+import styles from './Notification.module.css';
+
+/**
+ * want callbacks to:
+ * - mark notification as seen
+ * - ignore notification in the future
+ */
+type Props = {
+  notification: IncomingNotification;
+  onClose: () => void;
+  onNotificationSeen: (id: string) => void;
+  onNotificationDismissed: (id: string) => void;
+};
+
+/**
+ * So far, there is only one hard-coded notification that we can display.
+ */
+
+const Notification = (props: Props) => {
+  const { notification } = props;
+
+  useEffect(() => {
+    props.onNotificationSeen(notification.id);
+  });
+
+  const onNotificationDismissed = () => {
+    props.onNotificationDismissed(notification.id);
+    props.onClose();
+  };
+
+  return (
+    <div className={styles.container}>
+      <BetaIntroRapidRetirement
+        onClose={props.onClose}
+        onNotificationDismissed={onNotificationDismissed}
+      />
+    </div>
+  );
+};
+
+export default Notification;

--- a/src/shared/components/communication-framework/notifications/Notifications.tsx
+++ b/src/shared/components/communication-framework/notifications/Notifications.tsx
@@ -1,0 +1,57 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Notification from './Notification';
+
+import type { IncomingNotification } from '../hooks/useNotifications';
+
+/**
+ * want callbacks to:
+ * - mark notification as seen
+ * - ignore notification in the future
+ */
+type Props = {
+  notifications: IncomingNotification[];
+  onClose: () => void;
+  onNotificationSeen: (id: string) => void;
+  onNotificationDismissed: (id: string) => void;
+};
+
+const Notifications = (props: Props) => {
+  const { notifications } = props;
+  if (!notifications.length) {
+    return null;
+  }
+
+  /**
+   * It seems reasonable to assume that the client
+   * may need to deal with multiple notifications;
+   * yet, so far, in practice, there can only ever be at most one,
+   * and it is not yet clear what our strategy for multiple notifications is going to be.
+   */
+  const notification = notifications[0];
+
+  return (
+    <Notification
+      notification={notification}
+      onClose={props.onClose}
+      onNotificationSeen={props.onNotificationSeen}
+      onNotificationDismissed={props.onNotificationDismissed}
+    />
+  );
+};
+
+export default Notifications;

--- a/src/shared/components/communication-framework/notifications/beta-intro-rapid-retirement/BetaIntroRapidRetirement.module.css
+++ b/src/shared/components/communication-framework/notifications/beta-intro-rapid-retirement/BetaIntroRapidRetirement.module.css
@@ -1,0 +1,9 @@
+.strong {
+  font-weight: var(--font-weight-bold);
+}
+
+.buttons {
+  display: flex;
+  column-gap: var(--standard-gutter);
+  margin-top: var(--standard-gutter);
+}

--- a/src/shared/components/communication-framework/notifications/beta-intro-rapid-retirement/BetaIntroRapidRetirement.tsx
+++ b/src/shared/components/communication-framework/notifications/beta-intro-rapid-retirement/BetaIntroRapidRetirement.tsx
@@ -1,0 +1,66 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PrimaryButton } from 'src/shared/components/button/Button';
+import TextButton from 'src/shared/components/text-button/TextButton';
+
+import styles from './BetaIntroRapidRetirement.module.css';
+
+/**
+ * This is an entirely hard-coded notification to be shown during a brief period of time.
+ *
+ * The actions that this component needs to be able to perform:
+ * - Close the communication panel and mark this notification
+ *   with a 'less powerful' flag, so that it will still show up in the communication panel,
+ *   but will not cause it to open on its own.
+ * - Close the communication panel and mark this notification
+ *   with a 'more powerful' flag, so that it does not even show up in the communication panel
+ *
+ */
+
+type Props = {
+  onClose: () => void;
+  onNotificationDismissed: () => void;
+};
+
+const BetaIntroRapidRetirement = (props: Props) => {
+  return (
+    <>
+      <p className={styles.strong}>
+        Beta is a fresher, faster way to see genome annotation across the
+        taxonomic tree and get the data you need.
+      </p>
+      <p>
+        This is the new home for both the most popular genome assemblies from
+        each of the Ensembl divisions, as well as new genomes which would
+        previously have been made available on Ensembl Rapid Release.
+      </p>
+      <p>
+        It's early days for this new service, and we're working to continually
+        improve and expand functionality - so any feedback would be much
+        appreciated…
+      </p>
+      <div className={styles.buttons}>
+        <PrimaryButton onClick={props.onClose}>Use Beta</PrimaryButton>
+        <TextButton onClick={props.onNotificationDismissed}>
+          Clear message
+        </TextButton>
+      </div>
+    </>
+  );
+};
+
+export default BetaIntroRapidRetirement;

--- a/src/shared/services/notificationsStorageConstants.ts
+++ b/src/shared/services/notificationsStorageConstants.ts
@@ -14,30 +14,4 @@
  * limitations under the License.
  */
 
-import { createSlice } from '@reduxjs/toolkit';
-
-type State = {
-  isCommunicationPanelOpen: boolean;
-};
-
-const initialState: State = {
-  isCommunicationPanelOpen: false
-};
-
-const communicationSlice = createSlice({
-  name: 'communication',
-  initialState,
-  reducers: {
-    openCommunicationPanel(state) {
-      state.isCommunicationPanelOpen = true;
-    },
-    toggleCommunicationPanel(state) {
-      state.isCommunicationPanelOpen = !state.isCommunicationPanelOpen;
-    }
-  }
-});
-
-export const { openCommunicationPanel, toggleCommunicationPanel } =
-  communicationSlice.actions;
-
-export default communicationSlice.reducer;
+export const NOTIFICATIONS_STORE_NAME = 'notifications';

--- a/src/shared/services/notificationsStorageService.ts
+++ b/src/shared/services/notificationsStorageService.ts
@@ -1,0 +1,64 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import IndexedDB from 'src/services/indexeddb-service';
+
+import { NOTIFICATIONS_STORE_NAME as STORE_NAME } from './notificationsStorageConstants';
+
+export type StoredNotification = {
+  id: string;
+  seen: boolean;
+  dismissed: boolean;
+  savedAt: number;
+};
+
+export const saveNotification = async (notification: StoredNotification) => {
+  const notificationId = notification.id;
+  await IndexedDB.set(STORE_NAME, notificationId, notification);
+};
+
+export const getNotification = async (
+  notificationId: string
+): Promise<StoredNotification | undefined> => {
+  return await IndexedDB.get(STORE_NAME, notificationId);
+};
+
+export const getAllNotifications = async (): Promise<StoredNotification[]> => {
+  const db = await IndexedDB.getDB();
+  return await db.getAll(STORE_NAME);
+};
+
+export const updateNotification = async (
+  notificationId: string,
+  fragment: Partial<StoredNotification>
+) => {
+  const storedNotification = await getNotification(notificationId);
+
+  if (!storedNotification) {
+    return;
+  }
+
+  const updatedNotification = {
+    ...storedNotification,
+    ...fragment
+  };
+
+  await saveNotification(updatedNotification);
+};
+
+export const deleteNotification = async (notificationId: string) => {
+  await IndexedDB.delete(STORE_NAME, notificationId);
+};


### PR DESCRIPTION
## Description
Up until now, the CommunicationPanel (the panel that slides from the right upon click on the conversation icon) only showed the "Contact Us" form. This PR adds the capability to show notifications ("Messages").

The proper, long-term architecture for notifications is unclear. For now, the requirement is only to show one notification ("welcome to beta, etc."), which automatically opens the communication panel if the user hasn't seen it. If the user simply closes the panel or clicks on the "use beta" button, the notification remains accessible (shows up as a green dot next to the conversation icon). If the user chooses to "clear the message", it disappears completely.


https://github.com/user-attachments/assets/c053d40c-618f-45e2-992f-90b1ee36d548


I wonder if the `is_important: true` field should instead be something like `behavior: "noisy"`. 

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2690

## Deployment URL(s)
http://announce-rapid.review.ensembl.org