### PR TITLE
EV for transcript: add gene image, transcript image, transcript info panel

### DIFF
--- a/src/content/app/entity-viewer/gene-view/components/gene-overview-image/GeneOverviewImage.module.css
+++ b/src/content/app/entity-viewer/gene-view/components/gene-overview-image/GeneOverviewImage.module.css
@@ -13,7 +13,6 @@
 .containerSVG {
   grid-column: 3/4;
   background-color: var(--color-light-grey);
-  height: 18px;
 }
 
 .transcript rect {

--- a/src/content/app/entity-viewer/gene-view/components/gene-overview-image/GeneOverviewImage.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-overview-image/GeneOverviewImage.tsx
@@ -24,10 +24,14 @@ import {
 import { getStrandDisplayName } from 'src/shared/helpers/formatters/strandFormatter';
 import { pluralise } from 'src/shared/helpers/formatters/pluralisationFormatter';
 
-import { GENE_IMAGE_WIDTH } from 'src/content/app/entity-viewer/gene-view/constants/geneViewConstants';
+import {
+  GENE_IMAGE_WIDTH,
+  GENE_IMAGE_HEIGHT
+} from 'src/content/app/entity-viewer/gene-view/constants/geneViewConstants';
 
 import UnsplicedTranscript, {
-  UnsplicedTranscriptProps
+  UnsplicedTranscriptProps,
+  UNSPLICED_TRANSCRIPT_HEIGHT
 } from 'src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript';
 import FeatureLengthRuler from 'src/shared/components/feature-length-ruler/FeatureLengthRuler';
 
@@ -89,7 +93,7 @@ export const GeneImage = (props: GeneOverviewImageProps) => {
         getFeatureCoordinates(transcript);
       const startX = scale(transcriptStart);
       const endX = scale(transcriptEnd);
-      const y = 10;
+      const y = GENE_IMAGE_HEIGHT / 2 - UNSPLICED_TRANSCRIPT_HEIGHT / 2;
       const width = Math.floor(endX - startX);
       return (
         <g key={index} transform={`translate(${startX} ${y})`}>
@@ -105,8 +109,10 @@ export const GeneImage = (props: GeneOverviewImageProps) => {
     }
   );
 
+  const viewBox = `0 0 ${GENE_IMAGE_WIDTH} ${GENE_IMAGE_HEIGHT}`;
+
   return (
-    <svg className={styles.containerSVG} width={GENE_IMAGE_WIDTH}>
+    <svg className={styles.containerSVG} viewBox={viewBox}>
       {renderedTranscripts}
     </svg>
   );

--- a/src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript.tsx
@@ -26,6 +26,7 @@ import type { FullCDS } from 'src/shared/types/core-api/cds';
 import styles from './UnsplicedTranscript.module.css';
 
 const BLOCK_HEIGHT = 7;
+export const UNSPLICED_TRANSCRIPT_HEIGHT = BLOCK_HEIGHT;
 
 type ProductGeneratingContext = {
   cds: Pick<FullCDS, 'relative_start' | 'relative_end'> | null;
@@ -95,7 +96,7 @@ const UnsplicedTranscript = (props: UnsplicedTranscriptProps) => {
       className={styles.containerSvg}
       width={scale(transcriptLength)}
       height={BLOCK_HEIGHT}
-      viewBox={`0 0 ${scale(transcriptLength)} ${BLOCK_HEIGHT}`}
+      viewBox={`0 0 ${scale(transcriptLength)} ${UNSPLICED_TRANSCRIPT_HEIGHT}`}
     >
       {renderedTranscript}
     </svg>
@@ -116,6 +117,8 @@ const Backbone = (props: BackboneProps) => {
   }
 
   const segments: ReactNode[] = [];
+  const backboneHeight = 1;
+  const backboneTopOffset = BLOCK_HEIGHT / 2 - backboneHeight / 2;
 
   for (let i = 0; i < exonRectangles.length - 1; i++) {
     /*
@@ -143,8 +146,8 @@ const Backbone = (props: BackboneProps) => {
       <rect
         key={currentRectangleEnd}
         className={className}
-        y={0}
-        height={1}
+        y={backboneTopOffset}
+        height={backboneHeight}
         x={currentRectangleEnd + 1}
         width={segmentWidth}
       />
@@ -162,7 +165,7 @@ type ExonBlockProps = {
 };
 
 const ExonBlock = (props: ExonBlockProps) => {
-  const y = -3;
+  const y = 0;
   const height = BLOCK_HEIGHT;
 
   const rectElements = props.exonRectangles.map((exonRect, index) => {

--- a/src/content/app/entity-viewer/gene-view/constants/geneViewConstants.ts
+++ b/src/content/app/entity-viewer/gene-view/constants/geneViewConstants.ts
@@ -15,3 +15,4 @@
  */
 
 export const GENE_IMAGE_WIDTH = 695;
+export const GENE_IMAGE_HEIGHT = 18;

--- a/src/content/app/entity-viewer/state/api/queries/transcriptDefaultQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/transcriptDefaultQuery.ts
@@ -14,12 +14,34 @@
  * limitations under the License.
  */
 
+import { Pick3 } from 'ts-multipick';
+
 import { gql } from 'graphql-request';
 
 import {
   transcriptFieldsFragment,
   type DefaultEntityViewerTranscript
 } from './defaultGeneQuery';
+
+import type { FullGene } from 'src/shared/types/core-api/gene';
+
+const geneFieldsFragment = gql`
+  fragment geneFields on Gene {
+    stable_id
+    symbol
+    unversioned_stable_id
+    slice {
+      location {
+        start
+        end
+        length
+      }
+      strand {
+        code
+      }
+    }
+  }
+`;
 
 export const defaultTranscriptQuery = gql`
   query DefaultEntityViewerTranscript(
@@ -28,11 +50,24 @@ export const defaultTranscriptQuery = gql`
   ) {
     transcript(by_id: { genome_id: $genomeId, stable_id: $transcriptId }) {
       ...transcriptFields
+      gene {
+        ...geneFields
+      }
     }
   }
   ${transcriptFieldsFragment}
+  ${geneFieldsFragment}
 `;
 
+type GeneInDefaultTranscriptRequest = Pick<
+  FullGene,
+  'stable_id' | 'symbol' | 'unversioned_stable_id'
+> &
+  Pick3<FullGene, 'slice', 'location', 'start' | 'end' | 'length'> &
+  Pick3<FullGene, 'slice', 'strand', 'code'>;
+
 export type DefaultEntityViewerTranscriptQueryResult = {
-  transcript: DefaultEntityViewerTranscript;
+  transcript: DefaultEntityViewerTranscript & {
+    gene: GeneInDefaultTranscriptRequest;
+  };
 };

--- a/src/content/app/entity-viewer/transcript-view/TranscriptView.module.css
+++ b/src/content/app/entity-viewer/transcript-view/TranscriptView.module.css
@@ -48,6 +48,12 @@
 
 .tabsSection {
   align-self: end;
+  position: sticky;
+  top: -80px;
+  background-color: var(--color-black);
+  height: 76px;
+  align-items: flex-end;
+  z-index: 2;
 }
 
 .tabs {

--- a/src/content/app/entity-viewer/transcript-view/TranscriptView.tsx
+++ b/src/content/app/entity-viewer/transcript-view/TranscriptView.tsx
@@ -43,7 +43,7 @@ const TranscriptView = () => {
     }
   );
 
-  if (!currentData) {
+  if (!activeGenomeId || !currentData) {
     return null; // FIXME: show a spinner?
   }
 
@@ -64,6 +64,7 @@ const TranscriptView = () => {
       </div>
       {selectedView === 'Transcript' && rulerTicks ? (
         <TranscriptDetails
+          genomeId={activeGenomeId}
           transcript={currentData.transcript}
           rulerTicks={rulerTicks}
         />

--- a/src/content/app/entity-viewer/transcript-view/TranscriptView.tsx
+++ b/src/content/app/entity-viewer/transcript-view/TranscriptView.tsx
@@ -22,13 +22,17 @@ import { useDefaultEntityViewerTranscriptQuery } from 'src/content/app/entity-vi
 
 import GeneOverviewImage from './components/gene-overview-image/GeneOverviewImage';
 import TranscriptViewTabs from './components/transcript-view-tabs/TranscriptViewTabs';
+import TranscriptDetails from './components/transcript-details/TranscriptDetails';
 import TranscriptFunction from './components/transcript-function/TranscriptFunction';
+
+import type { TicksAndScale } from 'src/shared/components/feature-length-ruler/FeatureLengthRuler';
 
 import styles from './TranscriptView.module.css';
 
 const TranscriptView = () => {
   const { activeGenomeId, transcriptId } = useTranscriptViewIds();
   const [selectedView, setSelectedView] = useState('Transcript'); // this is temporary
+  const [rulerTicks, setRulerTicks] = useState<TicksAndScale | null>(null);
   const { currentData } = useDefaultEntityViewerTranscriptQuery(
     {
       genomeId: activeGenomeId ?? '',
@@ -48,7 +52,7 @@ const TranscriptView = () => {
       <GeneOverviewImage
         transcript={currentData.transcript}
         gene={currentData.transcript.gene}
-        onTicksCalculated={(ticks) => console.log('ticks calculated!', ticks)}
+        onTicksCalculated={setRulerTicks}
       />
       <div className={classNames(styles.tabsSection, styles.gridColumns)}>
         <div className={styles.tabs}>
@@ -58,14 +62,11 @@ const TranscriptView = () => {
           />
         </div>
       </div>
-      {selectedView === 'Transcript' ? (
-        <div className={styles.gridColumns}>
-          <div>Left</div>
-          <div className={styles.middleColumn}>
-            Default content for the transcript view for{' '}
-            {currentData?.transcript.stable_id}
-          </div>
-        </div>
+      {selectedView === 'Transcript' && rulerTicks ? (
+        <TranscriptDetails
+          transcript={currentData.transcript}
+          rulerTicks={rulerTicks}
+        />
       ) : (
         <TranscriptFunction />
       )}

--- a/src/content/app/entity-viewer/transcript-view/TranscriptView.tsx
+++ b/src/content/app/entity-viewer/transcript-view/TranscriptView.tsx
@@ -20,6 +20,7 @@ import classNames from 'classnames';
 import useTranscriptViewIds from 'src/content/app/entity-viewer/transcript-view/hooks/useTranscriptViewIds';
 import { useDefaultEntityViewerTranscriptQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
 
+import GeneOverviewImage from './components/gene-overview-image/GeneOverviewImage';
 import TranscriptViewTabs from './components/transcript-view-tabs/TranscriptViewTabs';
 import TranscriptFunction from './components/transcript-function/TranscriptFunction';
 
@@ -38,13 +39,17 @@ const TranscriptView = () => {
     }
   );
 
+  if (!currentData) {
+    return null; // FIXME: show a spinner?
+  }
+
   return (
     <div className={styles.container}>
-      <div className={styles.gridColumns}>
-        <div className={styles.geneSectionLeft}>gene section left</div>
-        <div className={styles.geneSectionMiddle}>gene section middle</div>
-        <div className={styles.geneSectionRight}>gene section right</div>
-      </div>
+      <GeneOverviewImage
+        transcript={currentData.transcript}
+        gene={currentData.transcript.gene}
+        onTicksCalculated={(ticks) => console.log('ticks calculated!', ticks)}
+      />
       <div className={classNames(styles.tabsSection, styles.gridColumns)}>
         <div className={styles.tabs}>
           <TranscriptViewTabs

--- a/src/content/app/entity-viewer/transcript-view/components/gene-overview-image/GeneOverviewImage.module.css
+++ b/src/content/app/entity-viewer/transcript-view/components/gene-overview-image/GeneOverviewImage.module.css
@@ -1,0 +1,51 @@
+.svg {
+  grid-column: 3/4;
+  background-color: var(--color-light-grey);
+  height: 18px;
+}
+
+.transcript rect {
+  stroke: var(--color-dark-grey);
+  fill: var(--color-dark-grey);
+}
+
+.geneId {
+  grid-column: 1/2;
+  grid-row: 2/3;
+  text-align: right;
+  font-size: 13px;
+  font-weight: var(--font-weight-bold);
+  word-break: break-all;
+}
+
+.directionIndicator {
+  grid-column: 3/4;
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: 6px;
+  font-size: 12px;
+}
+
+.strand {
+  grid-column: 5/6;
+  grid-row: 1/2;
+  font-size: 12px;
+}
+
+.numberOfTranscripts {
+  grid-column: 5/6;
+  grid-row: 2/3;
+}
+
+.transcriptsCount {
+  font-weight: var(--font-weight-bold);
+  margin-right: 0.4em;
+}
+
+.ruler {
+  --sequence-ruler-name-color: white;
+  --sequence-ruler-label-color: white;
+  grid-column: 3/4;
+  grid-row: 3/4;
+  padding-top: 15px;
+}

--- a/src/content/app/entity-viewer/transcript-view/components/gene-overview-image/GeneOverviewImage.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/gene-overview-image/GeneOverviewImage.tsx
@@ -30,7 +30,8 @@ import {
 } from 'src/content/app/entity-viewer/gene-view/constants/geneViewConstants';
 
 import UnsplicedTranscript, {
-  UnsplicedTranscriptProps
+  UnsplicedTranscriptProps,
+  UNSPLICED_TRANSCRIPT_HEIGHT
 } from 'src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript';
 import FeatureLengthRuler, {
   type TicksAndScale
@@ -90,7 +91,7 @@ export const GeneImage = (props: GeneOverviewImageProps) => {
     getFeatureCoordinates(transcript);
   const startX = geneScale(transcriptStart);
   const endX = geneScale(transcriptEnd);
-  const y = 10; // offset from the top of the drawing area
+  const y = GENE_IMAGE_HEIGHT / 2 - UNSPLICED_TRANSCRIPT_HEIGHT / 2; // offset from the top of the drawing area
   const width = Math.floor(endX - startX);
 
   return (

--- a/src/content/app/entity-viewer/transcript-view/components/gene-overview-image/GeneOverviewImage.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/gene-overview-image/GeneOverviewImage.tsx
@@ -1,0 +1,152 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { scaleLinear } from 'd3';
+import { Pick3 } from 'ts-multipick';
+
+import {
+  getFeatureCoordinates,
+  getFeatureLength
+} from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
+import { getStrandDisplayName } from 'src/shared/helpers/formatters/strandFormatter';
+// import { pluralise } from 'src/shared/helpers/formatters/pluralisationFormatter';
+
+import {
+  GENE_IMAGE_WIDTH,
+  GENE_IMAGE_HEIGHT
+} from 'src/content/app/entity-viewer/gene-view/constants/geneViewConstants';
+
+import UnsplicedTranscript, {
+  UnsplicedTranscriptProps
+} from 'src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript';
+import FeatureLengthRuler, {
+  type TicksAndScale
+} from 'src/shared/components/feature-length-ruler/FeatureLengthRuler';
+
+import type { FullGene } from 'src/shared/types/core-api/gene';
+import type { FullTranscript } from 'src/shared/types/core-api/transcript';
+
+import commonStyles from '../../TranscriptView.module.css';
+import styles from './GeneOverviewImage.module.css';
+
+type Gene = Pick<FullGene, 'stable_id'> &
+  Pick3<FullGene, 'slice', 'location', 'start' | 'end' | 'length'> &
+  Pick3<FullGene, 'slice', 'strand', 'code'>;
+
+type Transcript = UnsplicedTranscriptProps['transcript'] &
+  Pick3<FullTranscript, 'slice', 'location', 'start' | 'end' | 'length'>;
+
+export type GeneOverviewImageProps = {
+  transcript: Transcript;
+  gene: Gene;
+  onTicksCalculated: (payload: TicksAndScale) => void;
+};
+
+const GeneOverviewImage = (props: GeneOverviewImageProps) => {
+  const length = getFeatureLength(props.gene);
+
+  return (
+    <div className={commonStyles.gridColumns}>
+      <GeneId {...props} />
+      <DirectionIndicator />
+      <GeneImage {...props} />
+      <StrandIndicator {...props} />
+      {/* <NumberOfTranscripts {...props} /> */}
+      <div className={styles.ruler}>
+        <FeatureLengthRuler
+          length={length}
+          width={GENE_IMAGE_WIDTH}
+          rulerLabel="bp"
+          onTicksCalculated={props.onTicksCalculated}
+          standalone={true}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const GeneImage = (props: GeneOverviewImageProps) => {
+  const { start: geneStart, end: geneEnd } = getFeatureCoordinates(props.gene);
+  const { transcript } = props;
+
+  const geneScale = scaleLinear()
+    .domain([geneStart, geneEnd])
+    .rangeRound([0, GENE_IMAGE_WIDTH]);
+
+  const { start: transcriptStart, end: transcriptEnd } =
+    getFeatureCoordinates(transcript);
+  const startX = geneScale(transcriptStart);
+  const endX = geneScale(transcriptEnd);
+  const y = 10; // offset from the top of the drawing area
+  const width = Math.floor(endX - startX);
+
+  return (
+    <svg
+      className={styles.svg}
+      viewBox={`0 0 ${GENE_IMAGE_WIDTH} ${GENE_IMAGE_HEIGHT}`}
+      width={GENE_IMAGE_WIDTH}
+    >
+      <g transform={`translate(${startX} ${y})`}>
+        <UnsplicedTranscript
+          transcript={transcript}
+          width={width}
+          classNames={{
+            transcript: styles.transcript
+          }}
+        />
+      </g>
+    </svg>
+  );
+};
+
+const GeneId = (props: GeneOverviewImageProps) => (
+  <div className={styles.geneId}>{props.gene.stable_id}</div>
+);
+
+const DirectionIndicator = () => {
+  return (
+    <div className={styles.directionIndicator}>
+      <span>5'</span>
+      <span>3'</span>
+    </div>
+  );
+};
+
+const StrandIndicator = (props: GeneOverviewImageProps) => {
+  const {
+    gene: {
+      slice: {
+        strand: { code: strandCode }
+      }
+    }
+  } = props;
+
+  return (
+    <div className={styles.strand}>{getStrandDisplayName(strandCode)}</div>
+  );
+};
+
+// const NumberOfTranscripts = (props: GeneOverviewImageProps) => {
+//   const transcripts = props.gene.transcripts;
+//   return (
+//     <div className={styles.numberOfTranscripts}>
+//       <span className={styles.transcriptsCount}>{transcripts.length}</span>
+//       {` ${pluralise('transcript', transcripts.length)}`}
+//     </div>
+//   );
+// };
+
+export default GeneOverviewImage;

--- a/src/content/app/entity-viewer/transcript-view/components/gene-overview-image/GeneOverviewImage.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/gene-overview-image/GeneOverviewImage.tsx
@@ -140,14 +140,4 @@ const StrandIndicator = (props: GeneOverviewImageProps) => {
   );
 };
 
-// const NumberOfTranscripts = (props: GeneOverviewImageProps) => {
-//   const transcripts = props.gene.transcripts;
-//   return (
-//     <div className={styles.numberOfTranscripts}>
-//       <span className={styles.transcriptsCount}>{transcripts.length}</span>
-//       {` ${pluralise('transcript', transcripts.length)}`}
-//     </div>
-//   );
-// };
-
 export default GeneOverviewImage;

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-details/TranscriptDetails.module.css
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-details/TranscriptDetails.module.css
@@ -1,0 +1,57 @@
+.container {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  height: 100%;
+}
+
+.header {
+  border-bottom: 1px solid var(--color-orange);
+  padding: 0;
+  position: sticky;
+  top: -5px;
+  background-color: var(--color-black);
+  z-index: 1;
+  font-size: 12px;
+  font-weight: var(--font-weight-light);
+}
+
+.main {
+  position: relative;
+  padding-top: 36px;
+  padding-bottom: var(--global-padding-bottom);
+}
+
+.stripedBackground {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: calc(var(--gene-view-left-column-width) + var(--gene-view-middle-column-left-gap));
+}
+
+.stripe {
+  position: absolute;
+  width: 1px;
+  top: 0;
+  bottom: 0;
+  background: var(--color-orange);
+  opacity: 0.4;
+}
+
+.row {
+  align-items: center;
+}
+
+.columnRight {
+  grid-column: column-right;
+}
+
+.columnMiddle {
+  grid-column: column-middle;
+}
+
+.transcriptImageWrapper {
+  display: inline-block;
+  fill: white;
+  stroke: white;
+}
+

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-details/TranscriptDetails.module.css
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-details/TranscriptDetails.module.css
@@ -38,7 +38,13 @@
 }
 
 .row {
+  position: relative;
   align-items: center;
+  padding: 9px 0;
+}
+
+.row + .row {
+  padding-top: 0;
 }
 
 .columnRight {
@@ -54,4 +60,3 @@
   fill: white;
   stroke: white;
 }
-

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-details/TranscriptDetails.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-details/TranscriptDetails.tsx
@@ -1,0 +1,89 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classNames from 'classnames';
+
+import { getFeatureLength } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
+
+import { TranscriptQualityLabel } from 'src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel';
+import UnsplicedTranscript from 'src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript';
+
+import type { DefaultEntityViewerTranscriptQueryResult } from 'src/content/app/entity-viewer/state/api/queries/transcriptDefaultQuery';
+import type { TicksAndScale } from 'src/shared/components/feature-length-ruler/FeatureLengthRuler';
+
+import commonStyles from '../../TranscriptView.module.css';
+import styles from './TranscriptDetails.module.css';
+
+type Transcript = DefaultEntityViewerTranscriptQueryResult['transcript'];
+
+export type Props = {
+  transcript: Transcript;
+  rulerTicks: TicksAndScale;
+};
+
+const TranscriptDetails = (props: Props) => {
+  const { scale } = props.rulerTicks;
+  const {
+    relative_location: { start: relativeTranscriptStart },
+    slice: {
+      location: { length: transcriptLength }
+    }
+  } = props.transcript;
+  const transcriptStartX = scale(relativeTranscriptStart) as number;
+  const transcriptWidth = scale(transcriptLength) as number;
+
+  return (
+    <div className={styles.container}>
+      <div className={classNames(styles.header, commonStyles.gridColumns)}>
+        <div className={styles.columnRight}>Header</div>
+      </div>
+      <div className={styles.main}>
+        <StripedBackground {...props} />
+        <div className={classNames(commonStyles.gridColumns, styles.row)}>
+          <TranscriptQualityLabel metadata={props.transcript.metadata} />
+          <div className={styles.columnMiddle}>
+            <div
+              className={styles.transcriptImageWrapper}
+              style={{ transform: `translateX(${transcriptStartX}px)` }}
+            >
+              <UnsplicedTranscript
+                transcript={props.transcript}
+                width={transcriptWidth}
+                standalone={true}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const StripedBackground = (props: Props) => {
+  const { scale, ticks } = props.rulerTicks;
+  const geneLength = getFeatureLength(props.transcript.gene);
+  const extendedTicks = [1, ...ticks, geneLength];
+
+  const stripes = extendedTicks.map((tick) => {
+    const x = Math.floor(scale(tick) as number);
+    const style = { left: `${x}px` };
+    return <span key={x} className={styles.stripe} style={style} />;
+  });
+
+  return <div className={styles.stripedBackground}>{stripes}</div>;
+};
+
+export default TranscriptDetails;

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-details/TranscriptDetails.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-details/TranscriptDetails.tsx
@@ -20,6 +20,7 @@ import { getFeatureLength } from 'src/content/app/entity-viewer/shared/helpers/e
 
 import { TranscriptQualityLabel } from 'src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel';
 import UnsplicedTranscript from 'src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript';
+import TranscriptInfoPanel from 'src/content/app/entity-viewer/transcript-view/components/transcript-details/transcript-info-panel/TranscriptInfoPanel';
 
 import type { DefaultEntityViewerTranscriptQueryResult } from 'src/content/app/entity-viewer/state/api/queries/transcriptDefaultQuery';
 import type { TicksAndScale } from 'src/shared/components/feature-length-ruler/FeatureLengthRuler';
@@ -30,6 +31,7 @@ import styles from './TranscriptDetails.module.css';
 type Transcript = DefaultEntityViewerTranscriptQueryResult['transcript'];
 
 export type Props = {
+  genomeId: string;
   transcript: Transcript;
   rulerTicks: TicksAndScale;
 };
@@ -48,7 +50,7 @@ const TranscriptDetails = (props: Props) => {
   return (
     <div className={styles.container}>
       <div className={classNames(styles.header, commonStyles.gridColumns)}>
-        <div className={styles.columnRight}>Header</div>
+        <div className={styles.columnRight}>Transcript ID</div>
       </div>
       <div className={styles.main}>
         <StripedBackground {...props} />
@@ -66,6 +68,15 @@ const TranscriptDetails = (props: Props) => {
               />
             </div>
           </div>
+          <div className={styles.columnRight}>{props.transcript.stable_id}</div>
+        </div>
+        <div className={classNames(commonStyles.gridColumns, styles.row)}>
+          <TranscriptInfoPanel
+            genomeId={props.genomeId}
+            transcript={props.transcript}
+            gene={props.transcript.gene}
+            className={styles.columnMiddle}
+          />
         </div>
       </div>
     </div>

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-details/transcript-info-panel/TranscriptInfoPanel.module.css
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-details/transcript-info-panel/TranscriptInfoPanel.module.css
@@ -1,0 +1,98 @@
+.container {
+  display: grid;
+  grid-template-areas:
+    'left middle right'
+    'more-info-button . .'
+    'more-info more-info more-info'
+    'download-button . .'
+    'download download download';
+  column-gap: 10px;
+  background: var(--color-soft-black);
+  padding: 15px 30px;
+  color: var(--color-white);
+  font-weight: var(--font-weight-light);
+}
+
+.topLeft {
+  grid-area: left;
+  width: 190px;
+  margin-bottom: 12px;
+}
+
+.topLeft div {
+  padding-bottom: 6px;
+}
+
+.topMiddle {
+  grid-area: middle;
+  width: 150px;
+}
+
+.topMiddle div {
+  padding-bottom: 6px;
+}
+
+.topRight {
+  grid-area: right;
+  width: 210px;
+}
+
+.topRight div {
+  padding-bottom: 6px;
+}
+
+.moreInfoShowHide,
+.downloadShowHide {
+  justify-self: start;
+}
+
+.moreInfoShowHide {
+  grid-area: more-info-button;
+  padding-top: 6px;
+  font-weight: var(--font-weight-normal);
+}
+
+.normalText {
+  font-weight: var(--font-weight-normal);
+}
+
+.wrapText {
+  overflow-wrap: break-word;
+}
+
+.moreInformation {
+  grid-area: more-info;
+  display: grid;
+  grid-template-columns: 190px auto;
+  column-gap: 20px;
+  padding-top: 6px;
+  padding-left: 12px;
+  margin-bottom: 6px;
+}
+
+.moreInfoColumn {
+  width: 190px;
+}
+
+.moreInfoColumn div {
+  padding-bottom: 6px;
+}
+
+.externalRefLink {
+  font-weight: var(--font-weight-normal);
+}
+
+.downloadShowHide {
+  grid-area: download-button;
+  padding-top: 6px;
+  font-weight: var(--font-weight-normal);
+}
+
+.download {
+  grid-area: download;
+  padding-top: 6px;
+}
+
+.viewInApp {
+  padding-top: 12px;
+}

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-details/transcript-info-panel/TranscriptInfoPanel.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-details/transcript-info-panel/TranscriptInfoPanel.tsx
@@ -1,0 +1,264 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, useMemo } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import classNames from 'classnames';
+
+import { formatNumber } from 'src/shared/helpers/formatters/numberFormatter';
+import { getFormattedLocation } from 'src/shared/helpers/formatters/regionFormatter';
+import {
+  isProteinCodingTranscript,
+  getFeatureCoordinates,
+  getRegionName,
+  getNumberOfCodingExons,
+  getSplicedRNALength,
+  getProductAminoAcidLength
+} from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
+
+import { InstantDownloadTranscript } from 'src/shared/components/instant-download';
+import ShowHide from 'src/shared/components/show-hide/ShowHide';
+import ExternalReference from 'src/shared/components/external-reference/ExternalReference';
+
+import type { DefaultEntityViewerTranscript } from 'src/content/app/entity-viewer/state/api/queries/defaultGeneQuery';
+import type {
+  GetSplicedRNALengthParam,
+  GetProductAminoAcidLengthParam
+} from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
+
+import styles from './TranscriptInfoPanel.module.css';
+
+type GeneFields = {
+  stable_id: string;
+};
+
+type TranscriptFields = Pick<
+  DefaultEntityViewerTranscript,
+  | 'stable_id'
+  | 'slice'
+  | 'metadata'
+  | 'external_references'
+  | 'product_generating_contexts'
+  | 'spliced_exons'
+> &
+  GetSplicedRNALengthParam &
+  GetProductAminoAcidLengthParam;
+
+export type Props = {
+  genomeId: string;
+  gene: GeneFields;
+  transcript: TranscriptFields;
+  className?: string;
+};
+
+export const TranscriptsListItemInfo = (props: Props) => {
+  const { transcript } = props;
+  const [isMoreInfoExpanded, setMoreInfoExpanded] = useState(false);
+  const [isDownloadExpanded, setDownloadExpanded] = useState(false);
+  const location = useLocation();
+
+  const getTranscriptLocation = () => {
+    const { start, end } = getFeatureCoordinates(transcript);
+    const chromosome = getRegionName(transcript);
+
+    return getFormattedLocation({
+      chromosome,
+      start,
+      end
+    });
+  };
+
+  const splicedRNALength = formatNumber(getSplicedRNALength(transcript));
+
+  const aminoAcidLength = formatNumber(getProductAminoAcidLength(transcript));
+
+  const { hasMoreInfo, moreInfoComponent } = useMemo(() => {
+    const hasLeftColumnElements = (
+      ['gencode_basic', 'tsl', 'appris'] as const
+    ).some((key) => transcript.metadata[key]);
+    const consensusCDS = transcript.external_references.find(
+      (xref) => xref.source.name === 'CCDS'
+    );
+    const transcriptNCBI = transcript.metadata.mane?.ncbi_transcript;
+
+    const hasRightColumnElements = Boolean(consensusCDS || transcriptNCBI);
+
+    const moreInfoComponent = (
+      <MoreTranscriptInfo
+        genomeId={props.genomeId}
+        transcript={props.transcript}
+        gene={props.gene}
+        consensusCDS={consensusCDS}
+        hasLeftColumnElements={hasLeftColumnElements}
+        hasRightColumnElements={hasRightColumnElements}
+      />
+    );
+
+    return {
+      hasMoreInfo: hasLeftColumnElements || hasRightColumnElements,
+      moreInfoComponent
+    };
+  }, [
+    props.transcript,
+    props.gene,
+    props.genomeId,
+    transcript.external_references,
+    transcript.metadata
+  ]);
+
+  const getLinkToProteinView = () => {
+    const { pathname } = location;
+    const searchParams = new URLSearchParams();
+    searchParams.set('view', 'protein');
+    return `${pathname}?${searchParams.toString()}`;
+  };
+
+  const proteinIdClasses = classNames(styles.normalText, styles.wrapText);
+  const product = transcript.product_generating_contexts[0].product;
+
+  return (
+    <div className={classNames(styles.container, props.className)}>
+      <div className={styles.topLeft}>
+        <div>
+          Biotype{' '}
+          <span className={styles.normalText}>
+            {transcript.metadata.biotype.label}
+          </span>
+        </div>
+        <div>{getTranscriptLocation()}</div>
+      </div>
+      <div>
+        {isProteinCodingTranscript(transcript) && (
+          <>
+            <div className={styles.normalText} data-test-id="proteinLength">
+              {aminoAcidLength} aa
+            </div>
+            <div className={proteinIdClasses}>
+              {product && (
+                <Link to={getLinkToProteinView()}>{product.stable_id}</Link>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+      <div className={styles.topRight}>
+        <div>
+          Combined exon length{' '}
+          <span className={styles.normalText}>{splicedRNALength}</span> bp
+        </div>
+        <div>
+          Coding exons{' '}
+          <span className={styles.normalText}>
+            {getNumberOfCodingExons(transcript)}
+          </span>{' '}
+          of {transcript.spliced_exons.length}
+        </div>
+      </div>
+
+      {hasMoreInfo && (
+        <ShowHide
+          onClick={() => setMoreInfoExpanded((prev) => !prev)}
+          label="More information"
+          isExpanded={isMoreInfoExpanded}
+          className={styles.moreInfoShowHide}
+        />
+      )}
+
+      {isMoreInfoExpanded && (
+        <div className={styles.moreInformation}>{moreInfoComponent}</div>
+      )}
+
+      <ShowHide
+        onClick={() => setDownloadExpanded((prev) => !prev)}
+        label="Download"
+        isExpanded={isDownloadExpanded}
+        className={styles.downloadShowHide}
+      />
+      {isDownloadExpanded && (
+        <div className={styles.download}>
+          <InstantDownloadTranscript
+            genomeId={props.genomeId}
+            transcript={{
+              id: transcript.stable_id,
+              isProteinCoding: isProteinCodingTranscript(transcript)
+            }}
+            gene={{ id: props.gene.stable_id }}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+const MoreTranscriptInfo = (
+  props: Props & {
+    consensusCDS:
+      | DefaultEntityViewerTranscript['external_references'][0]
+      | undefined;
+    hasLeftColumnElements: boolean;
+    hasRightColumnElements: boolean;
+  }
+) => {
+  const {
+    transcript,
+    consensusCDS,
+    hasLeftColumnElements,
+    hasRightColumnElements
+  } = props;
+  const transcriptNCBI = transcript.metadata.mane?.ncbi_transcript;
+
+  if (!hasLeftColumnElements && !hasRightColumnElements) {
+    return null;
+  }
+
+  return (
+    <>
+      {hasLeftColumnElements && (
+        <div className={styles.moreInfoColumn}>
+          {transcript.metadata.gencode_basic?.label && (
+            <div>{transcript.metadata.gencode_basic?.label}</div>
+          )}
+          {transcript.metadata?.tsl && (
+            <div>{transcript.metadata.tsl?.label}</div>
+          )}
+          {transcript.metadata?.appris && (
+            <div>{transcript.metadata.appris?.label}</div>
+          )}
+        </div>
+      )}
+      {hasRightColumnElements && (
+        <div className={styles.moreInfoColumn}>
+          {!!transcriptNCBI && (
+            <ExternalReference label="RefSeq match" to={transcriptNCBI.url}>
+              <span className={styles.externalRefLink}>
+                {transcriptNCBI.id}
+              </span>
+            </ExternalReference>
+          )}
+          {consensusCDS?.url && (
+            <ExternalReference label="CCDS" to={consensusCDS.url}>
+              <span className={styles.externalRefLink}>
+                {consensusCDS.accession_id}
+              </span>
+            </ExternalReference>
+          )}
+        </div>
+      )}
+    </>
+  );
+};
+
+export default TranscriptsListItemInfo;


### PR DESCRIPTION
## Description
- Add gene image
- Add transcript diagram in the main section
- Add transcript info panel
  - "More information" dropdown works
  - Download works


## Deployment URL(s)
http://ev-transcript-as-object.review.ensembl.org

e.g. http://ev-transcript-as-object.review.ensembl.org/entity-viewer/grch38/transcript:ENST00000380152