### PR TITLE
Activity viewer

### DIFF
--- a/src/content/app/regulatory-activity-viewer/RegulatoryActivityViewer.tsx
+++ b/src/content/app/regulatory-activity-viewer/RegulatoryActivityViewer.tsx
@@ -38,6 +38,7 @@ import ActivityViewerEpigenomesContextProvider from 'src/content/app/regulatory-
 import { StandardAppLayout } from 'src/shared/components/layout';
 import ActivityViewerAppBar from './components/activity-viewer-app-bar/ActivityViewerAppBar';
 import ActivityViewerTopBar from './components/activity-viewer-top-bar/ActivityViewerTopBar';
+import ActivityViewerSidebarToolstrip from './components/activity-viewer-sidebar-toolstrip/ActivityViewerSidebarToolstrip';
 import ActivityViewerInterstitial from './components/activity-viewer-interstitial/ActivityViewerInterstitial';
 import NoActivityData from './components/no-activity-data/NoActivityData';
 import RegionOverview from './components/region-overview/RegionOverview';
@@ -123,6 +124,7 @@ const ActivityViewer = () => {
         isSidebarOpen={isSidebarOpen}
         topbarContent={<ActivityViewerTopBar />}
         sidebarNavigation={<SidebarNavigation genomeId={genomeId ?? null} />}
+        sidebarToolstripContent={<ActivityViewerSidebarToolstrip />}
         onSidebarToggle={toggleSidebar}
         viewportWidth={1800}
       />
@@ -130,13 +132,11 @@ const ActivityViewer = () => {
   );
 };
 
