### PR TITLE
Update epigenome labelling in regulatory activity viewer

### DIFF
--- a/src/content/app/regulatory-activity-viewer/RegulatoryActivityViewer.module.css
+++ b/src/content/app/regulatory-activity-viewer/RegulatoryActivityViewer.module.css
@@ -4,3 +4,8 @@
   align-items: start;
   grid-template-rows: auto 1fr;
 }
+
+.mainContentContainer {
+  container-name: main-content-container;
+  container-type: size;
+}

--- a/src/content/app/regulatory-activity-viewer/RegulatoryActivityViewer.tsx
+++ b/src/content/app/regulatory-activity-viewer/RegulatoryActivityViewer.tsx
@@ -85,7 +85,7 @@ const MainContent = ({ genomeId }: { genomeId: string | null }) => {
   }
 
   return (
-    <div>
+    <div className={styles.mainContentContainer}>
       Placeholder for focus feature information
       <RegionOverview />
       {/* The spacer divs below are temporary */}

--- a/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.module.css
@@ -17,10 +17,6 @@
   backdrop-filter: blur(3px);
 }
 
-.middleColumnImage {
-  width: 100%;
-}
-
 .positionRelative {
   position: relative;
 }

--- a/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.module.css
@@ -20,3 +20,7 @@
 .middleColumnImage {
   width: 100%;
 }
+
+.positionRelative {
+  position: relative;
+}

--- a/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.tsx
@@ -23,6 +23,7 @@ import useRegionActivityData from './useRegionActivityData';
 import EpigenomeActivityImage from 'src/content/app/regulatory-activity-viewer/components/epigenomes-activity/EpigenomesActivityImage';
 import GeneExpressionLevels from 'src/content/app/regulatory-activity-viewer/components/gene-expression-levels/GeneExpressionLevels';
 import EpigenomeLabels from 'src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/EpigenomeLabels';
+import EpigenomesTable from './epigenomes-table/EpigenomesTable';
 import { CircleLoader } from 'src/shared/components/loader';
 
 // FIXME: promote these styles to the top level of region activity viewer
@@ -73,7 +74,13 @@ const RegionActivitySection = () => {
           </div>
         )}
       </div>
