### PR TITLE
Update gitlab-ci to remove the dev branch and switch from master to main

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,13 +12,13 @@ stages:
   - test
   - test_build_static
   - build_docker_images
-  - deploy
+  - deploy-preview
+  - deploy-live
 
 variables:
   CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:nginx-${CI_COMMIT_SHORT_SHA}
   CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}
   KUBE_CONTEXT: ens-dev-ctx
-  DEPLOYENV: dev
   ENVIRONMENT: production
   DOCKER_TLS_CERTDIR: ""
 
@@ -79,7 +79,7 @@ variables:
 # Template for publishing static assets for the new kubernetes cluster
 .publish_assets:
   image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:latest
-  stage: deploy
+  stage: deploy-live
   environment:
     name: jobs/k8s-job
 
@@ -114,10 +114,10 @@ variables:
     - docker rmi ${CONTAINER_NODE_IMAGE}
     - docker logout $CI_REGISTRY
 
-# Template for deployment to the new kubernetes cluster
-# For live deployment, it does not need to deploy a static assets container
+# Template for deployment to "stable" (non-review) environments that have static assets on a mounted drive
+# (therefore, does not need to deploy a static assets container)
 .deploy:
-  stage: deploy
+  stage: deploy-live # is overwritten in some of the jobs that are extending this template
   image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:latest
   before_script:
     - *gitlab-agent-setup-commands
@@ -130,7 +130,7 @@ variables:
 
 # Template to deploy review-app to WP k8s cluster
 .deploy-review:
-  stage: deploy
+  stage: deploy-preview
   image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:latest
   before_script:
     - *gitlab-agent-setup-commands
@@ -147,7 +147,7 @@ variables:
 
 # Template for stopping review app - Do cleanup here 
 .stop-review:
-  stage: deploy
+  stage: deploy-preview
   image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:latest
   before_script:
     - kubectl config use-context ${AGENT}
@@ -210,7 +210,6 @@ Node:Live:
 Nginx:review:
   extends: .build-nginx
   variables:
-    DEPLOYENV: dev
     CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:nginx-${CI_COMMIT_SHORT_SHA}-${CI_COMMIT_REF_SLUG}
   rules:
     - if: $CI_COMMIT_BRANCH != "main" && $CI_COMMIT_BRANCH !~ /^nodeploy\/.*$/
@@ -222,7 +221,6 @@ Nginx:review:
 Node:review:
   extends: .build-node
   variables:
-    DEPLOYENV: dev
     CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}-${CI_COMMIT_REF_SLUG}
   rules:
     - if: $CI_COMMIT_BRANCH != "main" && $CI_COMMIT_BRANCH !~ /^nodeploy\/.*$/
@@ -248,8 +246,7 @@ Live:
     - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "main"'
   when: manual
   needs:
-    - Test_N_Build
-    - Node:Live
+    - Staging
 
 # Publish static assets
 Pub:Live:
@@ -263,8 +260,7 @@ Pub:Live:
     - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "main"'
   when: manual
   needs:
-    - Test_N_Build
-    - Node:Live
+    - Pub:Staging
 
 
 # DEPLOYMENT TO THE LIVE (PRODUCTION) FALLBACK ENVIRONMENT (beta.ensembl.org, running in Hinxton)
@@ -283,8 +279,7 @@ LiveFallback:
     - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "main"'
   when: manual
   needs:
-    - Test_N_Build
-    - Node:Live
+    - Staging
 
 # Publish static assets
 Pub::LiveFallback:
@@ -298,8 +293,7 @@ Pub::LiveFallback:
     - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "main"'
   when: manual
   needs:
-    - Test_N_Build
-    - Node:Live
+    - Pub:Staging
 
 
 # DEPLOYMENT TO THE STAGING ENVIRONMENT (staging-2020.ensembl.org)
@@ -307,6 +301,7 @@ Pub::LiveFallback:
 # Deploy the Node server
 Staging:
   extends: .deploy
+  stage: deploy-preview
   environment:
     name: staging
   rules:
@@ -321,6 +316,7 @@ Staging:
 # Publish static assets
 Pub:Staging:
   extends: .publish_assets
+  stage: deploy-preview
   environment:
     name: staging
   variables:
@@ -338,6 +334,7 @@ Pub:Staging:
 # Deploy the Node server
 Dev:
   extends: .deploy
+  stage: deploy-preview
   variables:
     CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}
     AGENT: ${DEV_AGENT}
@@ -355,6 +352,7 @@ Dev:
 # Publish static assets
 Pub:Dev:
   extends: .publish_assets
