### PR TITLE
Update species search matches and species lozenges

### DIFF
--- a/src/content/app/species-selector/components/selectable-genomes-table/useOrderedGenomes.ts
+++ b/src/content/app/species-selector/components/selectable-genomes-table/useOrderedGenomes.ts
@@ -32,6 +32,7 @@ type SortableColumn =
   | 'type'
   | 'assembly_name'
   | 'assembly_accession_id'
+  | 'release_name'
   | 'coding_genes_count'
   | 'contig_n50';
 
@@ -113,6 +114,16 @@ const useOrderedGenomes = (genomes: SelectableGenome[]) => {
     } else {
       orderedGenomes = [...genomes].sort((a, b) => {
         return sortStringDesc(a.assembly.accession_id, b.assembly.accession_id);
+      });
+    }
+  } else if (sortRule?.column === 'release_name') {
+    if (sortRule.sortOrder === 'asc') {
+      orderedGenomes = [...genomes].sort((a, b) => {
+        return sortStringAsc(a.release.name, b.release.name);
+      });
+    } else {
+      orderedGenomes = [...genomes].sort((a, b) => {
+        return sortStringDesc(a.release.name, b.release.name);
       });
     }
   } else if (sortRule?.column === 'coding_genes_count') {

--- a/src/content/app/species-selector/components/species-search-results-table/SpeciesSearchResultsTable.module.css
+++ b/src/content/app/species-selector/components/species-search-results-table/SpeciesSearchResultsTable.module.css
@@ -18,7 +18,7 @@
 }
 
 .assemblyAccessionId {
-  /* --assembly-accession-table-font-weight: var(--font-weight-normal); */
+  --assembly-accession-table-font-weight: var(--font-weight-normal);
 }
 
 .showMore {

--- a/src/content/app/species-selector/components/species-search-results-table/SpeciesSearchResultsTable.module.css
+++ b/src/content/app/species-selector/components/species-search-results-table/SpeciesSearchResultsTable.module.css
@@ -18,7 +18,7 @@
 }
 
 .assemblyAccessionId {
-  --assembly-accession-table-font-weight: var(--font-weight-normal);
+  /* --assembly-accession-table-font-weight: var(--font-weight-normal); */
 }
 
 .showMore {

--- a/src/content/app/species-selector/components/species-search-results-table/SpeciesSearchResultsTable.tsx
+++ b/src/content/app/species-selector/components/species-search-results-table/SpeciesSearchResultsTable.tsx
@@ -30,7 +30,9 @@ import {
   ScientificName,
   AssemblyName,
   AssemblyAccessionId,
-  SpeciesType
+  SpeciesType,
+  GenomeRelease,
+  GenomeReleaseType
 } from 'src/shared/components/species-name-parts-for-table';
 
 import type { SpeciesSearchMatch } from 'src/content/app/species-selector/types/speciesSearchMatch';
@@ -111,6 +113,18 @@ const SpeciesSearchResultsTable = (props: Props) => {
           >
             Assembly
           </ColumnHead>
+
+          <ColumnHead
+            sortOrder={getSortOrderForColumn('release_name', sortRule)}
+            onSortOrderChange={(newOrder) =>
+              onSortRuleChange('release_name', newOrder)
+            }
+          >
+            Release
+          </ColumnHead>
+
+          <ColumnHead>Release type</ColumnHead>
+
           <ColumnHead
             sortOrder={getSortOrderForColumn('assembly_accession_id', sortRule)}
             onSortOrderChange={(newOrder) =>
@@ -180,6 +194,12 @@ const SpeciesSearchResultsTable = (props: Props) => {
             </td>
             <td>
               <AssemblyName {...searchMatch} />
+            </td>
+            <td>
+              <GenomeRelease release={searchMatch.release} />
+            </td>
+            <td>
+              <GenomeReleaseType release={searchMatch.release} />
             </td>
             <td className={styles.assemblyAccessionId}>
               {!shouldDisableRow(searchMatch, canAddToStaged) ? (

--- a/src/content/app/species-selector/types/speciesSearchMatch.ts
+++ b/src/content/app/species-selector/types/speciesSearchMatch.ts
@@ -24,7 +24,8 @@ type SearchMatchFieldsFromGenomeInfo =
   | 'species_taxonomy_id'
   | 'type'
   | 'is_reference'
-  | 'assembly';
+  | 'assembly'
+  | 'release';
 
 export type SpeciesSearchMatch = Pick<
   GenomeInfo,

--- a/src/content/app/species-selector/views/species-manager/selected-genomes-table/SelectedGenomesTable.module.css
+++ b/src/content/app/species-selector/views/species-manager/selected-genomes-table/SelectedGenomesTable.module.css
@@ -28,12 +28,6 @@
   background-color: var(--color-light-grey);
 }
 
-/* the second to last column should have a right offset that is equal to the width of the last column */
-.table th:nth-child(7),
-.table td:nth-child(7) {
-  right: 78px;
-}
-
 .table th:nth-child(8),
 .table td:nth-child(8) {
   right: 0;

--- a/src/shared/components/external-link/DisabledExternalLink.module.css
+++ b/src/shared/components/external-link/DisabledExternalLink.module.css
@@ -15,4 +15,5 @@
 .text {
   grid-column: text;
   color: var(--disabled-external-link-text-color, var(--color-grey));
+  font-size: 12px; /* same as for external link */
 }

--- a/src/shared/components/selected-species/SpeciesLozenge.module.css
+++ b/src/shared/components/selected-species/SpeciesLozenge.module.css
@@ -1,4 +1,5 @@
 .species {
+  position: relative;
   display: inline-flex;
   align-items: center;
   height: 28px;
@@ -6,7 +7,6 @@
   border-width: 1px;
   border-radius: 20px;
   border-style: solid;
-  overflow: hidden;
   user-select: none;
 }
 
@@ -57,4 +57,19 @@
 .inner [data-part="assembly-name"],
 .inner [data-part="assembly-id"] {
   font-size: 11px;
+}
+
+
+.releasePill {
+  position: absolute;
+  border: 1px solid var(--color-black);
+  border-radius: 6px;
+  background-color: var(--color-white);
+  color: var(--color-black);
+  padding: 2px 3px;
+  font-size: 9px;
+  font-weight: var(--font-weight-bold);
+  top: 0;
+  right: 12px;
+  transform: translate(0, -75%);
 }

--- a/src/shared/components/selected-species/SpeciesLozenge.tsx
+++ b/src/shared/components/selected-species/SpeciesLozenge.tsx
@@ -22,6 +22,7 @@ import type { DetailedHTMLProps, ButtonHTMLAttributes } from 'react';
 import SpeciesName from 'src/shared/components/species-name/SpeciesName';
 
 import type { CommittedItem } from 'src/content/app/species-selector/types/committedItem';
+import type { Release } from 'src/shared/types/release';
 
 import styles from './SpeciesLozenge.module.css';
 
@@ -33,12 +34,14 @@ export type Props = DetailedHTMLProps<
 > & {
   species: CommittedItem;
   theme: SpeciesLozengeTheme;
+  isCurrent?: boolean;
 };
 
 const SpeciesLozenge = (props: Props) => {
   const {
     species,
     theme,
+    isCurrent = true,
     className: classNameFromProps,
     ...otherProps
   } = props;
@@ -54,8 +57,15 @@ const SpeciesLozenge = (props: Props) => {
       <div className={styles.inner}>
         <SpeciesName species={species} />
       </div>
+      {!isCurrent && species.release && (
+        <ReleasePill release={species.release} />
+      )}
     </button>
   );
+};
+
+const ReleasePill = ({ release }: { release: Release }) => {
+  return <div className={styles.releasePill}>{release.name}</div>;
 };
 
 export default SpeciesLozenge;

--- a/src/shared/components/species-name-parts-for-table/GenomeReleaseForTable.tsx
+++ b/src/shared/components/species-name-parts-for-table/GenomeReleaseForTable.tsx
@@ -14,10 +14,27 @@
  * limitations under the License.
  */
 
-export { default as CommonName } from './SpeciesCommonNameForTable';
-export { default as ScientificName } from './SpeciesScientificNameForTable';
-export { default as AssemblyName } from './AssemblyNameForTable';
-export { default as AssemblyAccessionId } from './AssemblyAccessionIdForTable';
-export { default as SpeciesType } from './SpeciesTypeForTable';
-export { default as GenomeRelease } from './GenomeReleaseForTable';
-export { default as GenomeReleaseType } from './GenomeReleaseTypeForTable';
+import classNames from 'classnames';
+
+import type { Release } from 'src/shared/types/release';
+
+type Props = {
+  release: Release;
+  className?: string;
+};
+
+import styles from './SpeciesNamePartsForTable.module.css';
+
+/**
+ * In a table, release label is typically rendered with a light font and in a smaller size.
+ */
+
+const GenomeReleaseForTable = (props: Props) => {
+  const { release, className: classNameFromProps } = props;
+
+  const componentClasses = classNames(styles.genomeRelease, classNameFromProps);
+
+  return <span className={componentClasses}>{release.name}</span>;
+};
+
+export default GenomeReleaseForTable;

--- a/src/shared/components/species-name-parts-for-table/GenomeReleaseTypeForTable.tsx
+++ b/src/shared/components/species-name-parts-for-table/GenomeReleaseTypeForTable.tsx
@@ -14,10 +14,30 @@
  * limitations under the License.
  */
 
-export { default as CommonName } from './SpeciesCommonNameForTable';
-export { default as ScientificName } from './SpeciesScientificNameForTable';
-export { default as AssemblyName } from './AssemblyNameForTable';
-export { default as AssemblyAccessionId } from './AssemblyAccessionIdForTable';
-export { default as SpeciesType } from './SpeciesTypeForTable';
-export { default as GenomeRelease } from './GenomeReleaseForTable';
-export { default as GenomeReleaseType } from './GenomeReleaseTypeForTable';
+import classNames from 'classnames';
+
+import type { Release } from 'src/shared/types/release';
+
+type Props = {
+  release: Release;
+  className?: string;
+};
+
+import styles from './SpeciesNamePartsForTable.module.css';
+
+/**
+ * In a table, release label is typically rendered with a light font and in a smaller size.
+ */
+
+const GenomeReleaseTypeForTable = (props: Props) => {
+  const { release, className: classNameFromProps } = props;
+
+  const componentClasses = classNames(
+    styles.genomeReleaseType,
+    classNameFromProps
+  );
+
+  return <span className={componentClasses}>{release.type}</span>;
+};
+
+export default GenomeReleaseTypeForTable;

--- a/src/shared/components/species-name-parts-for-table/SpeciesNamePartsForTable.module.css
+++ b/src/shared/components/species-name-parts-for-table/SpeciesNamePartsForTable.module.css
@@ -1,17 +1,18 @@
 .assemblyName {
+  font-size: var(--assembly-name-table-font-size, 11px);
   font-weight: var(--assembly-name-table-font-weight, var(--font-weight-light));
 }
 
 .assemblyAccessionId {
   font-weight: var(--assembly-accession-table-font-weight, var(--font-weight-light));
+  font-size: var(--assembly-accession-table-font-weight, 11px);
 }
 
 .genomeRelease {
-  font-size: var(--genome-release-table-font-size, 12px);
-  font-weight: var(--genome-release-table-font-weight, var(--font-weight-light));
+  font-size: var(--genome-release-table-font-size, 13px);
 }
 
 .genomeReleaseType {
-  font-size: var(--genome-release-table-font-size, 12px);
+  font-size: var(--genome-release-table-font-size, 11px);
   font-weight: var(--genome-release-table-font-weight, var(--font-weight-light));
 }

--- a/src/shared/components/species-name-parts-for-table/SpeciesNamePartsForTable.module.css
+++ b/src/shared/components/species-name-parts-for-table/SpeciesNamePartsForTable.module.css
@@ -5,3 +5,13 @@
 .assemblyAccessionId {
   font-weight: var(--assembly-accession-table-font-weight, var(--font-weight-light));
 }
+
+.genomeRelease {
+  font-size: var(--genome-release-table-font-size, 12px);
+  font-weight: var(--genome-release-table-font-weight, var(--font-weight-light));
+}
+
+.genomeReleaseType {
+  font-size: var(--genome-release-table-font-size, 12px);
+  font-weight: var(--genome-release-table-font-weight, var(--font-weight-light));
+}

--- a/src/shared/components/species-name/fixtures/speciesTestData.ts
+++ b/src/shared/components/species-name/fixtures/speciesTestData.ts
@@ -30,6 +30,10 @@ export const humanGenome = {
     accession_id: 'GCA_000001405.29',
     name: 'GRCh38'
   },
+  release: {
+    name: '2023-10-18',
+    type: 'partial'
+  },
   genome_tag: 'grch38',
   isEnabled: true
 } satisfies CommittedItem;

--- a/src/shared/components/table/Table.module.css
+++ b/src/shared/components/table/Table.module.css
@@ -12,7 +12,7 @@
 }
 
 .table th {
-  font-size: var(--table-head-font-size, 12px);
+  font-size: var(--table-head-font-size, 11px);
   font-weight: var(--table-head-font-weight, var(--font-weight-light));
   box-shadow: inset 0 -1.5px 0 var(--table-head-border-color, var(--color-blue));
   background-clip: padding-box;

--- a/src/shared/state/genome/genomeTypes.ts
+++ b/src/shared/state/genome/genomeTypes.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import type { Release } from 'src/shared/types/release';
+
 export type ExampleFocusObject = {
   id: string;
   type: string;
@@ -41,6 +43,7 @@ export type GenomeInfo = {
     name: string;
     url: string;
   };
+  release: Release;
   assembly_provider: Provider | null;
   assembly_level: string;
   assembly_date: string | null;

--- a/src/shared/types/release.ts
+++ b/src/shared/types/release.ts
@@ -14,23 +14,9 @@
  * limitations under the License.
  */
 
-import type { Release } from 'src/shared/types/release';
+export type ReleaseType = 'integrated' | 'partial';
 
-export type CommittedItem = {
-  genome_id: string;
-  genome_tag: string | null;
-  common_name: string | null;
-  scientific_name: string;
-  species_taxonomy_id: string;
-  type: {
-    kind: string; // e.g. "population"
-    value: string; // e.g. "European"
-  } | null;
-  is_reference: boolean;
-  assembly: {
-    accession_id: string;
-    name: string;
-  };
-  release?: Release; // Release is going to be mandatory; but making it optional temporarily for dev purposes
-  isEnabled: boolean;
+export type Release = {
+  name: string;
+  type: ReleaseType;
 };

--- a/stories/shared-components/species-lozenge/SpeciesLozenge.stories.tsx
+++ b/stories/shared-components/species-lozenge/SpeciesLozenge.stories.tsx
@@ -163,6 +163,27 @@ const SpeciesLozengeContentFormatting = () => {
   );
 };
 
+const SpeciesLozengeRelease = () => {
+  return (
+    <div className={styles.wrapper}>
+      <p>
+        Species lozenge can show the date when the genome was released (relevant
+        when user has several genomes from the same assembly selected).
+      </p>
+
+      <div className={styles.innerWrapper}>
+        <WrapInRedux speciesNameDisplayOption="common-name_assembly-name">
+          <SpeciesLozenge
+            theme="blue"
+            species={humanGenome}
+            isCurrent={false}
+          />
+        </WrapInRedux>
+      </div>
+    </div>
+  );
+};
+
 export const SpeciesLozengeThemesStory = {
   name: 'Themes',
   render: () => <SpeciesLozengeThemes />
@@ -171,4 +192,9 @@ export const SpeciesLozengeThemesStory = {
 export const SpeciesLozengeContentFormattingStory = {
   name: 'Content formatting',
   render: () => <SpeciesLozengeContentFormatting />
+};
+
+export const SpeciesLozengeReleaseStory = {
+  name: 'Release info',
+  render: () => <SpeciesLozengeRelease />
 };


### PR DESCRIPTION
## Description
This PR contains the following changes

1. Species lozenge has been updated to be able to display release information. So far, this is impossible to see in action; so the only visible change is in Storybook

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/03bde817-d4f2-4b61-854d-289fee61bb6a" />

2. The 'Release' and 'Release type' columns have been added to the table of species search matches. Additionally, some general table styles have been updated after discussion with Andrea. This should be visible in the review deployment.

![image](https://github.com/user-attachments/assets/504b4458-3552-45ba-b200-49ca8c820dd7)

**NOTE:**
- Species release still isn't being saved to browser persistent storage, or retrieved from it, which is why the species table of the species manager has not been updated

## Related JIRA Issue(s)
- https://embl.atlassian.net/browse/ENSWBSITES-2917
- https://embl.atlassian.net/browse/ENSWBSITES-2912


## Deployment URL(s)
http://update-species-lozenges.review.ensembl.org