### PR TITLE
Fix the display of the 404 screen for missing gene

### DIFF
--- a/src/content/app/entity-viewer/hooks/useEntityViewerUrlChecks.ts
+++ b/src/content/app/entity-viewer/hooks/useEntityViewerUrlChecks.ts
@@ -16,7 +16,6 @@
 
 import useEntityViewerIds from 'src/content/app/entity-viewer/hooks/useEntityViewerIds';
 import { useGeneSummaryQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
-import usePrevious from 'src/shared/hooks/usePrevious';
 
 /**
  * A hook for validating individual parts of the url.
@@ -32,11 +31,6 @@ const useEntityViewerUrlCheck = () => {
     entityIdInUrl,
     parsedEntityId
   } = useEntityViewerIds();
-  const previousGenomeIdInUrl = usePrevious(genomeIdInUrl);
-  const previousEntityIdInUrl = usePrevious(entityIdInUrl);
-  const hasUrlChanged =
-    genomeIdInUrl !== previousGenomeIdInUrl ||
-    entityIdInUrl !== previousEntityIdInUrl;
 
   const isGene = parsedEntityId?.type === 'gene';
   let geneId;
@@ -55,7 +49,7 @@ const useEntityViewerUrlCheck = () => {
       geneId: geneId ?? ''
     },
     {
-      skip: !genomeId || !geneId || !hasUrlChanged
+      skip: !genomeId || !geneId
     }
   );
 

--- a/src/content/app/entity-viewer/services/entity-viewer-storage-service.ts
+++ b/src/content/app/entity-viewer/services/entity-viewer-storage-service.ts
@@ -45,11 +45,15 @@ export class EntityViewerStorageService {
   }
 
   public updateGeneralState(updatedState: Partial<EntityViewerGeneralState>) {
-    this.storageService.update(
+    localStorage.setItem(
       StorageKeys.GENERAL_STATE,
-      updatedState,
-      localStorageOptions
+      JSON.stringify(updatedState)
     );
+    // this.storageService.update(
+    //   StorageKeys.GENERAL_STATE,
+    //   updatedState,
+    //   localStorageOptions
+    // );
   }
 
   public deleteGenome(genomeIdToDelete: string): void {

--- a/src/content/app/entity-viewer/state/general/entityViewerGeneralSlice.ts
+++ b/src/content/app/entity-viewer/state/general/entityViewerGeneralSlice.ts
@@ -114,7 +114,11 @@ export const deleteActiveEntityIdAndSave =
       activeEntityIds: updatedActiveEntityIds
     });
 
-    return dispatch(deleteActiveEntityIdForGenome(activeGenomeId));
+    // dispatch(deleteActiveEntityIdForGenome(activeGenomeId));
+    window.location.pathname =
+      '/entity-viewer/2df86696-b80f-475c-b327-590a36260c6e';
+
+    // return dispatch(deleteActiveEntityIdForGenome(activeGenomeId));
   };
 
 export const setDefaultActiveGenomeId =
@@ -123,7 +127,9 @@ export const setDefaultActiveGenomeId =
     const state = getState();
     const [firstCommittedSpecies] = getCommittedSpecies(state);
     const activeGenomeId = firstCommittedSpecies?.genome_id;
-    activeGenomeId && dispatch(setActiveGenomeId(activeGenomeId));
+    if (activeGenomeId) {
+      dispatch(setActiveGenomeId(activeGenomeId));
+    }
   };
 
 export const deleteGenome = createAsyncThunk(


### PR DESCRIPTION
## Description

**Problem:** When the Entity Viewer loads a page for a non-existing genome, it shows a mostly blank page, without the expected error screen:

![image](https://github.com/user-attachments/assets/27ff22d7-3984-4bb3-bdb8-d382171c8419)

**Causes:**

Although code was written previously to detect and display the 'gene not found' errors, it must have rotted over time and react version updates.

- The most proximate cause was that the function for getting the data based on which it could check the absence of the gene was not called, because it was skipped if the url hasn't changed ([link](https://github.com/Ensembl/ensembl-client/blob/c9b929985f70fd3cb117a927d0359137e9374f9f/src/content/app/entity-viewer/hooks/useEntityViewerUrlChecks.ts#L58)).
  - **CAUTION!** This check was introduced to "Fix infinite requests to Thoas on broken network". As it turns out, without it, the requests will indeed be infinite.
- **Next problem:** When the error screen appeared, the "Continue" button didn't work due to a race condition. Specifically, the "Continue" button should take user to the interstitial screen; and in order to do so, it needs to remove the active entity id from the state ([link](https://github.com/Ensembl/ensembl-client/blob/dac57dac6134f6ce83f0053d4c4bd14c94c3e073/src/content/app/entity-viewer/EntityViewerForGene.tsx#L63-L66)). However, there is another hook with a function that immediately restores the active entity id from the url ([link](https://github.com/Ensembl/ensembl-client/blob/dac57dac6134f6ce83f0053d4c4bd14c94c3e073/src/content/app/entity-viewer/EntityViewer.tsx#L148-L153)). This is a race condition, which probably used to work out fine before, but likely became apparent after an update to React.
- There is a very old file entity-viewer-storage-service, which stores some EntityViewer data in localStorage. Since we should be storing data in indexedDB anyway, this service should be rewritten later; but in the meantime, it became obvious that it cannot properly delete data from nested objects, i.e. if it has saved something like below:

```
{
  foo: {
    bar: 'a',
    baz: 'b'
  }
}
```

and I want to remove the `baz` field from the stored object, the service will fail to do so.


## Deployment URL(s)
http://gene-404-page.review.ensembl.org