-const MainContent = ({ genomeId }: { genomeId: string | null }) => {
+const MainContent = memo(({ genomeId }: { genomeId: string | null }) => {
   if (!genomeId) {
     // this will be an interstitial in the future
     return null;
   }
-
-  /* <ActivityViewerFocusFeatureInfo /> */
 
   return (
     <div className={styles.mainContentContainer}>
@@ -158,7 +158,7 @@ const MainContent = ({ genomeId }: { genomeId: string | null }) => {
       <div style={{ margin: '4rem 0' }} />
     </div>
   );
-};
+});
 
 const MainContentBottom = ({ genomeId }: { genomeId: string }) => {
   const activeView = useAppSelector((state) =>

--- a/src/content/app/regulatory-activity-viewer/RegulatoryActivityViewer.tsx
+++ b/src/content/app/regulatory-activity-viewer/RegulatoryActivityViewer.tsx
@@ -150,7 +150,7 @@ const MainContent = ({ genomeId }: { genomeId: string | null }) => {
         <RegionOverview />
         {/* The spacer divs below are temporary */}
         <div style={{ margin: '0.6rem 0' }} />
-        <MainContentBottomViewControls genomeId={genomeId} />
+        <MainContentBottomViewControls />
       </div>
       <div style={{ margin: '0.6rem 0' }} />
       <MainContentBottom genomeId={genomeId} />

--- a/src/content/app/regulatory-activity-viewer/RegulatoryActivityViewer.tsx
+++ b/src/content/app/regulatory-activity-viewer/RegulatoryActivityViewer.tsx
@@ -37,9 +37,9 @@ import {
 import ActivityViewerEpigenomesContextProvider from 'src/content/app/regulatory-activity-viewer/contexts/ActivityViewerEpigenomesContextProvider';
 import { StandardAppLayout } from 'src/shared/components/layout';
 import ActivityViewerAppBar from './components/activity-viewer-app-bar/ActivityViewerAppBar';
+import ActivityViewerTopBar from './components/activity-viewer-top-bar/ActivityViewerTopBar';
 import ActivityViewerInterstitial from './components/activity-viewer-interstitial/ActivityViewerInterstitial';
 import NoActivityData from './components/no-activity-data/NoActivityData';
-import ActivityViewerFocusFeatureInfo from 'src/content/app/regulatory-activity-viewer/components/activity-viewer-focus-feature-info/ActivityViewerFocusFeatureInfo';
 import RegionOverview from './components/region-overview/RegionOverview';
 import RegionActivitySection from './components/region-activity-section/RegionActivitySection';
 import ActivityViewerSidebar from './components/activity-viewer-sidebar/ActivityViewerSidebar';
@@ -121,7 +121,7 @@ const ActivityViewer = () => {
         mainContent={<MainContent genomeId={genomeId ?? null} />}
         sidebarContent={<ActivityViewerSidebar genomeId={genomeId ?? null} />}
         isSidebarOpen={isSidebarOpen}
-        topbarContent={<div />}
+        topbarContent={<ActivityViewerTopBar />}
         sidebarNavigation={<SidebarNavigation genomeId={genomeId ?? null} />}
         onSidebarToggle={toggleSidebar}
         viewportWidth={1800}
@@ -136,6 +136,8 @@ const MainContent = ({ genomeId }: { genomeId: string | null }) => {
     return null;
   }
 
+  /* <ActivityViewerFocusFeatureInfo /> */
+
   return (
     <div className={styles.mainContentContainer}>
       <div
@@ -146,7 +148,6 @@ const MainContent = ({ genomeId }: { genomeId: string | null }) => {
           zIndex: 1
         }}
       >
-        <ActivityViewerFocusFeatureInfo />
         <RegionOverview />
         {/* The spacer divs below are temporary */}
         <div style={{ margin: '0.6rem 0' }} />

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-actions-selector/ActivityViewerActionsSelector.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-actions-selector/ActivityViewerActionsSelector.tsx
@@ -91,7 +91,7 @@ const ActivityViewerActionSelector = () => {
     <div className={styles.selectContainer}>
       <SimpleSelect
         options={options}
-        placeholder="Actions"
+        placeholder="Manage data display"
         defaultValue=""
         onChange={onActionSelected}
         disabled={action !== null}

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-focus-feature-info/ActivityViewerFocusFeatureInfo.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-focus-feature-info/ActivityViewerFocusFeatureInfo.module.css
@@ -1,12 +1,7 @@
-.container {
-  min-height: 40px;
-}
-
-.grid {
-  display: grid;
-  /* grid columns are the same across activity viewer app */
-  grid-template-columns: [left] 150px [middle] 1fr [right] 150px;
-  padding: 16px 0;
+.feature {
+  display: flex;
+  align-items: center;
+  column-gap: 20px;
 }
 
 .leftColumn {
@@ -22,20 +17,20 @@
   row-gap: 2px;
 }
 
+.labelledElement {
+  display: flex;
+  column-gap: 0.7ch;
+  align-items: baseline;
+}
+
 .geneName {
   display: inline-flex;
   align-items: baseline;
   column-gap: 10px;
 }
 
-.geneFullName {
-  display: inline-flex;
-  align-items: baseline;
-  column-gap: 10px;
-}
-
 .smallLight {
-  font-size: 11px;
+  font-size: 12px;
   font-weight: var(--font-weight-light);
 }
 

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-focus-feature-info/ActivityViewerFocusFeatureInfo.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-focus-feature-info/ActivityViewerFocusFeatureInfo.tsx
@@ -21,24 +21,19 @@ import useActivityViewerIds from 'src/content/app/regulatory-activity-viewer/hoo
 import { useFocusGeneQuery } from 'src/content/app/regulatory-activity-viewer/state/api/activityViewerApiSlice';
 
 import GeneName from 'src/shared/components/gene-name/GeneName';
-import ExternalLink from 'src/shared/components/external-link/ExternalLink';
 
 import styles from './ActivityViewerFocusFeatureInfo.module.css';
 
 const ActivityViewerFocusFeatureInfo = () => {
   const { assemblyAccessionId, focusGeneId, location } = useActivityViewerIds();
 
-  return (
-    <div className={styles.container}>
-      {assemblyAccessionId && location && focusGeneId && (
-        <ActivityViewerFocusGene
-          assemblyId={assemblyAccessionId}
-          geneId={focusGeneId}
-          regionName={location.regionName}
-        />
-      )}
-    </div>
-  );
+  return assemblyAccessionId && location && focusGeneId ? (
+    <ActivityViewerFocusGene
+      assemblyId={assemblyAccessionId}
+      geneId={focusGeneId}
+      regionName={location.regionName}
+    />
+  ) : null;
 };
 
 const ActivityViewerFocusGene = ({
@@ -60,53 +55,23 @@ const ActivityViewerFocusGene = ({
   }
 
   return (
-    <div className={styles.grid}>
-      <div className={styles.leftColumn}>Gene</div>
-      <div className={styles.mainColumn}>
+    <div className={styles.feature}>
+      <span className={styles.labelledElement}>
+        <span className={styles.smallLight}>Gene</span>
         <GeneName symbol={gene.symbol} stable_id={gene.stable_id} />
-        <GeneBiotype biotype={gene.biotype} />
-        <FullLocation
-          regionName={regionName}
-          start={gene.start}
-          end={gene.end}
-          strand={gene.strand}
-        />
-        {gene.name && (
-          <GeneFullName
-            name={gene.name.value}
-            accessionId={gene.name.accession_id}
-            url={gene.name.url}
-          />
-        )}
-      </div>
+      </span>
+      <GeneBiotype biotype={gene.biotype} />
+      <span>{getStrandDisplayName(gene.strand)}</span>
+      <FullLocation regionName={regionName} start={gene.start} end={gene.end} />
     </div>
   );
 };
 
 const GeneBiotype = ({ biotype }: { biotype: string }) => {
   return (
-    <span className={styles.geneBiotype}>
+    <span className={styles.labelledElement}>
       <span className={styles.smallLight}>Biotype</span>
       <span>{biotype}</span>
-    </span>
-  );
-};
-
-const GeneFullName = ({
-  name,
-  accessionId,
-  url
-}: {
-  name: string;
-  accessionId?: string;
-  url?: string;
-}) => {
-  return (
-    <span className={styles.geneFullName}>
-      <span>{name}</span>
-      {accessionId && url && (
-        <ExternalLink to={url}>{accessionId}</ExternalLink>
-      )}
     </span>
   );
 };
@@ -114,13 +79,11 @@ const GeneFullName = ({
 const FullLocation = ({
   regionName,
   start,
-  end,
-  strand
+  end
 }: {
   regionName: string;
   start: number;
   end: number;
-  strand: 'forward' | 'reverse';
 }) => {
   const formattedLocationString = getFormattedLocation({
     chromosome: regionName,
@@ -131,7 +94,6 @@ const FullLocation = ({
   return (
     <span className={styles.fullLocation}>
       <span>{formattedLocationString}</span>
-      <span className={styles.smallLight}>{getStrandDisplayName(strand)}</span>
     </span>
   );
 };

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-middle-column-loader/ActivityViewerMiddleColumnLoader.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-middle-column-loader/ActivityViewerMiddleColumnLoader.module.css
@@ -1,0 +1,8 @@
+.container {
+  border: 1px dashed var(--color-dark-grey);
+  border-radius: 6px;
+  padding-top: 40px;
+  min-height: 200px;
+  display: flex;
+  justify-content: center;
+}

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-middle-column-loader/ActivityViewerMiddleColumnLoader.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-middle-column-loader/ActivityViewerMiddleColumnLoader.tsx
@@ -1,0 +1,29 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CircleLoader } from 'src/shared/components/loader';
+
+import styles from './ActivityViewerMiddleColumnLoader.module.css';
+
+const ActivityViewerMiddleColumnLoader = () => {
+  return (
+    <div className={styles.container}>
+      <CircleLoader />
+    </div>
+  );
+};
+
+export default ActivityViewerMiddleColumnLoader;

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar-toolstrip/ActivityViewerSidebarToolstrip.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar-toolstrip/ActivityViewerSidebarToolstrip.tsx
@@ -1,0 +1,59 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ImageButton from 'src/shared/components/image-button/ImageButton';
+
+import SearchIcon from 'static/icons/icon_search.svg';
+import BookmarkIcon from 'static/icons/icon_bookmark.svg';
+import ShareIcon from 'static/icons/icon_share.svg';
+import DownloadIcon from 'static/icons/icon_download.svg';
+
+import { Status } from 'src/shared/types/status';
+
+import styles from 'src/shared/components/layout/StandardAppLayout.module.css';
+
+const ActivityViewerSidebarToolstrip = () => {
+  return (
+    <>
+      <ImageButton
+        status={Status.DISABLED}
+        description="Search"
+        className={styles.sidebarIcon}
+        image={SearchIcon}
+      />
+      <ImageButton
+        status={Status.DISABLED}
+        description="Previously viewed"
+        className={styles.sidebarIcon}
+        image={BookmarkIcon}
+      />
+      <ImageButton
+        status={Status.DISABLED}
+        description="Share"
+        className={styles.sidebarIcon}
+        image={ShareIcon}
+      />
+      <ImageButton
+        status={Status.DISABLED}
+        description="Download"
+        className={styles.sidebarIcon}
+        image={DownloadIcon}
+      />
+    </>
+  );
+};
+
+export default ActivityViewerSidebarToolstrip;

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar/activity-tracks-legend/ActivityTracksLegend.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar/activity-tracks-legend/ActivityTracksLegend.module.css
@@ -1,0 +1,23 @@
+.row {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 10px;
+  align-items: center;
+}
+
+.openChromatinPeak {
+  width: 10px;
+  height: 10px;
+  border: 1px solid var(--color-black);
+}
+
+.openChromatinSignal {
+  width: 10px;
+  height: 10px;
+  background: linear-gradient(to right, var(--color-medium-light-grey), var(--color-medium-dark-grey), var(--color-dark-grey), var(--color-medium-light-grey));
+}
+
+.histone {
+  width: 10px;
+  height: 2px;
+}

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar/activity-tracks-legend/ActivityTracksLegend.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar/activity-tracks-legend/ActivityTracksLegend.tsx
@@ -1,0 +1,65 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useAppSelector } from 'src/store';
+
+import { getHistones } from 'src/content/app/regulatory-activity-viewer/state/ui/uiSelectors';
+
+import styles from './ActivityTracksLegend.module.css';
+
+type Props = {
+  genomeId: string;
+};
+
+const ActivityTracksLegend = ({ genomeId }: Props) => {
+  const histones = useAppSelector((state) => getHistones(state, genomeId));
+
+  return (
+    <div>
+      <div className={styles.row}>
+        <span className={styles.openChromatinPeak} />
+        <span>Open chromatin: Peak</span>
+      </div>
+      <div className={styles.row}>
+        <span className={styles.openChromatinSignal} />
+        <span>Open chromatin: Signal</span>
+      </div>
+      {histones.map((histoneMetadata) => (
+        <HistoneLegendElement
+          key={histoneMetadata.label}
+          {...histoneMetadata}
+        />
+      ))}
+    </div>
+  );
+};
+
+const HistoneLegendElement = ({
+  label,
+  color
+}: {
+  label: string;
+  color: string;
+}) => {
+  return (
+    <div className={styles.row}>
+      <span className={styles.histone} style={{ backgroundColor: color }} />
+      <span>{label}</span>
+    </div>
+  );
+};
+
+export default ActivityTracksLegend;

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar/epigenome-filters-view/EpigenomeFiltersView.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar/epigenome-filters-view/EpigenomeFiltersView.module.css
@@ -2,7 +2,6 @@
   display: grid;
   grid-template-columns: 1fr auto;
   align-items: start;
-  padding: 0 20px;
 }
 
 .epigenomeFilter + .epigenomeFilter {

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar/sidebar-default-view/SidebarDefaultView.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar/sidebar-default-view/SidebarDefaultView.module.css
@@ -1,3 +1,11 @@
+.features {
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  font-size: 12px;
+  row-gap: 8px;
+}
+
 .activeFeature {
   --text-button-disabled-color: var(--color-black);
 }

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar/sidebar-default-view/SidebarDefaultView.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar/sidebar-default-view/SidebarDefaultView.tsx
@@ -35,6 +35,7 @@ import {
   CollapsibleSectionHead,
   CollapsibleSectionBody
 } from 'src/shared/components/collapsible-section/CollapsibleSection';
+import ActivityTracksLegend from '../activity-tracks-legend/ActivityTracksLegend';
 
 import type { GeneInRegionOverview } from 'src/content/app/regulatory-activity-viewer/types/regionOverview';
 
@@ -42,6 +43,7 @@ import styles from './SidebarDefaultView.module.css';
 
 const SidebarDefaultView = () => {
   const {
+    genomeId,
     assemblyAccessionId,
     location,
     genomeIdForUrl,
@@ -124,6 +126,12 @@ const SidebarDefaultView = () => {
           />
         </CollapsibleSectionBody>
       </CollapsibleSection>
+      <CollapsibleSection>
+        <CollapsibleSectionHead>Epigenome tracks</CollapsibleSectionHead>
+        <CollapsibleSectionBody>
+          {genomeId && <ActivityTracksLegend genomeId={genomeId} />}
+        </CollapsibleSectionBody>
+      </CollapsibleSection>
     </div>
   );
 };
@@ -152,7 +160,7 @@ const Genes = ({
     );
   });
 
-  return <div>{geneElements}</div>;
+  return <div className={styles.features}>{geneElements}</div>;
 };
 
 const SliceTooLargeNotice = () => {

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar/sidebar-default-view/SidebarDefaultView.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-sidebar/sidebar-default-view/SidebarDefaultView.tsx
@@ -30,11 +30,13 @@ import useRegionOverviewData from 'src/content/app/regulatory-activity-viewer/se
 import GeneName from 'src/shared/components/gene-name/GeneName';
 import TextButton from 'src/shared/components/text-button/TextButton';
 import RegulatoryFeatureLegend from '../regulatory-feature-legend/RegulatoryFeatureLegend';
+import {
+  CollapsibleSection,
+  CollapsibleSectionHead,
+  CollapsibleSectionBody
+} from 'src/shared/components/collapsible-section/CollapsibleSection';
 
-import type {
-  OverviewRegion,
-  GeneInRegionOverview
-} from 'src/content/app/regulatory-activity-viewer/types/regionOverview';
+import type { GeneInRegionOverview } from 'src/content/app/regulatory-activity-viewer/types/regionOverview';
 
 import styles from './SidebarDefaultView.module.css';
 
@@ -103,15 +105,25 @@ const SidebarDefaultView = () => {
       {isSliceTooLarge ? (
         <SliceTooLargeNotice />
       ) : (
-        <Genes
-          genes={data.genes}
-          onGeneFocus={onGeneFocus}
-          focusGeneId={focusGeneId}
-        />
+        <CollapsibleSection>
+          <CollapsibleSectionHead>Genes</CollapsibleSectionHead>
+          <CollapsibleSectionBody>
+            <Genes
+              genes={data.genes}
+              onGeneFocus={onGeneFocus}
+              focusGeneId={focusGeneId}
+            />
+          </CollapsibleSectionBody>
+        </CollapsibleSection>
       )}
-      <RegulatoryFeatureLegendSection
-        featureTypes={data.regulatory_features.feature_types}
-      />
+      <CollapsibleSection>
+        <CollapsibleSectionHead>Regulatory features</CollapsibleSectionHead>
+        <CollapsibleSectionBody>
+          <RegulatoryFeatureLegend
+            featureTypes={data.regulatory_features.feature_types}
+          />
+        </CollapsibleSectionBody>
+      </CollapsibleSection>
     </div>
   );
 };
@@ -129,37 +141,18 @@ const Genes = ({
     const isFocusGene = gene.unversioned_stable_id === focusGeneId;
 
     return (
-      <div key={gene.stable_id}>
-        <TextButton
-          onClick={() => onGeneFocus(gene)}
-          disabled={isFocusGene}
-          className={isFocusGene ? styles.activeFeature : undefined}
-        >
-          <GeneName symbol={gene.symbol} stable_id={gene.stable_id} />
-        </TextButton>
-      </div>
+      <TextButton
+        key={gene.stable_id}
+        onClick={() => onGeneFocus(gene)}
+        disabled={isFocusGene}
+        className={isFocusGene ? styles.activeFeature : undefined}
+      >
+        <GeneName symbol={gene.symbol} stable_id={gene.stable_id} />
+      </TextButton>
     );
   });
 
-  // TODO: change this into an accordion
-  return (
-    <div>
-      <div style={{ fontWeight: 'bold' }}>Genes</div>
-      {geneElements}
-    </div>
-  );
-};
-
-const RegulatoryFeatureLegendSection = (props: {
-  featureTypes: OverviewRegion['regulatory_features']['feature_types'];
-}) => {
-  // TODO: change this into an accordion
-  return (
-    <div style={{ marginTop: '1.5rem' }}>
-      <div style={{ fontWeight: 'bold' }}>Regulatory features</div>
-      <RegulatoryFeatureLegend featureTypes={props.featureTypes} />
-    </div>
-  );
+  return <div>{geneElements}</div>;
 };
 
 const SliceTooLargeNotice = () => {

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-top-bar/ActivityViewerTopBar.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-top-bar/ActivityViewerTopBar.module.css
@@ -1,0 +1,10 @@
+.grid {
+  display: grid;
+  grid-template-columns: 150px 1fr; /* left column similar to */
+}
+
+.title {
+  font-size: 15px;
+  font-weight: var(--font-weight-bold);
+  justify-self: center;
+}

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-top-bar/ActivityViewerTopBar.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-top-bar/ActivityViewerTopBar.tsx
@@ -1,0 +1,30 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ActivityViewerFocusFeatureInfo from 'src/content/app/regulatory-activity-viewer/components/activity-viewer-focus-feature-info/ActivityViewerFocusFeatureInfo';
+
+import styles from './ActivityViewerTopBar.module.css';
+
+const ActivityViewerTopBar = () => {
+  return (
+    <div className={styles.grid}>
+      <div className={styles.title}>Regulation</div>
+      <ActivityViewerFocusFeatureInfo />
+    </div>
+  );
+};
+
+export default ActivityViewerTopBar;

--- a/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/EpigenomesActivityContainer.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/EpigenomesActivityContainer.module.css
@@ -6,3 +6,15 @@
   min-height: 100%; /* FIXME: shouldn't need this */
   overflow: hidden;
 }
+
+.loaderContainer {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  background-color: white;
+  display: flex;
+  justify-content: center;
+  padding-top: 40px;
+}

--- a/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/EpigenomesActivityContainer.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/EpigenomesActivityContainer.module.css
@@ -1,0 +1,8 @@
+.container {
+  border: 1px dashed var(--color-dark-grey);
+  border-radius: 6px;
+  padding-top: 40px;
+  position: relative;
+  min-height: 100%; /* FIXME: shouldn't need this */
+  overflow: hidden;
+}

--- a/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/EpigenomesActivityImage.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/EpigenomesActivityImage.tsx
@@ -35,7 +35,7 @@ import type {
   TrackDataForDisplay
 } from 'src/content/app/regulatory-activity-viewer/components/epigenomes-activity/prepareActivityDataForDisplay';
 
-type Props = {
+export type Props = {
   data: EpigenomicActivityForDisplay;
   scale: ScaleLinear<number, number>;
   width: number;

--- a/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/EpigenomesActivityImageContainer.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/EpigenomesActivityImageContainer.tsx
@@ -1,0 +1,40 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import EpigenomesTable from '../epigenomes-activity/epigenomes-table/EpigenomesTable';
+import EpigenomeActivityImage, {
+  type Props as EpigenomeActivityImageProps
+} from 'src/content/app/regulatory-activity-viewer/components/epigenomes-activity/EpigenomesActivityImage';
+
+import styles from './EpigenomesActivityContainer.module.css';
+
+/**
+ * Container for the epigenomes activity image,
+ * and the epigenomes table
+ */
+
+const EpigenomesActivityImageContainer = (
+  props: EpigenomeActivityImageProps
+) => {
+  return (
+    <div className={styles.container}>
+      <EpigenomesTable />
+      <EpigenomeActivityImage {...props} />
+    </div>
+  );
+};
+
+export default EpigenomesActivityImageContainer;

--- a/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/EpigenomesActivityImageContainer.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/EpigenomesActivityImageContainer.tsx
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { memo } from 'react';
+
 import EpigenomesTable from '../epigenomes-activity/epigenomes-table/EpigenomesTable';
 import EpigenomeActivityImage, {
   type Props as EpigenomeActivityImageProps
@@ -49,4 +51,4 @@ const Loader = () => {
   );
 };
 
-export default EpigenomesActivityImageContainer;
+export default memo(EpigenomesActivityImageContainer);

--- a/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/EpigenomesActivityImageContainer.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/EpigenomesActivityImageContainer.tsx
@@ -18,6 +18,7 @@ import EpigenomesTable from '../epigenomes-activity/epigenomes-table/EpigenomesT
 import EpigenomeActivityImage, {
   type Props as EpigenomeActivityImageProps
 } from 'src/content/app/regulatory-activity-viewer/components/epigenomes-activity/EpigenomesActivityImage';
+import { CircleLoader } from 'src/shared/components/loader';
 
 import styles from './EpigenomesActivityContainer.module.css';
 
@@ -27,12 +28,23 @@ import styles from './EpigenomesActivityContainer.module.css';
  */
 
 const EpigenomesActivityImageContainer = (
-  props: EpigenomeActivityImageProps
+  props: EpigenomeActivityImageProps & { isPending: boolean }
 ) => {
+  const { isPending, ...otherProps } = props;
+
   return (
     <div className={styles.container}>
-      <EpigenomesTable />
-      <EpigenomeActivityImage {...props} />
+      {isPending && <Loader />}
+      {!isPending && <EpigenomesTable />}
+      <EpigenomeActivityImage {...otherProps} />
+    </div>
+  );
+};
+
+const Loader = () => {
+  return (
+    <div className={styles.loaderContainer}>
+      <CircleLoader />
     </div>
   );
 };

--- a/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/epigenomes-table/EpigenomesTable.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/epigenomes-table/EpigenomesTable.module.css
@@ -39,6 +39,10 @@
   text-overflow: ellipsis;
 }
 
+.tableCellContent > * {
+  flex-shrink: 0;
+}
+
 /* Same as in EpigenomeLabels coloredBlock class */
 .colorLabel {
   display: inline-block;

--- a/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/epigenomes-table/EpigenomesTable.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/epigenomes-table/EpigenomesTable.module.css
@@ -1,24 +1,14 @@
 .container {
   --header-height: 30px;
-  --offset-left: 150px; /* width of the left column of the main grid */
+  --table-background: transparent;
   position: absolute;
-  top: calc(-1 * var(--header-height));
-  left: var(--offset-left);
+  top: calc(40px + (-1 * var(--header-height)));
+  animation: animate-table-entry 0.3s ease-in-out;
+  overflow: auto;
 }
 
-/* this element contains the table and the close button */
-.tableContainerGrid {
-  display: grid;
-  column-gap: 1rem;
-  padding-right: 10px;
-  animation: animate-table-entry 0.2s ease-in-out;
-  background-color: white;
-}
-
-/* a wrapper for the table, whose purpose is to scroll on overflow-x */
-.tableContainer {
-  text-align: left;
-  overflow-x: auto;
+.container tbody {
+  background-color: rgb(from var(--color-light-grey) r g b / 0.85);
 }
 
 @container main-content-container (min-width: 0) {
@@ -30,11 +20,7 @@
   FIXME: at least left and right main column widths should be extracted into css variables
   */
 
-  .tableContainerGrid {
-    grid-template-columns: [table] minmax(min-content, calc(100cqi - 150px - 150px)) [close-button] auto;
-  }
-
-  .tableContainer {
+  .container {
     max-width: calc(100cqi - 150px - 150px - 30px);
   }
 }
@@ -53,18 +39,11 @@
   text-overflow: ellipsis;
 }
 
+/* Same as in EpigenomeLabels coloredBlock class */
 .colorLabel {
   display: inline-block;
-  height: 10px;
-  aspect-ratio: 1;
-}
-
-.openButton {
-  --chevron-fill: white;
-  position: absolute;
-  left: calc(-1 * var(--offset-left));
-  padding: 3px 2px;
-  background-color: var(--color-blue);
+  height: 24px;
+  width: 3px;
 }
 
 .closeButton {

--- a/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/epigenomes-table/EpigenomesTable.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/epigenomes-table/EpigenomesTable.tsx
@@ -54,7 +54,7 @@ const EpigenomesTableContainer = () => {
     updateTableState({ isAvailable: true });
 
     return () => {
-      updateTableState({ isAvailable: false });
+      updateTableState({ isAvailable: false, isOpen: false });
     };
   }, []);
 

--- a/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/epigenomes-table/EpigenomesTable.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/epigenomes-table/EpigenomesTable.tsx
@@ -14,19 +14,18 @@
  * limitations under the License.
  */
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 import { TRACK_HEIGHT } from 'src/content/app/regulatory-activity-viewer/components/epigenomes-activity/epigenomeActivityImageConstants';
 
 import useEpigenomes from 'src/content/app/regulatory-activity-viewer/hooks/useEpigenomes';
 
+import { tableVisibility$, updateTableState } from './epigenomesTableState';
 import { displayEpigenomeValue } from 'src/content/app/regulatory-activity-viewer/components/selected-epigenomes/SelectedEpigenomes';
 import { getEpigenomeLabels } from 'src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/EpigenomeLabels';
 
 import { Table, ColumnHead } from 'src/shared/components/table';
-import CloseButton from 'src/shared/components/close-button/CloseButton';
 import TextButton from 'src/shared/components/text-button/TextButton';
-import Chevron from 'src/shared/components/chevron/Chevron';
 
 import type { EpigenomeMetadataDimensions } from 'src/content/app/regulatory-activity-viewer/types/epigenomeMetadataDimensions';
 
@@ -35,7 +34,9 @@ import styles from './EpigenomesTable.module.css';
 type TableDisplayType = 'full' | 'partial';
 
 const EpigenomesTableContainer = () => {
-  const [displayType, setDisplayType] = useState<TableDisplayType | null>(null);
+  const [displayType, setDisplayType] = useState<TableDisplayType | null>(
+    'partial'
+  );
 
   const showPartialTable = () => {
     setDisplayType('partial');
@@ -49,31 +50,38 @@ const EpigenomesTableContainer = () => {
     setDisplayType(null);
   };
 
+  useEffect(() => {
+    updateTableState({ isAvailable: true });
+
+    return () => {
+      updateTableState({ isAvailable: false });
+    };
+  }, []);
+
+  useEffect(() => {
+    const subscription = tableVisibility$.subscribe((state) => {
+      if (state.isOpen) {
+        showPartialTable();
+      } else {
+        hideTable();
+      }
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  if (displayType === null) {
+    return null;
+  }
+
   return (
     <div className={styles.container}>
-      {displayType === null ? (
-        <button
-          className={styles.openButton}
-          onClick={showPartialTable}
-          aria-label="show table of epigenomes"
-        >
-          <Chevron direction="right" />
-        </button>
-      ) : (
-        <div className={styles.tableContainerGrid}>
-          <div className={styles.tableContainer}>
-            <EpigenomesTable
-              displayType={displayType}
-              showFullTable={showFullTable}
-            />
-          </div>
-          <CloseButton
-            className={styles.closeButton}
-            onClick={hideTable}
-            aria-label="hide table of epigenomes"
-          />
-        </div>
-      )}
+      <EpigenomesTable
+        displayType={displayType}
+        showFullTable={showFullTable}
+      />
     </div>
   );
 };
@@ -178,6 +186,7 @@ const EpigenomesTable = ({
                 </td>
               );
             })}
+            {displayType === 'partial' && <td />}
           </tr>
         ))}
       </tbody>

--- a/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/epigenomes-table/EpigenomesTableToggle.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/epigenomes-table/EpigenomesTableToggle.module.css
@@ -1,0 +1,20 @@
+.button {
+  display: flex;
+  column-gap: 12px;
+  align-items: center;
+  color: var(--color-blue);
+}
+
+.button:disabled {
+  color: var(--color-grey);
+}
+
+.chevronContainer {
+  --chevron-fill: white;
+  padding: 3px 2px;
+  background-color: var(--color-blue);
+}
+
+.button:disabled .chevronContainer {
+  background-color: var(--color-grey);
+}

--- a/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/epigenomes-table/EpigenomesTableToggle.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/epigenomes-table/EpigenomesTableToggle.tsx
@@ -1,0 +1,85 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, useEffect } from 'react';
+import classNames from 'classnames';
+
+import {
+  updateTableState,
+  tableVisibility$,
+  initialState as initialTableState,
+  type TableState
+} from './epigenomesTableState';
+
+import Chevron from 'src/shared/components/chevron/Chevron';
+import { CloseButtonWithLabel } from 'src/shared/components/close-button/CloseButton';
+
+import styles from './EpigenomesTableToggle.module.css';
+
+type Props = {
+  className?: string;
+};
+
+const EpigenomesTableToggle = (props: Props) => {
+  const [tableState, setTableState] = useState<TableState>(initialTableState);
+
+  const onOpen = () => {
+    updateTableState({ isOpen: true });
+  };
+
+  const onClose = () => {
+    updateTableState({ isOpen: false });
+  };
+
+  useEffect(() => {
+    const subscription = tableVisibility$.subscribe((state) => {
+      setTableState(state);
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  if (tableState.isOpen) {
+    return (
+      <CloseButtonWithLabel
+        className={props.className}
+        onClick={onClose}
+        label="Row info"
+        aria-label="hide table of epigenomes"
+      />
+    );
+  }
+
+  const componentClasses = classNames(styles.button, props.className);
+
+  return (
+    <button
+      className={componentClasses}
+      onClick={onOpen}
+      aria-label="show table of epigenomes"
+      disabled={!tableState.isAvailable}
+    >
+      <span>Row info</span>
+      <span className={styles.chevronContainer}>
+        <Chevron direction="right" />
+      </span>
+    </button>
+  );
+};
+
+export default EpigenomesTableToggle;

--- a/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/epigenomes-table/epigenomesTableState.ts
+++ b/src/content/app/regulatory-activity-viewer/components/epigenomes-activity/epigenomes-table/epigenomesTableState.ts
@@ -1,0 +1,71 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BehaviorSubject } from 'rxjs';
+
+/**
+ * A simple store to track the open/closed state of the epigenomes table,
+ * and to couple the table with the button that toggles its visibility.
+ *
+ * The button is separated from the table into a different component;
+ * and the purpose of using this component rather than parent component's state
+ * was to avoid re-rendering of the epigenomes activity diagram when the table
+ * is shown or hidden.
+ *
+ * This could have easily been implemented via React context;
+ * but that would have required wrapping the relevant part of the tree
+ * into a context provider component.
+ *
+ * Note that because the store created in this file is a singleton,
+ * the implementation assumes that there will ever only be one epigenomes table
+ * on any given page. So far, this looks like a reasonable assumption.
+ */
+
+export type TableState = {
+  isOpen: boolean;
+  isAvailable: boolean;
+};
+
+export const initialState: TableState = {
+  isOpen: false,
+  isAvailable: false
+};
+
+const tableVisibilitySubject = new BehaviorSubject<TableState>(initialState);
+
+export const updateTableState = (fragment: Partial<TableState>) => {
+  const currentState = tableVisibilitySubject.value;
+  const newState = { ...currentState, ...fragment };
+  tableVisibilitySubject.next(newState);
+};
+
+export const changeTableVisibility = ({ isOpen }: { isOpen: boolean }) => {
+  const currentState = tableVisibilitySubject.value;
+  const newState = { ...currentState, isOpen };
+  tableVisibilitySubject.next(newState);
+};
+
+export const changeTableAvailability = ({
+  isAvailable
+}: {
+  isAvailable: boolean;
+}) => {
+  const currentState = tableVisibilitySubject.value;
+  const newState = { ...currentState, isAvailable };
+  tableVisibilitySubject.next(newState);
+};
+
+export const tableVisibility$ = tableVisibilitySubject.asObservable();

--- a/src/content/app/regulatory-activity-viewer/components/main-content-bottom-view-controls/MainContentBottomViewControls.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/main-content-bottom-view-controls/MainContentBottomViewControls.module.css
@@ -15,6 +15,11 @@
   column-gap: 16px;
 }
 
+.epigenomesTableToggle {
+  justify-self: end;
+  margin-right: 14px;
+}
+
 .viewButtonActive {
   --secondary-button-color: var(--color-black);
 }

--- a/src/content/app/regulatory-activity-viewer/components/main-content-bottom-view-controls/MainContentBottomViewControls.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/main-content-bottom-view-controls/MainContentBottomViewControls.module.css
@@ -1,16 +1,36 @@
 .outerGrid {
   display: grid;
+  align-items: center;
   grid-template-columns: 150px [main] 1fr 150px;  
 }
 
-.grid {
+.rightColumn {
+  padding-left: 20px; /* Same as for right column of the outer grid of other components in this view */
+}
+
+.innerGrid {
   display: grid;
   grid-column: main;
-  grid-template-columns: 1fr [view-buttons] auto;
+  grid-template-columns: 1fr [inner-right] auto;
+  align-items: center;
+}
+
+.innerLeft {
+  font-size: 12px;
+}
+
+.innerRight {
+  display: flex;
+  column-gap: 1.6rem;
+  grid-column: inner-right;
+}
+
+.assayTargetLabel {
+  display: flex;
+  column-gap: 0.6ch;
 }
 
 .viewButtons {
-  grid-column: view-buttons;
   display: flex;
   column-gap: 16px;
 }
@@ -22,4 +42,12 @@
 
 .viewButtonActive {
   --secondary-button-color: var(--color-black);
+}
+
+.strong {
+  font-weight: var(--font-weight-bold); 
+}
+
+.light {
+  font-weight: var(--font-weight-light);
 }

--- a/src/content/app/regulatory-activity-viewer/components/main-content-bottom-view-controls/MainContentBottomViewControls.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/main-content-bottom-view-controls/MainContentBottomViewControls.tsx
@@ -26,25 +26,47 @@ import {
   type MainContentBottomView
 } from 'src/content/app/regulatory-activity-viewer/state/ui/uiSlice';
 
+import useActivityViewerIds from 'src/content/app/regulatory-activity-viewer/hooks/useActivityViewerIds';
+import useEpigenomes from 'src/content/app/regulatory-activity-viewer/hooks/useEpigenomes';
+
 import { SecondaryButton } from 'src/shared/components/button/Button';
 import ActivityViewerActionSelector from 'src/content/app/regulatory-activity-viewer/components/activity-viewer-actions-selector/ActivityViewerActionsSelector';
 import EpigenomesTableToggle from 'src/content/app/regulatory-activity-viewer/components/epigenomes-activity/epigenomes-table/EpigenomesTableToggle';
 
 import styles from './MainContentBottomViewControls.module.css';
 
-type Props = {
-  genomeId: string;
-};
+const MainContentBottomViewControls = () => {
+  const { genomeId } = useActivityViewerIds();
+  const { sortedCombinedEpigenomes } = useEpigenomes();
 
-const MainContentBottomViewControls = (props: Props) => {
-  const { genomeId } = props;
+  if (!genomeId) {
+    return null;
+  }
+
   return (
     <div className={styles.outerGrid}>
       <EpigenomesTableToggleContainer genomeId={genomeId} />
-      <div className={styles.grid}>
-        <ActivityViewerActionSelector />
-        <ContentViewButtons genomeId={genomeId} />
+      <div className={styles.innerGrid}>
+        <div className={styles.innerLeft}>
+          <AssayTargetLabel />
+        </div>
+        <div className={styles.innerRight}>
+          <ActivityViewerActionSelector />
+          <ContentViewButtons genomeId={genomeId} />
+        </div>
       </div>
+      <div className={styles.rightColumn}>
+        <EpigenomesCount epigenomes={sortedCombinedEpigenomes || []} />
+      </div>
+    </div>
+  );
+};
+
+const AssayTargetLabel = () => {
+  return (
+    <div className={styles.assayTargetLabel}>
+      <span className={styles.light}>Assay target</span>
+      <span>Open chromatin</span>
     </div>
   );
 };
@@ -81,7 +103,7 @@ const ContentViewButtons = ({ genomeId }: { genomeId: string }) => {
         activeView={activeView}
         onClick={() => changeView('epigenomes-list')}
       >
-        Table
+        Epigenomes
       </ContentViewButton>
 
       <ContentViewButton
@@ -133,6 +155,16 @@ const EpigenomesTableToggleContainer = ({ genomeId }: { genomeId: string }) => {
   }
 
   return <EpigenomesTableToggle className={styles.epigenomesTableToggle} />;
+};
+
+const EpigenomesCount = ({ epigenomes }: { epigenomes: unknown[] }) => {
+  const count = epigenomes.length;
+
+  return (
+    <div>
+      <span className={styles.strong}>{count}</span> epigenomes
+    </div>
+  );
 };
 
 export default MainContentBottomViewControls;

--- a/src/content/app/regulatory-activity-viewer/components/main-content-bottom-view-controls/MainContentBottomViewControls.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/main-content-bottom-view-controls/MainContentBottomViewControls.tsx
@@ -28,6 +28,7 @@ import {
 
 import { SecondaryButton } from 'src/shared/components/button/Button';
 import ActivityViewerActionSelector from 'src/content/app/regulatory-activity-viewer/components/activity-viewer-actions-selector/ActivityViewerActionsSelector';
+import EpigenomesTableToggle from 'src/content/app/regulatory-activity-viewer/components/epigenomes-activity/epigenomes-table/EpigenomesTableToggle';
 
 import styles from './MainContentBottomViewControls.module.css';
 
@@ -39,6 +40,7 @@ const MainContentBottomViewControls = (props: Props) => {
   const { genomeId } = props;
   return (
     <div className={styles.outerGrid}>
+      <EpigenomesTableToggleContainer genomeId={genomeId} />
       <div className={styles.grid}>
         <ActivityViewerActionSelector />
         <ContentViewButtons genomeId={genomeId} />
@@ -119,6 +121,18 @@ const ContentViewButton = ({
       {children}
     </SecondaryButton>
   );
+};
+
+const EpigenomesTableToggleContainer = ({ genomeId }: { genomeId: string }) => {
+  const activeView = useAppSelector((state) =>
+    getMainContentBottomView(state, genomeId)
+  );
+
+  if (activeView !== 'dataviz') {
+    return null;
+  }
+
+  return <EpigenomesTableToggle className={styles.epigenomesTableToggle} />;
 };
 
 export default MainContentBottomViewControls;

--- a/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.module.css
@@ -17,6 +17,11 @@
   backdrop-filter: blur(3px);
 }
 
+.rightColumn {
+  padding-top: 40px; /* Same as for EpigenomesActivityContainer */
+  padding-left: 20px;
+}
+
 .positionRelative {
   position: relative;
 }

--- a/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.module.css
@@ -5,6 +5,12 @@
   padding-bottom: var(--global-padding-bottom);
 }
 
+.grid {
+  /* same as in RegionOverview styles */
+  display: grid;
+  grid-template-columns: [left] 150px [middle] 1fr [right] 150px;
+}
+
 .loader {
   position: absolute;
   left: 0;
@@ -17,7 +23,16 @@
   backdrop-filter: blur(3px);
 }
 
+.leftColumn {
+  grid-column: left;
+}
+
+.middleColumn {
+  grid-column: middle;
+}
+
 .rightColumn {
+  grid-column: right;
   padding-top: 40px; /* Same as for EpigenomesActivityContainer */
   padding-left: 20px;
 }

--- a/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.tsx
@@ -28,8 +28,6 @@ import GeneExpressionLevels from 'src/content/app/regulatory-activity-viewer/com
 import EpigenomeLabels from 'src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/EpigenomeLabels';
 // import { CircleLoader } from 'src/shared/components/loader';
 
-// FIXME: promote these styles to the top level of region activity viewer
-import regionOverviewStyles from '../region-overview/RegionOverview.module.css';
 import styles from './RegionActivitySection.module.css';
 
 const RegionActivitySectionWrapper = () => {
@@ -88,17 +86,14 @@ const RegionActivitySection = () => {
     width
   });
 
-  const componentClasses = classNames(
-    styles.section,
-    regionOverviewStyles.grid
-  );
+  const componentClasses = classNames(styles.section, styles.grid);
 
   const isPending =
     isLoading || isTransitionPending || isComponentTransitionPending;
 
   return (
     <div className={componentClasses}>
-      <div className={classNames(regionOverviewStyles.leftColumn)}>
+      <div className={classNames(styles.leftColumn)}>
         {preparedData && epigenomeMetadataDimensionsResponse && (
           <EpigenomeLabels
             epigenomes={sortedCombinedEpigenomes ?? []}
@@ -111,7 +106,7 @@ const RegionActivitySection = () => {
         )}
       </div>
       <div
-        className={regionOverviewStyles.middleColumn}
+        className={styles.middleColumn}
         ref={onImageContainerMount}
         style={isPending ? { visibility: 'hidden' } : {}}
       >
@@ -123,12 +118,7 @@ const RegionActivitySection = () => {
           />
         )}
       </div>
-      <div
-        className={classNames(
-          styles.rightColumn,
-          regionOverviewStyles.rightColumn
-        )}
-      >
+      <div className={classNames(styles.rightColumn)}>
         {preparedData && <GeneExpressionLevels />}
       </div>
     </div>

--- a/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.tsx
@@ -26,7 +26,7 @@ import useActivityViewerIds from 'src/content/app/regulatory-activity-viewer/hoo
 import EpigenomesActivityImageContainer from 'src/content/app/regulatory-activity-viewer/components/epigenomes-activity/EpigenomesActivityImageContainer';
 import GeneExpressionLevels from 'src/content/app/regulatory-activity-viewer/components/gene-expression-levels/GeneExpressionLevels';
 import EpigenomeLabels from 'src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/EpigenomeLabels';
-// import { CircleLoader } from 'src/shared/components/loader';
+import ActivityViewerMiddleColumnLoader from 'src/content/app/regulatory-activity-viewer/components/activity-viewer-middle-column-loader/ActivityViewerMiddleColumnLoader';
 
 import styles from './RegionActivitySection.module.css';
 
@@ -105,17 +105,16 @@ const RegionActivitySection = () => {
           />
         )}
       </div>
-      <div
-        className={styles.middleColumn}
-        ref={onImageContainerMount}
-        style={isPending ? { visibility: 'hidden' } : {}}
-      >
-        {preparedData && width && (
+      <div className={styles.middleColumn} ref={onImageContainerMount}>
+        {preparedData && width ? (
           <EpigenomesActivityImageContainer
             data={preparedData.epigenomeActivityData}
             scale={preparedData.scale}
             width={width}
+            isPending={isPending}
           />
+        ) : (
+          <ActivityViewerMiddleColumnLoader />
         )}
       </div>
       <div className={classNames(styles.rightColumn)}>
@@ -124,57 +123,5 @@ const RegionActivitySection = () => {
     </div>
   );
 };
-
-/**
-
-
-  return (
-    <div className={componentClasses}>
-      <div className={regionOverviewStyles.middleColumn}>
-        {isPending && (
-          <div className={styles.loader}>
-            <CircleLoader />
-          </div>
-        )}
-      </div>
-      <div
-        className={classNames(
-          regionOverviewStyles.leftColumn,
-          styles.positionRelative
-        )}
-      >
-        <EpigenomesTable />
-        {preparedData && epigenomeMetadataDimensionsResponse && (
-          <EpigenomeLabels
-            epigenomes={sortedCombinedEpigenomes ?? []}
-            sortingDimensions={epigenomeSortingDimensions ?? []}
-            displayDimensions={
-              epigenomeMetadataDimensionsResponse.ui_spec.table_layout
-            }
-            allDimensions={epigenomeMetadataDimensionsResponse.dimensions}
-          />
-        )}
-      </div>
-      <div
-        className={regionOverviewStyles.middleColumn}
-        ref={onImageContainerMount}
-        style={isPending ? { visibility: 'hidden' } : {}}
-      >
-        {preparedData && width && (
-          <EpigenomeActivityImage
-            data={preparedData.epigenomeActivityData}
-            scale={preparedData.scale}
-            width={width}
-          />
-        )}
-      </div>
-      <div className={regionOverviewStyles.rightColumn}>
-        {preparedData && <GeneExpressionLevels />}
-      </div>
-    </div>
-  );
-
-
- */
 
 export default memo(RegionActivitySectionWrapper);

--- a/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/region-activity-section/RegionActivitySection.tsx
@@ -23,11 +23,10 @@ import useEpigenomes from 'src/content/app/regulatory-activity-viewer/hooks/useE
 import useRegionActivityData from './useRegionActivityData';
 import useActivityViewerIds from 'src/content/app/regulatory-activity-viewer/hooks/useActivityViewerIds';
 
-import EpigenomeActivityImage from 'src/content/app/regulatory-activity-viewer/components/epigenomes-activity/EpigenomesActivityImage';
+import EpigenomesActivityImageContainer from 'src/content/app/regulatory-activity-viewer/components/epigenomes-activity/EpigenomesActivityImageContainer';
 import GeneExpressionLevels from 'src/content/app/regulatory-activity-viewer/components/gene-expression-levels/GeneExpressionLevels';
 import EpigenomeLabels from 'src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/EpigenomeLabels';
-import EpigenomesTable from './epigenomes-table/EpigenomesTable';
-import { CircleLoader } from 'src/shared/components/loader';
+// import { CircleLoader } from 'src/shared/components/loader';
 
 // FIXME: promote these styles to the top level of region activity viewer
 import regionOverviewStyles from '../region-overview/RegionOverview.module.css';
@@ -99,6 +98,48 @@ const RegionActivitySection = () => {
 
   return (
     <div className={componentClasses}>
+      <div className={classNames(regionOverviewStyles.leftColumn)}>
+        {preparedData && epigenomeMetadataDimensionsResponse && (
+          <EpigenomeLabels
+            epigenomes={sortedCombinedEpigenomes ?? []}
+            sortingDimensions={epigenomeSortingDimensions ?? []}
+            displayDimensions={
+              epigenomeMetadataDimensionsResponse.ui_spec.table_layout
+            }
+            allDimensions={epigenomeMetadataDimensionsResponse.dimensions}
+          />
+        )}
+      </div>
+      <div
+        className={regionOverviewStyles.middleColumn}
+        ref={onImageContainerMount}
+        style={isPending ? { visibility: 'hidden' } : {}}
+      >
+        {preparedData && width && (
+          <EpigenomesActivityImageContainer
+            data={preparedData.epigenomeActivityData}
+            scale={preparedData.scale}
+            width={width}
+          />
+        )}
+      </div>
+      <div
+        className={classNames(
+          styles.rightColumn,
+          regionOverviewStyles.rightColumn
+        )}
+      >
+        {preparedData && <GeneExpressionLevels />}
+      </div>
+    </div>
+  );
+};
+
+/**
+
+
+  return (
+    <div className={componentClasses}>
       <div className={regionOverviewStyles.middleColumn}>
         {isPending && (
           <div className={styles.loader}>
@@ -142,6 +183,8 @@ const RegionActivitySection = () => {
       </div>
     </div>
   );
-};
+
+
+ */
 
 export default memo(RegionActivitySectionWrapper);

--- a/src/content/app/regulatory-activity-viewer/components/region-overview/RegionOverview.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/region-overview/RegionOverview.module.css
@@ -1,16 +1,37 @@
 .grid {
   display: grid;
+  grid-template-areas:
+    'top-left top-middle .'
+    'left middle right';
   grid-template-columns: [left] 150px [middle] 1fr [right] 150px;
+  padding-top: 28px;
+}
+
+.topLeftColumn {
+  grid-area: top-left;
+  text-align: right;
+  padding-bottom: 18px;
+  padding-right: 16px;
+  font-size: 12px;
+}
+
+.topMiddleColumn {
+  grid-area: top-middle;
+  display: flex;
+  justify-content: flex-end;
+  padding-bottom: 18px;
 }
 
 .leftColumn {
-  grid-column: left;
+  grid-area: left;
   position: relative;
   text-align: right;
+  font-size: 12px;
+  font-weight: var(--font-weight-light);
 }
 
 .middleColumn {
-  grid-column: middle;
+  grid-area: middle;
 }
 
 .rightColumn {
@@ -20,4 +41,8 @@
 .imageContainer {
   position: relative;
   min-height: 100px;
+}
+
+.light {
+  font-weight: var(--font-weight-light);
 }

--- a/src/content/app/regulatory-activity-viewer/components/region-overview/RegionOverview.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/region-overview/RegionOverview.tsx
@@ -220,7 +220,7 @@ const LeftColumn = (props: {
         style={{
           position: 'absolute',
           top: `${strandDividerTopOffset}px`,
-          right: '10px',
+          right: '16px',
           transform: 'translateY(-50%)'
         }}
       >
@@ -230,7 +230,7 @@ const LeftColumn = (props: {
         style={{
           position: 'absolute',
           top: `${regulatoryFeatureTracksTopOffset}px`,
-          right: '10px',
+          right: '16px',
           transform: 'translateY(-50%)'
         }}
       >

--- a/src/content/app/regulatory-activity-viewer/components/region-overview/RegionOverview.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/region-overview/RegionOverview.tsx
@@ -165,10 +165,20 @@ const RegionOverview = () => {
 
   return (
     <div className={styles.grid}>
-      <div className={styles.leftColumn}>
-        {deferredData && topOffsets && (
-          <LeftColumn data={deferredData} topOffsets={topOffsets} />
+      <div className={styles.topLeftColumn}>
+        {deferredData && <RegionName data={deferredData} />}
+      </div>
+      <div className={styles.topMiddleColumn}>
+        {location && regionLength && (
+          <RegionOverviewZoomButtons
+            genomeId={activeGenomeId}
+            location={location}
+            regionLength={regionLength}
+          />
         )}
+      </div>
+      <div className={styles.leftColumn}>
+        {deferredData && topOffsets && <LeftColumn topOffsets={topOffsets} />}
       </div>
       <div className={styles.middleColumn} ref={onImageContainerMount}>
         <div className={styles.imageContainer}>
@@ -189,30 +199,30 @@ const RegionOverview = () => {
             )}
         </div>
       </div>
-      <div className={styles.rightColumn}>
-        {location && regionLength && (
-          <RegionOverviewZoomButtons
-            genomeId={activeGenomeId}
-            location={location}
-            regionLength={regionLength}
-          />
-        )}
-      </div>
+    </div>
+  );
+};
+
+const RegionName = (props: { data: RegionData }) => {
+  const { data } = props;
+  const {
+    region: { name: regionName, coordinate_system }
+  } = data;
+
+  return (
+    <div>
+      <span className={styles.light}>{coordinate_system + ' '}</span>
+      <span>{regionName}</span>
     </div>
   );
 };
 
 const LeftColumn = (props: {
-  data: RegionData;
   topOffsets: ReturnType<typeof getImageHeightAndTopOffsets>;
 }) => {
-  const { data, topOffsets } = props;
+  const { topOffsets } = props;
   const { strandDividerTopOffset, regulatoryFeatureTracksTopOffset } =
     topOffsets;
-
-  const {
-    region: { name: regionName, coordinate_system }
-  } = data;
 
   return (
     <>
@@ -224,7 +234,7 @@ const LeftColumn = (props: {
           transform: 'translateY(-50%)'
         }}
       >
-        {coordinate_system} {regionName}
+        Genes
       </div>
       <div
         style={{

--- a/src/content/app/regulatory-activity-viewer/components/region-overview/RegionOverview.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/region-overview/RegionOverview.tsx
@@ -17,6 +17,7 @@
 import {
   useState,
   useEffect,
+  useRef,
   useMemo,
   useDeferredValue,
   useTransition
@@ -59,6 +60,10 @@ const RegionOverview = () => {
   const [, startWidthTransition] = useTransition();
   const [width, setWidth] = useState(0);
   const navigate = useNavigate();
+
+  const widthRef = useRef(width);
+
+  widthRef.current = width; // update the ref during every rerender
 
   const extendedLocation = useMemo(() => {
     if (!location) {
@@ -119,9 +124,11 @@ const RegionOverview = () => {
     const resizeObserver = new ResizeObserver((entries) => {
       const [imageContainer] = entries;
       const { width: imageContainerWidth } = imageContainer.contentRect;
-      startWidthTransition(() => {
-        setWidth(imageContainerWidth);
-      });
+      if (imageContainerWidth !== widthRef.current) {
+        startWidthTransition(() => {
+          setWidth(imageContainerWidth);
+        });
+      }
     });
 
     resizeObserver.observe(element);

--- a/src/content/app/regulatory-activity-viewer/components/region-overview/region-overview-image/RegionOverviewImage.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/region-overview/region-overview-image/RegionOverviewImage.tsx
@@ -128,7 +128,8 @@ const RegionOverviewImage = (props: Props) => {
         height: `${imageHeight}px`,
         borderStyle: 'dashed',
         borderWidth: '1px',
-        borderColor: 'var(--color-dark-grey)'
+        borderColor: 'var(--color-dark-grey)',
+        borderRadius: '6px'
       }}
     >
       <RegionOverviewLocationSelector

--- a/src/content/app/regulatory-activity-viewer/components/region-overview/region-overview-image/TranslateRegionOverviewContents.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/region-overview/region-overview-image/TranslateRegionOverviewContents.tsx
@@ -194,6 +194,11 @@ const TranslateRegionOverviewContents = (props: Props) => {
 
   const updateLocation = () => {
     const distance = stateRef.current.currentOffset;
+
+    if (!distance) {
+      return;
+    }
+
     const { start: genomicStart, end: genomicEnd } = calculateLocationAfterDrag(
       {
         location,

--- a/src/content/app/regulatory-activity-viewer/components/region-overview/region-overview-zoom-buttons/RegionOverviewZoomButtons.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/region-overview/region-overview-zoom-buttons/RegionOverviewZoomButtons.module.css
@@ -1,11 +1,15 @@
 .buttons {
   display: flex;
-  column-gap: 0.4rem;
-  margin-left: 0.6rem;
+  column-gap: 25px;
 }
 
-.buttons button {
-  background-color: var(--color-blue);
-  color: white;
-  padding: 0.2rem 0.4rem;
+.button {
+  width: 16px;
+  aspect-ratio: 1;
+}
+
+.button svg {
+  width: 100%;
+  height: 100%;
+  fill: var(--color-blue);
 }

--- a/src/content/app/regulatory-activity-viewer/components/region-overview/region-overview-zoom-buttons/RegionOverviewZoomButtons.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/region-overview/region-overview-zoom-buttons/RegionOverviewZoomButtons.tsx
@@ -16,6 +16,11 @@
 
 import { useLocation, useNavigate } from 'react-router';
 
+// FIXME: either create shared NavigationButtons components, or reuse the same approach as in genome browser (with ImageButton)
+
+import CirclePlusIcon from 'static/icons/icon_plus_circle.svg';
+import CircleMinusIcon from 'static/icons/icon_minus_circle.svg';
+
 import styles from './RegionOverviewZoomButtons.module.css';
 
 type Props = {
@@ -56,8 +61,16 @@ const RegionOverviewZoomButtons = (props: Props) => {
 
   return (
     <div className={styles.buttons}>
-      <button onClick={onZoomOut}>-</button>
-      <button onClick={onZoomIn}>+</button>
+      <button className={styles.button} onClick={onZoomIn} aria-label="Zoom in">
+        <CirclePlusIcon />
+      </button>
+      <button
+        className={styles.button}
+        onClick={onZoomOut}
+        aria-label="Zoom out"
+      >
+        <CircleMinusIcon />
+      </button>
     </div>
   );
 };

--- a/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/SelectedEpigenomes.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/SelectedEpigenomes.module.css
@@ -25,7 +25,3 @@
   padding-left: 2rem;
   margin-top: 2rem;
 }
-
-.strong {
-  font-weight: var(--font-weight-bold); 
-}

--- a/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/SelectedEpigenomes.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/SelectedEpigenomes.tsx
@@ -111,9 +111,6 @@ const SelectedEpigenomes = (props: Props) => {
           </div>
         )}
       </div>
-      <div className={styles.rightColumn}>
-        <EpigenomesCount epigenomes={sortedCombinedEpigenomes} />
-      </div>
     </div>
   );
 };
@@ -133,16 +130,6 @@ export const displayEpigenomeValue = (value?: Epigenome[keyof Epigenome]) => {
   } else {
     return '-';
   }
-};
-
-const EpigenomesCount = ({ epigenomes }: { epigenomes: unknown[] }) => {
-  const count = epigenomes.length;
-
-  return (
-    <div>
-      <span className={styles.strong}>{count}</span> epigenomes
-    </div>
-  );
 };
 
 const EpigenomeLabels = ({

--- a/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/SelectedEpigenomes.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/SelectedEpigenomes.tsx
@@ -131,7 +131,7 @@ export const displayEpigenomeValue = (value?: Epigenome[keyof Epigenome]) => {
   } else if (typeof value === 'string') {
     return value;
   } else {
-    return null;
+    return '-';
   }
 };
 

--- a/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/SelectedEpigenomes.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/SelectedEpigenomes.tsx
@@ -145,15 +145,12 @@ const EpigenomeLabels = ({
     <div
       style={{
         display: 'flex',
-        position: 'absolute',
-        top: '2px',
-        bottom: '2px',
         columnGap: '2px'
       }}
     >
       {labelData.map(({ color }, index) => (
         <div
-          style={{ width: '5px', height: '100%', backgroundColor: color }}
+          style={{ width: '3px', height: '24px', backgroundColor: color }}
           key={index}
         />
       ))}

--- a/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/EpigenomeLabels.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/EpigenomeLabels.module.css
@@ -2,7 +2,8 @@
   display: flex;
   flex-direction: column;
   align-items: end;
-  padding-right: 30px;
+  padding-right: 14px;
+  padding-top: 40px; /* Same as for EpigenomesActivityContainer */
 }
 
 .epigenomeLabel {
@@ -23,8 +24,8 @@
 }
 
 .coloredBlock {
-  width: 6px;
-  height: 25px;
+  width: 3px;
+  height: 24px;
 }
 
 .labelPopupContent {

--- a/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/EpigenomeLabels.module.css
+++ b/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/EpigenomeLabels.module.css
@@ -10,6 +10,7 @@
   display: flex;
   align-items: start;
   column-gap: 0.6rem;
+  text-align: end;
 }
 
 .epigenomeTextLabel {

--- a/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/EpigenomeLabels.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/EpigenomeLabels.tsx
@@ -214,7 +214,7 @@ const EpigenomeColorLabel = ({
 }: {
   data: ReturnType<typeof getEpigenomeLabels>[number];
 }) => {
-  const labelHeight = 40; // FIXME: import the constant
+  const labelHeight = 24; // FIXME: import the constant
 
   return (
     <div className={styles.epigenomeColorLabel}>
@@ -224,7 +224,7 @@ const EpigenomeColorLabel = ({
           className={styles.coloredBlock}
           style={{
             backgroundColor: item.color,
-            height: `${labelHeight - 2}px`,
+            height: `${labelHeight}px`,
             margin: '1px 0'
           }}
         />

--- a/src/content/app/regulatory-activity-viewer/contexts/ActivityViewerEpigenomesContextProvider.tsx
+++ b/src/content/app/regulatory-activity-viewer/contexts/ActivityViewerEpigenomesContextProvider.tsx
@@ -87,6 +87,13 @@ const useEpigenomesData = () => {
     }
   );
 
+  const allEpigenomeDimensions = useMemo(() => {
+    if (!epigenomeMetadataDimensionsResponse) {
+      return [];
+    }
+    return Object.keys(epigenomeMetadataDimensionsResponse.dimensions);
+  }, [epigenomeMetadataDimensionsResponse]);
+
   const filteredEpigenomes = useMemo(() => {
     if (!baseEpigenomes) {
       return [];
@@ -98,11 +105,20 @@ const useEpigenomesData = () => {
   }, [baseEpigenomes, epigenomeSelectionCriteria]);
 
   const combinedEpigenomes = useMemo(() => {
+    if (!epigenomeCombiningDimensions.length) {
+      return filteredEpigenomes;
+    }
+
     return getCombinedEpigenomes({
       baseEpigenomes: filteredEpigenomes,
-      combiningDimensions: epigenomeCombiningDimensions
+      combiningDimensions: epigenomeCombiningDimensions,
+      allEpigenomeDimensions
     });
-  }, [filteredEpigenomes, epigenomeCombiningDimensions]);
+  }, [
+    filteredEpigenomes,
+    epigenomeCombiningDimensions,
+    allEpigenomeDimensions
+  ]);
 
   // List of dimensions actually used to sort the epigenomes (up to three dimensions)
   const epigenomeSortableDimensions =

--- a/src/content/app/regulatory-activity-viewer/helpers/combine-epigenomes/combineEpigenomes.ts
+++ b/src/content/app/regulatory-activity-viewer/helpers/combine-epigenomes/combineEpigenomes.ts
@@ -18,17 +18,22 @@ import type { Epigenome } from 'src/content/app/regulatory-activity-viewer/types
 
 export const getCombinedEpigenomes = ({
   baseEpigenomes,
-  combiningDimensions
+  combiningDimensions,
+  allEpigenomeDimensions
 }: {
   baseEpigenomes: Epigenome[];
   combiningDimensions: string[];
+  allEpigenomeDimensions: string[];
 }) => {
   const combinedEpigenomesMap = new Map<string, Epigenome>();
+  const distinguishingDimensions = allEpigenomeDimensions.filter(
+    (dimension) => !combiningDimensions.includes(dimension)
+  );
 
   for (const epigenome of baseEpigenomes) {
     const combinedEpigenomeKey = createCombinedEpigenomeKey(
       epigenome,
-      combiningDimensions
+      distinguishingDimensions
     );
     const storedCombinedEpigenome =
       combinedEpigenomesMap.get(combinedEpigenomeKey);
@@ -45,15 +50,14 @@ export const getCombinedEpigenomes = ({
 
 const createCombinedEpigenomeKey = (
   epigenome: Epigenome,
-  combiningDimensions: string[]
+  distinguishingDimensions: string[]
 ) => {
-  const dimensionsForKey = eligibleDimensions.filter(
-    (dimension) => !combiningDimensions.includes(dimension)
+  const keyPartFromDimensions = distinguishingDimensions.reduce(
+    (acc, dimension) => {
+      return `${acc}-${epigenome[dimension]}`;
+    },
+    ''
   );
-
-  const keyPartFromDimensions = dimensionsForKey.reduce((acc, dimension) => {
-    return `${acc}-${epigenome[dimension]}`;
-  }, '');
 
   const key = `${epigenome.term}${keyPartFromDimensions}`;
   return key;
@@ -85,10 +89,3 @@ const createCombinedEpigenome = ({
 
   return combinedEpigenome;
 };
-
-/**
- * A list of dimensions that can possibly be used when combining epigenomes.
- * For example, it is meaningless to combine epigenomes on the "term" dimension or "organ" dimension;
- * but meaningful to combine them on the sex or life stage dimension
- */
-const eligibleDimensions = ['sex', 'life_stage'] as const;

--- a/src/content/app/regulatory-activity-viewer/state/ui/uiSelectors.ts
+++ b/src/content/app/regulatory-activity-viewer/state/ui/uiSelectors.ts
@@ -17,8 +17,7 @@
 import type { RootState } from 'src/store';
 
 export const getMainContentBottomView = (state: RootState, genomeId: string) =>
-  state.regionActivityViewer.ui[genomeId]?.mainContentBottomView ??
-  'epigenomes-list';
+  state.regionActivityViewer.ui[genomeId]?.mainContentBottomView ?? 'dataviz';
 
 export const getIsEpigenomeSelectorOpen = (
   state: RootState,

--- a/src/content/app/regulatory-activity-viewer/state/ui/uiSelectors.ts
+++ b/src/content/app/regulatory-activity-viewer/state/ui/uiSelectors.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { createSelector } from '@reduxjs/toolkit';
+
 import type { RootState } from 'src/store';
 
 export const getMainContentBottomView = (state: RootState, genomeId: string) =>
@@ -29,3 +31,11 @@ export const getIsSidebarOpen = (state: RootState, genomeId: string) =>
 
 export const getSidebarView = (state: RootState, genomeId: string) =>
   state.regionActivityViewer.ui[genomeId]?.sidebarView ?? 'default';
+
+export const getHistones = createSelector(
+  [
+    (state: RootState) => state.regionActivityViewer.ui,
+    (_, genomeId: string) => genomeId
+  ],
+  (uiState, genomeId) => uiState[genomeId]?.histones ?? []
+);

--- a/src/content/app/regulatory-activity-viewer/state/ui/uiSlice.ts
+++ b/src/content/app/regulatory-activity-viewer/state/ui/uiSlice.ts
@@ -30,7 +30,7 @@ type StatePerGenome = {
 type State = Record<string, StatePerGenome>;
 
 const initialStateForGenome: StatePerGenome = {
-  mainContentBottomView: 'epigenomes-list',
+  mainContentBottomView: 'dataviz',
   isEpigenomesSelectorOpen: false,
   isSidebarOpen: true,
   sidebarView: 'default'

--- a/src/content/app/regulatory-activity-viewer/state/ui/uiSlice.ts
+++ b/src/content/app/regulatory-activity-viewer/state/ui/uiSlice.ts
@@ -16,6 +16,8 @@
 
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
+import type { HistoneMetadata } from 'src/content/app/regulatory-activity-viewer/types/epigenomeActivity';
+
 export type MainContentBottomView = 'epigenomes-list' | 'dataviz';
 
 export type SidebarView = 'default' | 'epigenome-filters';
@@ -25,6 +27,7 @@ type StatePerGenome = {
   isEpigenomesSelectorOpen: boolean;
   isSidebarOpen: boolean;
   sidebarView: SidebarView;
+  histones: HistoneMetadata[];
 };
 
 type State = Record<string, StatePerGenome>;
@@ -33,7 +36,8 @@ const initialStateForGenome: StatePerGenome = {
   mainContentBottomView: 'dataviz',
   isEpigenomesSelectorOpen: false,
   isSidebarOpen: true,
-  sidebarView: 'default'
+  sidebarView: 'default',
+  histones: []
 };
 
 const ensureStateForGenome = (state: State, genomeId: string) => {
@@ -84,6 +88,14 @@ const uiSlice = createSlice({
       const { genomeId, view } = action.payload;
       ensureStateForGenome(state, genomeId);
       state[genomeId].sidebarView = view;
+    },
+    setHistones(
+      state,
+      action: PayloadAction<{ genomeId: string; histones: HistoneMetadata[] }>
+    ) {
+      const { genomeId, histones } = action.payload;
+      ensureStateForGenome(state, genomeId);
+      state[genomeId].histones = histones;
     }
   }
 });
@@ -94,7 +106,8 @@ export const {
   openSidebar,
   closeSidebar,
   openEpigenomesSelector,
-  closeEpigenomesSelector
+  closeEpigenomesSelector,
+  setHistones
 } = uiSlice.actions;
 
 export default uiSlice.reducer;

--- a/src/content/app/regulatory-activity-viewer/types/epigenomeActivity.ts
+++ b/src/content/app/regulatory-activity-viewer/types/epigenomeActivity.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-type HistoneMetadata = Record<
+export type HistoneMetadata = {
+  peak_type: 'gapped' | 'narrow';
+  label: string; // arbitrary string
+  color: string; // hex color
+};
+
+export type HistoneMetadataMap = Record<
   string,
   {
     peak_type: 'gapped' | 'narrow';
@@ -24,7 +30,7 @@ type HistoneMetadata = Record<
 >;
 
 export type EpigenomeActivityMetadata = {
-  histone: HistoneMetadata;
+  histone: HistoneMetadataMap;
 };
 
 export type TrackData = {

--- a/src/global/globalConfig.ts
+++ b/src/global/globalConfig.ts
@@ -37,7 +37,7 @@ export enum AppName {
   SPECIES_SELECTOR = 'Species selector',
   SPECIES_PAGE = 'Species page',
   ENTITY_VIEWER = 'Entity viewer',
-  REGULATORY_ACTIVITY_VIEWER = 'Regulation explorer',
+  REGULATORY_ACTIVITY_VIEWER = 'Regulatory activity viewer',
   TOOLS = 'Tools' // this is the name of a group of apps
 }
 

--- a/src/shared/components/close-button/CloseButton.tsx
+++ b/src/shared/components/close-button/CloseButton.tsx
@@ -15,20 +15,18 @@
  */
 
 import classNames from 'classnames';
+import type { ComponentProps } from 'react';
 
 import CloseIcon from 'static/icons/icon_close.svg';
 
 import styles from './CloseButton.module.css';
 
-type Props = {
-  onClick?: () => void;
-  className?: string;
-};
+type Props = Omit<ComponentProps<'button'>, 'children'>;
 
 const CloseButton = (props: Props) => {
   const className = classNames(styles.closeButton, props.className);
   return (
-    <button type="button" className={className} onClick={props.onClick}>
+    <button {...props} type="button" className={className}>
       <CloseIcon className={styles.icon} />
     </button>
   );
@@ -50,7 +48,6 @@ export const CloseButtonWithLabel = (
   const {
     label = 'Close',
     labelPosition = 'left',
-    onClick,
     className: classNameFromProps
   } = props;
 
@@ -75,7 +72,7 @@ export const CloseButtonWithLabel = (
     );
 
   return (
-    <button type="button" onClick={onClick} className={componentClasses}>
+    <button {...props} type="button" className={componentClasses}>
       {buttonContent}
     </button>
   );

--- a/src/shared/components/collapsible-section/CollapsibleSection.module.css
+++ b/src/shared/components/collapsible-section/CollapsibleSection.module.css
@@ -1,5 +1,10 @@
 @layer components {
 
+  .section {
+    --collapsible-section-padding-left: 17px;
+    --collapsible-section-padding-right: 15px;
+  }
+
   .section + .section {
     margin-top: 2px;
   }
@@ -13,13 +18,18 @@
     color: var(--color-blue);
     background-color: var(--color-light-grey);
     border-radius: 5px;
-    padding: 5px 15px 5px 17px;
+    padding-block: 5px;
+    padding-left: var(--collapsible-section-padding-left);
+    padding-right: var(--collapsible-section-padding-right);
     font-size: 12px;
     width: 100%;
   }
 
   .sectionBody {
-    padding: 10px 0 20px;
+    padding-top: 10px;
+    padding-bottom: 20px;
+    padding-left: var(--collapsible-section-padding-left);
+    padding-right: var(--collapsible-section-padding-right);
     animation: collapsible-section-body-fadein 0.2s ease-in;
   }
   

--- a/src/shared/components/gene-name/GeneName.tsx
+++ b/src/shared/components/gene-name/GeneName.tsx
@@ -48,7 +48,7 @@ const GeneName = ({
   className: classNameFromProps
 }: Props) => {
   const geneNamePrimary = symbol ?? stable_id;
-  const geneNameSecondary = geneNamePrimary ? stable_id : null;
+  const geneNameSecondary = symbol ? stable_id : null;
 
   const componentClasses = classNames(styles.geneName, classNameFromProps);
 


### PR DESCRIPTION
## Description
Various cosmetic updates, based on [updated design](https://xd.adobe.com/view/ba9038a6-02e5-4f33-8531-a44ed9873f87-efc3):

- Updated the name of the app ('Regulatory activity viewer'), and the content of the top (grey) bar, which now shows the focus gene if it is selected.
- Updated the shape of the zoom buttons and moved them slightly
- Moved things in the middle part of the page slightly: 1) Added label 'Assay target: Open chromatin' to make it clear what is being shown in the epigenome activity diagram. 2) Always displaying the number of selected epigenomes
- Moved the button for showing the slide-in overlay table (it now has the label 'Row info') into the middle zone
- The 'Visualise' bottom view is now the default
- Updated the design and slide-in behaviour of the overlay table
- The diagram in the bottom now has a dotted border around it
- Updated style of the colour labels for epigenomes — they are now smaller and not as thick
- Updated contents of the sidebar — wrapped genes and regulatory features legend into an expandable/collapsible section, and added a legend for epigenome tracks
- Added a column of disabled buttons (search, bookmarks, share, downloads) to the sidebar toolbar

**Before**

https://github.com/user-attachments/assets/12c400a7-e2a2-40eb-ba46-1dac09a2e998

**After:**

https://github.com/user-attachments/assets/f4515ce8-84b3-4201-96f1-78c0c077cf70



## Deployment URL(s)
http://activity-viewer.review.ensembl.org

