### PR TITLE
Fix species lozenge order after full page reload

### DIFF
--- a/src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors.ts
+++ b/src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors.ts
@@ -24,7 +24,7 @@ export const getCommittedSpecies = createSelector(
   (state: RootState) => state.speciesSelector.general.committedItems,
   (committedItems) => {
     return committedItems.toSorted(
-      (species1, species2) => species2.selectedAt - species1.selectedAt
+      (species1, species2) => species2.addedAt - species1.addedAt
     );
   }
 );

--- a/src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors.ts
+++ b/src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors.ts
@@ -20,9 +20,14 @@ import type { RootState } from 'src/store';
 import type { CommittedItem } from 'src/content/app/species-selector/types/committedItem';
 import type { SpeciesNameDisplayOption } from 'src/content/app/species-selector/types/speciesNameDisplayOption';
 
-export const getCommittedSpecies = (state: RootState): CommittedItem[] => {
-  return state.speciesSelector.general.committedItems;
-};
+export const getCommittedSpecies = createSelector(
+  (state: RootState) => state.speciesSelector.general.committedItems,
+  (committedItems) => {
+    return committedItems.toSorted(
+      (species1, species2) => species2.selectedAt - species1.selectedAt
+    );
+  }
+);
 
 export const getSpeciesNameDisplayOption = (
   state: RootState

--- a/src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSlice.ts
+++ b/src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSlice.ts
@@ -112,7 +112,18 @@ export const initialState: SpeciesSelectorState = {
 const prepareSelectedSpeciesForCommit = (
   selectedSpecies: SpeciesSearchMatch[]
 ): CommittedItem[] => {
-  return selectedSpecies.map((species) => ({
+  const timestamp = Date.now();
+
+  // NOTE:
+  // In the UI, the lozenges of the selected species are sorted
+  // in reverse chronological order based on the value
+  // of the `selectedAt` field. Since, according to designer's instructions,
+  // if user adds multiple species at once, their lozenges should be displayed
+  // in the same order species search matches were displayed,
+  // the list of species is reversed in the code below
+  // (so as to create an impression that search matches at the top were added the latest)
+
+  return selectedSpecies.toReversed().map((species, index) => ({
     genome_id: species.genome_id,
     genome_tag: species.genome_tag,
     common_name: species.common_name,
@@ -125,7 +136,8 @@ const prepareSelectedSpeciesForCommit = (
     release: species.release,
     is_reference: species.is_reference,
     type: species.type,
-    isEnabled: true
+    isEnabled: true,
+    selectedAt: timestamp + index
   }));
 };
 

--- a/src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSlice.ts
+++ b/src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSlice.ts
@@ -117,7 +117,7 @@ const prepareSelectedSpeciesForCommit = (
   // NOTE:
   // In the UI, the lozenges of the selected species are sorted
   // in reverse chronological order based on the value
-  // of the `selectedAt` field. Since, according to designer's instructions,
+  // of the `addedAt` field. Since, according to designer's instructions,
   // if user adds multiple species at once, their lozenges should be displayed
   // in the same order species search matches were displayed,
   // the list of species is reversed in the code below
@@ -137,7 +137,7 @@ const prepareSelectedSpeciesForCommit = (
     is_reference: species.is_reference,
     type: species.type,
     isEnabled: true,
-    selectedAt: timestamp + index
+    addedAt: timestamp + index
   }));
 };
 

--- a/src/content/app/species-selector/state/speciesSelectorEpics.ts
+++ b/src/content/app/species-selector/state/speciesSelectorEpics.ts
@@ -145,6 +145,7 @@ const buildCommittedItemFromBriefGenomeSummary = (
       name: genome.assembly.name
     },
     release: genome.release,
-    isEnabled: true
+    isEnabled: true,
+    selectedAt: Date.now()
   };
 };

--- a/src/content/app/species-selector/state/speciesSelectorEpics.ts
+++ b/src/content/app/species-selector/state/speciesSelectorEpics.ts
@@ -146,6 +146,6 @@ const buildCommittedItemFromBriefGenomeSummary = (
     },
     release: genome.release,
     isEnabled: true,
-    selectedAt: Date.now()
+    addedAt: Date.now()
   };
 };

