### PR TITLE
Make release a mandatory part of selected species; migrate species stored in indexeddb

### DIFF
--- a/src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSlice.ts
+++ b/src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSlice.ts
@@ -122,6 +122,7 @@ const prepareSelectedSpeciesForCommit = (
       accession_id: species.assembly.accession_id,
       name: species.assembly.name
     },
+    release: species.release,
     is_reference: species.is_reference,
     type: species.type,
     isEnabled: true

--- a/src/content/app/species-selector/state/speciesSelectorEpics.ts
+++ b/src/content/app/species-selector/state/speciesSelectorEpics.ts
@@ -144,6 +144,7 @@ const buildCommittedItemFromBriefGenomeSummary = (
       accession_id: genome.assembly.accession_id,
       name: genome.assembly.name
     },
+    release: genome.release,
     isEnabled: true
   };
 };

--- a/src/content/app/species-selector/types/committedItem.ts
+++ b/src/content/app/species-selector/types/committedItem.ts
@@ -31,6 +31,6 @@ export type CommittedItem = {
     accession_id: string;
     name: string;
   };
-  release?: Release; // Release is going to be mandatory; but making it optional temporarily for dev purposes
+  release: Release;
   isEnabled: boolean;
 };

--- a/src/content/app/tools/blast/components/blast-app-bar/BlastAppBar.tsx
+++ b/src/content/app/tools/blast/components/blast-app-bar/BlastAppBar.tsx
@@ -61,22 +61,7 @@ const BlastAppBar = () => {
 
   const speciesLozengeClick = (species: CommittedItem) => {
     if (!speciesListIds.includes(species.genome_id)) {
-      dispatch(
-        addSelectedSpecies({
-          genome_id: species.genome_id,
-          genome_tag: species.genome_tag,
-          common_name: species.common_name,
-          scientific_name: species.scientific_name,
-          species_taxonomy_id: species.species_taxonomy_id,
-          assembly: {
-            accession_id: species.assembly.name,
-            name: species.assembly.name
-          },
-          is_reference: species.is_reference,
-          type: species.type,
-          isEnabled: true
-        })
-      );
+      dispatch(addSelectedSpecies(species));
     }
   };
 

--- a/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelectorModal.tsx
+++ b/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelectorModal.tsx
@@ -50,17 +50,7 @@ const Content = (props: { onClose: () => void }) => {
 
   const onSpeciesAdd = (genomes: SpeciesSearchMatch[]) => {
     const preparedGenomes = genomes.map((genome) => ({
-      genome_id: genome.genome_id,
-      genome_tag: genome.genome_tag,
-      common_name: genome.common_name,
-      scientific_name: genome.scientific_name,
-      species_taxonomy_id: genome.species_taxonomy_id,
-      assembly: {
-        accession_id: genome.assembly.name,
-        name: genome.assembly.name
-      },
-      is_reference: genome.is_reference,
-      type: genome.type,
+      ...genome,
       isEnabled: true
     }));
     dispatch(addSelectedSpecies(preparedGenomes));

--- a/src/content/app/tools/blast/state/epics/tests/fixtures/blastSubmissionFixtures.ts
+++ b/src/content/app/tools/blast/state/epics/tests/fixtures/blastSubmissionFixtures.ts
@@ -35,12 +35,16 @@ export const createBlastSubmissionPayload = (
       accession_id: 'gca_000001405',
       name: 'grch38'
     },
+    release: {
+      name: '2025-02',
+      type: 'integrated'
+    },
     genome_tag: 'grch38',
     species_taxonomy_id: '1000',
     is_reference: true,
     type: null,
     isEnabled: true
-  };
+  } as const;
 
   const submission = {
     species: [human],

--- a/src/services/indexeddb-migrations/speciesStoreMigrations.test.ts
+++ b/src/services/indexeddb-migrations/speciesStoreMigrations.test.ts
@@ -1,0 +1,166 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'fake-indexeddb/auto';
+import { IDBFactory } from 'fake-indexeddb';
+import { openDB } from 'idb';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { waitFor } from '@testing-library/react';
+import times from 'lodash/times';
+
+import { SELECTED_SPECIES_STORE_NAME } from 'src/content/app/species-selector/services/speciesSelectorStorageConstants';
+
+import { migrateSpeciesStore } from 'src/services/indexeddb-migrations/speciesStoreMigrations';
+import { createSelectedSpecies } from 'tests/fixtures/selected-species';
+
+const mockMetadataBaseApi = 'http://metadata-api';
+
+jest.mock('config', () => ({
+  metadataApiBaseUrl: 'http://metadata-api'
+}));
+
+const server = setupServer(
+  http.get(`${mockMetadataBaseApi}/genome/:genomeId/explain`, ({ params }) => {
+    const { genomeId } = params;
+
+    const minimalGenomeData = {
+      genome_id: genomeId,
+      release: {
+        name: 'new-release',
+        type: 'integrated'
+      }
+    };
+
+    return HttpResponse.json(minimalGenomeData);
+  })
+);
+
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest(req) {
+      const errorMessage = `Found an unhandled ${req.method} request to ${req.url}`;
+      throw new Error(errorMessage);
+    }
+  })
+);
+beforeEach(() => {
+  // create a fresh copy of the database
+  indexedDB = new IDBFactory();
+});
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+// Mock out window.location.reload
+Object.defineProperty(window, 'location', {
+  configurable: true,
+  value: { reload: jest.fn() }
+});
+
+describe('v6 -> v7 migration', () => {
+  // During migration to version 7,
+  // all stored species should receive a release field
+
+  const oldVersion = 6;
+  const newVersion = 7;
+
+  test('adding release information to stored species', async () => {
+    // Create a db using a version prior to when genome releases were introduced
+    const oldDb = await openDB('test-db', oldVersion, {
+      upgrade(db) {
+        db.createObjectStore(SELECTED_SPECIES_STORE_NAME);
+      }
+    });
+
+    const speciesList = times(3, () => {
+      const species = createSelectedSpecies() as any;
+      delete species['release'];
+      return species;
+    });
+
+    // Just making sure that species don't have the release field before saving
+    expect(speciesList.every((species) => species.release === undefined)).toBe(
+      true
+    );
+
+    // Save the species into the database
+    for (const species of speciesList) {
+      await oldDb.put(SELECTED_SPECIES_STORE_NAME, species, species.genome_id);
+    }
+
+    oldDb.close();
+
+    // Now run the db migration
+    const newDb = await openDB('test-db', newVersion, {
+      upgrade(db, oldVersion, __, transaction) {
+        migrateSpeciesStore({ db, oldVersion, transaction });
+      }
+    });
+
+    await waitFor(async () => {
+      // Read back the species, and confirm that all of them now have release data
+      const retrievedSpecies = await newDb.getAll(SELECTED_SPECIES_STORE_NAME);
+      expect(
+        retrievedSpecies.every((species) => species.release !== undefined)
+      ).toBe(true);
+    });
+  });
+
+  // Make sure release data isn't modified in the future
+  test('no changes to species stored after version 7', async () => {
+    const versionSeven = 7;
+    const versionEight = 8;
+    const newReleaseName = 'new-and-shiny';
+
+    const oldDb = await openDB('test-db', versionSeven, {
+      upgrade(db) {
+        db.createObjectStore(SELECTED_SPECIES_STORE_NAME);
+      }
+    });
+
+    const speciesList = times(3, () => {
+      const species = createSelectedSpecies({
+        release: {
+          name: newReleaseName,
+          type: 'integrated'
+        }
+      });
+      return species;
+    });
+
+    // Save the species into the database
+    for (const species of speciesList) {
+      await oldDb.put(SELECTED_SPECIES_STORE_NAME, species, species.genome_id);
+    }
+
+    oldDb.close();
+
+    // Now run the db migration
+    const newDb = await openDB('test-db', versionEight, {
+      upgrade(db, oldVersion, __, transaction) {
+        migrateSpeciesStore({ db, oldVersion, transaction });
+      }
+    });
+
+    // Read back the species, and confirm that their release data hasn't changed
+    const retrievedSpecies = await newDb.getAll(SELECTED_SPECIES_STORE_NAME);
+    expect(
+      retrievedSpecies.every(
+        (species) => species.release.name === newReleaseName
+      )
+    ).toBe(true);
+  });
+});

