### PR TITLE
Fix genome browser navigation

### DIFF
--- a/src/content/app/genome-browser/components/browser-app-bar/BrowserAppBar.tsx
+++ b/src/content/app/genome-browser/components/browser-app-bar/BrowserAppBar.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { memo, useMemo } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import isEqual from 'lodash/isEqual';
 
@@ -38,16 +38,20 @@ type BrowserAppBarProps = {
 };
 
 const BrowserAppBar = (props: BrowserAppBarProps) => {
+  const { onSpeciesSelect: speciesSelectHandlerFromProps } = props;
   const enabledCommittedSpecies = useSelector(getEnabledCommittedSpecies);
   const activeGenomeId = useSelector(getBrowserActiveGenomeId);
 
   const { trackGenomeChanged } = useGenomeBrowserAnalytics();
 
-  const onSpeciesSelect = (species: CommittedItem) => {
-    props.onSpeciesSelect(species.genome_id);
+  const onSpeciesSelect = useCallback(
+    (species: CommittedItem) => {
+      speciesSelectHandlerFromProps(species.genome_id);
 
-    trackGenomeChanged();
-  };
+      trackGenomeChanged();
+    },
+    [speciesSelectHandlerFromProps, trackGenomeChanged]
+  );
 
   const speciesTabs = useMemo(() => {
     return enabledCommittedSpecies.map((species, index) => (
@@ -58,7 +62,7 @@ const BrowserAppBar = (props: BrowserAppBarProps) => {
         onClick={() => onSpeciesSelect(species)}
       />
     ));
-  }, [enabledCommittedSpecies.length, activeGenomeId]);
+  }, [enabledCommittedSpecies, activeGenomeId, onSpeciesSelect]);
 
   const tabsSlider = <SpeciesTabsSlider>{speciesTabs}</SpeciesTabsSlider>;
 

--- a/src/content/app/genome-browser/hooks/useBrowserRouting.ts
+++ b/src/content/app/genome-browser/hooks/useBrowserRouting.ts
@@ -34,7 +34,6 @@ import {
   parseFocusIdFromUrl
 } from 'src/shared/helpers/focusObjectHelpers';
 
-import { setActiveGenomeId } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSlice';
 import { setDataFromUrlAndSave } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSlice';
 import { fetchFocusObject } from 'src/content/app/genome-browser/state/focus-object/focusObjectSlice';
 
@@ -117,7 +116,6 @@ const useBrowserRouting = () => {
         location: chrLocation ? getChrLocationStr(chrLocation) : null
       };
 
-      dispatch(setActiveGenomeId(genomeId));
       // Consider it as first render when we change genome
       firstRenderRef.current = true;
 
@@ -137,7 +135,6 @@ const useBrowserRouting = () => {
       allActiveFocusObjectIds,
       allChrLocations,
       allCommittedSpecies,
-      dispatch,
       navigate
     ]
   );