+  stage: deploy-preview
   environment:
     name: development
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -260,6 +260,7 @@ Pub:Live:
     - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "main"'
   when: manual
   needs:
+    - Test_N_Build
     - Pub:Staging
 
 
@@ -293,6 +294,7 @@ Pub::LiveFallback:
     - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "main"'
   when: manual
   needs:
+    - Test_N_Build
     - Pub:Staging
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -260,7 +260,7 @@ Pub:Live:
     - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "main"'
   when: manual
   needs:
-    - Test_N_Build
+    - Test_N_Build # The reason this job has to be in dependencies array is so that the Publish job can recover its BUILD_JOB_ID
     - Pub:Staging
 
 
@@ -294,7 +294,7 @@ Pub::LiveFallback:
     - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "main"'
   when: manual
   needs:
-    - Test_N_Build
+    - Test_N_Build # The reason this job has to be in dependencies array is so that the Publish job can recover its BUILD_JOB_ID
     - Pub:Staging
 
 
@@ -327,7 +327,7 @@ Pub:Staging:
   rules:
     - if: $CI_COMMIT_BRANCH == "main"
   needs:
-    - Test_N_Build
+    - Test_N_Build # The reason this job has to be in dependencies array is so that the Publish job can recover its BUILD_JOB_ID
     - Node:Live
 
 
@@ -363,7 +363,7 @@ Pub:Dev:
   rules:
     - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "main"'
   needs:
-    - Test_N_Build
+    - Test_N_Build # The reason this job has to be in dependencies array is so that the Publish job can recover its BUILD_JOB_ID
     - Node:Live
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 # CI/CD Pipeline
-# dev branch -> staging (runs exactly the same code as live; opportunity to inspect the site before pushing to production)
-# master branch -> internal (runs from the same master branch as live; but with flags enabled for seeing the latest UI changes that may not be ready for production)
-# master branch -> live
+# - Live deployment (runs the latest code, with unfinished features hidden from the user; requires manual deployment)
+# - Staging deployment (runs exactly the same code as live; opportunity to inspect the site before pushing to production)
+# - Development deployment (runs the latest code, has all in-progress features enabled)
 
 # include template to setup review app
 include: '/gitlab-ci-templates/.setup-review-template.yaml'
@@ -179,90 +179,53 @@ Test:
   rules:
     - if: $CI_COMMIT_BRANCH =~ /^nodeploy\/.*$/
 
-# Job to build static assets for staging and live environment
-# dev branch -> Staging
-# master branch -> Live
+# Job to build static assets for staging, live, and dev environments
+# from the main branch
 Test_N_Build:
   extends: .build-static
-  variables:
-    GOOGLE_ANALYTICS_KEY: ${GA_KEY}
-    ENVIRONMENT: production
-    API_HOST: ""
   rules:
-    - if: $CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "dev"
+    - if: $CI_COMMIT_BRANCH == "main"
 
-# Job to build static assets for internal environment
-# master branch -> Internal
-Test_N_Build:internal:
-  extends: .build-static
-  variables:
-    GOOGLE_ANALYTICS_KEY: ${GA_KEY}
-    ENVIRONMENT: internal
-    API_HOST: ""
-  rules:
-    - if: $CI_COMMIT_BRANCH == "master"
-
+# Job to build static assets for review deployments
+# Should run after commits to feature branches.
+# If, for whatever reason, we do not need deployment on a feature branch, we prefix branch name with "nodeploy"
 Test_N_Build:review:
   extends: .build-static
-  variables:
-    ENVIRONMENT: development
-    API_HOST: ""
   rules:
-    - if: $CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "dev" && $CI_COMMIT_BRANCH !~ /^nodeploy\/.*$/
+    - if: $CI_COMMIT_BRANCH != "main" && $CI_COMMIT_BRANCH !~ /^nodeploy\/.*$/
 
-# Job to build node docker image for staging environment
-# dev branch -> Staging
-Node:Staging:
-  extends: .build-node
-  rules:
-    - if: $CI_COMMIT_BRANCH == "dev"
-  needs:
-    - Test_N_Build
-
-# Job to build node docker image for live environment
-# master branch -> Live
+# Job to build node docker image for staging, live, and dev environments
+# main branch -> Staging, Live
 Node:Live:
   extends: .build-node
   variables:
-    CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}-prod
+    CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}
   rules:
-    - if: $CI_COMMIT_BRANCH == "master"
+    - if: $CI_COMMIT_BRANCH == "main"
   needs:
     - Test_N_Build
 