--- a/src/services/indexeddb-migrations/speciesStoreMigrations.ts
+++ b/src/services/indexeddb-migrations/speciesStoreMigrations.ts
@@ -1,0 +1,96 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { IDBPDatabase, IDBPTransaction } from 'idb';
+
+import config from 'config';
+
+import { SELECTED_SPECIES_STORE_NAME } from 'src/content/app/species-selector/services/speciesSelectorStorageConstants';
+
+import type { CommittedItem } from 'src/content/app/species-selector/types/committedItem';
+import type { Release } from 'src/shared/types/release';
+
+export const migrateSpeciesStore = async ({
+  db,
+  oldVersion,
+  transaction
+}: {
+  db: IDBPDatabase;
+  oldVersion: number;
+  transaction: IDBPTransaction<unknown, string[], 'versionchange'>;
+}) => {
+  if (oldVersion <= 6) {
+    await runSixToSevenMigration({ db, transaction });
+  }
+};
+
+// Species saved to indexedDB before version 7 do not have release information on them.
+// During the migration, fetch this information from the 'explain' endpoint,
+// and update the saved species
+const runSixToSevenMigration = async ({
+  db,
+  transaction
+}: {
+  db: IDBPDatabase;
+  transaction: IDBPTransaction<unknown, string[], 'versionchange'>;
+}) => {
+  // use the 'versionchange' transaction to read the saved genomes from the store
+  const speciesStore = transaction.objectStore(SELECTED_SPECIES_STORE_NAME);
+
+  const allSpecies: CommittedItem[] = await speciesStore.getAll();
+  await transaction.done;
+
+  if (!allSpecies.length) {
+    return;
+  }
+
+  const releaseRequestPromises = allSpecies.map(async (species) => {
+    const genomeId = species.genome_id;
+    const url = `${config.metadataApiBaseUrl}/genome/${genomeId}/explain`;
+    try {
+      const response = await fetch(url);
+      const data = await response.json();
+      return {
+        ...species,
+        release: data.release as Release
+      };
+    } catch {
+      return null;
+    }
+  });
+  const updatedSpeciesList = await Promise.all(releaseRequestPromises);
+
+  for await (const [index, species] of allSpecies.entries()) {
+    const updatedSpeciesData = updatedSpeciesList[index];
+    if (updatedSpeciesData) {
+      const speciesWithRelease = {
+        ...species,
+        release: updatedSpeciesData.release
+      };
+      await db.put(
+        SELECTED_SPECIES_STORE_NAME,
+        speciesWithRelease,
+        species.genome_id
+      );
+    } else {
+      // failed to fetch data for a genome; something has gone wrong; delete the genome from the store
+      await db.delete(SELECTED_SPECIES_STORE_NAME, species.genome_id);
+    }
+  }
+
+  // To pick up the new data and avoid client-side errors, reload the window
+  window.location.reload();
+};

