### PR TITLE
Add navigation from genome browser to regulatory activity viewer

### DIFF
--- a/src/content/app/genome-browser/components/zmenu/ZmenuAppLinks.tsx
+++ b/src/content/app/genome-browser/components/zmenu/ZmenuAppLinks.tsx
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { useNavigate } from 'react-router';
+import { useNavigate, useLocation } from 'react-router';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
+import { isProductionEnvironment } from 'src/shared/helpers/environment';
 
 import useGenomeBrowserIds from 'src/content/app/genome-browser/hooks/useGenomeBrowserIds';
 import useGenomeBrowser from '../../hooks/useGenomeBrowser';
@@ -38,6 +39,10 @@ const ZmenuAppLinks = (props: Props) => {
     useGenomeBrowserIds();
   const { changeFocusObject } = useGenomeBrowser();
   const navigate = useNavigate();
+
+  const { search } = useLocation();
+  const urlSearchParams = new URLSearchParams(search);
+  const locationInUrl = urlSearchParams.get('location');
 
   const onGenomeBrowserAppClick = () => {
     if (!(focusObjectIdForUrl && focusObjectId)) {
@@ -67,6 +72,17 @@ const ZmenuAppLinks = (props: Props) => {
       })
     }
   };
+
+  if (isProductionEnvironment()) {
+    // In the future, links to regulatory activity viewer will depend
+    // on the presence of regulatory annotation for a given genome
+    links.activityViewer = {
+      url: urlFor.regulatoryActivityViewer({
+        genomeId: genomeIdForUrl,
+        location: locationInUrl
+      })
+    };
+  }
 
   return (
     <div className={styles.zmenuAppLinks}>

--- a/src/content/app/genome-browser/components/zmenu/ZmenuAppLinks.tsx
+++ b/src/content/app/genome-browser/components/zmenu/ZmenuAppLinks.tsx
@@ -73,7 +73,7 @@ const ZmenuAppLinks = (props: Props) => {
     }
   };
 
-  if (isProductionEnvironment()) {
+  if (!isProductionEnvironment()) {
     // In the future, links to regulatory activity viewer will depend
     // on the presence of regulatory annotation for a given genome
     links.activityViewer = {

--- a/src/content/app/genome-browser/components/zmenu/zmenus/GeneAndOneTranscriptZmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/zmenus/GeneAndOneTranscriptZmenu.tsx
@@ -74,7 +74,9 @@ const GeneAndOneTranscriptZmenu = (props: Props) => {
   }
 
   useEffect(() => {
-    gene && dispatch(changeHighlightedTrackId(gene.metadata.track));
+    if (gene) {
+      dispatch(changeHighlightedTrackId(gene.metadata.track));
+    }
   }, []);
 
   const mainContent = (

--- a/src/shared/components/in-app-search/InAppSearchMatches.tsx
+++ b/src/shared/components/in-app-search/InAppSearchMatches.tsx
@@ -39,6 +39,7 @@ import TextButton from 'src/shared/components/text-button/TextButton';
 import type { SearchResults } from 'src/shared/types/search-api/search-results';
 import type { SearchMatch } from 'src/shared/types/search-api/search-match';
 import type { AppName } from 'src/shared/state/in-app-search/inAppSearchSlice';
+import type { AppName as AppNameForViewInApp } from 'src/shared/components/view-in-app/ViewInApp';
 import type { InAppSearchMode } from './InAppSearch';
 
 import styles from './InAppSearch.module.css';
@@ -106,7 +107,7 @@ const InAppSearchMatch = (props: InAppSearchMatchProps) => {
     }
   };
 
-  const onAppClick = (selectedAppName?: AppName) => {
+  const onAppClick = (selectedAppName?: AppNameForViewInApp) => {
     if (app === 'genomeBrowser') {
       dispatch(changeHighlightedTrackId(''));
     }
@@ -165,7 +166,7 @@ const InAppSearchMatch = (props: InAppSearchMatchProps) => {
 
 const MatchDetails = (
   props: Pick<InAppSearchMatchProps, 'match' | 'mode' | 'genomeIdForUrl'> & {
-    onClick: (appName?: AppName) => void;
+    onClick: (appName?: AppNameForViewInApp) => void;
   }
 ) => {
   const { match, genomeIdForUrl } = props;

--- a/src/shared/components/view-in-app/ViewInApp.tsx
+++ b/src/shared/components/view-in-app/ViewInApp.tsx
@@ -36,6 +36,27 @@ export const Apps = {
   entityViewer: {
     tooltip: 'Entity Viewer',
     icon: EntityViewerIcon
+  },
+  activityViewer: {
+    tooltip: 'Regulatory Activity Viewer',
+    // the icon component below is temporary, until we have a proper one
+    icon: () => (
+      <div
+        style={{
+          display: 'flex',
+          height: '25px',
+          width: '25px',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: '20px',
+          lineHeight: 1,
+          color: 'white',
+          backgroundColor: 'var(--app-icon-bg-color)'
+        }}
+      >
+        R
+      </div>
+    )
   }
 };
 


### PR DESCRIPTION
## Description
- Add a provisional navigation button to gene&transcript zmenus in the genome browser that takes user to the regulatory activity viewer preserving the location.
  - Note that so far, the gene used for navigation from the genome browser does not become focused in regulatory activity viewer (the focusing on features in regulatory activity viewer is not yet fully developed)
  - As with regulatory activity viewer in general, the button will be hidden in production until we are ready to go live 

https://github.com/user-attachments/assets/8b2dc726-f0ac-4567-b086-5fb6668853dd

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2905

## Deployment URL(s)
http://activity-viewer.review.ensembl.org/