-# Job to build node docker image for internal environment
-# master branch -> internal
-Node:Internal:
-  extends: .build-node
-  variables:
-    DEPLOYENV: internal
-    CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}-internal
-  rules:
-    - if: $CI_COMMIT_BRANCH == "master"
-  needs:
-    - Test_N_Build:internal
-
 # Job to build nginx docker image for review environment
-# all other branch -> dev
+# Runs after commits to feature branches
 Nginx:review:
   extends: .build-nginx
   variables:
     DEPLOYENV: dev
     CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:nginx-${CI_COMMIT_SHORT_SHA}-${CI_COMMIT_REF_SLUG}
   rules:
-    - if: $CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "dev" && $CI_COMMIT_BRANCH !~ /^nodeploy\/.*$/
+    - if: $CI_COMMIT_BRANCH != "main" && $CI_COMMIT_BRANCH !~ /^nodeploy\/.*$/
   needs:
     - Test_N_Build:review
 
 # Job to build node docker image for review environment
-# all other branch -> dev
+# Runs after commits to feature branches
 Node:review:
   extends: .build-node
   variables:
     DEPLOYENV: dev
     CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}-${CI_COMMIT_REF_SLUG}
   rules:
-    - if: $CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "dev" && $CI_COMMIT_BRANCH !~ /^nodeploy\/.*$/
+    - if: $CI_COMMIT_BRANCH != "main" && $CI_COMMIT_BRANCH !~ /^nodeploy\/.*$/
   needs:
     - Test_N_Build:review
 
@@ -276,13 +239,14 @@ Node:review:
 Live:
   extends: .deploy
   variables:
-    CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}-prod
+    CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}
     AGENT: ${PROD_AGENT}
     NAMESPACE: ${PROD_NS}
   environment:
     name: production
   rules:
-    - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "master"'
+    - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "main"'
+  when: manual
   needs:
     - Test_N_Build
     - Node:Live
@@ -296,7 +260,8 @@ Pub:Live:
     AGENT: ${PROD_AGENT}
     NAMESPACE: ${PROD_NS}
   rules:
-    - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "master"'
+    - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "main"'
+  when: manual
   needs:
     - Test_N_Build
     - Node:Live
@@ -308,14 +273,15 @@ Pub:Live:
 LiveFallback:
   extends: .deploy
   variables:
-    CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:nginx-${CI_COMMIT_SHORT_SHA}-prod
-    CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}-prod
+    CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:nginx-${CI_COMMIT_SHORT_SHA}
+    CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}
     AGENT: ${FALLBACK_AGENT}
     NAMESPACE: ${FALLBACK_NS}
   environment:
     name: fallback
   rules:
-    - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "master"'
+    - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "main"'
+  when: manual
   needs:
     - Test_N_Build
     - Node:Live
@@ -329,7 +295,8 @@ Pub::LiveFallback:
     AGENT: ${FALLBACK_AGENT}
     NAMESPACE: ${FALLBACK_NS}
   rules:
-    - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "master"'
+    - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "main"'
+  when: manual
   needs:
     - Test_N_Build
     - Node:Live
@@ -343,10 +310,10 @@ Staging:
   environment:
     name: staging
   rules:
-    - if: $CI_COMMIT_BRANCH == "dev"
+    - if: $CI_COMMIT_BRANCH == "main"
   needs:
     - Test_N_Build
-    - Node:Staging
+    - Node:Live
   variables:
     AGENT: ${STAGING_AGENT}
     NAMESPACE: ${STAGING_NS}
@@ -360,43 +327,10 @@ Pub:Staging:
     AGENT: ${STAGING_AGENT}
     NAMESPACE: ${STAGING_NS}
   rules:
-    - if: $CI_COMMIT_BRANCH == "dev"
+    - if: $CI_COMMIT_BRANCH == "main"
   needs:
     - Test_N_Build
-    - Node:Staging
-
-
-# DEPLOYMENT TO THE INTERNAL ENVIRONMENT (internal-2020.ensembl.org)
-
-# Deploy the Node server
-Internal:
-  extends: .deploy
-  variables:
-    CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:nginx-${CI_COMMIT_SHORT_SHA}-internal
-    CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}-internal
-    AGENT: ${INTERNAL_AGENT}
-    NAMESPACE: ${INTERNAL_NS}
-  environment:
-    name: internal
-  rules:
-    - if: $CI_COMMIT_BRANCH == "master"
-  needs:
-    - Test_N_Build:internal
-    - Node:Internal
-
-# Publish static assets
-Pub:Internal:
-  extends: .publish_assets
-  environment:
-    name: internal
-  variables:
-    AGENT: ${INTERNAL_AGENT}
-    NAMESPACE: ${INTERNAL_NS}
-  rules:
-    - if: $CI_COMMIT_BRANCH == "master"
-  needs:
-    - Test_N_Build:internal
-    - Node:Internal
+    - Node:Live
 
 
 # DEPLOYMENT TO THE DEVELOPMENT ENVIRONMENT (dev-2020.ensembl.org)