--- a/src/services/indexeddb-service.ts
+++ b/src/services/indexeddb-service.ts
@@ -25,14 +25,16 @@ import { VEP_SUBMISSIONS_STORE_NAME } from 'src/content/app/tools/vep/services/v
 import { PREVIOUSLY_VIEWED_OBJECTS_STORE_NAME } from 'src/shared/services/previouslyViewedObjectsStorageConstants';
 import { NOTIFICATIONS_STORE_NAME } from 'src/shared/services/notificationsStorageConstants';
 
+import { migrateSpeciesStore } from './indexeddb-migrations/speciesStoreMigrations';
+
 const DB_NAME = 'ensembl-website';
-const DB_VERSION = 6;
+const DB_VERSION = 7;
 
 const getDbPromise = (params?: {
   onBlocking?: OpenDBCallbacks<unknown>['blocking'];
 }) => {
   return openDB(DB_NAME, DB_VERSION, {
-    upgrade(db) {
+    upgrade(db, oldVersion, _, transaction) {
       // FIXME use constants for object store names
       if (!db.objectStoreNames.contains('contact-forms')) {
         db.createObjectStore('contact-forms');
@@ -42,6 +44,8 @@ const getDbPromise = (params?: {
       }
       if (!db.objectStoreNames.contains(SELECTED_SPECIES_STORE_NAME)) {
         db.createObjectStore(SELECTED_SPECIES_STORE_NAME);
+      } else {
+        migrateSpeciesStore({ db, oldVersion, transaction });
       }
       if (!db.objectStoreNames.contains(BLAST_SUBMISSIONS_STORE_NAME)) {
         db.createObjectStore(BLAST_SUBMISSIONS_STORE_NAME);

--- a/src/shared/state/genome/genomeTypes.ts
+++ b/src/shared/state/genome/genomeTypes.ts
@@ -64,6 +64,7 @@ export type BriefGenomeSummary = Pick<
   | 'scientific_name'
   | 'species_taxonomy_id'
   | 'type'
+  | 'release'
   | 'is_reference'
   | 'number_of_genomes_in_group'
 > & {

--- a/stories/shared-components/species-tabs-slider/speciesData.ts
+++ b/stories/shared-components/species-tabs-slider/speciesData.ts
@@ -27,6 +27,10 @@ export default [
       accession_id: 'GCA_000001405.15',
       name: 'GRCh38'
     },
+    release: {
+      name: '2025-02',
+      type: 'integrated'
+    },
     type: null,
     is_reference: true,
     isEnabled: true
@@ -40,6 +44,10 @@ export default [
     assembly: {
       accession_id: 'GCA_000001405.14',
       name: 'GRCh37.p13'
+    },
+    release: {
+      name: '2025-02',
+      type: 'integrated'
     },
     type: null,
     is_reference: false,
@@ -55,6 +63,10 @@ export default [
       accession_id: 'GCA_001050555.1',
       name: 'ASM105055v1'
     },
+    release: {
+      name: '2025-02',
+      type: 'integrated'
+    },
     type: null,
     is_reference: false,
     isEnabled: true
@@ -68,6 +80,10 @@ export default [
     assembly: {
       accession_id: 'GCA_000001735.2',
       name: 'TAIR10'
+    },
+    release: {
+      name: '2025-02',
+      type: 'integrated'
     },
     type: null,
     is_reference: false,
@@ -83,6 +99,10 @@ export default [
       accession_id: 'GCA_000001215.4',
       name: 'BDGP6.22'
     },
+    release: {
+      name: '2025-02',
+      type: 'integrated'
+    },
     type: null,
     is_reference: true,
     isEnabled: true
@@ -96,6 +116,10 @@ export default [
     assembly: {
       accession_id: 'GCA_000005975.1',
       name: 'dyak_caf1'
+    },
+    release: {
+      name: '2025-02',
+      type: 'integrated'
     },
     type: null,
     is_reference: false,
@@ -111,6 +135,10 @@ export default [
       accession_id: 'GCA_000002985.3',
       name: 'WBcel235'
     },
+    release: {
+      name: '2025-02',
+      type: 'integrated'
+    },
     type: null,
     is_reference: true,
     isEnabled: true
@@ -124,6 +152,10 @@ export default [
     assembly: {
       accession_id: 'GCA_000001635.9',
       name: 'WBcel235'
+    },
+    release: {
+      name: '2025-02',
+      type: 'integrated'
     },
     type: null,
     is_reference: true,
@@ -139,6 +171,10 @@ export default [
       accession_id: 'GCA_014441545.1',
       name: 'ROS_Cfam_1.0'
     },
+    release: {
+      name: '2025-02',
+      type: 'integrated'
+    },
     type: null,
     is_reference: true,
     isEnabled: true
@@ -153,6 +189,10 @@ export default [
       accession_id: 'GCA_000001635.9',
       name: 'B73_RefGen_v4'
     },
+    release: {
+      name: '2025-02',
+      type: 'integrated'
+    },
     type: null,
     is_reference: true,
     isEnabled: true
@@ -166,6 +206,10 @@ export default [
     assembly: {
       accession_id: 'GCA_000006665',
       name: 'ASM666v1'
+    },
+    release: {
+      name: '2025-02',
+      type: 'integrated'
     },
     type: null,
     is_reference: true,

--- a/tests/fixtures/selected-species.ts
+++ b/tests/fixtures/selected-species.ts
@@ -32,6 +32,10 @@ export const createSelectedSpecies = (
     accession_id: faker.lorem.word(),
     name: faker.lorem.word()
   },
+  release: {
+    name: '2025-02',
+    type: 'integrated'
+  },
   isEnabled: true,
   ...fragment
 });


### PR DESCRIPTION
## Description
Added an indexedDB migration to add release information to the genomes that the user has already selected.

During the migration, the script will query the `explain` endpoint of the metadata api for every saved genome, and update the stored genomes with the fetched release data to ensure that from now on selected species always have information about their release. 

### Steps for testing
The easiest way to test this PR is to run the code locally. Here are the steps that should confirm that the code is working:

1. Currently, species matches retrieved from the search api already contain release information. So, in order to simulate life before releases, strip release information off the selected species. For example, since we are testing indexedDB, you can do so before saving data to the db. One way of doing so is the following:

In `speciesSelectorStorageService`, look up function `saveMultipleSelectedSpecies`, and change the code inside the `for (const species of speciesList)` block:

```ts
    for (const species of speciesList) {
      // strip release information away
      const x = [...Object.entries(species)].reduce((acc, [key, val]) => {
        if (key !== 'release') {
          acc[key] = val;
        }
        return acc
      }, {})
      await transaction.store.put(x, species.genome_id);
    }
```

2. Open `indexeddb-service.ts`. Make sure `DB_VERSION` is set to 6.
3. Start the site, delete indexedDB (Chrome -> Dev tools -> Application -> Storage -> Clear site data)
4. Reload the page, and select several species
5. Take a look at the saved species in indexedDB (Chrome -> Dev tools -> Application -> IndexedDB -> ensembl-website -> selected-species). Notice that they do not have any release information.

![image](https://github.com/user-attachments/assets/83562bee-cb6a-47c2-929a-f2c157cc6c7f)

6. In `indexeddb-service.ts`, change `DB_VERSION` to 7.
7. Refresh the browser. Take another look at the saved species in IndexedDB. Your previously saved species should now have release information 

![image](https://github.com/user-attachments/assets/385a1c44-78b0-4ab2-b879-1391caffde44)

## Related JIRA Issue(s)
This is part of support for integrated releases.

## Deployment URL(s)
http://update-indexeddb-species.review.ensembl.org — **BUT** there is nothing new that could be seen on that deployment