### PR TITLE
Add flag to toggle species selector modal in VEP tools

### DIFF
--- a/src/content/app/tools/vep/VepPageContent.tsx
+++ b/src/content/app/tools/vep/VepPageContent.tsx
@@ -24,22 +24,35 @@ import VepSubmissions from './views/vep-submissions/VepSubmissions';
 import VepSubmissionResults from './views/vep-submission-results/VepSubmissionResults';
 import { NotFoundErrorScreen } from 'src/shared/components/error-screen';
 
+import { useAppDispatch, useAppSelector } from 'src/store';
+import { updateSpeciesSelectorModalOpenFlag } from 'src/content/app/tools/vep/state/vep-form/vepFormSlice';
+import { getSpeciesSelectorModalOpenFlag } from 'src/content/app/tools/vep/state/vep-form/vepFormSelectors';
+
 import styles from './VepPageContent.module.css';
 
 const VepPageContent = () => {
-  return (
-    <Routes>
-      <Route path="species-selector" element={<SpeciesSelectorWrapper />} />
-      <Route path="*" element={<MainWrapper />} />
-    </Routes>
+  const speciesSelectorModalOpenFlag = useAppSelector(
+    getSpeciesSelectorModalOpenFlag
   );
+
+  if (speciesSelectorModalOpenFlag) {
+    return <SpeciesSelectorWrapper />;
+  } else {
+    return <MainWrapper />;
+  }
 };
 
 const SpeciesSelectorWrapper = () => {
+  const dispatch = useAppDispatch();
+
+  const closeSpeciesSelectorModal = () => {
+    dispatch(updateSpeciesSelectorModalOpenFlag(false));
+  };
+
   return (
     <div className={styles.speciesSelectorGrid}>
       <VepAppBar />
-      <VepSpeciesSelector />
+      <VepSpeciesSelector onClose={closeSpeciesSelectorModal} />
     </div>
   );
 };

--- a/src/content/app/tools/vep/state/vep-form/vepFormSelectors.ts
+++ b/src/content/app/tools/vep/state/vep-form/vepFormSelectors.ts
@@ -38,3 +38,6 @@ export const getVepFormInputFileName = (state: RootState) =>
 
 export const getVepFormInputCommittedFlag = (state: RootState) =>
   state.vep.vepForm.isInputCommitted;
+
+export const getSpeciesSelectorModalOpenFlag = (state: RootState) =>
+  state.vep.vepForm.isSpeciesSelectorModalOpen;

--- a/src/content/app/tools/vep/state/vep-form/vepFormSlice.ts
+++ b/src/content/app/tools/vep/state/vep-form/vepFormSlice.ts
@@ -62,7 +62,7 @@ export type VepFormState = {
   inputFileName: string | null;
   isInputCommitted: boolean;
   parameters: VepFormParameters;
-  isSpeciesSelectorModalOpen?: boolean;
+  isSpeciesSelectorModalOpen: boolean;
 };
 
 export const initialState: VepFormState = {
@@ -217,7 +217,8 @@ export const fillVepFormWithExistingSubmissionData = createAsyncThunk(
       inputFileName: storedSubmission.inputFile?.name ?? null,
       inputText: storedSubmission.inputText,
       parameters: storedSubmission.parameters,
-      isInputCommitted: true
+      isInputCommitted: true,
+      isSpeciesSelectorModalOpen: false
     };
 
     return newFormState;

--- a/src/content/app/tools/vep/state/vep-form/vepFormSlice.ts
+++ b/src/content/app/tools/vep/state/vep-form/vepFormSlice.ts
@@ -62,6 +62,7 @@ export type VepFormState = {
   inputFileName: string | null;
   isInputCommitted: boolean;
   parameters: VepFormParameters;
+  isSpeciesSelectorModalOpen?: boolean;
 };
 
 export const initialState: VepFormState = {
@@ -71,7 +72,8 @@ export const initialState: VepFormState = {
   inputText: '',
   inputFileName: null,
   isInputCommitted: false,
-  parameters: {}
+  parameters: {},
+  isSpeciesSelectorModalOpen: false
 };
 
 // Creates an id that is used to identify the submission that is being filled in the form
@@ -352,6 +354,12 @@ const vepFormSlice = createSlice({
     updateInputCommittedFlag: (state, action: PayloadAction<boolean>) => {
       state.isInputCommitted = action.payload;
     },
+    updateSpeciesSelectorModalOpenFlag: (
+      state,
+      action: PayloadAction<boolean>
+    ) => {
+      state.isSpeciesSelectorModalOpen = action.payload;
+    },
     resetForm: (state) => {
       return {
         ...initialState,
@@ -397,6 +405,7 @@ export const {
   updateSubmissionName,
   updateInputText,
   updateInputCommittedFlag,
+  updateSpeciesSelectorModalOpenFlag,
   resetForm
 } = vepFormSlice.actions;
 

--- a/src/content/app/tools/vep/views/vep-form/VepForm.tsx
+++ b/src/content/app/tools/vep/views/vep-form/VepForm.tsx
@@ -58,10 +58,12 @@ const VepForm = () => {
         <FormSection>
           <div className={styles.topFormSectionRegularGrid}>
             <div className={styles.topFormSectionName}>Species</div>
-            <VepFormSpecies className={styles.topFormSectionMain} />
-            <VepSpeciesSelectorNavButton
-              className={styles.topFormSectionToggle}
-            />
+            <div className={styles.topFormSectionMain}>
+              <VepFormSpecies />
+            </div>
+            <div className={styles.topFormSectionToggle}>
+              <VepSpeciesSelectorNavButton />
+            </div>
           </div>
         </FormSection>
         <VepFormVariantsSection />

--- a/src/content/app/tools/vep/views/vep-form/vep-form-species-section/VepFormSpeciesSection.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-species-section/VepFormSpeciesSection.tsx
@@ -14,40 +14,45 @@
  * limitations under the License.
  */
 
-import { Link } from 'react-router-dom';
-
-import * as urlFor from 'src/shared/helpers/urlHelper';
-
-import { useAppSelector } from 'src/store';
+import { useAppDispatch, useAppSelector } from 'src/store';
 
 import { getSelectedSpecies } from 'src/content/app/tools/vep/state/vep-form/vepFormSelectors';
+import { updateSpeciesSelectorModalOpenFlag } from 'src/content/app/tools/vep/state/vep-form/vepFormSlice';
 
 import { VepSpeciesName } from 'src/content/app/tools/vep/components/vep-species-name/VepSpeciesName';
 import PlusButton from 'src/shared/components/plus-button/PlusButton';
 import TextButton from 'src/shared/components/text-button/TextButton';
 
-const vepSpeciesSelectorUrl = urlFor.vepSpeciesSelector();
-
-export const VepFormSpecies = (props: { className?: string }) => {
+export const VepFormSpecies = () => {
+  const dispatch = useAppDispatch();
   const selectedSpecies = useAppSelector(getSelectedSpecies);
+
+  const openSpeciesSelectorModal = () => {
+    dispatch(updateSpeciesSelectorModalOpenFlag(true));
+  };
 
   if (!selectedSpecies) {
-    return <Link to={vepSpeciesSelectorUrl}>Select a species / assembly</Link>;
+    return (
+      <TextButton onClick={openSpeciesSelectorModal}>
+        Select a species / assembly
+      </TextButton>
+    );
   }
 
-  return (
-    <div className={props.className}>
-      <VepSpeciesName selectedSpecies={selectedSpecies} />
-    </div>
-  );
+  return <VepSpeciesName selectedSpecies={selectedSpecies} />;
 };
 
-export const VepSpeciesSelectorNavButton = (props: { className?: string }) => {
+export const VepSpeciesSelectorNavButton = () => {
+  const dispatch = useAppDispatch();
   const selectedSpecies = useAppSelector(getSelectedSpecies);
 
-  return (
-    <Link to={vepSpeciesSelectorUrl} className={props.className}>
-      {!selectedSpecies ? <PlusButton /> : <TextButton>Change</TextButton>}
-    </Link>
-  );
+  const openSpeciesSelector = () => {
+    dispatch(updateSpeciesSelectorModalOpenFlag(true));
+  };
+
+  if (!selectedSpecies) {
+    return <PlusButton onClick={openSpeciesSelector} />;
+  } else {
+    return <TextButton onClick={openSpeciesSelector}>Change</TextButton>;
+  }
 };

--- a/src/content/app/tools/vep/views/vep-species-selector/VepSpeciesSelector.tsx
+++ b/src/content/app/tools/vep/views/vep-species-selector/VepSpeciesSelector.tsx
@@ -15,7 +15,6 @@
  */
 
 import { useState, useDeferredValue, type FormEvent } from 'react';
-import { useNavigate } from 'react-router';
 
 import { useAppDispatch } from 'src/store';
 
@@ -42,12 +41,11 @@ import styles from './VepSpeciesSelector.module.css';
  * - The view might have a list of popular species if/when we figure out where to get it from
  */
 
-const VepSpeciesSelector = () => {
+const VepSpeciesSelector = (props: { onClose: () => void }) => {
   const [searchQuery, setSearchQuery] = useState('');
   const [canSubmitSearch, setCanSubmitSearch] = useState(false);
   const [searchTrigger, result] = useLazyGetSpeciesSearchResultsQuery();
   const { currentData, isLoading, isError } = result;
-  const navigate = useNavigate();
   const dispatch = useAppDispatch();
 
   const {
@@ -85,7 +83,7 @@ const VepSpeciesSelector = () => {
   };
 
   const onClose = () => {
-    navigate(-1);
+    props.onClose();
   };
 
   return (


### PR DESCRIPTION
## Description
Currently VEP tools uses react router to display the species selector modal. When VEP species selector modal is open and if we come back to VEP tools from any other page (ex: species selector page), clicking close button of VEP species selector modal navigates to previous page in history instead of closing the modal.

Change this by adding a flag in redux which toggles the VEP species selector modal.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2891

## Deployment URL(s)
http://vep-species-selector-toggle.review.ensembl.org
