### PR TITLE
Integrate focus transcript to genome browser view

### DIFF
--- a/src/content/app/genome-browser/components/browser-cog/BrowserCog.tsx
+++ b/src/content/app/genome-browser/components/browser-cog/BrowserCog.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState } from 'react';
+import { useState, memo } from 'react';
 
 import useGenomeBrowserAnalytics from 'src/content/app/genome-browser/hooks/useGenomeBrowserAnalytics';
 
@@ -80,4 +80,4 @@ const BrowserCog = (props: BrowserCogProps) => {
   );
 };
 
-export default BrowserCog;
+export default memo(BrowserCog);

--- a/src/content/app/genome-browser/components/browser-cog/BrowserCogList.test.tsx
+++ b/src/content/app/genome-browser/components/browser-cog/BrowserCogList.test.tsx
@@ -116,6 +116,7 @@ describe('<BrowserCogList />', () => {
         summary: [
           {
             'switch-id': 'focus',
+            type: 'focus-gene',
             height: 200,
             offset: 0
           },
@@ -135,7 +136,7 @@ describe('<BrowserCogList />', () => {
       });
 
       const expectedPayload = newTrackSummary.summary.map((track) => ({
-        id: track['switch-id'],
+        id: track['switch-id'] === 'focus' ? track.type : track['switch-id'],
         height: track.height,
         offsetTop: track.offset
       }));

--- a/src/content/app/genome-browser/components/browser-cog/BrowserCogList.tsx
+++ b/src/content/app/genome-browser/components/browser-cog/BrowserCogList.tsx
@@ -18,7 +18,7 @@ import { useEffect, useCallback, memo } from 'react';
 
 import { useAppDispatch, useAppSelector } from 'src/store';
 
-import { getDisplayedTracks } from 'src/content/app/genome-browser/state/displayed-tracks/displayedTracksSelectors';
+import { getOrderedDisplayedTracks } from 'src/content/app/genome-browser/state/displayed-tracks/displayedTracksSelectors';
 import { getAllTrackSettingsForGenome } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSelectors';
 import {
   getBrowserActiveFocusObjectId,
@@ -48,7 +48,7 @@ export const BrowserCogList = () => {
 
   const { genomeBrowserService } = useGenomeBrowser();
 
-  const displayedTracks = useAppSelector(getDisplayedTracks);
+  const displayedTracks = useAppSelector(getOrderedDisplayedTracks);
   const dispatch = useAppDispatch();
 
   const updateDisplayedTracks = useCallback(

--- a/src/content/app/genome-browser/components/browser-cog/BrowserCogList.tsx
+++ b/src/content/app/genome-browser/components/browser-cog/BrowserCogList.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useEffect, memo } from 'react';
+import { useEffect, useCallback, memo } from 'react';
 
 import { useAppDispatch, useAppSelector } from 'src/store';
 
@@ -32,7 +32,10 @@ import useGenomeBrowser from 'src/content/app/genome-browser/hooks/useGenomeBrow
 import BrowserCog from './BrowserCog';
 
 import type { TrackSummaryMessage } from 'src/content/app/genome-browser/services/genome-browser-service/types/genomeBrowserMessages';
-import type { TrackSummary } from 'src/content/app/genome-browser/services/genome-browser-service/types/trackSummary';
+import type {
+  TrackSummary,
+  FocusTrackSummary
+} from 'src/content/app/genome-browser/services/genome-browser-service/types/trackSummary';
 
 import styles from './BrowserCogList.module.css';
 
@@ -48,6 +51,19 @@ export const BrowserCogList = () => {
   const displayedTracks = useAppSelector(getDisplayedTracks);
   const dispatch = useAppDispatch();
 
+  const updateDisplayedTracks = useCallback(
+    (trackSummaryList: TrackSummary[]) => {
+      const payload = trackSummaryList.map((track) => ({
+        id: getTrackId(track),
+        height: track.height,
+        offsetTop: track.offset
+      }));
+
+      dispatch(setDisplayedTracks(payload));
+    },
+    [dispatch]
+  );
+
   useEffect(() => {
     const subscription = genomeBrowserService?.subscribe(
       'track_summary',
@@ -56,17 +72,7 @@ export const BrowserCogList = () => {
       }
     );
     return () => subscription?.unsubscribe();
-  }, [genomeBrowserService, genomeId, focusObjectId]);
-
-  const updateDisplayedTracks = (trackSummaryList: TrackSummary[]) => {
-    const payload = trackSummaryList.map((track) => ({
-      id: getTrackId(track),
-      height: track.height,
-      offsetTop: track.offset
-    }));
-
-    dispatch(setDisplayedTracks(payload));
-  };
+  }, [genomeBrowserService, genomeId, focusObjectId, updateDisplayedTracks]);
 
   const cogs = displayedTracks.map((track) => {
     const posStyle = { top: `${track.offsetTop}px` };
@@ -90,8 +96,8 @@ export const BrowserCogList = () => {
 };
 
 const getTrackId = (trackSummary: TrackSummary) => {
-  if (trackSummary['switch-id'] === 'focus' && 'variant-id' in trackSummary) {
-    return 'focus-variant';
+  if (trackSummary['switch-id'] === 'focus') {
+    return (trackSummary as FocusTrackSummary).type;
   } else {
     return trackSummary['switch-id'];
   }

--- a/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/BookmarksModal.test.tsx
+++ b/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/BookmarksModal.test.tsx
@@ -103,8 +103,11 @@ describe('<BookmarksModal />', () => {
   it('renders previously viewed links', () => {
     const geneId = 'TraesCS3D02G273600';
     const location = '3D:2585940-2634711';
+    const transcriptId = 'ENST00000380152';
+    const geneSymbol = 'BRCA2';
     const geneObjectId = `${activeGenomeId}:gene:${geneId}`;
     const locationObjectId = `${activeGenomeId}:location:${location}`;
+    const transcriptObjectId = `${activeGenomeId}:transcript:${transcriptId}`;
     const previouslyViewedObjects = [
       {
         genome_id: activeGenomeId,
@@ -117,6 +120,12 @@ describe('<BookmarksModal />', () => {
         object_id: locationObjectId,
         type: 'location',
         label: [location]
+      },
+      {
+        genome_id: activeGenomeId,
+        object_id: transcriptObjectId,
+        type: 'transcript',
+        label: [geneSymbol, transcriptId]
       }
     ];
     const newMockState = merge(mockState, {
@@ -133,12 +142,20 @@ describe('<BookmarksModal />', () => {
 
     const geneLink = screen.getByText(geneId).closest('a') as HTMLElement;
     const locationLink = screen.getByText(location).closest('a') as HTMLElement;
+    const transcriptLink = screen
+      .getByText(transcriptId)
+      .closest('a') as HTMLElement;
 
     const expectedGeneHref = `/genome-browser/${mockGenomeId}?focus=gene:${geneId}`;
     const expectedLocationHref = `/genome-browser/${mockGenomeId}?focus=location:${location}`;
 
     expect(geneLink.getAttribute('href')).toBe(expectedGeneHref);
     expect(locationLink.getAttribute('href')).toBe(expectedLocationHref);
+    expect(screen.getByText(geneSymbol)).toBeTruthy();
+    expect(screen.getByText('Transcript')).toBeTruthy();
+    expect(transcriptLink.getAttribute('href')).toBe(
+      `/genome-browser/${mockGenomeId}?focus=transcript:${transcriptId}`
+    );
   });
 
   it('shows link to view more only when there are more than 20 objects', () => {

--- a/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/BookmarksModal.test.tsx
+++ b/src/content/app/genome-browser/components/browser-sidebar-modal/modal-views/BookmarksModal.test.tsx
@@ -104,7 +104,6 @@ describe('<BookmarksModal />', () => {
     const geneId = 'TraesCS3D02G273600';
     const location = '3D:2585940-2634711';
     const transcriptId = 'ENST00000380152';
-    const geneSymbol = 'BRCA2';
     const geneObjectId = `${activeGenomeId}:gene:${geneId}`;
     const locationObjectId = `${activeGenomeId}:location:${location}`;
     const transcriptObjectId = `${activeGenomeId}:transcript:${transcriptId}`;
@@ -125,7 +124,7 @@ describe('<BookmarksModal />', () => {
         genome_id: activeGenomeId,
         object_id: transcriptObjectId,
         type: 'transcript',
-        label: [geneSymbol, transcriptId]
+        label: [transcriptId]
       }
     ];
     const newMockState = merge(mockState, {
@@ -151,7 +150,7 @@ describe('<BookmarksModal />', () => {
 
     expect(geneLink.getAttribute('href')).toBe(expectedGeneHref);
     expect(locationLink.getAttribute('href')).toBe(expectedLocationHref);
-    expect(screen.getByText(geneSymbol)).toBeTruthy();
+    expect(screen.getByText(transcriptId)).toBeTruthy();
     expect(screen.getByText('Transcript')).toBeTruthy();
     expect(transcriptLink.getAttribute('href')).toBe(
       `/genome-browser/${mockGenomeId}?focus=transcript:${transcriptId}`

--- a/src/content/app/genome-browser/components/drawer/Drawer.tsx
+++ b/src/content/app/genome-browser/components/drawer/Drawer.tsx
@@ -40,7 +40,7 @@ export const Drawer = () => {
       case 'track_details':
         return <TrackDetails drawerView={drawerView} />;
       case 'gene_summary':
-        return <GeneSummary />;
+        return <GeneSummary geneId={drawerView.geneId} />;
       case 'transcript_summary':
         return <TranscriptSummary drawerView={drawerView} />;
       case 'variant_summary':

--- a/src/content/app/genome-browser/components/drawer/drawer-views/gene-summary/GeneSummary.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/gene-summary/GeneSummary.tsx
@@ -59,7 +59,9 @@ const GeneSummary = (props: Props) => {
     geneId,
     genomeId: activeGenomeId ?? ''
   };
-  const { currentData, isFetching } = useGbGeneSummaryQuery(geneQueryParams);
+  const { currentData, isFetching } = useGbGeneSummaryQuery(geneQueryParams, {
+    skip: !activeGenomeId
+  });
 
   if (isFetching) {
     return <Spinner />;

--- a/src/content/app/genome-browser/components/drawer/drawer-views/gene-summary/GeneSummary.tsx
+++ b/src/content/app/genome-browser/components/drawer/drawer-views/gene-summary/GeneSummary.tsx
@@ -15,7 +15,6 @@
  */
 
 import { useState } from 'react';
-import { useSelector } from 'react-redux';
 import classNames from 'classnames';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
@@ -34,8 +33,6 @@ import {
 } from 'src/shared/helpers/focusObjectHelpers';
 import { pluralise } from 'src/shared/helpers/formatters/pluralisationFormatter';
 
-import { getBrowserActiveFocusObject } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
-
 import GeneSequenceView from 'src/content/app/genome-browser/components/drawer/components/sequence-view/GeneSequenceView';
 import ExternalReference from 'src/shared/components/external-reference/ExternalReference';
 import InstantDownloadGene, {
@@ -46,29 +43,29 @@ import ShowHide from 'src/shared/components/show-hide/ShowHide';
 import QuestionButton from 'src/shared/components/question-button/QuestionButton';
 import { Spinner } from 'src/content/app/genome-browser/components/drawer/DrawerSpinner';
 
-import { FocusGene } from 'src/shared/types/focus-object/focusObjectTypes';
-
 import styles from './GeneSummary.module.css';
 
-const GeneSummary = () => {
-  const { genomeIdForUrl } = useGenomeBrowserIds();
-  const focusGene = useSelector(getBrowserActiveFocusObject) as FocusGene;
+type Props = {
+  geneId: string; // gene stable id; probably unversioned
+};
+
+const GeneSummary = (props: Props) => {
+  const { activeGenomeId, genomeIdForUrl } = useGenomeBrowserIds();
+  const { geneId } = props;
   const [shouldShowDownload, showDownload] = useState(false);
   const { trackDrawerSequenceDownloaded } = useGenomeBrowserAnalytics();
 
   const geneQueryParams = {
-    geneId: focusGene.stable_id,
-    genomeId: focusGene.genome_id
+    geneId,
+    genomeId: activeGenomeId ?? ''
   };
-  const { currentData, isFetching } = useGbGeneSummaryQuery(geneQueryParams, {
-    skip: !focusGene.stable_id
-  });
+  const { currentData, isFetching } = useGbGeneSummaryQuery(geneQueryParams);
 
   if (isFetching) {
     return <Spinner />;
   }
 
-  if (!currentData?.gene) {
+  if (!currentData?.gene || !activeGenomeId) {
     return <div>No data available</div>;
   }
 
@@ -136,7 +133,13 @@ const GeneSummary = () => {
               </div>
             )}
             <div className={styles.featureDetail}>
-              <span>{getFormattedLocation(focusGene.location)}</span>
+              <span>
+                {getFormattedLocation({
+                  chromosome: gene.slice.region.name,
+                  start: gene.slice.location.start,
+                  end: gene.slice.location.end
+                })}
+              </span>
             </div>
           </div>
         </div>
@@ -156,7 +159,7 @@ const GeneSummary = () => {
           {shouldShowDownload && (
             <div className={styles.downloadWrapper}>
               <InstantDownloadGene
-                genomeId={focusGene.genome_id}
+                genomeId={activeGenomeId}
                 gene={{
                   id: gene.stable_id,
                   isProteinCoding: isProteinCodingGene(gene)

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.module.css
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.module.css
@@ -6,13 +6,6 @@
   background: var(--color-white);
 }
 
-.trackPanelList h4 {
-  border-bottom: 1px solid var(--color-grey);
-  color: var(--color-grey);
-  font-size: 10px;
-  padding-bottom: 2px;
-}
-
 .mainTrackItem {
   width: 100%;
   margin-bottom: 30px;

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.test.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.test.tsx
@@ -139,7 +139,6 @@ describe('<TrackPanelList />', () => {
       );
 
       expect(getByText(transcriptFocusObject.stable_id)).toBeTruthy();
-      expect(getByText(transcriptFocusObject.gene_symbol)).toBeTruthy();
 
       const showMoreButton = container.querySelector(
         '.mainTrackItem .showMore button'

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.test.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.test.tsx
@@ -27,6 +27,7 @@ import createRootReducer from 'src/root/rootReducer';
 import restApiSlice from 'src/shared/state/api-slices/restSlice';
 
 import { getBrowserSidebarModalView } from 'src/content/app/genome-browser/state/browser-sidebar-modal/browserSidebarModalSelectors';
+import { getActiveDrawerView } from 'src/content/app/genome-browser/state/drawer/drawerSelectors';
 
 import { createFocusObject } from 'tests/fixtures/focus-object';
 import { createMockBrowserState } from 'tests/fixtures/browser';
@@ -53,7 +54,10 @@ vi.mock('./track-panel-items/TrackPanelRegularItem', () => ({
 vi.mock(
   'src/content/app/genome-browser/hooks/useGenomeBrowserAnalytics',
   () => ({
-    default: () => vi.fn()
+    default: () => ({
+      reportTrackPanelSectionToggled: vi.fn(),
+      trackDrawerOpened: vi.fn()
+    })
   })
 );
 
@@ -111,6 +115,44 @@ describe('<TrackPanelList />', () => {
       const { container } = renderComponent();
 
       expect(container.querySelectorAll('.trackPanelGene').length).toBe(1);
+    });
+
+    it('opens transcript drawer for transcript focus track', async () => {
+      const activeFocusObjectId = (
+        mockState.browser.browserGeneral.activeFocusObjectIds as any
+      )[activeGenomeId];
+      const transcriptFocusObject = {
+        ...createFocusObject('transcript'),
+        genome_id: activeGenomeId
+      };
+
+      if (transcriptFocusObject.type !== 'transcript') {
+        throw new Error('Expected transcript focus object');
+      }
+
+      const { store, container, getByText } = renderComponent(
+        set(
+          `browser.focusObjects.${activeFocusObjectId}.data`,
+          transcriptFocusObject,
+          mockState
+        )
+      );
+
+      expect(getByText(transcriptFocusObject.stable_id)).toBeTruthy();
+      expect(getByText(transcriptFocusObject.gene_symbol)).toBeTruthy();
+
+      const showMoreButton = container.querySelector(
+        '.mainTrackItem .showMore button'
+      ) as HTMLButtonElement | null;
+
+      expect(showMoreButton).toBeTruthy();
+
+      await userEvent.click(showMoreButton as HTMLButtonElement);
+
+      expect(getActiveDrawerView(store.getState())).toEqual({
+        name: 'transcript_summary',
+        transcriptId: transcriptFocusObject.stable_id
+      });
     });
 
     it('does not render main track if the focus feature is a region', () => {

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.test.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.test.tsx
@@ -25,9 +25,9 @@ import set from 'lodash/fp/set';
 import createRootReducer from 'src/root/rootReducer';
 
 import restApiSlice from 'src/shared/state/api-slices/restSlice';
+import graphqlApiSlice from 'src/shared/state/api-slices/graphqlApiSlice';
 
 import { getBrowserSidebarModalView } from 'src/content/app/genome-browser/state/browser-sidebar-modal/browserSidebarModalSelectors';
-import { getActiveDrawerView } from 'src/content/app/genome-browser/state/drawer/drawerSelectors';
 
 import { createFocusObject } from 'tests/fixtures/focus-object';
 import { createMockBrowserState } from 'tests/fixtures/browser';
@@ -79,7 +79,10 @@ const renderComponent = (state: typeof mockState = mockState) => {
   const store = configureStore({
     reducer: createRootReducer(),
     middleware: (getDefaultMiddleware) =>
-      getDefaultMiddleware().concat([restApiSlice.middleware]),
+      getDefaultMiddleware().concat([
+        restApiSlice.middleware,
+        graphqlApiSlice.middleware
+      ]),
     preloadedState: state as any
   });
 
@@ -115,43 +118,6 @@ describe('<TrackPanelList />', () => {
       const { container } = renderComponent();
 
       expect(container.querySelectorAll('.trackPanelGene').length).toBe(1);
-    });
-
-    it('opens transcript drawer for transcript focus track', async () => {
-      const activeFocusObjectId = (
-        mockState.browser.browserGeneral.activeFocusObjectIds as any
-      )[activeGenomeId];
-      const transcriptFocusObject = {
-        ...createFocusObject('transcript'),
-        genome_id: activeGenomeId
-      };
-
-      if (transcriptFocusObject.type !== 'transcript') {
-        throw new Error('Expected transcript focus object');
-      }
-
-      const { store, container, getByText } = renderComponent(
-        set(
-          `browser.focusObjects.${activeFocusObjectId}.data`,
-          transcriptFocusObject,
-          mockState
-        )
-      );
-
-      expect(getByText(transcriptFocusObject.stable_id)).toBeTruthy();
-
-      const showMoreButton = container.querySelector(
-        '.mainTrackItem .showMore button'
-      ) as HTMLButtonElement | null;
-
-      expect(showMoreButton).toBeTruthy();
-
-      await userEvent.click(showMoreButton as HTMLButtonElement);
-
-      expect(getActiveDrawerView(store.getState())).toEqual({
-        name: 'transcript_summary',
-        transcriptId: transcriptFocusObject.stable_id
-      });
     });
 
     it('does not render main track if the focus feature is a region', () => {

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
@@ -20,6 +20,7 @@ import classNames from 'classnames';
 import { useAppDispatch, useAppSelector } from 'src/store';
 import { useGenomeTracksQuery } from 'src/content/app/genome-browser/state/api/genomeBrowserApiSlice';
 import useGenomeBrowserAnalytics from 'src/content/app/genome-browser/hooks/useGenomeBrowserAnalytics';
+import { changeDrawerViewForGenome } from 'src/content/app/genome-browser/state/drawer/drawerSlice';
 
 import {
   getBrowserActiveFocusObject,
@@ -34,6 +35,7 @@ import {
 import TrackPanelGene from './track-panel-items/TrackPanelGene';
 import TrackPanelVariant from './track-panel-items/track-panel-variant/TrackPanelVariant';
 import TrackPanelRegularItem from './track-panel-items/TrackPanelRegularItem';
+import SimpleTrackPanelItemLayout from './track-panel-items/track-panel-item-layout/SimpleTrackPanelItemLayout';
 import {
   Accordion,
   AccordionItem,
@@ -52,10 +54,12 @@ import type { GenomeTrackCategory } from 'src/content/app/genome-browser/state/t
 import type {
   FocusObject as FocusObjectType,
   FocusGene as FocusGeneType,
+  FocusTranscript as FocusTranscriptType,
   FocusVariant as FocusVariantType
 } from 'src/shared/types/focus-object/focusObjectTypes';
 
 import styles from './TrackPanelList.module.css';
+import trackPanelItemStyles from './track-panel-items/TrackPanelItem.module.css';
 
 export const TrackPanelList = () => {
   // by the time this component renders, genome id should be available
@@ -175,6 +179,8 @@ const FocusObject = (props: { focusObject: FocusObjectType | null }) => {
 
   if (focusObject?.type === 'gene') {
     content = <FocusGene focusGene={focusObject} />;
+  } else if (focusObject?.type === 'transcript') {
+    content = <FocusTranscript focusTranscript={focusObject} />;
   } else if (focusObject?.type === 'variant') {
     content = <FocusVariant focusVariant={focusObject} />;
   }
@@ -200,6 +206,39 @@ const FocusGene = (props: { focusGene: FocusGeneType }) => {
 
 const FocusVariant = (props: { focusVariant: FocusVariantType }) => {
   return <TrackPanelVariant focusVariant={props.focusVariant} />;
+};
+
+const FocusTranscript = (props: { focusTranscript: FocusTranscriptType }) => {
+  const { focusTranscript } = props;
+  const dispatch = useAppDispatch();
+  const { trackDrawerOpened } = useGenomeBrowserAnalytics();
+
+  const onShowMore = () => {
+    trackDrawerOpened('transcript_summary');
+
+    dispatch(
+      changeDrawerViewForGenome({
+        genomeId: focusTranscript.genome_id,
+        drawerView: {
+          name: 'transcript_summary',
+          transcriptId: focusTranscript.stable_id
+        }
+      })
+    );
+  };
+
+  return (
+    <SimpleTrackPanelItemLayout onShowMore={onShowMore}>
+      <div className={trackPanelItemStyles.label}>
+        <span className={trackPanelItemStyles.labelText}>
+          {focusTranscript.stable_id}
+        </span>
+        <span className={trackPanelItemStyles.labelTextSecondaryStrong}>
+          {focusTranscript.gene_symbol}
+        </span>
+      </div>
+    </SimpleTrackPanelItemLayout>
+  );
 };
 
 export default memo(TrackPanelList);

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
@@ -20,7 +20,6 @@ import classNames from 'classnames';
 import { useAppDispatch, useAppSelector } from 'src/store';
 import { useGenomeTracksQuery } from 'src/content/app/genome-browser/state/api/genomeBrowserApiSlice';
 import useGenomeBrowserAnalytics from 'src/content/app/genome-browser/hooks/useGenomeBrowserAnalytics';
-import { changeDrawerViewForGenome } from 'src/content/app/genome-browser/state/drawer/drawerSlice';
 
 import {
   getBrowserActiveFocusObject,
@@ -33,9 +32,9 @@ import {
 } from 'src/content/app/genome-browser/state/browser-sidebar-modal/browserSidebarModalSlice';
 
 import TrackPanelGene from './track-panel-items/TrackPanelGene';
+import TrackPanelTranscript from './track-panel-items/track-panel-transcript/TrackPanelTranscript';
 import TrackPanelVariant from './track-panel-items/track-panel-variant/TrackPanelVariant';
 import TrackPanelRegularItem from './track-panel-items/TrackPanelRegularItem';
-import SimpleTrackPanelItemLayout from './track-panel-items/track-panel-item-layout/SimpleTrackPanelItemLayout';
 import {
   Accordion,
   AccordionItem,
@@ -59,7 +58,6 @@ import type {
 } from 'src/shared/types/focus-object/focusObjectTypes';
 
 import styles from './TrackPanelList.module.css';
-import trackPanelItemStyles from './track-panel-items/TrackPanelItem.module.css';
 
 export const TrackPanelList = () => {
   // by the time this component renders, genome id should be available
@@ -209,36 +207,7 @@ const FocusVariant = (props: { focusVariant: FocusVariantType }) => {
 };
 
 const FocusTranscript = (props: { focusTranscript: FocusTranscriptType }) => {
-  const { focusTranscript } = props;
-  const dispatch = useAppDispatch();
-  const { trackDrawerOpened } = useGenomeBrowserAnalytics();
-
-  const onShowMore = () => {
-    trackDrawerOpened('transcript_summary');
-
-    dispatch(
-      changeDrawerViewForGenome({
-        genomeId: focusTranscript.genome_id,
-        drawerView: {
-          name: 'transcript_summary',
-          transcriptId: focusTranscript.stable_id
-        }
-      })
-    );
-  };
-
-  return (
-    <SimpleTrackPanelItemLayout onShowMore={onShowMore}>
-      <div className={trackPanelItemStyles.label}>
-        <span className={trackPanelItemStyles.labelText}>
-          {focusTranscript.stable_id}
-        </span>
-        <span className={trackPanelItemStyles.labelTextSecondaryStrong}>
-          {focusTranscript.gene_symbol}
-        </span>
-      </div>
-    </SimpleTrackPanelItemLayout>
-  );
+  return <TrackPanelTranscript focusTranscript={props.focusTranscript} />;
 };
 
 export default memo(TrackPanelList);

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelItem.module.css
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelItem.module.css
@@ -1,3 +1,7 @@
+.container {
+  padding: 4px 10px;
+}
+
 .label {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -13,6 +17,17 @@
 
 .labelTextStrong {
   font-weight: var(--font-weight-bold);
+}
+
+.labelTextLight {
+  font-weight: var(--font-weight-light);
+}
+
+.twoItemsGrid {
+  display: inline-grid;
+  grid-template-columns: repeat(2, auto);
+  column-gap: 12px;
+  align-items: baseline;
 }
 
 .labelTextSecondary {

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/track-panel-transcript/TrackPanelTranscript.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/track-panel-transcript/TrackPanelTranscript.tsx
@@ -1,0 +1,113 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useAppDispatch } from 'src/store';
+
+import { formatNumber } from 'src/shared/helpers/formatters/numberFormatter';
+
+import { useGbTranscriptSummaryQuery } from 'src/content/app/genome-browser/state/api/genomeBrowserApiSlice';
+import { changeDrawerViewForGenome } from 'src/content/app/genome-browser/state/drawer/drawerSlice';
+
+import SidebarSectionHeading from 'src/shared/components/sidebar-section-heading/SidebarSectionHeading';
+import SimpleTrackPanelItemLayout from '../track-panel-item-layout/SimpleTrackPanelItemLayout';
+
+import type { FocusTranscript } from 'src/shared/types/focus-object/focusObjectTypes';
+
+import trackPanelItemStyles from '../TrackPanelItem.module.css';
+
+const TrackPanelTranscript = (props: { focusTranscript: FocusTranscript }) => {
+  const { focusTranscript } = props;
+  const { currentData: transcriptData } = useGbTranscriptSummaryQuery({
+    genomeId: focusTranscript.genome_id,
+    transcriptId: focusTranscript.versioned_stable_id
+  });
+  const dispatch = useAppDispatch();
+
+  const transcript = transcriptData?.transcript;
+  if (!transcript) {
+    return null;
+  }
+
+  const showTranscriptInfo = () => {
+    dispatch(
+      changeDrawerViewForGenome({
+        genomeId: focusTranscript.genome_id,
+        drawerView: {
+          name: 'transcript_summary',
+          transcriptId: focusTranscript.stable_id
+        }
+      })
+    );
+  };
+
+  const showGeneInfo = () => {
+    dispatch(
+      changeDrawerViewForGenome({
+        genomeId: focusTranscript.genome_id,
+        drawerView: {
+          name: 'gene_summary',
+          geneId: transcript.gene.unversioned_stable_id
+        }
+      })
+    );
+  };
+
+  return (
+    <>
+      <SimpleTrackPanelItemLayout onShowMore={showTranscriptInfo}>
+        <span className={trackPanelItemStyles.twoItemsGrid}>
+          <span className={trackPanelItemStyles.labelTextLight}>
+            Transcript
+          </span>
+          <span className={trackPanelItemStyles.labelTextStrong}>
+            {transcript.stable_id}
+          </span>
+        </span>
+      </SimpleTrackPanelItemLayout>
+
+      <div className={trackPanelItemStyles.container}>
+        <span className={trackPanelItemStyles.twoItemsGrid}>
+          <span className={trackPanelItemStyles.labelTextLight}>Biotype</span>
+          <span>{transcript.metadata.biotype.value}</span>
+        </span>
+      </div>
+
+      <div className={trackPanelItemStyles.container}>
+        <span className={trackPanelItemStyles.twoItemsGrid}>
+          <span className={trackPanelItemStyles.labelTextLight}>Length</span>
+          <span>
+            {formatNumber(transcript.slice.location.length)}{' '}
+            <span className={trackPanelItemStyles.labelTextLight}>bp</span>
+          </span>
+        </span>
+      </div>
+
+      <SidebarSectionHeading>Gene</SidebarSectionHeading>
+      <SimpleTrackPanelItemLayout onShowMore={showGeneInfo}>
+        <span className={trackPanelItemStyles.twoItemsGrid}>
+          <span className={trackPanelItemStyles.labelTextStrong}>
+            {transcript.gene.symbol ?? transcript.gene.stable_id}
+          </span>
+          <span className={trackPanelItemStyles.labelTextSecondary}>
+            {transcript.gene.metadata.biotype.label}
+          </span>
+        </span>
+      </SimpleTrackPanelItemLayout>
+    </>
+  );
+};
+
+export default TrackPanelTranscript;

--- a/src/content/app/genome-browser/components/track-panel/trackPanelConfig.ts
+++ b/src/content/app/genome-browser/components/track-panel/trackPanelConfig.ts
@@ -53,6 +53,7 @@ export type TrackStates = {
 };
 
 export const TrackId = {
-  FOCUS_GENE: 'focus',
+  FOCUS_GENE: 'focus-gene',
+  FOCUS_TRANSCRIPT: 'focus-transcript',
   FOCUS_VARIANT: 'focus-variant'
-};
+} as const;

--- a/src/content/app/genome-browser/components/track-settings-panel/TrackSettingsPanel.tsx
+++ b/src/content/app/genome-browser/components/track-settings-panel/TrackSettingsPanel.tsx
@@ -53,7 +53,10 @@ export const TrackSettingsPanel = (props: Props) => {
   ) {
     return <VariantTrackSettings {...commonProps} />;
   }
-  if (trackType === TrackType.REGULAR) {
+  if (
+    trackType === TrackType.REGULAR ||
+    trackType === TrackType.FOCUS_TRANSCRIPT
+  ) {
     return <RegularTrackSettings {...commonProps} />;
   }
 };

--- a/src/content/app/genome-browser/components/track-settings-panel/TrackSettingsPanel.tsx
+++ b/src/content/app/genome-browser/components/track-settings-panel/TrackSettingsPanel.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useRef } from 'react';
+import { useRef, memo } from 'react';
 
 import useOutsideClick from 'src/shared/hooks/useOutsideClick';
 
@@ -61,4 +61,4 @@ export const TrackSettingsPanel = (props: Props) => {
   }
 };
 
-export default TrackSettingsPanel;
+export default memo(TrackSettingsPanel);

--- a/src/content/app/genome-browser/components/track-settings-panel/TrackSettingsPanel.tsx
+++ b/src/content/app/genome-browser/components/track-settings-panel/TrackSettingsPanel.tsx
@@ -31,19 +31,6 @@ type Props = {
   className?: string;
 };
 
-const getTrackSettingsPanelComponent = (trackType: TrackType) => {
-  switch (trackType) {
-    case TrackType.GENE:
-    case TrackType.FOCUS_GENE:
-      return GeneTrackSettings;
-    case TrackType.VARIANT:
-    case TrackType.FOCUS_VARIANT:
-      return VariantTrackSettings;
-    case TrackType.REGULAR:
-      return RegularTrackSettings;
-  }
-};
-
 export const TrackSettingsPanel = (props: Props) => {
   const { trackId, trackType } = props;
 
@@ -51,19 +38,24 @@ export const TrackSettingsPanel = (props: Props) => {
 
   useOutsideClick(trackSettingsRef, props.onOutsideClick);
 
-  if (!trackType) {
-    return null;
+  const commonProps = {
+    trackId,
+    className: props.className,
+    ref: trackSettingsRef
+  };
+
+  if (trackType === TrackType.GENE || trackType === TrackType.FOCUS_GENE) {
+    return <GeneTrackSettings {...commonProps} />;
   }
-
-  const Track = getTrackSettingsPanelComponent(trackType);
-
-  return (
-    <Track
-      trackId={trackId}
-      className={props.className}
-      ref={trackSettingsRef}
-    />
-  );
+  if (
+    trackType === TrackType.VARIANT ||
+    trackType === TrackType.FOCUS_VARIANT
+  ) {
+    return <VariantTrackSettings {...commonProps} />;
+  }
+  if (trackType === TrackType.REGULAR) {
+    return <RegularTrackSettings {...commonProps} />;
+  }
 };
 
 export default TrackSettingsPanel;

--- a/src/content/app/genome-browser/components/track-settings-panel/useTrackSettings.ts
+++ b/src/content/app/genome-browser/components/track-settings-panel/useTrackSettings.ts
@@ -17,15 +17,11 @@
 import { useAppSelector, useAppDispatch } from 'src/store';
 
 import { getBrowserActiveGenomeId } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
-import {
-  getTrackSettingsForTrackId,
-  getAllTrackSettingsForGenome
-} from 'src/content/app/genome-browser/state/track-settings/trackSettingsSelectors';
+import { getTrackSettingsForTrackId } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSelectors';
 
 import { updateTrackSettingsAndSave } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSlice';
 
 import useGenomeBrowserAnalytics from 'src/content/app/genome-browser/hooks/useGenomeBrowserAnalytics';
-import useGenomeBrowser from 'src/content/app/genome-browser/hooks/useGenomeBrowser';
 
 type Params = {
   selectedTrackId: string;
@@ -34,17 +30,12 @@ type Params = {
 const useBrowserTrackSettings = (params: Params) => {
   const { selectedTrackId } = params;
   const activeGenomeId = useAppSelector(getBrowserActiveGenomeId);
-  const allTrackSettingsForGenome = useAppSelector((state) =>
-    getAllTrackSettingsForGenome(state, activeGenomeId ?? '')
-  );
   const selectedTrackSettings = useAppSelector((state) =>
     getTrackSettingsForTrackId(state, selectedTrackId)
   );
   const dispatch = useAppDispatch();
 
   const { trackToggledTrackSetting } = useGenomeBrowserAnalytics();
-
-  const { toggleTrackSetting } = useGenomeBrowser();
 
   const updateTrackSetting = (setting: string, isEnabled: boolean) => {
     if (!activeGenomeId || !selectedTrackSettings) {
@@ -58,18 +49,6 @@ const useBrowserTrackSettings = (params: Params) => {
         isEnabled
       })
     );
-
-    Object.entries(
-      allTrackSettingsForGenome?.settingsForIndividualTracks ?? {}
-    ).forEach(([trackId, track]) => {
-      if (setting in track.settings) {
-        toggleTrackSetting({
-          trackId: trackId,
-          setting,
-          isEnabled
-        });
-      }
-    });
 
     trackToggledTrackSetting(selectedTrackId, setting, isEnabled);
   };

--- a/src/content/app/genome-browser/components/zmenu/Zmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/Zmenu.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { useEffect, type ReactNode, type RefObject } from 'react';
+import { useEffect, useCallback, type ReactNode, type RefObject } from 'react';
 import pickBy from 'lodash/pickBy';
 import usePrevious from 'src/shared/hooks/usePrevious';
 
 import { useAppSelector, useAppDispatch } from 'src/store';
 import useGenomeBrowser from 'src/content/app/genome-browser/hooks/useGenomeBrowser';
-import useRefWithRerender from 'src/shared/hooks/useRefWithRerender';
+import useDOMElement from 'src/shared/hooks/useDOMElement';
 
 import { changeHighlightedTrackId } from 'src/content/app/genome-browser/state/track-panel/trackPanelSlice';
 
@@ -28,6 +28,7 @@ import { getActualChrLocation } from 'src/content/app/genome-browser/state/brows
 
 import { Toolbox, ToolboxPosition } from 'src/shared/components/toolbox';
 import GeneAndOneTranscriptZmenu from './zmenus/GeneAndOneTranscriptZmenu';
+import TranscriptZmenu from './zmenus/TranscriptZmenu';
 import VariantZmenu from './zmenus/VariantZmenu';
 import RegulationZmenu from './zmenus/RegulationZmenu';
 import DefaultZmenu from './zmenus/DefaultZmenu';
@@ -52,12 +53,18 @@ export type ZmenuProps = {
 };
 
 const Zmenu = (props: ZmenuProps) => {
-  const [anchorRef, setAnchorRef] = useRefWithRerender<HTMLDivElement>(null);
+  const [anchor, setAnchorRef] = useDOMElement<HTMLDivElement>();
   const { zmenus, setZmenus } = useGenomeBrowser();
   const chromosomeLocation = useAppSelector(getActualChrLocation);
   const previousChromosomeLocation = usePrevious(chromosomeLocation);
 
   const dispatch = useAppDispatch();
+
+  const destroyZmenu = useCallback(() => {
+    dispatch(changeHighlightedTrackId(''));
+    setZmenus(pickBy(zmenus, (_, key) => key !== props.zmenuId));
+  }, [dispatch, props.zmenuId, setZmenus, zmenus]);
+
   useEffect(() => {
     if (
       chromosomeLocation &&
@@ -66,12 +73,7 @@ const Zmenu = (props: ZmenuProps) => {
     ) {
       destroyZmenu();
     }
-  }, [chromosomeLocation]);
-
-  const destroyZmenu = () => {
-    dispatch(changeHighlightedTrackId(''));
-    setZmenus(pickBy(zmenus, (_, key) => key !== props.zmenuId));
-  };
+  }, [chromosomeLocation, previousChromosomeLocation, destroyZmenu]);
 
   const direction = chooseDirection(props);
   const toolboxPosition =
@@ -92,6 +94,10 @@ const Zmenu = (props: ZmenuProps) => {
         onDestroy={destroyZmenu}
       />
     );
+  } else if (zmenuType === ZmenuPayloadVarietyType.TRANSCRIPT) {
+    zmenuContent = (
+      <TranscriptZmenu payload={props.payload} onDestroy={destroyZmenu} />
+    );
   } else if (zmenuType === ZmenuPayloadVarietyType.VARIANT) {
     zmenuContent = (
       <VariantZmenu payload={props.payload} onDestroy={destroyZmenu} />
@@ -110,10 +116,10 @@ const Zmenu = (props: ZmenuProps) => {
 
   return (
     <div ref={setAnchorRef} className={styles.zmenuAnchor} style={anchorStyles}>
-      {anchorRef.current && (
+      {anchor && (
         <Toolbox
           onOutsideClick={destroyZmenu}
-          anchor={anchorRef.current}
+          anchor={anchor}
           position={toolboxPosition}
           className={styles.toolbox}
         >

--- a/src/content/app/genome-browser/components/zmenu/zmenus/TranscriptZmenu.tsx
+++ b/src/content/app/genome-browser/components/zmenu/zmenus/TranscriptZmenu.tsx
@@ -1,0 +1,88 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { buildFocusIdForUrl } from 'src/shared/helpers/focusObjectHelpers';
+
+import {
+  ToolboxExpandableContent,
+  ToggleButton as ToolboxToggleButton
+} from 'src/shared/components/toolbox';
+import ZmenuContent from '../ZmenuContent';
+import ZmenuInstantDownload from '../ZmenuInstantDownload';
+import ZmenuAppLinks from '../ZmenuAppLinks';
+
+import type {
+  ZmenuContentTranscriptMetadata,
+  ZmenuPayload
+} from 'src/content/app/genome-browser/services/genome-browser-service/types/zmenu';
+
+import styles from '../Zmenu.module.css';
+
+type Props = {
+  payload: ZmenuPayload;
+  onDestroy: () => void;
+};
+
+const TranscriptZmenu = (props: Props) => {
+  const { content: contentList } = props.payload;
+  const content = contentList.at(0);
+
+  if (!content) {
+    return null;
+  }
+
+  const transcriptMetadata = content.metadata as ZmenuContentTranscriptMetadata;
+  const transcriptId = transcriptMetadata.versioned_id;
+  const transcriptIdForUrl = buildFocusIdForUrl({
+    type: 'transcript',
+    objectId: transcriptMetadata.unversioned_id
+  });
+
+  const mainContent = (
+    <>
+      <ZmenuContent
+        features={contentList}
+        featureId={transcriptId}
+        destroyZmenu={props.onDestroy}
+      />
+      <div className={styles.zmenuLinksGrid}>
+        <ToolboxToggleButton
+          className={styles.zmenuToggleFooter}
+          label="Download"
+        />
+        <ZmenuAppLinks
+          featureId={transcriptIdForUrl}
+          destroyZmenu={props.onDestroy}
+        />
+      </div>
+    </>
+  );
+
+  const footerContent = (
+    <div className={styles.zmenuFooterContent}>
+      <ZmenuInstantDownload id={transcriptId} />
+    </div>
+  );
+
+  return (
+    <ToolboxExpandableContent
+      mainContent={mainContent}
+      footerContent={footerContent}
+    />
+  );
+};
+
+export default TranscriptZmenu;

--- a/src/content/app/genome-browser/contexts/genome-browser-ids-context/useGenomeBrowserUrlValidator.ts
+++ b/src/content/app/genome-browser/contexts/genome-browser-ids-context/useGenomeBrowserUrlValidator.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 
 import { useAppDispatch } from 'src/store';
 
@@ -23,7 +23,10 @@ import {
   validateGenomicLocation
 } from 'src/content/app/genome-browser/helpers/browserHelper';
 
-import { getTrackPanelGene } from 'src/content/app/genome-browser/state/api/genomeBrowserApiSlice';
+import {
+  gbTranscriptSummary,
+  getTrackPanelGene
+} from 'src/content/app/genome-browser/state/api/genomeBrowserApiSlice';
 
 import type { ChrLocation } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSlice';
 import type { FocusObjectIdConstituents } from 'src/shared/types/focus-object/focusObjectTypes';
@@ -43,7 +46,11 @@ const initialState = {
 };
 
 const useGenomeBrowserUrlValidator = (params: Params) => {
-  const [state, setState] = useState(initialState);
+  const [validationResultState, setValidationResultState] = useState({
+    validationKey: null as string | null,
+    isMissingFocusObject: false,
+    isInvalidLocation: false
+  });
   const {
     genomeId,
     parsedFocusObjectId,
@@ -51,20 +58,56 @@ const useGenomeBrowserUrlValidator = (params: Params) => {
     hasMalformedLocation
   } = params;
   const dispatch = useAppDispatch();
+  const focusObjectType = parsedFocusObjectId?.type;
+  const focusObjectId = parsedFocusObjectId?.objectId;
+  const locationRegionName = parsedLocation?.[0];
+  const locationStart = parsedLocation?.[1];
+  const locationEnd = parsedLocation?.[2];
+  const hasFocusObjectToValidate = Boolean(
+    genomeId && focusObjectType && focusObjectId
+  );
+  const validationKey = hasFocusObjectToValidate
+    ? JSON.stringify({
+        genomeId,
+        focusObjectType,
+        focusObjectId,
+        locationRegionName,
+        locationStart,
+        locationEnd,
+        hasMalformedLocation
+      })
+    : null;
+  const currentState = getCurrentValidationState({
+    hasFocusObjectToValidate,
+    validationKey,
+    validationResultState
+  });
 
-  const stateRef = useRef(state);
+  const stateRef = useRef(currentState);
   const postValidationQueueRef = useRef<Array<() => unknown>>([]);
 
-  useEffect(() => {
-    setState(initialState);
+  const flushPostValidationQueue = useCallback(() => {
+    postValidationQueueRef.current.forEach((fn) => fn());
+    postValidationQueueRef.current = [];
+  }, []);
 
-    if (!genomeId || !parsedFocusObjectId) {
-      onValidationComplete(initialState); // nothing to validate
+  useEffect(() => {
+    if (!hasFocusObjectToValidate) {
+      flushPostValidationQueue();
       return;
     }
+
+    let isCancelled = false;
+    const validatedGenomeId = genomeId as string;
+    const validatedParsedFocusObjectId = {
+      genomeId: validatedGenomeId,
+      type: focusObjectType as string,
+      objectId: focusObjectId as string
+    };
+
     const focusCheckParams = {
-      genomeId,
-      parsedFocusObjectId,
+      genomeId: validatedGenomeId,
+      parsedFocusObjectId: validatedParsedFocusObjectId,
       dispatch
     };
 
@@ -75,23 +118,27 @@ const useGenomeBrowserUrlValidator = (params: Params) => {
 
     if (hasMalformedLocation) {
       checkPromises.push(Promise.resolve({ isInvalidLocation: true }));
-    } else if (parsedLocation) {
-      const [regionName, start, end] = parsedLocation;
+    } else if (
+      locationRegionName &&
+      typeof locationStart === 'number' &&
+      typeof locationEnd === 'number'
+    ) {
       const locationCheckPromise = checkLocationFromUrl({
-        genomeId,
-        regionName,
-        start,
-        end
+        genomeId: validatedGenomeId,
+        regionName: locationRegionName,
+        start: locationStart,
+        end: locationEnd
       });
       checkPromises.push(locationCheckPromise);
     }
 
-    setState({ ...initialState, isValidating: true });
-
     Promise.all(checkPromises).then((checkResults) => {
+      if (isCancelled) {
+        return;
+      }
+
       const newState = {
-        isValidating: false,
-        doneValidating: true,
+        validationKey,
         isMissingFocusObject: false,
         isInvalidLocation: hasMalformedLocation || false
       };
@@ -102,20 +149,41 @@ const useGenomeBrowserUrlValidator = (params: Params) => {
           newState.isInvalidLocation = result.isInvalidLocation;
         }
       }
-      setState(newState);
-      onValidationComplete(newState);
+
+      setValidationResultState(newState);
+
+      if (!newState.isMissingFocusObject && !newState.isInvalidLocation) {
+        flushPostValidationQueue();
+      }
     });
-  }, [genomeId]);
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [
+    dispatch,
+    flushPostValidationQueue,
+    genomeId,
+    focusObjectId,
+    focusObjectType,
+    hasMalformedLocation,
+    hasFocusObjectToValidate,
+    locationEnd,
+    locationRegionName,
+    locationStart,
+    validationKey
+  ]);
 
   useEffect(() => {
-    stateRef.current = state;
-  });
+    stateRef.current = currentState;
+  }, [currentState]);
 
   const runAfterValidation = (fn: () => unknown) => {
     if (
-      stateRef.current.doneValidating &&
-      !stateRef.current.isMissingFocusObject &&
-      !stateRef.current.isInvalidLocation
+      !hasFocusObjectToValidate ||
+      (stateRef.current.doneValidating &&
+        !stateRef.current.isMissingFocusObject &&
+        !stateRef.current.isInvalidLocation)
     ) {
       fn();
     } else {
@@ -123,26 +191,52 @@ const useGenomeBrowserUrlValidator = (params: Params) => {
     }
   };
 
-  const onValidationComplete = (state: typeof initialState) => {
-    setState({ ...state, doneValidating: true });
-    if (state.isMissingFocusObject || state.isInvalidLocation) {
-      return;
-    }
-    postValidationQueueRef.current.forEach((fn) => fn());
-    postValidationQueueRef.current = [];
-  };
-
   const resetValidator = () => {
-    setState({
-      ...initialState,
-      doneValidating: true // so that functions that need to run after validation could run
+    setValidationResultState({
+      validationKey,
+      isMissingFocusObject: false,
+      isInvalidLocation: false
     });
   };
 
   return {
-    ...state,
+    ...currentState,
     runAfterValidation,
     resetValidator
+  };
+};
+
+const getCurrentValidationState = (params: {
+  hasFocusObjectToValidate: boolean;
+  validationKey: string | null;
+  validationResultState: {
+    validationKey: string | null;
+    isMissingFocusObject: boolean;
+    isInvalidLocation: boolean;
+  };
+}) => {
+  const { hasFocusObjectToValidate, validationKey, validationResultState } =
+    params;
+
+  if (!hasFocusObjectToValidate) {
+    return {
+      ...initialState,
+      doneValidating: true
+    };
+  }
+
+  if (validationResultState.validationKey !== validationKey) {
+    return {
+      ...initialState,
+      isValidating: true
+    };
+  }
+
+  return {
+    isValidating: false,
+    doneValidating: true,
+    isMissingFocusObject: validationResultState.isMissingFocusObject,
+    isInvalidLocation: validationResultState.isInvalidLocation
   };
 };
 
@@ -159,6 +253,8 @@ const checkFocusObject = async (
 
   if (type === 'gene') {
     return checkFocusGene(params);
+  } else if (type === 'transcript') {
+    return checkFocusTranscript(params);
   } else if (type === 'location') {
     return checkFocusLocation(params);
   } else if (type === 'variant') {
@@ -218,6 +314,36 @@ const checkFocusLocation = async (params: CheckFocusObjectParams) => {
   }
 
   return { isMissingFocusObject };
+};
+
+const checkFocusTranscript = async (params: CheckFocusObjectParams) => {
+  const {
+    genomeId,
+    parsedFocusObjectId: { objectId: transcriptId },
+    dispatch
+  } = params;
+
+  const dispatchedPromise = dispatch(
+    gbTranscriptSummary.initiate({
+      genomeId,
+      transcriptId
+    })
+  );
+
+  const result = await dispatchedPromise;
+  dispatchedPromise.unsubscribe();
+
+  const transcriptQueryError = result.error as any;
+  const isMissingTranscript =
+    (result.isError &&
+      transcriptQueryError &&
+      'meta' in transcriptQueryError &&
+      transcriptQueryError.meta?.data?.transcript === null) ||
+    !result.data?.transcript;
+
+  return {
+    isMissingFocusObject: isMissingTranscript
+  };
 };
 
 const checkFocusVariant = async (params: CheckFocusObjectParams) => {

--- a/src/content/app/genome-browser/contexts/genome-browser-ids-context/useGenomeBrowserUrlValidator.ts
+++ b/src/content/app/genome-browser/contexts/genome-browser-ids-context/useGenomeBrowserUrlValidator.ts
@@ -24,7 +24,7 @@ import {
 } from 'src/content/app/genome-browser/helpers/browserHelper';
 
 import {
-  gbTranscriptSummary,
+  getGBTranscriptSummary,
   getTrackPanelGene
 } from 'src/content/app/genome-browser/state/api/genomeBrowserApiSlice';
 
@@ -324,7 +324,7 @@ const checkFocusTranscript = async (params: CheckFocusObjectParams) => {
   } = params;
 
   const dispatchedPromise = dispatch(
-    gbTranscriptSummary.initiate({
+    getGBTranscriptSummary.initiate({
       genomeId,
       transcriptId
     })

--- a/src/content/app/genome-browser/hooks/useBrowserRouting.test.tsx
+++ b/src/content/app/genome-browser/hooks/useBrowserRouting.test.tsx
@@ -344,6 +344,19 @@ describe('useBrowserRouting', () => {
         expect(mockChangeBrowserLocation).not.toHaveBeenCalled();
       });
     });
+
+    it('supports transcript focus object from the url', async () => {
+      const transcriptStableId = 'ENST00000380737';
+      const url = `/genome-browser/${humanGenomeInfo.genome_tag}?focus=transcript:${transcriptStableId}`;
+
+      renderComponent({ path: url });
+
+      await waitFor(() => {
+        expect(mockChangeFocusObject).toHaveBeenCalledWith(
+          `${humanGenomeInfo.genome_id}:transcript:${transcriptStableId}`
+        );
+      });
+    });
   });
 
   describe('navigation to /genome-browser/:genome_id with focus object and location', () => {
@@ -386,6 +399,25 @@ describe('useBrowserRouting', () => {
           focus: {
             id: 'ENSG00000139618',
             type: 'gene'
+          }
+        });
+      });
+    });
+
+    it('supports transcript focus object and location from the url', async () => {
+      const transcriptStableId = 'ENST00000380737';
+
+      renderComponent({
+        path: `/genome-browser/${humanGenomeInfo.genome_tag}?focus=transcript:${transcriptStableId}&location=13:100-200`
+      });
+
+      await waitFor(() => {
+        expect(mockChangeBrowserLocation).toHaveBeenCalledWith({
+          genomeId: humanGenomeInfo.genome_id,
+          chrLocation: ['13', 100, 200],
+          focus: {
+            id: transcriptStableId,
+            type: 'transcript'
           }
         });
       });

--- a/src/content/app/genome-browser/hooks/useFocusTrack.ts
+++ b/src/content/app/genome-browser/hooks/useFocusTrack.ts
@@ -60,6 +60,12 @@ import type {
  * Only one copy of this hook should be run.
  */
 
+/** Although the client uses different ids for focus gene, focus transcript, and focus variant tracks (see TrackId),
+ *  which helps the client independently keep track of the different settings for these focus tracks,
+ *  the genome browser uses the same id for all of them, which is 'focus'.
+ */
+const GENOME_BROWSER_FOCUS_TRACK_ID = 'focus';
+
 const useFocusTrack = () => {
   const genomeBrowserMethods = useGenomeBrowser(); // getting it here once to avoid unnecessarily calling this hook from inside child hooks
   const { focusObjectId = '', parsedFocusObjectId = null } =
@@ -306,8 +312,6 @@ const sendFocusGeneTrackSettings = (
   trackSettings: FocusGeneTrackSettings,
   toggleTrackSetting: ReturnType<typeof useGenomeBrowser>['toggleTrackSetting']
 ) => {
-  const trackId = 'focus'; // this is the id of this track in the genome browser
-
   // Notice that in contrast to genomic tracks, we aren't sending the "show five transcripts"
   // message to the genome browser here. We haven't found a good way of reconciling the state
   // of the "show five transcripts" toggle for the focus gene track, and the list of manually shown/hidden transcripts
@@ -316,7 +320,7 @@ const sendFocusGeneTrackSettings = (
     .forEach((keyValuePair) => {
       const [settingName, settingValue] = keyValuePair as [string, boolean];
       toggleTrackSetting({
-        trackId,
+        trackId: GENOME_BROWSER_FOCUS_TRACK_ID,
         setting: settingName,
         isEnabled: settingValue
       });
@@ -348,7 +352,7 @@ const useFocusTranscript = ({
       focusTranscriptTrackSettings
     )) {
       toggleTrackSetting({
-        trackId: TrackId.FOCUS_TRANSCRIPT,
+        trackId: GENOME_BROWSER_FOCUS_TRACK_ID,
         setting: settingName,
         isEnabled: settingValue
       });
@@ -388,7 +392,7 @@ const useFocusVariant = (params: UseFocusVariantParams) => {
       focusVariantTrackSettings
     )) {
       toggleTrackSetting({
-        trackId: TrackId.FOCUS_VARIANT,
+        trackId: GENOME_BROWSER_FOCUS_TRACK_ID,
         setting: settingName,
         isEnabled: settingValue
       });

--- a/src/content/app/genome-browser/hooks/useFocusTrack.ts
+++ b/src/content/app/genome-browser/hooks/useFocusTrack.ts
@@ -103,14 +103,20 @@ type UseFocusGeneParams = {
 
 const useFocusGene = (params: UseFocusGeneParams) => {
   const { focusGene, genomeBrowserMethods, focusObjectId } = params;
-  const { genomeBrowser, genomeBrowserService, updateFocusGeneTranscripts } =
-    genomeBrowserMethods;
+  const {
+    genomeBrowser,
+    toggleTrackSetting,
+    genomeBrowserService,
+    updateFocusGeneTranscripts
+  } = genomeBrowserMethods;
   const geneStableId = focusGene?.stable_id;
   const focusObjectIdRef = useRef(focusObjectId);
   const geneIdRef = useRef(geneStableId);
   const visibleTranscriptIds = focusGene?.visibleTranscriptIds ?? null;
   const focusGeneTrackSettings = useAppSelector(getAllTrackSettings)
-    ?.settingsForIndividualTracks.focus as FocusGeneTrack | undefined;
+    ?.settingsForIndividualTracks[TrackId.FOCUS_GENE] as
+    | FocusGeneTrack
+    | undefined;
 
   const allSortedFocusGeneTranscriptsRef = useRef<string[]>([]);
   const visibleTranscriptIdsRef = useRef(visibleTranscriptIds);
@@ -120,6 +126,7 @@ const useFocusGene = (params: UseFocusGeneParams) => {
   const previousSeveralTranscriptsSetting = usePrevious(
     focusGeneTrackSettings?.settings.several
   );
+  const previousVisibleTranscriptIds = usePrevious(visibleTranscriptIds);
 
   const { currentData: fetchedFocusGeneData } = useGetTrackPanelGeneQuery(
     {
@@ -241,10 +248,9 @@ const useFocusGene = (params: UseFocusGeneParams) => {
    * 2) if not, then what is the value of the 1/5 transcripts toggle in track settings panel
    */
   useEffect(() => {
-    if (!geneStableId || !fetchedFocusGeneData) {
+    if (!geneStableId || !fetchedFocusGeneData || !focusGene) {
       return;
     }
-    let transcriptIds: string[];
 
     if (
       !visibleTranscriptIds || // hopefully, there won't be any race conditions
@@ -257,24 +263,24 @@ const useFocusGene = (params: UseFocusGeneParams) => {
         focusGeneTrackSettings?.settings.several;
       const numberOfTranscriptsToShow = shouldShowSeveralTranscripts ? 5 : 1;
 
-      transcriptIds = allSortedFocusGeneTranscriptsRef.current.slice(
+      const transcriptIds = allSortedFocusGeneTranscriptsRef.current.slice(
         0,
         numberOfTranscriptsToShow
       );
-    } else {
-      transcriptIds = visibleTranscriptIds;
+      updateFocusGeneTranscripts(transcriptIds);
+    } else if (visibleTranscriptIds !== previousVisibleTranscriptIds) {
+      updateFocusGeneTranscripts(visibleTranscriptIds);
     }
-
-    updateFocusGeneTranscripts(transcriptIds);
   }, [
     genomeBrowser, // updateFocusGeneTranscripts requires genomeBrowser to be defined
     geneStableId,
-    stringifiedVisibleTranscriptIds,
     focusGeneTrackSettings?.settings.several,
     fetchedFocusGeneData,
     previousSeveralTranscriptsSetting,
     updateFocusGeneTranscripts,
-    visibleTranscriptIds
+    focusGene,
+    visibleTranscriptIds,
+    previousVisibleTranscriptIds
   ]);
 
   // apply track settings other than several transcripts
@@ -285,14 +291,9 @@ const useFocusGene = (params: UseFocusGeneParams) => {
 
     sendFocusGeneTrackSettings(
       focusGeneTrackSettings.settings,
-      genomeBrowserMethods
+      toggleTrackSetting
     );
-  }, [
-    genomeBrowser,
-    focusGeneTrackSettings,
-    geneStableId,
-    genomeBrowserMethods
-  ]);
+  }, [genomeBrowser, focusGeneTrackSettings, geneStableId, toggleTrackSetting]);
 };
 
 const haveDifferentMembers = (arr1: string[], arr2: string[]) => {
@@ -303,10 +304,9 @@ const haveDifferentMembers = (arr1: string[], arr2: string[]) => {
 
 const sendFocusGeneTrackSettings = (
   trackSettings: FocusGeneTrackSettings,
-  genomeBrowserMethods: ReturnType<typeof useGenomeBrowser>
+  toggleTrackSetting: ReturnType<typeof useGenomeBrowser>['toggleTrackSetting']
 ) => {
   const trackId = TrackId.FOCUS_GENE;
-  const { toggleTrackSetting } = genomeBrowserMethods;
 
   // Notice that in contrast to genomic tracks, we aren't sending the "show five transcripts"
   // message to the genome browser here. We haven't found a good way of reconciling the state

--- a/src/content/app/genome-browser/hooks/useFocusTrack.ts
+++ b/src/content/app/genome-browser/hooks/useFocusTrack.ts
@@ -15,13 +15,14 @@
  */
 
 import { useEffect, useRef, useCallback } from 'react';
-import xor from 'lodash/xor';
 
 import { useAppSelector, useAppDispatch } from 'src/store';
 import useGenomeBrowserIds from './useGenomeBrowserIds';
 import useGenomeBrowser from 'src/content/app/genome-browser/hooks/useGenomeBrowser';
 import { useGetTrackPanelGeneQuery } from 'src/content/app/genome-browser/state/api/genomeBrowserApiSlice';
 import usePrevious from 'src/shared/hooks/usePrevious';
+
+import { TrackId } from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
 
 import { defaultSort } from 'src/content/app/entity-viewer/shared/helpers/transcripts-sorter';
 
@@ -32,6 +33,7 @@ import { updateFocusGeneTranscriptsVisibility } from 'src/content/app/genome-bro
 import {
   type FocusGeneTrack,
   type FocusGeneTrackSettings,
+  type FocusTranscriptTrackSettings,
   type FocusVariantTrackSettings
 } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSlice';
 
@@ -46,6 +48,7 @@ import type {
 import type { TranscriptsLozengePayload } from 'src/content/app/genome-browser/services/genome-browser-service/types/hotspot';
 import type {
   FocusGene,
+  FocusTranscript,
   FocusVariant
 } from 'src/shared/types/focus-object/focusObjectTypes';
 
@@ -69,6 +72,12 @@ const useFocusTrack = () => {
     genomeBrowserMethods,
     focusGene:
       parsedFocusObjectId?.type === 'gene' ? (focusObject as FocusGene) : null,
+    focusObjectId
+  });
+
+  useFocusTranscript({
+    genomeBrowserMethods,
+    focusTranscript: focusObject?.type === 'transcript' ? focusObject : null,
     focusObjectId
   });
 
@@ -128,6 +137,33 @@ const useFocusGene = (params: UseFocusGeneParams) => {
 
   const dispatch = useAppDispatch();
 
+  const onLozengeClick = useCallback(() => {
+    const allTranscriptIds = allSortedFocusGeneTranscriptsRef.current;
+    let transcriptIds: string[];
+    if (visibleTranscriptIdsRef.current?.length === allTranscriptIds.length) {
+      // all transcripts shown; should collapse transcripts to one or several
+      transcriptIds = showSeveralTranscriptsRef.current
+        ? allTranscriptIds.slice(0, 5)
+        : allTranscriptIds.slice(0, 1);
+    } else {
+      transcriptIds = allTranscriptIds;
+    }
+
+    updateFocusGeneTranscripts(transcriptIds);
+  }, [updateFocusGeneTranscripts]);
+
+  const setVisibleTranscriptIds = useCallback(
+    (transcriptIds: string[]) => {
+      dispatch(
+        updateFocusGeneTranscriptsVisibility({
+          focusGeneId: focusObjectIdRef.current,
+          visibleTranscriptIds: transcriptIds
+        })
+      );
+    },
+    [dispatch]
+  );
+
   // update all the refs
   useEffect(() => {
     focusObjectIdRef.current = focusObjectId;
@@ -144,7 +180,9 @@ const useFocusGene = (params: UseFocusGeneParams) => {
     focusObjectId,
     geneStableId,
     fetchedFocusGeneData,
-    stringifiedVisibleTranscriptIds
+    stringifiedVisibleTranscriptIds,
+    focusGeneTrackSettings?.settings.several,
+    visibleTranscriptIds
   ]);
 
   useEffect(() => {
@@ -164,7 +202,10 @@ const useFocusGene = (params: UseFocusGeneParams) => {
         const { gene_id, transcript_ids } = focusGeneTrackInfo;
         if (
           gene_id === geneIdRef.current &&
-          xor(transcript_ids, visibleTranscriptIdsRef.current).length // symmetric difference between two arrays; TODO: replace with Set.prototype.symmetricDifference when it is included in JS standard
+          haveDifferentMembers(
+            transcript_ids,
+            visibleTranscriptIdsRef.current ?? []
+          )
         ) {
           setVisibleTranscriptIds(transcript_ids);
         }
@@ -191,7 +232,7 @@ const useFocusGene = (params: UseFocusGeneParams) => {
     return () => {
       subscriptions.forEach((subscription) => subscription.unsubscribe());
     };
-  }, [genomeBrowserService]);
+  }, [genomeBrowserService, onLozengeClick, setVisibleTranscriptIds]);
 
   /**
    * In the below hook, we are making a choice about how many transcript ids to send to the genome browser.
@@ -230,7 +271,10 @@ const useFocusGene = (params: UseFocusGeneParams) => {
     geneStableId,
     stringifiedVisibleTranscriptIds,
     focusGeneTrackSettings?.settings.several,
-    allSortedFocusGeneTranscriptsRef.current.length
+    fetchedFocusGeneData,
+    previousSeveralTranscriptsSetting,
+    updateFocusGeneTranscripts,
+    visibleTranscriptIds
   ]);
 
   // apply track settings other than several transcripts
@@ -243,42 +287,25 @@ const useFocusGene = (params: UseFocusGeneParams) => {
       focusGeneTrackSettings.settings,
       genomeBrowserMethods
     );
-  }, [genomeBrowser, focusGeneTrackSettings]);
-
-  const setVisibleTranscriptIds = (transcriptIds: string[]) => {
-    dispatch(
-      updateFocusGeneTranscriptsVisibility({
-        focusGeneId: focusObjectIdRef.current,
-        visibleTranscriptIds: transcriptIds
-      })
-    );
-  };
-
-  const onLozengeClick = useCallback(() => {
-    const allTranscriptIds = allSortedFocusGeneTranscriptsRef.current;
-    let transcriptIds: string[];
-    if (visibleTranscriptIdsRef.current?.length === allTranscriptIds.length) {
-      // all transcripts shown; should collapse transcripts to one or several
-      transcriptIds = showSeveralTranscriptsRef.current
-        ? allTranscriptIds.slice(0, 5)
-        : allTranscriptIds.slice(0, 1);
-    } else {
-      transcriptIds = allTranscriptIds;
-    }
-
-    updateFocusGeneTranscripts(transcriptIds);
   }, [
-    stringifiedVisibleTranscriptIds,
-    updateFocusGeneTranscripts,
-    focusGeneTrackSettings
+    genomeBrowser,
+    focusGeneTrackSettings,
+    geneStableId,
+    genomeBrowserMethods
   ]);
+};
+
+const haveDifferentMembers = (arr1: string[], arr2: string[]) => {
+  const set1 = new Set(arr1);
+  const set2 = new Set(arr2);
+  return set1.symmetricDifference(set2).size > 0;
 };
 
 const sendFocusGeneTrackSettings = (
   trackSettings: FocusGeneTrackSettings,
   genomeBrowserMethods: ReturnType<typeof useGenomeBrowser>
 ) => {
-  const trackId = 'focus';
+  const trackId = TrackId.FOCUS_GENE;
   const { toggleTrackSetting } = genomeBrowserMethods;
 
   // Notice that in contrast to genomic tracks, we aren't sending the "show five transcripts"
@@ -296,6 +323,39 @@ const sendFocusGeneTrackSettings = (
     });
 };
 
+type UseFocusTranscriptParams = {
+  focusTranscript: FocusTranscript | null;
+  focusObjectId: string;
+  genomeBrowserMethods: ReturnType<typeof useGenomeBrowser>;
+};
+
+const useFocusTranscript = ({
+  focusTranscript,
+  genomeBrowserMethods
+}: UseFocusTranscriptParams) => {
+  const { toggleTrackSetting } = genomeBrowserMethods;
+  const focusTranscriptTrackSettings = useAppSelector(getAllTrackSettings)
+    ?.settingsForIndividualTracks[TrackId.FOCUS_TRANSCRIPT]?.settings as
+    | FocusTranscriptTrackSettings
+    | undefined;
+
+  useEffect(() => {
+    if (!focusTranscriptTrackSettings) {
+      return;
+    }
+
+    for (const [settingName, settingValue] of Object.entries(
+      focusTranscriptTrackSettings
+    )) {
+      toggleTrackSetting({
+        trackId: TrackId.FOCUS_TRANSCRIPT,
+        setting: settingName,
+        isEnabled: settingValue
+      });
+    }
+  }, [focusTranscript, focusTranscriptTrackSettings, toggleTrackSetting]);
+};
+
 type UseFocusVariantParams = {
   focusVariant: FocusVariant | null;
   focusObjectId: string;
@@ -307,7 +367,7 @@ const useFocusVariant = (params: UseFocusVariantParams) => {
   const { setFocusObject, toggleTrackSetting, genomeBrowser } =
     genomeBrowserMethods;
   const focusVariantTrackSettings = useAppSelector(getAllTrackSettings)
-    ?.settingsForIndividualTracks['focus-variant']?.settings as
+    ?.settingsForIndividualTracks[TrackId.FOCUS_VARIANT]?.settings as
     | FocusVariantTrackSettings
     | undefined;
 
@@ -317,7 +377,7 @@ const useFocusVariant = (params: UseFocusVariantParams) => {
     }
 
     setFocusObject(focusVariant.object_id);
-  }, [genomeBrowser, focusVariant?.object_id]);
+  }, [genomeBrowser, focusVariant?.object_id, focusVariant, setFocusObject]);
 
   useEffect(() => {
     if (!focusVariant || !focusVariantTrackSettings) {
@@ -328,12 +388,12 @@ const useFocusVariant = (params: UseFocusVariantParams) => {
       focusVariantTrackSettings
     )) {
       toggleTrackSetting({
-        trackId: 'focus-variant',
+        trackId: TrackId.FOCUS_VARIANT,
         setting: settingName,
         isEnabled: settingValue
       });
     }
-  }, [focusVariant, focusVariantTrackSettings]);
+  }, [focusVariant, focusVariantTrackSettings, toggleTrackSetting]);
 };
 
 const getFocusGeneTrackInfo = (trackSummary: TrackSummary[]) => {

--- a/src/content/app/genome-browser/hooks/useFocusTrack.ts
+++ b/src/content/app/genome-browser/hooks/useFocusTrack.ts
@@ -306,7 +306,7 @@ const sendFocusGeneTrackSettings = (
   trackSettings: FocusGeneTrackSettings,
   toggleTrackSetting: ReturnType<typeof useGenomeBrowser>['toggleTrackSetting']
 ) => {
-  const trackId = TrackId.FOCUS_GENE;
+  const trackId = 'focus'; // this is the id of this track in the genome browser
 
   // Notice that in contrast to genomic tracks, we aren't sending the "show five transcripts"
   // message to the genome browser here. We haven't found a good way of reconciling the state

--- a/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useContext, useRef, useEffect } from 'react';
+import { useContext, useRef, useEffect, useCallback, useMemo } from 'react';
 
 import config from 'config';
 import { useAppSelector } from 'src/store';
@@ -66,119 +66,134 @@ const useGenomeBrowser = () => {
     genomeBrowserServiceRef.current = genomeBrowserService;
   }, [genomeBrowserService]);
 
-  const activateGenomeBrowser = async (params: { container: HTMLElement }) => {
-    const genomeBrowserService =
-      await GenomeBrowserLoader.activateGenomeBrowser({
-        backend_url: config.genomeBrowserBackendBaseUrl,
-        target_element: params.container
-      });
-    const genomeBrowser = genomeBrowserService.getGenomeBrowser();
+  const activateGenomeBrowser = useCallback(
+    async (params: { container: HTMLElement }) => {
+      const genomeBrowserService =
+        await GenomeBrowserLoader.activateGenomeBrowser({
+          backend_url: config.genomeBrowserBackendBaseUrl,
+          target_element: params.container
+        });
+      const genomeBrowser = genomeBrowserService.getGenomeBrowser();
 
-    setGenomeBrowser(() => genomeBrowser);
-    setGenomeBrowserService(() => genomeBrowserService); // using the callback api of the state setter to avoid it calling genomeBrowserService thinking that it is a function
-  };
+      setGenomeBrowser(() => genomeBrowser);
+      setGenomeBrowserService(() => genomeBrowserService); // using the callback api of the state setter to avoid it calling genomeBrowserService thinking that it is a function
+    },
+    [setGenomeBrowser, setGenomeBrowserService]
+  );
 
   // NOTE: the cleanup code in the method below refers only to ensembl-client's code that deals with the genome browser.
   // There is no cleanup method on the genome browser itself.
   // We trust it to terminate correctly when the DOM element that it is given control over is unmounted.
-  const clearGenomeBrowser = () => {
+  const clearGenomeBrowser = useCallback(() => {
     genomeBrowserServiceRef.current?.reset();
     setGenomeBrowser(null);
     setGenomeBrowserService(null);
-  };
+  }, [setGenomeBrowser, setGenomeBrowserService]);
 
   // the focusObjectId is in the format "genome_id:object_type:object_id"
-  const setFocusObject = (focusObjectId: string, bringIntoView?: boolean) => {
-    if (!activeGenomeId || !genomeBrowser) {
-      return;
-    }
+  const setFocusObject = useCallback(
+    (focusObjectId: string, bringIntoView?: boolean) => {
+      if (!activeGenomeId || !genomeBrowser) {
+        return;
+      }
 
-    const { genomeId, objectId, type } = parseFocusObjectId(focusObjectId);
+      const { genomeId, objectId, type } = parseFocusObjectId(focusObjectId);
 
-    genomeBrowserCommands.setFocus({
-      genomeBrowser,
-      focusId: objectId,
-      focusType: type,
-      genomeId,
-      bringIntoView
-    });
-  };
+      genomeBrowserCommands.setFocus({
+        genomeBrowser,
+        focusId: objectId,
+        focusType: type,
+        genomeId,
+        bringIntoView
+      });
+    },
+    [activeGenomeId, genomeBrowser]
+  );
 
-  const changeFocusObject = (focusObjectId: string) => {
-    setFocusObject(focusObjectId, true);
-  };
+  const changeFocusObject = useCallback(
+    (focusObjectId: string) => {
+      setFocusObject(focusObjectId, true);
+    },
+    [setFocusObject]
+  );
 
-  const changeBrowserLocation = (locationData: {
-    genomeId: string;
-    chrLocation: ChrLocation;
-    focus?: {
-      id: string;
-      type: string;
-    };
-  }) => {
-    if (!genomeBrowser) {
-      return;
-    }
+  const changeBrowserLocation = useCallback(
+    (locationData: {
+      genomeId: string;
+      chrLocation: ChrLocation;
+      focus?: {
+        id: string;
+        type: string;
+      };
+    }) => {
+      if (!genomeBrowser) {
+        return;
+      }
 
-    const { genomeId, chrLocation, focus } = locationData;
+      const { genomeId, chrLocation, focus } = locationData;
 
-    const [regionName, start, end] = chrLocation;
+      const [regionName, start, end] = chrLocation;
 
-    genomeBrowserCommands.setBrowserLocation({
-      genomeBrowser,
-      genomeId,
-      regionName,
-      start,
-      end,
-      focus
-    });
-  };
+      genomeBrowserCommands.setBrowserLocation({
+        genomeBrowser,
+        genomeId,
+        regionName,
+        start,
+        end,
+        focus
+      });
+    },
+    [genomeBrowser]
+  );
 
-  const toggleTrack = (params: { trackId: string; isEnabled: boolean }) => {
-    if (!genomeBrowser) {
-      return;
-    }
-    const { trackId, isEnabled } = params;
-    const trackPath = trackIdToPathMap[trackId] ?? ['track', trackId];
+  const toggleTrack = useCallback(
+    (params: { trackId: string; isEnabled: boolean }) => {
+      if (!genomeBrowser) {
+        return;
+      }
+      const { trackId, isEnabled } = params;
+      const trackPath = trackIdToPathMap[trackId] ?? ['track', trackId];
 
-    genomeBrowserCommands.toggleTrack({
-      genomeBrowser,
-      trackPath,
-      isEnabled
-    });
-  };
+      genomeBrowserCommands.toggleTrack({
+        genomeBrowser,
+        trackPath,
+        isEnabled
+      });
+    },
+    [genomeBrowser, trackIdToPathMap]
+  );
 
   // At the moment, most track settings are just a boolean flag. Will this continue to be the case? Who knows.
-  const toggleTrackSetting = (params: {
-    trackId: string;
-    setting: string;
-    isEnabled: boolean;
-  }) => {
-    if (!genomeBrowser) {
-      return;
-    }
-    const { trackId, setting, isEnabled } = params;
-    const trackPath = trackIdToPathMap[trackId] ?? ['track', trackId];
+  const toggleTrackSetting = useCallback(
+    (params: { trackId: string; setting: string; isEnabled: boolean }) => {
+      if (!genomeBrowser) {
+        return;
+      }
+      const { trackId, setting, isEnabled } = params;
+      const trackPath = trackIdToPathMap[trackId] ?? ['track', trackId];
 
-    genomeBrowserCommands.toggleTrackSetting({
-      genomeBrowser,
-      trackPath,
-      setting,
-      isEnabled
-    });
-  };
+      genomeBrowserCommands.toggleTrackSetting({
+        genomeBrowser,
+        trackPath,
+        setting,
+        isEnabled
+      });
+    },
+    [genomeBrowser, trackIdToPathMap]
+  );
 
-  const updateFocusGeneTranscripts = (
-    visibleTranscriptIds: string[] | null
-  ) => {
-    if (!genomeBrowser) {
-      return;
-    }
-    genomeBrowserCommands.setVisibleTranscripts({
-      genomeBrowser,
-      transcriptIds: visibleTranscriptIds
-    });
-  };
+  const updateFocusGeneTranscripts = useCallback(
+    (visibleTranscriptIds: string[] | null) => {
+      if (!genomeBrowser) {
+        return;
+      }
+      genomeBrowserCommands.setVisibleTranscripts({
+        genomeBrowser,
+        transcriptIds: visibleTranscriptIds
+      });
+    },
+    [genomeBrowser]
+  );
 
   return {
     activateGenomeBrowser,
@@ -214,11 +229,6 @@ const useGenomeBrowser = () => {
 const useTrackIdToTrackPathMap = () => {
   const activeGenomeId = useAppSelector(getBrowserActiveGenomeId);
 
-  const trackCategoriesRef = useRef<{
-    previous: GenomeTrackCategory[];
-    current: GenomeTrackCategory[];
-  }>({ previous: [], current: [] });
-
   const { currentData: trackCategories = [] } = useGenomeTracksQuery(
     activeGenomeId ?? '',
     {
@@ -226,20 +236,9 @@ const useTrackIdToTrackPathMap = () => {
     }
   );
 
-  useEffect(() => {
-    if (
-      trackCategories.length &&
-      trackCategories !== trackCategoriesRef.current.previous
-    ) {
-      trackCategoriesRef.current.previous = trackCategoriesRef.current.current;
-      trackCategoriesRef.current.current = trackCategories;
-    }
+  const trackIdToPathMap = useMemo(() => {
+    return getTrackIdToTrackPathMap(trackCategories);
   }, [trackCategories]);
-
-  const trackIdToPathMap = getTrackIdToTrackPathMap([
-    ...trackCategoriesRef.current.previous,
-    ...trackCategoriesRef.current.current
-  ]);
 
   return trackIdToPathMap;
 };

--- a/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
@@ -39,6 +39,7 @@ import {
 } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSlice';
 import {
   buildDefaultFocusGeneTrack,
+  buildDefaultFocusTranscriptTrack,
   buildDefaultFocusVariantTrack,
   buildDefaultGeneTrack,
   buildDefaultVariantTrack,
@@ -190,11 +191,11 @@ const prepareTrackSettings = ({
 }) => {
   const defaultTrackSettings: TrackSettingsPerTrack = {};
 
-  if (
-    focusObject?.type === TrackType.GENE ||
-    focusObject?.type === 'transcript'
-  ) {
+  if (focusObject?.type === TrackType.GENE) {
     defaultTrackSettings[TrackId.FOCUS_GENE] = buildDefaultFocusGeneTrack();
+  } else if (focusObject?.type === 'transcript') {
+    defaultTrackSettings[TrackId.FOCUS_TRANSCRIPT] =
+      buildDefaultFocusTranscriptTrack();
   } else if (focusObject?.type === TrackType.VARIANT) {
     defaultTrackSettings[TrackId.FOCUS_VARIANT] =
       buildDefaultFocusVariantTrack();

--- a/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { useAppDispatch, useAppSelector } from 'src/store';
 import { useGenomeTracksQuery } from 'src/content/app/genome-browser/state/api/genomeBrowserApiSlice';
@@ -72,6 +72,11 @@ const useGenomeBrowserTracks = () => {
   const { toggleTrack, genomeBrowser } = useGenomeBrowser();
 
   const dispatch = useAppDispatch();
+  const toggleTrackRef = useRef(toggleTrack);
+
+  useEffect(() => {
+    toggleTrackRef.current = toggleTrack;
+  }, [toggleTrack]);
 
   // This effect is for initialising track setting if they are missing
   useEffect(() => {
@@ -92,7 +97,13 @@ const useGenomeBrowserTracks = () => {
       trackCategories,
       focusObject
     });
-  }, [trackCategories, focusObject, genomeId]);
+  }, [
+    trackCategories,
+    focusObject,
+    genomeId,
+    trackSettingsForGenome,
+    dispatch
+  ]);
 
   // make sure to tell genome browser to hide tracks that a given genome doesn't have
   useEffect(() => {
@@ -115,9 +126,9 @@ const useGenomeBrowserTracks = () => {
     );
 
     trackIdsToHide.forEach((trackId) => {
-      toggleTrack({ trackId, isEnabled: false });
+      toggleTrackRef.current({ trackId, isEnabled: false });
     });
-  }, [trackSettingsForGenome, visibleTrackIds]);
+  }, [trackSettingsForGenome, visibleTrackIds, trackCategories]);
 
   // mark the tracks that reflect the content of the current tab inside the track panel
   useEffect(() => {
@@ -179,7 +190,10 @@ const prepareTrackSettings = ({
 }) => {
   const defaultTrackSettings: TrackSettingsPerTrack = {};
 
-  if (focusObject?.type === TrackType.GENE) {
+  if (
+    focusObject?.type === TrackType.GENE ||
+    focusObject?.type === 'transcript'
+  ) {
     defaultTrackSettings[TrackId.FOCUS_GENE] = buildDefaultFocusGeneTrack();
   } else if (focusObject?.type === TrackType.VARIANT) {
     defaultTrackSettings[TrackId.FOCUS_VARIANT] =

--- a/src/content/app/genome-browser/hooks/useGenomicTracks.ts
+++ b/src/content/app/genome-browser/hooks/useGenomicTracks.ts
@@ -76,7 +76,8 @@ const useGenomicTracks = () => {
     activeGenomeId,
     genomeTrackCategories,
     trackSettingsForGenome,
-    genomeBrowser
+    genomeBrowser,
+    genomeBrowserMethods.toggleTrack
   ]);
 
   useEffect(() => {
@@ -85,7 +86,7 @@ const useGenomicTracks = () => {
     }
 
     sendTrackSettings(trackSettingsForGenome, genomeBrowserMethods);
-  }, [trackSettingsForGenome, genomeBrowser]);
+  }, [trackSettingsForGenome, genomeBrowser, genomeBrowserMethods]);
 };
 
 type TrackIdsList = {
@@ -123,7 +124,7 @@ const sendTrackSettings = (
   const { toggleTrackSetting } = genomeBrowserMethods;
   const genomicTrackSettings = pickBy(
     trackSettings,
-    (_, key) => key !== 'focus'
+    (_, key) => !key.startsWith('focus')
   ); // exclude the focus track
   Object.entries(genomicTrackSettings).forEach(([trackId, { settings }]) => {
     Object.entries(settings).forEach((keyValuePair) => {

--- a/src/content/app/genome-browser/services/genome-browser-service/genomeBrowserCommands.test.ts
+++ b/src/content/app/genome-browser/services/genome-browser-service/genomeBrowserCommands.test.ts
@@ -1,0 +1,86 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { setFocus } from './genomeBrowserCommands';
+
+const createMockGenomeBrowser = () => ({
+  jump: vi.fn(),
+  wait: vi.fn(),
+  switch: vi.fn()
+});
+
+describe('genomeBrowserCommands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('setFocus', () => {
+    it('supports transcript focus with bringIntoView', () => {
+      const genomeBrowser = createMockGenomeBrowser();
+
+      setFocus({
+        genomeBrowser: genomeBrowser as any,
+        genomeId: 'homo_sapiens_GCA_000001405_28',
+        focusType: 'transcript',
+        focusId: 'ENST00000380737',
+        bringIntoView: true
+      });
+
+      expect(genomeBrowser.jump).toHaveBeenCalledWith(
+        'focus:transcript:homo_sapiens_GCA_000001405_28:ENST00000380737'
+      );
+      expect(genomeBrowser.wait).toHaveBeenCalled();
+      expect(genomeBrowser.switch).toHaveBeenCalledWith(
+        ['track', 'focus'],
+        true
+      );
+      expect(genomeBrowser.switch).toHaveBeenCalledWith(
+        ['track', 'focus', 'label'],
+        true
+      );
+      expect(genomeBrowser.switch).toHaveBeenCalledWith(
+        ['track', 'focus', 'item', 'transcript'],
+        {
+          genome_id: 'homo_sapiens_GCA_000001405_28',
+          item_id: 'ENST00000380737'
+        }
+      );
+    });
+
+    it('supports transcript focus without bringIntoView jump', () => {
+      const genomeBrowser = createMockGenomeBrowser();
+
+      setFocus({
+        genomeBrowser: genomeBrowser as any,
+        genomeId: 'homo_sapiens_GCA_000001405_28',
+        focusType: 'transcript',
+        focusId: 'ENST00000380737'
+      });
+
+      expect(genomeBrowser.jump).not.toHaveBeenCalled();
+      expect(genomeBrowser.wait).not.toHaveBeenCalled();
+      expect(genomeBrowser.switch).toHaveBeenCalledWith(
+        ['track', 'focus', 'item', 'transcript'],
+        {
+          genome_id: 'homo_sapiens_GCA_000001405_28',
+          item_id: 'ENST00000380737'
+        }
+      );
+    });
+  });
+});

--- a/src/content/app/genome-browser/services/genome-browser-service/genomeBrowserCommands.ts
+++ b/src/content/app/genome-browser/services/genome-browser-service/genomeBrowserCommands.ts
@@ -27,6 +27,8 @@ export const setFocus = (payload: {
 
   if (focusType === 'gene') {
     setFocusGene(payload);
+  } else if (focusType === 'transcript') {
+    setFocusTranscript(payload);
   } else if (focusType === 'variant') {
     setFocusVariant(payload);
   } else if (focusType === 'location') {
@@ -125,6 +127,22 @@ const setFocusGene: typeof setFocus = (payload) => {
   genomeBrowser.switch(['track', 'focus'], true);
   genomeBrowser.switch(['track', 'focus', 'label'], true);
   genomeBrowser.switch(['track', 'focus', 'item', 'gene'], {
+    genome_id: genomeId,
+    item_id: focusId
+  });
+};
+
+const setFocusTranscript: typeof setFocus = (payload) => {
+  const { genomeBrowser, genomeId, focusId, bringIntoView } = payload;
+
+  if (bringIntoView) {
+    genomeBrowser.jump(`focus:transcript:${genomeId}:${focusId}`);
+    genomeBrowser.wait();
+  }
+
+  genomeBrowser.switch(['track', 'focus'], true);
+  genomeBrowser.switch(['track', 'focus', 'label'], true);
+  genomeBrowser.switch(['track', 'focus', 'item', 'transcript'], {
     genome_id: genomeId,
     item_id: focusId
   });

--- a/src/content/app/genome-browser/services/genome-browser-service/types/trackSummary.ts
+++ b/src/content/app/genome-browser/services/genome-browser-service/types/trackSummary.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { TrackId } from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
+
 // Fields that all track summaries should have
 export type CommonTrackSummary = {
   'switch-id': string; // This is the track id. Genome browser calls them switches
@@ -21,10 +23,17 @@ export type CommonTrackSummary = {
   height: number;
 };
 
-export type FocusGeneTrackSummary = Omit<CommonTrackSummary, 'switch-id'> & {
+export type FocusTrackSummary = Omit<CommonTrackSummary, 'switch-id'> & {
   'switch-id': 'focus';
+  type: (typeof TrackId)[keyof typeof TrackId];
+};
+
+export type FocusGeneTrackSummary = FocusTrackSummary & {
   id: string; // Focus gene id
   'transcripts-shown': string[]; // an array of ids of visible transcripts
 };
 
-export type TrackSummary = CommonTrackSummary | FocusGeneTrackSummary;
+export type TrackSummary =
+  | CommonTrackSummary
+  | FocusTrackSummary
+  | FocusGeneTrackSummary;

--- a/src/content/app/genome-browser/services/genome-browser-service/types/zmenu.ts
+++ b/src/content/app/genome-browser/services/genome-browser-service/types/zmenu.ts
@@ -124,6 +124,7 @@ export type ZmenuContent =
 
 export enum ZmenuPayloadVarietyType {
   GENE_AND_ONE_TRANSCRIPT = 'gene-and-one-transcript',
+  TRANSCRIPT = 'transcript',
   VARIANT = 'variant',
   REGULATION = 'regulation'
 }

--- a/src/content/app/genome-browser/state/api/genomeBrowserApiSlice.ts
+++ b/src/content/app/genome-browser/state/api/genomeBrowserApiSlice.ts
@@ -160,7 +160,7 @@ const genomeBrowserRestApiSlice = restApiSlice.injectEndpoints({
 
 export const {
   getTrackPanelGene,
-  gbTranscriptSummary,
+  gbTranscriptSummary: getGBTranscriptSummary,
   gbRegion: getGBRegion
 } = genomeBrowserApiSlice.endpoints;
 export const {

--- a/src/content/app/genome-browser/state/api/genomeBrowserApiSlice.ts
+++ b/src/content/app/genome-browser/state/api/genomeBrowserApiSlice.ts
@@ -158,8 +158,11 @@ const genomeBrowserRestApiSlice = restApiSlice.injectEndpoints({
   })
 });
 
-export const { getTrackPanelGene, gbRegion: getGBRegion } =
-  genomeBrowserApiSlice.endpoints;
+export const {
+  getTrackPanelGene,
+  gbTranscriptSummary,
+  gbRegion: getGBRegion
+} = genomeBrowserApiSlice.endpoints;
 export const {
   useGetTrackPanelGeneQuery,
   useGbGeneSummaryQuery,

--- a/src/content/app/genome-browser/state/api/queries/geneSummaryQuery.ts
+++ b/src/content/app/genome-browser/state/api/queries/geneSummaryQuery.ts
@@ -45,6 +45,7 @@ export const geneSummaryQuery = gql`
       }
       slice {
         region {
+          name
           sequence {
             checksum
           }
@@ -100,6 +101,7 @@ type GeneSummary = Pick<
   metadata: GeneMetadata;
 } & Pick3<FullGene, 'slice', 'strand', 'code'> &
   Pick3<FullGene, 'slice', 'location', 'length' | 'start' | 'end'> &
+  Pick3<FullGene, 'slice', 'region', 'name'> &
   Pick4<FullGene, 'slice', 'region', 'sequence', 'checksum'> & {
     transcripts: Transcript[];
   };

--- a/src/content/app/genome-browser/state/api/queries/transcriptSummaryQuery.ts
+++ b/src/content/app/genome-browser/state/api/queries/transcriptSummaryQuery.ts
@@ -122,6 +122,11 @@ export const transcriptSummaryQuery = gql`
         stable_id
         unversioned_stable_id
         symbol
+        metadata {
+          biotype {
+            label
+          }
+        }
       }
     }
   }
@@ -130,7 +135,8 @@ export const transcriptSummaryQuery = gql`
 type GeneInSummaryTranscript = Pick<
   FullGene,
   'name' | 'stable_id' | 'unversioned_stable_id' | 'symbol'
->;
+> &
+  Pick3<FullGene, 'metadata', 'biotype', 'label'>;
 
 type SummaryTranscriptMetadata = Pick2<
   TranscriptMetadata,

--- a/src/content/app/genome-browser/state/browser-bookmarks/browserBookmarksSlice.ts
+++ b/src/content/app/genome-browser/state/browser-bookmarks/browserBookmarksSlice.ts
@@ -81,17 +81,22 @@ export const updatePreviouslyViewedObjectsAndSave =
     }
 
     const stable_id =
-      activeFocusObject.type === 'gene'
+      activeFocusObject.type === 'gene' ||
+      activeFocusObject.type === 'transcript'
         ? activeFocusObject.versioned_stable_id || activeFocusObject.stable_id
         : null;
 
     const geneSymbol =
-      activeFocusObject.type === 'gene' && activeFocusObject.label !== stable_id
-        ? activeFocusObject.label
-        : null;
+      activeFocusObject.type === 'gene'
+        ? activeFocusObject.label !== stable_id
+          ? activeFocusObject.label
+          : null
+        : activeFocusObject.type === 'transcript'
+          ? activeFocusObject.gene_symbol
+          : null;
 
     const label =
-      activeFocusObject.type === 'gene' && geneSymbol
+      geneSymbol && stable_id
         ? [geneSymbol, stable_id as string]
         : activeFocusObject.label;
 

--- a/src/content/app/genome-browser/state/browser-bookmarks/browserBookmarksSlice.ts
+++ b/src/content/app/genome-browser/state/browser-bookmarks/browserBookmarksSlice.ts
@@ -91,9 +91,7 @@ export const updatePreviouslyViewedObjectsAndSave =
         ? activeFocusObject.label !== stable_id
           ? activeFocusObject.label
           : null
-        : activeFocusObject.type === 'transcript'
-          ? activeFocusObject.gene_symbol
-          : null;
+        : null;
 
     const label =
       geneSymbol && stable_id

--- a/src/content/app/genome-browser/state/displayed-tracks/displayedTracksSelectors.ts
+++ b/src/content/app/genome-browser/state/displayed-tracks/displayedTracksSelectors.ts
@@ -21,7 +21,12 @@ import type { RootState } from 'src/store';
 export const getDisplayedTracks = (state: RootState) =>
   state.browser.displayedTracks;
 
-export const getDisplayedTrackIds = createSelector(
+export const getOrderedDisplayedTracks = createSelector(
   getDisplayedTracks,
+  (tracks) => tracks.toSorted((a, b) => a.id.localeCompare(b.id))
+);
+
+export const getDisplayedTrackIds = createSelector(
+  getOrderedDisplayedTracks,
   (tracks) => tracks.map((track) => track.id)
 );

--- a/src/content/app/genome-browser/state/focus-object/focusObjectSlice.ts
+++ b/src/content/app/genome-browser/state/focus-object/focusObjectSlice.ts
@@ -19,7 +19,10 @@ import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import isGeneFocusObject from './isGeneFocusObject';
 import * as focusObjectStorageService from 'src/content/app/genome-browser/services/focus-objects/focusObjectStorageService';
 
-import { getTrackPanelGene } from 'src/content/app/genome-browser/state/api/genomeBrowserApiSlice';
+import {
+  gbTranscriptSummary,
+  getTrackPanelGene
+} from 'src/content/app/genome-browser/state/api/genomeBrowserApiSlice';
 
 import { shouldFetch } from 'src/shared/helpers/fetchHelper';
 import {
@@ -38,9 +41,11 @@ import type {
   FocusGene,
   FocusObjectIdConstituents,
   FocusLocation,
+  FocusTranscript,
   FocusVariant
 } from 'src/shared/types/focus-object/focusObjectTypes';
 import type { RootState, ThunkApi } from 'src/store';
+import type { TranscriptSummaryQueryResult } from 'src/content/app/genome-browser/state/api/queries/transcriptSummaryQuery';
 
 export type FocusObjectsState = Readonly<{
   [focusObjectId: string]: {
@@ -53,6 +58,12 @@ type BuildGeneObjectParams = {
   genomeId: string;
   objectId: string;
   gene: TrackPanelGene;
+};
+
+type BuildTranscriptObjectParams = {
+  genomeId: string;
+  objectId: string;
+  transcript: TranscriptSummaryQueryResult['transcript'];
 };
 
 // FIXME: many fields here are unnecessary for an focusObject
@@ -82,6 +93,37 @@ export const buildFocusGeneObject = (
     bio_type: params.gene.metadata.biotype.label,
     strand,
     visibleTranscriptIds: null
+  };
+};
+
+const buildFocusTranscriptObject = (
+  params: BuildTranscriptObjectParams
+): FocusTranscript => {
+  const {
+    slice: {
+      location: { start, end },
+      region: { name: chromosome },
+      strand: { code: strand }
+    }
+  } = params.transcript;
+
+  return {
+    type: 'transcript',
+    object_id: params.objectId,
+    genome_id: params.genomeId,
+    label: params.transcript.unversioned_stable_id,
+    location: {
+      chromosome,
+      start,
+      end
+    },
+    stable_id: params.transcript.unversioned_stable_id,
+    versioned_stable_id: params.transcript.stable_id,
+    bio_type: params.transcript.metadata.biotype.label,
+    strand,
+    gene_symbol:
+      params.transcript.gene.symbol ||
+      params.transcript.gene.unversioned_stable_id
   };
 };
 
@@ -182,6 +224,15 @@ export const fetchFocusObject = createAsyncThunk(
           },
           thunkAPI
         );
+      } else if (payload.type === 'transcript') {
+        return await fetchFocusTranscript(
+          {
+            genomeId,
+            transcriptId: objectId,
+            objectId: focusObjectId
+          },
+          thunkAPI
+        );
       } else if (payload.type === 'variant') {
         return await fetchFocusVariant({
           genomeId,
@@ -231,6 +282,42 @@ const fetchFocusGene = async (
   });
 };
 
+const fetchFocusTranscript = async (
+  payload: {
+    genomeId: string;
+    transcriptId: string;
+    objectId: string;
+  },
+  thunkApi: ThunkApi
+) => {
+  const { genomeId, transcriptId, objectId } = payload;
+  const { dispatch } = thunkApi;
+  const dispatchedPromise = dispatch(
+    gbTranscriptSummary.initiate({
+      genomeId,
+      transcriptId
+    })
+  );
+
+  const result = await dispatchedPromise;
+  dispatchedPromise.unsubscribe();
+
+  if (!result.data?.transcript) {
+    throw new Error(`Failed to load transcript ${transcriptId}`);
+  }
+
+  const transcriptFocusObject = buildFocusTranscriptObject({
+    objectId,
+    genomeId,
+    transcript: result.data.transcript
+  });
+
+  return buildLoadedObject({
+    id: objectId,
+    data: transcriptFocusObject
+  });
+};
+
 const fetchFocusVariant = async (payload: {
   genomeId: string;
   variantId: string;
@@ -249,7 +336,7 @@ export const updateFocusGeneTranscriptsVisibility = createAsyncThunk(
     payload: { focusGeneId: string; visibleTranscriptIds: string[] },
     thunkAPI
   ) => {
-    // focusGeneId is in the focus object id format, i.e. "<genome_id>:gene:<stable_id>"
+    // focusGeneId is in the focus object id format, i.e. "<genome_id>:gene:<stable_id>"
     const { focusGeneId, visibleTranscriptIds } = payload;
     const state = thunkAPI.getState() as RootState;
     const focusGene = state.browser.focusObjects[focusGeneId]?.data;

--- a/src/content/app/genome-browser/state/focus-object/focusObjectSlice.ts
+++ b/src/content/app/genome-browser/state/focus-object/focusObjectSlice.ts
@@ -15,12 +15,13 @@
  */
 
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import type { Pick3 } from 'ts-multipick';
 
 import isGeneFocusObject from './isGeneFocusObject';
 import * as focusObjectStorageService from 'src/content/app/genome-browser/services/focus-objects/focusObjectStorageService';
 
 import {
-  gbTranscriptSummary,
+  getGBTranscriptSummary,
   getTrackPanelGene
 } from 'src/content/app/genome-browser/state/api/genomeBrowserApiSlice';
 
@@ -35,6 +36,7 @@ import { getChrLocationFromStr } from 'src/content/app/genome-browser/helpers/br
 import { getFocusObject as getFocusObjectFromStorage } from 'src/content/app/genome-browser/services/focus-objects/focusObjectStorageService';
 
 import { LoadingState } from 'src/shared/types/loading-state';
+import type { RootState, ThunkApi } from 'src/store';
 import type { TrackPanelGene } from 'src/content/app/genome-browser/state/types/track-panel-gene';
 import type {
   FocusObject,
@@ -44,8 +46,7 @@ import type {
   FocusTranscript,
   FocusVariant
 } from 'src/shared/types/focus-object/focusObjectTypes';
-import type { RootState, ThunkApi } from 'src/store';
-import type { TranscriptSummaryQueryResult } from 'src/content/app/genome-browser/state/api/queries/transcriptSummaryQuery';
+import { FullTranscript } from 'src/shared/types/core-api/transcript';
 
 export type FocusObjectsState = Readonly<{
   [focusObjectId: string]: {
@@ -60,10 +61,19 @@ type BuildGeneObjectParams = {
   gene: TrackPanelGene;
 };
 
+type TranscriptDataForFocusObject = Pick<
+  FullTranscript,
+  'stable_id' | 'unversioned_stable_id'
+> &
+  Pick3<FullTranscript, 'slice', 'location', 'start' | 'end'> &
+  Pick3<FullTranscript, 'slice', 'region', 'name'> &
+  Pick3<FullTranscript, 'slice', 'strand', 'code'> &
+  Pick3<FullTranscript, 'metadata', 'biotype', 'label'>;
+
 type BuildTranscriptObjectParams = {
   genomeId: string;
   objectId: string;
-  transcript: TranscriptSummaryQueryResult['transcript'];
+  transcript: TranscriptDataForFocusObject;
 };
 
 // FIXME: many fields here are unnecessary for an focusObject
@@ -120,10 +130,7 @@ const buildFocusTranscriptObject = (
     stable_id: params.transcript.unversioned_stable_id,
     versioned_stable_id: params.transcript.stable_id,
     bio_type: params.transcript.metadata.biotype.label,
-    strand,
-    gene_symbol:
-      params.transcript.gene.symbol ||
-      params.transcript.gene.unversioned_stable_id
+    strand
   };
 };
 
@@ -293,7 +300,7 @@ const fetchFocusTranscript = async (
   const { genomeId, transcriptId, objectId } = payload;
   const { dispatch } = thunkApi;
   const dispatchedPromise = dispatch(
-    gbTranscriptSummary.initiate({
+    getGBTranscriptSummary.initiate({
       genomeId,
       transcriptId
     })

--- a/src/content/app/genome-browser/state/track-settings/trackSettingsConstants.ts
+++ b/src/content/app/genome-browser/state/track-settings/trackSettingsConstants.ts
@@ -27,13 +27,15 @@ import type {
   FocusVariantTrack,
   FocusGeneTrack,
   RegularTrack,
-  TrackSettings
+  TrackSettings,
+  FocusTranscriptTrack
 } from './trackSettingsSlice';
 
 export enum TrackType {
   GENE = 'gene',
   VARIANT = 'variant',
   FOCUS_GENE = 'focus-gene',
+  FOCUS_TRANSCRIPT = 'focus-transcript',
   FOCUS_VARIANT = 'focus-variant',
   REGULAR = 'regular'
 }
@@ -92,6 +94,12 @@ export const buildDefaultFocusGeneTrack = (): FocusGeneTrack => ({
   id: TrackId.FOCUS_GENE,
   trackType: TrackType.FOCUS_GENE,
   settings: getDefaultGeneTrackSettings()
+});
+
+export const buildDefaultFocusTranscriptTrack = (): FocusTranscriptTrack => ({
+  id: TrackId.FOCUS_GENE,
+  trackType: TrackType.FOCUS_TRANSCRIPT,
+  settings: getDefaultRegularTrackSettings()
 });
 
 export const buildDefaultFocusVariantTrack = (): FocusVariantTrack => {

--- a/src/content/app/genome-browser/state/track-settings/trackSettingsConstants.ts
+++ b/src/content/app/genome-browser/state/track-settings/trackSettingsConstants.ts
@@ -97,7 +97,7 @@ export const buildDefaultFocusGeneTrack = (): FocusGeneTrack => ({
 });
 
 export const buildDefaultFocusTranscriptTrack = (): FocusTranscriptTrack => ({
-  id: TrackId.FOCUS_GENE,
+  id: TrackId.FOCUS_TRANSCRIPT,
   trackType: TrackType.FOCUS_TRANSCRIPT,
   settings: getDefaultRegularTrackSettings()
 });

--- a/src/content/app/genome-browser/state/track-settings/trackSettingsSelectors.ts
+++ b/src/content/app/genome-browser/state/track-settings/trackSettingsSelectors.ts
@@ -69,7 +69,7 @@ export const getAllNonFocusTrackSettingsForGenome = createSelector(
     for (const [trackId, trackSettings] of Object.entries(
       trackSettingsForGenome.settingsForIndividualTracks
     )) {
-      if (trackId !== 'focus' && trackId !== 'focus-variant') {
+      if (!trackId.startsWith('focus')) {
         settings[trackId] = trackSettings;
       }
     }

--- a/src/content/app/genome-browser/state/track-settings/trackSettingsSlice.ts
+++ b/src/content/app/genome-browser/state/track-settings/trackSettingsSlice.ts
@@ -25,6 +25,7 @@ import * as trackSettingsStorageService from 'src/content/app/genome-browser/ser
 import { getAllTrackSettingsForGenome } from './trackSettingsSelectors';
 
 import { TrackType } from './trackSettingsConstants';
+import { TrackId } from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
 
 import type { RootState } from 'src/store';
 
@@ -47,6 +48,7 @@ export type VariantTrackSettings = {
 };
 
 export type FocusGeneTrackSettings = Omit<GeneTrackSettings, 'isVisible'>;
+export type FocusTranscriptTrackSettings = { name: boolean };
 export type FocusVariantTrackSettings = Omit<VariantTrackSettings, 'isVisible'>;
 
 export type RegularTrackSettings = {
@@ -72,6 +74,12 @@ export type FocusGeneTrack = {
   settings: FocusGeneTrackSettings;
 };
 
+export type FocusTranscriptTrack = {
+  id: string;
+  trackType: TrackType.FOCUS_TRANSCRIPT;
+  settings: RegularTrackSettings;
+};
+
 export type FocusVariantTrack = {
   id: string;
   trackType: TrackType.FOCUS_VARIANT;
@@ -88,6 +96,7 @@ export type TrackSettings =
   | GeneTrack
   | VariantTrack
   | FocusGeneTrack
+  | FocusTranscriptTrack
   | FocusVariantTrack
   | RegularTrack;
 
@@ -198,7 +207,7 @@ export const getTrackType = (trackId: string) => {
     return null;
   }
 
-  if (trackId.startsWith('gene') || trackId === 'focus') {
+  if (trackId.startsWith('gene') || trackId === TrackId.FOCUS_GENE) {
     return TrackType.GENE;
   } else if (trackId === 'focus-variant') {
     return TrackType.FOCUS_VARIANT;

--- a/src/server/middleware/proxyMiddleware.ts
+++ b/src/server/middleware/proxyMiddleware.ts
@@ -55,8 +55,8 @@ const serverConfig = getConfigForServer();
 
 const createApiProxyMiddleware = () => {
   const apiProxyMiddleware = createHttpProxyMiddleware({
-    pathFilter: '/api',
-    target: 'https://staging-2020.ensembl.org',
+    pathFilter: ['/api/**'],
+    target: 'http://transcript-focus.review.ensembl.org', // FIXME: undo before merging
     changeOrigin: true,
     secure: false
   });

--- a/src/server/middleware/proxyMiddleware.ts
+++ b/src/server/middleware/proxyMiddleware.ts
@@ -55,8 +55,8 @@ const serverConfig = getConfigForServer();
 
 const createApiProxyMiddleware = () => {
   const apiProxyMiddleware = createHttpProxyMiddleware({
-    pathFilter: ['/api/**'],
-    target: 'http://transcript-focus.review.ensembl.org', // FIXME: undo before merging
+    pathFilter: '/api',
+    target: 'https://staging-2020.ensembl.org',
     changeOrigin: true,
     secure: false
   });

--- a/src/shared/components/feature-summary-strip/FeatureSummaryStrip.test.tsx
+++ b/src/shared/components/feature-summary-strip/FeatureSummaryStrip.test.tsx
@@ -29,6 +29,9 @@ vi.mock('./GeneSummaryStrip', () => ({
 vi.mock('./LocationSummaryStrip', () => ({
   default: () => <div>Location Summary Strip</div>
 }));
+vi.mock('./TranscriptSummaryStrip', () => ({
+  default: () => <div>Transcript Summary Strip</div>
+}));
 
 describe('<FeatureSummaryStrip />', () => {
   const defaultProps = {
@@ -60,6 +63,16 @@ describe('<FeatureSummaryStrip />', () => {
         })
       );
       expect(container.textContent).toBe('Location Summary Strip'); // text from the mocked module
+    });
+
+    it('renders a TranscriptSummaryStrip if the focus object is a transcript', () => {
+      const { container } = render(
+        renderFeatureSummaryStrip({
+          focusObject: createFocusObject('transcript')
+        })
+      );
+
+      expect(container.textContent).toBe('Transcript Summary Strip');
     });
   });
 });

--- a/src/shared/components/feature-summary-strip/FeatureSummaryStrip.tsx
+++ b/src/shared/components/feature-summary-strip/FeatureSummaryStrip.tsx
@@ -18,6 +18,7 @@ import type { RefObject } from 'react';
 
 import GeneSummaryStrip from './GeneSummaryStrip';
 import LocationSummaryStrip from './LocationSummaryStrip';
+import TranscriptSummaryStrip from './TranscriptSummaryStrip';
 import VariantSummaryStrip from './VariantSummaryStrip';
 
 import type { FocusObject } from 'src/shared/types/focus-object/focusObjectTypes';
@@ -37,6 +38,14 @@ export const FeatureSummaryStrip = (props: FeatureSummaryStripProps) => {
         <GeneSummaryStrip
           gene={focusObject}
           ref={ref}
+          className={props.className}
+        />
+      );
+    case 'transcript':
+      return (
+        <TranscriptSummaryStrip
+          transcript={focusObject}
+          elementRef={ref}
           className={props.className}
         />
       );

--- a/src/shared/components/feature-summary-strip/FeatureSummaryStrip.tsx
+++ b/src/shared/components/feature-summary-strip/FeatureSummaryStrip.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { RefObject } from 'react';
+import { memo, type RefObject } from 'react';
 
 import GeneSummaryStrip from './GeneSummaryStrip';
 import LocationSummaryStrip from './LocationSummaryStrip';
@@ -70,4 +70,4 @@ export const FeatureSummaryStrip = (props: FeatureSummaryStripProps) => {
   }
 };
 
-export default FeatureSummaryStrip;
+export default memo(FeatureSummaryStrip);

--- a/src/shared/components/feature-summary-strip/TranscriptSummaryStrip.tsx
+++ b/src/shared/components/feature-summary-strip/TranscriptSummaryStrip.tsx
@@ -31,8 +31,7 @@ type TranscriptFields =
   | 'versioned_stable_id'
   | 'stable_id'
   | 'strand'
-  | 'location'
-  | 'gene_symbol';
+  | 'location';
 type Transcript = Pick<FocusTranscript, TranscriptFields>;
 
 type Props = {
@@ -50,32 +49,15 @@ const TranscriptSummaryStrip = (props: Props) => {
     <div className={stripClasses} ref={elementRef}>
       <div className={styles.section}>
         <span className={styles.featureSummaryStripLabel}>Transcript</span>
-        {transcript.label && (
-          <span className={styles.featureNameEmphasized}>
-            {transcript.label}
-          </span>
-        )}
-        {transcript.label !== stableId && <span>{stableId}</span>}
+        <span className={styles.featureNameEmphasized}>{stableId}</span>
       </div>
-      {transcript.gene_symbol && (
-        <div className={styles.section}>
-          <span className={styles.featureSummaryStripLabel}>Gene</span>
-          <span className={styles.featureNameEmphasized}>
-            {transcript.gene_symbol}
-          </span>
-        </div>
-      )}
-      {transcript.bio_type && (
-        <div className={styles.section}>
-          <span className={styles.featureSummaryStripLabel}>Biotype</span>
-          {transcript.bio_type}
-        </div>
-      )}
-      {transcript.strand && (
-        <div className={styles.section}>
-          {getStrandDisplayName(transcript.strand)}
-        </div>
-      )}
+      <div className={styles.section}>
+        <span className={styles.featureSummaryStripLabel}>Biotype</span>
+        {transcript.bio_type}
+      </div>
+      <div className={styles.section}>
+        {getStrandDisplayName(transcript.strand)}
+      </div>
       <div className={styles.section}>
         {getFormattedLocation(transcript.location)}
       </div>

--- a/src/shared/components/feature-summary-strip/TranscriptSummaryStrip.tsx
+++ b/src/shared/components/feature-summary-strip/TranscriptSummaryStrip.tsx
@@ -1,0 +1,86 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classNames from 'classnames';
+import type { RefObject } from 'react';
+
+import { getDisplayStableId } from 'src/shared/helpers/focusObjectHelpers';
+import { getFormattedLocation } from 'src/shared/helpers/formatters/regionFormatter';
+import { getStrandDisplayName } from 'src/shared/helpers/formatters/strandFormatter';
+
+import type { FocusTranscript } from 'src/shared/types/focus-object/focusObjectTypes';
+
+import styles from './FeatureSummaryStrip.module.css';
+
+type TranscriptFields =
+  | 'bio_type'
+  | 'label'
+  | 'versioned_stable_id'
+  | 'stable_id'
+  | 'strand'
+  | 'location'
+  | 'gene_symbol';
+type Transcript = Pick<FocusTranscript, TranscriptFields>;
+
+type Props = {
+  transcript: Transcript;
+  className?: string;
+  elementRef?: RefObject<HTMLDivElement | null>;
+};
+
+const TranscriptSummaryStrip = (props: Props) => {
+  const { transcript, className, elementRef } = props;
+  const stableId = getDisplayStableId(transcript);
+  const stripClasses = classNames(styles.featureSummaryStrip, className);
+
+  return (
+    <div className={stripClasses} ref={elementRef}>
+      <div className={styles.section}>
+        <span className={styles.featureSummaryStripLabel}>Transcript</span>
+        {transcript.label && (
+          <span className={styles.featureNameEmphasized}>
+            {transcript.label}
+          </span>
+        )}
+        {transcript.label !== stableId && <span>{stableId}</span>}
+      </div>
+      {transcript.gene_symbol && (
+        <div className={styles.section}>
+          <span className={styles.featureSummaryStripLabel}>Gene</span>
+          <span className={styles.featureNameEmphasized}>
+            {transcript.gene_symbol}
+          </span>
+        </div>
+      )}
+      {transcript.bio_type && (
+        <div className={styles.section}>
+          <span className={styles.featureSummaryStripLabel}>Biotype</span>
+          {transcript.bio_type}
+        </div>
+      )}
+      {transcript.strand && (
+        <div className={styles.section}>
+          {getStrandDisplayName(transcript.strand)}
+        </div>
+      )}
+      <div className={styles.section}>
+        {getFormattedLocation(transcript.location)}
+      </div>
+    </div>
+  );
+};
+
+export default TranscriptSummaryStrip;

--- a/src/shared/helpers/focusObjectHelpers.ts
+++ b/src/shared/helpers/focusObjectHelpers.ts
@@ -16,6 +16,7 @@
 
 import type {
   FocusGene,
+  FocusTranscript,
   FocusObjectIdConstituents,
   UrlFocusIdConstituents
 } from 'src/shared/types/focus-object/focusObjectTypes';
@@ -80,8 +81,9 @@ export const parseFocusObjectIdFromUrl = (
   };
 };
 
-export const getDisplayStableId = (focusObject: Partial<FocusGene>) =>
-  focusObject.versioned_stable_id || focusObject.stable_id || '';
+export const getDisplayStableId = (
+  focusObject: Partial<FocusGene | FocusTranscript>
+) => focusObject.versioned_stable_id || focusObject.stable_id || '';
 
 export const buildFocusVariantId = (params: {
   regionName: string;

--- a/src/shared/hooks/useDOMElement.ts
+++ b/src/shared/hooks/useDOMElement.ts
@@ -1,0 +1,43 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, useCallback } from 'react';
+
+/**
+ * This is a replacement for the useRefWithRerender hook,
+ * whose downside is that it returns a ref; and refs aren't supposed
+ * to be read from during render.
+ *
+ * This hook, instead, stores the referenced DOM element in the state,
+ * and returns that state.
+ * Its purpose is to abstract away the repetitive logic
+ * of assigning the element received via a ref callback to the state.
+ */
+
+const useDOMElement = <T>(): [T | null, (element: T) => () => void] => {
+  const [element, setElement] = useState<T | null>(null);
+
+  const refCallback = useCallback((element: T) => {
+    setElement(element);
+    return () => {
+      setElement(null);
+    };
+  }, []);
+
+  return [element, refCallback];
+};
+
+export default useDOMElement;

--- a/src/shared/types/focus-object/focusObjectTypes.ts
+++ b/src/shared/types/focus-object/focusObjectTypes.ts
@@ -47,7 +47,6 @@ export type FocusTranscript = BasicFocusObject & {
   versioned_stable_id: string;
   bio_type: string;
   strand: Strand;
-  gene_symbol: string;
 };
 
 export type FocusLocation = BasicFocusObject & {

--- a/src/shared/types/focus-object/focusObjectTypes.ts
+++ b/src/shared/types/focus-object/focusObjectTypes.ts
@@ -22,7 +22,7 @@ export type FocusObjectLocation = {
   start: number;
 };
 
-export type FocusObjectType = 'gene' | 'location' | 'variant';
+export type FocusObjectType = 'gene' | 'transcript' | 'location' | 'variant';
 
 type BasicFocusObject = {
   object_id: string;
@@ -41,6 +41,15 @@ export type FocusGene = BasicFocusObject & {
   visibleTranscriptIds: string[] | null; // null means that chrome doesn't have an opinion on which transcripts should be visible in the genome browser
 };
 
+export type FocusTranscript = BasicFocusObject & {
+  type: 'transcript';
+  stable_id: string;
+  versioned_stable_id: string;
+  bio_type: string;
+  strand: Strand;
+  gene_symbol: string;
+};
+
 export type FocusLocation = BasicFocusObject & {
   type: 'location';
 };
@@ -50,7 +59,11 @@ export type FocusVariant = BasicFocusObject & {
   variant_id: string; // to store the variant id as it is read from the url; this field will likely change when we change what a variant id is
 };
 
-export type FocusObject = FocusGene | FocusLocation | FocusVariant;
+export type FocusObject =
+  | FocusGene
+  | FocusTranscript
+  | FocusLocation
+  | FocusVariant;
 
 export type FocusObjectResponse = FocusGene;
 

--- a/tests/fixtures/focus-object.ts
+++ b/tests/fixtures/focus-object.ts
@@ -20,6 +20,7 @@ import {
   FocusObject,
   FocusGene,
   FocusLocation,
+  FocusTranscript,
   FocusObjectType
 } from 'src/shared/types/focus-object/focusObjectTypes';
 import { Strand } from 'src/shared/types/core-api/strand';
@@ -28,6 +29,8 @@ export const createFocusObject = (
   objectType?: FocusObjectType
 ): FocusObject => {
   switch (objectType) {
+    case 'transcript':
+      return createFocusTranscript();
     case 'location':
       return createFocusLocation();
     default:
@@ -55,6 +58,18 @@ const createFocusLocation = (): FocusLocation => {
     ...commonFocusObjectFields({ genome_id }),
     type: 'location',
     object_id
+  };
+};
+
+const createFocusTranscript = (): FocusTranscript => {
+  const genome_id = faker.lorem.word();
+  const object_id = `${genome_id}:transcript:${faker.string.uuid()};`;
+
+  return {
+    ...commonFocusObjectFields({ genome_id }),
+    type: 'transcript',
+    object_id,
+    gene_symbol: faker.lorem.word()
   };
 };
 

--- a/tests/fixtures/focus-object.ts
+++ b/tests/fixtures/focus-object.ts
@@ -68,8 +68,7 @@ const createFocusTranscript = (): FocusTranscript => {
   return {
     ...commonFocusObjectFields({ genome_id }),
     type: 'transcript',
-    object_id,
-    gene_symbol: faker.lorem.word()
+    object_id
   };
 };
 


### PR DESCRIPTION
## Description
Add client-side support for focus transcripts in genome browser view.
Focus transcript track itself is implemented in respective [genome browser PR](https://github.com/Ensembl/ensembl-dauphin-style-compiler/pull/144).


### Other changes made in this PR
- Made updates to focus track payload from the genome browser. Added a `type` field to the payload, which helps distinguish focus gene from focus transcript from focus variant, even though all these three tracks have a `switch-id` of `focus`
- Fixed linter warnings about non-exhaustive dependencies of `useEffect` hooks in `useFocusTrack` and `useGenomicTracks` custom hooks, as well as in the `BrowserCogList` component


## Related JIRA Issue(s)
[ENSWBSITES-2995](https://embl.atlassian.net/browse/ENSWBSITES-2995)

## Deployment URL(s)
[http://transcript-focus.review.ensembl.org/genome-browser/grch38?focus=transcript:ENST00000380152](http://transcript-focus.review.ensembl.org/genome-browser/grch38?focus=transcript:ENST00000380152)