### PR TITLE
Transcript as focus object in Entity viewer - first steps

### DIFF
--- a/src/content/app/entity-viewer/EntityViewer.tsx
+++ b/src/content/app/entity-viewer/EntityViewer.tsx
@@ -35,6 +35,7 @@ import EntityViewerInterstitial from './interstitial/EntityViewerInterstitial';
 import MissingGenomeError from 'src/shared/components/error-screen/url-errors/MissingGenomeError';
 import MissingFeatureError from 'src/shared/components/error-screen/url-errors/MissingFeatureError';
 import EntityViewerForGene from './EntityViewerForGene';
+import EntityViewerForTranscript from './EntityViewerForTranscript';
 import EntityViewerForVariant from './EntityViewerForVariant';
 
 import styles from './EntityViewer.module.css';
@@ -100,6 +101,8 @@ const EntityViewerController = (props: { entityType: string }) => {
 
   if (entityType === 'gene') {
     return <EntityViewerForGene />;
+  } else if (entityType === 'transcript') {
+    return <EntityViewerForTranscript />;
   } else if (entityType === 'variant') {
     return <EntityViewerForVariant />;
   } else {

--- a/src/content/app/entity-viewer/EntityViewerForTranscript.tsx
+++ b/src/content/app/entity-viewer/EntityViewerForTranscript.tsx
@@ -1,0 +1,40 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useAppSelector } from 'src/store';
+
+import { getBreakpointWidth } from 'src/global/globalSelectors';
+
+import { StandardAppLayout } from 'src/shared/components/layout';
+import TranscriptView from './transcript-view/TranscriptView';
+
+const EntityViewerForTranscript = () => {
+  const viewportWidth = useAppSelector(getBreakpointWidth);
+
+  return (
+    <StandardAppLayout
+      topbarContent={null}
+      mainContent={<TranscriptView />}
+      sidebarContent={null}
+      isSidebarOpen={true}
+      onSidebarToggle={() => true}
+      sidebarNavigation={null}
+      viewportWidth={viewportWidth}
+    />
+  );
+};
+
+export default EntityViewerForTranscript;

--- a/src/content/app/entity-viewer/contexts/entity-viewer-ids-context/EntityViewerIdsContext.ts
+++ b/src/content/app/entity-viewer/contexts/entity-viewer-ids-context/EntityViewerIdsContext.ts
@@ -25,10 +25,10 @@ import type { FocusObjectIdConstituents } from 'src/shared/types/focus-object/fo
  * - genomeIdForUrl — same; but generated considering what the active genome id is
  * - entityIdInUrl — a combination of the entity type with the stable id of the entity
  * - genomeId — actual id of a genome, as retrieved from the backend
- * - entityId — the full id that is used on the client as a key when storing entity information;
+ * - entityId — the full id that is used on the client as a key when storing entity information;
  *   is comprised of genome id, entity type, and entity stable id
- * - activeGenomeId — the id of the genome that is currently being viewed
- * - activeEntityId — the full id of the entity that that is currently being viewed
+ * - activeGenomeId — the id of the genome that is currently being viewed
+ * - activeEntityId — the full id of the entity that that is currently being viewed
  */
 
 export type EntityViewerIdsContextType = {

--- a/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
+++ b/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
@@ -56,6 +56,10 @@ import {
   type EntityViewerGeneHomologiesQueryResult
 } from './queries/geneHomologiesQuery';
 import {
+  defaultTranscriptQuery,
+  type DefaultEntityViewerTranscriptQueryResult
+} from './queries/transcriptDefaultQuery';
+import {
   variantPageMetaQuery,
   type VariantPageMetaQueryResult,
   type VariantPageMeta
@@ -182,6 +186,16 @@ const entityViewerThoasSlice = graphqlApiSlice.injectEndpoints({
       query: (params) => ({
         url: config.comparaApiBaseUrl,
         body: geneHomologiesQuery,
+        variables: params
+      })
+    }),
+    defaultEntityViewerTranscript: builder.query<
+      DefaultEntityViewerTranscriptQueryResult,
+      TranscriptQueryParams
+    >({
+      query: (params) => ({
+        url: config.coreApiUrl,
+        body: defaultTranscriptQuery,
         variables: params
       })
     }),
@@ -326,6 +340,7 @@ export const {
   useGeneForSequenceDownloadQuery,
   useProteinDomainsQuery,
   useEvGeneHomologyQuery,
+  useDefaultEntityViewerTranscriptQuery,
   useVariantPageMetaQuery,
   useDefaultEntityViewerVariantQuery,
   useVariantStudyPopulationsQuery,

--- a/src/content/app/entity-viewer/state/api/queries/defaultGeneQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/defaultGeneQuery.ts
@@ -24,7 +24,7 @@ import type { FullProductGeneratingContext } from 'src/shared/types/core-api/pro
 import type { Product } from 'src/shared/types/core-api/product';
 import type { TranscriptMetadata } from 'src/shared/types/core-api/metadata';
 
-const transcriptFieldsFragment = gql`
+export const transcriptFieldsFragment = gql`
   fragment transcriptFields on Transcript {
     stable_id
     unversioned_stable_id

--- a/src/content/app/entity-viewer/state/api/queries/transcriptDefaultQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/transcriptDefaultQuery.ts
@@ -1,0 +1,38 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from 'graphql-request';
+
+import {
+  transcriptFieldsFragment,
+  type DefaultEntityViewerTranscript
+} from './defaultGeneQuery';
+
+export const defaultTranscriptQuery = gql`
+  query DefaultEntityViewerTranscript(
+    $genomeId: String!
+    $transcriptId: String!
+  ) {
+    transcript(by_id: { genome_id: $genomeId, stable_id: $transcriptId }) {
+      ...transcriptFields
+    }
+  }
+  ${transcriptFieldsFragment}
+`;
+
+export type DefaultEntityViewerTranscriptQueryResult = {
+  transcript: DefaultEntityViewerTranscript;
+};

--- a/src/content/app/entity-viewer/transcript-view/TranscriptView.module.css
+++ b/src/content/app/entity-viewer/transcript-view/TranscriptView.module.css
@@ -1,0 +1,55 @@
+.container {
+  --gene-image-width: 695px; /* Note that there is a GENE_IMAGE_WIDTH js constant that this value should be in agreement with */
+  --gene-view-left-column-width: 160px;
+  --gene-view-middle-column-left-gap: 18px;
+  --gene-view-middle-column-width: var(--gene-image-width);
+  --gene-view-middle-column-right-gap: 27px;
+  --gene-view-right-column-width: 180px;
+
+  color: var(--color-white);
+  display: grid;
+  grid-template-rows:
+    [gene-section-row] min-content
+    [tabs-row] minmax(76px, auto)
+    [tab-content-row] minmax(0, 1fr);
+  
+  background-color: var(--color-black);
+  padding: 60px var(--standard-gutter) 0;
+  height: 100%; /* may need to change this later */
+  width: 100%;
+  overflow: auto;
+}
+
+.gridColumns {
+  display: grid;
+  grid-template-columns:
+    [column-left] 160px
+    [column-left-gap] 18px
+    [column-middle] var(--gene-image-width)
+    [column-right-gap] 27px
+    [column-right] minmax(180px, 1fr);
+}
+
+.middleColumn {
+  grid-column: column-middle;
+}
+
+.geneSectionLeft {
+  grid-column: column-left;
+}
+
+.geneSectionMiddle {
+  grid-column: column-middle;
+}
+
+.geneSectionRight {
+  grid-column: column-right;
+}
+
+.tabsSection {
+  align-self: end;
+}
+
+.tabs {
+  grid-column: column-middle;
+}

--- a/src/content/app/entity-viewer/transcript-view/TranscriptView.tsx
+++ b/src/content/app/entity-viewer/transcript-view/TranscriptView.tsx
@@ -14,9 +14,58 @@
  * limitations under the License.
  */
 
+import { useState } from 'react';
+import classNames from 'classnames';
+
+import useTranscriptViewIds from 'src/content/app/entity-viewer/transcript-view/hooks/useTranscriptViewIds';
+import { useDefaultEntityViewerTranscriptQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
+
+import TranscriptViewTabs from './components/transcript-view-tabs/TranscriptViewTabs';
+import TranscriptFunction from './components/transcript-function/TranscriptFunction';
+
+import styles from './TranscriptView.module.css';
+
 const TranscriptView = () => {
-  return <div>Transcript view!</div>;
-  // <div>{ JSON.stringify({ activeGenomeId, activeEntityId }) }</div>
+  const { activeGenomeId, transcriptId } = useTranscriptViewIds();
+  const [selectedView, setSelectedView] = useState('Transcript'); // this is temporary
+  const { currentData } = useDefaultEntityViewerTranscriptQuery(
+    {
+      genomeId: activeGenomeId ?? '',
+      transcriptId: transcriptId ?? ''
+    },
+    {
+      skip: !activeGenomeId || !transcriptId
+    }
+  );
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.gridColumns}>
+        <div className={styles.geneSectionLeft}>gene section left</div>
+        <div className={styles.geneSectionMiddle}>gene section middle</div>
+        <div className={styles.geneSectionRight}>gene section right</div>
+      </div>
+      <div className={classNames(styles.tabsSection, styles.gridColumns)}>
+        <div className={styles.tabs}>
+          <TranscriptViewTabs
+            activeView={selectedView}
+            onViewChange={setSelectedView}
+          />
+        </div>
+      </div>
+      {selectedView === 'Transcript' ? (
+        <div className={styles.gridColumns}>
+          <div>Left</div>
+          <div className={styles.middleColumn}>
+            Default content for the transcript view for{' '}
+            {currentData?.transcript.stable_id}
+          </div>
+        </div>
+      ) : (
+        <TranscriptFunction />
+      )}
+    </div>
+  );
 };
 
 export default TranscriptView;

--- a/src/content/app/entity-viewer/transcript-view/TranscriptView.tsx
+++ b/src/content/app/entity-viewer/transcript-view/TranscriptView.tsx
@@ -1,0 +1,22 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const TranscriptView = () => {
+  return <div>Transcript view!</div>;
+  // <div>{ JSON.stringify({ activeGenomeId, activeEntityId }) }</div>
+};
+
+export default TranscriptView;

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-function/TranscriptFunction.module.css
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-function/TranscriptFunction.module.css
@@ -1,0 +1,34 @@
+.panel {
+  width: initial;
+  min-height: 100%;
+}
+
+.panelBody {
+  color: var(--color-black);
+  min-height: 300px;
+  margin-right: 30px;
+  padding-bottom: 100px;
+  z-index: 0; /* so that a tooltip brought up inside the body goes behind the panel header instead of over it on scrolling */
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  position: sticky;
+  z-index: 1;
+}
+
+/* FIXME: instead of trying to unset the height of the tabs component, the tabs component should be updated to not have default height */
+.tabsContainer {
+  height: auto;
+}
+
+.tab {
+  padding: 3px 30px;
+}
+
+.selectedTab {
+  background-color: transparent;
+  color: var(--color-black);
+  font-weight: var(--font-weight-bold);
+}

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-function/TranscriptFunction.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-function/TranscriptFunction.tsx
@@ -1,0 +1,62 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import noop from 'lodash/noop';
+
+import Tabs, { type Tab } from 'src/shared/components/tabs/Tabs';
+import Panel from 'src/shared/components/panel/Panel';
+
+import styles from './TranscriptFunction.module.css';
+
+const tabsData: Tab[] = [
+  { title: 'Protein' },
+  { title: 'Variants', isDisabled: true },
+  { title: 'Phenotypes', isDisabled: true }
+];
+
+const tabClassNames = {
+  default: styles.tab,
+  selected: styles.selectedTab,
+  tabsContainer: styles.tabsContainer
+};
+
+const TranscriptFunction = () => {
+  return (
+    <Panel
+      header={<TabWrapper />}
+      classNames={{
+        panel: styles.panel,
+        header: styles.header,
+        body: styles.panelBody
+      }}
+    >
+      Protein view
+    </Panel>
+  );
+};
+
+const TabWrapper = () => {
+  return (
+    <Tabs
+      tabs={tabsData}
+      selectedTab={tabsData[0].title}
+      classNames={tabClassNames}
+      onTabChange={noop}
+    />
+  );
+};
+
+export default TranscriptFunction;

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-view-tabs/TranscriptViewTabs.module.css
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-view-tabs/TranscriptViewTabs.module.css
@@ -1,0 +1,19 @@
+.tabs {
+  z-index: 2;
+}
+
+.tab {
+  background-color: var(--color-blue);
+  color: var(--color-white);
+  font-weight: var(--font-weight-bold);
+  border-radius: 3px;
+  margin-right: 3px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+}
+
+.tabSelected {
+  background-color: transparent;
+  border: 1px solid var(--color-blue);
+}

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-view-tabs/TranscriptViewTabs.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-view-tabs/TranscriptViewTabs.tsx
@@ -1,0 +1,49 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Tabs, { type Tab } from 'src/shared/components/tabs/Tabs';
+
+import styles from './TranscriptViewTabs.module.css';
+
+const tabsData: Tab[] = [
+  { title: 'Transcript' },
+  { title: 'Transcript function' }
+];
+
+const TranscriptViewTabs = ({
+  activeView,
+  onViewChange
+}: {
+  activeView: string;
+  onViewChange: (view: string) => void;
+}) => {
+  const tabClassNames = {
+    default: styles.tab,
+    selected: styles.tabSelected,
+    tabsContainer: styles.geneViewTabs //FIXME: Pass this as a props so that it can be styled from the parent
+  };
+
+  return (
+    <Tabs
+      tabs={tabsData}
+      classNames={tabClassNames}
+      selectedTab={activeView}
+      onTabChange={onViewChange}
+    />
+  );
+};
+
+export default TranscriptViewTabs;

--- a/src/content/app/entity-viewer/transcript-view/hooks/useTranscriptViewIds.ts
+++ b/src/content/app/entity-viewer/transcript-view/hooks/useTranscriptViewIds.ts
@@ -1,0 +1,37 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { parseFocusObjectId } from 'src/shared/helpers/focusObjectHelpers';
+
+import useEntityViewerIds from 'src/content/app/entity-viewer/hooks/useEntityViewerIds';
+
+const useTranscriptViewIds = () => {
+  const bagOfIds = useEntityViewerIds();
+  const { entityId } = bagOfIds; // this is the id used as a key for entity information in redux store
+
+  let transcriptId;
+
+  if (entityId) {
+    transcriptId = parseFocusObjectId(entityId).objectId;
+  }
+
+  return {
+    ...bagOfIds,
+    transcriptId
+  };
+};
+
+export default useTranscriptViewIds;

--- a/src/shared/components/tabs/Tabs.module.css
+++ b/src/shared/components/tabs/Tabs.module.css
@@ -1,25 +1,29 @@
-.tabsContainer {
-  display: flex;
-  overflow-y: hidden;
-  height: 40px;
-  scrollbar-width: none;
-}
+@layer components {
 
-.tab {
-  padding: 3px 18px;
-  color: var(--color-blue);
-  cursor: pointer;
-  margin-right: 3px;
-  white-space: nowrap;
-}
+  .tabsContainer {
+    display: flex;
+    overflow-y: hidden;
+    height: 40px;
+    scrollbar-width: none;
+  }
+  
+  .tab {
+    padding: 3px 18px;
+    color: var(--color-blue);
+    cursor: pointer;
+    margin-right: 3px;
+    white-space: nowrap;
+  }
+  
+  .disabled {
+    color: var(--color-medium-dark-grey);
+    cursor: default;
+  }
+  
+  .selected {
+    color: var(--color-black);
+    position: relative;
+    cursor: default;
+  }
 
-.disabled {
-  color: var(--color-medium-dark-grey);
-  cursor: default;
-}
-
-.selected {
-  color: var(--color-black);
-  position: relative;
-  cursor: default;
 }

--- a/src/shared/components/tabs/Tabs.tsx
+++ b/src/shared/components/tabs/Tabs.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from 'classnames';
-import noop from 'lodash/noop';
 
 import styles from './Tabs.module.css';
 
@@ -68,13 +67,14 @@ export const Tabs = (props: TabsProps) => {
   return (
     <div className={tabsContainerClassName}>
       {Object.values(props.tabs).map((tab: Tab) => (
-        <span
+        <button
           className={getTabClassNames(tab)}
           key={tab.title}
-          onClick={tab.isDisabled ? noop : () => onTabSelect(tab.title)}
+          onClick={() => onTabSelect(tab.title)}
+          disabled={tab.isDisabled}
         >
           {tab.title}
-        </span>
+        </button>
       ))}
     </div>
   );

--- a/src/shared/helpers/focusObjectHelpers.ts
+++ b/src/shared/helpers/focusObjectHelpers.ts
@@ -55,15 +55,14 @@ export const buildFocusIdForUrl = (
 };
 
 export const parseFocusIdFromUrl = (id: string) => {
-  const regex = /(.+?):(.+)/;
+  const regex = /(?<feature_type>.+?):(?<feature_id>.+)/;
   const match = id.match(regex);
 
-  if (match?.length === 3) {
-    // whole id plus its two constituent parts
-    const [, type, objectId] = match;
+  if (match?.groups?.feature_type && match?.groups?.feature_id) {
+    const { feature_type, feature_id } = match.groups;
     return {
-      type,
-      objectId
+      type: feature_type,
+      objectId: feature_id
     };
   } else {
     throw new Error(`Malformed focus id "${id}" in url`);


### PR DESCRIPTION
## Description
- Recognise transcript as entity from the url parameter (e.g. `transcript:ENST00000680887`), and enable a new transcript view, which is distinct from gene view and variant view
- The view so far shows a mostly empty standard app layout, with two tabs in the main area, which will switch between the default view and the protein view

### Additional minor changes along the way
- Updated the `Tabs` component, changing a `span` element to a `button` element for more appropriate behaviour; plus wrapping its styles in a `components` layer to make it more styleable. We should review and rewrite the `Tabs` component in the future. On the one hand, it is useful, because tabs keep recurring over and over again. On the other hand, the way it is being styled is old (it receives multiple classnames), and it has a default height, which was a mistake.
- Updated `focusObjectHelpers.ts‎` to make the regex slightly smarter with capture groups.

## Related JIRA Issue(s)
Part of https://embl.atlassian.net/browse/ENSWBSITES-2993 (see XD in that ticket's description)

## Deployment URL(s)
http://ev-transcript-as-object.review.ensembl.org (e.g. http://ev-transcript-as-object.review.ensembl.org/entity-viewer/grch38/transcript:ENST00000680887)