### PR TITLE
Add genome-based routing to regulatory activity viewer

### DIFF
--- a/src/content/app/entity-viewer/contexts/entity-viewer-ids-context/EntityViewerIdsContextProvider.tsx
+++ b/src/content/app/entity-viewer/contexts/entity-viewer-ids-context/EntityViewerIdsContextProvider.tsx
@@ -26,7 +26,10 @@ import {
 import { useAppSelector } from 'src/store';
 import usePrevious from 'src/shared/hooks/usePrevious';
 import { useUrlParams } from 'src/shared/hooks/useUrlParams';
-import { useGenomeSummaryByGenomeSlugQuery } from 'src/shared/state/genome/genomeApiSlice';
+import {
+  useGenomeSummaryByGenomeSlugQuery,
+  isGenomeNotFoundError
+} from 'src/shared/state/genome/genomeApiSlice';
 
 import {
   getEntityViewerActiveGenomeId,
@@ -39,8 +42,6 @@ import {
   EntityViewerIdsContext,
   type EntityViewerIdsContextType
 } from './EntityViewerIdsContext';
-
-import type { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 
 const EntityViewerIdsContextProvider = (props: { children: ReactNode }) => {
   const activeGenomeId = useAppSelector(getEntityViewerActiveGenomeId);
@@ -117,7 +118,7 @@ const EntityViewerIdsContextProvider = (props: { children: ReactNode }) => {
     parsedEntityId,
     hasActiveGenomeIdChanged,
     hasActiveEntityIdChanged,
-    isMissingGenomeId: isMissingGenomeId(error as FetchBaseQueryError),
+    isMissingGenomeId: !!error && isGenomeNotFoundError(error),
     isMalformedEntityId
   };
 
@@ -126,11 +127,6 @@ const EntityViewerIdsContextProvider = (props: { children: ReactNode }) => {
       {props.children}
     </EntityViewerIdsContext.Provider>
   );
-};
-
-const isMissingGenomeId = (error: FetchBaseQueryError) => {
-  const errorStatus = (error as FetchBaseQueryError)?.status;
-  return typeof errorStatus === 'number' && errorStatus >= 400; // FIXME change status to 404 when the backend behaves
 };
 
 export default EntityViewerIdsContextProvider;

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-app-bar/ActivityViewerAppBar.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-app-bar/ActivityViewerAppBar.tsx
@@ -15,8 +15,11 @@
  */
 
 import { memo } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { useAppSelector } from 'src/store';
+
+import * as urlFor from 'src/shared/helpers/urlHelper';
 
 import { AppName as AppNameText } from 'src/global/globalConfig';
 
@@ -28,13 +31,19 @@ import SpeciesManagerIndicator from 'src/shared/components/species-manager-indic
 import { SelectedSpecies } from 'src/shared/components/selected-species';
 import SpeciesTabsSlider from 'src/shared/components/species-tabs-slider/SpeciesTabsSlider';
 
+import type { CommittedItem } from 'src/content/app/species-selector/types/committedItem';
+
 const ActivityViewerAppBar = () => {
   const speciesList = useAppSelector(getEnabledCommittedSpecies);
   const activeGenomeId = useAppSelector(getActiveGenomeId);
+  const navigate = useNavigate();
 
-  const onSpeciesTabClick = () => {
-    // eslint-disable-next-line
-    console.log('what to do?');
+  const onSpeciesTabClick = (species: CommittedItem) => {
+    const genomeIdForUrl = species.genome_tag ?? species.genome_id;
+    const url = urlFor.regulatoryActivityViewer({
+      genomeId: genomeIdForUrl
+    });
+    navigate(url);
   };
 
   const speciesTabs = speciesList.map((species, index) => (

--- a/src/content/app/regulatory-activity-viewer/contexts/ActivityViewerIdContext.ts
+++ b/src/content/app/regulatory-activity-viewer/contexts/ActivityViewerIdContext.ts
@@ -19,10 +19,14 @@ import { createContext } from 'react';
 import type { Location } from 'src/content/app/regulatory-activity-viewer/state/api/activityViewerApiSlice';
 
 type ActivityViewerIdContextType = {
+  genomeIdInUrl?: string;
   activeGenomeId: string | null;
+  genomeId?: string; // <-- disambiguated genome id retrieved from the 'explain' endpoint of the metadata api
+  genomeIdForUrl?: string;
   assemblyAccessionId: string | null;
   assemblyName: string | null; // <-- temporary data; won't be needed when all regulation endpoints switch to using assembly accession id
   location: Location | null; // not quite sure if location belongs here; but provisionally placing it here
+  locationForUrl?: string;
 };
 
 const defaultContext: ActivityViewerIdContextType = {

--- a/src/content/app/regulatory-activity-viewer/state/api/activityViewerApiSlice.ts
+++ b/src/content/app/regulatory-activity-viewer/state/api/activityViewerApiSlice.ts
@@ -58,7 +58,7 @@ const activityViewerApiSlice = restApiSlice.injectEndpoints({
       query: (params) => {
         const { assemblyName, location } = params;
         return {
-          url: `${config.regulationApiBaseUrl}/region-of-interest/v0.1.0/${assemblyName}?location=${location}`
+          url: `${config.regulationApiBaseUrl}/region-of-interest/v0.2/assembly/${assemblyName}?location=${location}`
         };
       }
     }),

--- a/src/content/app/regulatory-activity-viewer/state/general/generalSlice.ts
+++ b/src/content/app/regulatory-activity-viewer/state/general/generalSlice.ts
@@ -14,7 +14,15 @@
  * limitations under the License.
  */
 
-import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import {
+  createSlice,
+  createAsyncThunk,
+  type PayloadAction
+} from '@reduxjs/toolkit';
+
+import { getCommittedSpecies } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors';
+
+import type { RootState } from 'src/store';
 
 type State = {
   activeGenomeId: string | null;
@@ -23,6 +31,17 @@ type State = {
 const initialState: State = {
   activeGenomeId: null
 };
+
+export const setDefaultActiveGenomeId = createAsyncThunk(
+  'regulatory-activity-viewer-general/set-default-active-genome-id',
+  (_, { getState, dispatch }) => {
+    const state = getState() as RootState;
+    const [firstCommittedSpecies] = getCommittedSpecies(state);
+    if (firstCommittedSpecies) {
+      dispatch(setActiveGenomeId(firstCommittedSpecies.genome_id));
+    }
+  }
+);
 
 const generalSlice = createSlice({
   name: 'regulatory-activity-viewer-general',

--- a/src/shared/helpers/urlHelper.ts
+++ b/src/shared/helpers/urlHelper.ts
@@ -31,6 +31,11 @@ type EntityViewerUrlParams = {
   proteinId?: string | null;
 };
 
+type RegulatoryActivityViewerUrlParams = {
+  genomeId?: string | null;
+  location?: string;
+};
+
 type SpeciesPageUrlParams = {
   genomeId: string;
 };
@@ -163,6 +168,23 @@ export const entityViewerVariant = (params?: {
   }
 
   const query = urlSearchParams.toString();
+
+  return query ? `${path}?${query}` : path;
+};
+
+export const regulatoryActivityViewer = (
+  params?: RegulatoryActivityViewerUrlParams
+) => {
+  const genomeId = params?.genomeId || '';
+  let path = '/activity-viewer';
+  if (genomeId) {
+    path += `/${genomeId}`;
+  }
+  const urlSearchParams = new URLSearchParams('');
+  if (params?.location) {
+    urlSearchParams.append('location', params.location);
+  }
+  const query = decodeURIComponent(urlSearchParams.toString());
 
   return query ? `${path}?${query}` : path;
 };

--- a/src/shared/state/genome/genomeApiSlice.ts
+++ b/src/shared/state/genome/genomeApiSlice.ts
@@ -67,5 +67,5 @@ export const isGenomeNotFoundError = (
   }
 
   const errorStatus = error.status;
-  return typeof errorStatus === 'number' && errorStatus >= 400; // FIXME: change to 404 when the backend is updated
+  return typeof errorStatus === 'number' && errorStatus === 404;
 };


### PR DESCRIPTION
## Description
As a first step towards routing in regulatory activity viewer, reflect the selected genome id in the url.

**Logic currently implemented in the PR:**

```
If there is no genome id suggested by the url (e.g. ensembl.org/activity-viewer)
  If active genome id exists (in redux)
    Update url to reflect active genome id
  If active genome id does not exist
    If there are some selected species
      Make the first selected species' genome id into an active one
      Update url to reflect new active genome id
If genome id (or tag) exists in the url:
  Send the url part that contains genome id (or genome tag) to metadata api to check whether it is valid
  Read genome id from the api response
  If genome id in the response is different from the current active genome id
    Update active genome id
```

https://github.com/user-attachments/assets/5bd76d14-7d5d-4896-afb3-29b7e836ca1b

**Not yet implemented:** code is not yet reading the location from the url (there is some uncertainty about the url structure; will discuss it with the regulation team)

## Deployment URL(s)
http://activity-viewer.review.ensembl.org