### PR TITLE
Link genome groups to genome results table

### DIFF
--- a/src/content/app/species-selector/components/genome-groups/GenomeGroups.module.css
+++ b/src/content/app/species-selector/components/genome-groups/GenomeGroups.module.css
@@ -11,7 +11,10 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  align-self: flex-start;
   row-gap: 6px;
+  color: inherit;
+  text-decoration: none;
 }
 
 .groupTitle {

--- a/src/content/app/species-selector/components/genome-groups/GenomeGroups.module.css
+++ b/src/content/app/species-selector/components/genome-groups/GenomeGroups.module.css
@@ -11,10 +11,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  align-self: flex-start;
   row-gap: 6px;
-  color: inherit;
-  text-decoration: none;
 }
 
 .groupTitle {
@@ -35,4 +32,5 @@
   align-items: center;
   column-gap: 8px;
   color: var(--color-blue);
+  text-decoration: none;
 }

--- a/src/content/app/species-selector/components/genome-groups/GenomeGroups.module.css
+++ b/src/content/app/species-selector/components/genome-groups/GenomeGroups.module.css
@@ -32,5 +32,4 @@
   align-items: center;
   column-gap: 8px;
   color: var(--color-blue);
-  text-decoration: none;
 }

--- a/src/content/app/species-selector/components/genome-groups/GenomeGroups.tsx
+++ b/src/content/app/species-selector/components/genome-groups/GenomeGroups.tsx
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
+import { Link } from 'react-router-dom';
+
 import Pill from 'src/shared/components/pill/Pill';
