### PR TITLE
Display release pills in species lozenges

### DIFF
--- a/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.module.css
+++ b/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.module.css
@@ -2,13 +2,14 @@
   display: grid;
   grid-template-columns: auto minmax(max-content, 1fr);
   align-items: center;
-  column-gap: 4px;
+  column-gap: 15px;
 }
 
 .aside {
   display: flex;
   align-items: center;
   column-gap: 30px;
+  padding-top: 9px; /* to align vertically with species lozenges, whose container also has a top padding */
 }
 
 .placeholderMessage {

--- a/src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors.ts
+++ b/src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors.ts
@@ -48,3 +48,26 @@ export const getEnabledCommittedSpecies = createSelector(
   (state: RootState) => getCommittedSpecies(state),
   (committedSpecies) => committedSpecies.filter(({ isEnabled }) => isEnabled)
 );
+
+/**
+ * Identifies ids of the assemblies each of which has more than one genome
+ * among the saved species
+ */
+export const getAssembliesWithMultipleCommittedGenomes = createSelector(
+  (state: RootState) => getCommittedSpecies(state),
+  (committedSpeciesList) => {
+    const seenAssemblyIds = new Set<string>();
+    const finalAssemblyIdsSet = new Set<string>();
+
+    for (const species of committedSpeciesList) {
+      const assemblyId = species.assembly.accession_id;
+      if (seenAssemblyIds.has(assemblyId)) {
+        finalAssemblyIdsSet.add(assemblyId);
+      } else {
+        seenAssemblyIds.add(assemblyId);
+      }
+    }
+
+    return finalAssemblyIdsSet;
+  }
+);

--- a/src/shared/components/selected-species/ConnectedSelectedSpecies.tsx
+++ b/src/shared/components/selected-species/ConnectedSelectedSpecies.tsx
@@ -1,0 +1,45 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useAppSelector } from 'src/store';
+
+import { getAssembliesWithMultipleCommittedGenomes } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors';
+
+import SelectedSpecies from 'src/shared/components/selected-species/SelectedSpecies';
+
+import type { Props as SelectedSpeciesProps } from './SelectedSpecies';
+
+type Props = Omit<SelectedSpeciesProps, 'withReleaseInfo'>;
+
+/**
+ * The purpose of this component is to be a wrapper around the SelectedSpecies component,
+ * and to inject some data retrieved from redux into it.
+ */
+
+const ConnectedSelectedSpecies = (props: Props) => {
+  const { species } = props;
+  const assembliesWithMultipleGenomes = useAppSelector(
+    getAssembliesWithMultipleCommittedGenomes
+  );
+
+  const shouldShowReleaseInfo = assembliesWithMultipleGenomes.has(
+    species.assembly.accession_id
+  );
+
+  return <SelectedSpecies withReleaseInfo={shouldShowReleaseInfo} {...props} />;
+};
+
+export default ConnectedSelectedSpecies;

