### PR TITLE
Fetch epigenome labels from the api

### DIFF
--- a/src/content/app/regulatory-activity-viewer/components/gene-expression-levels/GeneExpressionLevels.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/gene-expression-levels/GeneExpressionLevels.tsx
@@ -30,6 +30,8 @@ import useEpigenomes from 'src/content/app/regulatory-activity-viewer/hooks/useE
 import useActivityViewerIds from 'src/content/app/regulatory-activity-viewer/hooks/useActivityViewerIds';
 import { useEpigenomesGeneActivityQuery } from 'src/content/app/regulatory-activity-viewer/state/api/activityViewerApiSlice';
 
+import type { EpigenomeGeneActivity } from 'src/content/app/regulatory-activity-viewer/types/epigenomeGeneActivity';
+
 /**
  * This component displays gene expression levels,
  * and is only displayed when there is a focus gene.
@@ -87,9 +89,13 @@ const GeneExpressionIndicator = ({
   value,
   trackIndex
 }: {
-  value: number;
+  value: EpigenomeGeneActivity['value'];
   trackIndex: number;
 }) => {
+  if (!value) {
+    return null;
+  }
+
   const darkRectWidth = Math.round(GENE_EXPRESSION_INDICATOR_WIDTH * value);
   const lightRectX = darkRectWidth;
   const lightRectWidth = GENE_EXPRESSION_INDICATOR_WIDTH - darkRectWidth;

--- a/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/EpigenomeLabels.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/EpigenomeLabels.tsx
@@ -22,13 +22,13 @@ import { stringifyDimensionValue } from './sortEpigenomes';
 
 import Tooltip from 'src/shared/components/tooltip/Tooltip';
 
-import type { Epigenome } from 'src/content/app/regulatory-activity-viewer/types/epigenome';
+import type { LabelledEpigenome } from 'src/content/app/regulatory-activity-viewer/types/epigenome';
 import type { EpigenomeMetadataDimensions } from 'src/content/app/regulatory-activity-viewer/types/epigenomeMetadataDimensions';
 
 import styles from './EpigenomeLabels.module.css';
 
 type Props = {
-  epigenomes: Epigenome[];
+  epigenomes: LabelledEpigenome[];
   displayDimensions: string[];
   sortingDimensions: string[];
   allDimensions: EpigenomeMetadataDimensions;
@@ -75,7 +75,7 @@ export const getEpigenomeLabels = ({
   epigenomes,
   sortingDimensions
 }: {
-  epigenomes: Epigenome[];
+  epigenomes: LabelledEpigenome[];
   sortingDimensions: string[];
 }) => {
   const labelData = sortingDimensions.map((dimension, index) => {
@@ -126,7 +126,7 @@ const EpigenomeLabel = ({
   allDimensions
 }: {
   data: ReturnType<typeof getEpigenomeLabels>[number];
-  epigenome: Epigenome;
+  epigenome: LabelledEpigenome;
   displayDimensions: string[];
   allDimensions: EpigenomeMetadataDimensions;
 }) => {
@@ -147,19 +147,17 @@ const EpigenomeTextLabel = ({
   displayDimensions,
   allDimensions
 }: {
-  epigenome: Epigenome;
+  epigenome: LabelledEpigenome;
   displayDimensions: string[];
   allDimensions: EpigenomeMetadataDimensions;
 }) => {
   const [hoverRef, isHovered] = useHover<HTMLSpanElement>();
 
-  const [mainDimension] = displayDimensions;
-
   const labelHeight = 40; // FIXME: import the constant
 
   return (
     <div className={styles.epigenomeTextLabel} style={{ height: labelHeight }}>
-      <span ref={hoverRef}>{epigenome[mainDimension]}</span>
+      <span ref={hoverRef}>{epigenome.label}</span>
 
       {isHovered && (
         <Tooltip anchor={hoverRef.current} autoAdjust={true}>
@@ -179,7 +177,7 @@ const LabelPopupContents = ({
   displayDimensions,
   allDimensions
 }: {
-  epigenome: Epigenome;
+  epigenome: LabelledEpigenome;
   displayDimensions: string[];
   allDimensions: EpigenomeMetadataDimensions;
 }) => {
@@ -238,7 +236,7 @@ const buildEpigenomeLabelsDataForDimension = ({
   dimension,
   colorMap
 }: {
-  epigenomes: Epigenome[];
+  epigenomes: LabelledEpigenome[];
   dimension: string;
   colorMap: Record<string, string>;
 }) => {
@@ -264,7 +262,7 @@ const getColorScaleForValues = (values: string[], order: number) => {
 };
 
 const getDistinctValuesForDimension = (
-  epigenomes: Epigenome[],
+  epigenomes: LabelledEpigenome[],
   dimension: string
 ) => {
   const distinctValues = new Set<string>();

--- a/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/sortEpigenomes.ts
+++ b/src/content/app/regulatory-activity-viewer/components/selected-epigenomes/epigenomes-sorter/sortEpigenomes.ts
@@ -16,12 +16,12 @@
 
 import type { Epigenome } from 'src/content/app/regulatory-activity-viewer/types/epigenome';
 
-export const sortEpigenomes = ({
+export const sortEpigenomes = <T extends Epigenome>({
   sortingDimensions,
   epigenomes
 }: {
   sortingDimensions: string[];
-  epigenomes: Epigenome[];
+  epigenomes: T[];
 }) => {
   return epigenomes.toSorted((e1, e2) => {
     for (const dimension of sortingDimensions) {

--- a/src/content/app/regulatory-activity-viewer/contexts/ActivityViewerEpigenomesContext.ts
+++ b/src/content/app/regulatory-activity-viewer/contexts/ActivityViewerEpigenomesContext.ts
@@ -16,7 +16,10 @@
 
 import { createContext } from 'react';
 
-import type { Epigenome } from 'src/content/app/regulatory-activity-viewer/types/epigenome';
+import type {
+  Epigenome,
+  LabelledEpigenome
+} from 'src/content/app/regulatory-activity-viewer/types/epigenome';
 import type { EpigenomeMetadataDimensionsResponse } from 'src/content/app/regulatory-activity-viewer/types/epigenomeMetadataDimensions';
 
 type ActivityViewerEpigenomesContextType = {
@@ -24,7 +27,7 @@ type ActivityViewerEpigenomesContextType = {
   isError: boolean;
   baseEpigenomes: Epigenome[] | null;
   filteredCombinedEpigenomes: Epigenome[] | null;
-  sortedCombinedEpigenomes: Epigenome[] | null;
+  sortedCombinedEpigenomes: LabelledEpigenome[] | null;
   epigenomeSortingDimensions: string[] | null; // List of up to three dimensions actually used to sort epigenomes
   allEpigenomeSortableDimensions: string[] | null; // List of all dimensions from which the sorting dimensions can be selected
   epigenomeCombiningDimensions: string[]; // List of dimensions to ignore when distinguishing between epigenomes. Selected by user. Starts as empty list

--- a/src/content/app/regulatory-activity-viewer/types/epigenome.ts
+++ b/src/content/app/regulatory-activity-viewer/types/epigenome.ts
@@ -19,3 +19,7 @@
 export type Epigenome = Record<string, string | string[]> & {
   id: string;
 };
+
+export type LabelledEpigenome = Epigenome & {
+  label: string;
+};

--- a/src/content/app/regulatory-activity-viewer/types/epigenomeGeneActivity.ts
+++ b/src/content/app/regulatory-activity-viewer/types/epigenomeGeneActivity.ts
@@ -16,7 +16,7 @@
 
 export type EpigenomeGeneActivity = {
   epigenome_ids: string[]; // <-- one or more epigenome id, corresponding to a track of epigenome activity data
-  value: number;
+  value: number | null;
 };
 
 export type EpigenomeGeneActivityResponse = {

--- a/src/content/app/regulatory-activity-viewer/types/epigenomeLabels.ts
+++ b/src/content/app/regulatory-activity-viewer/types/epigenomeLabels.ts
@@ -1,0 +1,41 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This is the label suggested for an epigenome suggested by the epigenomes api.
+ *
+ * Note:
+ *  - An epigenome displayed by the client can be a combination
+ *    of several base epigenomes (hence the 'epigenome_ids' field)
+ *  - Due to the capability to combine epigenomes dynamically,
+ *    and to Regulation team's willingness to fine-tune the text of the labels,
+ *    they are requested from the server dynamincally, rather than generated
+ *    on the client.
+ *
+ */
+export type EpigenomeLabel = {
+  epigenome_ids: string[]; // ids of one or more base epigenomes used to generate data for this given epigenome
+  label: string;
+};
+
+export type EpigenomeLabelsRequest = {
+  collapsed_by: string[];
+  epigenome_ids: string[][];
+};
+
+// There is a promise from the api to return the labels in the same order
+// in which they were requested
+export type EpigenomeLabelsResponse = EpigenomeLabel[];


