### PR TITLE
EV for transcript: add routing, and store active view in redux

### DIFF
--- a/src/content/app/entity-viewer/state/entityViewerReducer.ts
+++ b/src/content/app/entity-viewer/state/entityViewerReducer.ts
@@ -19,6 +19,7 @@ import { combineReducers } from 'redux';
 import entityViewerGeneralReducer from './general/entityViewerGeneralSlice';
 import entityViewerSidebarReducer from './sidebar/entityViewerSidebarSlice';
 import entityViewerGeneViewReducer from './gene-view/entityViewerGeneViewReducer';
+import entityViewerTranscriptViewReducer from './transcript-view/entityViewerTranscriptViewReducer';
 import entityViewerBookmarksReducer from './bookmarks/entityViewerBookmarksSlice';
 import entityViewerVariantViewReducer from './variant-view/entityViewerVariantViewReducer';
 
@@ -26,6 +27,7 @@ export default combineReducers({
   general: entityViewerGeneralReducer,
   sidebar: entityViewerSidebarReducer,
   geneView: entityViewerGeneViewReducer,
+  transcriptView: entityViewerTranscriptViewReducer,
   variantView: entityViewerVariantViewReducer,
   bookmarks: entityViewerBookmarksReducer
 });

--- a/src/content/app/entity-viewer/state/transcript-view/entityViewerTranscriptViewReducer.ts
+++ b/src/content/app/entity-viewer/state/transcript-view/entityViewerTranscriptViewReducer.ts
@@ -1,0 +1,23 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { combineReducers } from 'redux';
+
+import variantViewGeneralReducer from './general/transcriptViewGeneralSlice';
+
+export default combineReducers({
+  general: variantViewGeneralReducer
+});

--- a/src/content/app/entity-viewer/state/transcript-view/general/transcriptViewGeneralSelectors.ts
+++ b/src/content/app/entity-viewer/state/transcript-view/general/transcriptViewGeneralSelectors.ts
@@ -1,0 +1,36 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defaultView } from './transcriptViewGeneralSlice';
+
+import type { RootState } from 'src/store';
+
+const getSliceForTranscript = (
+  state: RootState,
+  genomeId: string,
+  variantId: string
+) => {
+  return state.entityViewer.transcriptView.general[genomeId]?.[variantId];
+};
+
+export const getViewForTranscript = (
+  state: RootState,
+  genomeId: string,
+  variantId: string
+) => {
+  const slice = getSliceForTranscript(state, genomeId, variantId);
+  return slice?.view ?? defaultView;
+};

--- a/src/content/app/entity-viewer/state/transcript-view/general/transcriptViewGeneralSlice.ts
+++ b/src/content/app/entity-viewer/state/transcript-view/general/transcriptViewGeneralSlice.ts
@@ -1,0 +1,76 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+const viewNames = ['transcript', 'protein'] as const;
+
+export type ViewName = (typeof viewNames)[number];
+
+export const defaultView = 'transcript';
+
+export const isValidView = (view: string) =>
+  (viewNames as readonly string[]).includes(view);
+
+export type StateForTranscript = {
+  view: ViewName;
+};
+
+type State = {
+  [genomeId: string]: {
+    [transcriptId: string]: StateForTranscript;
+  };
+};
+
+const initialStateForTranscript: StateForTranscript = {
+  view: 'transcript'
+};
+
+const ensureTranscriptState = (
+  state: State,
+  genomeId: string,
+  transcriptId: string
+) => {
+  if (!state[genomeId]) {
+    state[genomeId] = {};
+  }
+  if (!state[genomeId][transcriptId]) {
+    state[genomeId][transcriptId] = structuredClone(initialStateForTranscript);
+  }
+};
+
+const transcriptViewGeneralSlice = createSlice({
+  name: 'entity-viewer-transcript-view-general',
+  initialState: {} as State,
+  reducers: {
+    setView(
+      state,
+      action: PayloadAction<{
+        genomeId: string;
+        transcriptId: string;
+        view: ViewName;
+      }>
+    ) {
+      const { genomeId, transcriptId, view } = action.payload;
+      ensureTranscriptState(state, genomeId, transcriptId);
+      state[genomeId][transcriptId].view = view;
+    }
+  }
+});
+
+export const { setView } = transcriptViewGeneralSlice.actions;
+
+export default transcriptViewGeneralSlice.reducer;

