### PR TITLE
Navigate to previous app when we delete last species in species manager

### DIFF
--- a/src/content/app/species-selector/views/species-manager/selected-genomes-table/SelectedGenomesTable.tsx
+++ b/src/content/app/species-selector/views/species-manager/selected-genomes-table/SelectedGenomesTable.tsx
@@ -227,10 +227,10 @@ const SelectedGenomesTable = (props: {
     }
     exitDeletionMode();
     if (filteredGenomes.length === genomeIdsForDeletion.length) {
-      if (!previousApp) {
-        navigate(urlFor.speciesSelector());
-      } else {
+      if (previousApp) {
         navigate(`/${previousApp}`);
+      } else {
+        navigate(urlFor.speciesSelector());
       }
     }
   };

--- a/src/content/app/species-selector/views/species-manager/selected-genomes-table/SelectedGenomesTable.tsx
+++ b/src/content/app/species-selector/views/species-manager/selected-genomes-table/SelectedGenomesTable.tsx
@@ -15,9 +15,9 @@
  */
 
 import { Fragment, useReducer, type FormEvent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
-import { useAppDispatch } from 'src/store';
+import { useAppDispatch, useAppSelector } from 'src/store';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
 
@@ -140,6 +140,8 @@ const SelectedGenomesTable = (props: {
   const { allSelectedGenomes, filteredGenomes } = props;
   const [tableState, tableDispatch] = useReducer(reducer, initialState);
   const reduxDispatch = useAppDispatch();
+  const navigate = useNavigate();
+  const previousApp = useAppSelector((state) => state.global.previousApp);
 
   const isInDeletionMode = Boolean(tableState.deletionModeSettings);
   const genomeIdsForDeletion = new Set<string>(
@@ -224,6 +226,13 @@ const SelectedGenomesTable = (props: {
       reduxDispatch(deleteSpeciesAndSave(genomeId));
     }
     exitDeletionMode();
+    if (filteredGenomes.length === genomeIdsForDeletion.length) {
+      if (!previousApp) {
+        navigate(urlFor.speciesSelector());
+      } else {
+        navigate(`/${previousApp}`);
+      }
+    }
   };
 
   const toggleGenomeUse = (genome: CommittedItem) => {

--- a/src/global/globalSelectors.ts
+++ b/src/global/globalSelectors.ts
@@ -28,3 +28,6 @@ export const getScrollPosition = (state: RootState): ScrollPosition =>
 
 export const getCurrentApp = (state: RootState): string =>
   state.global.currentApp;
+
+export const getPreviousApp = (state: RootState): string =>
+  state.global.previousApp;

--- a/src/global/globalSlice.ts
+++ b/src/global/globalSlice.ts
@@ -35,13 +35,15 @@ export type GlobalState = Readonly<{
   breakpointWidth: BreakpointWidth;
   scrollPosition: ScrollPosition;
   currentApp: string;
+  previousApp: string;
 }>;
 
 export const defaultState: GlobalState = {
   browserTabId: null,
   breakpointWidth: BreakpointWidth.DESKTOP,
   scrollPosition: {},
-  currentApp: ''
+  currentApp: '',
+  previousApp: ''
 };
 
 export const updateBreakpointWidth: ActionCreator<
@@ -83,6 +85,10 @@ const globalSlice = createSlice({
       state.scrollPosition = { ...state.scrollPosition, ...action.payload };
     },
     changeCurrentApp(state, action: PayloadAction<string>) {
+      if (!action.payload || action.payload === state.currentApp) {
+        return;
+      }
+      state.previousApp = state.currentApp;
       state.currentApp = action.payload;
     }
   },


### PR DESCRIPTION
## Description
This PR updats species manager navigation workflow so that when the last species is deleted, user is navigated to previous app they were working using.


## Related JIRA Issue(s)
[ENSWBSITES-2536](https://embl.atlassian.net/browse/ENSWBSITES-2536)

## Deployment URL(s)
http://navigate-ss-page.review.ensembl.org
