### PR TITLE
Fix bugs with messaging to the genome browser

### DIFF
--- a/src/content/app/genome-browser/hooks/useBrowserRouting.ts
+++ b/src/content/app/genome-browser/hooks/useBrowserRouting.ts
@@ -34,6 +34,7 @@ import {
   parseFocusIdFromUrl
 } from 'src/shared/helpers/focusObjectHelpers';
 
+import { setActiveGenomeId } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSlice';
 import { setDataFromUrlAndSave } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSlice';
 import { fetchFocusObject } from 'src/content/app/genome-browser/state/focus-object/focusObjectSlice';
 
@@ -113,6 +114,7 @@ const useBrowserRouting = () => {
         location: chrLocation ? getChrLocationStr(chrLocation) : null
       };
 
+      dispatch(setActiveGenomeId(genomeId));
       // Consider it as first render when we change genome
       firstRenderRef.current = true;
 
@@ -132,6 +134,7 @@ const useBrowserRouting = () => {
       allActiveFocusObjectIds,
       allChrLocations,
       allCommittedSpecies,
+      dispatch,
       navigate
     ]
   );
@@ -152,8 +155,8 @@ const useBrowserRouting = () => {
     previousChrLocation: ChrLocation | null | undefined;
   }) => {
     return (
-      genomeId === previousGenomeId ||
-      focusObjectIdInUrl === previousFocusObjectIdInUrl ||
+      genomeId === previousGenomeId &&
+      focusObjectIdInUrl === previousFocusObjectIdInUrl &&
       JSON.stringify(chrLocation) === JSON.stringify(previousChrLocation)
     );
   };

--- a/src/content/app/genome-browser/hooks/useBrowserRouting.ts
+++ b/src/content/app/genome-browser/hooks/useBrowserRouting.ts
@@ -21,6 +21,7 @@ import isEqual from 'lodash/isEqual';
 import { useAppSelector, useAppDispatch, type RootState } from 'src/store';
 import useGenomeBrowser from 'src/content/app/genome-browser/hooks/useGenomeBrowser';
 import useGenomeBrowserIds from 'src/content/app/genome-browser/hooks/useGenomeBrowserIds';
