### PR TITLE
Add protein diagram to entity viewer for transcript

### DIFF
--- a/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
@@ -54,7 +54,7 @@ import type { ProteinCodingTranscript } from 'src/content/app/entity-viewer/gene
 import styles from './ProteinsListItemInfo.module.css';
 
 export type Props = {
-  gene: DefaultEntityViewerGene;
+  gene: Pick<DefaultEntityViewerGene, 'symbol' | 'stable_id'>;
   transcript: ProteinCodingTranscript;
   trackLength: number;
 };

--- a/src/content/app/entity-viewer/shared/helpers/entity-helpers.ts
+++ b/src/content/app/entity-viewer/shared/helpers/entity-helpers.ts
@@ -200,3 +200,16 @@ export const getProteinXrefs = <
 
   return proteinXrefs;
 };
+
+export const getProteinDescription = <
+  T extends Pick<ExternalReference, 'description'> &
+    Pick2<ExternalReference, 'source', 'id'>
+>(product: {
+  external_references: T[];
+}) => {
+  const swissprotReference = product.external_references.find(
+    (reference) => reference.source.id === SWISSPROT_SOURCE
+  );
+
+  return swissprotReference?.description;
+};

--- a/src/content/app/entity-viewer/transcript-view/TranscriptView.tsx
+++ b/src/content/app/entity-viewer/transcript-view/TranscriptView.tsx
@@ -89,7 +89,7 @@ const TranscriptView = () => {
           rulerTicks={rulerTicks}
         />
       ) : (
-        <TranscriptFunction />
+        <TranscriptFunction transcript={currentData.transcript} />
       )}
     </div>
   );

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-function/TranscriptFunction.module.css
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-function/TranscriptFunction.module.css
@@ -32,3 +32,14 @@
   color: var(--color-black);
   font-weight: var(--font-weight-bold);
 }
+
+.proteinInfo {
+  font-weight: var(--font-weight-light);
+}
+
+.proteinInfoMiddle {
+  display: grid;
+  grid-template-columns: 10% 43% 43%;
+  column-gap: 2%;
+  font-weight: var(--font-weight-normal);
+}

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-function/TranscriptFunction.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-function/TranscriptFunction.tsx
@@ -14,11 +14,25 @@
  * limitations under the License.
  */
 
+import classNames from 'classnames';
 import noop from 'lodash/noop';
+
+import {
+  isProteinCodingTranscript,
+  getProductAminoAcidLength,
+  getProteinDescription
+} from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
 
 import Tabs, { type Tab } from 'src/shared/components/tabs/Tabs';
 import Panel from 'src/shared/components/panel/Panel';
+import ProteinsListItemInfo, {
+  type Props as ProteinListItemInfoProps
+} from 'src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo';
+import { TranscriptQualityLabel } from 'src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel';
 
+import type { DefaultEntityViewerTranscriptQueryResult } from 'src/content/app/entity-viewer/state/api/queries/transcriptDefaultQuery';
+
+import transcriptsListStyles from 'src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.module.css';
 import styles from './TranscriptFunction.module.css';
 
 const tabsData: Tab[] = [
@@ -33,7 +47,13 @@ const tabClassNames = {
   tabsContainer: styles.tabsContainer
 };
 
-const TranscriptFunction = () => {
+type Props = {
+  transcript: DefaultEntityViewerTranscriptQueryResult['transcript'];
+};
+
+const TranscriptFunction = (props: Props) => {
+  const canDisplayProtein = isProteinCodingTranscript(props.transcript);
+
   return (
     <Panel
       header={<TabWrapper />}
@@ -43,8 +63,59 @@ const TranscriptFunction = () => {
         body: styles.panelBody
       }}
     >
-      Protein view
+      {canDisplayProtein ? (
+        <ProteinInfo
+          transcript={
+            props.transcript as ProteinListItemInfoProps['transcript']
+          }
+          gene={props.transcript.gene}
+        />
+      ) : (
+        <div>This transcript is not protein-coding</div>
+      )}
     </Panel>
+  );
+};
+
+const ProteinInfo = ({
+  transcript,
+  gene
+}: {
+  transcript: ProteinListItemInfoProps['transcript'];
+  gene: ProteinListItemInfoProps['gene'];
+}) => {
+  const { product } = transcript.product_generating_contexts[0];
+  const proteinLength = getProductAminoAcidLength(transcript);
+
+  // ProteinsListItemInfo component was developed for Entity Viewer gene view;
+  // which is why it has "list" in its name, and also why it receives a "track length"
+  // property (in gene view, proteins are drawn relative to the longest protein in a gene)
+  return (
+    <div className={styles.proteinInfo}>
+      <div className={transcriptsListStyles.row}>
+        <div className={transcriptsListStyles.left}>
+          <TranscriptQualityLabel metadata={transcript.metadata} />
+        </div>
+        <div
+          className={classNames(
+            transcriptsListStyles.middle,
+            styles.proteinInfoMiddle
+          )}
+        >
+          <div>{getProductAminoAcidLength(transcript)} aa</div>
+          <div>{getProteinDescription(product)}</div>
+          <div className={styles.productStableId}>{product?.stable_id}</div>
+        </div>
+        <div className={transcriptsListStyles.right}>
+          <span className={styles.transcriptId}>{transcript.stable_id}</span>
+        </div>
+      </div>
+      <ProteinsListItemInfo
+        transcript={transcript}
+        gene={gene}
+        trackLength={proteinLength}
+      />
+    </div>
   );
 };
 


### PR DESCRIPTION
## Description
Add content for the "Transcript function" tab of entity viewer for transcript.

The content of the tab has been lifted from the gene view, where there are many transcripts and thus, potentially, many proteins. This is why the imports have names such as `ProteinListItem` or `ProteinListItemInfo`.


## Related JIRA Issue(s)
Part of https://embl.atlassian.net/browse/ENSWBSITES-2993

## Deployment URL(s)
http://ev-transcript-as-object.review.ensembl.org

Example: http://ev-transcript-as-object.review.ensembl.org/entity-viewer/grch38/transcript:ENST00000380152?view=protein