### PR TITLE
VEP fixes

### DIFF
--- a/src/content/app/tools/vep/state/vep-action-listeners/vepActionListeners.ts
+++ b/src/content/app/tools/vep/state/vep-action-listeners/vepActionListeners.ts
@@ -123,8 +123,17 @@ const vepSubmissionsRestoreListener = {
       }
     }
 
+    // Make sure to not pass the actual submission objects to VepSubmissionStatusPolling,
+    // because the submission objects belong to the redux state, and are therefore immutable
+    const submissionsDataForPolling = unresolvedSubmissions.map(
+      (submission) => ({
+        id: submission.id,
+        status: submission.status
+      })
+    );
+
     vepSubmissionStatusPolling.processSubmissionsOnStartup({
-      submissions: unresolvedSubmissions,
+      submissions: submissionsDataForPolling,
       dispatch
     });
 


### PR DESCRIPTION
## Description
- Use actual species genome ids instead of the hard-coded ones in the table of VEP results (forgotten leftover from early prototype of VEP results table) 
- Fix errors during submission status update caused by direct mutation of the redux state. _NOTE:_ the steps to reproduce the error were: 1) Submit a VEP job; 2) Wait for the "Submitting" status to change to "Queued"; 3) Refresh the browser. The error happened during status updates to the VEP submissions that were restored from IndexedDB

![image](https://github.com/user-attachments/assets/8fc68a35-37c3-42fd-9133-d852147594b4)


## Related JIRA Issue(s)
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2772

## Deployment URL(s)
http://vep-fixes.review.ensembl.org