--- a/src/content/app/entity-viewer/transcript-view/TranscriptView.module.css
+++ b/src/content/app/entity-viewer/transcript-view/TranscriptView.module.css
@@ -54,6 +54,7 @@
   height: 76px;
   align-items: flex-end;
   z-index: 2;
+  padding-bottom: 4px;
 }
 
 .tabs {

--- a/src/content/app/entity-viewer/transcript-view/TranscriptView.tsx
+++ b/src/content/app/entity-viewer/transcript-view/TranscriptView.tsx
@@ -14,11 +14,22 @@
  * limitations under the License.
  */
 
-import { useState } from 'react';
+import { useEffect, useState, useRef, useCallback } from 'react';
 import classNames from 'classnames';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+
+import { useAppSelector, useAppDispatch } from 'src/store';
+
+import { getViewForTranscript } from 'src/content/app/entity-viewer/state/transcript-view/general/transcriptViewGeneralSelectors';
 
 import useTranscriptViewIds from 'src/content/app/entity-viewer/transcript-view/hooks/useTranscriptViewIds';
 import { useDefaultEntityViewerTranscriptQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
+import {
+  setView,
+  isValidView,
+  defaultView,
+  type ViewName as TranscriptViewName
+} from 'src/content/app/entity-viewer/state/transcript-view/general/transcriptViewGeneralSlice';
 
 import GeneOverviewImage from './components/gene-overview-image/GeneOverviewImage';
 import TranscriptViewTabs from './components/transcript-view-tabs/TranscriptViewTabs';
@@ -31,8 +42,8 @@ import styles from './TranscriptView.module.css';
 
 const TranscriptView = () => {
   const { activeGenomeId, transcriptId } = useTranscriptViewIds();
-  const [selectedView, setSelectedView] = useState('Transcript'); // this is temporary
   const [rulerTicks, setRulerTicks] = useState<TicksAndScale | null>(null);
+  const [searchParams] = useSearchParams();
   const { currentData } = useDefaultEntityViewerTranscriptQuery(
     {
       genomeId: activeGenomeId ?? '',
@@ -43,9 +54,21 @@ const TranscriptView = () => {
     }
   );
 
+  const viewInUrl = searchParams.get('view');
+
+  const { view, navigateToView } = useTranscriptViewRouter({
+    genomeId: activeGenomeId ?? '',
+    transcriptId: transcriptId ?? '',
+    viewInUrl
+  });
+
   if (!activeGenomeId || !currentData) {
     return null; // FIXME: show a spinner?
   }
+
+  const onViewChange = (view: string) => {
+    navigateToView({ view });
+  };
 
   return (
     <div className={styles.container}>
@@ -56,13 +79,10 @@ const TranscriptView = () => {
       />
       <div className={classNames(styles.tabsSection, styles.gridColumns)}>
         <div className={styles.tabs}>
-          <TranscriptViewTabs
-            activeView={selectedView}
-            onViewChange={setSelectedView}
-          />
+          <TranscriptViewTabs activeView={view} onViewChange={onViewChange} />
         </div>
       </div>
-      {selectedView === 'Transcript' && rulerTicks ? (
+      {view === defaultView && rulerTicks ? (
         <TranscriptDetails
           genomeId={activeGenomeId}
           transcript={currentData.transcript}
@@ -73,6 +93,81 @@ const TranscriptView = () => {
       )}
     </div>
   );
+};
+
+const useTranscriptViewRouter = ({
+  genomeId,
+  transcriptId,
+  viewInUrl
+}: {
+  genomeId: string;
+  transcriptId: string;
+  viewInUrl: string | null;
+}) => {
+  const prevViewInUrl = useRef(viewInUrl);
+  const viewInRedux = useAppSelector((state) =>
+    getViewForTranscript(state, genomeId, transcriptId)
+  );
+  const dispatch = useAppDispatch();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const navigateToView = useCallback(
+    ({ view, replace = false }: { view: string | null; replace?: boolean }) => {
+      const searchParams = new URLSearchParams(location.search);
+      if (!view || view === defaultView) {
+        searchParams.delete('view');
+      } else {
+        searchParams.set('view', view);
+      }
+      const url = `${location.pathname}?${searchParams.toString()}`;
+      navigate(url, { replace });
+    },
+    [location.pathname, location.search, navigate]
+  );
+
+  const updateReduxData = useCallback(() => {
+    const view = viewInUrl ?? defaultView;
+    dispatch(
+      setView({
+        genomeId,
+        transcriptId,
+        view: view as TranscriptViewName
+      })
+    );
+  }, [dispatch, genomeId, transcriptId, viewInUrl]);
+
+  useEffect(() => {
+    if (viewInUrl) {
+      if (!isValidView(viewInUrl)) {
+        // this can only happen if user edited the url
+        // remove the view information from the url
+        navigateToView({ view: null, replace: true });
+      }
+      // always trust the url
+      if (viewInUrl !== viewInRedux) {
+        updateReduxData();
+      }
+    } else {
+      // choose between showing the default view or updating url with view stored in redux
+      if (!prevViewInUrl.current) {
+        // this is the first navigation to the transcripts view
+        // check redux for stored view
+        if (viewInRedux !== defaultView) {
+          navigateToView({ view: viewInRedux, replace: true });
+        }
+      } else {
+        updateReduxData();
+      }
+    }
+
+    prevViewInUrl.current = viewInUrl;
+  }, [viewInUrl, navigateToView, updateReduxData, viewInRedux]);
+
+  return {
+    view: viewInRedux,
+    navigateToView
+  };
 };
 
 export default TranscriptView;

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-details/TranscriptDetails.module.css
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-details/TranscriptDetails.module.css
@@ -13,6 +13,7 @@
   z-index: 1;
   font-size: 12px;
   font-weight: var(--font-weight-light);
+  padding: 9px 0;
 }
 
 .main {

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-view-tabs/TranscriptViewTabs.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-view-tabs/TranscriptViewTabs.tsx
@@ -14,13 +14,18 @@
  * limitations under the License.
  */
 
-import Tabs, { type Tab } from 'src/shared/components/tabs/Tabs';
+import {
+  defaultView,
+  type ViewName
+} from 'src/content/app/entity-viewer/state/transcript-view/general/transcriptViewGeneralSlice';
+
+import Tabs from 'src/shared/components/tabs/Tabs';
 
 import styles from './TranscriptViewTabs.module.css';
 
-const tabsData: Tab[] = [
-  { title: 'Transcript' },
-  { title: 'Transcript function' }
+const tabsData: Array<{ title: string; view: ViewName }> = [
+  { title: 'Transcript', view: defaultView },
+  { title: 'Transcript function', view: 'protein' }
 ];
 
 const TranscriptViewTabs = ({
@@ -36,12 +41,23 @@ const TranscriptViewTabs = ({
     tabsContainer: styles.geneViewTabs //FIXME: Pass this as a props so that it can be styled from the parent
   };
 
+  const handleTabChange = (tabTitle: string) => {
+    const tab = tabsData.find((tab) => tab.title === tabTitle) as {
+      view: string;
+    };
+    onViewChange(tab.view);
+  };
+
+  const selectedTab = tabsData.find((tab) => tab.view === activeView) as {
+    title: string;
+  };
+
   return (
     <Tabs
       tabs={tabsData}
       classNames={tabClassNames}
-      selectedTab={activeView}
-      onTabChange={onViewChange}
+      selectedTab={selectedTab.title}
+      onTabChange={handleTabChange}
     />
   );
 };


### PR DESCRIPTION
## Description
- Connect the view within the main content area to the url (default view vs transcript view)
- Store the selected view in redux such that last visited view can be restored after navigation between genomes or between apps


## Related JIRA Issue(s)
Part of https://embl.atlassian.net/browse/ENSWBSITES-2993

## Deployment URL(s)
http://ev-transcript-as-object.review.ensembl.org
Specific example: http://ev-transcript-as-object.review.ensembl.org/entity-viewer/grch38/transcript:ENST00000380152