### PR TITLE
Bump GB version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ensembl/ensembl-genome-browser": "0.6.10",
+        "@ensembl/ensembl-genome-browser": "0.6.11",
         "@react-spring/web": "9.7.4",
         "@reduxjs/toolkit": "2.2.7",
         "@sentry/browser": "8.30.0",
@@ -2902,9 +2902,9 @@
       }
     },
     "node_modules/@ensembl/ensembl-genome-browser": {
-      "version": "0.6.10",
-      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.10.tgz",
-      "integrity": "sha1-SJGE6aVeelwWclJ7J0oxSqbF8cQ="
+      "version": "0.6.11",
+      "resolved": "https://gitlab.ebi.ac.uk/api/v4/projects/3500/packages/npm/@ensembl/ensembl-genome-browser/-/@ensembl/ensembl-genome-browser-0.6.11.tgz",
+      "integrity": "sha1-3Xj6SJzSKbX15l/OA9Qm0kfAfmU="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.23.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "coverage": "jest --coverage"
   },
   "dependencies": {
-    "@ensembl/ensembl-genome-browser": "0.6.10",
+    "@ensembl/ensembl-genome-browser": "0.6.11",
     "@react-spring/web": "9.7.4",
     "@reduxjs/toolkit": "2.2.7",
     "@sentry/browser": "8.30.0",


### PR DESCRIPTION
## Description
Update genome browser package version to 0.6.11

## Deployment URL(s)
http://fix-zoom.review.ensembl.org


## Views affected
Genome browser