### PR TITLE
Entity Viewer for transcript: add sidebar content

### DIFF
--- a/src/content/app/entity-viewer/EntityViewerForTranscript.tsx
+++ b/src/content/app/entity-viewer/EntityViewerForTranscript.tsx
@@ -21,18 +21,19 @@ import { getBreakpointWidth } from 'src/global/globalSelectors';
 import { StandardAppLayout } from 'src/shared/components/layout';
 import TranscriptView from './transcript-view/TranscriptView';
 import TranscriptViewSidebar from './transcript-view/components/transcript-view-sidebar/TranscriptViewSidebar';
+import TranscriptViewSidebarTabs from './transcript-view/components/transcript-view-sidebar-tabs/TranscriptViewSidebarTabs';
 
 const EntityViewerForTranscript = () => {
   const viewportWidth = useAppSelector(getBreakpointWidth);
 
   return (
     <StandardAppLayout
-      topbarContent={null}
+      topbarContent={<div />}
       mainContent={<TranscriptView />}
       sidebarContent={<TranscriptViewSidebar />}
       isSidebarOpen={true}
       onSidebarToggle={() => true}
-      sidebarNavigation={null}
+      sidebarNavigation={<TranscriptViewSidebarTabs />}
       viewportWidth={viewportWidth}
     />
   );

--- a/src/content/app/entity-viewer/EntityViewerForTranscript.tsx
+++ b/src/content/app/entity-viewer/EntityViewerForTranscript.tsx
@@ -14,9 +14,15 @@
  * limitations under the License.
  */
 
-import { useAppSelector } from 'src/store';
+import { useAppSelector, useAppDispatch } from 'src/store';
 
 import { getBreakpointWidth } from 'src/global/globalSelectors';
+
+import useTranscriptViewIds from 'src/content/app/entity-viewer/transcript-view/hooks/useTranscriptViewIds';
+
+import { getIsSidebarOpen } from 'src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSelectors';
+
+import { toggleSidebar } from 'src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSlice';
 
 import { StandardAppLayout } from 'src/shared/components/layout';
 import TranscriptView from './transcript-view/TranscriptView';
@@ -24,15 +30,33 @@ import TranscriptViewSidebar from './transcript-view/components/transcript-view-
 import TranscriptViewSidebarTabs from './transcript-view/components/transcript-view-sidebar-tabs/TranscriptViewSidebarTabs';
 
 const EntityViewerForTranscript = () => {
+  const { activeGenomeId, transcriptId } = useTranscriptViewIds();
+  const isSidebarOpen = useAppSelector((state) =>
+    getIsSidebarOpen(state, activeGenomeId ?? '', transcriptId ?? '')
+  );
   const viewportWidth = useAppSelector(getBreakpointWidth);
+  const dispatch = useAppDispatch();
+
+  const onSidebarToggle = () => {
+    if (!activeGenomeId || !transcriptId) {
+      // this should not happen
+      return;
+    }
+    dispatch(
+      toggleSidebar({
+        genomeId: activeGenomeId,
+        transcriptId
+      })
+    );
+  };
 
   return (
     <StandardAppLayout
       topbarContent={<div />}
       mainContent={<TranscriptView />}
       sidebarContent={<TranscriptViewSidebar />}
-      isSidebarOpen={true}
-      onSidebarToggle={() => true}
+      isSidebarOpen={isSidebarOpen}
+      onSidebarToggle={onSidebarToggle}
       sidebarNavigation={<TranscriptViewSidebarTabs />}
       viewportWidth={viewportWidth}
     />

--- a/src/content/app/entity-viewer/EntityViewerForTranscript.tsx
+++ b/src/content/app/entity-viewer/EntityViewerForTranscript.tsx
@@ -20,6 +20,7 @@ import { getBreakpointWidth } from 'src/global/globalSelectors';
 
 import { StandardAppLayout } from 'src/shared/components/layout';
 import TranscriptView from './transcript-view/TranscriptView';
+import TranscriptViewSidebar from './transcript-view/components/transcript-view-sidebar/TranscriptViewSidebar';
 
 const EntityViewerForTranscript = () => {
   const viewportWidth = useAppSelector(getBreakpointWidth);
@@ -28,7 +29,7 @@ const EntityViewerForTranscript = () => {
     <StandardAppLayout
       topbarContent={null}
       mainContent={<TranscriptView />}
-      sidebarContent={null}
+      sidebarContent={<TranscriptViewSidebar />}
       isSidebarOpen={true}
       onSidebarToggle={() => true}
       sidebarNavigation={null}

--- a/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
@@ -54,7 +54,7 @@ import type { ProteinCodingTranscript } from 'src/content/app/entity-viewer/gene
 import styles from './ProteinsListItemInfo.module.css';
 
 export type Props = {
-  gene: DefaultEntityViewerGene;
+  gene: Pick<DefaultEntityViewerGene, 'symbol' | 'stable_id'>;
   transcript: ProteinCodingTranscript;
   trackLength: number;
 };

--- a/src/content/app/entity-viewer/shared/helpers/entity-helpers.ts
+++ b/src/content/app/entity-viewer/shared/helpers/entity-helpers.ts
@@ -200,3 +200,16 @@ export const getProteinXrefs = <
 
   return proteinXrefs;
 };
+
+export const getProteinDescription = <
+  T extends Pick<ExternalReference, 'description'> &
+    Pick2<ExternalReference, 'source', 'id'>
+>(product: {
+  external_references: T[];
+}) => {
+  const swissprotReference = product.external_references.find(
+    (reference) => reference.source.id === SWISSPROT_SOURCE
+  );
+
+  return swissprotReference?.description;
+};

--- a/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
+++ b/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
@@ -60,6 +60,10 @@ import {
   type DefaultEntityViewerTranscriptQueryResult
 } from './queries/transcriptDefaultQuery';
 import {
+  transcriptExternalReferencesQuery,
+  type TranscriptExternalReferencesQueryResult
+} from './queries/transcriptExternalReferencesQuery';
+import {
   variantPageMetaQuery,
   type VariantPageMetaQueryResult,
   type VariantPageMeta
@@ -196,6 +200,16 @@ const entityViewerThoasSlice = graphqlApiSlice.injectEndpoints({
       query: (params) => ({
         url: config.coreApiUrl,
         body: defaultTranscriptQuery,
+        variables: params
+      })
+    }),
+    transcriptExternalReferences: builder.query<
+      TranscriptExternalReferencesQueryResult,
+      TranscriptQueryParams
+    >({
+      query: (params) => ({
+        url: config.coreApiUrl,
+        body: transcriptExternalReferencesQuery,
         variables: params
       })
     }),
@@ -341,6 +355,7 @@ export const {
   useProteinDomainsQuery,
   useEvGeneHomologyQuery,
   useDefaultEntityViewerTranscriptQuery,
+  useTranscriptExternalReferencesQuery,
   useVariantPageMetaQuery,
   useDefaultEntityViewerVariantQuery,
   useVariantStudyPopulationsQuery,

--- a/src/content/app/entity-viewer/state/api/queries/geneExternalReferencesQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/geneExternalReferencesQuery.ts
@@ -23,7 +23,7 @@ import type { FullProductGeneratingContext } from 'src/shared/types/core-api/pro
 import type { TranscriptMetadata } from 'src/shared/types/core-api/metadata';
 import type { ExternalReference } from 'src/shared/types/core-api/externalReference';
 
-const transcriptFieldsFragment = gql`
+export const transcriptFieldsFragment = gql`
   fragment transcriptFields on Transcript {
     stable_id
     slice {

--- a/src/content/app/entity-viewer/state/api/queries/transcriptDefaultQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/transcriptDefaultQuery.ts
@@ -28,8 +28,10 @@ import type { FullGene } from 'src/shared/types/core-api/gene';
 const geneFieldsFragment = gql`
   fragment geneFields on Gene {
     stable_id
-    symbol
     unversioned_stable_id
+    symbol
+    alternative_symbols
+    name
     slice {
       location {
         start
@@ -38,6 +40,15 @@ const geneFieldsFragment = gql`
       }
       strand {
         code
+      }
+    }
+    metadata {
+      name {
+        accession_id
+        url
+      }
+      biotype {
+        value
       }
     }
   }
@@ -61,10 +72,22 @@ export const defaultTranscriptQuery = gql`
 
 type GeneInDefaultTranscriptRequest = Pick<
   FullGene,
-  'stable_id' | 'symbol' | 'unversioned_stable_id'
+  | 'stable_id'
+  | 'unversioned_stable_id'
+  | 'symbol'
+  | 'alternative_symbols'
+  | 'name'
 > &
   Pick3<FullGene, 'slice', 'location', 'start' | 'end' | 'length'> &
-  Pick3<FullGene, 'slice', 'strand', 'code'>;
+  Pick3<FullGene, 'slice', 'strand', 'code'> & {
+    metadata: {
+      name: Pick<
+        NonNullable<FullGene['metadata']['name']>,
+        'accession_id' | 'url'
+      > | null;
+      biotype: Pick<FullGene['metadata']['biotype'], 'value'>;
+    };
+  };
 
 export type DefaultEntityViewerTranscriptQueryResult = {
   transcript: DefaultEntityViewerTranscript & {

--- a/src/content/app/entity-viewer/state/api/queries/transcriptExternalReferencesQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/transcriptExternalReferencesQuery.ts
@@ -1,0 +1,38 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from 'graphql-request';
+
+import {
+  transcriptFieldsFragment,
+  type QueriedTranscript
+} from './geneExternalReferencesQuery';
+
+export const transcriptExternalReferencesQuery = gql`
+  query TranscriptExternalReferences(
+    $transcriptId: String!
+    $genomeId: String!
+  ) {
+    transcript(by_id: { stable_id: $transcriptId, genome_id: $genomeId }) {
+      ...transcriptFields
+    }
+  }
+  ${transcriptFieldsFragment}
+`;
+
+export type TranscriptExternalReferencesQueryResult = {
+  transcript: QueriedTranscript;
+};

--- a/src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSelectors.ts
+++ b/src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSelectors.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { defaultView } from './transcriptViewGeneralSlice';
+import { defaultSidebarTabName } from './transcriptViewSidebarSlice';
 
 import type { RootState } from 'src/store';
 
@@ -23,14 +23,23 @@ const getSliceForTranscript = (
   genomeId: string,
   transcriptId: string
 ) => {
-  return state.entityViewer.transcriptView.general[genomeId]?.[transcriptId];
+  return state.entityViewer.transcriptView.sidebar[genomeId]?.[transcriptId];
 };
 
-export const getViewForTranscript = (
+export const getIsSidebarOpen = (
   state: RootState,
   genomeId: string,
   transcriptId: string
 ) => {
   const slice = getSliceForTranscript(state, genomeId, transcriptId);
-  return slice?.view ?? defaultView;
+  return slice?.isOpen ?? true;
+};
+
+export const getActiveSidebarTab = (
+  state: RootState,
+  genomeId: string,
+  transcriptId: string
+) => {
+  const slice = getSliceForTranscript(state, genomeId, transcriptId);
+  return slice?.selectedTabName ?? defaultSidebarTabName;
 };

--- a/src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSelectors.ts
+++ b/src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSelectors.ts
@@ -43,3 +43,12 @@ export const getActiveSidebarTab = (
   const slice = getSliceForTranscript(state, genomeId, transcriptId);
   return slice?.selectedTabName ?? defaultSidebarTabName;
 };
+
+export const getSidebarModalView = (
+  state: RootState,
+  genomeId: string,
+  transcriptId: string
+) => {
+  const slice = getSliceForTranscript(state, genomeId, transcriptId);
+  return slice?.sidebarModalView ?? null;
+};

--- a/src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSlice.ts
+++ b/src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSlice.ts
@@ -1,0 +1,86 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+export const sidebarTabNames = ['Overview', 'External references'] as const;
+export const defaultSidebarTabName = sidebarTabNames[0];
+
+type SidebarTabName = (typeof sidebarTabNames)[number];
+
+type StateForTranscript = {
+  isOpen: boolean;
+  selectedTabName: SidebarTabName;
+};
+
+type State = {
+  [genomeId: string]: {
+    [transcriptId: string]: StateForTranscript;
+  };
+};
+
+const initialStateForTranscript = {
+  isOpen: true,
+  selectedTabName: sidebarTabNames[0]
+};
+
+const ensureTranscriptState = (
+  state: State,
+  genomeId: string,
+  transcriptId: string
+) => {
+  if (!state[genomeId]) {
+    state[genomeId] = {};
+  }
+  if (!state[genomeId][transcriptId]) {
+    state[genomeId][transcriptId] = structuredClone(initialStateForTranscript);
+  }
+};
+
+const transcriptViewSidebarSlice = createSlice({
+  name: 'entity-viewer-transcript-view-sidebar',
+  initialState: {} as State,
+  reducers: {
+    setIsOpen(
+      state,
+      action: PayloadAction<{
+        genomeId: string;
+        transcriptId: string;
+        isOpen: boolean;
+      }>
+    ) {
+      const { genomeId, transcriptId, isOpen } = action.payload;
+      ensureTranscriptState(state, genomeId, transcriptId);
+      state[genomeId][transcriptId].isOpen = isOpen;
+    },
+    setSelectedTab(
+      state,
+      action: PayloadAction<{
+        genomeId: string;
+        transcriptId: string;
+        selectedTabName: SidebarTabName;
+      }>
+    ) {
+      const { genomeId, transcriptId, selectedTabName } = action.payload;
+      ensureTranscriptState(state, genomeId, transcriptId);
+      state[genomeId][transcriptId].selectedTabName = selectedTabName;
+    }
+  }
+});
+
+export const { setIsOpen, setSelectedTab } = transcriptViewSidebarSlice.actions;
+
+export default transcriptViewSidebarSlice.reducer;

--- a/src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSlice.ts
+++ b/src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSlice.ts
@@ -82,6 +82,18 @@ const transcriptViewSidebarSlice = createSlice({
       ensureTranscriptState(state, genomeId, transcriptId);
       state[genomeId][transcriptId].isOpen = false;
     },
+    toggleSidebar(
+      state,
+      action: PayloadAction<{
+        genomeId: string;
+        transcriptId: string;
+      }>
+    ) {
+      const { genomeId, transcriptId } = action.payload;
+      ensureTranscriptState(state, genomeId, transcriptId);
+      state[genomeId][transcriptId].isOpen =
+        !state[genomeId][transcriptId].isOpen;
+    },
     setSelectedTab(
       state,
       action: PayloadAction<{
@@ -123,6 +135,7 @@ const transcriptViewSidebarSlice = createSlice({
 export const {
   openSidebar,
   closeSidebar,
+  toggleSidebar,
   setSelectedTab,
   setSidebarModalView,
   closeSidebarModal

--- a/src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSlice.ts
+++ b/src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSlice.ts
@@ -19,7 +19,7 @@ import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 export const sidebarTabNames = ['Overview', 'External references'] as const;
 export const defaultSidebarTabName = sidebarTabNames[0];
 
-type SidebarTabName = (typeof sidebarTabNames)[number];
+export type SidebarTabName = (typeof sidebarTabNames)[number];
 
 type StateForTranscript = {
   isOpen: boolean;
@@ -54,17 +54,27 @@ const transcriptViewSidebarSlice = createSlice({
   name: 'entity-viewer-transcript-view-sidebar',
   initialState: {} as State,
   reducers: {
-    setIsOpen(
+    openSidebar(
       state,
       action: PayloadAction<{
         genomeId: string;
         transcriptId: string;
-        isOpen: boolean;
       }>
     ) {
-      const { genomeId, transcriptId, isOpen } = action.payload;
+      const { genomeId, transcriptId } = action.payload;
       ensureTranscriptState(state, genomeId, transcriptId);
-      state[genomeId][transcriptId].isOpen = isOpen;
+      state[genomeId][transcriptId].isOpen = true;
+    },
+    closeSidebar(
+      state,
+      action: PayloadAction<{
+        genomeId: string;
+        transcriptId: string;
+      }>
+    ) {
+      const { genomeId, transcriptId } = action.payload;
+      ensureTranscriptState(state, genomeId, transcriptId);
+      state[genomeId][transcriptId].isOpen = false;
     },
     setSelectedTab(
       state,
@@ -81,6 +91,7 @@ const transcriptViewSidebarSlice = createSlice({
   }
 });
 
-export const { setIsOpen, setSelectedTab } = transcriptViewSidebarSlice.actions;
+export const { openSidebar, closeSidebar, setSelectedTab } =
+  transcriptViewSidebarSlice.actions;
 
 export default transcriptViewSidebarSlice.reducer;

--- a/src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSlice.ts
+++ b/src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSlice.ts
@@ -21,9 +21,14 @@ export const defaultSidebarTabName = sidebarTabNames[0];
 
 export type SidebarTabName = (typeof sidebarTabNames)[number];
 
+export const sidebarModalViews = ['search', 'bookmarks', 'download'];
+
+export type SidebarModalView = (typeof sidebarModalViews)[number];
+
 type StateForTranscript = {
   isOpen: boolean;
   selectedTabName: SidebarTabName;
+  sidebarModalView: SidebarModalView | null;
 };
 
 type State = {
@@ -32,9 +37,10 @@ type State = {
   };
 };
 
-const initialStateForTranscript = {
+const initialStateForTranscript: StateForTranscript = {
   isOpen: true,
-  selectedTabName: sidebarTabNames[0]
+  selectedTabName: sidebarTabNames[0],
+  sidebarModalView: null
 };
 
 const ensureTranscriptState = (
@@ -87,11 +93,39 @@ const transcriptViewSidebarSlice = createSlice({
       const { genomeId, transcriptId, selectedTabName } = action.payload;
       ensureTranscriptState(state, genomeId, transcriptId);
       state[genomeId][transcriptId].selectedTabName = selectedTabName;
+    },
+    setSidebarModalView(
+      state,
+      action: PayloadAction<{
+        genomeId: string;
+        transcriptId: string;
+        view: SidebarModalView | null;
+      }>
+    ) {
+      const { genomeId, transcriptId, view } = action.payload;
+      ensureTranscriptState(state, genomeId, transcriptId);
+      state[genomeId][transcriptId].sidebarModalView = view;
+    },
+    closeSidebarModal(
+      state,
+      action: PayloadAction<{
+        genomeId: string;
+        transcriptId: string;
+      }>
+    ) {
+      const { genomeId, transcriptId } = action.payload;
+      ensureTranscriptState(state, genomeId, transcriptId);
+      state[genomeId][transcriptId].sidebarModalView = null;
     }
   }
 });
 
-export const { openSidebar, closeSidebar, setSelectedTab } =
-  transcriptViewSidebarSlice.actions;
+export const {
+  openSidebar,
+  closeSidebar,
+  setSelectedTab,
+  setSidebarModalView,
+  closeSidebarModal
+} = transcriptViewSidebarSlice.actions;
 
 export default transcriptViewSidebarSlice.reducer;

--- a/src/content/app/entity-viewer/transcript-view/TranscriptView.tsx
+++ b/src/content/app/entity-viewer/transcript-view/TranscriptView.tsx
@@ -89,7 +89,7 @@ const TranscriptView = () => {
           rulerTicks={rulerTicks}
         />
       ) : (
-        <TranscriptFunction />
+        <TranscriptFunction transcript={currentData.transcript} />
       )}
     </div>
   );

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-function/TranscriptFunction.module.css
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-function/TranscriptFunction.module.css
@@ -32,3 +32,14 @@
   color: var(--color-black);
   font-weight: var(--font-weight-bold);
 }
+
+.proteinInfo {
+  font-weight: var(--font-weight-light);
+}
+
+.proteinInfoMiddle {
+  display: grid;
+  grid-template-columns: 10% 43% 43%;
+  column-gap: 2%;
+  font-weight: var(--font-weight-normal);
+}

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-function/TranscriptFunction.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-function/TranscriptFunction.tsx
@@ -14,11 +14,25 @@
  * limitations under the License.
  */
 
+import classNames from 'classnames';
 import noop from 'lodash/noop';
+
+import {
+  isProteinCodingTranscript,
+  getProductAminoAcidLength,
+  getProteinDescription
+} from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
 
 import Tabs, { type Tab } from 'src/shared/components/tabs/Tabs';
 import Panel from 'src/shared/components/panel/Panel';
+import ProteinsListItemInfo, {
+  type Props as ProteinListItemInfoProps
+} from 'src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo';
+import { TranscriptQualityLabel } from 'src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel';
 
+import type { DefaultEntityViewerTranscriptQueryResult } from 'src/content/app/entity-viewer/state/api/queries/transcriptDefaultQuery';
+
+import transcriptsListStyles from 'src/content/app/entity-viewer/gene-view/components/default-transcripts-list/DefaultTranscriptsList.module.css';
 import styles from './TranscriptFunction.module.css';
 
 const tabsData: Tab[] = [
@@ -33,7 +47,13 @@ const tabClassNames = {
   tabsContainer: styles.tabsContainer
 };
 
-const TranscriptFunction = () => {
+type Props = {
+  transcript: DefaultEntityViewerTranscriptQueryResult['transcript'];
+};
+
+const TranscriptFunction = (props: Props) => {
+  const canDisplayProtein = isProteinCodingTranscript(props.transcript);
+
   return (
     <Panel
       header={<TabWrapper />}
@@ -43,8 +63,59 @@ const TranscriptFunction = () => {
         body: styles.panelBody
       }}
     >
-      Protein view
+      {canDisplayProtein ? (
+        <ProteinInfo
+          transcript={
+            props.transcript as ProteinListItemInfoProps['transcript']
+          }
+          gene={props.transcript.gene}
+        />
+      ) : (
+        <div>This transcript is not protein-coding</div>
+      )}
     </Panel>
+  );
+};
+
+const ProteinInfo = ({
+  transcript,
+  gene
+}: {
+  transcript: ProteinListItemInfoProps['transcript'];
+  gene: ProteinListItemInfoProps['gene'];
+}) => {
+  const { product } = transcript.product_generating_contexts[0];
+  const proteinLength = getProductAminoAcidLength(transcript);
+
+  // ProteinsListItemInfo component was developed for Entity Viewer gene view;
+  // which is why it has "list" in its name, and also why it receives a "track length"
+  // property (in gene view, proteins are drawn relative to the longest protein in a gene)
+  return (
+    <div className={styles.proteinInfo}>
+      <div className={transcriptsListStyles.row}>
+        <div className={transcriptsListStyles.left}>
+          <TranscriptQualityLabel metadata={transcript.metadata} />
+        </div>
+        <div
+          className={classNames(
+            transcriptsListStyles.middle,
+            styles.proteinInfoMiddle
+          )}
+        >
+          <div>{getProductAminoAcidLength(transcript)} aa</div>
+          <div>{getProteinDescription(product)}</div>
+          <div className={styles.productStableId}>{product?.stable_id}</div>
+        </div>
+        <div className={transcriptsListStyles.right}>
+          <span className={styles.transcriptId}>{transcript.stable_id}</span>
+        </div>
+      </div>
+      <ProteinsListItemInfo
+        transcript={transcript}
+        gene={gene}
+        trackLength={proteinLength}
+      />
+    </div>
   );
 };
 

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar-tabs/TranscriptViewSidebarTabs.module.css
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar-tabs/TranscriptViewSidebarTabs.module.css
@@ -1,0 +1,39 @@
+.defaultTab {
+  background-color: transparent;
+  color: var(--color-blue);
+  border-radius: 3px;
+  margin-right: 3px;
+  height: 30px;
+  border: none;
+}
+
+.disabledTab {
+  color: var(--color-grey);
+}
+
+.selectedTab {
+  background-color: transparent;
+  color: var(--color-black);
+}
+
+.selectedTab::after {
+  border: 6px solid var(--color-grey);
+  border-color: transparent transparent var(--color-light-grey) var(--color-light-grey);
+  box-shadow: -2px 2px 2px 0 var(--color-grey);
+
+  content: '';
+  width: 0;
+  height: 0;
+  box-sizing: border-box;
+  position: absolute;
+  left: calc(50% - 8px);
+  transform-origin: 0 0;
+  transform: rotate(-45deg);
+  top: 29px;
+}
+
+.tabsContainer {
+  height: 23px;
+  overflow: unset;
+  padding-bottom: 23px;
+}

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar-tabs/TranscriptViewSidebarTabs.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar-tabs/TranscriptViewSidebarTabs.tsx
@@ -1,0 +1,99 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useAppSelector, useAppDispatch } from 'src/store';
+
+import useTranscriptViewIds from 'src/content/app/entity-viewer/transcript-view/hooks/useTranscriptViewIds';
+
+import {
+  openSidebar,
+  setSelectedTab,
+  sidebarTabNames,
+  // closeSidebarModal,
+  // setSidebarTabName,
+  type SidebarTabName
+} from 'src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSlice';
+
+import {
+  getIsSidebarOpen,
+  getActiveSidebarTab
+} from 'src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSelectors';
+
+import Tabs, { Tab } from 'src/shared/components/tabs/Tabs';
+
+// import styles from './GeneViewSidebarTabs.module.css';
+
+const tabsData: Tab[] = sidebarTabNames.map((name) => ({ title: name }));
+
+const TranscriptViewSidebarTabs = () => {
+  const { activeGenomeId, transcriptId } = useTranscriptViewIds();
+  const isSidebarOpen = useAppSelector((state) =>
+    getIsSidebarOpen(state, activeGenomeId ?? '', transcriptId ?? '')
+  );
+  const selectedTabName = useAppSelector((state) =>
+    getActiveSidebarTab(state, activeGenomeId ?? '', transcriptId ?? '')
+  );
+  // const isSidebarModalViewOpen = Boolean(
+  //   useAppSelector(getEntityViewerSidebarModalView)
+  // );
+  const dispatch = useAppDispatch();
+
+  const handleTabChange = (name: string) => {
+    if (!activeGenomeId || !transcriptId) {
+      // this will not happen
+      return;
+    }
+    if (!isSidebarOpen) {
+      dispatch(
+        openSidebar({
+          genomeId: activeGenomeId,
+          transcriptId
+        })
+      );
+    }
+    // if (isSidebarModalViewOpen) {
+    //   dispatch(closeSidebarModal());
+    // }
+    dispatch(
+      setSelectedTab({
+        genomeId: activeGenomeId,
+        transcriptId,
+        selectedTabName: name as SidebarTabName
+      })
+    );
+  };
+
+  const tabClassNames = {
+    // default: styles.defaultTab,
+    // selected: styles.selectedTab,
+    // disabled: styles.disabledTab,
+    // tabsContainer: styles.tabsContainer
+  };
+
+  // const isSidebarActive = isSidebarOpen && !isSidebarModalViewOpen;
+  const isSidebarActive = isSidebarOpen;
+
+  return (
+    <Tabs
+      tabs={tabsData}
+      selectedTab={isSidebarActive ? selectedTabName : null}
+      onTabChange={handleTabChange}
+      classNames={tabClassNames}
+    />
+  );
+};
+
+export default TranscriptViewSidebarTabs;

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar-tabs/TranscriptViewSidebarTabs.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar-tabs/TranscriptViewSidebarTabs.tsx
@@ -22,19 +22,19 @@ import {
   openSidebar,
   setSelectedTab,
   sidebarTabNames,
-  // closeSidebarModal,
-  // setSidebarTabName,
+  closeSidebarModal,
   type SidebarTabName
 } from 'src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSlice';
 
 import {
   getIsSidebarOpen,
-  getActiveSidebarTab
+  getActiveSidebarTab,
+  getSidebarModalView
 } from 'src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSelectors';
 
 import Tabs, { Tab } from 'src/shared/components/tabs/Tabs';
 
-// import styles from './GeneViewSidebarTabs.module.css';
+import styles from './TranscriptViewSidebarTabs.module.css';
 
 const tabsData: Tab[] = sidebarTabNames.map((name) => ({ title: name }));
 
@@ -46,9 +46,11 @@ const TranscriptViewSidebarTabs = () => {
   const selectedTabName = useAppSelector((state) =>
     getActiveSidebarTab(state, activeGenomeId ?? '', transcriptId ?? '')
   );
-  // const isSidebarModalViewOpen = Boolean(
-  //   useAppSelector(getEntityViewerSidebarModalView)
-  // );
+  const isSidebarModalViewOpen = Boolean(
+    useAppSelector((state) =>
+      getSidebarModalView(state, activeGenomeId ?? '', transcriptId ?? '')
+    )
+  );
   const dispatch = useAppDispatch();
 
   const handleTabChange = (name: string) => {
@@ -64,9 +66,14 @@ const TranscriptViewSidebarTabs = () => {
         })
       );
     }
-    // if (isSidebarModalViewOpen) {
-    //   dispatch(closeSidebarModal());
-    // }
+    if (isSidebarModalViewOpen) {
+      dispatch(
+        closeSidebarModal({
+          genomeId: activeGenomeId,
+          transcriptId
+        })
+      );
+    }
     dispatch(
       setSelectedTab({
         genomeId: activeGenomeId,
@@ -77,14 +84,13 @@ const TranscriptViewSidebarTabs = () => {
   };
 
   const tabClassNames = {
-    // default: styles.defaultTab,
-    // selected: styles.selectedTab,
-    // disabled: styles.disabledTab,
-    // tabsContainer: styles.tabsContainer
+    default: styles.defaultTab,
+    selected: styles.selectedTab,
+    disabled: styles.disabledTab,
+    tabsContainer: styles.tabsContainer
   };
 
-  // const isSidebarActive = isSidebarOpen && !isSidebarModalViewOpen;
-  const isSidebarActive = isSidebarOpen;
+  const isSidebarActive = isSidebarOpen && !isSidebarModalViewOpen;
 
   return (
     <Tabs

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/TranscriptViewSidebar.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/TranscriptViewSidebar.tsx
@@ -22,6 +22,7 @@ import { sidebarTabNames } from 'src/content/app/entity-viewer/state/transcript-
 import useTranscriptViewIds from 'src/content/app/entity-viewer/transcript-view/hooks/useTranscriptViewIds';
 
 import SidebarDefault from './sidebar-default/SidebarDefault';
+import SidebarExternalReferences from './sidebar-external-references/SidebarExternalReferences';
 import Sidebar from 'src/shared/components/layout/sidebar/Sidebar';
 
 const TranscriptViewSidebar = () => {
@@ -40,7 +41,10 @@ const TranscriptViewSidebar = () => {
         <SidebarDefault genomeId={activeGenomeId} transcriptId={transcriptId} />
       )}
       {activeSidebarTab === sidebarTabNames[1] && (
-        <div>External references!</div>
+        <SidebarExternalReferences
+          genomeId={activeGenomeId}
+          transcriptId={transcriptId}
+        />
       )}
     </Sidebar>
   );

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/TranscriptViewSidebar.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/TranscriptViewSidebar.tsx
@@ -1,0 +1,49 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useAppSelector } from 'src/store';
+
+import { getActiveSidebarTab } from 'src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSelectors';
+import { sidebarTabNames } from 'src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSlice';
+
+import useTranscriptViewIds from 'src/content/app/entity-viewer/transcript-view/hooks/useTranscriptViewIds';
+
+import SidebarDefault from './sidebar-default/SidebarDefault';
+import Sidebar from 'src/shared/components/layout/sidebar/Sidebar';
+
+const TranscriptViewSidebar = () => {
+  const { activeGenomeId, transcriptId } = useTranscriptViewIds();
+  const activeSidebarTab = useAppSelector((state) =>
+    getActiveSidebarTab(state, activeGenomeId ?? '', transcriptId ?? '')
+  );
+
+  if (!activeGenomeId || !transcriptId) {
+    return null;
+  }
+
+  return (
+    <Sidebar>
+      {activeSidebarTab === sidebarTabNames[0] && (
+        <SidebarDefault genomeId={activeGenomeId} transcriptId={transcriptId} />
+      )}
+      {activeSidebarTab === sidebarTabNames[1] && (
+        <div>External references!</div>
+      )}
+    </Sidebar>
+  );
+};
+
+export default TranscriptViewSidebar;

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-default/SidebarDefault.module.css
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-default/SidebarDefault.module.css
@@ -1,0 +1,22 @@
+.sectionContent {
+  padding-left: 12px;
+}
+
+.row + .row {
+  margin-top: 6px;
+}
+
+.rowWithLabel {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 12px;
+}
+
+.label {
+  font-size: 12px;
+  font-weight: var(--font-weight-light);
+}
+
+.strong {
+  font-weight: var(--font-weight-bold);
+}

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-default/SidebarDefault.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-default/SidebarDefault.tsx
@@ -1,0 +1,142 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classNames from 'classnames';
+
+import { getFeatureLength } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
+
+import { useDefaultEntityViewerTranscriptQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
+
+import SidebarSectionHeading from 'src/shared/components/sidebar-section-heading/SidebarSectionHeading';
+import GeneName from 'src/shared/components/gene-name/GeneName';
+import ExternalLink from 'src/shared/components/external-link/ExternalLink';
+import { SidebarLoader } from 'src/shared/components/loader';
+
+import type { DefaultEntityViewerTranscriptQueryResult } from 'src/content/app/entity-viewer/state/api/queries/transcriptDefaultQuery';
+
+import styles from './SidebarDefault.module.css';
+
+type Props = {
+  genomeId: string;
+  transcriptId: string;
+};
+
+const SidebarDefault = (props: Props) => {
+  const { currentData, isLoading } = useDefaultEntityViewerTranscriptQuery({
+    genomeId: props.genomeId,
+    transcriptId: props.transcriptId
+  });
+
+  if (isLoading) {
+    return <SidebarLoader />;
+  } else if (!currentData) {
+    return null;
+  }
+
+  const transcript = currentData.transcript;
+  const gene = transcript.gene;
+
+  return (
+    <>
+      <div className={styles.sectionContent}>
+        <div className={classNames(styles.row, styles.rowWithLabel)}>
+          <span className={styles.label}>Transcript</span>
+          <span className={styles.strong}>{transcript.stable_id}</span>
+        </div>
+        <div className={classNames(styles.row, styles.rowWithLabel)}>
+          <span className={styles.label}>Biotype</span>
+          <span>{transcript.metadata.biotype.label}</span>
+        </div>
+        <div className={classNames(styles.row, styles.rowWithLabel)}>
+          <span className={styles.label}>Length</span>
+          <span>{getFeatureLength(transcript)} bp</span>
+        </div>
+      </div>
+      <SidebarSectionHeading>Gene</SidebarSectionHeading>
+      <div className={styles.sectionContent}>
+        <GeneName stable_id={gene.stable_id} symbol={gene.symbol} />
+      </div>
+      <GeneNameSection gene={gene} />
+      <SynonymsSection gene={gene} />
+      <AttributesSection gene={gene} />
+    </>
+  );
+};
+
+const GeneNameSection = ({
+  gene
+}: {
+  gene: DefaultEntityViewerTranscriptQueryResult['transcript']['gene'];
+}) => {
+  if (!gene.name) {
+    return null;
+  }
+  const url = gene.metadata.name?.url;
+  const accessionId = gene.metadata.name?.accession_id;
+
+  return (
+    <>
+      <SidebarSectionHeading>Gene name</SidebarSectionHeading>
+      <div className={styles.sectionContent}>
+        <div>
+          <span>{gene.name}</span>
+        </div>
+        {url && accessionId && (
+          <div>
+            <ExternalLink to={url}>{accessionId}</ExternalLink>
+          </div>
+        )}
+      </div>
+    </>
+  );
+};
+
+const SynonymsSection = ({
+  gene
+}: {
+  gene: DefaultEntityViewerTranscriptQueryResult['transcript']['gene'];
+}) => {
+  if (!gene.alternative_symbols.length) {
+    return null;
+  }
+
+  return (
+    <>
+      <SidebarSectionHeading>Synonyms</SidebarSectionHeading>
+      <div className={styles.sectionContent}>
+        {gene.alternative_symbols.join(', ')}
+      </div>
+    </>
+  );
+};
+
+const AttributesSection = ({
+  gene
+}: {
+  gene: DefaultEntityViewerTranscriptQueryResult['transcript']['gene'];
+}) => {
+  return (
+    <>
+      <SidebarSectionHeading>Attributes</SidebarSectionHeading>
+      <div className={classNames(styles.sectionContent, styles.rowWithLabel)}>
+        <span className={styles.label}>Biotype</span>
+        <span>{gene.metadata.biotype.value}</span>
+      </div>
+    </>
+  );
+};
+
+export default SidebarDefault;

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-external-references/SidebarExternalReferences.module.css
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-external-references/SidebarExternalReferences.module.css
@@ -1,0 +1,12 @@
+.container {
+  padding-left: 12px;
+}
+
+.listContainer {
+  margin-left: 15px;
+}
+
+.showHide,
+.externalReference {
+  margin-bottom: 10px;
+}

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-external-references/SidebarExternalReferences.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-external-references/SidebarExternalReferences.tsx
@@ -1,0 +1,194 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, useMemo } from 'react';
+import sortBy from 'lodash/sortBy';
+
+import { useTranscriptExternalReferencesQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
+
+import ExternalReference from 'src/shared/components/external-reference/ExternalReference';
+import ShowHide from 'src/shared/components/show-hide/ShowHide';
+
+import type { QueriedExternalReference } from 'src/content/app/entity-viewer/state/api/queries/geneExternalReferencesQuery';
+
+import styles from './SidebarExternalReferences.module.css';
+
+type ExternalReferencesGroupType = {
+  source: QueriedExternalReference['source'];
+  references: Omit<QueriedExternalReference, 'source'>[];
+};
+
+const SidebarExternalReferences = ({
+  genomeId,
+  transcriptId
+}: {
+  genomeId: string;
+  transcriptId: string;
+}) => {
+  const { currentData, isFetching } = useTranscriptExternalReferencesQuery({
+    transcriptId: transcriptId,
+    genomeId: genomeId
+  });
+
+  if (isFetching) {
+    return <div>Loading...</div>;
+  }
+
+  if (!currentData || !currentData.transcript) {
+    return <div>No data to display</div>;
+  }
+  const { transcript } = currentData;
+  const unsortedExternalReferences = [
+    ...currentData.transcript.external_references
+  ];
+
+  // Add protein level external references
+  transcript.product_generating_contexts.forEach(
+    (product_generating_context) => {
+      if (product_generating_context.product) {
+        unsortedExternalReferences.push(
+          ...product_generating_context.product.external_references
+        );
+      }
+    }
+  );
+
+  const externalReferenceGroups = groupExternalReferences(
+    unsortedExternalReferences
+  );
+
+  return (
+    <div className={styles.container}>
+      <ExternalReferencesGroups groups={externalReferenceGroups} />
+    </div>
+  );
+};
+
+const ExternalReferenceGroup = (props: {
+  group: ExternalReferencesGroupType;
+}) => {
+  const [areReferencesVisible, setReferencesVisibility] = useState(false);
+
+  const toggleExternalReferencesGroup = () =>
+    setReferencesVisibility(!areReferencesVisible);
+
+  const { references, source } = props.group;
+  const externalReferenceList = useMemo(
+    () =>
+      references.map((reference) =>
+        reference.url ? (
+          <ExternalReference
+            label={
+              reference.description === reference.accession_id ||
+              source.name === reference.description
+                ? ''
+                : reference.description
+            }
+            to={reference.url}
+            key={reference.accession_id}
+            className={styles.externalReference}
+          >
+            {reference.accession_id}
+          </ExternalReference>
+        ) : null
+      ),
+    [references, source.name]
+  );
+
+  return (
+    <>
+      <ShowHide
+        className={styles.showHide}
+        onClick={toggleExternalReferencesGroup}
+        isExpanded={areReferencesVisible}
+        label={source.name}
+      />
+      {areReferencesVisible && (
+        <div className={styles.listContainer}>{externalReferenceList}</div>
+      )}
+    </>
+  );
+};
+
+const groupExternalReferences = (
+  externalReferences: QueriedExternalReference[]
+) => {
+  const groups: {
+    [key: string]: ExternalReferencesGroupType;
+  } = {};
+
+  const sortedExternalReferences = sortBy(
+    externalReferences,
+    (reference) => reference.source.name
+  );
+
+  sortedExternalReferences.forEach((externalReference) => {
+    const sourceId = externalReference.source.id;
+
+    if (!groups[sourceId]) {
+      groups[sourceId] = {
+        source: externalReference.source,
+        references: []
+      };
+    }
+
+    groups[sourceId].references.push({
+      accession_id: externalReference.accession_id,
+      url: externalReference.url,
+      name: externalReference.name,
+      description: externalReference.description
+    });
+  });
+
+  // Sort external references within each group based on their description
+  // (or accession_id when description is empty)
+  Object.values(groups).forEach((group) => {
+    group.references = sortBy(
+      group.references,
+      (reference) => reference.description || reference.accession_id
+    );
+  });
+
+  return groups;
+};
+
+const ExternalReferencesGroups = ({
+  groups
+}: {
+  groups: {
+    [key: string]: ExternalReferencesGroupType;
+  };
+}) => {
+  return Object.values(groups).map((group, key) => (
+    <div key={key}>
+      {group.references.length === 1 ? (
+        group.references[0].url ? (
+          <ExternalReference
+            label={group.source.name}
+            to={group.references[0].url}
+            className={styles.externalReference}
+          >
+            {group.references[0].accession_id}
+          </ExternalReference>
+        ) : null
+      ) : (
+        <ExternalReferenceGroup group={group} />
+      )}
+    </div>
+  ));
+};
+
+export default SidebarExternalReferences;

--- a/src/shared/components/sidebar-section-heading/SidebarSectionHeading.module.css
+++ b/src/shared/components/sidebar-section-heading/SidebarSectionHeading.module.css
@@ -1,0 +1,11 @@
+@layer components {
+
+  .container {
+    font-size: 11px;
+    font-weight: var(--font-weight-light);
+    border-bottom: 1px solid var(--color-medium-light-grey);
+    padding-bottom: 3px;
+    margin-top: 20px;
+    margin-bottom: 15px;
+  }
+}

--- a/src/shared/components/sidebar-section-heading/SidebarSectionHeading.tsx
+++ b/src/shared/components/sidebar-section-heading/SidebarSectionHeading.tsx
@@ -14,12 +14,20 @@
  * limitations under the License.
  */
 
-import { combineReducers } from 'redux';
+import classNames from 'classnames';
+import type { ReactNode } from 'react';
 
-import transcriptViewGeneralReducer from './general/transcriptViewGeneralSlice';
-import transcriptViewSidebarReducer from './sidebar/transcriptViewSidebarSlice';
+import styles from './SidebarSectionHeading.module.css';
 
-export default combineReducers({
-  general: transcriptViewGeneralReducer,
-  sidebar: transcriptViewSidebarReducer
-});
+type Props = {
+  children: ReactNode;
+  className?: string;
+};
+
+const SidebarSectionHeading = (props: Props) => {
+  const componentClasses = classNames(styles.container, props.className);
+
+  return <div className={componentClasses}>{props.children}</div>;
+};
+
+export default SidebarSectionHeading;


### PR DESCRIPTION
## Description
- [x] Add sidebar content for default view
- [x] Add a sidebar view for transcript external references
- [x] Add redux state for the sidebar
- [x] Clean up and style sidebar navigation tabs
- [x] Enable opening and closing of the sidebar

## Related JIRA Issue(s)
Part of  https://embl.atlassian.net/browse/ENSWBSITES-2993

## Deployment URL(s)
http://ev-transcript-as-object.review.ensembl.org

Example: http://ev-transcript-as-object.review.ensembl.org/entity-viewer/grch38/transcript:ENST00000380152