### PR TITLE
Show release information in species manager and on the species page

### DIFF
--- a/src/content/app/species-selector/views/species-manager/selected-genomes-table/SelectedGenomesTable.module.css
+++ b/src/content/app/species-selector/views/species-manager/selected-genomes-table/SelectedGenomesTable.module.css
@@ -16,10 +16,10 @@
 }
 
 /* two last columns contain only narrow icons; no need for a regular wide padding */
-.table th:nth-child(7),
-.table th:nth-child(8),
-.table td:nth-child(7),
-.table td:nth-child(8) {
+.table th:nth-child(9),
+.table th:nth-child(10),
+.table td:nth-child(9),
+.table td:nth-child(10) {
   --table-column-head-padding-right: 10px;
   --table-column-head-padding-left: 10px;
   --table-cell-padding-left: 0;
@@ -28,8 +28,8 @@
   background-color: var(--color-light-grey);
 }
 
-.table th:nth-child(8),
-.table td:nth-child(8) {
+.table th:nth-child(10),
+.table td:nth-child(10) {
   right: 0;
 }
 

--- a/src/content/app/species-selector/views/species-manager/selected-genomes-table/SelectedGenomesTable.tsx
+++ b/src/content/app/species-selector/views/species-manager/selected-genomes-table/SelectedGenomesTable.tsx
@@ -40,7 +40,9 @@ import {
   ScientificName,
   AssemblyName,
   AssemblyAccessionId,
-  SpeciesType
+  SpeciesType,
+  GenomeRelease,
+  GenomeReleaseType
 } from 'src/shared/components/species-name-parts-for-table';
 
 import SpeciesSelectorIcon from 'static/icons/icon_launchbar_species_selector.svg';
@@ -221,6 +223,8 @@ const SelectedGenomesTable = (props: {
           <ColumnHead>Scientific name</ColumnHead>
           <ColumnHead>Type</ColumnHead>
           <ColumnHead>Assembly</ColumnHead>
+          <ColumnHead>Release</ColumnHead>
+          <ColumnHead>Release type</ColumnHead>
           <ColumnHead>Assembly accession</ColumnHead>
           <ColumnHead>Remove from list</ColumnHead>
           <ColumnHead>Use in apps</ColumnHead>
@@ -258,6 +262,12 @@ const SelectedGenomesTable = (props: {
               </td>
               <td>
                 <AssemblyName {...genome} />
+              </td>
+              <td>
+                <GenomeRelease release={genome.release} />
+              </td>
+              <td>
+                <GenomeReleaseType release={genome.release} />
               </td>
               <td>
                 <AssemblyAccessionId {...genome} />
@@ -353,7 +363,7 @@ const ConfirmDeletion = (props: {
 }) => {
   // this row will use the two rightmost columns of the table,
   // but will merge all the columns to the left
-  const tableColumnsCount = 8;
+  const tableColumnsCount = 10;
   const spanColumnsCount = tableColumnsCount - 2;
 
   const onDelete = () => {

--- a/src/content/app/species/components/species-page-sidebar/SpeciesPageSidebar.tsx
+++ b/src/content/app/species/components/species-page-sidebar/SpeciesPageSidebar.tsx
@@ -98,6 +98,17 @@ const SpeciesPageSidebar = (props: Props) => {
         </div>
 
         <div className={styles.fieldsGroup}>
+          <div className={styles.field}>
+            <span className={styles.label}>Release</span>
+            <span>{data.release.name}</span>
+          </div>
+          <div className={styles.field}>
+            <span className={styles.label}>Release type</span>
+            <span>{data.release.type}</span>
+          </div>
+        </div>
+
+        <div className={styles.fieldsGroup}>
           <AnnotationDate {...data} />
           <AnnotationVersion {...data} />
         </div>


### PR DESCRIPTION
## Description
- Display 'Release' and 'Release type' columns in the table of selected genomes in the species manager
- Display release information in the sidebar of the species page

## Related JIRA Issue(s)
- https://embl.atlassian.net/browse/ENSWBSITES-2920
- https://embl.atlassian.net/browse/ENSWBSITES-2918

## Deployment URL(s)
http://genome-release-info.review.ensembl.org