+import usePrevious from 'src/shared/hooks/usePrevious';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import {
@@ -33,10 +34,7 @@ import {
   parseFocusIdFromUrl
 } from 'src/shared/helpers/focusObjectHelpers';
 
-import {
-  setActiveGenomeId,
-  setDataFromUrlAndSave
-} from 'src/content/app/genome-browser/state/browser-general/browserGeneralSlice';
+import { setDataFromUrlAndSave } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSlice';
 import { fetchFocusObject } from 'src/content/app/genome-browser/state/focus-object/focusObjectSlice';
 
 import { getEnabledCommittedSpecies } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors';
@@ -45,6 +43,7 @@ import { getFocusObjectById } from 'src/content/app/genome-browser/state/focus-o
 import { getAllChrLocations } from '../state/browser-general/browserGeneralSelectors';
 
 import type { CommittedItem } from 'src/content/app/species-selector/types/committedItem';
+import type { ChrLocation } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSlice';
 
 /*
  * Possible urls that the GenomeBrowser page has to deal with:
@@ -92,6 +91,9 @@ const useBrowserRouting = () => {
   );
 
   const chrLocation = location ? getParsedChromosomeLocation(location) : null;
+  const previousGenomeId = usePrevious(genomeId);
+  const previousFocusObjectIdInUrl = usePrevious(focusObjectIdInUrl);
+  const previousChrLocation = usePrevious(chrLocation);
 
   const changeGenomeId = useCallback(
     (genomeId: string) => {
@@ -111,7 +113,6 @@ const useBrowserRouting = () => {
         location: chrLocation ? getChrLocationStr(chrLocation) : null
       };
 
-      dispatch(setActiveGenomeId(genomeId));
       // Consider it as first render when we change genome
       firstRenderRef.current = true;
 
@@ -131,10 +132,31 @@ const useBrowserRouting = () => {
       allActiveFocusObjectIds,
       allChrLocations,
       allCommittedSpecies,
-      dispatch,
       navigate
     ]
   );
+
+  const areSameParameters = ({
+    genomeId,
+    previousGenomeId,
+    focusObjectIdInUrl,
+    previousFocusObjectIdInUrl,
+    chrLocation,
+    previousChrLocation
+  }: {
+    genomeId: string | undefined;
+    previousGenomeId: string | undefined;
+    focusObjectIdInUrl: string | null;
+    previousFocusObjectIdInUrl: string | null;
+    chrLocation: ChrLocation | null | undefined;
+    previousChrLocation: ChrLocation | null | undefined;
+  }) => {
+    return (
+      genomeId === previousGenomeId ||
+      focusObjectIdInUrl === previousFocusObjectIdInUrl ||
+      JSON.stringify(chrLocation) === JSON.stringify(previousChrLocation)
+    );
+  };
 
   const shouldUpdateRedux = useCallback(() => {
     return (
@@ -197,23 +219,34 @@ const useBrowserRouting = () => {
       */
       changeFocusObject(focusObjectId);
     } else if (focusObjectIdInUrl && chrLocation && genomeBrowser) {
-      const isSameLocationAsInRedux =
-        activeGenomeId && isEqual(chrLocation, allChrLocations[activeGenomeId]);
-      const isFirstRender = firstRenderRef.current;
-      if (genomeId && genomeBrowser) {
-        if (!isSameLocationAsInRedux || isFirstRender) {
-          const { type, objectId } = parseFocusIdFromUrl(focusObjectIdInUrl);
-          changeBrowserLocation({
-            genomeId,
-            chrLocation,
-            focus: {
-              type,
-              id: objectId
-            }
-          });
+      const sameAsPrev = areSameParameters({
+        genomeId,
+        previousGenomeId,
+        focusObjectIdInUrl,
+        previousFocusObjectIdInUrl,
+        chrLocation,
+        previousChrLocation
+      });
 
-          firstRenderRef.current = false;
-        }
+      const isFirstRender = firstRenderRef.current;
+
+      if ((isFirstRender && genomeId) || (!sameAsPrev && genomeId)) {
+        const { type, objectId } = parseFocusIdFromUrl(focusObjectIdInUrl);
+        changeBrowserLocation({
+          genomeId,
+          chrLocation,
+          focus: {
+            type,
+            id: objectId
+          }
+        });
+      }
+      if (isFirstRender) {
+        firstRenderRef.current = false;
+        runAfterValidation(() => {
+          dispatch(setDataFromUrlAndSave(payload));
+        });
+        return;
       }
     }
 
@@ -224,6 +257,7 @@ const useBrowserRouting = () => {
     }
   }, [
     genomeId,
+    previousGenomeId,
     activeGenomeId,
     activeFocusObjectId,
     allChrLocations,
@@ -232,11 +266,13 @@ const useBrowserRouting = () => {
     changeFocusObject,
     changeGenomeId,
     chrLocation,
+    previousChrLocation,
     genomeIdForUrl,
     genomeIdInUrl,
     runAfterValidation,
     isFetchingGenomeId,
     focusObjectIdInUrl,
+    previousFocusObjectIdInUrl,
     focusObjectId,
     genomeBrowser,
     shouldUpdateRedux,

--- a/src/content/app/genome-browser/hooks/useFocusTrack.ts
+++ b/src/content/app/genome-browser/hooks/useFocusTrack.ts
@@ -129,10 +129,11 @@ const useFocusGene = (params: UseFocusGeneParams) => {
   const showSeveralTranscriptsRef = useRef(
     focusGeneTrackSettings?.settings.several
   );
+  const visibleTranscriptsReportedRef = useRef(false);
   const previousSeveralTranscriptsSetting = usePrevious(
     focusGeneTrackSettings?.settings.several
   );
-  const previousVisibleTranscriptIds = usePrevious(visibleTranscriptIds);
+  const previousVisibleTranscriptIdsRef = useRef<string[]>(null);
 
   const { currentData: fetchedFocusGeneData } = useGetTrackPanelGeneQuery(
     {
@@ -208,8 +209,8 @@ const useFocusGene = (params: UseFocusGeneParams) => {
         const focusGeneTrackInfo = getFocusGeneTrackInfo(
           message.payload.summary
         );
-        if (!focusGeneTrackInfo) {
-          return; // shouldn't happen
+        if (!focusGeneTrackInfo || !visibleTranscriptsReportedRef.current) {
+          return;
         }
 
         const { gene_id, transcript_ids } = focusGeneTrackInfo;
@@ -254,7 +255,13 @@ const useFocusGene = (params: UseFocusGeneParams) => {
    * 2) if not, then what is the value of the 1/5 transcripts toggle in track settings panel
    */
   useEffect(() => {
-    if (!geneStableId || !fetchedFocusGeneData || !focusGene) {
+    // NOTE updateFocusGeneTranscripts requires genomeBrowser to be defined
+    if (
+      !genomeBrowser ||
+      !geneStableId ||
+      !fetchedFocusGeneData ||
+      !focusGene
+    ) {
       return;
     }
 
@@ -274,19 +281,24 @@ const useFocusGene = (params: UseFocusGeneParams) => {
         numberOfTranscriptsToShow
       );
       updateFocusGeneTranscripts(transcriptIds);
-    } else if (visibleTranscriptIds !== previousVisibleTranscriptIds) {
+      previousVisibleTranscriptIdsRef.current = visibleTranscriptIds;
+      visibleTranscriptsReportedRef.current = true;
+    } else if (
+      visibleTranscriptIds !== previousVisibleTranscriptIdsRef.current
+    ) {
       updateFocusGeneTranscripts(visibleTranscriptIds);
+      previousVisibleTranscriptIdsRef.current = visibleTranscriptIds;
+      visibleTranscriptsReportedRef.current = true;
     }
   }, [
-    genomeBrowser, // updateFocusGeneTranscripts requires genomeBrowser to be defined
+    genomeBrowser,
     geneStableId,
     focusGeneTrackSettings?.settings.several,
     fetchedFocusGeneData,
     previousSeveralTranscriptsSetting,
     updateFocusGeneTranscripts,
     focusGene,
-    visibleTranscriptIds,
-    previousVisibleTranscriptIds
+    visibleTranscriptIds
   ]);
 
   // apply track settings other than several transcripts

--- a/src/content/app/genome-browser/hooks/useFocusTrack.ts
+++ b/src/content/app/genome-browser/hooks/useFocusTrack.ts
@@ -129,7 +129,6 @@ const useFocusGene = (params: UseFocusGeneParams) => {
   const showSeveralTranscriptsRef = useRef(
     focusGeneTrackSettings?.settings.several
   );
-  const visibleTranscriptsReportedRef = useRef(false);
   const previousSeveralTranscriptsSetting = usePrevious(
     focusGeneTrackSettings?.settings.several
   );
@@ -209,7 +208,7 @@ const useFocusGene = (params: UseFocusGeneParams) => {
         const focusGeneTrackInfo = getFocusGeneTrackInfo(
           message.payload.summary
         );
-        if (!focusGeneTrackInfo || !visibleTranscriptsReportedRef.current) {
+        if (!focusGeneTrackInfo) {
           return;
         }
 
@@ -282,13 +281,11 @@ const useFocusGene = (params: UseFocusGeneParams) => {
       );
       updateFocusGeneTranscripts(transcriptIds);
       previousVisibleTranscriptIdsRef.current = visibleTranscriptIds;
-      visibleTranscriptsReportedRef.current = true;
     } else if (
       visibleTranscriptIds !== previousVisibleTranscriptIdsRef.current
     ) {
       updateFocusGeneTranscripts(visibleTranscriptIds);
       previousVisibleTranscriptIdsRef.current = visibleTranscriptIds;
-      visibleTranscriptsReportedRef.current = true;
     }
   }, [
     genomeBrowser,

--- a/src/content/app/genome-browser/hooks/useGenomeBrowserPosition.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowserPosition.ts
@@ -31,7 +31,6 @@ import {
 
 import {
   updateActualChrLocation,
-  updateChrLocation,
   type ChrLocation
 } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSlice';
 
@@ -84,11 +83,6 @@ const useGenomeBrowserPosition = () => {
       } else {
         const chrLocation = [chromosome, start, end] as ChrLocation;
 
-        dispatch(
-          updateChrLocation({
-            [activeGenomeId as string]: [chromosome, start, end]
-          })
-        );
         navigate(
           urlFor.browser({
             genomeId: genomeIdForUrl,

--- a/src/content/app/genome-browser/hooks/useGenomeBrowserPosition.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowserPosition.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useCallback, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
@@ -66,6 +66,44 @@ const useGenomeBrowserPosition = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
 
+  const onBrowserLocationChange = useCallback(
+    (message: CurrentPositionMessage | TargetPositionMessage) => {
+      const { activeGenomeId, genomeIdForUrl, focusObjectIdForUrl } =
+        idRef.current;
+      const { stick, start, end } = message.payload;
+      const [genomeId, chromosome] = stick.split(':');
+
+      if (genomeId !== activeGenomeId) {
+        // ignore the message, because it must be a delayed message for the previous species
+        // when the user has already switched to another one
+        return;
+      }
+
+      if (message.type === 'current_position') {
+        dispatch(updateActualChrLocation([chromosome, start, end]));
+      } else {
+        const chrLocation = [chromosome, start, end] as ChrLocation;
+
+        dispatch(
+          updateChrLocation({
+            [activeGenomeId as string]: [chromosome, start, end]
+          })
+        );
+        navigate(
+          urlFor.browser({
+            genomeId: genomeIdForUrl,
+            focus: focusObjectIdForUrl,
+            location: getChrLocationStr(chrLocation)
+          }),
+          {
+            replace: true
+          }
+        );
+      }
+    },
+    [dispatch, navigate]
+  );
+
   useEffect(() => {
     idRef.current = {
       activeGenomeId,
@@ -91,44 +129,7 @@ const useGenomeBrowserPosition = () => {
       subscriptionToActualPotitionMessages?.unsubscribe();
       subscriptionToTargetPotitionMessages?.unsubscribe();
     };
-  }, [genomeBrowserService]);
-
-  const onBrowserLocationChange = (
-    message: CurrentPositionMessage | TargetPositionMessage
-  ) => {
-    const { activeGenomeId, genomeIdForUrl, focusObjectIdForUrl } =
-      idRef.current;
-    const { stick, start, end } = message.payload;
-    const [genomeId, chromosome] = stick.split(':');
-
-    if (genomeId !== activeGenomeId) {
-      // ignore the message, because it must be a delayed message for the previous species
-      // when the user has already switched to another one
-      return;
-    }
-
-    if (message.type === 'current_position') {
-      dispatch(updateActualChrLocation([chromosome, start, end]));
-    } else {
-      const chrLocation = [chromosome, start, end] as ChrLocation;
-
-      dispatch(
-        updateChrLocation({
-          [activeGenomeId as string]: [chromosome, start, end]
-        })
-      );
-      navigate(
-        urlFor.browser({
-          genomeId: genomeIdForUrl,
-          focus: focusObjectIdForUrl,
-          location: getChrLocationStr(chrLocation)
-        }),
-        {
-          replace: true
-        }
-      );
-    }
-  };
+  }, [genomeBrowserService, onBrowserLocationChange]);
 };
 
 export default useGenomeBrowserPosition;

--- a/src/header/launchbar/GenomeBrowserLaunchbarButton.tsx
+++ b/src/header/launchbar/GenomeBrowserLaunchbarButton.tsx
@@ -1,0 +1,79 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useLocation } from 'react-router-dom';
+
+import { useAppSelector } from 'src/store';
+
+import * as urlFor from 'src/shared/helpers/urlHelper';
+
+import {
+  parseFocusObjectId,
+  buildFocusIdForUrl
+} from 'src/shared/helpers/focusObjectHelpers';
+import { getChrLocationStr } from 'src/content/app/genome-browser/helpers/browserHelper';
+
+import {
+  getBrowserActiveGenomeId,
+  getBrowserActiveFocusObjectId,
+  getChrLocation
+} from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
+import { getCommittedSpeciesById } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors';
+
+import LaunchbarButton from './LaunchbarButton';
+import { GenomeBrowserIcon } from 'src/shared/components/app-icon';
+
+const GenomeBrowserLaunchbarButton = () => {
+  const activeGenomeId = useAppSelector(getBrowserActiveGenomeId);
+  const focusObjectId = useAppSelector(getBrowserActiveFocusObjectId);
+  // const focusObject = useAppSelector(getBrowserActiveFocusObject);
+  const chrLocation = useAppSelector(getChrLocation);
+  const activeSpecies = useAppSelector((state) =>
+    getCommittedSpeciesById(state, activeGenomeId)
+  );
+  const location = useLocation();
+
+  const parsedFocusObjectId = focusObjectId
+    ? parseFocusObjectId(focusObjectId)
+    : null;
+
+  const genomeIdForUrl = activeSpecies?.genome_tag ?? activeGenomeId;
+  const focusIdForUrl = parsedFocusObjectId
+    ? buildFocusIdForUrl({
+        type: parsedFocusObjectId.type,
+        objectId: parsedFocusObjectId.objectId
+      })
+    : null;
+  const chrLocationString = chrLocation ? getChrLocationStr(chrLocation) : null;
+
+  const genomeBrowserUrl = urlFor.browser({
+    genomeId: genomeIdForUrl ?? null,
+    focus: focusIdForUrl,
+    location: chrLocationString
+  });
+
+  return (
+    <LaunchbarButton
+      path={genomeBrowserUrl}
+      description="Genome browser"
+      icon={GenomeBrowserIcon}
+      enabled={true}
+      isActive={location.pathname.startsWith('/genome-browser')}
+    />
+  );
+};
+
+export default GenomeBrowserLaunchbarButton;

--- a/src/header/launchbar/Launchbar.tsx
+++ b/src/header/launchbar/Launchbar.tsx
@@ -20,13 +20,10 @@ import classNames from 'classnames';
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import useHeaderAnalytics from '../hooks/useHeaderAnalytics';
 
-import {
-  GenomeBrowserIcon,
-  GlobalSearchIcon,
-  HelpIcon
-} from 'src/shared/components/app-icon';
+import { GlobalSearchIcon, HelpIcon } from 'src/shared/components/app-icon';
 import LaunchbarButton from './LaunchbarButton';
 import SpeciesSelectorLaunchbarButton from './SpeciesSelectorLaunchbarButton';
+import GenomeBrowserLaunchbarButton from './GenomeBrowserLaunchbarButton';
 import EntityViewerLaunchbarButton from './EntityViewerLaunchbarButton';
 import AlignmentsViewerLaunchbarButton from './AlignmentsViewerLaunchbarButton';
 import RegulatoryActivityViewerLaunchbarButton from './RegulationViewerLaunchbarButton';
@@ -62,12 +59,7 @@ const Launchbar = () => {
             <SpeciesSelectorLaunchbarButton />
           </div>
           <div className={styles.category}>
-            <LaunchbarButton
-              path="/genome-browser"
-              description="Genome browser"
-              icon={GenomeBrowserIcon}
-              enabled={true}
-            />
+            <GenomeBrowserLaunchbarButton />
             <AlignmentsViewerLaunchbarButton />
           </div>
           <div className={styles.category}>


### PR DESCRIPTION
## Description
This PR attempts to fix several bugs that are currently visible on staging.

1. The "dancing genome browser" bug, which is a regression introduced in [this PR](https://github.com/Ensembl/ensembl-client/pull/1305). It results from a desynchronisation between the location that the the client instructs the genome browser to go to, and the browser's confirmation that it has reached that location. It manifests as follows: user moves the genome browser to the side, or zooms in/out; the genome browser sends back a message to update the url; and this starts an infinite cycle of the client sending to the genome browser an older url location, the genome browser navigating to it, and sending back a message that updates the url, and so on, and so forth.

https://github.com/user-attachments/assets/95a24770-0594-49e1-a252-08936b2203d0

The fix for this bug is a slight modification of the `useBrowserRouting` hook. The regression was caused by adding all useEffect's dependencies to the dependency array, which increased the rate at which that hook was called, and broke the conditional logic somewhat. Note that the `useGenomeBrowserPosition` hook has also been updated slightly (one function wrapped in a useCallback and moved above a useEffect) to satisfy the linter.

2. Transcripts within gene become hidden after navigation from different app to genome browser.

This is a fairly old bug, which might have gotten worse recently. It presents as follows: you visit the genome browser for the first time (e.g. refresh the page) and confirm that you can see the gene with an enabled transcript. Then you navigate to a different page; and then you return to the genome browser — and you notice that the transcript in the gene has become disabled (visibly, only a faintly drawn canonical transcript).

https://github.com/user-attachments/assets/3a3e7b0f-72b5-452a-b30c-7b93253a010c

The cause of the bug was a race condition. On a return visit to the genome browser page, the focus object information is already present in redux, but the genome browser module has not loaded yet; and the useFocusTrack hooks sends a message prematurely, which the genome browser misses. See line 259 in the `useFocusTrack` file in the diff.


ALSO:
The PR updates the genome browser launchbar button, so that when user returns to the genome browser by pressing it, the generated url is not just the `/genome-browser`; but `/genome-browser/:genome?focus=focus-object&location=location`.  

## Deployment URL(s)
http://fix-gb-position.review.ensembl.org