### PR TITLE
Show integrated Ensembl release in the masthead

### DIFF
--- a/src/header/EnsemblReleaseVersion.tsx
+++ b/src/header/EnsemblReleaseVersion.tsx
@@ -1,0 +1,44 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import styles from './Header.module.css';
+
+import { useReleasesQuery } from 'src/shared/state/release/releaseApiSlice';
+
+const EnsemblReleaseVersion = () => {
+  const { data, isLoading } = useReleasesQuery();
+
+  if (isLoading) {
+    return null;
+  }
+
+  const integratedRelease = data?.find(
+    (release) => release.is_current && release.type === 'integrated'
+  );
+
+  if (!integratedRelease) {
+    return <div className={styles.release}>Beta</div>;
+  }
+
+  return (
+    <div className={styles.release}>
+      <span className={styles.light}>Beta Release </span>
+      {integratedRelease.name}
+    </div>
+  );
+};
+
+export default EnsemblReleaseVersion;

--- a/src/header/Header.module.css
+++ b/src/header/Header.module.css
@@ -15,11 +15,6 @@
   line-height: 1;
 }
 
-.topbarLeftTextBlock {
-  display: flex;
-  align-items: center;
-}
-
 .homeLink {
   font-size: 0;
   margin-right: 16px;
@@ -33,6 +28,7 @@
 
 .logotypeWrapper {
   margin-top: 3px;
+  margin-right: 15px;
 }
 
 .logotype {
@@ -40,20 +36,19 @@
   fill: var(--color-white);
 }
 
-.logotypeAssociatedText {
+.topbarLeftText {
   display: flex;
   align-items: baseline;
   margin-bottom: -3px;
+  column-gap: 30px;
 }
 
 .release {
   font-size: 11px;
-  margin-left: 15px;
 }
 
 .copyright {
   font-size: 12px;
-  margin-left: 30px;
 }
 
 .copyright a {
@@ -62,4 +57,8 @@
 
 .topbarRight {
   font-size: 13px;
+}
+
+.light {
+  font-weight: var(--font-weight-light);
 }

--- a/src/header/Header.tsx
+++ b/src/header/Header.tsx
@@ -19,13 +19,12 @@ import { Link } from 'react-router-dom';
 import useHasMounted from 'src/shared/hooks/useHasMounted';
 
 import Launchbar from './launchbar/Launchbar';
+import EnsemblReleaseVersion from './EnsemblReleaseVersion';
 
 import Logotype from 'static/img/brand/logotype.svg';
 import HomeIcon from 'static/icons/icon_home.svg';
 
 import styles from './Header.module.css';
-
-export const ReleaseVersion = () => <div className={styles.release}>Beta</div>;
 
 export const Copyright = () => (
   <div className={styles.copyright}>
@@ -47,14 +46,12 @@ export const Topbar = () => (
   <div className={styles.topbar}>
     <div className={styles.topbarLeft}>
       <HomeLink />
-      <div className={styles.topbarLeftTextBlock}>
-        <div className={styles.logotypeWrapper}>
-          <Logotype className={styles.logotype} />
-        </div>
-        <div className={styles.logotypeAssociatedText}>
-          <ReleaseVersion />
-          <Copyright />
-        </div>
+      <div className={styles.logotypeWrapper}>
+        <Logotype className={styles.logotype} />
+      </div>
+      <div className={styles.topbarLeftText}>
+        <EnsemblReleaseVersion />
+        <Copyright />
       </div>
     </div>
     <div className={styles.topbarRight}>Genome data & annotation</div>

--- a/src/shared/state/release/releaseApiSlice.ts
+++ b/src/shared/state/release/releaseApiSlice.ts
@@ -1,0 +1,33 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import config from 'config';
+import restApiSlice from 'src/shared/state/api-slices/restSlice';
+
+import type { Release } from './releaseTypes';
+
+const releaseApiSlice = restApiSlice.injectEndpoints({
+  endpoints: (builder) => ({
+    // query intended to discover whether a string available to the client is a genome id or a genome tag
+    releases: builder.query<Release[], void>({
+      query: () => ({
+        url: `${config.metadataApiBaseUrl}/releases`
+      })
+    })
+  })
+});
+
+export const { useReleasesQuery } = releaseApiSlice;

--- a/src/shared/state/release/releaseTypes.ts
+++ b/src/shared/state/release/releaseTypes.ts
@@ -1,0 +1,23 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+type ReleaseType = 'integrated' | 'partial';
+
+export type Release = {
+  name: string;
+  type: ReleaseType;
+  is_current: boolean;
+};


### PR DESCRIPTION
## Description
Display current integrated release (if data for it exists) in the masthead 

## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2909

## Deployment URL(s)
http://release-in-header.review.ensembl.org