### PR TITLE
Entity Viewer for transcript: topbar and sidebar updates

### DIFF
--- a/src/content/app/entity-viewer/EntityViewerForTranscript.tsx
+++ b/src/content/app/entity-viewer/EntityViewerForTranscript.tsx
@@ -29,6 +29,7 @@ import TranscriptSummaryStrip from './transcript-view/components/transcript-summ
 import TranscriptView from './transcript-view/TranscriptView';
 import TranscriptViewSidebar from './transcript-view/components/transcript-view-sidebar/TranscriptViewSidebar';
 import TranscriptViewSidebarTabs from './transcript-view/components/transcript-view-sidebar-tabs/TranscriptViewSidebarTabs';
+import SidebarToolstrip from './transcript-view/components/transcript-view-sidebar/sidebar-toolstrip/SidebarToolstrip';
 
 const EntityViewerForTranscript = () => {
   const { activeGenomeId, transcriptId } = useTranscriptViewIds();
@@ -56,6 +57,7 @@ const EntityViewerForTranscript = () => {
       topbarContent={<TranscriptSummaryStrip />}
       mainContent={<TranscriptView />}
       sidebarContent={<TranscriptViewSidebar />}
+      sidebarToolstripContent={<SidebarToolstrip />}
       isSidebarOpen={isSidebarOpen}
       onSidebarToggle={onSidebarToggle}
       sidebarNavigation={<TranscriptViewSidebarTabs />}

--- a/src/content/app/entity-viewer/EntityViewerForTranscript.tsx
+++ b/src/content/app/entity-viewer/EntityViewerForTranscript.tsx
@@ -25,6 +25,7 @@ import { getIsSidebarOpen } from 'src/content/app/entity-viewer/state/transcript
 import { toggleSidebar } from 'src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSlice';
 
 import { StandardAppLayout } from 'src/shared/components/layout';
+import TranscriptSummaryStrip from './transcript-view/components/transcript-summary-strip/TranscriptSummaryStrip';
 import TranscriptView from './transcript-view/TranscriptView';
 import TranscriptViewSidebar from './transcript-view/components/transcript-view-sidebar/TranscriptViewSidebar';
 import TranscriptViewSidebarTabs from './transcript-view/components/transcript-view-sidebar-tabs/TranscriptViewSidebarTabs';
@@ -52,7 +53,7 @@ const EntityViewerForTranscript = () => {
 
   return (
     <StandardAppLayout
-      topbarContent={<div />}
+      topbarContent={<TranscriptSummaryStrip />}
       mainContent={<TranscriptView />}
       sidebarContent={<TranscriptViewSidebar />}
       isSidebarOpen={isSidebarOpen}

--- a/src/content/app/entity-viewer/EntityViewerPage.tsx
+++ b/src/content/app/entity-viewer/EntityViewerPage.tsx
@@ -26,6 +26,7 @@ import useHasMounted from 'src/shared/hooks/useHasMounted';
 import { updatePageMeta } from 'src/shared/state/page-meta/pageMetaSlice';
 import {
   useGenePageMetaQuery,
+  useTranscriptPageMetaQuery,
   useVariantPageMetaQuery
 } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
 
@@ -48,7 +49,7 @@ const useEntityViewerPageMeta = () => {
   const { activeGenomeId, parsedEntityId } = useEntityViewerIds();
   const { type: entityType, objectId: entityId } = parsedEntityId ?? {};
 
-  const { currentData: genePageMeta, isLoading: isGenePageMetaLoading } =
+  const { currentData: genePageMeta, isFetching: isGenePageMetaLoading } =
     useGenePageMetaQuery(
       {
         genomeId: activeGenomeId ?? '',
@@ -59,7 +60,20 @@ const useEntityViewerPageMeta = () => {
       }
     );
 
-  const { currentData: variantPageMeta, isLoading: isVariantPageMetaLoading } =
+  const {
+    currentData: transcriptPageMeta,
+    isFetching: isTranscriptPageMetaLoading
+  } = useTranscriptPageMetaQuery(
+    {
+      genomeId: activeGenomeId ?? '',
+      transcriptId: entityId ?? ''
+    },
+    {
+      skip: entityType !== 'transcript' || !activeGenomeId || !entityId
+    }
+  );
+
+  const { currentData: variantPageMeta, isFetching: isVariantPageMetaLoading } =
     useVariantPageMetaQuery(
       {
         genomeId: activeGenomeId ?? '',
@@ -70,11 +84,14 @@ const useEntityViewerPageMeta = () => {
       }
     );
 
-  const pageMeta = genePageMeta || variantPageMeta;
-  const isLoading = isGenePageMetaLoading || isVariantPageMetaLoading;
+  const pageMeta = genePageMeta || transcriptPageMeta || variantPageMeta;
+  const isLoading =
+    isGenePageMetaLoading ||
+    isTranscriptPageMetaLoading ||
+    isVariantPageMetaLoading;
 
   useEffect(() => {
-    if (isLoading) {
+    if (!pageMeta || isLoading) {
       return;
     }
 
@@ -85,7 +102,7 @@ const useEntityViewerPageMeta = () => {
       : buildPageMeta();
 
     dispatch(updatePageMeta(preparedPageMeta));
-  }, [isLoading]);
+  }, [isLoading, pageMeta, dispatch, entityId]);
 };
 
 const WrappedEntityViewerPage = () => {

--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/GeneOverview.tsx
@@ -24,6 +24,7 @@ import { useAppDispatch } from 'src/store';
 import GenePublications from '../publications/GenePublications';
 import MainAccordion from './MainAccordion';
 import ExternalReference from 'src/shared/components/external-reference/ExternalReference';
+import SearchButton from 'src/shared/components/search-button/SearchButton';
 
 import {
   openSidebarModal,
@@ -32,7 +33,6 @@ import {
 } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSlice';
 
 import styles from './GeneOverview.module.css';
-import SearchButton from 'src/shared/components/search-button/SearchButton';
 
 const GeneOverview = () => {
   const { genomeId, geneId } = useGeneViewIds();

--- a/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.tsx
+++ b/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.tsx
@@ -84,6 +84,11 @@ const buildEntityUrl = (genomeId: string, entity: PreviouslyViewedEntity) => {
       genomeId: genomeId,
       variantId: entity.id
     });
+  } else if (entity.type === 'transcript') {
+    return urlFor.entityViewerVariant({
+      genomeId: genomeId,
+      variantId: entity.id
+    });
   } else {
     // this should never happen; making typescript happy
     return '';

--- a/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.tsx
+++ b/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks.tsx
@@ -85,9 +85,12 @@ const buildEntityUrl = (genomeId: string, entity: PreviouslyViewedEntity) => {
       variantId: entity.id
     });
   } else if (entity.type === 'transcript') {
-    return urlFor.entityViewerVariant({
+    return urlFor.entityViewerTranscript({
       genomeId: genomeId,
-      variantId: entity.id
+      transcriptId: buildFocusIdForUrl({
+        type: 'transcript',
+        objectId: entity.urlId
+      })
     });
   } else {
     // this should never happen; making typescript happy

--- a/src/content/app/entity-viewer/shared/server-fetch/entityViewerServerFetch.ts
+++ b/src/content/app/entity-viewer/shared/server-fetch/entityViewerServerFetch.ts
@@ -188,7 +188,7 @@ const fetchTranscriptData = async ({
 
   if (pageMetaQueryResult?.error) {
     if ((pageMetaQueryResult.error as any)?.meta?.data?.gene === null) {
-      // this is graphql's way of telling us that there is no such gene
+      // this is graphql's way of telling us that there is no such transcript
       throw new NotFoundError();
     } else {
       throw new Error(); // must be some other error; we will respond with a status code 500

--- a/src/content/app/entity-viewer/shared/server-fetch/entityViewerServerFetch.ts
+++ b/src/content/app/entity-viewer/shared/server-fetch/entityViewerServerFetch.ts
@@ -25,6 +25,7 @@ import {
 import { updatePageMeta } from 'src/shared/state/page-meta/pageMetaSlice';
 import {
   fetchGenePageMeta,
+  fetchTranscriptPageMeta,
   fetchVariantPageMeta
 } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
 
@@ -115,6 +116,11 @@ const fetchEntityData = async (params: {
 
   if (parsedEntityId.type === 'gene') {
     return await fetchGeneData({ ...params, geneId: parsedEntityId.objectId });
+  } else if (parsedEntityId.type === 'transcript') {
+    return await fetchTranscriptData({
+      ...params,
+      transcriptId: parsedEntityId.objectId
+    });
   } else if (parsedEntityId.type === 'variant') {
     return await fetchVariantData({
       ...params,
@@ -138,6 +144,43 @@ const fetchGeneData = async ({
     fetchGenePageMeta.initiate({
       genomeId,
       geneId
+    })
+  );
+  const pageMetaQueryResult = await pageMetaPromise;
+  pageMetaPromise.unsubscribe();
+
+  if (pageMetaQueryResult?.error) {
+    if ((pageMetaQueryResult.error as any)?.meta?.data?.gene === null) {
+      // this is graphql's way of telling us that there is no such gene
+      throw new NotFoundError();
+    } else {
+      throw new Error(); // must be some other error; we will respond with a status code 500
+    }
+  } else {
+    const title = pageMetaQueryResult.data?.title;
+    dispatch(
+      updatePageMeta(
+        buildPageMeta({
+          title
+        })
+      )
+    );
+  }
+};
+
+const fetchTranscriptData = async ({
+  genomeId,
+  transcriptId,
+  dispatch
+}: {
+  genomeId: string;
+  transcriptId: string;
+  dispatch: AppDispatch;
+}) => {
+  const pageMetaPromise = dispatch(
+    fetchTranscriptPageMeta.initiate({
+      genomeId,
+      transcriptId
     })
   );
   const pageMetaQueryResult = await pageMetaPromise;

--- a/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
+++ b/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
@@ -56,6 +56,11 @@ import {
   type EntityViewerGeneHomologiesQueryResult
 } from './queries/geneHomologiesQuery';
 import {
+  transcriptPageMetaQuery,
+  TranscriptPageMetaQueryResult,
+  TranscriptPageMeta
+} from './queries/transcriptPageMetaQuery';
+import {
   defaultTranscriptQuery,
   type DefaultEntityViewerTranscriptQueryResult
 } from './queries/transcriptDefaultQuery';
@@ -192,6 +197,27 @@ const entityViewerThoasSlice = graphqlApiSlice.injectEndpoints({
         body: geneHomologiesQuery,
         variables: params
       })
+    }),
+    transcriptPageMeta: builder.query<
+      TranscriptPageMeta,
+      TranscriptQueryParams
+    >({
+      query: (params) => ({
+        url: config.coreApiUrl,
+        body: transcriptPageMetaQuery,
+        variables: params
+      }),
+      transformResponse(response: TranscriptPageMetaQueryResult) {
+        const {
+          transcript: { stable_id }
+        } = response;
+
+        const title = `Transcript: ${stable_id ?? stable_id} — Ensembl`;
+
+        return {
+          title
+        };
+      }
     }),
     defaultEntityViewerTranscript: builder.query<
       DefaultEntityViewerTranscriptQueryResult,
@@ -354,6 +380,7 @@ export const {
   useGeneForSequenceDownloadQuery,
   useProteinDomainsQuery,
   useEvGeneHomologyQuery,
+  useTranscriptPageMetaQuery,
   useDefaultEntityViewerTranscriptQuery,
   useTranscriptExternalReferencesQuery,
   useVariantPageMetaQuery,
@@ -367,6 +394,7 @@ export const {
 
 export const {
   genePageMeta: fetchGenePageMeta,
+  transcriptPageMeta: fetchTranscriptPageMeta,
   variantPageMeta: fetchVariantPageMeta,
   defaultEntityViewerVariant: fetchDefaultEntityViewerVariant
 } = entityViewerThoasSlice.endpoints;

--- a/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
+++ b/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
@@ -212,7 +212,7 @@ const entityViewerThoasSlice = graphqlApiSlice.injectEndpoints({
           transcript: { stable_id }
         } = response;
 
-        const title = `Transcript: ${stable_id ?? stable_id} — Ensembl`;
+        const title = `Transcript: ${stable_id} — Ensembl`;
 
         return {
           title

--- a/src/content/app/entity-viewer/state/api/queries/transcriptPageMetaQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/transcriptPageMetaQuery.ts
@@ -1,0 +1,35 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from 'graphql-request';
+
+export const transcriptPageMetaQuery = gql`
+  query TranscriptPageMeta($genomeId: String!, $transcriptId: String!) {
+    transcript(by_id: { genome_id: $genomeId, stable_id: $transcriptId }) {
+      stable_id
+    }
+  }
+`;
+
+export type TranscriptPageMetaQueryResult = {
+  transcript: {
+    stable_id: string;
+  };
+};
+
+export type TranscriptPageMeta = {
+  title: string;
+};

--- a/src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSlice.ts
+++ b/src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSlice.ts
@@ -34,7 +34,7 @@ export type PreviouslyViewedEntity = {
   id: string;
   urlId: string; // e.g. for genes, this is unversioned stable id rather than stable id
   label: string | string[];
-  type: 'gene' | 'variant';
+  type: 'gene' | 'variant' | 'transcript';
 };
 
 export type PreviouslyViewedEntities = {

--- a/src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSlice.ts
+++ b/src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSlice.ts
@@ -21,7 +21,7 @@ export const defaultSidebarTabName = sidebarTabNames[0];
 
 export type SidebarTabName = (typeof sidebarTabNames)[number];
 
-export const sidebarModalViews = ['search', 'bookmarks', 'download'];
+export const sidebarModalViews = ['search', 'bookmarks', 'download'] as const;
 
 export type SidebarModalView = (typeof sidebarModalViews)[number];
 
@@ -106,7 +106,7 @@ const transcriptViewSidebarSlice = createSlice({
       ensureTranscriptState(state, genomeId, transcriptId);
       state[genomeId][transcriptId].selectedTabName = selectedTabName;
     },
-    setSidebarModalView(
+    openSidebarModal(
       state,
       action: PayloadAction<{
         genomeId: string;
@@ -137,7 +137,7 @@ export const {
   closeSidebar,
   toggleSidebar,
   setSelectedTab,
-  setSidebarModalView,
+  openSidebarModal,
   closeSidebarModal
 } = transcriptViewSidebarSlice.actions;
 

--- a/src/content/app/entity-viewer/transcript-view/TranscriptView.tsx
+++ b/src/content/app/entity-viewer/transcript-view/TranscriptView.tsx
@@ -22,6 +22,7 @@ import { useAppSelector, useAppDispatch } from 'src/store';
 
 import { getViewForTranscript } from 'src/content/app/entity-viewer/state/transcript-view/general/transcriptViewGeneralSelectors';
 
+import { updatePreviouslyViewedEntities } from 'src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSlice';
 import useTranscriptViewIds from 'src/content/app/entity-viewer/transcript-view/hooks/useTranscriptViewIds';
 import { useDefaultEntityViewerTranscriptQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
 import {
@@ -53,6 +54,28 @@ const TranscriptView = () => {
       skip: !activeGenomeId || !transcriptId
     }
   );
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    if (!activeGenomeId || !currentData?.transcript) {
+      return;
+    }
+    const { transcript } = currentData;
+
+    return () => {
+      dispatch(
+        updatePreviouslyViewedEntities({
+          genomeId: activeGenomeId,
+          entity: {
+            id: transcript.stable_id,
+            urlId: transcript.unversioned_stable_id,
+            label: transcript.stable_id,
+            type: 'transcript'
+          }
+        })
+      );
+    };
+  }, [activeGenomeId, currentData, dispatch]);
 
   const viewInUrl = searchParams.get('view');
 

--- a/src/content/app/entity-viewer/transcript-view/components/gene-overview-image/GeneOverviewImage.module.css
+++ b/src/content/app/entity-viewer/transcript-view/components/gene-overview-image/GeneOverviewImage.module.css
@@ -9,9 +9,11 @@
   fill: var(--color-dark-grey);
 }
 
-.geneId {
+.transcriptId {
   grid-column: 1/2;
-  grid-row: 2/3;
+  grid-row: 1/3;
+  display: grid;
+  grid-template-rows: subgrid;
   text-align: right;
   font-size: 13px;
   font-weight: var(--font-weight-bold);
@@ -48,4 +50,8 @@
   grid-column: 3/4;
   grid-row: 3/4;
   padding-top: 15px;
+}
+
+.light {
+  font-weight: var(--font-weight-light);
 }

--- a/src/content/app/entity-viewer/transcript-view/components/gene-overview-image/GeneOverviewImage.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/gene-overview-image/GeneOverviewImage.tsx
@@ -48,7 +48,8 @@ type Gene = Pick<FullGene, 'stable_id'> &
   Pick3<FullGene, 'slice', 'strand', 'code'>;
 
 type Transcript = UnsplicedTranscriptProps['transcript'] &
-  Pick3<FullTranscript, 'slice', 'location', 'start' | 'end' | 'length'>;
+  Pick3<FullTranscript, 'slice', 'location', 'start' | 'end' | 'length'> &
+  Pick<FullTranscript, 'stable_id'>;
 
 export type GeneOverviewImageProps = {
   transcript: Transcript;
@@ -61,7 +62,7 @@ const GeneOverviewImage = (props: GeneOverviewImageProps) => {
 
   return (
     <div className={commonStyles.gridColumns}>
-      <GeneId {...props} />
+      <TranscriptId {...props} />
       <DirectionIndicator />
       <GeneImage {...props} />
       <StrandIndicator {...props} />
@@ -113,8 +114,11 @@ export const GeneImage = (props: GeneOverviewImageProps) => {
   );
 };
 
-const GeneId = (props: GeneOverviewImageProps) => (
-  <div className={styles.geneId}>{props.gene.stable_id}</div>
+const TranscriptId = (props: GeneOverviewImageProps) => (
+  <div className={styles.transcriptId}>
+    <span className={styles.light}>Location in gene</span>
+    <span>{props.transcript.stable_id}</span>
+  </div>
 );
 
 const DirectionIndicator = () => {

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-summary-strip/TranscriptSummaryStrip.module.css
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-summary-strip/TranscriptSummaryStrip.module.css
@@ -1,0 +1,3 @@
+.container {
+  padding-left: var(--double-standard-gutter);
+}

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-summary-strip/TranscriptSummaryStrip.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-summary-strip/TranscriptSummaryStrip.tsx
@@ -1,0 +1,95 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classNames from 'classnames';
+import type { Pick2, Pick3 } from 'ts-multipick';
+
+import { getStrandDisplayName } from 'src/shared/helpers/formatters/strandFormatter';
+import { getFormattedLocation } from 'src/shared/helpers/formatters/regionFormatter';
+
+import useTranscriptViewIds from 'src/content/app/entity-viewer/transcript-view/hooks/useTranscriptViewIds';
+import { useDefaultEntityViewerTranscriptQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
+
+import type { FullTranscript } from 'src/shared/types/core-api/transcript';
+
+import commonStyles from 'src/shared/components/feature-summary-strip/FeatureSummaryStrip.module.css';
+import styles from './TranscriptSummaryStrip.module.css';
+
+type TranscriptInSummaryStrip = Pick<FullTranscript, 'stable_id'> &
+  Pick2<FullTranscript, 'slice', 'location'> &
+  Pick3<FullTranscript, 'slice', 'region', 'name'> &
+  Pick3<FullTranscript, 'slice', 'strand', 'code'> &
+  Pick3<FullTranscript, 'metadata', 'biotype', 'value'>;
+
+type Props = {
+  transcript: TranscriptInSummaryStrip;
+};
+
+const TranscriptSummaryStripDataWrapper = () => {
+  const { activeGenomeId, transcriptId } = useTranscriptViewIds();
+  const { currentData } = useDefaultEntityViewerTranscriptQuery(
+    {
+      genomeId: activeGenomeId ?? '',
+      transcriptId: transcriptId ?? ''
+    },
+    {
+      skip: !activeGenomeId || !transcriptId
+    }
+  );
+
+  if (currentData) {
+    return <TranscriptSummaryStrip transcript={currentData.transcript} />;
+  }
+};
+
+/**
+ * NOTE: This component might be extracted into a shared component
+ * to be reused in the genome browser page.
+ */
+
+const TranscriptSummaryStrip = (props: Props) => {
+  const { transcript } = props;
+  return (
+    <div
+      className={classNames(commonStyles.featureSummaryStrip, styles.container)}
+    >
+      <span className={commonStyles.section}>
+        <span className={commonStyles.featureSummaryStripLabel}>
+          Transcript{' '}
+        </span>
+        <span className={commonStyles.featureNameEmphasized}>
+          {transcript.stable_id}
+        </span>
+      </span>
+      <span className={commonStyles.section}>
+        <span className={commonStyles.featureSummaryStripLabel}>Biotype </span>
+        <span>{transcript.metadata.biotype.value}</span>
+      </span>
+      <span className={commonStyles.section}>
+        {getStrandDisplayName(transcript.slice.strand.code)}
+      </span>
+      <span className={commonStyles.section}>
+        {getFormattedLocation({
+          chromosome: transcript.slice.region.name,
+          start: transcript.slice.location.start,
+          end: transcript.slice.location.end
+        })}
+      </span>
+    </div>
+  );
+};
+
+export default TranscriptSummaryStripDataWrapper;

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/TranscriptViewSidebar.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/TranscriptViewSidebar.tsx
@@ -16,7 +16,10 @@
 
 import { useAppSelector } from 'src/store';
 
-import { getActiveSidebarTab } from 'src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSelectors';
+import {
+  getActiveSidebarTab,
+  getSidebarModalView
+} from 'src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSelectors';
 import { sidebarTabNames } from 'src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSlice';
 
 import useTranscriptViewIds from 'src/content/app/entity-viewer/transcript-view/hooks/useTranscriptViewIds';
@@ -24,15 +27,28 @@ import useTranscriptViewIds from 'src/content/app/entity-viewer/transcript-view/
 import SidebarDefault from './sidebar-default/SidebarDefault';
 import SidebarExternalReferences from './sidebar-external-references/SidebarExternalReferences';
 import Sidebar from 'src/shared/components/layout/sidebar/Sidebar';
+import TranscriptViewSidebarModal from 'src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-modal/TranscriptViewSidebarModal';
 
 const TranscriptViewSidebar = () => {
   const { activeGenomeId, transcriptId } = useTranscriptViewIds();
   const activeSidebarTab = useAppSelector((state) =>
     getActiveSidebarTab(state, activeGenomeId ?? '', transcriptId ?? '')
   );
+  const sidebarModalView = useAppSelector((state) =>
+    getSidebarModalView(state, activeGenomeId ?? '', transcriptId ?? '')
+  );
 
   if (!activeGenomeId || !transcriptId) {
     return null;
+  }
+  if (sidebarModalView) {
+    return (
+      <TranscriptViewSidebarModal
+        genomeId={activeGenomeId}
+        transcriptId={transcriptId}
+        view={sidebarModalView}
+      />
+    );
   }
 
   return (

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-default/SidebarDefault.module.css
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-default/SidebarDefault.module.css
@@ -20,3 +20,7 @@
 .strong {
   font-weight: var(--font-weight-bold);
 }
+
+.searchButtonSection {
+  margin-top: 20px;
+}

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-default/SidebarDefault.module.css
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-default/SidebarDefault.module.css
@@ -21,6 +21,10 @@
   font-weight: var(--font-weight-bold);
 }
 
+.viewInAppGene {
+  margin-top: 20px;
+}
+
 .searchButtonSection {
   margin-top: 20px;
 }

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-default/SidebarDefault.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-default/SidebarDefault.tsx
@@ -16,14 +16,18 @@
 
 import classNames from 'classnames';
 
+import { useAppDispatch } from 'src/store';
+
 import { getFeatureLength } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
 
 import { useDefaultEntityViewerTranscriptQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
+import { openSidebarModal } from 'src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSlice';
 
 import SidebarSectionHeading from 'src/shared/components/sidebar-section-heading/SidebarSectionHeading';
 import GeneName from 'src/shared/components/gene-name/GeneName';
 import ExternalLink from 'src/shared/components/external-link/ExternalLink';
 import { SidebarLoader } from 'src/shared/components/loader';
+import SearchButton from 'src/shared/components/search-button/SearchButton';
 
 import type { DefaultEntityViewerTranscriptQueryResult } from 'src/content/app/entity-viewer/state/api/queries/transcriptDefaultQuery';
 
@@ -72,6 +76,10 @@ const SidebarDefault = (props: Props) => {
       <GeneNameSection gene={gene} />
       <SynonymsSection gene={gene} />
       <AttributesSection gene={gene} />
+      <SearchButtonSection
+        genomeId={props.genomeId}
+        transcriptId={props.transcriptId}
+      />
     </>
   );
 };
@@ -136,6 +144,38 @@ const AttributesSection = ({
         <span>{gene.metadata.biotype.value}</span>
       </div>
     </>
+  );
+};
+
+const SearchButtonSection = ({
+  genomeId,
+  transcriptId
+}: {
+  genomeId: string;
+  transcriptId: string;
+}) => {
+  const dispatch = useAppDispatch();
+
+  const openSearch = () => {
+    dispatch(
+      openSidebarModal({
+        genomeId,
+        transcriptId,
+        view: 'search'
+      })
+    );
+  };
+
+  return (
+    <div
+      className={classNames(styles.searchButtonSection, styles.sectionContent)}
+    >
+      <SearchButton
+        onClick={openSearch}
+        label="Find"
+        className={styles.searchButton}
+      />
+    </div>
   );
 };
 

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-default/SidebarDefault.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-default/SidebarDefault.tsx
@@ -79,7 +79,7 @@ const SidebarDefault = (props: Props) => {
       <div className={styles.sectionContent}>
         <GeneName stable_id={gene.stable_id} symbol={gene.symbol} />
       </div>
-      <GeneNameSection genomeId={props.genomeId} gene={gene} />
+      <GeneNameSection genomeId={genomeIdForUrl as string} gene={gene} />
       <SynonymsSection gene={gene} />
       <AttributesSection gene={gene} />
       <SearchButtonSection
@@ -104,7 +104,7 @@ const GeneNameSection = ({
   const accessionId = gene.metadata.name?.accession_id;
 
   const geneFocusIdForUrl = buildFocusIdForUrl({
-    objectId: gene.stable_id,
+    objectId: gene.unversioned_stable_id,
     type: 'gene'
   });
   const linkToGenomeBrowser = urlFor.browser({

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-default/SidebarDefault.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-default/SidebarDefault.tsx
@@ -18,7 +18,11 @@ import classNames from 'classnames';
 
 import { useAppDispatch } from 'src/store';
 
+import * as urlFor from 'src/shared/helpers/urlHelper';
 import { getFeatureLength } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
+import { buildFocusIdForUrl } from 'src/shared/helpers/focusObjectHelpers';
+
+import useEntityViewerIds from 'src/content/app/entity-viewer/hooks/useEntityViewerIds';
 
 import { useDefaultEntityViewerTranscriptQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
 import { openSidebarModal } from 'src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSlice';
@@ -28,6 +32,7 @@ import GeneName from 'src/shared/components/gene-name/GeneName';
 import ExternalLink from 'src/shared/components/external-link/ExternalLink';
 import { SidebarLoader } from 'src/shared/components/loader';
 import SearchButton from 'src/shared/components/search-button/SearchButton';
+import ViewInApp from 'src/shared/components/view-in-app/ViewInApp';
 
 import type { DefaultEntityViewerTranscriptQueryResult } from 'src/content/app/entity-viewer/state/api/queries/transcriptDefaultQuery';
 
@@ -39,6 +44,7 @@ type Props = {
 };
 
 const SidebarDefault = (props: Props) => {
+  const { genomeIdForUrl } = useEntityViewerIds();
   const { currentData, isLoading } = useDefaultEntityViewerTranscriptQuery({
     genomeId: props.genomeId,
     transcriptId: props.transcriptId
@@ -73,11 +79,11 @@ const SidebarDefault = (props: Props) => {
       <div className={styles.sectionContent}>
         <GeneName stable_id={gene.stable_id} symbol={gene.symbol} />
       </div>
-      <GeneNameSection gene={gene} />
+      <GeneNameSection genomeId={props.genomeId} gene={gene} />
       <SynonymsSection gene={gene} />
       <AttributesSection gene={gene} />
       <SearchButtonSection
-        genomeId={props.genomeId}
+        genomeId={genomeIdForUrl as string}
         transcriptId={props.transcriptId}
       />
     </>
@@ -85,8 +91,10 @@ const SidebarDefault = (props: Props) => {
 };
 
 const GeneNameSection = ({
+  genomeId,
   gene
 }: {
+  genomeId: string;
   gene: DefaultEntityViewerTranscriptQueryResult['transcript']['gene'];
 }) => {
   if (!gene.name) {
@@ -94,6 +102,19 @@ const GeneNameSection = ({
   }
   const url = gene.metadata.name?.url;
   const accessionId = gene.metadata.name?.accession_id;
+
+  const geneFocusIdForUrl = buildFocusIdForUrl({
+    objectId: gene.stable_id,
+    type: 'gene'
+  });
+  const linkToGenomeBrowser = urlFor.browser({
+    genomeId: genomeId,
+    focus: geneFocusIdForUrl
+  });
+  const linkToEntityViewer = urlFor.entityViewer({
+    genomeId: genomeId,
+    entityId: geneFocusIdForUrl
+  });
 
   return (
     <>
@@ -107,6 +128,15 @@ const GeneNameSection = ({
             <ExternalLink to={url}>{accessionId}</ExternalLink>
           </div>
         )}
+
+        <ViewInApp
+          links={{
+            genomeBrowser: { url: linkToGenomeBrowser },
+            entityViewer: { url: linkToEntityViewer }
+          }}
+          theme="light"
+          className={styles.viewInAppGene}
+        />
       </div>
     </>
   );

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-modal/SidebarTranscriptDownload.module.css
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-modal/SidebarTranscriptDownload.module.css
@@ -1,0 +1,6 @@
+.instantDownloadTranscript [data-part="transcript-section-checkbox-grid"] {
+  grid-template-areas:
+      'genomic cdna'
+      'protein cds'
+      'exons .'; 
+}

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-modal/SidebarTranscriptDownload.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-modal/SidebarTranscriptDownload.tsx
@@ -1,0 +1,60 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isProteinCodingTranscript } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
+
+import useTranscriptViewIds from 'src/content/app/entity-viewer/transcript-view/hooks/useTranscriptViewIds';
+import { useDefaultEntityViewerTranscriptQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
+
+import InstantDownloadTranscript from 'src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript';
+
+import styles from './SidebarTranscriptDownload.module.css';
+
+const SidebarTranscriptDownload = () => {
+  const { activeGenomeId, transcriptId } = useTranscriptViewIds();
+  const { currentData } = useDefaultEntityViewerTranscriptQuery(
+    {
+      genomeId: activeGenomeId ?? '',
+      transcriptId: transcriptId ?? ''
+    },
+    {
+      skip: !activeGenomeId || !transcriptId
+    }
+  );
+
+  const transcript = currentData?.transcript;
+  if (!activeGenomeId || !transcript) {
+    return null;
+  }
+
+  return (
+    <InstantDownloadTranscript
+      genomeId={activeGenomeId}
+      transcript={{
+        id: transcript.stable_id,
+        isProteinCoding: isProteinCodingTranscript(transcript)
+      }}
+      gene={{
+        id: transcript.gene.stable_id
+      }}
+      layout="vertical"
+      theme="light"
+      className={styles.instantDownloadTranscript}
+    />
+  );
+};
+
+export default SidebarTranscriptDownload;

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-modal/TranscriptViewSidebarModal.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-modal/TranscriptViewSidebarModal.tsx
@@ -1,0 +1,64 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useAppDispatch } from 'src/store';
+
+import {
+  closeSidebarModal,
+  type SidebarModalView
+} from 'src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSlice';
+
+import SidebarModal from 'src/shared/components/layout/sidebar-modal/SidebarModal';
+import EntityViewerSearch from 'src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerSearch';
+import EntityViewerBookmarks from 'src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks';
+
+type Props = {
+  genomeId: string;
+  transcriptId: string;
+  view: SidebarModalView;
+};
+
+const entityViewerSidebarModalTitles = {
+  search: 'Search this species',
+  bookmarks: 'Previously viewed',
+  download: 'Download'
+} as const;
+
+export const EntityViewerSidebarModal = (props: Props) => {
+  const { genomeId, transcriptId, view } = props;
+  const dispatch = useAppDispatch();
+
+  const onCloseModal = () => {
+    dispatch(
+      closeSidebarModal({
+        genomeId,
+        transcriptId
+      })
+    );
+  };
+
+  const modalViewTitle = entityViewerSidebarModalTitles[view];
+
+  return (
+    <SidebarModal title={modalViewTitle} onClose={onCloseModal}>
+      {view === 'search' && <EntityViewerSearch />}
+      {view === 'bookmarks' && <EntityViewerBookmarks />}
+      {view === 'download' && <div>Download</div>}
+    </SidebarModal>
+  );
+};
+
+export default EntityViewerSidebarModal;

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-modal/TranscriptViewSidebarModal.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-modal/TranscriptViewSidebarModal.tsx
@@ -24,6 +24,7 @@ import {
 import SidebarModal from 'src/shared/components/layout/sidebar-modal/SidebarModal';
 import EntityViewerSearch from 'src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerSearch';
 import EntityViewerBookmarks from 'src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerBookmarks';
+import SidebarTranscriptDownload from './SidebarTranscriptDownload';
 
 type Props = {
   genomeId: string;
@@ -56,7 +57,7 @@ export const EntityViewerSidebarModal = (props: Props) => {
     <SidebarModal title={modalViewTitle} onClose={onCloseModal}>
       {view === 'search' && <EntityViewerSearch />}
       {view === 'bookmarks' && <EntityViewerBookmarks />}
-      {view === 'download' && <div>Download</div>}
+      {view === 'download' && <SidebarTranscriptDownload />}
     </SidebarModal>
   );
 };

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-toolstrip/SidebarToolstrip.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar/sidebar-toolstrip/SidebarToolstrip.tsx
@@ -1,0 +1,128 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { memo } from 'react';
+
+import { useAppSelector, useAppDispatch } from 'src/store';
+
+import useTranscriptViewIds from 'src/content/app/entity-viewer/transcript-view/hooks/useTranscriptViewIds';
+
+import {
+  getIsSidebarOpen,
+  getSidebarModalView
+} from 'src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSelectors';
+
+import {
+  openSidebar,
+  openSidebarModal,
+  closeSidebarModal,
+  type SidebarModalView
+} from 'src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSlice';
+
+import ImageButton from 'src/shared/components/image-button/ImageButton';
+
+import SearchIcon from 'static/icons/icon_search.svg';
+import BookmarkIcon from 'static/icons/icon_bookmark.svg';
+import ShareIcon from 'static/icons/icon_share.svg';
+import DownloadIcon from 'static/icons/icon_download.svg';
+
+import { Status } from 'src/shared/types/status';
+
+import styles from 'src/shared/components/layout/StandardAppLayout.module.css';
+
+export const SidebarToolstrip = () => {
+  const { activeGenomeId, transcriptId } = useTranscriptViewIds();
+  const sidebarModalView = useAppSelector((state) =>
+    getSidebarModalView(state, activeGenomeId ?? '', transcriptId ?? '')
+  );
+  const isSidebarOpen = useAppSelector((state) =>
+    getIsSidebarOpen(state, activeGenomeId ?? '', transcriptId ?? '')
+  );
+  const dispatch = useAppDispatch();
+
+  const toggleModalView = (view: SidebarModalView) => {
+    if (!activeGenomeId || !transcriptId) {
+      // this should not happen
+      return;
+    }
+    if (!isSidebarOpen) {
+      dispatch(
+        openSidebar({
+          genomeId: activeGenomeId,
+          transcriptId
+        })
+      );
+    }
+
+    if (view === sidebarModalView) {
+      dispatch(
+        closeSidebarModal({
+          genomeId: activeGenomeId,
+          transcriptId
+        })
+      );
+    } else {
+      dispatch(
+        openSidebarModal({
+          genomeId: activeGenomeId,
+          transcriptId,
+          view
+        })
+      );
+    }
+  };
+
+  const getViewIconStatus = (selectedItem: SidebarModalView) => {
+    return selectedItem === sidebarModalView && isSidebarOpen
+      ? Status.SELECTED
+      : Status.UNSELECTED;
+  };
+
+  return (
+    <>
+      <ImageButton
+        status={getViewIconStatus('search')}
+        description="Search"
+        className={styles.sidebarIcon}
+        onClick={() => toggleModalView('search')}
+        image={SearchIcon}
+      />
+      <ImageButton
+        status={getViewIconStatus('bookmarks')}
+        description="Previously viewed"
+        className={styles.sidebarIcon}
+        onClick={() => toggleModalView('bookmarks')}
+        image={BookmarkIcon}
+      />
+      <ImageButton
+        status={Status.DISABLED}
+        description="Share"
+        className={styles.sidebarIcon}
+        key="share"
+        image={ShareIcon}
+      />
+      <ImageButton
+        status={getViewIconStatus('download')}
+        description="Download"
+        className={styles.sidebarIcon}
+        onClick={() => toggleModalView('download')}
+        image={DownloadIcon}
+      />
+    </>
+  );
+};
+
+export default memo(SidebarToolstrip);

--- a/src/shared/components/feature-summary-strip/GeneSummaryStrip.tsx
+++ b/src/shared/components/feature-summary-strip/GeneSummaryStrip.tsx
@@ -41,14 +41,17 @@ type Props = {
 };
 
 const GeneSummaryStrip = (props: Props) => {
-  const { gene } = props;
+  const { gene, className: classNameFromProps, ref } = props;
 
-  const stripClasses = classNames(styles.featureSummaryStrip, props.className);
+  const componentClasses = classNames(
+    styles.featureSummaryStrip,
+    classNameFromProps
+  );
 
   return (
-    <div className={stripClasses} ref={props.ref}>
-      <GeneName {...props} />
-      <Biotype {...props} />
+    <div className={componentClasses} ref={ref}>
+      <GeneName gene={gene} />
+      <Biotype gene={gene} />
       {gene.strand && (
         <div className={styles.section}>
           {getStrandDisplayName(gene.strand)}

--- a/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.module.css
+++ b/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.module.css
@@ -1,142 +1,154 @@
-.checkboxGrid {
-  margin-top: 0.5em;
-  display: grid;
-  grid-template-columns: repeat(2, max-content);
-  grid-template-rows: auto;
-  column-gap: 42px;
-  row-gap: 0.2em;
-}
+/*
 
-.label {
-  margin-bottom: 0.5em;
-  font-weight: var(--font-weight-light);
-  word-break: break-all;
-  font-size: 12px;
-}
+This component exposes the following parts for styling
+that can be directly targeted by the parent:
+- data-part="transcript-section"
+- data-part="transcript-visualization"
+- data-part="transcript-section-checkbox-grid"
 
-.featureId {
-  margin-left: 0.5em;
-  font-weight: var(--font-weight-normal);
-}
+*/
 
-.transcriptVis {
-  margin-top: 18px;
-  margin-bottom: 9px;
-}
-
-.downloadButton {
-  align-self: end;
-  justify-self: end;
-  font-size: 12px;
-}
-
-.geneSection .checkboxes {
-  display: flex;
-  flex-direction: column;
-}
-
-.layout {
-  display: grid;
-  font-size: 13px;
-  align-items: start;
-}
-
-.layoutHorizontal {
-  grid-template-columns: 1fr 1fr;
-  column-gap: 10px;
-  grid-template-areas:
-    'transcript gene'
-    'transcript download';
-  margin-bottom: 12px;
-}
-
-.layoutHorizontal .transcriptSection {
-  grid-area: transcript;
-  width: 393px;
-}
-
-.layoutHorizontal .geneSection {
-  grid-area: gene;
-}
-
-.layoutHorizontal .geneSection .checkbox {
-  margin-left: 12px;
-}
-
-.layoutHorizontal .transcriptVis {
-  margin-left: 12px;
-}
-
-.layoutHorizontal .checkboxGrid {
-  padding-left: 14px;
-}
-
-.layoutHorizontal button {
-  grid-area: download;
-  justify-self: end;
-  align-self: end;
-}
-
-
-.layoutVertical {
-  row-gap: 0.5rem;
-}
-
-.layoutVertical .transcriptSection,
-.layoutVertical .geneSection {
-  padding-left: 18px;
-}
-
-.layoutVertical .geneSection {
-  margin-top: 18px;
-  margin-bottom: 18px;
-}
-
-.layoutVertical .geneSection .label {
-  margin-left: -18px;
-}
-
-.layoutVertical .geneSection .checkbox {
-  margin-left: 6px;
-}
-
-.layoutVertical .geneSection .checkbox:first-child {
-  margin-top: 12px;
-}
-
-.layoutVertical .transcriptSection .label {
-  margin-left: -18px;
-}
-
-.layoutVertical .checkboxGrid {
-  grid-template-columns: repeat(3, max-content);
-  grid-template-areas:
-    'genomic cdna exons'
-    'protein cds .';
-  padding-left: 6px;
-
-  .genomic {
-    grid-area: genomic;
+@layer components {
+ .checkboxGrid {
+    margin-top: 0.5em;
+    display: grid;
+    grid-template-columns: repeat(2, max-content);
+    grid-template-rows: auto;
+    column-gap: 42px;
+    row-gap: 0.2em;
   }
 
-  .cdna {
-    grid-area: cdna;
+  .label {
+    margin-bottom: 0.5em;
+    font-weight: var(--font-weight-light);
+    word-break: break-all;
+    font-size: 12px;
   }
 
-  .exons {
-    grid-area: exons;
+  .featureId {
+    margin-left: 0.5em;
+    font-weight: var(--font-weight-normal);
   }
 
-  .protein {
-    grid-area: protein;
+  .transcriptVis {
+    margin-top: 18px;
+    margin-bottom: 9px;
   }
 
-  .cds {
-    grid-area: cds;
+  .downloadButton {
+    align-self: end;
+    justify-self: end;
+    font-size: 12px;
   }
-}
 
-.layoutVertical button {
-  justify-self: end;
-  align-self: end;
+  .geneSection .checkboxes {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .layout {
+    display: grid;
+    font-size: 13px;
+    align-items: start;
+  }
+
+  .layoutHorizontal {
+    grid-template-columns: 1fr 1fr;
+    column-gap: 10px;
+    grid-template-areas:
+      'transcript gene'
+      'transcript download';
+    margin-bottom: 12px;
+  }
+
+  .layoutHorizontal .transcriptSection {
+    grid-area: transcript;
+    width: 393px;
+  }
+
+  .layoutHorizontal .geneSection {
+    grid-area: gene;
+  }
+
+  .layoutHorizontal .geneSection .checkbox {
+    margin-left: 12px;
+  }
+
+  .layoutHorizontal .transcriptVis {
+    margin-left: 12px;
+  }
+
+  .layoutHorizontal .checkboxGrid {
+    padding-left: 14px;
+  }
+
+  .layoutHorizontal button {
+    grid-area: download;
+    justify-self: end;
+    align-self: end;
+  }
+
+
+  .layoutVertical {
+    row-gap: 0.5rem;
+  }
+
+  .layoutVertical .transcriptSection,
+  .layoutVertical .geneSection {
+    padding-left: 18px;
+  }
+
+  .layoutVertical .geneSection {
+    margin-top: 18px;
+    margin-bottom: 18px;
+  }
+
+  .layoutVertical .geneSection .label {
+    margin-left: -18px;
+  }
+
+  .layoutVertical .geneSection .checkbox {
+    margin-left: 6px;
+  }
+
+  .layoutVertical .geneSection .checkbox:first-child {
+    margin-top: 12px;
+  }
+
+  .layoutVertical .transcriptSection .label {
+    margin-left: -18px;
+  }
+
+  .layoutVertical .checkboxGrid {
+    grid-template-columns: repeat(3, max-content);
+    grid-template-areas:
+      'genomic cdna exons'
+      'protein cds .';
+    padding-left: 6px;
+
+    .genomic {
+      grid-area: genomic;
+    }
+
+    .cdna {
+      grid-area: cdna;
+    }
+
+    .exons {
+      grid-area: exons;
+    }
+
+    .protein {
+      grid-area: protein;
+    }
+
+    .cds {
+      grid-area: cds;
+    }
+  }
+
+  .layoutVertical button {
+    justify-self: end;
+    align-self: end;
+  }
 }

--- a/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.tsx
+++ b/src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript.tsx
@@ -62,6 +62,7 @@ export type InstantDownloadTranscriptEntityProps = {
 type Props = InstantDownloadTranscriptEntityProps & {
   layout?: Layout;
   theme?: Theme;
+  className?: string;
 };
 
 type TranscriptSectionProps = {
@@ -190,7 +191,7 @@ const InstantDownloadTranscript = (props: Props) => {
     });
   };
 
-  const wrapperClasses = classNames(styles.layout, {
+  const wrapperClasses = classNames(styles.layout, props.className, {
     [styles.layoutHorizontal]: layout === 'horizontal',
     [styles.layoutVertical]: layout === 'vertical'
   });
@@ -253,13 +254,23 @@ const TranscriptSection = (props: TranscriptSectionProps) => {
   );
 
   return (
-    <div className={styles.transcriptSection}>
+    <div data-part="transcript-section" className={styles.transcriptSection}>
       <div className={styles.label}>
         Transcript
         <span className={styles.featureId}>{transcript.id}</span>
       </div>
-      <div className={styles.transcriptVis}>{transcriptVisualisation}</div>
-      <div className={styles.checkboxGrid}>{checkboxes}</div>
+      <div
+        data-part="transcript-visualization"
+        className={styles.transcriptVis}
+      >
+        {transcriptVisualisation}
+      </div>
+      <div
+        data-part="transcript-section-checkbox-grid"
+        className={styles.checkboxGrid}
+      >
+        {checkboxes}
+      </div>
     </div>
   );
 };

--- a/src/shared/helpers/urlHelper.ts
+++ b/src/shared/helpers/urlHelper.ts
@@ -145,12 +145,13 @@ export const entityViewer = (params?: EntityViewerUrlParams) => {
   return query ? `${path}?${query}` : path;
 };
 
-export const entityViewerTranscript = (params?: {
+export const entityViewerTranscript = (params: {
   genomeId: string;
   transcriptId: string;
   view?: string | null;
 }) => {
-  const pathname = '/entity-viewer/${genomeId}/${transcriptId}';
+  const { genomeId, transcriptId } = params;
+  const pathname = `/entity-viewer/${genomeId}/${transcriptId}`;
   const urlSearchParams = new URLSearchParams('');
   if (params?.view) {
     urlSearchParams.append('view', params.view);

--- a/src/shared/helpers/urlHelper.ts
+++ b/src/shared/helpers/urlHelper.ts
@@ -145,6 +145,21 @@ export const entityViewer = (params?: EntityViewerUrlParams) => {
   return query ? `${path}?${query}` : path;
 };
 
+export const entityViewerTranscript = (params?: {
+  genomeId: string;
+  transcriptId: string;
+  view?: string | null;
+}) => {
+  const pathname = '/entity-viewer/${genomeId}/${transcriptId}';
+  const urlSearchParams = new URLSearchParams('');
+  if (params?.view) {
+    urlSearchParams.append('view', params.view);
+  }
+  const query = decodeURIComponent(urlSearchParams.toString());
+
+  return query ? `${pathname}?${query}` : pathname;
+};
+
 export const entityViewerVariant = (params?: {
   genomeId?: string | null;
   variantId?: string | null;


### PR DESCRIPTION
## Description
- [x] Added transcript summary strip to the grey bar at the top
- [x] Added a buttons toolstrip to the tidebar (the vertical grey bar with buttons)
- [x] Enabled sidebar modals (search, with no content; previously viewed objects, download)
  - [x] "Search" and "previously used" modals are reused
  - [x] "Download" modal updated to specifically address the transcript
- [x] Added the "Find" and the "View in" buttons to the sidebar 
- [x] Fixed page metadata for transcript page
- [x] Fixed the stale page metadata that occurred during client-side navigation from one entity to another in entity viewer

## Related JIRA Issue(s)
Related to https://embl.atlassian.net/browse/ENSWBSITES-2993

## Deployment URL(s)
http://ev-transcript-as-object.review.ensembl.org

Example: http://ev-transcript-as-object.review.ensembl.org/entity-viewer/grch38/transcript:ENST00000380152
