### PR TITLE
Add gene expression level indicators with mock data

### DIFF
--- a/src/content/app/regulatory-activity-viewer/components/gene-expression-levels/GeneExpressionLevels.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/gene-expression-levels/GeneExpressionLevels.tsx
@@ -49,10 +49,12 @@ const GeneExpressionLevels = () => {
       viewBox={`0 0 ${TOTAL_WIDTH} ${totalHeight}`}
       style={{
         width: `${TOTAL_WIDTH}px`,
-        height: `${totalHeight}px`
+        height: `${totalHeight}px`,
+        overflow: 'visible'
       }}
       width={TOTAL_WIDTH}
     >
+      <Heading medianValue={mockExpressionData.median} />
       {mockExpressionData.per_epigenome.map(({ id, value }, index) => (
         <GeneExpressionIndicator key={id} value={value} trackIndex={index} />
       ))}
@@ -128,6 +130,20 @@ const MedianLine = ({ value, height }: { value: number; height: number }) => {
       stroke="#ff9900"
       strokeDasharray="2"
     />
+  );
+};
+
+const Heading = ({ medianValue }: { medianValue: number }) => {
+  return (
+    <g transform="translate(0, -30)" style={{ fontWeight: 300 }}>
+      <text x={0} y={0}>
+        Expression level
+      </text>
+      <text x={0} y={18} style={{ fontSize: '11px', whiteSpace: 'pre' }}>
+        Median {'  '}
+        <tspan style={{ fontWeight: 400 }}>{medianValue}</tspan>
+      </text>
+    </g>
   );
 };
 

--- a/src/content/app/regulatory-activity-viewer/components/gene-expression-levels/GeneExpressionLevels.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/gene-expression-levels/GeneExpressionLevels.tsx
@@ -1,0 +1,159 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TRACK_HEIGHT } from 'src/content/app/regulatory-activity-viewer/components/epigenomes-activity/epigenomeActivityImageConstants';
+import {
+  GENE_EXPRESSION_INDICATOR_HEIGHT,
+  GENE_EXPRESSION_INDICATOR_WIDTH,
+  TOTAL_WIDTH,
+  DISTANCE_TO_LABEL,
+  INDICATOR_OFFSET_TOP,
+  GENE_EXPRESSION_INDICATOR_FONT_SIZE
+} from './geneExpressionLevelConstants';
+
+import useEpigenomes from 'src/content/app/regulatory-activity-viewer/hooks/useEpigenomes';
+
+/**
+ * This component displays gene expression levels,
+ * and is only displayed when there is a focus gene.
+ */
+
+const GeneExpressionLevels = () => {
+  const { sortedCombinedEpigenomes } = useEpigenomes();
+
+  if (!sortedCombinedEpigenomes) {
+    return null;
+  }
+
+  const mockExpressionData = getMockGeneExpressionData(
+    sortedCombinedEpigenomes
+  );
+
+  const totalHeight = mockExpressionData.per_epigenome.length * TRACK_HEIGHT;
+
+  return (
+    <svg
+      viewBox={`0 0 ${TOTAL_WIDTH} ${totalHeight}`}
+      style={{
+        width: `${TOTAL_WIDTH}px`,
+        height: `${totalHeight}px`
+      }}
+      width={TOTAL_WIDTH}
+    >
+      {mockExpressionData.per_epigenome.map(({ id, value }, index) => (
+        <GeneExpressionIndicator key={id} value={value} trackIndex={index} />
+      ))}
+      <MedianLine value={mockExpressionData.median} height={totalHeight} />
+    </svg>
+  );
+};
+
+// the value passed with props is between 0 and 1
+const GeneExpressionIndicator = ({
+  value,
+  trackIndex
+}: {
+  value: number;
+  trackIndex: number;
+}) => {
+  const darkRectWidth = Math.round(GENE_EXPRESSION_INDICATOR_WIDTH * value);
+  const lightRectX = darkRectWidth;
+  const lightRectWidth = GENE_EXPRESSION_INDICATOR_WIDTH - darkRectWidth;
+
+  const trackOffsetTop = trackIndex * TRACK_HEIGHT;
+  const indicatorOffsetTop = INDICATOR_OFFSET_TOP;
+
+  const labelX = GENE_EXPRESSION_INDICATOR_WIDTH + DISTANCE_TO_LABEL;
+
+  /**
+   * the dark grey colour is the same as the --color-dark-grey CSS variable
+   */
+
+  return (
+    <g transform={`translate(0, ${trackOffsetTop})`}>
+      <rect
+        x={0}
+        y={indicatorOffsetTop}
+        width={darkRectWidth}
+        height={GENE_EXPRESSION_INDICATOR_HEIGHT}
+        fill="#6f8190"
+      />
+      <rect
+        x={lightRectX}
+        y={indicatorOffsetTop}
+        width={lightRectWidth}
+        height={GENE_EXPRESSION_INDICATOR_HEIGHT}
+        fill="#e9ecee"
+      />
+      <text
+        x={labelX}
+        y={indicatorOffsetTop + GENE_EXPRESSION_INDICATOR_FONT_SIZE / 2}
+        style={{
+          fontSize: `${GENE_EXPRESSION_INDICATOR_FONT_SIZE}px`,
+          fontWeight: 300
+        }}
+      >
+        {value}
+      </text>
+    </g>
+  );
+};
+
+const MedianLine = ({ value, height }: { value: number; height: number }) => {
+  const x = Math.round(GENE_EXPRESSION_INDICATOR_WIDTH * value);
+
+  /**
+   * the orange colour is the same as the --color-orange CSS variable
+   */
+
+  return (
+    <line
+      x1={x}
+      x2={x}
+      y1={0}
+      y2={height}
+      stroke="#ff9900"
+      strokeDasharray="2"
+    />
+  );
+};
+
+/**
+ * Generate mock data:
+ * - Receive a list of epignomes
+ * - Generate some random number for each epigenome
+ *  - Should be between 0 and 1, with 2 decimal places
+ *  - Also, calculate an average of those numbers
+ *    (it will likely be a median in the future, but doesn't matter now)
+ */
+const getMockGeneExpressionData = (epigenomes: { id: string }[]) => {
+  const geneExpressionLevels = epigenomes.map(({ id }) => ({
+    id,
+    value: Math.round(Math.random() * 100) / 100
+  }));
+
+  const averageExpressionLevel =
+    geneExpressionLevels.reduce((acc, item) => {
+      return acc + item.value;
+    }, 0) / geneExpressionLevels.length;
+
+  return {
+    median: Math.round(averageExpressionLevel * 100) / 100,
+    per_epigenome: geneExpressionLevels
+  };
+};
+
+export default GeneExpressionLevels;

