### PR TITLE
Make regulatory activity images respond to width changes; and enable sidebar toggling

### DIFF
--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar/epigenome-filters-view/EpigenomeFiltersView.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar/epigenome-filters-view/EpigenomeFiltersView.tsx
@@ -23,7 +23,7 @@ import useEpigenomes from 'src/content/app/regulatory-activity-viewer/hooks/useE
 import { getEpigenomeSelectionCriteria } from 'src/content/app/regulatory-activity-viewer/state/epigenome-selection/epigenomeSelectionSelectors';
 
 import { removeSelectionCriterion } from 'src/content/app/regulatory-activity-viewer/state/epigenome-selection/epigenomeSelectionSlice';
-import { setMainContentBottomView } from 'src/content/app/regulatory-activity-viewer/state/ui/uiSlice';
+import { openEpigenomesSelector } from 'src/content/app/regulatory-activity-viewer/state/ui/uiSlice';
 
 import { getMetadataItems } from 'src/content/app/regulatory-activity-viewer/components/epigenome-selection-panel/getEpigenomeCounts';
 
@@ -166,9 +166,8 @@ const ConfigureButton = ({ genomeId }: { genomeId: string }) => {
 
   const onClick = () => {
     dispatch(
-      setMainContentBottomView({
-        genomeId,
-        view: 'epigenomes-selection'
+      openEpigenomesSelector({
+        genomeId
       })
     );
   };

--- a/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/EpigenomesActivityImage.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/EpigenomesActivityImage.tsx
@@ -49,7 +49,7 @@ const EpigenomeActivityImage = (props: Props) => {
     <svg
       viewBox={`0 0 ${width} ${imageHeight}`}
       style={{
-        width: `${width}px`,
+        width: '100%',
         height: `${imageHeight}px`
       }}
     >

--- a/src/content/app/regulatory-activity-viewer/components/main-content-bottom-view-controls/MainContentBottomViewControls.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/main-content-bottom-view-controls/MainContentBottomViewControls.tsx
@@ -77,7 +77,6 @@ const ContentViewButtons = ({ genomeId }: { genomeId: string }) => {
       <ContentViewButton
         view="epigenomes-list"
         activeView={activeView}
-        genomeId={genomeId}
         onClick={() => changeView('epigenomes-list')}
       >
         Table
@@ -86,20 +85,12 @@ const ContentViewButtons = ({ genomeId }: { genomeId: string }) => {
       <ContentViewButton
         view="dataviz"
         activeView={activeView}
-        genomeId={genomeId}
         onClick={() => changeView('dataviz')}
       >
         Visualise
       </ContentViewButton>
 
-      <ContentViewButton
-        view="epigenomes-selection"
-        activeView={activeView}
-        genomeId={genomeId}
-        onClick={onConfigure}
-      >
-        Configure
-      </ContentViewButton>
+      <SecondaryButton onClick={onConfigure}>Configure</SecondaryButton>
     </div>
   );
 };
@@ -110,7 +101,6 @@ const ContentViewButton = ({
   children,
   onClick
 }: {
-  genomeId: string;
   view: MainContentBottomView;
   activeView: MainContentBottomView;
   onClick: () => void;

--- a/src/content/app/regulatory-activity-viewer/components/region-overview/region-overview-image/RegionOverviewImage.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/region-overview/region-overview-image/RegionOverviewImage.tsx
@@ -124,7 +124,7 @@ const RegionOverviewImage = (props: Props) => {
       ref={onMount}
       className={styles.image}
       style={{
-        width: `${width}px`,
+        width: `100%`,
         height: `${imageHeight}px`,
         borderStyle: 'dashed',
         borderWidth: '1px',

--- a/src/content/app/regulatory-activity-viewer/state/ui/uiSelectors.ts
+++ b/src/content/app/regulatory-activity-viewer/state/ui/uiSelectors.ts
@@ -25,5 +25,8 @@ export const getIsEpigenomeSelectorOpen = (
   genomeId: string
 ) => state.regionActivityViewer.ui[genomeId]?.isEpigenomesSelectorOpen ?? false;
 
+export const getIsSidebarOpen = (state: RootState, genomeId: string) =>
+  state.regionActivityViewer.ui[genomeId]?.isSidebarOpen ?? true;
+
 export const getSidebarView = (state: RootState, genomeId: string) =>
   state.regionActivityViewer.ui[genomeId]?.sidebarView ?? 'default';

--- a/src/content/app/regulatory-activity-viewer/state/ui/uiSlice.ts
+++ b/src/content/app/regulatory-activity-viewer/state/ui/uiSlice.ts
@@ -26,6 +26,7 @@ export type SidebarView = 'default' | 'epigenome-filters';
 type StatePerGenome = {
   mainContentBottomView: MainContentBottomView;
   isEpigenomesSelectorOpen: boolean;
+  isSidebarOpen: boolean;
   sidebarView: SidebarView;
 };
 
@@ -34,6 +35,7 @@ type State = Record<string, StatePerGenome>;
 const initialStateForGenome: StatePerGenome = {
   mainContentBottomView: 'epigenomes-list',
   isEpigenomesSelectorOpen: false,
+  isSidebarOpen: true,
   sidebarView: 'default'
 };
 
@@ -65,7 +67,18 @@ const uiSlice = createSlice({
       action: PayloadAction<{ genomeId: string }>
     ) {
       const { genomeId } = action.payload;
+      ensureStateForGenome(state, genomeId);
       state[genomeId].isEpigenomesSelectorOpen = false;
+    },
+    openSidebar(state, action: PayloadAction<{ genomeId: string }>) {
+      const { genomeId } = action.payload;
+      ensureStateForGenome(state, genomeId);
+      state[genomeId].isSidebarOpen = true;
+    },
+    closeSidebar(state, action: PayloadAction<{ genomeId: string }>) {
+      const { genomeId } = action.payload;
+      ensureStateForGenome(state, genomeId);
+      state[genomeId].isSidebarOpen = false;
     },
     setSidebarView(
       state,
@@ -81,6 +94,8 @@ const uiSlice = createSlice({
 export const {
   setMainContentBottomView,
   setSidebarView,
+  openSidebar,
+  closeSidebar,
   openEpigenomesSelector,
   closeEpigenomesSelector
 } = uiSlice.actions;

--- a/src/content/app/regulatory-activity-viewer/state/ui/uiSlice.ts
+++ b/src/content/app/regulatory-activity-viewer/state/ui/uiSlice.ts
@@ -16,10 +16,7 @@
 
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
-export type MainContentBottomView =
-  | 'epigenomes-list'
-  | 'epigenomes-selection'
-  | 'dataviz';
+export type MainContentBottomView = 'epigenomes-list' | 'dataviz';
 
 export type SidebarView = 'default' | 'epigenome-filters';
 


### PR DESCRIPTION
## Description
- Instead of setting the width of svg images in pixels, set it to 100% to occupy all available width of the container.
- Add a ResizeObserver to listen to the width of the image container. Update the `width` property passed into the components when the  `ResizeObserver` fires. The image will then readjust its scale, and recalculate the parameters of its contents. The computation are made in the low-priority queue to avoid blocking the main thread.
- Now that the images (`RegionOverview` and `EpigenomeActivityImage`) can adapt to the width of their containers, add the code to open/close the sidebar of the regulatory activity viewer.


## Deployment URL(s)
http://activity-viewer.review.ensembl.org