### PR TITLE
Make region overview stick at the top, and display focus gene information

### DIFF
--- a/src/content/app/regulatory-activity-viewer/RegulatoryActivityViewer.module.css
+++ b/src/content/app/regulatory-activity-viewer/RegulatoryActivityViewer.module.css
@@ -7,5 +7,7 @@
 
 .mainContentContainer {
   container-name: main-content-container;
+  height: 100%;
+  overflow: auto;
   container-type: size;
 }

--- a/src/content/app/regulatory-activity-viewer/RegulatoryActivityViewer.tsx
+++ b/src/content/app/regulatory-activity-viewer/RegulatoryActivityViewer.tsx
@@ -28,6 +28,7 @@ import ActivityViewerEpigenomesContextProvider from 'src/content/app/regulatory-
 import { StandardAppLayout } from 'src/shared/components/layout';
 import ActivityViewerAppBar from './components/activity-viewer-app-bar/ActivityViewerAppBar';
 import ActivityViewerInterstitial from './components/activity-viewer-interstitial/ActivityViewerInterstitial';
+import ActivityViewerFocusFeatureInfo from 'src/content/app/regulatory-activity-viewer/components/activity-viewer-focus-feature-info/ActivityViewerFocusFeatureInfo';
 import RegionOverview from './components/region-overview/RegionOverview';
 import RegionActivitySection from './components/region-activity-section/RegionActivitySection';
 import ActivityViewerSidebar from './components/activity-viewer-sidebar/ActivityViewerSidebar';
@@ -94,7 +95,7 @@ const MainContent = ({ genomeId }: { genomeId: string | null }) => {
           zIndex: 1
         }}
       >
-        Placeholder for focus feature information
+        <ActivityViewerFocusFeatureInfo />
         <RegionOverview />
         {/* The spacer divs below are temporary */}
         <div style={{ margin: '0.6rem 0' }} />

