### PR TITLE
Some cosmetic improvements to regulatory activity viewer

### DIFF
--- a/src/content/app/regulatory-activity-viewer/RegulatoryActivityViewer.tsx
+++ b/src/content/app/regulatory-activity-viewer/RegulatoryActivityViewer.tsx
@@ -18,7 +18,10 @@ import noop from 'lodash/noop';
 
 import { useAppSelector } from 'src/store';
 
-import { getMainContentBottomView } from 'src/content/app/regulatory-activity-viewer/state/ui/uiSelectors';
+import {
+  getMainContentBottomView,
+  getIsEpigenomeSelectorOpen
+} from 'src/content/app/regulatory-activity-viewer/state/ui/uiSelectors';
 
 import useActivityViewerIds from './hooks/useActivityViewerIds';
 import usePreselectedEpigenomes from './hooks/usePreselectedEpigenomes';
@@ -112,16 +115,19 @@ const MainContentBottom = ({ genomeId }: { genomeId: string }) => {
   const activeView = useAppSelector((state) =>
     getMainContentBottomView(state, genomeId)
   );
+  const isEpigenomeSelectorOpen = useAppSelector((state) =>
+    getIsEpigenomeSelectorOpen(state, genomeId)
+  );
 
   return (
     <>
-      {['epigenomes-list', 'epigenomes-selection'].includes(activeView) && (
+      {activeView === 'epigenomes-list' && (
         <SelectedEpigenomes genomeId={genomeId} />
       )}
-      {activeView === 'epigenomes-selection' && (
+      {activeView === 'dataviz' && <RegionActivitySection />}
+      {isEpigenomeSelectorOpen && (
         <EpigenomeSelectionModal genomeId={genomeId} />
       )}
-      {activeView === 'dataviz' && <RegionActivitySection />}
     </>
   );
 };

--- a/src/content/app/regulatory-activity-viewer/components/epigenome-selection-modal/EpigenomeSelectionModal.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/epigenome-selection-modal/EpigenomeSelectionModal.tsx
@@ -16,7 +16,7 @@
 
 import { useAppDispatch } from 'src/store';
 
-import { setMainContentBottomView } from 'src/content/app/regulatory-activity-viewer/state/ui/uiSlice';
+import { closeEpigenomesSelector } from 'src/content/app/regulatory-activity-viewer/state/ui/uiSlice';
 
 import EpigenomeSelectionPanel from '../epigenome-selection-panel/EpigenomeSelectionPanel';
 import Modal from 'src/shared/components/modal/Modal';
@@ -31,9 +31,8 @@ const EpigenomeSelectionModal = (props: Props) => {
 
   const onClose = () => {
     dispatch(
-      setMainContentBottomView({
-        genomeId,
-        view: 'epigenomes-list'
+      closeEpigenomesSelector({
+        genomeId
       })
     );
   };

--- a/src/content/app/regulatory-activity-viewer/components/main-content-bottom-view-controls/MainContentBottomViewControls.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/main-content-bottom-view-controls/MainContentBottomViewControls.tsx
@@ -21,6 +21,7 @@ import { useAppSelector, useAppDispatch } from 'src/store';
 import { getMainContentBottomView } from 'src/content/app/regulatory-activity-viewer/state/ui/uiSelectors';
 import {
   setMainContentBottomView,
+  openEpigenomesSelector,
   setSidebarView,
   type MainContentBottomView
 } from 'src/content/app/regulatory-activity-viewer/state/ui/uiSlice';
@@ -50,6 +51,26 @@ const ContentViewButtons = ({ genomeId }: { genomeId: string }) => {
   const activeView = useAppSelector((state) =>
     getMainContentBottomView(state, genomeId)
   );
+  const dispatch = useAppDispatch();
+
+  const changeView = (view: MainContentBottomView) => {
+    dispatch(
+      setMainContentBottomView({
+        genomeId,
+        view
+      })
+    );
+  };
+
+  const onConfigure = () => {
+    dispatch(openEpigenomesSelector({ genomeId }));
+    dispatch(
+      setSidebarView({
+        genomeId,
+        view: 'epigenome-filters'
+      })
+    );
+  };
 
   return (
     <div className={styles.viewButtons}>
@@ -57,6 +78,7 @@ const ContentViewButtons = ({ genomeId }: { genomeId: string }) => {
         view="epigenomes-list"
         activeView={activeView}
         genomeId={genomeId}
+        onClick={() => changeView('epigenomes-list')}
       >
         Table
       </ContentViewButton>
@@ -65,6 +87,7 @@ const ContentViewButtons = ({ genomeId }: { genomeId: string }) => {
         view="dataviz"
         activeView={activeView}
         genomeId={genomeId}
+        onClick={() => changeView('dataviz')}
       >
         Visualise
       </ContentViewButton>
@@ -73,6 +96,7 @@ const ContentViewButtons = ({ genomeId }: { genomeId: string }) => {
         view="epigenomes-selection"
         activeView={activeView}
         genomeId={genomeId}
+        onClick={onConfigure}
       >
         Configure
       </ContentViewButton>
@@ -81,37 +105,17 @@ const ContentViewButtons = ({ genomeId }: { genomeId: string }) => {
 };
 
 const ContentViewButton = ({
-  genomeId,
   view,
   activeView,
-  children
+  children,
+  onClick
 }: {
   genomeId: string;
   view: MainContentBottomView;
   activeView: MainContentBottomView;
+  onClick: () => void;
   children: ReactNode;
 }) => {
-  const dispatch = useAppDispatch();
-
-  const onClick = () => {
-    dispatch(
-      setMainContentBottomView({
-        genomeId,
-        view
-      })
-    );
-    // if the 'Configure' button is pressed,
-    // also change the sidebar contents
-    if (view === 'epigenomes-selection') {
-      dispatch(
-        setSidebarView({
-          genomeId,
-          view: 'epigenome-filters'
-        })
-      );
-    }
-  };
-
   const isActive = view === activeView;
 
   const buttonClassName = isActive ? styles.viewButtonActive : undefined;

--- a/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, memo } from 'react';
 import classNames from 'classnames';
 
 import useEpigenomes from 'src/content/app/regulatory-activity-viewer/hooks/useEpigenomes';
@@ -88,6 +88,7 @@ const RegionActivitySection = () => {
             displayDimensions={
               epigenomeMetadataDimensionsResponse.ui_spec.table_layout
             }
+            allDimensions={epigenomeMetadataDimensionsResponse.dimensions}
           />
         )}
       </div>
@@ -107,4 +108,4 @@ const RegionActivitySection = () => {
   );
 };
 
-export default RegionActivitySection;
+export default memo(RegionActivitySection);

--- a/src/content/app/regulatory-activity-viewer/components/region-activity-section/epigenomes-table/EpigenomesTable.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/region-activity-section/epigenomes-table/EpigenomesTable.module.css
@@ -1,13 +1,13 @@
 .container {
   --header-height: 30px;
+  --offset-left: 150px; /* width of the left column of the main grid */
   position: absolute;
   top: calc(-1 * var(--header-height));
-  left: 0;
+  left: var(--offset-left);
 }
 
 /* this element contains the table and the close button */
 .tableContainerGrid {
-  margin-left: 150px; /* skip over the left column of the main grid */
   display: grid;
   column-gap: 1rem;
   padding-right: 10px;
@@ -47,7 +47,7 @@
   display: flex;
   align-items: center;
   column-gap: 0.5rem;
-  max-width: 150px;
+  max-width: 250px;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -61,6 +61,8 @@
 
 .openButton {
   --chevron-fill: white;
+  position: absolute;
+  left: calc(-1 * var(--offset-left));
   padding: 3px 2px;
   background-color: var(--color-blue);
 }

--- a/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/SelectedEpigenomes.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/SelectedEpigenomes.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { memo } from 'react';
 import { useAppSelector } from 'src/store';
 
 import useEpigenomes from 'src/content/app/regulatory-activity-viewer/hooks/useEpigenomes';
@@ -182,4 +183,4 @@ const getTableColumns = (params: EpigenomeMetadataDimensionsResponse) => {
   }));
 };
 
-export default SelectedEpigenomes;
+export default memo(SelectedEpigenomes);

--- a/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/EpigenomeLabels.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/EpigenomeLabels.module.css
@@ -14,6 +14,7 @@
 .epigenomeTextLabel {
   font-size: 11px;
   font-weight: var(--font-weight-light);
+  line-height: 1;
 }
 
 .epigenomeColorLabel {
@@ -24,4 +25,24 @@
 .coloredBlock {
   width: 6px;
   height: 25px;
+}
+
+.labelPopupContent {
+  --label-popup-content-padding-left: 10px;
+  display: flex;
+  flex-direction: column;
+  row-gap: 0.3em;
+  padding-left: var(--label-popup-content-padding-left); /* to create hanging indent effect */
+}
+
+.labelPopupContent p {
+  margin: 0;
+  text-indent: calc(-1 * var(--label-popup-content-padding-left)); /* to create hanging indent effect */
+  line-height: 1.2;
+}
+
+.labelPopupContent .dimensionName {
+  display: inline-block;
+  font-weight: var(--font-weight-light);
+  margin-right: 1ch;
 }

--- a/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/EpigenomeLabels.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/EpigenomeLabels.tsx
@@ -23,6 +23,7 @@ import { stringifyDimensionValue } from './sortEpigenomes';
 import Tooltip from 'src/shared/components/tooltip/Tooltip';
 
 import type { Epigenome } from 'src/content/app/regulatory-activity-viewer/types/epigenome';
+import type { EpigenomeMetadataDimensions } from 'src/content/app/regulatory-activity-viewer/types/epigenomeMetadataDimensions';
 
 import styles from './EpigenomeLabels.module.css';
 
@@ -30,6 +31,7 @@ type Props = {
   epigenomes: Epigenome[];
   displayDimensions: string[];
   sortingDimensions: string[];
+  allDimensions: EpigenomeMetadataDimensions;
   className?: string;
 };
 
@@ -39,7 +41,8 @@ const colors2 = ['#0399ff', '#b6e1ff'];
 const colors3 = ['#024b02', '#cce5cd'];
 
 const EpigenomeLabels = (props: Props) => {
-  const { epigenomes, sortingDimensions, displayDimensions } = props;
+  const { epigenomes, sortingDimensions, displayDimensions, allDimensions } =
+    props;
 
   const epigenomeLabelsData = getEpigenomeLabels({
     epigenomes,
@@ -54,6 +57,7 @@ const EpigenomeLabels = (props: Props) => {
           epigenome={epigenomes[index]}
           data={labelData}
           displayDimensions={displayDimensions}
+          allDimensions={allDimensions}
         />
       ))}
     </div>
@@ -118,17 +122,20 @@ export const getEpigenomeLabels = ({
 const EpigenomeLabel = ({
   data,
   epigenome,
-  displayDimensions
+  displayDimensions,
+  allDimensions
 }: {
   data: ReturnType<typeof getEpigenomeLabels>[number];
   epigenome: Epigenome;
   displayDimensions: string[];
+  allDimensions: EpigenomeMetadataDimensions;
 }) => {
   return (
     <div className={styles.epigenomeLabel}>
       <EpigenomeTextLabel
         epigenome={epigenome}
         displayDimensions={displayDimensions}
+        allDimensions={allDimensions}
       />
       <EpigenomeColorLabel data={data} />
     </div>
@@ -137,10 +144,12 @@ const EpigenomeLabel = ({
 
 const EpigenomeTextLabel = ({
   epigenome,
-  displayDimensions
+  displayDimensions,
+  allDimensions
 }: {
   epigenome: Epigenome;
   displayDimensions: string[];
+  allDimensions: EpigenomeMetadataDimensions;
 }) => {
   const [hoverRef, isHovered] = useHover<HTMLSpanElement>();
 
@@ -153,10 +162,11 @@ const EpigenomeTextLabel = ({
       <span ref={hoverRef}>{epigenome[mainDimension]}</span>
 
       {isHovered && (
-        <Tooltip anchor={hoverRef.current}>
+        <Tooltip anchor={hoverRef.current} autoAdjust={true}>
           <LabelPopupContents
             epigenome={epigenome}
             displayDimensions={otherDimensions}
+            allDimensions={allDimensions}
           />
         </Tooltip>
       )}
@@ -166,10 +176,12 @@ const EpigenomeTextLabel = ({
 
 const LabelPopupContents = ({
   epigenome,
-  displayDimensions
+  displayDimensions,
+  allDimensions
 }: {
   epigenome: Epigenome;
   displayDimensions: string[];
+  allDimensions: EpigenomeMetadataDimensions;
 }) => {
   const lines = displayDimensions
     .map((dimension) => {
@@ -177,15 +189,21 @@ const LabelPopupContents = ({
         const line = Array.isArray(epigenome[dimension])
           ? epigenome[dimension].join(', ')
           : epigenome[dimension];
-        return line;
+        return {
+          label: allDimensions[dimension].name,
+          value: line
+        };
       }
     })
     .filter((line) => !!line);
 
   return (
-    <div>
+    <div className={styles.labelPopupContent}>
       {lines.map((line) => (
-        <div key={line}>{line}</div>
+        <p key={line.label}>
+          <span className={styles.dimensionName}>{line.label}:</span>
+          <span>{line.value}</span>
+        </p>
       ))}
     </div>
   );

--- a/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/EpigenomeLabels.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/EpigenomeLabels.tsx
@@ -153,7 +153,7 @@ const EpigenomeTextLabel = ({
 }) => {
   const [hoverRef, isHovered] = useHover<HTMLSpanElement>();
 
-  const [mainDimension, ...otherDimensions] = displayDimensions;
+  const [mainDimension] = displayDimensions;
 
   const labelHeight = 40; // FIXME: import the constant
 
@@ -165,7 +165,7 @@ const EpigenomeTextLabel = ({
         <Tooltip anchor={hoverRef.current} autoAdjust={true}>
           <LabelPopupContents
             epigenome={epigenome}
-            displayDimensions={otherDimensions}
+            displayDimensions={displayDimensions}
             allDimensions={allDimensions}
           />
         </Tooltip>

--- a/src/content/app/regulatory-activity-viewer/state/ui/uiSelectors.ts
+++ b/src/content/app/regulatory-activity-viewer/state/ui/uiSelectors.ts
@@ -20,5 +20,10 @@ export const getMainContentBottomView = (state: RootState, genomeId: string) =>
   state.regionActivityViewer.ui[genomeId]?.mainContentBottomView ??
   'epigenomes-list';
 
+export const getIsEpigenomeSelectorOpen = (
+  state: RootState,
+  genomeId: string
+) => state.regionActivityViewer.ui[genomeId]?.isEpigenomesSelectorOpen ?? false;
+
 export const getSidebarView = (state: RootState, genomeId: string) =>
   state.regionActivityViewer.ui[genomeId]?.sidebarView ?? 'default';

--- a/src/content/app/regulatory-activity-viewer/state/ui/uiSlice.ts
+++ b/src/content/app/regulatory-activity-viewer/state/ui/uiSlice.ts
@@ -25,6 +25,7 @@ export type SidebarView = 'default' | 'epigenome-filters';
 
 type StatePerGenome = {
   mainContentBottomView: MainContentBottomView;
+  isEpigenomesSelectorOpen: boolean;
   sidebarView: SidebarView;
 };
 
@@ -32,6 +33,7 @@ type State = Record<string, StatePerGenome>;
 
 const initialStateForGenome: StatePerGenome = {
   mainContentBottomView: 'epigenomes-list',
+  isEpigenomesSelectorOpen: false,
   sidebarView: 'default'
 };
 
@@ -53,6 +55,18 @@ const uiSlice = createSlice({
       ensureStateForGenome(state, genomeId);
       state[genomeId].mainContentBottomView = view;
     },
+    openEpigenomesSelector(state, action: PayloadAction<{ genomeId: string }>) {
+      const { genomeId } = action.payload;
+      ensureStateForGenome(state, genomeId);
+      state[genomeId].isEpigenomesSelectorOpen = true;
+    },
+    closeEpigenomesSelector(
+      state,
+      action: PayloadAction<{ genomeId: string }>
+    ) {
+      const { genomeId } = action.payload;
+      state[genomeId].isEpigenomesSelectorOpen = false;
+    },
     setSidebarView(
       state,
       action: PayloadAction<{ genomeId: string; view: SidebarView }>
@@ -64,6 +78,11 @@ const uiSlice = createSlice({
   }
 });
 
-export const { setMainContentBottomView, setSidebarView } = uiSlice.actions;
+export const {
+  setMainContentBottomView,
+  setSidebarView,
+  openEpigenomesSelector,
+  closeEpigenomesSelector
+} = uiSlice.actions;
 
 export default uiSlice.reducer;


### PR DESCRIPTION
## Description
- A dismissal of epigenomes selection modal should preserve the view from which the modal was called, rather than always switch to the epigenomes table view.

**Before:**

https://github.com/user-attachments/assets/54209b7c-abc3-4125-b802-d0ca1721c61a

**After:**

https://github.com/user-attachments/assets/38d08230-6962-4c5e-963c-1f1ee7b20c39

- Increased max width of columns of the overlay epigenomes table
- By updating the position of the overlay epigenomes table, made sure that hovering over the labels on the left still shows up a popup with more information
- Added structure to the popup: each row of data now has its own label, and when a row of text wraps to the next line, there is a left indent to make the distinction between the rows more obvious

https://github.com/user-attachments/assets/6bdf8ab1-e8a8-4351-b643-e818b12bc42b


## Deployment URL(s)
http://activity-viewer.review.ensembl.org