### PR TITLE
Fix focus object during species change in Genome Browser

### DIFF
--- a/src/content/app/genome-browser/contexts/genome-browser-ids-context/useGenomeBrowserUrlValidator.ts
+++ b/src/content/app/genome-browser/contexts/genome-browser-ids-context/useGenomeBrowserUrlValidator.ts
@@ -178,18 +178,21 @@ const useGenomeBrowserUrlValidator = (params: Params) => {
     stateRef.current = currentState;
   }, [currentState]);
 
-  const runAfterValidation = (fn: () => unknown) => {
-    if (
-      !hasFocusObjectToValidate ||
-      (stateRef.current.doneValidating &&
-        !stateRef.current.isMissingFocusObject &&
-        !stateRef.current.isInvalidLocation)
-    ) {
-      fn();
-    } else {
-      postValidationQueueRef.current.push(fn);
-    }
-  };
+  const runAfterValidation = useCallback(
+    (fn: () => unknown) => {
+      if (
+        !hasFocusObjectToValidate ||
+        (stateRef.current.doneValidating &&
+          !stateRef.current.isMissingFocusObject &&
+          !stateRef.current.isInvalidLocation)
+      ) {
+        fn();
+      } else {
+        postValidationQueueRef.current.push(fn);
+      }
+    },
+    [hasFocusObjectToValidate]
+  );
 
   const resetValidator = () => {
     setValidationResultState({

--- a/src/content/app/genome-browser/hooks/useBrowserRouting.ts
+++ b/src/content/app/genome-browser/hooks/useBrowserRouting.ts
@@ -93,6 +93,64 @@ const useBrowserRouting = () => {
 
   const chrLocation = location ? getParsedChromosomeLocation(location) : null;
 
+  const changeGenomeId = useCallback(
+    (genomeId: string) => {
+      const species = allCommittedSpecies.find(
+        (species) => species.genome_id === genomeId
+      ) as CommittedItem;
+      const genomeIdForUrl = species.genome_tag ?? species.genome_id;
+      const chrLocation = allChrLocations[genomeId];
+      const activeFocusObjectId = allActiveFocusObjectIds[genomeId];
+      const focusIdForUrl = activeFocusObjectId
+        ? buildFocusIdForUrl(activeFocusObjectId)
+        : null;
+
+      const nextUrlParams = {
+        genomeId: genomeIdForUrl,
+        focus: focusIdForUrl,
+        location: chrLocation ? getChrLocationStr(chrLocation) : null
+      };
+
+      dispatch(setActiveGenomeId(genomeId));
+      // Consider it as first render when we change genome
+      firstRenderRef.current = true;
+
+      // In case the url is simply /genome-browser, use the `replace` history method to redirect the user further.
+      // This will allow the user to return from the next page (genome browser with genome id selected)
+      // back to the page from which they have navigated to the current one. If the `push` method is used,
+      // the user will not be able to get back past this page, because the url without genome id will remain
+      // in the history, and the user will be forcefully redirected to the url with the genome id.
+      //
+      // NOTE: the logic will likely change in the future when /genome-browser without the selected genome id
+      // becomes a valid searchable page in its own right.
+
+      navigate(urlFor.browser(nextUrlParams), { replace: !genomeIdInUrl });
+    },
+    [
+      genomeIdInUrl,
+      allActiveFocusObjectIds,
+      allChrLocations,
+      allCommittedSpecies,
+      dispatch,
+      navigate
+    ]
+  );
+
+  const shouldUpdateRedux = useCallback(() => {
+    return (
+      genomeId !== activeGenomeId ||
+      focusObjectId !== activeFocusObjectId ||
+      !isEqual(chrLocation, allChrLocations[activeGenomeId])
+    );
+  }, [
+    genomeId,
+    activeGenomeId,
+    focusObjectId,
+    activeFocusObjectId,
+    chrLocation,
+    allChrLocations
+  ]);
+
   useEffect(() => {
     if (!genomeIdInUrl) {
       // handling navigation to /browser
@@ -159,15 +217,31 @@ const useBrowserRouting = () => {
       }
     }
 
-    runAfterValidation(() => {
-      dispatch(setDataFromUrlAndSave(payload));
-    });
+    if (shouldUpdateRedux()) {
+      runAfterValidation(() => {
+        dispatch(setDataFromUrlAndSave(payload));
+      });
+    }
   }, [
     genomeId,
+    activeGenomeId,
+    activeFocusObjectId,
+    allChrLocations,
+    allCommittedSpecies,
+    changeBrowserLocation,
+    changeFocusObject,
+    changeGenomeId,
+    chrLocation,
+    genomeIdForUrl,
+    genomeIdInUrl,
+    runAfterValidation,
     isFetchingGenomeId,
     focusObjectIdInUrl,
     focusObjectId,
     genomeBrowser,
+    shouldUpdateRedux,
+    dispatch,
+    navigate,
     location
   ]);
 
@@ -175,43 +249,7 @@ const useBrowserRouting = () => {
     if (!focusObject && activeFocusObjectId) {
       dispatch(fetchFocusObject(activeFocusObjectId));
     }
-  }, [focusObject, activeFocusObjectId]);
-
-  const changeGenomeId = useCallback(
-    (genomeId: string) => {
-      const species = allCommittedSpecies.find(
-        (species) => species.genome_id === genomeId
-      ) as CommittedItem;
-      const genomeIdForUrl = species.genome_tag ?? species.genome_id;
-      const chrLocation = allChrLocations[genomeId];
-      const activeFocusObjectId = allActiveFocusObjectIds[genomeId];
-      const focusIdForUrl = activeFocusObjectId
-        ? buildFocusIdForUrl(activeFocusObjectId)
-        : null;
-
-      const nextUrlParams = {
-        genomeId: genomeIdForUrl,
-        focus: focusIdForUrl,
-        location: chrLocation ? getChrLocationStr(chrLocation) : null
-      };
-
-      dispatch(setActiveGenomeId(genomeId));
-      // Consider it as first render when we change genome
-      firstRenderRef.current = true;
-
-      // In case the url is simply /genome-browser, use the `replace` history method to redirect the user further.
-      // This will allow the user to return from the next page (genome browser with genome id selected)
-      // back to the page from which they have navigated to the current one. If the `push` method is used,
-      // the user will not be able to get back past this page, because the url without genome id will remain
-      // in the history, and the user will be forcefully redirected to the url with the genome id.
-      //
-      // NOTE: the logic will likely change in the future when /genome-browser without the selected genome id
-      // becomes a valid searchable page in its own right.
-
-      navigate(urlFor.browser(nextUrlParams), { replace: !genomeIdInUrl });
-    },
-    [genomeIdInUrl]
-  );
+  }, [focusObject, activeFocusObjectId, dispatch]);
 
   return {
     changeGenomeId


### PR DESCRIPTION
## Description
### Bug description
- Have several species selected in the genome browser
- In one of the species, view a gene, then, by modifying the url, view a transcript (this will cause the page to reload); then, open the list of previously viewed features, and go to a previously viewed gene. The point is to keep more than one focus objects for a genome in memory
- Now, switch to a different species, then back to the initial one. You will notice that the species that you started with will sometimes focus on a gene, and other times on a transcript, in what seems to be a random order

https://github.com/user-attachments/assets/f359f406-d27f-460c-ab5e-4ab1e77943bc

### What this PR does
My hypothesis is that something is wrong in the `useBrowserRouting` hook. It is awfully written; and hopefully, we will get to refactoring it in the future. Meanwhile, I have updated the dependency array of a `useEffect` to include all variables that it captures from the outer scope. At first, this caused an infinite re-render of the component, because every time the hook runs, it updates the redux state, which causes a re-render, which triggers the hook. So I added a check before updating the redux state. 

## Deployment URL(s)
http://fix-species-switch-in-gb.review.ensembl.org