--- a/src/shared/components/selected-species/SelectedSpecies.tsx
+++ b/src/shared/components/selected-species/SelectedSpecies.tsx
@@ -22,6 +22,7 @@ export type Props = {
   species: CommittedItem;
   isActive?: boolean;
   disabled?: boolean;
+  withReleaseInfo?: boolean;
   onClick?: (species: CommittedItem) => void;
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
@@ -37,6 +38,7 @@ const SelectedSpecies = (props: Props) => {
     <SpeciesLozenge
       species={props.species}
       className={props.className}
+      withReleaseInfo={props.withReleaseInfo}
       onClick={onClick}
       {...getSpeciesLozengeProps(props)}
     />

--- a/src/shared/components/selected-species/SpeciesLozenge.module.css
+++ b/src/shared/components/selected-species/SpeciesLozenge.module.css
@@ -71,5 +71,5 @@
   font-weight: var(--font-weight-bold);
   top: 0;
   right: 12px;
-  transform: translate(0, -75%);
+  transform: translate(0, -65%);
 }

--- a/src/shared/components/selected-species/SpeciesLozenge.tsx
+++ b/src/shared/components/selected-species/SpeciesLozenge.tsx
@@ -34,14 +34,14 @@ export type Props = DetailedHTMLProps<
 > & {
   species: CommittedItem;
   theme: SpeciesLozengeTheme;
-  isCurrent?: boolean;
+  withReleaseInfo?: boolean;
 };
 
 const SpeciesLozenge = (props: Props) => {
   const {
     species,
     theme,
-    isCurrent = true,
+    withReleaseInfo = false,
     className: classNameFromProps,
     ...otherProps
   } = props;
@@ -57,9 +57,7 @@ const SpeciesLozenge = (props: Props) => {
       <div className={styles.inner}>
         <SpeciesName species={species} />
       </div>
-      {!isCurrent && species.release && (
-        <ReleasePill release={species.release} />
-      )}
+      {withReleaseInfo && <ReleasePill release={species.release} />}
     </button>
   );
 };

--- a/src/shared/components/selected-species/index.ts
+++ b/src/shared/components/selected-species/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export { default as SelectedSpecies } from './SelectedSpecies';
+export { default as SelectedSpecies } from './ConnectedSelectedSpecies';
 export { default as SpeciesLozenge } from './SpeciesLozenge';

--- a/src/shared/components/species-manager-indicator/SpeciesManagerIndicator.module.css
+++ b/src/shared/components/species-manager-indicator/SpeciesManagerIndicator.module.css
@@ -19,7 +19,7 @@
 
 /* similar to PillButton */
 .speciesInUsePill {
-  padding: 2px 8px;
+  padding: 0 8px;
   font-size: 12px;
   border-radius: 14px;
   border: 1px solid var(--color-grey);

--- a/src/shared/components/species-tabs-slider/SpeciesTabsSlider.module.css
+++ b/src/shared/components/species-tabs-slider/SpeciesTabsSlider.module.css
@@ -1,4 +1,5 @@
 .speciesTabsSlider {
+  --tabs-container-padding-top: 9px; /* padding to push species lozenges down, such that their release pills do not get cropped off */
   display: flex;
   align-items: center;
   overflow: hidden;
@@ -9,9 +10,16 @@
   column-gap: 15px;
   width: 100%;
   overflow-x: auto;
-  scrollbar-width: none; /* hides the scrollbar, but only on Firefox */
+  scrollbar-width: none;
+  padding-top: var(--tabs-container-padding-top);
 }
 
+/*
+  'scrollbar-width: none' is supported by all browsers since 2024
+  - Chrome and other Blink-based added support in January 2024
+  - Safari added support in December 2024
+  TODO: remove the webkit-scrollbar rule below some time in 2026.
+*/
 .tabsContainer::-webkit-scrollbar {
   display: none; /* hide the scrollbar in all webkit-based browsers */
 }
@@ -31,10 +39,12 @@
 
 .leftCorner {
   margin-right: 8px;
+  padding-top: var(--tabs-container-padding-top);
 }
 
 .rightCorner {
   margin-left: 8px;
+  padding-top: var(--tabs-container-padding-top);
 }
 
 .arrowButton {

--- a/stories/shared-components/species-lozenge/SpeciesLozenge.stories.tsx
+++ b/stories/shared-components/species-lozenge/SpeciesLozenge.stories.tsx
@@ -176,7 +176,7 @@ const SpeciesLozengeRelease = () => {
           <SpeciesLozenge
             theme="blue"
             species={humanGenome}
-            isCurrent={false}
+            withReleaseInfo={true}
           />
         </WrapInRedux>
       </div>


### PR DESCRIPTION
## Description
If the user has selected several genomes belonging to the same assembly, display release information
in each of the species lozenges corresponding to those genomes. 

## Related JIRA Issue(s)
https://embl.atlassian.net/browse/ENSWBSITES-2937

## Deployment URL(s)
http://update-species-lozenges.review.ensembl.org