-      <div className={regionOverviewStyles.leftColumn}>
+      <div
+        className={classNames(
+          regionOverviewStyles.leftColumn,
+          styles.positionRelative
+        )}
+      >
+        <EpigenomesTable />
         {preparedData && epigenomeMetadataDimensionsResponse && (
           <EpigenomeLabels
             epigenomes={sortedCombinedEpigenomes ?? []}

--- a/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.tsx
@@ -33,8 +33,11 @@ const RegionActivitySection = () => {
   // TODO: think about how best to handle width changes; maybe they should come from the parent
   const [width, setWidth] = useState(0);
   const imageContainerRef = useRef<HTMLDivElement>(null);
-  const { sortedCombinedEpigenomes, epigenomeSortingDimensions } =
-    useEpigenomes();
+  const {
+    sortedCombinedEpigenomes,
+    epigenomeSortingDimensions,
+    epigenomeMetadataDimensionsResponse
+  } = useEpigenomes();
 
   // TODO: width should be recalculated on resize
   // Consider if this is appropriate component for doing this.
@@ -71,10 +74,13 @@ const RegionActivitySection = () => {
         )}
       </div>
       <div className={regionOverviewStyles.leftColumn}>
-        {preparedData && (
+        {preparedData && epigenomeMetadataDimensionsResponse && (
           <EpigenomeLabels
             epigenomes={sortedCombinedEpigenomes ?? []}
             sortingDimensions={epigenomeSortingDimensions ?? []}
+            displayDimensions={
+              epigenomeMetadataDimensionsResponse.ui_spec.table_layout
+            }
           />
         )}
       </div>

--- a/src/content/app/regulatory-activity-viewer/components/region-activity-section/epigenomes-table/EpigenomesTable.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/region-activity-section/epigenomes-table/EpigenomesTable.module.css
@@ -3,13 +3,40 @@
   position: absolute;
   top: calc(-1 * var(--header-height));
   left: 0;
+}
+
+/* this element contains the table and the close button */
+.tableContainerGrid {
+  margin-left: 150px; /* skip over the left column of the main grid */
+  display: grid;
+  column-gap: 1rem;
+  padding-right: 10px;
+  animation: animate-table-entry 0.2s ease-in-out;
   background-color: white;
 }
 
+/* a wrapper for the table, whose purpose is to scroll on overflow-x */
 .tableContainer {
-  position: relative;
-  padding-right: 20px;
-  animation: animate-table-entry 0.2s ease-in-out;
+  text-align: left;
+  overflow-x: auto;
+}
+
+@container main-content-container (min-width: 0) {
+  /* 
+  NOTE:
+  150px is the width of the left column of the main grid
+  another 150px is the width of the left column of the main grid
+  the width of CloseButton is 15px
+  FIXME: at least left and right main column widths should be extracted into css variables
+  */
+
+  .tableContainerGrid {
+    grid-template-columns: [table] minmax(min-content, calc(100cqi - 150px - 150px)) [close-button] auto;
+  }
+
+  .tableContainer {
+    max-width: calc(100cqi - 150px - 150px - 30px);
+  }
 }
 
 .table thead {

--- a/src/content/app/regulatory-activity-viewer/components/region-activity-section/epigenomes-table/EpigenomesTable.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/region-activity-section/epigenomes-table/EpigenomesTable.module.css
@@ -1,0 +1,38 @@
+.container {
+  --header-height: 30px;
+  position: absolute;
+  top: calc(-1 * var(--header-height));
+  left: 0;
+  background-color: white;
+}
+
+.tableContainer {
+  position: relative;
+  padding-right: 20px;
+  animation: animate-table-entry 0.2s ease-in-out;
+}
+
+.table thead {
+  white-space: nowrap;
+}
+
+.openButton {
+  --chevron-fill: white;
+  padding: 3px 2px;
+  background-color: var(--color-blue);
+}
+
+.closeButton {
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
+@keyframes animate-table-entry {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}

--- a/src/content/app/regulatory-activity-viewer/components/region-activity-section/epigenomes-table/EpigenomesTable.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/region-activity-section/epigenomes-table/EpigenomesTable.tsx
@@ -1,0 +1,177 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState } from 'react';
+
+import { TRACK_HEIGHT } from 'src/content/app/regulatory-activity-viewer/components/epigenomes-activity/epigenomeActivityImageConstants';
+
+import useEpigenomes from 'src/content/app/regulatory-activity-viewer/hooks/useEpigenomes';
+
+import { displayEpigenomeValue } from 'src/content/app/regulatory-activity-viewer/components/selected-epigenomes/SelectedEpigenomes';
+
+import { Table, ColumnHead } from 'src/shared/components/table/';
+import CloseButton from 'src/shared/components/close-button/CloseButton';
+import Chevron from 'src/shared/components/chevron/Chevron';
+
+import type { EpigenomeMetadataDimensions } from 'src/content/app/regulatory-activity-viewer/types/epigenomeMetadataDimensions';
+
+import styles from './EpigenomesTable.module.css';
+
+type TableDisplayType = 'full' | 'partial';
+
+const EpigenomesTableContainer = () => {
+  const [displayType, setDisplayType] = useState<TableDisplayType | null>(null);
+
+  const showPartialTable = () => {
+    setDisplayType('partial');
+  };
+
+  // const showFullTable = () => {
+  //   setDisplayType('full');
+  // };
+
+  const hideTable = () => {
+    setDisplayType(null);
+  };
+
+  return (
+    <div className={styles.container}>
+      {displayType === null ? (
+        <button
+          className={styles.openButton}
+          onClick={showPartialTable}
+          aria-label="show table of epigenomes"
+        >
+          <Chevron direction="right" />
+        </button>
+      ) : (
+        <div className={styles.tableContainer}>
+          <EpigenomesTable displayType={displayType} />
+          <CloseButton
+            className={styles.closeButton}
+            onClick={hideTable}
+            aria-label="hide table of epigenomes"
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+/**
+ * This component is very similar to the SelectedEpigenomes component.
+ * One of its main difference is that it displays either the first three dimensions
+ * (used to determine sorting order), or the full list of dimensions.
+ *
+ * Its another difference is that it limits the height of table rows
+ * to the height of an epigenome activity track
+ */
+const EpigenomesTable = ({
+  displayType
+}: {
+  displayType: TableDisplayType;
+}) => {
+  const {
+    sortedCombinedEpigenomes,
+    epigenomeSortingDimensions,
+    allEpigenomeSortableDimensions,
+    epigenomeMetadataDimensionsResponse
+  } = useEpigenomes();
+
+  if (
+    !sortedCombinedEpigenomes ||
+    !epigenomeMetadataDimensionsResponse ||
+    !allEpigenomeSortableDimensions ||
+    !epigenomeSortingDimensions?.length
+  ) {
+    return null;
+  }
+
+  const tableColumns = getTableColumns({
+    sortingDimensionNames: epigenomeSortingDimensions,
+    allTableDimensionNames:
+      epigenomeMetadataDimensionsResponse.ui_spec.table_layout,
+    metadataDimensions: epigenomeMetadataDimensionsResponse.dimensions,
+    getShortList: displayType === 'partial'
+  });
+
+  // FIXME: consider collapsed dimensions
+
+  return (
+    <Table className={styles.table}>
+      <thead>
+        <tr>
+          {tableColumns.map((tableColumn) => (
+            <ColumnHead key={tableColumn.dimensionName}>
+              {tableColumn.columnHeading}
+            </ColumnHead>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {sortedCombinedEpigenomes.map((epigenome) => (
+          <tr key={epigenome.id}>
+            {tableColumns.map((tableColumn) => (
+              <td key={tableColumn.dimensionName}>
+                <div
+                  style={{
+                    height: `calc(${TRACK_HEIGHT}px - 18px - 1px)`,
+                    maxWidth: '150px',
+                    overflow: 'hidden',
+                    whiteSpace: 'nowrap',
+                    textOverflow: 'ellipsis'
+                  }}
+                >
+                  {displayEpigenomeValue(epigenome[tableColumn.dimensionName])}
+                </div>
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  );
+};
+
+const getTableColumns = ({
+  sortingDimensionNames,
+  allTableDimensionNames,
+  metadataDimensions,
+  getShortList
+}: {
+  sortingDimensionNames: string[];
+  allTableDimensionNames: string[];
+  metadataDimensions: EpigenomeMetadataDimensions;
+  getShortList: boolean;
+}): { dimensionName: string; columnHeading: string }[] => {
+  let dimensionNames: string[] = [];
+
+  if (getShortList) {
+    dimensionNames = sortingDimensionNames;
+  } else {
+    const nonSortingDimensionNames = allTableDimensionNames.filter(
+      (name) => !sortingDimensionNames.includes(name)
+    );
+    dimensionNames = sortingDimensionNames.concat(...nonSortingDimensionNames);
+  }
+
+  return dimensionNames.map((dimensionName) => ({
+    dimensionName,
+    columnHeading: metadataDimensions[dimensionName].name
+  }));
+};
+
+export default EpigenomesTableContainer;

--- a/src/content/app/regulatory-activity-viewer/components/region-activity-section/epigenomes-table/EpigenomesTable.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/region-activity-section/epigenomes-table/EpigenomesTable.tsx
@@ -24,6 +24,7 @@ import { displayEpigenomeValue } from 'src/content/app/regulatory-activity-viewe
 
 import { Table, ColumnHead } from 'src/shared/components/table/';
 import CloseButton from 'src/shared/components/close-button/CloseButton';
+import TextButton from 'src/shared/components/text-button/TextButton';
 import Chevron from 'src/shared/components/chevron/Chevron';
 
 import type { EpigenomeMetadataDimensions } from 'src/content/app/regulatory-activity-viewer/types/epigenomeMetadataDimensions';
@@ -39,9 +40,9 @@ const EpigenomesTableContainer = () => {
     setDisplayType('partial');
   };
 
-  // const showFullTable = () => {
-  //   setDisplayType('full');
-  // };
+  const showFullTable = () => {
+    setDisplayType('full');
+  };
 
   const hideTable = () => {
     setDisplayType(null);
@@ -59,7 +60,10 @@ const EpigenomesTableContainer = () => {
         </button>
       ) : (
         <div className={styles.tableContainer}>
-          <EpigenomesTable displayType={displayType} />
+          <EpigenomesTable
+            displayType={displayType}
+            showFullTable={showFullTable}
+          />
           <CloseButton
             className={styles.closeButton}
             onClick={hideTable}
@@ -80,9 +84,11 @@ const EpigenomesTableContainer = () => {
  * to the height of an epigenome activity track
  */
 const EpigenomesTable = ({
-  displayType
+  displayType,
+  showFullTable
 }: {
   displayType: TableDisplayType;
+  showFullTable: () => void;
 }) => {
   const {
     sortedCombinedEpigenomes,
@@ -119,6 +125,11 @@ const EpigenomesTable = ({
               {tableColumn.columnHeading}
             </ColumnHead>
           ))}
+          {displayType === 'partial' && (
+            <ColumnHead>
+              <TextButton onClick={showFullTable}>Show more</TextButton>
+            </ColumnHead>
+          )}
         </tr>
       </thead>
       <tbody>

--- a/src/content/app/regulatory-activity-viewer/components/region-activity-section/epigenomes-table/EpigenomesTable.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/region-activity-section/epigenomes-table/EpigenomesTable.tsx
@@ -59,11 +59,13 @@ const EpigenomesTableContainer = () => {
           <Chevron direction="right" />
         </button>
       ) : (
-        <div className={styles.tableContainer}>
-          <EpigenomesTable
-            displayType={displayType}
-            showFullTable={showFullTable}
-          />
+        <div className={styles.tableContainerGrid}>
+          <div className={styles.tableContainer}>
+            <EpigenomesTable
+              displayType={displayType}
+              showFullTable={showFullTable}
+            />
+          </div>
           <CloseButton
             className={styles.closeButton}
             onClick={hideTable}
@@ -94,7 +96,8 @@ const EpigenomesTable = ({
     sortedCombinedEpigenomes,
     epigenomeSortingDimensions,
     allEpigenomeSortableDimensions,
-    epigenomeMetadataDimensionsResponse
+    epigenomeMetadataDimensionsResponse,
+    epigenomeCombiningDimensions
   } = useEpigenomes();
 
   if (
@@ -114,17 +117,26 @@ const EpigenomesTable = ({
     getShortList: displayType === 'partial'
   });
 
+  const isCombiningDimension = (dimension: string) => {
+    return epigenomeCombiningDimensions.includes(dimension);
+  };
+
   // FIXME: consider collapsed dimensions
 
   return (
     <Table className={styles.table}>
       <thead>
         <tr>
-          {tableColumns.map((tableColumn) => (
-            <ColumnHead key={tableColumn.dimensionName}>
-              {tableColumn.columnHeading}
-            </ColumnHead>
-          ))}
+          {tableColumns.map((tableColumn) => {
+            if (isCombiningDimension(tableColumn.dimensionName)) {
+              return null;
+            }
+            return (
+              <ColumnHead key={tableColumn.dimensionName}>
+                {tableColumn.columnHeading}
+              </ColumnHead>
+            );
+          })}
           {displayType === 'partial' && (
             <ColumnHead>
               <TextButton onClick={showFullTable}>Show more</TextButton>
@@ -135,21 +147,29 @@ const EpigenomesTable = ({
       <tbody>
         {sortedCombinedEpigenomes.map((epigenome) => (
           <tr key={epigenome.id}>
-            {tableColumns.map((tableColumn) => (
-              <td key={tableColumn.dimensionName}>
-                <div
-                  style={{
-                    height: `calc(${TRACK_HEIGHT}px - 18px - 1px)`,
-                    maxWidth: '150px',
-                    overflow: 'hidden',
-                    whiteSpace: 'nowrap',
-                    textOverflow: 'ellipsis'
-                  }}
-                >
-                  {displayEpigenomeValue(epigenome[tableColumn.dimensionName])}
-                </div>
-              </td>
-            ))}
+            {tableColumns.map((tableColumn) => {
+              if (isCombiningDimension(tableColumn.dimensionName)) {
+                return null;
+              }
+
+              return (
+                <td key={tableColumn.dimensionName}>
+                  <div
+                    style={{
+                      height: `calc(${TRACK_HEIGHT}px - 18px - 1px)`, // track height minus vertical cell padding, minus table border height
+                      maxWidth: '150px',
+                      overflow: 'hidden',
+                      whiteSpace: 'nowrap',
+                      textOverflow: 'ellipsis'
+                    }}
+                  >
+                    {displayEpigenomeValue(
+                      epigenome[tableColumn.dimensionName]
+                    )}
+                  </div>
+                </td>
+              );
+            })}
           </tr>
         ))}
       </tbody>

--- a/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/SelectedEpigenomes.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/SelectedEpigenomes.tsx
@@ -124,7 +124,7 @@ const isDimensionCollapsed = (
   return collapsedDimensions.includes(dimensionName);
 };
 
-const displayEpigenomeValue = (value?: Epigenome[keyof Epigenome]) => {
+export const displayEpigenomeValue = (value?: Epigenome[keyof Epigenome]) => {
   if (Array.isArray(value)) {
     return value.join(', ');
   } else if (typeof value === 'string') {

--- a/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/EpigenomeLabels.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/EpigenomeLabels.module.css
@@ -7,6 +7,17 @@
 
 .epigenomeLabel {
   display: flex;
+  align-items: start;
+  column-gap: 0.6rem;
+}
+
+.epigenomeTextLabel {
+  font-size: 11px;
+  font-weight: var(--font-weight-light);
+}
+
+.epigenomeColorLabel {
+  display: flex;
   column-gap: 0.3rem;
 }
 


### PR DESCRIPTION
## Description
Some exploratory changes to the regulatory activity viewer. Andrea is not directing the changes at the moment; so they have been suggested by Garth. The understanding is that this is still an early-stage prototype that will be used in user testing and to inform design decisions.

The changes include:
1) Added text labels for tracks to the left of colour labels
2) Added a table overlay that expands over epigenome activity tracks to provide annotation for those tracks in-place (without having to switch to the view to the table of epigenomes)
  - the default view of the table contains only the three columns for the dimensions that are used to sort the epigenomes
  - the table can be expanded further to show the remaining dimensions

**Before:**

![staging-2020 ensembl org_activity-viewer_genome_grch38_location=17_58190566-58290566](https://github.com/user-attachments/assets/6a542cdd-ac05-4228-b5d8-016925ef9bca)

**After:**

https://github.com/user-attachments/assets/bd275dc4-37f1-49d8-a336-d815e4ae0d9a


## Deployment URL(s)
http://activity-viewer.review.ensembl.org