--- a/src/content/app/regulatory-activity-viewer/components/gene-expression-levels/geneExpressionLevelConstants.ts
+++ b/src/content/app/regulatory-activity-viewer/components/gene-expression-levels/geneExpressionLevelConstants.ts
@@ -1,0 +1,24 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const TOTAL_WIDTH = 100;
+
+export const GENE_EXPRESSION_INDICATOR_HEIGHT = 6;
+export const GENE_EXPRESSION_INDICATOR_WIDTH = 60;
+export const GENE_EXPRESSION_INDICATOR_FONT_SIZE = 11;
+
+export const INDICATOR_OFFSET_TOP = 2; // distance between the top of a track and the top of a gene expression indicator
+export const DISTANCE_TO_LABEL = 10; // distance between right edge of a gene expression indicator and the start of a label

--- a/src/content/app/regulatory-activity-viewer/components/main-content-bottom-view-controls/MainContentBottomViewControls.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/main-content-bottom-view-controls/MainContentBottomViewControls.tsx
@@ -21,6 +21,7 @@ import { useAppSelector, useAppDispatch } from 'src/store';
 import { getMainContentBottomView } from 'src/content/app/regulatory-activity-viewer/state/ui/uiSelectors';
 import {
   setMainContentBottomView,
+  setSidebarView,
   type MainContentBottomView
 } from 'src/content/app/regulatory-activity-viewer/state/ui/uiSlice';
 
@@ -99,6 +100,16 @@ const ContentViewButton = ({
         view
       })
     );
+    // if the 'Configure' button is pressed,
+    // also change the sidebar contents
+    if (view === 'epigenomes-selection') {
+      dispatch(
+        setSidebarView({
+          genomeId,
+          view: 'epigenome-filters'
+        })
+      );
+    }
   };
 
   const isActive = view === activeView;

--- a/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.module.css
@@ -1,6 +1,7 @@
 .section {
   margin-top: 2rem;
   position: relative;
+  row-gap: 4rem; /* temporary */
   padding-bottom: var(--global-padding-bottom);
 }
 

--- a/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.module.css
@@ -1,8 +1,5 @@
 .section {
   margin-top: 2rem;
-}
-
-.container {
   position: relative;
   padding-bottom: var(--global-padding-bottom);
 }

--- a/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.tsx
@@ -22,6 +22,7 @@ import useRegionActivityData from './useRegionActivityData';
 
 import RegionActivitySectionImage from './RegionActivitySectionImage';
 import EpigenomeActivityImage from 'src/content/app/regulatory-activity-viewer/components/epigenomes-activity/EpigenomesActivityImage';
+import GeneExpressionLevels from 'src/content/app/regulatory-activity-viewer/components/gene-expression-levels/GeneExpressionLevels';
 import EpigenomeLabels from 'src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/EpigenomeLabels';
 import { CircleLoader } from 'src/shared/components/loader';
 