@@ -237,19 +234,18 @@ const useBrowserRouting = () => {
       const isFirstRender = firstRenderRef.current;
 
       if ((isFirstRender && genomeId) || (!sameAsPrev && genomeId)) {
-        if (navigationType === 'REPLACE' && isUrlUpdatedByGenomeBrowser) {
-          // ignore url updates triggered by messages from the genome browser
-          return;
+        // ignore url updates triggered by messages from the genome browser
+        if (!(navigationType === 'REPLACE' && isUrlUpdatedByGenomeBrowser)) {
+          const { type, objectId } = parseFocusIdFromUrl(focusObjectIdInUrl);
+          changeBrowserLocation({
+            genomeId,
+            chrLocation,
+            focus: {
+              type,
+              id: objectId
+            }
+          });
         }
-        const { type, objectId } = parseFocusIdFromUrl(focusObjectIdInUrl);
-        changeBrowserLocation({
-          genomeId,
-          chrLocation,
-          focus: {
-            type,
-            id: objectId
-          }
-        });
       }
       if (isFirstRender) {
         firstRenderRef.current = false;

--- a/src/content/app/genome-browser/hooks/useBrowserRouting.ts
+++ b/src/content/app/genome-browser/hooks/useBrowserRouting.ts
@@ -15,7 +15,7 @@
  */
 
 import { useEffect, useRef, useCallback } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useNavigationType } from 'react-router-dom';
 import isEqual from 'lodash/isEqual';
 
 import { useAppSelector, useAppDispatch, type RootState } from 'src/store';
@@ -78,12 +78,15 @@ const useBrowserRouting = () => {
   );
   const { genomeBrowser, changeFocusObject, changeBrowserLocation } =
     useGenomeBrowser();
-  const { search } = useLocation(); // from document.location provided by the router
+  const { search, state: locationState } = useLocation(); // from document.location provided by the router
   const navigate = useNavigate();
+  const navigationType = useNavigationType();
   const dispatch = useAppDispatch();
 
   const urlSearchParams = new URLSearchParams(search);
   const location = urlSearchParams.get('location') || null;
+  const isUrlUpdatedByGenomeBrowser =
+    locationState?.updateSource === 'genome-browser'; // State set in useGenomeBrowserPosition hook
 
   const allCommittedSpecies = useAppSelector(getEnabledCommittedSpecies);
   const allChrLocations = useAppSelector(getAllChrLocations);
@@ -234,6 +237,10 @@ const useBrowserRouting = () => {
       const isFirstRender = firstRenderRef.current;
 
       if ((isFirstRender && genomeId) || (!sameAsPrev && genomeId)) {
+        if (navigationType === 'REPLACE' && isUrlUpdatedByGenomeBrowser) {
+          // ignore url updates triggered by messages from the genome browser
+          return;
+        }
         const { type, objectId } = parseFocusIdFromUrl(focusObjectIdInUrl);
         changeBrowserLocation({
           genomeId,
@@ -281,7 +288,9 @@ const useBrowserRouting = () => {
     shouldUpdateRedux,
     dispatch,
     navigate,
-    location
+    location,
+    navigationType,
+    isUrlUpdatedByGenomeBrowser
   ]);
 
   useEffect(() => {

--- a/src/content/app/genome-browser/hooks/useGenomeBrowserPosition.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowserPosition.ts
@@ -82,7 +82,6 @@ const useGenomeBrowserPosition = () => {
         dispatch(updateActualChrLocation([chromosome, start, end]));
       } else {
         const chrLocation = [chromosome, start, end] as ChrLocation;
-
         navigate(
           urlFor.browser({
             genomeId: genomeIdForUrl,
@@ -90,7 +89,8 @@ const useGenomeBrowserPosition = () => {
             location: getChrLocationStr(chrLocation)
           }),
           {
-            replace: true
+            replace: true,
+            state: { updateSource: 'genome-browser' } // this will be checked in useBrowserRouting hook
           }
         );
       }

--- a/src/content/app/genome-browser/hooks/useGenomeBrowserPosition.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowserPosition.ts
@@ -72,9 +72,13 @@ const useGenomeBrowserPosition = () => {
       const { stick, start, end } = message.payload;
       const [genomeId, chromosome] = stick.split(':');
 
-      if (genomeId !== activeGenomeId) {
-        // ignore the message, because it must be a delayed message for the previous species
-        // when the user has already switched to another one
+      if (genomeId !== activeGenomeId || start < 1) {
+        // It is a defect of the genome browser that it can sometimes, during a zoom-out gesture near the region start,
+        // report a negative start value. It should be fixed in the genome browser; but meanwhile, it is easy
+        // to guard against in the client.
+
+        // Also, if the message happened to be delayed such that user has switched to a different genome,
+        // just ignore it.
         return;
       }
 


### PR DESCRIPTION
## Description
This is a follow-up on https://github.com/Ensembl/ensembl-client/pull/1307, which turned out to be insufficient to prevent unnecessary location change messages to the genome browser causing surprising jumps, or even infinite animation loops.

The idea behind this PR is to avoid sending location change message to the genome browser if the reason the url got updated was because of a message from the genome browser. There is no need to ask genome browser to navigate to a location where it presumably already is anyway.

To tell url changes that were caused by the genome browser as opposed to other reasons, the client performs the following checks:
- Check whether browser history state contains key/value `updateSource: 'genome-browser'`. This state is set when the url is updated due to a message from the genome browser.  
- Check whether the navigation change is of a type "REPLACE". This excludes back/forward navigation (e.g. user navigating web browser history)

ALSO:
This PR filters out target_position messages with invalid locations that sometimes are emitted by the genome browser — specifically locations where start coordinate is a negative number. 


The recording below demonstrates both kinds of bugs: first, you may notice genome browser's erratic behaviour on zoom out; and then, continuous zoom in/out near the start of the region triggers the genome browser to send an invalid location to the client , which fails url validation and causes an error screen


https://github.com/user-attachments/assets/ebc483ed-13bc-41d7-a244-71429f23ad70


## Deployment URL(s)
https://fix-gb-navigation.review.ensembl.org