### PR TITLE
Improve interactions on a Species home page

### DIFF
--- a/src/content/app/species/SpeciesPage.module.css
+++ b/src/content/app/species/SpeciesPage.module.css
@@ -11,11 +11,14 @@
   justify-items: start;
   line-height: 1;
   max-width: 1380px;
-  padding-left: 30px;
 }
 
 .addSpeciesButton {
   --add-button-icon-color: var(--color-green);
   --add-button-label-color: var(--color-black);
-  padding-right: 35px;
+  padding-left: var(--double-standard-gutter);
+}
+
+.closeButton {
+  padding-right: var(--double-standard-gutter);
 }

--- a/src/content/app/species/SpeciesPageContent.tsx
+++ b/src/content/app/species/SpeciesPageContent.tsx
@@ -145,16 +145,16 @@ const TopBar = () => {
 
   return (
     <div className={styles.topbar}>
-      <CloseButtonWithLabel
-        className={styles.closeButton}
-        onClick={returnToSpeciesSelector}
-      />
       <AddButton
         onClick={returnToSpeciesSelector}
         className={styles.addSpeciesButton}
       >
         Add a species
       </AddButton>
+      <CloseButtonWithLabel
+        className={styles.closeButton}
+        onClick={returnToSpeciesSelector}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Description
In the header bar on a Species home page, 'Close' and 'Add a species' should replace each other

<img width="1195" alt="image" src="https://github.com/user-attachments/assets/e14bdec0-d6ae-450f-9ecd-d0d2e6428ca3" />


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2703

## Deployment URL(s)
n/a

## Views affected
Species home page
