### PR TITLE
Update Github action

### DIFF
--- a/.github/workflows/delete_gitlab_branch.yaml
+++ b/.github/workflows/delete_gitlab_branch.yaml
@@ -6,6 +6,8 @@ on:
       - master
       - dev
 
+permissions: {}
+
 jobs:
   branch-delete:
     if: github.event.ref_type == 'branch'


### PR DESCRIPTION
Potential fix for [https://github.com/Ensembl/ensembl-client/security/code-scanning/1](https://github.com/Ensembl/ensembl-client/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is restricted by default.

Best fix here (without changing existing functionality): add a root-level permissions map with no granted scopes (`permissions: {}`), since this workflow only calls GitLab using `secrets.GITLAB_TOKEN` and does not need GitHub API/token capabilities. This is the most restrictive and safe option.

Change needed:
- **File:** `.github/workflows/delete_gitlab_branch.yaml`
- **Region:** after `on:` block (before `jobs:`)
- **Edit:** insert:
  ```yaml
  permissions: {}
  ```

No imports, methods, or dependencies are required.