### PR DESCRIPTION
## Description
1) Regulation api now takes the responsibility of generating the labels for epigenome activity tracks. The reason for doing this on the backend are:
- The client makes it possible to 'combine' epigenomes out of base epigenomes; and the labels should be adjusted to reflect this
- Activity viewer was developed in such a way that the client is agnostic to the data. Therefore, with the current data it receives from the api, the client wouldn't know how to generate labels out of epigenome information on its own (i.e. which piece of data goes first in the data string, which goes next, and so forth). 

**Before:**

<img width="2044" height="1326" alt="image" src="https://github.com/user-attachments/assets/57022609-8846-4f34-8095-e1ca47cc4827" />

**After:**

<img width="2140" height="1812" alt="image" src="https://github.com/user-attachments/assets/f4d21d1a-cdcd-4ec8-84bc-76d8f998449c" />

2) Gene activity data (the indicator on the right that appears after you've focused on a gene) is not available for all epigenomes; so if no data is available, the indicator is skipped

**Before:**

<img width="1055" height="353" alt="image" src="https://github.com/user-attachments/assets/50ecfb19-52ea-46ed-9468-f52881da44f6" />


**After:**

<img width="1086" height="247" alt="image" src="https://github.com/user-attachments/assets/31c679ab-f577-404e-af28-c2cdbeded1cd" />



## Related JIRA Issue(s)
<!--_Please provide the URL(s) for any JIRA issues related to this PR._-->

## Deployment URL(s)
http://__BRANCH_NAME_HERE__.review.ensembl.org


## Views affected
<!--
_List the website view(s) that you know are affected by this change._
_If possible please provide a relative or localhost URL that can be used to view the change._
-->