--- a/src/content/app/species-selector/types/committedItem.ts
+++ b/src/content/app/species-selector/types/committedItem.ts
@@ -33,4 +33,5 @@ export type CommittedItem = {
   };
   release: Release;
   isEnabled: boolean;
+  selectedAt: number;
 };

--- a/src/content/app/species-selector/types/committedItem.ts
+++ b/src/content/app/species-selector/types/committedItem.ts
@@ -33,5 +33,5 @@ export type CommittedItem = {
   };
   release: Release;
   isEnabled: boolean;
-  selectedAt: number;
+  addedAt: number;
 };

--- a/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelectorModal.tsx
+++ b/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelectorModal.tsx
@@ -52,7 +52,7 @@ const Content = (props: { onClose: () => void }) => {
     const preparedGenomes = genomes.map((genome) => ({
       ...genome,
       isEnabled: true,
-      selectedAt: Date.now()
+      addedAt: Date.now()
     }));
     dispatch(addSelectedSpecies(preparedGenomes));
     props.onClose();

--- a/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelectorModal.tsx
+++ b/src/content/app/tools/blast/components/blast-species-selector/BlastSpeciesSelectorModal.tsx
@@ -51,7 +51,8 @@ const Content = (props: { onClose: () => void }) => {
   const onSpeciesAdd = (genomes: SpeciesSearchMatch[]) => {
     const preparedGenomes = genomes.map((genome) => ({
       ...genome,
-      isEnabled: true
+      isEnabled: true,
+      selectedAt: Date.now()
     }));
     dispatch(addSelectedSpecies(preparedGenomes));
     props.onClose();

--- a/src/content/app/tools/blast/state/blast-form/blastFormSlice.ts
+++ b/src/content/app/tools/blast/state/blast-form/blastFormSlice.ts
@@ -38,7 +38,7 @@ type BlastFormSettings = {
   parameters: Partial<Record<BlastParameterName, string>>;
 };
 
-export type Species = CommittedItem;
+export type Species = Omit<CommittedItem, 'isEnabled' | 'selectedAt'>;
 
 export type BlastFormState = {
   step: 'sequences' | 'species'; // will only be relevant on smaller screens

--- a/src/content/app/tools/blast/state/blast-form/blastFormSlice.ts
+++ b/src/content/app/tools/blast/state/blast-form/blastFormSlice.ts
@@ -38,7 +38,7 @@ type BlastFormSettings = {
   parameters: Partial<Record<BlastParameterName, string>>;
 };
 
-export type Species = Omit<CommittedItem, 'isEnabled' | 'selectedAt'>;
+export type Species = Omit<CommittedItem, 'isEnabled' | 'addedAt'>;
 
 export type BlastFormState = {
   step: 'sequences' | 'species'; // will only be relevant on smaller screens

--- a/src/content/app/tools/vep/types/vepSubmission.ts
+++ b/src/content/app/tools/vep/types/vepSubmission.ts
@@ -16,7 +16,10 @@
 
 import type { CommittedItem } from 'src/content/app/species-selector/types/committedItem';
 
-export type VepSelectedSpecies = Omit<CommittedItem, 'isEnabled'>;
+export type VepSelectedSpecies = Omit<
+  CommittedItem,
+  'isEnabled' | 'selectedAt'
+>;
 
 export const clientSideSubmissionStatuses = [
   'NOT_SUBMITTED', // initial status of a submission while it is being prepared by the user

--- a/src/content/app/tools/vep/types/vepSubmission.ts
+++ b/src/content/app/tools/vep/types/vepSubmission.ts
@@ -16,10 +16,7 @@
 
 import type { CommittedItem } from 'src/content/app/species-selector/types/committedItem';
 
-export type VepSelectedSpecies = Omit<
-  CommittedItem,
-  'isEnabled' | 'selectedAt'
->;
+export type VepSelectedSpecies = Omit<CommittedItem, 'isEnabled' | 'addedAt'>;
 
 export const clientSideSubmissionStatuses = [
   'NOT_SUBMITTED', // initial status of a submission while it is being prepared by the user

--- a/src/services/indexeddb-migrations/dbUpdateScheduler.ts
+++ b/src/services/indexeddb-migrations/dbUpdateScheduler.ts
@@ -1,0 +1,49 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The purpose of IndexedDBUpdateScheduler is to queue and run
+ * asynchronous updates of IndexedDB (e.g. ones that require network requests).
+ *
+ * As Jake Archibald points out in the documentation for the idb library:
+ * An IndexedDB transaction auto-closes if it doesn't have anything left do
+ * once microtasks have been processed. Therefore, do not await other things
+ * between the start and end of your transaction, otherwise
+ * the transaction will close before you're done.
+ */
+
+export class IndexedDBUpdateScheduler {
+  #queue: Array<() => Promise<unknown>> = [];
+
+  addTask = (task: () => Promise<unknown>) => {
+    this.#queue.push(task);
+  };
+
+  runTasks = async (params?: { onComplete?: () => void }) => {
+    // if the queue contains tasks
+    // run the tasks sequentially,
+    // and run the onComplete function, if provided, when they finish
+    if (!this.#queue.length) {
+      return;
+    }
+
+    for (const task of this.#queue) {
+      await task();
+    }
+
+    params?.onComplete?.();
+  };
+}

--- a/src/services/indexeddb-migrations/speciesStoreMigrations.test.ts
+++ b/src/services/indexeddb-migrations/speciesStoreMigrations.test.ts
@@ -25,6 +25,7 @@ import times from 'lodash/times';
 import { SELECTED_SPECIES_STORE_NAME } from 'src/content/app/species-selector/services/speciesSelectorStorageConstants';
 
 import { migrateSpeciesStore } from 'src/services/indexeddb-migrations/speciesStoreMigrations';
+import { IndexedDBUpdateScheduler } from 'src/services/indexeddb-migrations/dbUpdateScheduler';
 import { createSelectedSpecies } from 'tests/fixtures/selected-species';
 
 const mockMetadataBaseApi = 'http://metadata-api';
@@ -64,12 +65,6 @@ beforeEach(() => {
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
-// Mock out window.location.reload
-Object.defineProperty(window, 'location', {
-  configurable: true,
-  value: { reload: jest.fn() }
-});
-
 describe('v6 -> v7 migration', () => {
   // During migration to version 7,
   // all stored species should receive a release field
@@ -106,7 +101,14 @@ describe('v6 -> v7 migration', () => {
     // Now run the db migration
     const newDb = await openDB('test-db', newVersion, {
       upgrade(db, oldVersion, __, transaction) {
-        migrateSpeciesStore({ db, oldVersion, transaction });
+        const asyncTaskScheduler = new IndexedDBUpdateScheduler();
+        migrateSpeciesStore({
+          db,
+          oldVersion,
+          transaction,
+          scheduler: asyncTaskScheduler
+        });
+        asyncTaskScheduler.runTasks();
       }
     });
 
@@ -151,7 +153,14 @@ describe('v6 -> v7 migration', () => {
     // Now run the db migration
     const newDb = await openDB('test-db', versionEight, {
       upgrade(db, oldVersion, __, transaction) {
-        migrateSpeciesStore({ db, oldVersion, transaction });
+        const asyncTaskScheduler = new IndexedDBUpdateScheduler();
+        migrateSpeciesStore({
+          db,
+          oldVersion,
+          transaction,
+          scheduler: asyncTaskScheduler
+        });
+        asyncTaskScheduler.runTasks();
       }
     });
 
@@ -161,6 +170,61 @@ describe('v6 -> v7 migration', () => {
       retrievedSpecies.every(
         (species) => species.release.name === newReleaseName
       )
+    ).toBe(true);
+  });
+});
+
+describe('v7 -> v8 migration', () => {
+  // During migration to version 8,
+  // all stored species should receive a selectedAt field,
+  // with a unique timestamp
+
+  test('a field with a timestamp is added to stored species', async () => {
+    const oldDbVersion = 7;
+    const newDbVersion = 8;
+
+    // Create a db using a version prior to when timestamps for saved species were introduced
+    const oldDb = await openDB('test-db', oldDbVersion, {
+      upgrade(db) {
+        db.createObjectStore(SELECTED_SPECIES_STORE_NAME);
+      }
+    });
+
+    const speciesList = times(3, () => {
+      const species = createSelectedSpecies() as any;
+      delete species['selectedAt'];
+      return species;
+    });
+
+    // Just making sure that species don't have the selectedAt field before saving
+    expect(
+      speciesList.every((species) => species.selectedAt === undefined)
+    ).toBe(true);
+
+    // Save the species into the database
+    for (const species of speciesList) {
+      await oldDb.put(SELECTED_SPECIES_STORE_NAME, species, species.genome_id);
+    }
+
+    oldDb.close();
+
+    // Now run the db migration
+    const newDb = await openDB('test-db', newDbVersion, {
+      upgrade(db, oldVersion, __, transaction) {
+        const asyncTaskScheduler = new IndexedDBUpdateScheduler();
+        migrateSpeciesStore({
+          db,
+          oldVersion,
+          transaction,
+          scheduler: asyncTaskScheduler
+        });
+        asyncTaskScheduler.runTasks();
+      }
+    });
+
+    const retrievedSpecies = await newDb.getAll(SELECTED_SPECIES_STORE_NAME);
+    expect(
+      retrievedSpecies.every((species) => species.selectedAt !== undefined)
     ).toBe(true);
   });
 });

--- a/src/services/indexeddb-migrations/speciesStoreMigrations.test.ts
+++ b/src/services/indexeddb-migrations/speciesStoreMigrations.test.ts
@@ -176,7 +176,7 @@ describe('v6 -> v7 migration', () => {
 
 describe('v7 -> v8 migration', () => {
   // During migration to version 8,
-  // all stored species should receive a selectedAt field,
+  // all stored species should receive an `addedAt` field,
   // with a unique timestamp
 
   test('a field with a timestamp is added to stored species', async () => {
@@ -192,14 +192,14 @@ describe('v7 -> v8 migration', () => {
 
     const speciesList = times(3, () => {
       const species = createSelectedSpecies() as any;
-      delete species['selectedAt'];
+      delete species['addedAt'];
       return species;
     });
 
-    // Just making sure that species don't have the selectedAt field before saving
-    expect(
-      speciesList.every((species) => species.selectedAt === undefined)
-    ).toBe(true);
+    // Just making sure that species don't have the addedAt field before saving
+    expect(speciesList.every((species) => species.addedAt === undefined)).toBe(
+      true
+    );
 
     // Save the species into the database
     for (const species of speciesList) {
@@ -224,7 +224,7 @@ describe('v7 -> v8 migration', () => {
 
     const retrievedSpecies = await newDb.getAll(SELECTED_SPECIES_STORE_NAME);
     expect(
-      retrievedSpecies.every((species) => species.selectedAt !== undefined)
+      retrievedSpecies.every((species) => species.addedAt !== undefined)
     ).toBe(true);
   });
 });

--- a/src/services/indexeddb-migrations/speciesStoreMigrations.ts
+++ b/src/services/indexeddb-migrations/speciesStoreMigrations.ts
@@ -113,7 +113,7 @@ const runSevenToEightMigration = async ({
   const timestamp = Date.now();
 
   allSpecies.forEach((species, index) => {
-    species.selectedAt = timestamp + index;
+    species.addedAt = timestamp + index;
   });
 
   for (const species of allSpecies) {

--- a/src/services/indexeddb-migrations/speciesStoreMigrations.ts
+++ b/src/services/indexeddb-migrations/speciesStoreMigrations.ts
@@ -22,18 +22,24 @@ import { SELECTED_SPECIES_STORE_NAME } from 'src/content/app/species-selector/se
 
 import type { CommittedItem } from 'src/content/app/species-selector/types/committedItem';
 import type { Release } from 'src/shared/types/release';
+import type { IndexedDBUpdateScheduler } from './dbUpdateScheduler';
 
-export const migrateSpeciesStore = async ({
+export const migrateSpeciesStore = ({
   db,
   oldVersion,
-  transaction
+  transaction,
+  scheduler
 }: {
   db: IDBPDatabase;
   oldVersion: number;
   transaction: IDBPTransaction<unknown, string[], 'versionchange'>;
+  scheduler: IndexedDBUpdateScheduler;
 }) => {
   if (oldVersion <= 6) {
-    await runSixToSevenMigration({ db, transaction });
+    scheduler.addTask(() => runSixToSevenMigration({ db, transaction }));
+  }
+  if (oldVersion <= 7) {
+    runSevenToEightMigration({ transaction });
   }
 };
 
@@ -90,7 +96,27 @@ const runSixToSevenMigration = async ({
       await db.delete(SELECTED_SPECIES_STORE_NAME, species.genome_id);
     }
   }
+};
 
-  // To pick up the new data and avoid client-side errors, reload the window
-  window.location.reload();
+// Species saved to indexedDB before version 8 do not the timestamp
+// recording when they were added (selected) by the user.
+// This timestamp is used to ensure a stable sorting order of selected species lozenges.
+// During the migration, add a unique now-ish timestamp to each of the stored species.
+const runSevenToEightMigration = async ({
+  transaction
+}: {
+  transaction: IDBPTransaction<unknown, string[], 'versionchange'>;
+}) => {
+  const speciesStore = transaction.objectStore(SELECTED_SPECIES_STORE_NAME);
+  const allSpecies: CommittedItem[] = await speciesStore.getAll();
+
+  const timestamp = Date.now();
+
+  allSpecies.forEach((species, index) => {
+    species.selectedAt = timestamp + index;
+  });
+
+  for (const species of allSpecies) {
+    await speciesStore.put(species, species.genome_id);
+  }
 };

--- a/src/services/indexeddb-service.ts
+++ b/src/services/indexeddb-service.ts
@@ -25,16 +25,20 @@ import { VEP_SUBMISSIONS_STORE_NAME } from 'src/content/app/tools/vep/services/v
 import { PREVIOUSLY_VIEWED_OBJECTS_STORE_NAME } from 'src/shared/services/previouslyViewedObjectsStorageConstants';
 import { NOTIFICATIONS_STORE_NAME } from 'src/shared/services/notificationsStorageConstants';
 
+import { IndexedDBUpdateScheduler } from './indexeddb-migrations/dbUpdateScheduler';
+
 import { migrateSpeciesStore } from './indexeddb-migrations/speciesStoreMigrations';
 
 const DB_NAME = 'ensembl-website';
-const DB_VERSION = 7;
+const DB_VERSION = 8;
 
 const getDbPromise = (params?: {
   onBlocking?: OpenDBCallbacks<unknown>['blocking'];
 }) => {
   return openDB(DB_NAME, DB_VERSION, {
     upgrade(db, oldVersion, _, transaction) {
+      const asyncTaskScheduler = new IndexedDBUpdateScheduler();
+
       // FIXME use constants for object store names
       if (!db.objectStoreNames.contains('contact-forms')) {
         db.createObjectStore('contact-forms');
@@ -45,7 +49,12 @@ const getDbPromise = (params?: {
       if (!db.objectStoreNames.contains(SELECTED_SPECIES_STORE_NAME)) {
         db.createObjectStore(SELECTED_SPECIES_STORE_NAME);
       } else {
-        migrateSpeciesStore({ db, oldVersion, transaction });
+        migrateSpeciesStore({
+          db,
+          oldVersion,
+          transaction,
+          scheduler: asyncTaskScheduler
+        });
       }
       if (!db.objectStoreNames.contains(BLAST_SUBMISSIONS_STORE_NAME)) {
         db.createObjectStore(BLAST_SUBMISSIONS_STORE_NAME);
@@ -76,6 +85,13 @@ const getDbPromise = (params?: {
           unique: false
         });
       }
+
+      asyncTaskScheduler.runTasks({
+        onComplete: () => {
+          // To pick up the new data and avoid client-side errors, do a full-page reload
+          window.location.reload();
+        }
+      });
     },
     blocking(...args) {
       params?.onBlocking?.(...args);

--- a/src/shared/components/species-name/fixtures/speciesTestData.ts
+++ b/src/shared/components/species-name/fixtures/speciesTestData.ts
@@ -36,5 +36,5 @@ export const humanGenome = {
   },
   genome_tag: 'grch38',
   isEnabled: true,
-  selectedAt: Date.now()
+  addedAt: Date.now()
 } satisfies CommittedItem;

--- a/src/shared/components/species-name/fixtures/speciesTestData.ts
+++ b/src/shared/components/species-name/fixtures/speciesTestData.ts
@@ -35,5 +35,6 @@ export const humanGenome = {
     type: 'partial'
   },
   genome_tag: 'grch38',
-  isEnabled: true
+  isEnabled: true,
+  selectedAt: Date.now()
 } satisfies CommittedItem;

--- a/stories/shared-components/species-tabs-slider/speciesData.ts
+++ b/stories/shared-components/species-tabs-slider/speciesData.ts
@@ -34,7 +34,7 @@ export default [
     type: null,
     is_reference: true,
     isEnabled: true,
-    selectedAt: Date.now()
+    addedAt: Date.now()
   },
   {
     genome_id: 'homo_sapiens37',
@@ -53,7 +53,7 @@ export default [
     type: null,
     is_reference: false,
     isEnabled: true,
-    selectedAt: Date.now()
+    addedAt: Date.now()
   },
   {
     genome_id: 'bifidobacterium_longum_subsp_longum_cect_7347',
@@ -72,7 +72,7 @@ export default [
     type: null,
     is_reference: false,
     isEnabled: true,
-    selectedAt: Date.now()
+    addedAt: Date.now()
   },
   {
     genome_id: 'arabidopsis_thaliana',
@@ -91,7 +91,7 @@ export default [
     type: null,
     is_reference: false,
     isEnabled: true,
-    selectedAt: Date.now()
+    addedAt: Date.now()
   },
   {
     genome_id: 'drosophila_melanogaster',
@@ -110,7 +110,7 @@ export default [
     type: null,
     is_reference: true,
     isEnabled: true,
-    selectedAt: Date.now()
+    addedAt: Date.now()
   },
   {
     genome_id: 'drosophila_yakuba',
@@ -129,7 +129,7 @@ export default [
     type: null,
     is_reference: false,
     isEnabled: true,
-    selectedAt: Date.now()
+    addedAt: Date.now()
   },
   {
     genome_id: 'caenorhabditis_elegans',
@@ -148,7 +148,7 @@ export default [
     type: null,
     is_reference: true,
     isEnabled: true,
-    selectedAt: Date.now()
+    addedAt: Date.now()
   },
   {
     genome_id: 'mus_musculus',
@@ -167,7 +167,7 @@ export default [
     type: null,
     is_reference: true,
     isEnabled: true,
-    selectedAt: Date.now()
+    addedAt: Date.now()
   },
   {
     genome_id: 'canis_lupus_familiaris',
@@ -186,7 +186,7 @@ export default [
     type: null,
     is_reference: true,
     isEnabled: true,
-    selectedAt: Date.now()
+    addedAt: Date.now()
   },
   {
     genome_id: 'zea_mays',
@@ -205,7 +205,7 @@ export default [
     type: null,
     is_reference: true,
     isEnabled: true,
-    selectedAt: Date.now()
+    addedAt: Date.now()
   },
   {
     genome_id: 'escherichia_coli',
@@ -224,6 +224,6 @@ export default [
     type: null,
     is_reference: true,
     isEnabled: true,
-    selectedAt: Date.now()
+    addedAt: Date.now()
   }
 ] satisfies CommittedItem[];

--- a/stories/shared-components/species-tabs-slider/speciesData.ts
+++ b/stories/shared-components/species-tabs-slider/speciesData.ts
@@ -33,7 +33,8 @@ export default [
     },
     type: null,
     is_reference: true,
-    isEnabled: true
+    isEnabled: true,
+    selectedAt: Date.now()
   },
   {
     genome_id: 'homo_sapiens37',
@@ -51,7 +52,8 @@ export default [
     },
     type: null,
     is_reference: false,
-    isEnabled: true
+    isEnabled: true,
+    selectedAt: Date.now()
   },
   {
     genome_id: 'bifidobacterium_longum_subsp_longum_cect_7347',
@@ -69,7 +71,8 @@ export default [
     },
     type: null,
     is_reference: false,
-    isEnabled: true
+    isEnabled: true,
+    selectedAt: Date.now()
   },
   {
     genome_id: 'arabidopsis_thaliana',
@@ -87,7 +90,8 @@ export default [
     },
     type: null,
     is_reference: false,
-    isEnabled: true
+    isEnabled: true,
+    selectedAt: Date.now()
   },
   {
     genome_id: 'drosophila_melanogaster',
@@ -105,7 +109,8 @@ export default [
     },
     type: null,
     is_reference: true,
-    isEnabled: true
+    isEnabled: true,
+    selectedAt: Date.now()
   },
   {
     genome_id: 'drosophila_yakuba',
@@ -123,7 +128,8 @@ export default [
     },
     type: null,
     is_reference: false,
-    isEnabled: true
+    isEnabled: true,
+    selectedAt: Date.now()
   },
   {
     genome_id: 'caenorhabditis_elegans',
@@ -141,7 +147,8 @@ export default [
     },
     type: null,
     is_reference: true,
-    isEnabled: true
+    isEnabled: true,
+    selectedAt: Date.now()
   },
   {
     genome_id: 'mus_musculus',
@@ -159,7 +166,8 @@ export default [
     },
     type: null,
     is_reference: true,
-    isEnabled: true
+    isEnabled: true,
+    selectedAt: Date.now()
   },
   {
     genome_id: 'canis_lupus_familiaris',
@@ -177,7 +185,8 @@ export default [
     },
     type: null,
     is_reference: true,
-    isEnabled: true
+    isEnabled: true,
+    selectedAt: Date.now()
   },
   {
     genome_id: 'zea_mays',
@@ -195,7 +204,8 @@ export default [
     },
     type: null,
     is_reference: true,
-    isEnabled: true
+    isEnabled: true,
+    selectedAt: Date.now()
   },
   {
     genome_id: 'escherichia_coli',
@@ -213,6 +223,7 @@ export default [
     },
     type: null,
     is_reference: true,
-    isEnabled: true
+    isEnabled: true,
+    selectedAt: Date.now()
   }
 ] satisfies CommittedItem[];

--- a/tests/fixtures/selected-species.ts
+++ b/tests/fixtures/selected-species.ts
@@ -37,5 +37,6 @@ export const createSelectedSpecies = (
     type: 'integrated'
   },
   isEnabled: true,
+  selectedAt: Date.now(),
   ...fragment
 });

--- a/tests/fixtures/selected-species.ts
+++ b/tests/fixtures/selected-species.ts
@@ -37,6 +37,6 @@ export const createSelectedSpecies = (
     type: 'integrated'
   },
   isEnabled: true,
-  selectedAt: Date.now(),
+  addedAt: Date.now(),
   ...fragment
 });


### PR DESCRIPTION
## Description
**Problem:** After a page refresh, species lozenges often appear in an order that is different from the one they were displayed in right after the selection. Here's an example of this wrong behaviour:

https://github.com/user-attachments/assets/2d7da3fb-5047-46e3-80cb-26fa893f37f2

**Cause:** What causes this problem is that when selected genomes are saved to indexedDB, they are stored as key-value pairs (key being the genome uuid, and value being the actual selected genome data); and it looks like when they are read back from the db, the db returns them in the alphabetical order of the keys rather than in the order in which they were added to the db.

### Changes made in this PR

This PR adds a timestamp to the genomes (the `addedAt` field) before saving them to the db. When multiple genomes are selected at once, their array is first reversed before the timestamps are added — to pretend that the topmost species search match was selected the latest. This is to conform with the desired behaviour described by Andrea:

> if a user adds a single genome, that will appear to the left of the lozenges
> if a user selects multiple from one species (ie x6 human) then these should be added as a block to the left of existing lozenges, a block of genomes would be added as they appeared in the list - so the highest in the list would be left most, the next to the right (and so on), the lowest to the right of that (them)

### Other changes
- Since the shape of stored species objects is changing (a new `addedAt` field is added), indexedDb version will be bumped from 7 to 8. A database migration has been created.
- Some refactoring was done to the earlier db migration code, to extract the code that, due to its asynchronous nature, cannot run within a db version change transaction.

Results after the changes:

https://github.com/user-attachments/assets/fc206225-a2c8-465f-ac7a-2973ab5307cf


## Deployment URL(s)
http://selected-species-order.review.ensembl.org
