### PR TITLE
Fix to close VEP species selector modal

### DIFF
--- a/src/content/app/tools/vep/views/vep-species-selector/VepSpeciesSelector.tsx
+++ b/src/content/app/tools/vep/views/vep-species-selector/VepSpeciesSelector.tsx
@@ -17,6 +17,8 @@
 import { useState, useDeferredValue, type FormEvent } from 'react';
 import { useNavigate } from 'react-router';
 
+import * as urlFor from 'src/shared/helpers/urlHelper';
+
 import { useAppDispatch } from 'src/store';
 
 import { useLazyGetSpeciesSearchResultsQuery } from 'src/content/app/species-selector/state/species-selector-api-slice/speciesSelectorApiSlice';
@@ -85,7 +87,7 @@ const VepSpeciesSelector = () => {
   };
 
   const onClose = () => {
-    navigate(-1);
+    navigate(urlFor.vepForm(), { replace: true });
   };
 
   return (

--- a/src/header/launchbar/VepLaunchbarButton.tsx
+++ b/src/header/launchbar/VepLaunchbarButton.tsx
@@ -78,10 +78,7 @@ const usePathForVepNavigationButton = () => {
   const [vepAppPath, setVepAppPath] = useState(VEP_APP_ROOT_PATH);
 
   useEffect(() => {
-    if (
-      location.pathname.startsWith(VEP_APP_ROOT_PATH) &&
-      !location.pathname.includes('species-selector')
-    ) {
+    if (location.pathname.startsWith(VEP_APP_ROOT_PATH)) {
       setVepAppPath(location.pathname);
     }
   }, [[location.pathname]]);

--- a/src/header/launchbar/VepLaunchbarButton.tsx
+++ b/src/header/launchbar/VepLaunchbarButton.tsx
@@ -78,7 +78,10 @@ const usePathForVepNavigationButton = () => {
   const [vepAppPath, setVepAppPath] = useState(VEP_APP_ROOT_PATH);
 
   useEffect(() => {
-    if (location.pathname.startsWith(VEP_APP_ROOT_PATH)) {
+    if (
+      location.pathname.startsWith(VEP_APP_ROOT_PATH) &&
+      !location.pathname.includes('species-selector')
+    ) {
       setVepAppPath(location.pathname);
     }
   }, [[location.pathname]]);


### PR DESCRIPTION
## Description
This PR addresses vep ss modal close issue. Now, when we click on vep ss close button it closes the modal instead of navigating to previous location in history.

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2891

## Deployment URL(s)
http://vep-ss-close-fix.review.ensembl.org