--- a/src/content/app/regulatory-activity-viewer/RegulatoryActivityViewer.tsx
+++ b/src/content/app/regulatory-activity-viewer/RegulatoryActivityViewer.tsx
@@ -90,7 +90,8 @@ const MainContent = ({ genomeId }: { genomeId: string | null }) => {
         style={{
           position: 'sticky',
           top: 0,
-          backgroundColor: 'var(--color-white)'
+          backgroundColor: 'var(--color-white)',
+          zIndex: 1
         }}
       >
         Placeholder for focus feature information

--- a/src/content/app/regulatory-activity-viewer/RegulatoryActivityViewer.tsx
+++ b/src/content/app/regulatory-activity-viewer/RegulatoryActivityViewer.tsx
@@ -86,11 +86,19 @@ const MainContent = ({ genomeId }: { genomeId: string | null }) => {
 
   return (
     <div className={styles.mainContentContainer}>
-      Placeholder for focus feature information
-      <RegionOverview />
-      {/* The spacer divs below are temporary */}
-      <div style={{ margin: '0.6rem 0' }} />
-      <MainContentBottomViewControls genomeId={genomeId} />
+      <div
+        style={{
+          position: 'sticky',
+          top: 0,
+          backgroundColor: 'var(--color-white)'
+        }}
+      >
+        Placeholder for focus feature information
+        <RegionOverview />
+        {/* The spacer divs below are temporary */}
+        <div style={{ margin: '0.6rem 0' }} />
+        <MainContentBottomViewControls genomeId={genomeId} />
+      </div>
       <div style={{ margin: '0.6rem 0' }} />
       <MainContentBottom genomeId={genomeId} />
       <div style={{ margin: '4rem 0' }} />

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-focus-feature-info/ActivityViewerFocusFeatureInfo.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-focus-feature-info/ActivityViewerFocusFeatureInfo.module.css
@@ -28,16 +28,6 @@
   column-gap: 10px;
 }
 
-.geneNamePrimary {
-  font-weight: var(--font-weight-bold);
-}
-
-.geneBiotype {
-  display: inline-flex;
-  align-items: baseline;
-  column-gap: 10px;
-}
-
 .geneFullName {
   display: inline-flex;
   align-items: baseline;

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-focus-feature-info/ActivityViewerFocusFeatureInfo.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-focus-feature-info/ActivityViewerFocusFeatureInfo.module.css
@@ -1,0 +1,56 @@
+.container {
+  min-height: 40px;
+}
+
+.grid {
+  display: grid;
+  /* grid columns are the same across activity viewer app */
+  grid-template-columns: [left] 150px [middle] 1fr [right] 150px;
+  padding: 16px 0;
+}
+
+.leftColumn {
+  text-align: right;
+  font-weight: var(--font-weight-light);
+  padding-right: 10px;
+}
+
+.mainColumn {
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: 20px;
+  row-gap: 2px;
+}
+
+.geneName {
+  display: inline-flex;
+  align-items: baseline;
+  column-gap: 10px;
+}
+
+.geneNamePrimary {
+  font-weight: var(--font-weight-bold);
+}
+
+.geneBiotype {
+  display: inline-flex;
+  align-items: baseline;
+  column-gap: 10px;
+}
+
+.geneFullName {
+  display: inline-flex;
+  align-items: baseline;
+  column-gap: 10px;
+}
+
+.smallLight {
+  font-size: 11px;
+  font-weight: var(--font-weight-light);
+}
+
+.fullLocation {
+  display: inline-flex;
+  align-items: baseline;
+  column-gap: 10px;
+}

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-focus-feature-info/ActivityViewerFocusFeatureInfo.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-focus-feature-info/ActivityViewerFocusFeatureInfo.tsx
@@ -1,0 +1,139 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getFormattedLocation } from 'src/shared/helpers/formatters/regionFormatter';
+import { getStrandDisplayName } from 'src/shared/helpers/formatters/strandFormatter';
+
+import useActivityViewerIds from 'src/content/app/regulatory-activity-viewer/hooks/useActivityViewerIds';
+import { useFocusGeneQuery } from 'src/content/app/regulatory-activity-viewer/state/api/activityViewerApiSlice';
+
+import GeneName from 'src/shared/components/gene-name/GeneName';
+import ExternalLink from 'src/shared/components/external-link/ExternalLink';
+
+import styles from './ActivityViewerFocusFeatureInfo.module.css';
+
+const ActivityViewerFocusFeatureInfo = () => {
+  const { assemblyName, focusGeneId, location } = useActivityViewerIds();
+
+  return (
+    <div className={styles.container}>
+      {assemblyName && location && focusGeneId && (
+        <ActivityViewerFocusGene
+          assemblyName={assemblyName}
+          geneId={focusGeneId}
+          regionName={location.regionName}
+        />
+      )}
+    </div>
+  );
+};
+
+const ActivityViewerFocusGene = ({
+  assemblyName,
+  geneId,
+  regionName
+}: {
+  assemblyName: string;
+  geneId: string;
+  regionName: string;
+}) => {
+  const { data: gene } = useFocusGeneQuery({
+    assemblyName,
+    geneId
+  });
+
+  if (!gene) {
+    return null;
+  }
+
+  return (
+    <div className={styles.grid}>
+      <div className={styles.leftColumn}>Gene</div>
+      <div className={styles.mainColumn}>
+        <GeneName symbol={gene.symbol} stable_id={gene.stable_id} />
+        <GeneBiotype biotype={gene.biotype} />
+        <FullLocation
+          regionName={regionName}
+          start={gene.start}
+          end={gene.end}
+          strand={gene.strand}
+        />
+        {gene.name && (
+          <GeneFullName
+            name={gene.name.value}
+            accessionId={gene.name.accession_id}
+            url={gene.name.url}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+const GeneBiotype = ({ biotype }: { biotype: string }) => {
+  return (
+    <span className={styles.geneBiotype}>
+      <span className={styles.smallLight}>Biotype</span>
+      <span>{biotype}</span>
+    </span>
+  );
+};
+
+const GeneFullName = ({
+  name,
+  accessionId,
+  url
+}: {
+  name: string;
+  accessionId?: string;
+  url?: string;
+}) => {
+  return (
+    <span className={styles.geneFullName}>
+      <span>{name}</span>
+      {accessionId && url && (
+        <ExternalLink to={url}>{accessionId}</ExternalLink>
+      )}
+    </span>
+  );
+};
+
+const FullLocation = ({
+  regionName,
+  start,
+  end,
+  strand
+}: {
+  regionName: string;
+  start: number;
+  end: number;
+  strand: 'forward' | 'reverse';
+}) => {
+  const formattedLocationString = getFormattedLocation({
+    chromosome: regionName,
+    start,
+    end
+  });
+
+  return (
+    <span className={styles.fullLocation}>
+      <span>{formattedLocationString}</span>
+      <span className={styles.smallLight}>{getStrandDisplayName(strand)}</span>
+    </span>
+  );
+};
+
+export default ActivityViewerFocusFeatureInfo;

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-popup/activity-viewer-popup-content/GenePopupContent.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-popup/activity-viewer-popup-content/GenePopupContent.tsx
@@ -38,7 +38,7 @@ const GenePopupContent = (props: Props) => {
   const onFocus = () => {
     const event = new CustomEvent('focus-gene', {
       bubbles: true,
-      detail: gene.stable_id
+      detail: gene
     });
     componentRef.current?.dispatchEvent(event);
 

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-popup/activityViewerPopupMessageTypes.ts
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-popup/activityViewerPopupMessageTypes.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import type { GeneInRegionOverview } from 'src/content/app/regulatory-activity-viewer/types/regionOverview';
+
 type CommonMessageFields = {
   coordinates: {
     x: number;
@@ -23,15 +25,17 @@ type CommonMessageFields = {
 
 export type GenePopupMessage = CommonMessageFields & {
   type: 'gene';
-  content: {
-    stable_id: string;
-    unversioned_stable_id: string;
-    symbol?: string;
-    biotype: string;
+  content: Pick<
+    GeneInRegionOverview,
+    | 'symbol'
+    | 'stable_id'
+    | 'unversioned_stable_id'
+    | 'biotype'
+    | 'strand'
+    | 'start'
+    | 'end'
+  > & {
     region_name: string;
-    strand: string;
-    start: number;
-    end: number;
   };
 };
 

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar/sidebar-default-view/SidebarDefaultView.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar/sidebar-default-view/SidebarDefaultView.module.css
@@ -1,0 +1,3 @@
+.activeFeature {
+  --text-button-disabled-color: var(--color-black);
+}

--- a/src/content/app/regulatory-activity-viewer/components/region-overview/region-overview-image/RegionOverviewImage.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/region-overview/region-overview-image/RegionOverviewImage.tsx
@@ -65,7 +65,7 @@ type Props = {
     start: number;
     end: number;
   } | null;
-  focusGeneId: string | null; // TODO: this will need to evolve, because focused feature does not have to be gene; also, focus object will probably come from redux
+  focusGeneId?: string | null;
 };
 
 /**
@@ -171,7 +171,7 @@ const GeneTracks = (props: {
   tracks: FeatureTracks['geneTracks'];
   scale: ScaleLinear<number, number>;
   width: number; // full svg width
-  focusGeneId: string | null;
+  focusGeneId?: string | null;
 }) => {
   const { forwardStrandTracks, reverseStrandTracks } = props.tracks;
   let tempY = GENE_TRACKS_TOP_OFFSET; // keep track of the y coordinate for subsequent shapes to be drawn
@@ -235,14 +235,14 @@ const GeneTrack = (props: {
   trackIndex: number;
   trackOffsetsTop: number[];
   scale: ScaleLinear<number, number>;
-  focusGeneId: string | null;
+  focusGeneId?: string | null;
 }) => {
   const { tracks, trackIndex, trackOffsetsTop, scale, focusGeneId } = props;
   const track = tracks[trackIndex];
   const offsetTop = trackOffsetsTop[trackIndex];
 
   const geneElements = track.map((gene) => {
-    const isFocusGene = focusGeneId === gene.data.stable_id;
+    const isFocusGene = focusGeneId === gene.data.unversioned_stable_id;
 
     return (
       <Fragment key={gene.data.stable_id}>

--- a/src/content/app/regulatory-activity-viewer/contexts/ActivityViewerIdContext.ts
+++ b/src/content/app/regulatory-activity-viewer/contexts/ActivityViewerIdContext.ts
@@ -27,6 +27,7 @@ type ActivityViewerIdContextType = {
   assemblyName: string | null; // <-- temporary data; won't be needed when all regulation endpoints switch to using assembly accession id
   location: GenomicLocation | null; // not quite sure if location belongs here; but provisionally placing it here
   locationForUrl?: string | null;
+  focusGeneId?: string | null;
   isFetchingGenomeId: boolean;
   isMissingGenomeId: boolean;
 };

--- a/src/content/app/regulatory-activity-viewer/contexts/ActivityViewerIdContextProvider.tsx
+++ b/src/content/app/regulatory-activity-viewer/contexts/ActivityViewerIdContextProvider.tsx
@@ -96,6 +96,8 @@ const ActivityViewerIdContextProvider = ({
     }
   }
 
+  const focusGeneId = urlSearchParams.get('focus-gene');
+
   const contextValue = {
     genomeIdInUrl,
     activeGenomeId,
@@ -105,6 +107,7 @@ const ActivityViewerIdContextProvider = ({
     assemblyName: assemblyName ?? null,
     location,
     locationForUrl: locationInUrl,
+    focusGeneId,
     isFetchingGenomeId: isFetchingGenomeSummaryInfo,
     isMissingGenomeId:
       !!genomeQueryError && isGenomeNotFoundError(genomeQueryError)

--- a/src/content/app/regulatory-activity-viewer/state/api/activityViewerApiSlice.ts
+++ b/src/content/app/regulatory-activity-viewer/state/api/activityViewerApiSlice.ts
@@ -18,7 +18,10 @@ import restApiSlice from 'src/shared/state/api-slices/restSlice';
 
 import config from 'config';
 
-import type { OverviewRegion } from 'src/content/app/regulatory-activity-viewer/types/regionOverview';
+import type {
+  OverviewRegion,
+  FocusGene
+} from 'src/content/app/regulatory-activity-viewer/types/regionOverview';
 import type { Epigenome } from 'src/content/app/regulatory-activity-viewer/types/epigenome';
 import type { EpigenomeMetadataDimensionsResponse } from 'src/content/app/regulatory-activity-viewer/types/epigenomeMetadataDimensions';
 import type { EpigenomeActivityResponse } from 'src/content/app/regulatory-activity-viewer/types/epigenomeActivity';
@@ -27,6 +30,11 @@ import type { GenomicLocation } from 'src/shared/helpers/genomicLocationHelpers'
 type RegionOverviewRequestParams = {
   assemblyName: string; // <-- this will be replaced by assembly accession id
   location: string; // <-- as formatted by the stringifyLocation function
+};
+
+type FocusGeneParams = {
+  assemblyName: string;
+  geneId: string; // <-- versioned or unversioned gene stable id
 };
 
 type BaseEpigenomesRequestParams = {
@@ -60,6 +68,25 @@ const activityViewerApiSlice = restApiSlice.injectEndpoints({
         return {
           url: `${config.regulationApiBaseUrl}/annotation/v0.5/release/${releaseName}/assembly/${assemblyName}?location=${location}`
         };
+      }
+    }),
+    focusGene: builder.query<FocusGene, FocusGeneParams>({
+      queryFn: async (params, _, __, baseQuery) => {
+        const { assemblyName, geneId } = params;
+        try {
+          const url = `${config.regulationApiBaseUrl}/annotation/v0.5/release/${releaseName}/assembly/${assemblyName}/gene/${geneId}`;
+          const result = await baseQuery(url);
+          return {
+            data: result.data as FocusGene
+          };
+        } catch {
+          return {
+            error: {
+              status: 'FETCH_ERROR',
+              error: `Failed to fetch gene ${geneId}`
+            }
+          };
+        }
       }
     }),
     baseEpigenomes: builder.query<Epigenome[], BaseEpigenomesRequestParams>({
@@ -118,6 +145,7 @@ const prepareEpigenomeIdsForRequest = (epigenomeIds: string[]) =>
 
 export const {
   useRegionOverviewQuery,
+  useFocusGeneQuery,
   useEpigenomeMetadataDimensionsQuery,
   useBaseEpigenomesQuery,
   useEpigenomesActivityQuery

--- a/src/content/app/regulatory-activity-viewer/types/epigenomeActivity.ts
+++ b/src/content/app/regulatory-activity-viewer/types/epigenomeActivity.ts
@@ -71,18 +71,3 @@ export type EpigenomeActivityResponse = {
   track_metadata: EpigenomeActivityMetadata;
   track_data: TrackData[];
 };
-
-/**
- * Currently, Regulation team's proposal is that the client sends
- * a GET request with a 'location' query parameter, and a body.
- * It is unconventional for GET requests to include a body;
- * so maybe Regulation team will change their mind.
- *
- * The body of the request contains an array of arrays of epigenome ids.
- * A single array of epigenome ids corresponds to one row (track) of activity data.
- * The reason one track corresponds to an array of epigenome ids is because
- * of the possibility to combine epigenomes.
- */
-export type EpigenomeActivityRequest = {
-  epigenome_ids: string[][];
-};

--- a/src/content/app/regulatory-activity-viewer/types/epigenomeGeneActivity.ts
+++ b/src/content/app/regulatory-activity-viewer/types/epigenomeGeneActivity.ts
@@ -1,0 +1,25 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type EpigenomeGeneActivity = {
+  epigenome_ids: string[]; // <-- one or more epigenome id, corresponding to a track of epigenome activity data
+  value: number;
+};
+
+export type EpigenomeGeneActivityResponse = {
+  median: number;
+  gene_activity: EpigenomeGeneActivity[];
+};

--- a/src/content/app/regulatory-activity-viewer/types/regionOverview.ts
+++ b/src/content/app/regulatory-activity-viewer/types/regionOverview.ts
@@ -30,7 +30,7 @@ export type GeneInRegionOverview = {
   name?: {
     value: string;
     source?: string;
-    accession?: string;
+    accession_id?: string;
     url?: string;
   };
   biotype: string;
@@ -42,6 +42,21 @@ export type GeneInRegionOverview = {
   merged_exons: ExonInRegionOverview[];
   cds_counts: OverlappingCDSFragment[];
 };
+
+/**
+ * The focus gene fetched via a dedicated endpoint has a subset of fields of the GeneInRegionOverview type
+ */
+type FocusGeneFields =
+  | 'symbol'
+  | 'stable_id'
+  | 'unversioned_stable_id'
+  | 'biotype'
+  | 'name'
+  | 'start'
+  | 'end'
+  | 'strand';
+
+export type FocusGene = Pick<GeneInRegionOverview, FocusGeneFields>;
 
 type RepresentativeTranscriptInRegionOverview = {
   exons: ExonInRegionOverview[];

--- a/src/shared/components/gene-name/GeneName.module.css
+++ b/src/shared/components/gene-name/GeneName.module.css
@@ -1,0 +1,9 @@
+.geneName {
+  display: inline-flex;
+  align-items: baseline;
+  column-gap: 10px;
+}
+
+.geneNamePrimary {
+  font-weight: var(--gene-name-primary-font-weight, var(--font-weight-bold));
+}

--- a/src/shared/components/gene-name/GeneName.tsx
+++ b/src/shared/components/gene-name/GeneName.tsx
@@ -1,0 +1,63 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classNames from 'classnames';
+
+import styles from './GeneName.module.css';
+
+/**
+ * This component addresses a common pattern to display gene symbol and/or stable id.
+ *
+ * A gene will always have a stable id, and sometimes will also have a symbol.
+ *
+ * - If a gene has a symbol, both the symbol and the stable id are displayed.
+ * - If a gene does not have a symbol, then only the stable id is displayed.
+ *
+ * It is common for gene symbol to be displayed in a bold font.
+ * The stable id will use a regular font weight gene symbol exists;
+ * and may use a bold font if gene symbol does not exist.
+ *
+ * (Although technically, this component does not display gene name,
+ * but rather gene symbol / stable id, calling it GeneName is probably
+ * much more convenient that GeneSymbolAndStableId)
+ *
+ */
+
+type Props = {
+  symbol?: string | null;
+  stable_id: string;
+  className?: string;
+};
+
+const GeneName = ({
+  symbol,
+  stable_id,
+  className: classNameFromProps
+}: Props) => {
+  const geneNamePrimary = symbol ?? stable_id;
+  const geneNameSecondary = geneNamePrimary ? stable_id : null;
+
+  const componentClasses = classNames(styles.geneName, classNameFromProps);
+
+  return (
+    <span className={componentClasses}>
+      <span className={styles.geneNamePrimary}>{geneNamePrimary}</span>
+      {geneNameSecondary && <span>{geneNameSecondary}</span>}
+    </span>
+  );
+};
+
+export default GeneName;

--- a/src/shared/helpers/formatters/strandFormatter.ts
+++ b/src/shared/helpers/formatters/strandFormatter.ts
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-import { Strand } from 'src/shared/types/core-api/strand';
-
-export function getStrandDisplayName(strandCode: Strand) {
-  if (strandCode === Strand.FORWARD) {
+export function getStrandDisplayName(strandCode: 'forward' | 'reverse') {
+  if (strandCode === 'forward') {
     return 'forward strand';
   } else {
     return 'reverse strand';

--- a/src/shared/helpers/urlHelper.ts
+++ b/src/shared/helpers/urlHelper.ts
@@ -34,6 +34,7 @@ type EntityViewerUrlParams = {
 type RegulatoryActivityViewerUrlParams = {
   genomeId?: string | null;
   location?: string | null;
+  focusGeneId?: string;
 };
 
 type SpeciesPageUrlParams = {
@@ -183,6 +184,9 @@ export const regulatoryActivityViewer = (
   const urlSearchParams = new URLSearchParams('');
   if (params?.location) {
     urlSearchParams.append('location', params.location);
+  }
+  if (params?.focusGeneId) {
+    urlSearchParams.append('focus-gene', params.focusGeneId);
   }
   const query = decodeURIComponent(urlSearchParams.toString());
 


### PR DESCRIPTION
## Description
- Added `position: sticky` to region overview, so that it is always stuck at the top
  - It is quite possible that we will discover that it isn't useful on small screens; in which case we will try to think of a solution
- Added logic for focusing on a gene and displaying the focused gene information above the region overview panel
  - In this PR, every time focus gene changes, the client makes an http request to fetch gene information. This is usually unnecessary, because the client ought to already have gene information from the region overview panel. I will try to add some caching logic in a subsequent PR

https://github.com/user-attachments/assets/9397ea72-bad7-4b22-bab5-abc865b9a096


## Deployment URL(s)
http://activity-viewer.review.ensembl.org