+import * as urlFor from 'src/shared/helpers/urlHelper';
 
 import type {
   GenomeGroup as GenomeGroupType,
@@ -43,7 +46,12 @@ const GenomeGroup = (props: { group: GenomeGroupType }) => {
   const { group } = props;
 
   return (
-    <div className={styles.group}>
+    <Link
+      className={styles.group}
+      to={urlFor.speciesSelectorSearch({
+        genomeGroupId: group.group_id
+      })}
+    >
       <span className={styles.groupTitle}>{group.title}</span>
       {group.description && (
         <p className={styles.description}>{group.description}</p>
@@ -52,7 +60,7 @@ const GenomeGroup = (props: { group: GenomeGroupType }) => {
         <Pill>{group.genomes_count}</Pill>
         <span>genomes</span>
       </div>
-    </div>
+    </Link>
   );
 };
 

--- a/src/content/app/species-selector/components/genome-groups/GenomeGroups.tsx
+++ b/src/content/app/species-selector/components/genome-groups/GenomeGroups.tsx
@@ -16,8 +16,9 @@
 
 import { Link } from 'react-router-dom';
 
-import Pill from 'src/shared/components/pill/Pill';
 import * as urlFor from 'src/shared/helpers/urlHelper';
+
+import Pill from 'src/shared/components/pill/Pill';
 
 import type {
   GenomeGroup as GenomeGroupType,

--- a/src/content/app/species-selector/components/genome-groups/GenomeGroups.tsx
+++ b/src/content/app/species-selector/components/genome-groups/GenomeGroups.tsx
@@ -47,21 +47,21 @@ const GenomeGroup = (props: { group: GenomeGroupType }) => {
   const { group } = props;
 
   return (
-    <Link
-      className={styles.group}
-      to={urlFor.speciesSelectorSearch({
-        genomeGroupId: group.group_id
-      })}
-    >
+    <div className={styles.group}>
       <span className={styles.groupTitle}>{group.title}</span>
       {group.description && (
         <p className={styles.description}>{group.description}</p>
       )}
-      <div className={styles.genomesCount}>
+      <Link
+        className={styles.genomesCount}
+        to={urlFor.speciesSelectorSearch({
+          genomeGroupId: group.group_id
+        })}
+      >
         <Pill>{group.genomes_count}</Pill>
         <span>genomes</span>
-      </div>
-    </Link>
+      </Link>
+    </div>
   );
 };
 

--- a/src/content/app/species-selector/components/genome-selector-by-genome-group-id/GenomeSelectorByGenomeGroupId.module.css
+++ b/src/content/app/species-selector/components/genome-selector-by-genome-group-id/GenomeSelectorByGenomeGroupId.module.css
@@ -1,0 +1,43 @@
+.main {
+  height: 100%;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  row-gap: 10px;
+  padding-left: var(--double-standard-gutter);
+}
+
+.top {
+  display: grid;
+  align-items: center;
+  justify-self: start;
+  grid-template-columns: [genomes-count] auto [add-button] max-content [close-button] auto [filter] max-content;
+  column-gap: var(--standard-gutter);
+  white-space: nowrap;
+}
+
+.genomesCount {
+  grid-column: genomes-count;
+  display: flex;
+  column-gap: 1rem;
+}
+
+.addButton {
+  grid-column: add-button;
+}
+
+.closeButton {
+  grid-column: close-button;
+}
+
+.filterWrapper {
+  grid-column: filter;
+  margin-left: var(--double-standard-gutter);
+}
+
+.loader {
+  justify-self: center;
+}
+
+.downloadButton {
+  margin-left: var(--standard-gutter);
+}

--- a/src/content/app/species-selector/components/genome-selector-by-genome-group-id/GenomeSelectorByGenomeGroupId.tsx
+++ b/src/content/app/species-selector/components/genome-selector-by-genome-group-id/GenomeSelectorByGenomeGroupId.tsx
@@ -1,0 +1,207 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+import { useAppSelector } from 'src/store';
+
+import {
+  getSortRule,
+  isValidPerPageParam,
+  DEFAULT_NUM_RESULTS_PER_PAGE
+} from 'src/content/app/species-selector/helpers/genomeSearchHelpers';
+
+import { getCommittedSpecies } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors';
+
+import {
+  useGenomesByGenomeGroupIdQuery,
+  getSpeciesSearchLastPageNumber
+} from 'src/content/app/species-selector/state/species-selector-api-slice/speciesSelectorApiSlice';
+
+import useSelectableGenomesTable from 'src/content/app/species-selector/components/selectable-genomes-table/useSelectableGenomesTable';
+
+import {
+  SpeciesSearchResultsTableWrapper,
+  TableControlsSection,
+  TableSection
+} from 'src/content/app/species-selector/components/species-search-results-table-wrapper/SpeciesSearchResultsTableWrapper';
+import SpeciesSearchResultsTable from 'src/content/app/species-selector/components/species-search-results-table/SpeciesSearchResultsTable';
+import { PrimaryButton } from 'src/shared/components/button/Button';
+import { CircleLoader } from 'src/shared/components/loader';
+import { CloseButtonWithLabel } from 'src/shared/components/close-button/CloseButton';
+import InfoPill from 'src/shared/components/info-pill/InfoPill';
+import PaginationWithPerPage from 'src/shared/components/pagination/PaginationWithPerPage';
+import GenomesDownloadButton from 'src/content/app/species-selector/components/genomes-download-button/GenomesDownloadButton';
+
+import type { SpeciesSearchMatch } from 'src/content/app/species-selector/types/speciesSearchMatch';
+import type { SortOrderWithNone } from 'src/shared/types/sort-order';
+
+import styles from './GenomeSelectorByGenomeGroupId.module.css';
+
+type Props = {
+  genomeGroupId: string | number;
+  onSpeciesAdd: (genomes: SpeciesSearchMatch[]) => void;
+};
+
+const GenomeSelectorByGenomeGroupId = (props: Props) => {
+  const { genomeGroupId } = props;
+  const committedSpecies = useAppSelector(getCommittedSpecies);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const pageNumber = parseInt(searchParams.get('page') ?? '1');
+  const perPageParam = searchParams.get('per_page');
+  const sortBy = searchParams.get('sort_by');
+  const sortOrder = searchParams.get('order');
+
+  const perPage =
+    perPageParam && isValidPerPageParam(perPageParam)
+      ? parseInt(perPageParam)
+      : DEFAULT_NUM_RESULTS_PER_PAGE;
+
+  const { data, isLoading, isError } = useGenomesByGenomeGroupIdQuery({
+    genomeGroupId,
+    page: pageNumber,
+    perPage,
+    sortBy,
+    sortOrder
+  });
+
+  const { genomes, stagedGenomes, onTableExpandToggle, onGenomeStageToggle } =
+    useSelectableGenomesTable({
+      genomes: data?.matches ?? [],
+      selectedGenomes: committedSpecies
+    });
+
+  const onResultsPageChange = (page: number) => {
+    const newPageParam = new URLSearchParams(searchParams);
+    newPageParam.set('page', `${page}`);
+    setSearchParams(newPageParam, { replace: true });
+  };
+
+  const onSortRuleChange = useCallback(
+    (sortBy: string, sortOrder: SortOrderWithNone) => {
+      const newSearchParams = new URLSearchParams(searchParams);
+      if (sortOrder === 'none') {
+        newSearchParams.delete('sort_by');
+        newSearchParams.delete('order');
+      } else {
+        newSearchParams.set('sort_by', sortBy);
+        newSearchParams.set('order', sortOrder);
+      }
+      setSearchParams(newSearchParams, { replace: true });
+    },
+    [searchParams, setSearchParams]
+  );
+
+  const onResultsPerPageChange = (perPage: number) => {
+    const newSearchParams = new URLSearchParams(searchParams);
+    newSearchParams.set('per_page', `${perPage}`);
+    newSearchParams.set('page', `1`);
+    setSearchParams(newSearchParams, { replace: true });
+  };
+
+  const sortRule = getSortRule(sortBy, sortOrder);
+
+  return (
+    <div className={styles.main}>
+      {isLoading && <CircleLoader className={styles.loader} />}
+      {data && (
+        <>
+          <TopSection
+            {...props}
+            genomes={genomes}
+            stagedGenomes={stagedGenomes}
+          />
+          <SpeciesSearchResultsTableWrapper>
+            <TableControlsSection>
+              <PaginationWithPerPage
+                currentPageNumber={pageNumber}
+                lastPageNumber={getSpeciesSearchLastPageNumber({
+                  data,
+                  perPage: perPage
+                })}
+                onPageChange={onResultsPageChange}
+                perPageValue={perPage}
+                onPerPageChange={onResultsPerPageChange}
+              />
+              <GenomesDownloadButton
+                searchParam={{
+                  name: 'genome_group_id',
+                  value: `${genomeGroupId}`
+                }}
+                className={styles.downloadButton}
+              />
+            </TableControlsSection>
+            <TableSection>
+              <SpeciesSearchResultsTable
+                results={genomes}
+                sortRule={sortRule}
+                onTableExpandToggle={onTableExpandToggle}
+                onSpeciesSelectToggle={onGenomeStageToggle}
+                onSortRuleChange={onSortRuleChange}
+              />
+            </TableSection>
+          </SpeciesSearchResultsTableWrapper>
+        </>
+      )}
+      {isError && <div>An unexpected error has occurred</div>}
+    </div>
+  );
+};
+
+type TopSectionProps = Props & {
+  genomes: ReturnType<typeof useSelectableGenomesTable>['genomes'];
+  stagedGenomes: ReturnType<typeof useSelectableGenomesTable>['stagedGenomes'];
+};
+
+const TopSection = (props: TopSectionProps) => {
+  const { genomes, stagedGenomes } = props;
+  const navigate = useNavigate();
+
+  const onSpeciesAdd = () => {
+    props.onSpeciesAdd(stagedGenomes);
+  };
+
+  const onClose = () => {
+    navigate(-1);
+  };
+
+  const selectedGenomesCount = genomes.filter(
+    (genome) => genome.isSelected
+  ).length;
+  const totalGenomesCount = genomes.length;
+
+  return (
+    <section className={styles.top}>
+      <span className={styles.genomesCount}>
+        <InfoPill>
+          {selectedGenomesCount} / {totalGenomesCount}
+        </InfoPill>
+        assemblies selected
+      </span>
+      <PrimaryButton
+        className={styles.addButton}
+        disabled={stagedGenomes.length === 0}
+        onClick={onSpeciesAdd}
+      >
+        Add
+      </PrimaryButton>
+      <CloseButtonWithLabel className={styles.closeButton} onClick={onClose} />
+    </section>
+  );
+};
+
+export default GenomeSelectorByGenomeGroupId;

--- a/src/content/app/species-selector/components/genomes-download-button/GenomesDownloadButton.tsx
+++ b/src/content/app/species-selector/components/genomes-download-button/GenomesDownloadButton.tsx
@@ -19,7 +19,7 @@ import config from 'config';
 import DownloadLink from 'src/shared/components/download-button/DownloadLink';
 
 type SearchParam = {
-  name: 'query' | 'species_taxonomy_id';
+  name: 'query' | 'species_taxonomy_id' | 'genome_group_id';
   value: string;
 };
 

--- a/src/content/app/species-selector/state/species-selector-api-slice/speciesSelectorApiSlice.ts
+++ b/src/content/app/species-selector/state/species-selector-api-slice/speciesSelectorApiSlice.ts
@@ -66,6 +66,14 @@ export type GenomesSearchBySpeciesTaxonomyIdRequestParams = {
   sortOrder?: string | null;
 };
 
+export type GenomesSearchByGenomeGroupIdRequestParams = {
+  genomeGroupId: string | number;
+  page: number;
+  perPage?: number;
+  sortBy?: string | null;
+  sortOrder?: string | null;
+};
+
 const speciesSelectorApiSlice = restApiSlice.injectEndpoints({
   endpoints: (builder) => ({
     getPopularSpecies: builder.query<PopularSpeciesResponse, void>({
@@ -96,6 +104,14 @@ const speciesSelectorApiSlice = restApiSlice.injectEndpoints({
       query: (params) => ({
         url: `${config.searchApiBaseUrl}/genomes/v2?${prepareGenomeSearchParams(params)}`
       })
+    }),
+    getGenomesByGenomeGroupId: builder.query<
+      SpeciesSearchResponse,
+      GenomesSearchByGenomeGroupIdRequestParams
+    >({
+      query: (params) => ({
+        url: `${config.searchApiBaseUrl}/genomes/v2?${prepareGenomeSearchParams(params)}`
+      })
     })
   })
 });
@@ -104,12 +120,15 @@ const prepareGenomeSearchParams = (
   params:
     | SpeciesSearchRequestParams
     | GenomesSearchBySpeciesTaxonomyIdRequestParams
+    | GenomesSearchByGenomeGroupIdRequestParams
 ) => {
   const searchParams = new URLSearchParams();
   if ('query' in params) {
     searchParams.set('query', params.query);
   } else if ('speciesTaxonomyId' in params) {
     searchParams.set('species_taxonomy_id', `${params.speciesTaxonomyId}`);
+  } else if ('genomeGroupId' in params) {
+    searchParams.set('genome_group_id', `${params.genomeGroupId}`);
   }
   searchParams.set('page', `${params.page}`);
 
@@ -141,6 +160,8 @@ export const useLazyGenomesQuery =
   speciesSelectorApiSlice.useLazyGetSpeciesSearchResultsQuery;
 export const useGenomesBySpeciesTaxonomyIdQuery =
   speciesSelectorApiSlice.useGetGenomesBySpeciesTaxonomyIdQuery;
+export const useGenomesByGenomeGroupIdQuery =
+  speciesSelectorApiSlice.useGetGenomesByGenomeGroupIdQuery;
 export const usePopularSpeciesQuery =
   speciesSelectorApiSlice.useGetPopularSpeciesQuery;
 export const useGenomeGroupCategoriesQuery =

--- a/src/content/app/species-selector/views/species-selector-results-view/SpeciesSelectorResultsView.tsx
+++ b/src/content/app/species-selector/views/species-selector-results-view/SpeciesSelectorResultsView.tsx
@@ -29,6 +29,7 @@ import * as urlFor from 'src/shared/helpers/urlHelper';
 import ModalView from 'src/shared/components/modal-view/ModalView';
 import GenomeSelectorBySearchQuery from 'src/content/app/species-selector/components/genome-selector-by-search-query/GenomeSelectorBySearchQuery';
 import GenomeSelectorBySpeciesTaxonomyId from 'src/content/app/species-selector/components/genome-selector-by-species-taxonomy-id/GenomeSelectorBySpeciesTaxonomyId';
+import GenomeSelectorByGenomeGroupId from 'src/content/app/species-selector/components/genome-selector-by-genome-group-id/GenomeSelectorByGenomeGroupId';
 
 import type { SpeciesSearchMatch } from 'src/content/app/species-selector/types/speciesSearchMatch';
 
@@ -58,7 +59,8 @@ const Content = (props: { onClose: () => void }) => {
   useEffect(() => {
     if (
       !searchParams.get('query') &&
-      !searchParams.get('species_taxonomy_id')
+      !searchParams.get('species_taxonomy_id') &&
+      !searchParams.get('genome_group_id')
     ) {
       navigate(urlFor.speciesSelector());
     }
@@ -87,6 +89,11 @@ const Content = (props: { onClose: () => void }) => {
     <GenomeSelectorBySpeciesTaxonomyId
       onSpeciesAdd={onSpeciesAdd}
       speciesTaxonomyId={searchParams.get('species_taxonomy_id') as string}
+    />
+  ) : searchParams.has('genome_group_id') ? (
+    <GenomeSelectorByGenomeGroupId
+      onSpeciesAdd={onSpeciesAdd}
+      genomeGroupId={searchParams.get('genome_group_id') as string}
     />
   ) : null; // this last option should never happen
 };

--- a/src/shared/helpers/urlHelper.ts
+++ b/src/shared/helpers/urlHelper.ts
@@ -50,6 +50,7 @@ type SpeciesPageUrlParams = {
 type SpeciesSelectorSearchParams = {
   query?: string;
   speciesTaxonomyId?: string | number;
+  genomeGroupId?: string | number;
 };
 
 export const speciesPage = (params: SpeciesPageUrlParams) => {
@@ -75,6 +76,10 @@ export const speciesSelectorSearch = (params: SpeciesSelectorSearchParams) => {
       'species_taxonomy_id',
       String(params.speciesTaxonomyId)
     );
+  }
+
+  if (params.genomeGroupId) {
+    urlSearchParams.append('genome_group_id', String(params.genomeGroupId));
   }
 
   const query = decodeURIComponent(urlSearchParams.toString());


### PR DESCRIPTION
## Description
This PR provides navigation from genome groups (External projects and Ensembl genome collection) to sepcies selector results view. 

## Deployment URL(s)
http://extended-search-results.review.ensembl.org