### PR TITLE
Replace meta.total_count with meta.total_hits for genome search

### DIFF
--- a/src/content/app/species-selector/components/species-search-results-summary/SpeciesSearchResultsSummary.tsx
+++ b/src/content/app/species-selector/components/species-search-results-summary/SpeciesSearchResultsSummary.tsx
@@ -23,7 +23,7 @@ type Props = {
 };
 
 const SpeciesSearchResultsSummary = (props: Props) => {
-  const searchMatchesCount = props.searchResults?.meta.total_count ?? 0;
+  const searchMatchesCount = props.searchResults?.meta.total_hits ?? 0;
 
   return searchMatchesCount > 0 ? (
     <SuccessfulSearchResults count={searchMatchesCount} />

--- a/src/content/app/species-selector/state/species-selector-api-slice/speciesSelectorApiSlice.ts
+++ b/src/content/app/species-selector/state/species-selector-api-slice/speciesSelectorApiSlice.ts
@@ -32,7 +32,7 @@ export type SpeciesSearchRequestParams = {
 export type SpeciesSearchResponse = {
   matches: SpeciesSearchMatch[];
   meta: {
-    total_count: number;
+    total_hits: number;
   };
 };
 


### PR DESCRIPTION
## Description
A field in the metadata of genome search results got renamed for consistency with other searches (e.g. gene search); so this PR updates the client to migrate to that field.

**Before:**

<img width="1512" height="861" alt="image" src="https://github.com/user-attachments/assets/c1318825-a63c-4616-b34f-793132183057" />

**After:**

<img width="1512" height="865" alt="image" src="https://github.com/user-attachments/assets/908f9731-d170-4530-b00a-c225c90c774e" />


## Deployment URL(s)
http://fix-species-total-count.review.ensembl.org