### PR TITLE
Entity Viewer for gene: fix gene svg width in Safari

### DIFF
--- a/src/content/app/entity-viewer/gene-view/components/gene-overview-image/GeneOverviewImage.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-overview-image/GeneOverviewImage.tsx
@@ -112,7 +112,11 @@ export const GeneImage = (props: GeneOverviewImageProps) => {
   const viewBox = `0 0 ${GENE_IMAGE_WIDTH} ${GENE_IMAGE_HEIGHT}`;
 
   return (
-    <svg className={styles.containerSVG} viewBox={viewBox}>
+    <svg
+      className={styles.containerSVG}
+      viewBox={viewBox}
+      width={GENE_IMAGE_WIDTH}
+    >
       {renderedTranscripts}
     </svg>
   );


### PR DESCRIPTION
## Description
**In Safari**, the svg image of a gene at the top of the Entity Viewer page for the gene renders larger than expected, and extends beyond the allocated space, overlapping other elements:

<img width="3838" height="2012" alt="image" src="https://github.com/user-attachments/assets/ba9e6939-310e-4b57-af0f-495e240e59b2" />

After the fix:

<img width="3840" height="2105" alt="image" src="https://github.com/user-attachments/assets/3a190904-53bd-451d-9521-5e06b7514b98" />

## Related JIRA Issue(s)
https://embl.atlassian.net/browse/EBD-123

## Deployment URL(s)
http://fix-gene-svg-width.review.ensembl.org