@@ -60,7 +61,26 @@ const RegionActivitySection = () => {
 
   return (
     <div className={componentClasses}>
-      <div>
+      <div
+        className={regionOverviewStyles.middleColumn}
+        ref={imageContainerRef}
+      >
+        {preparedData && width && (
+          <RegionActivitySectionImage
+            width={width}
+            regionOverviewData={preparedData.regionOverviewData}
+            featureTracks={preparedData.featureTracksData}
+            start={preparedData.location.start}
+            end={preparedData.location.end}
+          />
+        )}
+        {(isLoading || isTransitionPending) && (
+          <div className={styles.loader}>
+            <CircleLoader />
+          </div>
+        )}
+      </div>
+      <div className={regionOverviewStyles.leftColumn}>
         {preparedData && (
           <EpigenomeLabels
             epigenomes={sortedCombinedEpigenomes ?? []}
@@ -68,35 +88,17 @@ const RegionActivitySection = () => {
           />
         )}
       </div>
-      <div
-        className={regionOverviewStyles.middleColumn}
-        ref={imageContainerRef}
-      >
-        <div className={styles.container}>
-          {preparedData && width && (
-            <>
-              <RegionActivitySectionImage
-                width={width}
-                regionOverviewData={preparedData.regionOverviewData}
-                featureTracks={preparedData.featureTracksData}
-                start={preparedData.location.start}
-                end={preparedData.location.end}
-              />
-              {/* A temporary vertical separator component below */}
-              <div style={{ margin: '1rem 0' }} />
-              <EpigenomeActivityImage
-                data={preparedData.epigenomeActivityData}
-                scale={preparedData.scale}
-                width={width}
-              />
-            </>
-          )}
-          {(isLoading || isTransitionPending) && (
-            <div className={styles.loader}>
-              <CircleLoader />
-            </div>
-          )}
-        </div>
+      <div className={regionOverviewStyles.middleColumn}>
+        {preparedData && width && (
+          <EpigenomeActivityImage
+            data={preparedData.epigenomeActivityData}
+            scale={preparedData.scale}
+            width={width}
+          />
+        )}
+      </div>
+      <div className={regionOverviewStyles.rightColumn}>
+        {preparedData && <GeneExpressionLevels />}
       </div>
     </div>
   );

--- a/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/EpigenomeLabels.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/EpigenomeLabels.module.css
@@ -1,7 +1,6 @@
 .container {
   display: flex;
   flex-direction: column;
-  margin-top: 238px; /* FIXME: top offset should be calculated dynamically */
   align-items: end;
   padding-right: 30px;
 }

--- a/src/content/app/regulatory-activity-viewer/contexts/ActivityViewerIdContextProvider.tsx
+++ b/src/content/app/regulatory-activity-viewer/contexts/ActivityViewerIdContextProvider.tsx
@@ -58,7 +58,9 @@ const ActivityViewerIdContextProvider = ({
   const species = useAppSelector((state) =>
     getCommittedSpeciesById(state, activeGenomeId)
   );
-  const params = useUrlParams<'genomeId'>(['/activity-viewer/:genomeId']);
+  const params = useUrlParams<'genomeId'>([
+    '/activity-viewer/genome/:genomeId'
+  ]);
   const { genomeId: genomeIdInUrl } = params;
   const { search } = useLocation();
   const urlSearchParams = new URLSearchParams(search);

--- a/src/content/app/regulatory-activity-viewer/helpers/filter-epigenomes/filterEpigenomes.ts
+++ b/src/content/app/regulatory-activity-viewer/helpers/filter-epigenomes/filterEpigenomes.ts
@@ -66,7 +66,7 @@ const applyFilters = (params: {
   const { epigenomes, selectionCriteria, selectedMetadataDimensions } = params;
 
   if (!selectedMetadataDimensions.length) {
-    return [];
+    return epigenomes;
   }
 
   // Iterate over the groups of enabled filters (the selected metadata dimensions),

--- a/src/shared/helpers/urlHelper.ts
+++ b/src/shared/helpers/urlHelper.ts
@@ -176,7 +176,7 @@ export const regulatoryActivityViewer = (
   params?: RegulatoryActivityViewerUrlParams
 ) => {
   const genomeId = params?.genomeId || '';
-  let path = '/activity-viewer';
+  let path = '/activity-viewer/genome';
   if (genomeId) {
     path += `/${genomeId}`;
   }


### PR DESCRIPTION
## Description
- Added gene expression indicators (to the right of epigenome activity visualisation), currently displaying mock data. In the future, this should only show up if a gene has been selected.
-  Added the `genome` namespace to url paths (e.g. `/activity-viewer/genome/grch38`). This does not quite follow url convention used for other pages, where genome id follows immediately after the name of the 'app'; but Garth feels strongly that regulatory data should be accessible not just by providing a genome id; and for now, this seems to be a decent compromise
- If no filters are selected, regulatory activity viewer now shows the full list of epigenomes instead of showing none
- When the "Configure" button in the main section of the page is pressed, the sidebar now changes its contents to 'region activity' view. This might come as a surprise to users; but at the same time, is a way to show the applied filters. We shall see if this is the right behaviour.

https://github.com/user-attachments/assets/d0758736-41b1-46ae-b5c6-838c69962870

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2902

## Deployment URL(s)
http://activity-viewer.review.ensembl.org