### PR TITLE
Read the `location` url parameter to display regulatory activity data

### DIFF
--- a/src/content/app/regulatory-activity-viewer/RegulatoryActivityViewer.tsx
+++ b/src/content/app/regulatory-activity-viewer/RegulatoryActivityViewer.tsx
@@ -27,6 +27,7 @@ import useActivityViewerRouting from './hooks/useActivityViewerRouting';
 import ActivityViewerEpigenomesContextProvider from 'src/content/app/regulatory-activity-viewer/contexts/ActivityViewerEpigenomesContextProvider';
 import { StandardAppLayout } from 'src/shared/components/layout';
 import ActivityViewerAppBar from './components/activity-viewer-app-bar/ActivityViewerAppBar';
+import ActivityViewerInterstitial from './components/activity-viewer-interstitial/ActivityViewerInterstitial';
 import RegionOverview from './components/region-overview/RegionOverview';
 import RegionActivitySection from './components/region-activity-section/RegionActivitySection';
 import ActivityViewerSidebar from './components/activity-viewer-sidebar/ActivityViewerSidebar';
@@ -38,9 +39,28 @@ import SelectedEpigenomes from './components/selected-epigenomes/SelectedEpigeno
 import styles from './RegulatoryActivityViewer.module.css';
 
 const ActivityViewer = () => {
-  const { activeGenomeId } = useActivityViewerIds();
+  const { activeGenomeId, genomeIdInUrl, location } = useActivityViewerIds();
   useActivityViewerRouting();
   usePreselectedEpigenomes();
+
+  if (!genomeIdInUrl) {
+    // TODO: add a proper component for this
+    return (
+      <div className={styles.container}>
+        <ActivityViewerAppBar />
+        <div>Please select species.</div>
+      </div>
+    );
+  } else if (!location) {
+    // NOTE: currently, regulatory activity data is fetched based on location.
+    // In the future, it should be possible to fetch regulatory data based on gene or regulatory feature
+    return (
+      <div className={styles.container}>
+        <ActivityViewerAppBar />
+        <ActivityViewerInterstitial />
+      </div>
+    );
+  }
 
   return (
     <div className={styles.container}>

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-interstitial/ActivityViewerInterstitial.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-interstitial/ActivityViewerInterstitial.module.css
@@ -1,0 +1,14 @@
+/* TODO: this panel is the same as in SpeciesSelector, Genome Browser, and EntityViewer.
+ We should extract it in a component (or at least reuse the same CSS classes) */
+.topPanel {
+  background-color: var(--color-light-grey);
+  min-height: 235px;
+  padding: 40px;
+  padding-left: var(--global-padding-left);
+  box-shadow: 0 3px 5px var(--global-box-shadow-color);
+}
+
+.main {
+  margin-top: 40px;
+  padding-left: var(--global-padding-left);
+}

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-interstitial/ActivityViewerInterstitial.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-interstitial/ActivityViewerInterstitial.tsx
@@ -18,6 +18,8 @@ import { Link } from 'react-router';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
 
+import { getGenomicLocationString } from 'src/shared/helpers/genomicLocationHelpers';
+
 import useActivityViewerIds from 'src/content/app/regulatory-activity-viewer/hooks/useActivityViewerIds';
 
 import styles from './ActivityViewerInterstitial.module.css';
@@ -32,9 +34,9 @@ const ActivityViewerInterstitial = () => {
   let location: string | null = null;
 
   if (assemblyAccessionId === humanAssemblyId) {
-    location = formatLocationForUrl(mockHumanLocation);
+    location = getGenomicLocationString(mockHumanLocation);
   } else if (assemblyAccessionId === mouseAssemblyId) {
-    location = formatLocationForUrl(mockMouseLocation);
+    location = getGenomicLocationString(mockMouseLocation);
   }
 
   if (!location) {
@@ -77,19 +79,6 @@ const mockMouseLocation = {
   regionName: '5',
   start: 28645230,
   end: 29636061
-};
-
-// TODO: extract this into a helper
-const formatLocationForUrl = ({
-  regionName,
-  start,
-  end
-}: {
-  regionName: string;
-  start: number;
-  end: number;
-}) => {
-  return `${regionName}:${start}-${end}`;
 };
 
 export default ActivityViewerInterstitial;

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-interstitial/ActivityViewerInterstitial.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-interstitial/ActivityViewerInterstitial.tsx
@@ -20,6 +20,8 @@ import * as urlFor from 'src/shared/helpers/urlHelper';
 
 import useActivityViewerIds from 'src/content/app/regulatory-activity-viewer/hooks/useActivityViewerIds';
 
+import styles from './ActivityViewerInterstitial.module.css';
+
 /**
  * Component to display when url does not contain enough data
  * to display regulatory activity
@@ -36,7 +38,14 @@ const ActivityViewerInterstitial = () => {
   }
 
   if (!location) {
-    return 'Please select reference human or reference mouse assembly.';
+    return (
+      <div>
+        <div className={styles.topPanel} />
+        <div className={styles.main}>
+          Please select reference human or reference mouse assembly.
+        </div>
+      </div>
+    );
   }
 
   const url = urlFor.regulatoryActivityViewer({
@@ -44,7 +53,14 @@ const ActivityViewerInterstitial = () => {
     location
   });
 
-  return <Link to={url}>Example location</Link>;
+  return (
+    <div>
+      <div className={styles.topPanel} />
+      <div className={styles.main}>
+        <Link to={url}>Example location</Link>
+      </div>
+    </div>
+  );
 };
 
 const humanAssemblyId = 'GCA_000001405.29';

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-interstitial/ActivityViewerInterstitial.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-interstitial/ActivityViewerInterstitial.tsx
@@ -1,0 +1,79 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Link } from 'react-router';
+
+import * as urlFor from 'src/shared/helpers/urlHelper';
+
+import useActivityViewerIds from 'src/content/app/regulatory-activity-viewer/hooks/useActivityViewerIds';
+
+/**
+ * Component to display when url does not contain enough data
+ * to display regulatory activity
+ */
+
+const ActivityViewerInterstitial = () => {
+  const { genomeIdForUrl, assemblyAccessionId } = useActivityViewerIds();
+  let location: string | null = null;
+
+  if (assemblyAccessionId === humanAssemblyId) {
+    location = formatLocationForUrl(mockHumanLocation);
+  } else if (assemblyAccessionId === mouseAssemblyId) {
+    location = formatLocationForUrl(mockMouseLocation);
+  }
+
+  if (!location) {
+    return 'Please select reference human or reference mouse assembly.';
+  }
+
+  const url = urlFor.regulatoryActivityViewer({
+    genomeId: genomeIdForUrl,
+    location
+  });
+
+  return <Link to={url}>Example location</Link>;
+};
+
+const humanAssemblyId = 'GCA_000001405.29';
+const mouseAssemblyId = 'GCA_000001635.9';
+
+const mockHumanLocation = {
+  regionName: '17',
+  start: 58190566,
+  end: 58290566 // <-- 100kB slice
+  // end: 59190566 // <-- 1MB slice; switch to it when backend apis get faster
+};
+
+const mockMouseLocation = {
+  regionName: '5',
+  start: 28645230,
+  end: 29636061
+};
+
+// TODO: extract this into a helper
+const formatLocationForUrl = ({
+  regionName,
+  start,
+  end
+}: {
+  regionName: string;
+  start: number;
+  end: number;
+}) => {
+  return `${regionName}:${start}-${end}`;
+};
+
+export default ActivityViewerInterstitial;

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar/epigenome-filters-view/EpigenomeFiltersView.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar/epigenome-filters-view/EpigenomeFiltersView.module.css
@@ -23,3 +23,17 @@
   font-size: 12px;
   font-weight: var(--font-weight-light);
 }
+
+.configureButton {
+  display: flex;
+  column-gap: 0.6rem;
+  color: var(--color-blue);
+  margin-bottom: 1.4rem;
+  margin-left: 17px;
+}
+
+.configureButton svg {
+  fill: var(--color-blue);
+  height: 14px;
+  width: 14px;
+}

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar/epigenome-filters-view/EpigenomeFiltersView.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar/epigenome-filters-view/EpigenomeFiltersView.tsx
@@ -23,6 +23,7 @@ import useEpigenomes from 'src/content/app/regulatory-activity-viewer/hooks/useE
 import { getEpigenomeSelectionCriteria } from 'src/content/app/regulatory-activity-viewer/state/epigenome-selection/epigenomeSelectionSelectors';
 
 import { removeSelectionCriterion } from 'src/content/app/regulatory-activity-viewer/state/epigenome-selection/epigenomeSelectionSlice';
+import { setMainContentBottomView } from 'src/content/app/regulatory-activity-viewer/state/ui/uiSlice';
 
 import { getMetadataItems } from 'src/content/app/regulatory-activity-viewer/components/epigenome-selection-panel/getEpigenomeCounts';
 
@@ -32,6 +33,8 @@ import {
   CollapsibleSectionBody
 } from 'src/shared/components/collapsible-section/CollapsibleSection';
 import DeleteButton from 'src/shared/components/delete-button/DeleteButton';
+
+import CogIcon from 'static/icons/icon_settings.svg';
 
 import type { Epigenome } from 'src/content/app/regulatory-activity-viewer/types/epigenome';
 import type { EpigenomeMetadataDimensions } from 'src/content/app/regulatory-activity-viewer/types/epigenomeMetadataDimensions';
@@ -63,7 +66,7 @@ const EpigenomeFiltersView = (props: Props) => {
     []
   );
 
-  if (!epigenomeMetadataDimensionsResponse || !baseEpigenomes) {
+  if (!genomeId || !epigenomeMetadataDimensionsResponse || !baseEpigenomes) {
     return null;
   }
 
@@ -73,6 +76,7 @@ const EpigenomeFiltersView = (props: Props) => {
 
   return (
     <div>
+      <ConfigureButton genomeId={genomeId} />
       {metadataDimensionNames.map((dimensionName) => (
         <FiltersSection
           key={dimensionName}
@@ -154,6 +158,28 @@ const EpigenomeFilter = ({
         <DeleteButton onClick={onDeleteClick} />
       </div>
     </div>
+  );
+};
+
+const ConfigureButton = ({ genomeId }: { genomeId: string }) => {
+  const dispatch = useAppDispatch();
+
+  const onClick = () => {
+    dispatch(
+      setMainContentBottomView({
+        genomeId,
+        view: 'epigenomes-selection'
+      })
+    );
+  };
+
+  return (
+    <button className={styles.configureButton} onClick={onClick}>
+      <span>Configure </span>
+      <span>
+        <CogIcon />
+      </span>
+    </button>
   );
 };
 

--- a/src/content/app/regulatory-activity-viewer/components/main-content-bottom-view-controls/MainContentBottomViewControls.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/main-content-bottom-view-controls/MainContentBottomViewControls.tsx
@@ -57,15 +57,7 @@ const ContentViewButtons = ({ genomeId }: { genomeId: string }) => {
         activeView={activeView}
         genomeId={genomeId}
       >
-        Epigenomes
-      </ContentViewButton>
-
-      <ContentViewButton
-        view="epigenomes-selection"
-        activeView={activeView}
-        genomeId={genomeId}
-      >
-        Configure
+        Table
       </ContentViewButton>
 
       <ContentViewButton
@@ -74,6 +66,14 @@ const ContentViewButtons = ({ genomeId }: { genomeId: string }) => {
         genomeId={genomeId}
       >
         Visualise
+      </ContentViewButton>
+
+      <ContentViewButton
+        view="epigenomes-selection"
+        activeView={activeView}
+        genomeId={genomeId}
+      >
+        Configure
       </ContentViewButton>
     </div>
   );

--- a/src/content/app/regulatory-activity-viewer/components/region-overview/region-overview-image/region-overview-location-selector/RegionOverviewLocationSelector.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/region-overview/region-overview-image/region-overview-location-selector/RegionOverviewLocationSelector.tsx
@@ -17,10 +17,13 @@
 import { type RefObject, type ReactNode } from 'react';
 import { type ScaleLinear } from 'd3';
 
-import { useAppDispatch } from 'src/store';
+import { useAppDispatch, useAppSelector } from 'src/store';
 
 import useLocationSelector from './useLocationSelector';
 
+import { getMainContentBottomView } from 'src/content/app/regulatory-activity-viewer/state/ui/uiSelectors';
+
+import { setMainContentBottomView } from 'src/content/app/regulatory-activity-viewer/state/ui/uiSlice';
 import { setRegionDetailLocation } from 'src/content/app/regulatory-activity-viewer/state/region-detail/regionDetailSlice';
 
 type Props = {
@@ -34,6 +37,9 @@ type Props = {
 
 const RegionOverviewLocationSelector = (props: Props) => {
   const { activeGenomeId, scale, imageRef, children } = props;
+  const mainContentBottomView = useAppSelector((state) =>
+    getMainContentBottomView(state, activeGenomeId)
+  );
   const dispatch = useAppDispatch();
 
   const onSelectionCompleted = (params: { start: number; end: number }) => {
@@ -50,6 +56,15 @@ const RegionOverviewLocationSelector = (props: Props) => {
         }
       })
     );
+
+    if (mainContentBottomView !== 'dataviz') {
+      dispatch(
+        setMainContentBottomView({
+          genomeId: activeGenomeId,
+          view: 'dataviz'
+        })
+      );
+    }
   };
 
   const selectedLocation = useLocationSelector({

--- a/src/content/app/regulatory-activity-viewer/contexts/ActivityViewerIdContext.ts
+++ b/src/content/app/regulatory-activity-viewer/contexts/ActivityViewerIdContext.ts
@@ -16,7 +16,7 @@
 
 import { createContext } from 'react';
 
-import type { Location } from 'src/content/app/regulatory-activity-viewer/state/api/activityViewerApiSlice';
+import type { GenomicLocation } from 'src/shared/helpers/genomicLocationHelpers';
 
 type ActivityViewerIdContextType = {
   genomeIdInUrl?: string;
@@ -25,7 +25,7 @@ type ActivityViewerIdContextType = {
   genomeIdForUrl?: string;
   assemblyAccessionId: string | null;
   assemblyName: string | null; // <-- temporary data; won't be needed when all regulation endpoints switch to using assembly accession id
-  location: Location | null; // not quite sure if location belongs here; but provisionally placing it here
+  location: GenomicLocation | null; // not quite sure if location belongs here; but provisionally placing it here
   locationForUrl?: string | null;
   isFetchingGenomeId: boolean;
   isMissingGenomeId: boolean;

--- a/src/content/app/regulatory-activity-viewer/contexts/ActivityViewerIdContext.ts
+++ b/src/content/app/regulatory-activity-viewer/contexts/ActivityViewerIdContext.ts
@@ -26,14 +26,18 @@ type ActivityViewerIdContextType = {
   assemblyAccessionId: string | null;
   assemblyName: string | null; // <-- temporary data; won't be needed when all regulation endpoints switch to using assembly accession id
   location: Location | null; // not quite sure if location belongs here; but provisionally placing it here
-  locationForUrl?: string;
+  locationForUrl?: string | null;
+  isFetchingGenomeId: boolean;
+  isMissingGenomeId: boolean;
 };
 
 const defaultContext: ActivityViewerIdContextType = {
   activeGenomeId: null,
   assemblyAccessionId: null,
   assemblyName: null,
-  location: null
+  location: null,
+  isFetchingGenomeId: false,
+  isMissingGenomeId: false
 };
 
 export const ActivityViewerIdContext =

--- a/src/content/app/regulatory-activity-viewer/contexts/ActivityViewerIdContextProvider.tsx
+++ b/src/content/app/regulatory-activity-viewer/contexts/ActivityViewerIdContextProvider.tsx
@@ -20,7 +20,10 @@ import { useLocation } from 'react-router-dom';
 import { useAppSelector } from 'src/store';
 
 // Importing this function from the genome browser app section suggests that it should be moved to shared helpers
-import { getChrLocationFromStr } from 'src/content/app/genome-browser/helpers/browserHelper';
+import {
+  getGenomicLocationFromString,
+  type GenomicLocation
+} from 'src/shared/helpers/genomicLocationHelpers';
 
 import {
   useGenomeSummaryByGenomeSlugQuery,
@@ -32,8 +35,6 @@ import { getActiveGenomeId } from 'src/content/app/regulatory-activity-viewer/st
 import { getCommittedSpeciesById } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors';
 
 import { ActivityViewerIdContext } from './ActivityViewerIdContext';
-
-import type { Location } from 'src/content/app/regulatory-activity-viewer/state/api/activityViewerApiSlice';
 
 /**
  * NOTE: The regulation team insists that their api endpoints
@@ -83,15 +84,14 @@ const ActivityViewerIdContextProvider = ({
     species?.genome_id;
 
   const locationInUrl = urlSearchParams.get('location');
-  let location: Location | null = null;
+  let location: GenomicLocation | null = null;
 
   if (locationInUrl) {
-    const [regionName, start, end] = getChrLocationFromStr(locationInUrl);
-    location = {
-      regionName,
-      start,
-      end
-    };
+    try {
+      location = getGenomicLocationFromString(locationInUrl);
+    } catch {
+      // Failed to parse genomic location string. Proceed as normal.
+    }
   }
 
   const contextValue = {

--- a/src/content/app/regulatory-activity-viewer/hooks/useActivityViewerRouting.ts
+++ b/src/content/app/regulatory-activity-viewer/hooks/useActivityViewerRouting.ts
@@ -57,7 +57,7 @@ const useActivityViewerRouting = () => {
     if (genomeIdForUrl && genomeIdForUrl !== genomeIdInUrl) {
       const newUrl = urlFor.regulatoryActivityViewer({
         genomeId: genomeIdForUrl,
-        location: locationForUrl
+        location: locationForUrl ?? undefined
       });
       navigate(newUrl, { replace: true });
     }

--- a/src/content/app/regulatory-activity-viewer/hooks/useActivityViewerRouting.ts
+++ b/src/content/app/regulatory-activity-viewer/hooks/useActivityViewerRouting.ts
@@ -57,7 +57,7 @@ const useActivityViewerRouting = () => {
     if (genomeIdForUrl && genomeIdForUrl !== genomeIdInUrl) {
       const newUrl = urlFor.regulatoryActivityViewer({
         genomeId: genomeIdForUrl,
-        location: locationForUrl ?? undefined
+        location: locationForUrl
       });
       navigate(newUrl, { replace: true });
     }

--- a/src/content/app/regulatory-activity-viewer/state/api/activityViewerApiSlice.ts
+++ b/src/content/app/regulatory-activity-viewer/state/api/activityViewerApiSlice.ts
@@ -22,12 +22,7 @@ import type { OverviewRegion } from 'src/content/app/regulatory-activity-viewer/
 import type { Epigenome } from 'src/content/app/regulatory-activity-viewer/types/epigenome';
 import type { EpigenomeMetadataDimensionsResponse } from 'src/content/app/regulatory-activity-viewer/types/epigenomeMetadataDimensions';
 import type { EpigenomeActivityResponse } from 'src/content/app/regulatory-activity-viewer/types/epigenomeActivity';
-
-export type Location = {
-  regionName: string;
-  start: number;
-  end: number;
-};
+import type { GenomicLocation } from 'src/shared/helpers/genomicLocationHelpers';
 
 type RegionOverviewRequestParams = {
   assemblyName: string; // <-- this will be replaced by assembly accession id
@@ -49,7 +44,7 @@ type EpigenomesActivityRequestParams = {
   epigenomeIds: string[];
 };
 
-export const stringifyLocation = (location: Location) =>
+export const stringifyLocation = (location: GenomicLocation) =>
   `${location.regionName}:${location.start}-${location.end}`;
 
 const activityViewerApiSlice = restApiSlice.injectEndpoints({

--- a/src/shared/helpers/genomicLocationHelpers.test.ts
+++ b/src/shared/helpers/genomicLocationHelpers.test.ts
@@ -1,0 +1,44 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  getGenomicLocationFromString,
+  getGenomicLocationString
+} from './genomicLocationHelpers';
+
+describe('getGenomicLocationFromString', () => {
+  it('parses string containing region name, start and end', () => {
+    const test = '8:26219137-26444628';
+
+    expect(getGenomicLocationFromString(test)).toEqual({
+      regionName: '8',
+      start: 26219137,
+      end: 26444628
+    });
+  });
+});
+
+describe('getGenomicLocationString', () => {
+  it('generates a genomic location string from GenomicLocation input', () => {
+    expect(
+      getGenomicLocationString({
+        regionName: '8',
+        start: 26219137,
+        end: 26444628
+      })
+    ).toEqual('8:26219137-26444628');
+  });
+});

--- a/src/shared/helpers/genomicLocationHelpers.ts
+++ b/src/shared/helpers/genomicLocationHelpers.ts
@@ -1,0 +1,76 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * NOTE:
+ * In the genome browser section, there are similar functions
+ * named getChrLocationFromStr and getChrLocationStr.
+ *
+ * The difference is the interface of those functions.
+ * They split a location string into an array of three elements (defined as a ChrLocation type),
+ * or take a ChrLocation-shaped input to generate a string.
+ *
+ * The functions in this helper, while identical in logic, use a different interface:
+ * an object with regionName, start, and end fields. This shape is more explicit,
+ * and thus, more convenient to use. The type with this shape is defined below as GenomicLocation.
+ *
+ * Over time, it might be worth replacing the helper functions
+ * from the genome browser section with the functions defined in this file.
+ */
+
+export type GenomicLocation = {
+  regionName: string;
+  start: number;
+  end: number;
+};
+
+export const getGenomicLocationFromString = (
+  input: string
+): GenomicLocation => {
+  try {
+    const locationRegex = /^(?<regionName>.+):(?<start>\d+)-(?<end>\d+)$/;
+
+    const result = locationRegex.exec(input);
+
+    if (!result?.groups) {
+      throw new Error();
+    }
+
+    const { regionName, start, end } = result.groups;
+
+    if (
+      typeof regionName !== 'string' ||
+      typeof start !== 'string' ||
+      typeof end !== 'string'
+    ) {
+      throw new Error();
+    }
+
+    return {
+      regionName,
+      start: parseInt(start, 10),
+      end: parseInt(end, 10)
+    };
+  } catch {
+    throw new Error('Malformed genomic location string');
+  }
+};
+
+export const getGenomicLocationString = (location: GenomicLocation) => {
+  const { regionName, start, end } = location;
+
+  return `${regionName}:${start}-${end}`;
+};

--- a/src/shared/helpers/urlHelper.ts
+++ b/src/shared/helpers/urlHelper.ts
@@ -33,7 +33,7 @@ type EntityViewerUrlParams = {
 
 type RegulatoryActivityViewerUrlParams = {
   genomeId?: string | null;
-  location?: string;
+  location?: string | null;
 };
 
 type SpeciesPageUrlParams = {


### PR DESCRIPTION
## Description
- Read the `location` url parameter to display regulatory activity data.
- Added an interstitial screen — very primitive so far; just shows example locations for reference human and mouse.

https://github.com/user-attachments/assets/56692c3e-9f4f-4d1f-a5ca-20924e95d87a

### Other changes
- Reshuffled the buttons ("Configure") now moved to the right, and changed text in one of them (`"Epigenomes"` replaced with `"Table"`)
- Added the "Configure" button to the sidebar (in the "Region activity" view)
- If user selects a location in RegionOverview while the bottom of the page shows the epigenomes table, the view automatically changes to regulatory activity visualisation

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2901

## Deployment URL(s)
http://activity-viewer.review.ensembl.org