### PR TITLE
Update the display of transcription start sites

### DIFF
--- a/src/content/app/regulatory-activity-viewer/components/region-activity-section/region-detail-image/RegionDetailImage.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/region-activity-section/region-detail-image/RegionDetailImage.tsx
@@ -26,7 +26,7 @@ import {
 
 import RegionDetailGene from './region-detail-gene/RegionDetailGene';
 import RegionDetailRegulatoryFeature from './region-detail-regulatory-feature/RegionDetailRegulatoryFeature';
-import TranscriptionStartSite from 'src/content/app/regulatory-activity-viewer/components/region-overview/region-overview-image/transcription-start-site/TranscriptionStartSite';
+import TranscriptionStartSites from 'src/content/app/regulatory-activity-viewer/components/region-overview/region-overview-image/transcription-start-sites/TranscriptionStartSites';
 
 import type {
   FeatureTracks,
@@ -146,7 +146,7 @@ const GeneTrack = (props: {
     return (
       <Fragment key={gene.data.stable_id}>
         <RegionDetailGene gene={gene} offsetTop={offsetTop} scale={scale} />
-        <TranscriptionStartSite
+        <TranscriptionStartSites
           tss={gene.data.tss}
           strand={gene.data.strand}
           scale={scale}

--- a/src/content/app/regulatory-activity-viewer/components/region-activity-section/region-detail-image/RegionDetailImage.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/region-activity-section/region-detail-image/RegionDetailImage.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Fragment } from 'react';
 import type { ScaleLinear } from 'd3';
 
 import {
@@ -25,6 +26,7 @@ import {
 
 import RegionDetailGene from './region-detail-gene/RegionDetailGene';
 import RegionDetailRegulatoryFeature from './region-detail-regulatory-feature/RegionDetailRegulatoryFeature';
+import TranscriptionStartSite from 'src/content/app/regulatory-activity-viewer/components/region-overview/region-overview-image/transcription-start-site/TranscriptionStartSite';
 
 import type {
   FeatureTracks,
@@ -84,8 +86,10 @@ const GeneTracks = (props: {
   const forwardStrandTrackYs: number[] = [];
   const reverseStrandTrackYs: number[] = [];
 
-  for (let i = 0; i < forwardStrandTracks.length; i++) {
-    forwardStrandTrackYs.push(tempY);
+  // Designer's instruction: forward strand genes above the central line should stack upwards
+  for (let i = forwardStrandTracks.length; i > 0; i--) {
+    const y = GENE_TRACKS_TOP_OFFSET + GENE_TRACK_HEIGHT * (i - 1);
+    forwardStrandTrackYs.push(y);
     tempY += GENE_TRACK_HEIGHT;
   }
 
@@ -111,8 +115,9 @@ const GeneTracks = (props: {
 
     return tracks.map((track, index) => (
       <GeneTrack
-        track={track}
-        offsetTop={yCoordLookup[index]}
+        tracks={tracks}
+        trackIndex={index}
+        trackOffsetsTop={yCoordLookup}
         scale={props.scale}
         key={index}
       />
@@ -128,20 +133,28 @@ const GeneTracks = (props: {
 };
 
 const GeneTrack = (props: {
-  track: GeneTrack;
-  offsetTop: number;
+  tracks: GeneTrack[];
+  trackIndex: number;
+  trackOffsetsTop: number[];
   scale: ScaleLinear<number, number>;
 }) => {
-  const { track, offsetTop, scale } = props;
+  const { tracks, trackIndex, trackOffsetsTop, scale } = props;
+  const track = tracks[trackIndex];
+  const offsetTop = trackOffsetsTop[trackIndex];
 
   const geneElements = track.map((gene) => {
     return (
-      <RegionDetailGene
-        gene={gene}
-        offsetTop={offsetTop}
-        scale={scale}
-        key={gene.data.stable_id}
-      />
+      <Fragment key={gene.data.stable_id}>
+        <RegionDetailGene gene={gene} offsetTop={offsetTop} scale={scale} />
+        <TranscriptionStartSite
+          tss={gene.data.tss}
+          strand={gene.data.strand}
+          scale={scale}
+          geneTracks={tracks}
+          trackIndex={trackIndex}
+          trackOffsetsTop={trackOffsetsTop}
+        />
+      </Fragment>
     );
   });
 

--- a/src/content/app/regulatory-activity-viewer/components/region-overview/region-overview-image/RegionOverviewImage.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/region-overview/region-overview-image/RegionOverviewImage.tsx
@@ -26,7 +26,6 @@ import RegionOverviewLocationSelector from './region-overview-location-selector/
 import {
   GENE_TRACKS_TOP_OFFSET,
   GENE_TRACK_HEIGHT,
-  GENE_HEIGHT,
   REGULATORY_FEATURE_TRACKS_TOP_OFFSET,
   REGULATORY_FEATURE_RADIUS,
   REGULATORY_FEATURE_TRACK_HEIGHT
@@ -149,9 +148,6 @@ const GeneTracks = (props: {
 
   // === by this point, tempY should be the y-coordinate of the bottom gene track
 
-  const totalGeneTracksCount =
-    forwardStrandTracks.length + reverseStrandTracks.length;
-
   const [forwardStrandTrackElements, reverseStrandTrackElements] = [
     props.tracks.forwardStrandTracks,
     props.tracks.reverseStrandTracks
@@ -161,12 +157,12 @@ const GeneTracks = (props: {
       ? forwardStrandTrackYs
       : reverseStrandTrackYs;
 
-    return tracks.map((track, index) => (
+    return tracks.map((_, index) => (
       <GeneTrack
         regionData={props.regionData}
-        track={track}
-        totalGeneTracksCount={totalGeneTracksCount}
-        offsetTop={yCoordLookup[index]}
+        tracks={tracks}
+        trackIndex={index}
+        trackOffsetsTop={yCoordLookup}
         scale={props.scale}
         focusGeneId={props.focusGeneId}
         onFocusGeneChange={props.onFocusGeneChange}
@@ -186,21 +182,18 @@ const GeneTracks = (props: {
 
 const GeneTrack = (props: {
   regionData: Props['data'];
-  track: GeneTrack;
-  totalGeneTracksCount: number;
-  offsetTop: number;
+  tracks: GeneTrack[];
+  trackIndex: number;
+  trackOffsetsTop: number[];
   scale: ScaleLinear<number, number>;
   focusGeneId: string | null;
   onFocusGeneChange: Props['onFocusGeneChange'];
 }) => {
-  const { track, offsetTop, scale, focusGeneId, totalGeneTracksCount } = props;
+  const { tracks, trackIndex, trackOffsetsTop, scale, focusGeneId } = props;
+  const track = tracks[trackIndex];
+  const offsetTop = trackOffsetsTop[trackIndex];
 
   const geneElements = track.map((gene) => {
-    const tssYStart = offsetTop + GENE_HEIGHT;
-    const tssYEnd =
-      gene.data.strand === 'forward'
-        ? GENE_TRACKS_TOP_OFFSET - 10
-        : GENE_TRACKS_TOP_OFFSET + totalGeneTracksCount * GENE_HEIGHT + 20; // <-- TSS_FONT_SIZE constant; this is probably getting removed
     const isFocusGene = focusGeneId === gene.data.stable_id;
 
     return (
@@ -215,11 +208,12 @@ const GeneTrack = (props: {
         />
         {isFocusGene && (
           <TranscriptionStartSite
-            yStart={tssYStart}
-            yEnd={tssYEnd}
+            tss={gene.data.tss}
             strand={gene.data.strand}
             scale={scale}
-            tss={gene.data.tss}
+            geneTracks={tracks}
+            trackIndex={trackIndex}
+            trackOffsetsTop={trackOffsetsTop}
           />
         )}
       </Fragment>

--- a/src/content/app/regulatory-activity-viewer/components/region-overview/region-overview-image/RegionOverviewImage.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/region-overview/region-overview-image/RegionOverviewImage.tsx
@@ -20,7 +20,7 @@ import { scaleLinear, type ScaleLinear } from 'd3';
 import useRefWithRerender from 'src/shared/hooks/useRefWithRerender';
 
 import RegionOverviewGene from './region-overview-gene/RegionOverviewGene';
-import TranscriptionStartSite from './transcription-start-site/TranscriptionStartSite';
+import TranscriptionStartSites from './transcription-start-sites/TranscriptionStartSites';
 import RegionOverviewLocationSelector from './region-overview-location-selector/RegionOverviewLocationSelector';
 
 import {
@@ -207,7 +207,7 @@ const GeneTrack = (props: {
           onClick={props.onFocusGeneChange}
         />
         {isFocusGene && (
-          <TranscriptionStartSite
+          <TranscriptionStartSites
             tss={gene.data.tss}
             strand={gene.data.strand}
             scale={scale}

--- a/src/content/app/regulatory-activity-viewer/components/region-overview/region-overview-image/transcription-start-site/TranscriptionStartSite.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/region-overview/region-overview-image/transcription-start-site/TranscriptionStartSite.tsx
@@ -16,7 +16,10 @@
 
 import { type ScaleLinear } from 'd3';
 
-import { GeneInRegionOverview } from 'src/content/app/regulatory-activity-viewer/types/regionOverview';
+import { GENE_TRACK_HEIGHT } from '../regionOverviewImageConstants';
+
+import type { GeneInRegionOverview } from 'src/content/app/regulatory-activity-viewer/types/regionOverview';
+import type { GeneTrack } from 'src/content/app/regulatory-activity-viewer/helpers/prepare-feature-tracks/prepareFeatureTracks';
 
 /**
  * A transcription start site is represented by an L-shaped arrow,
@@ -30,17 +33,20 @@ import { GeneInRegionOverview } from 'src/content/app/regulatory-activity-viewer
  *
  */
 
-const HORIZONTAL_ARM_LENGTH = 12;
-const ARROWHEAD_BASE_LENGTH = 8; // the base of the triangle that represents the arrowhead
-const ARROWHEAD_HEIGHT = 10; // the height of the triangle that represents the arrowhead
+const VERTICAL_ARM_LENGTH = 12;
+const HORIZONTAL_ARM_LENGTH = 6;
+const ARROWHEAD_BASE_LENGTH = 6; // the base of the triangle that represents the arrowhead
+const ARROWHEAD_HEIGHT = 6.75; // the height of the triangle that represents the arrowhead
+const VERTICAL_OFFSET_FROM_GENE = 2;
 const COLOR = 'black';
 
 type Props = {
-  yStart: number;
-  yEnd: number;
   tss: GeneInRegionOverview['tss']; // an array of genomic coordinates related to this transcription start site
   strand: 'forward' | 'reverse';
   scale: ScaleLinear<number, number>;
+  geneTracks: GeneTrack[];
+  trackIndex: number;
+  trackOffsetsTop: number[];
 };
 
 /**
@@ -64,22 +70,41 @@ type Props = {
 
 
   distance from gene: 5
+
+
+(1)  where no genes, bottom of down stroke at same level as intron stroke for lane 1 of genes
+(2)  where any part of arrow or down stroke sits over a gene, bottom of down stroke 3px above equivalent of top edge of exons for the the gene directly below
+(3)  multiple tss site count, align bottom of brackets with bottom of arrow
+below the line, invert the above
+
+
+Plan:
+- Make a single pass over all TSSs, and calculate their start coordinate (scaled to image coordinates)
+  - Merge TSSs that are less than a minimum distance apart (say, 1px), recording the count of merged TSSs
+- There will be a difference in the positioning depending on whether this is a forward or a reverse strand
+  - For forward strand, start from the TSS closest to the end, and go backwards
+  - For reverse strand, start from the TSS closest to the start, and go forwards
+- Keep track of the x coordinate of the "end" of the previous TSS
+  - On forward strand, this is closer to the end of the gene
+  - On reverse strand, this is closer to the start of the gene
+  - TSS end is the coordinate of the tip of the arrow, plus the width of the number (merged TSS count) if present
  */
 
 const TranscriptionStartSites = (props: Props) => {
-  const { tss } = props;
+  const preparedTss = prepareTssData(props);
 
-  return tss.map((site) => (
+  return preparedTss.map((site) => (
     <TranscriptionStartSite {...props} site={site} key={site.position} />
   ));
 };
 
 const TranscriptionStartSite = (
-  props: Props & { site: GeneInRegionOverview['tss'][number] }
+  props: Props & { site: ReturnType<typeof prepareTssData>[number] }
 ) => {
-  const { yStart, yEnd, strand, scale, site } = props;
+  const { strand, site } = props;
+  const { yStart, yEnd, x, count } = site;
 
-  const stemX = scale(site.position);
+  const stemX = x;
   const armEndX =
     strand === 'forward'
       ? stemX + HORIZONTAL_ARM_LENGTH
@@ -92,6 +117,12 @@ const TranscriptionStartSite = (
   const arrowheadBaseBottomCoords = `${armEndX}, ${yEnd - ARROWHEAD_BASE_LENGTH / 2}`;
   const arrowheadBaseTopCoords = `${armEndX}, ${yEnd + ARROWHEAD_BASE_LENGTH / 2}`;
   const arrowheadPointCoords = `${arrowheadPointX}, ${yEnd}`;
+
+  const countLabelX =
+    strand === 'forward' ? arrowheadPointX + 1 : arrowheadPointX - 1;
+  const countLabelY = yEnd;
+  const countLabelTextAnchor = strand === 'forward' ? 'start' : 'end';
+  const countLabelAlignmentBaseline = strand === 'forward' ? 'auto' : 'hanging';
 
   return (
     <g data-name="transcription start site">
@@ -114,8 +145,193 @@ const TranscriptionStartSite = (
       <polygon
         points={`${arrowheadBaseBottomCoords} ${arrowheadPointCoords} ${arrowheadBaseTopCoords}`}
       />
+      {count > 1 && (
+        <text
+          x={countLabelX}
+          y={countLabelY}
+          textAnchor={countLabelTextAnchor}
+          alignmentBaseline={countLabelAlignmentBaseline}
+          fontSize={12}
+          fontWeight="lighter"
+          fontStyle="italic"
+        >
+          ({count})
+        </text>
+      )}
     </g>
   );
+};
+
+const prepareTssData = ({
+  tss,
+  geneTracks,
+  trackIndex,
+  trackOffsetsTop,
+  strand,
+  scale
+}: Props) => {
+  const minDistanceBetweenTss = 2;
+
+  let mergedTss: Array<{ position: number; x: number; count: number }> = [];
+  let lastX = -Infinity;
+
+  for (const site of tss) {
+    const x = scale(site.position);
+    if (x - lastX < minDistanceBetweenTss) {
+      const lastPreparedTss = mergedTss.at(-1);
+      if (!lastPreparedTss) {
+        mergedTss.push({
+          position: site.position,
+          x,
+          count: 1
+        });
+      } else {
+        lastPreparedTss.count += 1;
+      }
+    } else {
+      mergedTss.push({
+        position: site.position,
+        x,
+        count: 1
+      });
+    }
+    lastX = x;
+  }
+
+  const yStart = getYStart({
+    geneTracks,
+    trackIndex,
+    trackOffsetsTop,
+    tssList: mergedTss,
+    strand,
+    scale
+  });
+
+  const preparedTss: Array<{
+    position: number;
+    x: number;
+    yStart: number;
+    yEnd: number;
+    count: number;
+  }> = [];
+  if (strand === 'forward') {
+    mergedTss = mergedTss.reverse();
+  }
+
+  for (const site of mergedTss) {
+    const previousTss = preparedTss.at(-1);
+
+    if (!previousTss) {
+      preparedTss.push({
+        ...site,
+        yStart,
+        yEnd:
+          strand === 'forward'
+            ? yStart - VERTICAL_ARM_LENGTH
+            : yStart + VERTICAL_ARM_LENGTH
+      });
+
+      continue;
+    }
+
+    const expectedWidth =
+      site.count > 1
+        ? HORIZONTAL_ARM_LENGTH + ARROWHEAD_HEIGHT + 5
+        : HORIZONTAL_ARM_LENGTH + ARROWHEAD_HEIGHT;
+    const expectedXEnd =
+      strand === 'forward' ? site.x + expectedWidth : site.x - expectedWidth;
+    const isOperlappingWithPreviousSite =
+      strand === 'forward'
+        ? previousTss.x <= expectedXEnd
+        : previousTss.x >= expectedXEnd;
+
+    const newTss = {
+      ...site,
+      yStart: previousTss.yStart,
+      yEnd:
+        strand === 'forward'
+          ? yStart - VERTICAL_ARM_LENGTH
+          : yStart + VERTICAL_ARM_LENGTH
+    };
+
+    if (isOperlappingWithPreviousSite) {
+      const yEndPrevious = previousTss.yEnd;
+      // FIXME: use a named constant for added y distance
+      const overshootDistance = 7;
+      const yEndCurrent =
+        strand === 'forward'
+          ? yEndPrevious - overshootDistance
+          : yEndPrevious + overshootDistance;
+
+      newTss.yEnd = yEndCurrent;
+    }
+
+    preparedTss.push(newTss);
+  }
+
+  return preparedTss;
+};
+
+const getYStart = ({
+  geneTracks,
+  trackIndex,
+  trackOffsetsTop,
+  tssList,
+  strand,
+  scale
+}: {
+  tssList: Array<{ x: number }>;
+  geneTracks: Props['geneTracks'];
+  trackIndex: Props['trackIndex'];
+  trackOffsetsTop: Props['trackOffsetsTop'];
+  strand: Props['strand'];
+  scale: Props['scale'];
+}) => {
+  const tracksWithPossiblyOverlappingGenes = geneTracks.slice(trackIndex + 1);
+
+  if (tracksWithPossiblyOverlappingGenes.length === 0) {
+    return strand === 'forward'
+      ? trackOffsetsTop[trackIndex] - VERTICAL_OFFSET_FROM_GENE
+      : trackOffsetsTop[trackIndex] +
+          GENE_TRACK_HEIGHT +
+          VERTICAL_OFFSET_FROM_GENE;
+  }
+
+  let trackShiftCount = 0;
+
+  for (const track of tracksWithPossiblyOverlappingGenes) {
+    for (const gene of track) {
+      const geneStartX = scale(gene.data.start);
+      const geneEndX = scale(gene.data.end);
+
+      let hasOverlap = false;
+
+      for (const tss of tssList) {
+        if (tss.x >= geneStartX && tss.x <= geneEndX) {
+          hasOverlap = true;
+          break;
+        }
+      }
+
+      if (hasOverlap) {
+        trackShiftCount++;
+        break;
+      }
+    }
+  }
+
+  const adjustedTrackIndex =
+    strand === 'forward'
+      ? Math.min(trackIndex - trackShiftCount, 0)
+      : Math.min(trackIndex + trackShiftCount, trackOffsetsTop.length - 1);
+  const yStart =
+    strand === 'forward'
+      ? trackOffsetsTop[adjustedTrackIndex] - VERTICAL_OFFSET_FROM_GENE
+      : trackOffsetsTop[adjustedTrackIndex] +
+        GENE_TRACK_HEIGHT +
+        VERTICAL_OFFSET_FROM_GENE;
+
+  return yStart;
 };
 
 export default TranscriptionStartSites;


### PR DESCRIPTION
## Description
- Slightly modify the appearance of the arrows that represent transcription start sites (slightly more compact size)
- Join transcription start site arrows into a single one if they are close together. Show several vertical branches of those joined arrows (to mark the actual positions of the start sites), if they can be resolved
- Display transcription start sites in the region in detail view (in the bottom)


https://github.com/user-attachments/assets/b64159a2-c277-45ac-bff9-e325f35bfb39




## Deployment URL(s)
http://activity-viewer.review.ensembl.org