@@ -405,7 +339,7 @@ Pub:Internal:
 Dev:
   extends: .deploy
   variables:
-    CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}-prod
+    CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}
     AGENT: ${DEV_AGENT}
     NAMESPACE: ${DEV_NS}
   environment:
@@ -413,7 +347,7 @@ Dev:
     kubernetes:
       namespace: ensembl-dev
   rules:
-    - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "master"'
+    - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "main"'
   needs:
     - Test_N_Build
     - Node:Live
@@ -427,7 +361,7 @@ Pub:Dev:
     AGENT: ${DEV_AGENT}
     NAMESPACE: ${DEV_NS}
   rules:
-    - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "master"'
+    - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "main"'
   needs:
     - Test_N_Build
     - Node:Live
@@ -449,7 +383,7 @@ Review:
     kubernetes:
       namespace: ${CI_COMMIT_REF_SLUG}
   rules:
-    - if: $CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "dev" && $CI_COMMIT_BRANCH !~ /^nodeploy\/.*$/
+    - if: $CI_COMMIT_BRANCH != "main" && $CI_COMMIT_BRANCH !~ /^nodeploy\/.*$/
   needs:
     - Test_N_Build:review
     - Nginx:review
@@ -466,8 +400,9 @@ CleanUpReview:
     DEV_NAMESPACE: ${DEV_NS}
     NAMESPACE: ${CI_COMMIT_REF_SLUG}
   except:
-    - dev
-    - master
+    - dev # keep temporarily until we delete the dev branch
+    - master # keep temporarily until we delete the master branch
+    - main
 
 
 # Create a review deployment (runs once per new branch)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,6 @@ stages:
 variables:
   CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:nginx-${CI_COMMIT_SHORT_SHA}
   CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}
-  KUBE_CONTEXT: ens-dev-ctx
   ENVIRONMENT: production
   DOCKER_TLS_CERTDIR: ""
 
@@ -198,8 +197,6 @@ Test_N_Build:review:
 # main branch -> Staging, Live
 Node:Live:
   extends: .build-node
-  variables:
-    CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}
   rules:
     - if: $CI_COMMIT_BRANCH == "main"
   needs:
@@ -237,7 +234,6 @@ Node:review:
 Live:
   extends: .deploy
   variables:
-    CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}
     AGENT: ${PROD_AGENT}
     NAMESPACE: ${PROD_NS}
   environment:
@@ -270,8 +266,6 @@ Pub:Live:
 LiveFallback:
   extends: .deploy
   variables:
-    CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:nginx-${CI_COMMIT_SHORT_SHA}
-    CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}
     AGENT: ${FALLBACK_AGENT}
     NAMESPACE: ${FALLBACK_NS}
   environment:
@@ -338,7 +332,6 @@ Dev:
   extends: .deploy
   stage: deploy-preview
   variables:
-    CONTAINER_NODE_IMAGE: ${CI_REGISTRY_IMAGE}:node-${CI_COMMIT_SHORT_SHA}
     AGENT: ${DEV_AGENT}
     NAMESPACE: ${DEV_NS}
   environment:


### PR DESCRIPTION
## Description
- Removed distinction between the `dev` and the `master` branch; and rename master to main
- Removed internal deployment (internal-2020) in favour of the dev deployment (dev-2020)

**Before:**

```
feature_branch => dev => master

review_deployment => staging => prod
```

**After**
```
feature_branch => main

review_deployment => staging (automatically) => prod (manually)
```

**Result of running the pipeline:**

Automatic steps (notice how the last box can run all manual jobs with the press of a single button at the top)

![image](https://github.com/user-attachments/assets/ccd8dbd5-fc62-4d6a-b347-085ae4e92f2b)

All jobs completed:

![image](https://github.com/user-attachments/assets/3b660692-c08f-4dc6-8886-c3d1820d641f)


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2783

## Deployment URL(s)
Expect something to be deployed to staging-2020 and dev-2020?