### PR TITLE
Show colours in overlay epigenomes table, and add pointer to sidebar navigation tabs

### DIFF
--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar/sidebar-navigation/SidebarNavigation.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar/sidebar-navigation/SidebarNavigation.module.css
@@ -1,4 +1,33 @@
 .container {
+  --text-button-disabled-color: var(--color-black);
   display: flex;
-  justify-content: space-evenly;
+}
+
+.tab {
+  padding: 0 18px;
+}
+
+.activeTab {
+  position: relative;
+}
+
+/*
+FIXME: The CSS below is copy-pasted from TrackPanelTabs css module
+(althought the 'top' rule has been updated)
+In the future, come up with a way to reuse it instead of copy-pasting.
+*/
+.activeTab::after {
+  border: 6px solid var(--color-grey);
+  border-color: transparent transparent var(--color-light-grey)
+    var(--color-light-grey);
+  box-shadow: -2px 2px 2px 0 var(--color-grey);
+  box-sizing: border-box;
+  content: '';
+  height: 0;
+  position: absolute;
+  right: calc(60% - 6px);
+  transform-origin: 0 0;
+  transform: rotate(-45deg);
+  top: 24px;
+  width: 0;
 }

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar/sidebar-navigation/SidebarNavigation.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar/sidebar-navigation/SidebarNavigation.tsx
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import classNames from 'classnames';
+
 import { useAppSelector, useAppDispatch } from 'src/store';
 
 import { getSidebarView } from 'src/content/app/regulatory-activity-viewer/state/ui/uiSelectors';
@@ -51,17 +53,29 @@ const SidebarNavigation = (props: Props) => {
     );
   };
 
+  const isDefaultTabSelected = activeView === 'default';
+  const defaultTabClasses = classNames(styles.tab, {
+    [styles.activeTab]: isDefaultTabSelected
+  });
+
+  const isEpigenomeFiltersTabSelected = activeView === 'epigenome-filters';
+  const epigenomeFiltersTabClasses = classNames(styles.tab, {
+    [styles.activeTab]: isEpigenomeFiltersTabSelected
+  });
+
   return (
     <div className={styles.container}>
       <TextButton
         onClick={() => onViewChange('default')}
-        disabled={activeView === 'default'}
+        disabled={isDefaultTabSelected}
+        className={defaultTabClasses}
       >
         In this region
       </TextButton>
       <TextButton
         onClick={() => onViewChange('epigenome-filters')}
-        disabled={activeView === 'epigenome-filters'}
+        disabled={isEpigenomeFiltersTabSelected}
+        className={epigenomeFiltersTabClasses}
       >
         Region activity
       </TextButton>

--- a/src/content/app/regulatory-activity-viewer/components/region-activity-section/epigenomes-table/EpigenomesTable.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/region-activity-section/epigenomes-table/EpigenomesTable.module.css
@@ -43,6 +43,22 @@
   white-space: nowrap;
 }
 
+.tableCellContent {
+  display: flex;
+  align-items: center;
+  column-gap: 0.5rem;
+  max-width: 150px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.colorLabel {
+  display: inline-block;
+  height: 10px;
+  aspect-ratio: 1;
+}
+
 .openButton {
   --chevron-fill: white;
   padding: 3px 2px;

--- a/src/content/app/regulatory-activity-viewer/components/region-activity-section/epigenomes-table/EpigenomesTable.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/region-activity-section/epigenomes-table/EpigenomesTable.tsx
@@ -21,8 +21,9 @@ import { TRACK_HEIGHT } from 'src/content/app/regulatory-activity-viewer/compone
 import useEpigenomes from 'src/content/app/regulatory-activity-viewer/hooks/useEpigenomes';
 
 import { displayEpigenomeValue } from 'src/content/app/regulatory-activity-viewer/components/selected-epigenomes/SelectedEpigenomes';
+import { getEpigenomeLabels } from 'src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/EpigenomeLabels';
 
-import { Table, ColumnHead } from 'src/shared/components/table/';
+import { Table, ColumnHead } from 'src/shared/components/table';
 import CloseButton from 'src/shared/components/close-button/CloseButton';
 import TextButton from 'src/shared/components/text-button/TextButton';
 import Chevron from 'src/shared/components/chevron/Chevron';
@@ -123,6 +124,11 @@ const EpigenomesTable = ({
 
   // FIXME: consider collapsed dimensions
 
+  const colorLabels = getEpigenomeLabels({
+    epigenomes: sortedCombinedEpigenomes,
+    sortingDimensions: epigenomeSortingDimensions
+  });
+
   return (
     <Table className={styles.table}>
       <thead>
@@ -145,9 +151,9 @@ const EpigenomesTable = ({
         </tr>
       </thead>
       <tbody>
-        {sortedCombinedEpigenomes.map((epigenome) => (
+        {sortedCombinedEpigenomes.map((epigenome, rowIndex) => (
           <tr key={epigenome.id}>
-            {tableColumns.map((tableColumn) => {
+            {tableColumns.map((tableColumn, columnIndex) => {
               if (isCombiningDimension(tableColumn.dimensionName)) {
                 return null;
               }
@@ -155,17 +161,19 @@ const EpigenomesTable = ({
               return (
                 <td key={tableColumn.dimensionName}>
                   <div
+                    className={styles.tableCellContent}
                     style={{
-                      height: `calc(${TRACK_HEIGHT}px - 18px - 1px)`, // track height minus vertical cell padding, minus table border height
-                      maxWidth: '150px',
-                      overflow: 'hidden',
-                      whiteSpace: 'nowrap',
-                      textOverflow: 'ellipsis'
+                      height: `calc(${TRACK_HEIGHT}px - 18px - 1px)` // track height minus vertical cell padding, minus table border height
                     }}
                   >
-                    {displayEpigenomeValue(
-                      epigenome[tableColumn.dimensionName]
-                    )}
+                    <ColorLabel
+                      color={colorLabels[rowIndex]?.[columnIndex]?.color}
+                    />
+                    <span>
+                      {displayEpigenomeValue(
+                        epigenome[tableColumn.dimensionName]
+                      )}
+                    </span>
                   </div>
                 </td>
               );
@@ -174,6 +182,16 @@ const EpigenomesTable = ({
         ))}
       </tbody>
     </Table>
+  );
+};
+
+const ColorLabel = ({ color }: { color?: string }) => {
+  if (!color) {
+    return null;
+  }
+
+  return (
+    <span className={styles.colorLabel} style={{ backgroundColor: color }} />
   );
 };
 


### PR DESCRIPTION
## Description
- Added colours to the epigenome table overlay, in order to explain the colour labels of epigenome activity tracks
- Added a pointer to indicate the selected tab in the sidebar (plus updated CSS slightly, to make colours and positioning more consistent with other pages of the site)

Resulting changes are shown in video below (first, what it looked like before the changes; then after) 

https://github.com/user-attachments/assets/bfe082b5-dcbf-4752-baf3-b892388cd33b

## Deployment URL(s)
http://activity-viewer.review.ensembl.org