### PR TITLE
Fix Safari bug with updating IndexedDB records that contain files (blobs)

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,11 +2,16 @@ const isTargetWeb = api =>
   api.caller((caller) => caller && caller.target === 'web');
 
 module.exports = (api) => {
-  const targets = isTargetWeb(api) ? {
-    esmodules: true
-  } : {
-    node: 'current'
+  const babelPresetEnvOptions = {
+    // debug: true, // <-- Enable if you want to debug what babel is doing
+    useBuiltIns: 'usage',
+    corejs: 3.39,
+    modules: false
   };
+  if (!isTargetWeb(api)) {
+    // change babel compile target for node
+    babelPresetEnvOptions.targets = { node: 'current' };
+  }
 
   return {
     presets: [
@@ -15,23 +20,18 @@ module.exports = (api) => {
       }],
       '@babel/typescript',
       [
-        '@babel/env',
-        {
-          useBuiltIns: 'usage',
-          corejs: 3.26,
-          modules: false,
-          targets
-        }
+        '@babel/preset-env',
+        babelPresetEnvOptions
       ]
     ],
     env: {
       test: {
         presets: [
           [
-            '@babel/env',
+            '@babel/preset-env',
             {
               useBuiltIns: 'usage',
-              corejs: 3.26
+              corejs: 3.39
             }
           ]
         ]

--- a/src/content/app/tools/vep/state/vep-form/vepFormSlice.ts
+++ b/src/content/app/tools/vep/state/vep-form/vepFormSlice.ts
@@ -240,24 +240,16 @@ export const onVepFormSubmission = createAsyncThunk(
     const inputText = vepFormState.inputText;
     const parameters = vepFormState.parameters;
 
-    const requestPayload = await prepareRequestPayload({
-      submissionId,
-      species,
-      inputText,
-      parameters
-    });
-
     // "Detach" the submission from the VEP form by assigning it another temporary id.
     // The id will be eventually finalized to a permanent one after the server response
     const updatedSubmissionId = createInFlightSubmissionId();
-    requestPayload.submission_id = updatedSubmissionId;
 
     await updateVepSubmission(submissionId, {
       id: submissionId,
-      species: vepFormState.selectedSpecies,
       submissionName: vepFormState.submissionName,
-      inputText: vepFormState.inputText,
-      parameters: vepFormState.parameters,
+      species,
+      inputText,
+      parameters,
       submittedAt: Date.now(),
       status: 'SUBMITTING'
     });
@@ -270,6 +262,13 @@ export const onVepFormSubmission = createAsyncThunk(
     dispatch(
       addSubmission(updatedStoredSubmission as VepSubmissionWithoutInputFile)
     );
+
+    const requestPayload = await prepareRequestPayload({
+      submissionId: updatedSubmissionId,
+      species,
+      inputText,
+      parameters
+    });
 
     dispatch(vepFormSubmit.initiate(requestPayload, { track: false }));
   }


### PR DESCRIPTION
## Description
### PART 1: Safari and IndexedDB
**Bug:** In Safari, if, when filling in the form for VEP submission, instead of entering your input in the text field, you attach your input as a file, the form will be sent with an empty file.

**Cause:** VEP form page is relying heavily on indexedDB for persistent in-browser storage. The bug is caused by Safari's misbehaviour while dealing with file storage in indexedDB.

**Background:** IndexedDB stores data in a key/value fashion, and does not allow mutation of the stored values. Which means that if you store a value that is an object:

```
key: 'my-stored-object'
value: {
  foo: 'hello',
  bar: 'world'
}
```

and if you want to update any of the fields of this object, then the only way to do so is to read this object from indexedDB, make the desired updates, and save the object back to the db.


**Problem:** Now, if the stored value happens to be an object containing fields that are files or blobs:

```
key: 'my-stored-object'
value: {
  foo: 'hello',
  bar: 'world',
  attachment: File...
}
```

then Safari seems to be having problems when reading the object from the db, changing its fields that are not the file, and saving the object (containing the original, unmodified file) back to the db. The error message I was getting from Safari (tested on Safari v18) was, `"Error preparing Blob/File data to be stored in object store"`.

The solution proposed in this PR is to create a clone of the file before saving it back to the db. This is clearly a hack, that would impose extra work on the browsers that do not have Safari's problems. Hopefully, in the future we can roll this back.


### PART 2: Babel preset env
While working on this PR, I have also made some modifications to the babel config. See details below

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2844

## Deployment URL(s)
http://fix-indexeddb-safari.review.ensembl.org


----

## Changes to the babel preset env plugin
Despite having a `browserslist` section in our package.json, where we define the list of browsers that our compilers should be targeting, the babel config file contained the following `targets` value for the web bundle that it was passing to the babel/preset-env plugin:

```
{ esmodules: true }
```

Meaning, that `babel/preset-env` was targeting all browsers that support esmodules, and that is a lot of browsers. By enabling the `debug` option to see what babel is doing, I saw that it was injecting polyfills for the following targets:

```
Using targets:                             
{                                                 
  "android": "61",
  "chrome": "61", 
  "edge": "16",
  "firefox": "60",
  "ios": "10.3",
  "node": "13.2",
  "opera": "48",
  "opera_mobile": "80",
  "safari": "10.1",
  "samsung": "8.2"
}

Using modules transform: false

Using plugins:
  transform-duplicate-named-capturing-groups-regex { android, chrome < 126, edge < 126, firefox < 129, ios < 17.4, node < 23, opera < 112, opera_mobile, safari < 17.4, samsung }
  transform-regexp-modifiers { android, chrome < 125, edge < 125, firefox < 132, ios, node < 23, opera < 111, opera_mobile, safari, samsung }
  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ios < 17, node < 20, opera < 98, safari < 17, samsung }
  proposal-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ios < 16.4, node < 16.11, opera < 80, safari < 16.4, samsung < 17 }
  proposal-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ios < 15, node < 16.9, opera < 77, safari < 15, samsung < 16 }
  proposal-class-properties { android, chrome < 74, edge < 79, firefox < 90, ios < 14.5, opera < 62, safari < 14.1, samsung < 11 }
  proposal-private-methods { android, chrome < 84, edge < 84, firefox < 90, ios < 15, node < 14.6, opera < 70, safari < 15, samsung < 14 }
  proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ios < 13, opera < 62, safari < 13, samsung < 11 }
  proposal-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ios < 14, node < 15, opera < 71, safari < 14, samsung < 14 }
  proposal-nullish-coalescing-operator { android, chrome < 80, edge < 80, firefox < 72, ios < 13.4, node < 14, opera < 67, safari < 13.1, samsung < 13 }
  proposal-optional-chaining { android, chrome < 91, edge < 91, firefox < 74, ios < 13.4, node < 16.9, opera < 77, safari < 13.1, samsung < 16 }
  proposal-json-strings { android, chrome < 66, edge < 79, firefox < 62, ios < 12, opera < 53, safari < 12, samsung < 9 }
  proposal-optional-catch-binding { android, chrome < 66, edge < 79, ios < 11.3, opera < 53, safari < 11.1, samsung < 9 }
  transform-parameters { edge < 18, ios < 16.3, safari < 16.3 }
  proposal-async-generator-functions { android, chrome < 63, edge < 79, ios < 12, opera < 50, safari < 12 }
  proposal-object-rest-spread { edge < 79, ios < 11.3, safari < 11.1 }
  transform-dotall-regex { android, chrome < 62, edge < 79, firefox < 78, ios < 11.3, opera < 49, safari < 11.1 }
  proposal-unicode-property-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
  transform-named-capturing-groups-regex { android, chrome < 64, edge < 79, firefox < 78, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
  transform-async-to-generator { ios < 11, safari < 11 }
  transform-template-literals { ios < 13, safari < 13 }
  transform-function-name { edge < 79 }
  transform-unicode-regex { ios < 12, safari < 12 }
  transform-block-scoping { ios < 11, safari < 11 }
  proposal-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ios < 14.5, opera < 60, safari < 14.1, samsung < 11.0 }
  syntax-dynamic-import
  syntax-top-level-await
  syntax-import-meta
corejs3: `DEBUG` option
```

That's a lot of polyfills. So I updated the babel config file to make it actually respect what we specify in the `browserslist` field of package.json. This resulted in the following reduced list of targets and polyfills:

```
Using targets:
{                 
  "chrome": "129",
  "edge": "129",
  "ios": "17.6",  
  "opera_mobile": "80",                                                                              
  "safari": "17.6"
}                 
                  
Using modules transform: false
                  
Using plugins:    
  transform-duplicate-named-capturing-groups-regex { opera_mobile }
  transform-regexp-modifiers { ios, opera_mobile, safari }        
  syntax-class-static-block                                                                          
  syntax-private-property-in-object
  syntax-class-properties                                                                            
  syntax-numeric-separator                                                                           
  syntax-nullish-coalescing-operator
  syntax-optional-chaining                                                                           
  syntax-json-strings                                                                                
  syntax-optional-catch-binding
  syntax-async-generators                                                                            
  syntax-object-rest-spread                                                                          
  syntax-export-namespace-from
  syntax-dynamic-import                                                                              
  syntax-top-level-await                                                                             
  syntax-import-meta
corejs3: `DEBUG` option
```

File size changes:

Before:

<img width="1079" alt="image" src="https://github.com/user-attachments/assets/4464ab21-3c56-40a2-8847-6079f77bd927" />

After:

<img width="1035" alt="image" src="https://github.com/user-attachments/assets/e6a92b03-49a8-4421-a358-1ec11c8ecbe3" />
