### PR TITLE
Fix screen flashing during route changes due to lazy loading of modules

### DIFF
--- a/src/content/app/App.tsx
+++ b/src/content/app/App.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useEffect, memo } from 'react';
+import { Suspense, useEffect, memo } from 'react';
 import { useLocation, useRoutes } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 
@@ -68,10 +68,10 @@ const useLocationReporting = () => {
 const App = memo(() => {
   const routes = useRoutes(routesConfig);
   return (
-    <>
+    <Suspense fallback={<Header />}>
       <Header />
       {routes}
-    </>
+    </Suspense>
   );
 });
 

--- a/src/content/home/HomePage.tsx
+++ b/src/content/home/HomePage.tsx
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import { lazy, useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { useAppDispatch } from 'src/store';
 import useHasMounted from 'src/shared/hooks/useHasMounted';
 
 import { updatePageMeta } from 'src/shared/state/page-meta/pageMetaSlice';
 
-import type { ServerFetch } from 'src/routes/routesConfig';
+import Home from './Home';
 
-const LazilyLoadedHome = lazy(() => import('./Home'));
+import type { ServerFetch } from 'src/routes/routesConfig';
 
 const pageTitle = 'Ensembl';
 const pageDescription = 'The new website of the Ensembl project';
@@ -42,7 +42,7 @@ const HomePage = () => {
     );
   }, []);
 
-  return hasMounted ? <LazilyLoadedHome /> : null;
+  return hasMounted ? <Home /> : null;
 };
 
 export default HomePage;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,14 +25,18 @@ import { CONFIG_FIELD_ON_WINDOW } from 'src/shared/constants/globals';
 import { Provider as IndexedDBProvider } from 'src/shared/contexts/IndexedDBContext';
 import configureStore from './store';
 
+// NOTE: importing global CSS before any of the components here is actually significant,
+// because the bundler (at least webpack in dev mode) will load modules in the order they are declared,
+// and since the global styles define the order of CSS layers (see main.css),
+// they have to be registered in the browser before any other CSS
+import './styles/globalStyles';
+
 import Html from 'src/content/html/Html';
 import Root from './root/Root';
 
 import { registerSW } from './registerServiceWorker';
 
 import type { TransferredClientConfig } from 'src/server/helpers/getConfigForClient';
-
-import './styles/globalStyles';
 
 ensureBrowserSupport();
 

--- a/src/shared/hooks/useHasMounted.ts
+++ b/src/shared/hooks/useHasMounted.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useLayoutEffect } from 'react';
 
 const useHasMounted = () => {
   const [hasMounted, setHasMounted] = useState(false);
-  useEffect(() => {
+  useLayoutEffect(() => {
     setHasMounted(true);
   }, []);
   return hasMounted;


### PR DESCRIPTION
## Description
The big upgrade from React 18 to React 19 (https://github.com/Ensembl/ensembl-client/pull/1190) has resulted in a regression: flashes of white screen during navigation between routes.

Compare:

Production deployment (still on react 18):

https://github.com/user-attachments/assets/22efdc46-a126-44a0-951a-76a1d920f90f

Staging deployment (on react 19):

https://github.com/user-attachments/assets/a8060ded-ba8f-44a6-a95c-8ee0d0916f05

Notice that the first time user visits a route, there is a flash of white (js module for the screen is loaded using React.lazy); whereas subsequent navigations just load the component.

While examining the trace, I found a timeout of about 250ms between when react has loaded the component needed for rendering the page, and the actual rendering:

![image](https://github.com/user-attachments/assets/c2672b5d-5559-462f-a325-ae6965863334)

Further investigation has revealed that at some point in react 19 development, react team has added a 300ms delay to `Suspense` to avoid flashes of content. See issue `https://github.com/facebook/react/issues/31819`.

In this PR, I am including the `Header` component as a fallback for Suspense, which results in a somewhat more tolerable routing behaviour:

https://github.com/user-attachments/assets/03e61ebe-cabb-4256-bd56-a45ec66b0904

The header (top black bar and the launchbar below it) remains stable during all navigations. First-time navigation to a route results in a white space below the header while the component is loading; but because the header persists, it does not look as jarring as flashes of pure white screen.

### Other changes
Since the home page js bundle is very small, and since it looks significantly different than other pages, I made it always load eagerly rather than lazily. While doing so, I came across CSS problems in dev mode caused by CSS layers not being defined in the order I was expecting. I wanted the declaration of the order of CSS layers to always be pretty high on top; but in the dev bundle, it ended up somewhere in the middle, which broke the layer ordering. While tracking down the issue, I came across a [StackOverflow comment](https://stackoverflow.com/a/70981237/3925302) that pointed out that webpack loads modules in the order they are declared in the source code (this makes a ton of sense; so might be true for other bundlers as well); and therefore, if I wanted some of my CSS declarations to be on top of the others, I should import my css module earlier than I import react components.

As a result, I changed the order of imports in `index.tsx`.

## Deployment URL(s)
http://update-dependencies.review.ensembl.org