### PR TITLE
Update layout and styles to fix VEP results table loading overlay

### DIFF
--- a/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.module.css
+++ b/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.module.css
@@ -84,11 +84,21 @@
   a wrapper around the table of results,
   which allows positioning the loading overlay over the table
 */
-.tableWrapper {
+.tableViewportWrapper {
   position: relative;
+  height: 100%;
+  overflow: hidden;
+  margin-right: -1rem;
+}
+
+/*
+  a scrollable container for the table of results
+  (allows vertical and horizontal scrolling of the table)
+*/
+.tableViewport {
   overflow: auto;
   padding-right: 1rem;
-  margin-right: -1rem;
+  height: 100%;
 }
 
 .tableLoadingOverlay {

--- a/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.tsx
@@ -126,13 +126,15 @@ const VepSubmissionResults = () => {
           perPage={perPage}
           onPerPageChange={setPerPage}
         />
-        <div className={styles.tableWrapper}>
+        <div className={styles.tableViewportWrapper}>
           {isFetching && (
             <div className={styles.tableLoadingOverlay}>
               <CircleLoader className={styles.tableLoadingSpinner} />
             </div>
           )}
-          <VepResultsTable variants={vepResults.variants} />
+          <div className={styles.tableViewport}>
+            <VepResultsTable variants={vepResults.variants} />
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Description
Turns out, there is a bug in the loading overlay for VEP results table (shown during pagination). You may notice that if you scroll down a bit, and change the page, a part of the table will be blurred while a part below remains sharp. This was due to the incorrect positioning of the element that created the blurring effect and that was the container for the spinner.

https://github.com/user-attachments/assets/48a4ba9f-75ed-4d07-a18f-6b81a3ffa8f8

Here is the result after applying the changes in this PR:

https://github.com/user-attachments/assets/025ac13b-227f-4ccb-939f-9b7d909b1b50
