### PR TITLE
Display message for when submission results have expired, and clear out old submissions

### DIFF
--- a/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.tsx
@@ -21,6 +21,8 @@ import { useAppDispatch, useAppSelector } from 'src/store';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
 
+import { UNAVAILABLE_RESULTS_WARNING } from 'src/content/app/tools/shared/constants/displayedMessages';
+
 import { getFormattedDateTime } from 'src/shared/helpers/formatters/dateFormatter';
 import { areSubmissionResultsAvailable } from 'src/content/app/tools/blast/utils/blastResultsAvailability';
 import {
@@ -48,12 +50,12 @@ import QuestionButton from 'src/shared/components/question-button/QuestionButton
 import ShowHide from 'src/shared/components/show-hide/ShowHide';
 import TextButton from 'src/shared/components/text-button/TextButton';
 import DeletionConfirmation from 'src/shared/components/deletion-confirmation/DeletionConfirmation';
+import UnavailableResults from 'src/content/app/tools/shared/components/help-messages/UnavailableResults';
 
 import type { BlastProgram } from 'src/content/app/tools/blast/types/blastSettings';
 
 import styles from './BlastSubmissionHeader.module.css';
 
-export const UNAVAILABLE_RESULTS_WARNING = 'Results no longer available';
 export const FAILED_SUBMISSION_WARNING = 'Submission failed';
 
 export type Props = {
@@ -213,7 +215,7 @@ const ControlsSection = (props: {
         <DeleteButton onClick={onDelete} disabled={isInDeleteMode} />
         <div className={styles.errorMessage}>
           <span>{UNAVAILABLE_RESULTS_WARNING}</span>
-          <QuestionButton helpText={<UnavailableResultsHelpText />} />
+          <QuestionButton helpText={<UnavailableResults />} />
         </div>
       </div>
     );
@@ -235,20 +237,6 @@ const ControlsSection = (props: {
     );
   }
 };
-
-const UnavailableResultsHelpText = () => (
-  <>
-    <p>Results are stored for 7 days from submission</p>
-    <p>
-      Use 'Edit/rerun' to start a new job with the same configuration as the
-      original submission
-    </p>
-    <p>
-      Configurations are stored for 28 days after submission, then removed from
-      the jobs list
-    </p>
-  </>
-);
 
 const FailedSubmissionHelpText = () => (
   <>

--- a/src/content/app/tools/blast/components/listed-blast-submission/ListedBlastSubmission.test.tsx
+++ b/src/content/app/tools/blast/components/listed-blast-submission/ListedBlastSubmission.test.tsx
@@ -22,7 +22,7 @@ import userEvent from '@testing-library/user-event';
 
 import * as blastStorageService from 'src/content/app/tools/blast/services/blastStorageService';
 import { BLAST_RESULTS_AVAILABILITY_DURATION } from 'src/content/app/tools/blast/services/blastStorageServiceConstants';
-import { UNAVAILABLE_RESULTS_WARNING } from 'src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader';
+import { UNAVAILABLE_RESULTS_WARNING } from 'src/content/app/tools/shared/constants/displayedMessages';
 
 import ListedBlastSubmission, {
   type Props as ListedBlastSubmissionProps

--- a/src/content/app/tools/shared/components/help-messages/UnavailableResults.tsx
+++ b/src/content/app/tools/shared/components/help-messages/UnavailableResults.tsx
@@ -1,0 +1,31 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const UnavailableResults = () => (
+  <>
+    <p>Results are stored for 7 days from submission</p>
+    <p>
+      Use 'Edit/rerun' to start a new job with the same configuration as the
+      original submission
+    </p>
+    <p>
+      Configurations are stored for 28 days after submission, then removed from
+      the jobs list
+    </p>
+  </>
+);
+
+export default UnavailableResults;

--- a/src/content/app/tools/shared/constants/displayedMessages.ts
+++ b/src/content/app/tools/shared/constants/displayedMessages.ts
@@ -1,0 +1,17 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const UNAVAILABLE_RESULTS_WARNING = 'Results no longer available';

--- a/src/content/app/tools/vep/components/vep-submission-header/VepSubmissionHeader.module.css
+++ b/src/content/app/tools/vep/components/vep-submission-header/VepSubmissionHeader.module.css
@@ -35,8 +35,7 @@ for ListedVepSubmission, and for the VEP results
 
 .controls {
   grid-column: controls;
-  display: grid;
-  grid-template-columns: repeat(3, min-content);
+  display: flex;
   column-gap: 42px;
   align-items: center;
   justify-self: end;
@@ -69,4 +68,13 @@ for ListedVepSubmission, and for the VEP results
 
 .deletionConfirmationMessage {
   color: var(--color-red);
+}
+
+/* Same as in BLAST submissions header */
+.errorMessage {
+  display: flex;
+  align-items: center;
+  column-gap: 0.6rem;
+  color: var(--color-red);
+  margin-right: 16px;
 }

--- a/src/content/app/tools/vep/components/vep-submission-header/VepSubmissionHeader.tsx
+++ b/src/content/app/tools/vep/components/vep-submission-header/VepSubmissionHeader.tsx
@@ -24,6 +24,7 @@ import * as urlFor from 'src/shared/helpers/urlHelper';
 import { useAppDispatch } from 'src/store';
 
 import { getFormattedDateTime } from 'src/shared/helpers/formatters/dateFormatter';
+import { areVepSubmissionResultsExpired } from 'src/content/app/tools/vep/utils/vepResultsAvailability';
 
 import { fillVepFormWithExistingSubmissionData } from 'src/content/app/tools/vep/state/vep-form/vepFormSlice';
 import { deleteSubmission } from 'src/content/app/tools/vep/state/vep-submissions/vepSubmissionsSlice';
@@ -38,6 +39,10 @@ import TextButton from 'src/shared/components/text-button/TextButton';
 import ButtonLink from 'src/shared/components/button-link/ButtonLink';
 import DeleteButton from 'src/shared/components/delete-button/DeleteButton';
 import DownloadLink from 'src/shared/components/download-button/DownloadLink';
+import QuestionButton from 'src/shared/components/question-button/QuestionButton';
+import UnavailableResults from 'src/content/app/tools/shared/components/help-messages/UnavailableResults';
+
+import { UNAVAILABLE_RESULTS_WARNING } from 'src/content/app/tools/shared/constants/displayedMessages';
 
 import styles from './VepSubmissionHeader.module.css';
 
@@ -128,19 +133,35 @@ const ControlButtons = (
   const vepResultsLink = urlFor.vepResults({
     submissionId: props.submission.id
   });
+  const isExpiredSubmission = areVepSubmissionResultsExpired(submission);
 
-  return (
-    <div className={styles.controls}>
-      <DeleteButton onClick={onDelete} disabled={isDeleting} />
-      <DownloadLink
-        href={downloadLink}
-        disabled={isDeleting || !canGetResults}
-      />
-      <ButtonLink isDisabled={isDeleting || !canGetResults} to={vepResultsLink}>
-        Results
-      </ButtonLink>
-    </div>
-  );
+  if (isExpiredSubmission) {
+    return (
+      <div className={styles.controls}>
+        <DeleteButton onClick={onDelete} disabled={isDeleting} />
+        <div className={styles.errorMessage}>
+          <span>{UNAVAILABLE_RESULTS_WARNING}</span>
+          <QuestionButton helpText={<UnavailableResults />} />
+        </div>
+      </div>
+    );
+  } else {
+    return (
+      <div className={styles.controls}>
+        <DeleteButton onClick={onDelete} disabled={isDeleting} />
+        <DownloadLink
+          href={downloadLink}
+          disabled={isDeleting || !canGetResults}
+        />
+        <ButtonLink
+          isDisabled={isDeleting || !canGetResults}
+          to={vepResultsLink}
+        >
+          Results
+        </ButtonLink>
+      </div>
+    );
+  }
 };
 
 const DeletionConfirmation = (

--- a/src/content/app/tools/vep/state/vep-action-listeners/vepActionListeners.ts
+++ b/src/content/app/tools/vep/state/vep-action-listeners/vepActionListeners.ts
@@ -41,7 +41,7 @@ import type {
  *   - SUBMITTED if submitted
  *   - UNSUCCESSFUL_SUBMISSION if failed to submit
  * 3. Start polling for submission status
- *   - SUBMITTED — continue polling
+ *   - SUBMITTED — continue polling
  *   - RUNNING - update status (in redux and in indexedDB); but continue polling
  *   - SUCCEEDED, FAILED, CANCELLED - update status (in redux and in indexedDB), and stop polling
  * 4. Note that user can refresh (or close/open) the browser while there are still some submissions pending.

--- a/src/content/app/tools/vep/state/vep-submissions/vepSubmissionsSlice.ts
+++ b/src/content/app/tools/vep/state/vep-submissions/vepSubmissionsSlice.ts
@@ -24,7 +24,8 @@ import {
   getVepSubmissions,
   updateVepSubmission as updateStoredVepSubmission,
   deleteVepSubmission as deleteStoredVepSubmission,
-  changeVepSubmissionId as changeStoredVepSubmissionId
+  changeVepSubmissionId as changeStoredVepSubmissionId,
+  deleteExpiredVepSubmissions
 } from 'src/content/app/tools/vep/services/vepStorageService';
 
 import type { VepSubmissionWithoutInputFile } from 'src/content/app/tools/vep/types/vepSubmission';
@@ -34,6 +35,7 @@ export type VepSubmissionsState = Record<string, VepSubmissionWithoutInputFile>;
 export const restoreVepSubmissions = createAsyncThunk(
   'vep-submissions/restoreSubmissions',
   async () => {
+    await deleteExpiredVepSubmissions();
     const storedSubmissions = await getVepSubmissions();
     const newState: VepSubmissionsState = {};
     for (const submission of storedSubmissions) {

--- a/src/content/app/tools/vep/types/vepSubmission.ts
+++ b/src/content/app/tools/vep/types/vepSubmission.ts
@@ -56,7 +56,7 @@ export type VepSubmission = {
   inputFile: File | null;
   submissionName: string | null;
   parameters: Record<string, unknown>;
-  createdAt: number; // <-- to allow enable the submissions list
+  createdAt: number; // <-- to enable chronological sorting of VEP submissions in the submissions list
   submittedAt: number | null; // <-- can get the unsubmitted submission
   resultsSeen: boolean;
   status: SubmissionStatus; // <-- a member of a closed dictionary of words

--- a/src/content/app/tools/vep/utils/vepResultsAvailability.ts
+++ b/src/content/app/tools/vep/utils/vepResultsAvailability.ts
@@ -1,0 +1,49 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  VEP_RESULTS_AVAILABILITY_DURATION,
+  VEP_SUBMISSION_STORAGE_DURATION
+} from 'src/content/app/tools/vep/services/vepStorageServiceConstants';
+
+import type { VepSubmission } from 'src/content/app/tools/vep/types/vepSubmission';
+
+// Results of the submission will no longer be available from the backend;
+// but the submission parameters may still be available on the client; so that the submission may be resubmitted
+export const areVepSubmissionResultsExpired = (
+  submission: Pick<VepSubmission, 'submittedAt'>
+) => {
+  const { submittedAt } = submission;
+
+  if (submittedAt) {
+    return Date.now() - submittedAt > VEP_RESULTS_AVAILABILITY_DURATION;
+  }
+
+  return false;
+};
+
+// Submission is too old, and should be removed from the client
+export const isVepSubmissionExpired = (
+  submission: Pick<VepSubmission, 'submittedAt'>
+) => {
+  const { submittedAt } = submission;
+
+  if (submittedAt) {
+    return Date.now() - submittedAt > VEP_SUBMISSION_STORAGE_DURATION;
+  }
+
+  return false;
+};

--- a/src/content/app/tools/vep/utils/vepResultsAvailability.ts
+++ b/src/content/app/tools/vep/utils/vepResultsAvailability.ts
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  VEP_RESULTS_AVAILABILITY_DURATION,
-  VEP_SUBMISSION_STORAGE_DURATION
-} from 'src/content/app/tools/vep/services/vepStorageServiceConstants';
+import { VEP_RESULTS_AVAILABILITY_DURATION } from 'src/content/app/tools/vep/services/vepStorageServiceConstants';
 
 import type { VepSubmission } from 'src/content/app/tools/vep/types/vepSubmission';
 
@@ -30,19 +27,6 @@ export const areVepSubmissionResultsExpired = (
 
   if (submittedAt) {
     return Date.now() - submittedAt > VEP_RESULTS_AVAILABILITY_DURATION;
-  }
-
-  return false;
-};
-
-// Submission is too old, and should be removed from the client
-export const isVepSubmissionExpired = (
-  submission: Pick<VepSubmission, 'submittedAt'>
-) => {
-  const { submittedAt } = submission;
-
-  if (submittedAt) {
-    return Date.now() - submittedAt > VEP_SUBMISSION_STORAGE_DURATION;
   }
 
   return false;


### PR DESCRIPTION
## Description
- For submissions that are 7 days and older, show message in the submissions list about unavailable results.
- At startup, delete submissions that are too old (28 days and older)

**Example**

https://github.com/user-attachments/assets/28db693c-4acb-4d30-aad3-2ea938011542


## Related JIRA Issue(s)
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2743
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2744

## Deployment URL(s)
http://expired-vep-submission.review.ensembl.org

If you would like to test the deployment, you might want to use the snippet below to update submission date in browser dev tools:

```
vepSubmissionId = "25uHWF4b7Arru7"; // <--- the id of your VEP submission
submittedDaysAgo = 30; // <--- how old (in days) you want the submission to be

dbRequest = indexedDB.open("ensembl-website");
dbRequest.onsuccess = (event) => {
  const db = event.target.result;
  const transaction = db.transaction("vep-submissions", 'readwrite')
  const objectStore = transaction.objectStore("vep-submissions")

  objectStore.get(vepSubmissionId).onsuccess = (event) => {
    updateSubmissionDate(event.target.result, objectStore);
  };
};

updateSubmissionDate = (data, objectStore) => {
  const dayInMilliseconds = 1000 * 60 * 60 * 24;
  const timeElapsedSinceSubmission = dayInMilliseconds * submittedDaysAgo;
  const submissionTimestamp = Date.now() - timeElapsedSinceSubmission;
  data.createdAt = submissionTimestamp;
  data.submittedAt = submissionTimestamp;

  const requestUpdate = objectStore.put(data, vepSubmissionId);
  requestUpdate.onsuccess = (event) => {
    console.log('vep submission date updated')
  };
}
```