### PR TITLE
Fix entity viewer sidebar slice, and remove unused code

### DIFF
--- a/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors.ts
+++ b/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors.ts
@@ -32,14 +32,6 @@ export const getEntityViewerGenomeState = (state: RootState) => {
     : null;
 };
 
-export const getEntityViewerSidebarUIState = (state: RootState) => {
-  const activeEntityId = getEntityViewerActiveEntityId(state);
-  return activeEntityId
-    ? getEntityViewerGenomeState(state)?.entities[activeEntityId]?.uiState ||
-        null
-    : null;
-};
-
 export const getEntityViewerSidebarTabName = (state: RootState) => {
   const activeEntityId = getEntityViewerActiveEntityId(state);
   return activeEntityId

--- a/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSlice.ts
+++ b/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSlice.ts
@@ -20,18 +20,12 @@ import {
   type Action,
   type ThunkAction
 } from '@reduxjs/toolkit';
-import merge from 'lodash/merge';
-import mergeWith from 'lodash/mergeWith';
 
-import {
-  getEntityViewerActiveGenomeId,
-  getEntityViewerActiveEntityId
-} from '../general/entityViewerGeneralSelectors';
+import { getEntityViewerActiveGenomeId } from '../general/entityViewerGeneralSelectors';
 import { isEntityViewerSidebarOpen } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors';
 
 import { Status } from 'src/shared/types/status';
 import type { AccordionSectionID as OverviewMainAccordionSectionID } from 'src/content/app/entity-viewer/gene-view/components/gene-view-sidebar/overview/MainAccordion';
-import type JSONValue from 'src/shared/types/JSON';
 import type { RootState } from 'src/store';
 
 export type ToggleStatus = Status.OPEN | Status.CLOSED;
@@ -54,11 +48,6 @@ export type EntityViewerSidebarState = Readonly<{
 export type EntityViewerSidebarGenomeState = Readonly<{
   status: ToggleStatus;
   selectedTabName: SidebarTabName;
-  entities: {
-    [entityId: string]: {
-      uiState: EntityViewerSidebarUIState;
-    };
-  };
   sidebarModalView: SidebarModalView | null;
 }>;
 
@@ -110,22 +99,6 @@ export const openSidebar = () => toggleSidebar(Status.OPEN);
 
 export const closeSidebar = () => toggleSidebar(Status.CLOSED);
 
-export const updateEntityUI =
-  (
-    fragment: Partial<EntityViewerSidebarUIState>
-  ): ThunkAction<void, RootState, void, Action<string>> =>
-  (dispatch, getState) => {
-    const state = getState();
-    const genomeId = getEntityViewerActiveGenomeId(state);
-    const entityId = getEntityViewerActiveEntityId(state);
-
-    if (!genomeId || !entityId) {
-      return;
-    }
-
-    dispatch(updateEntityUIState({ genomeId, entityId, fragment }));
-  };
-
 export const openSidebarModal =
   (
     sidebarModalView: SidebarModalView
@@ -174,7 +147,6 @@ export const buildInitialStateForGenome = (
   [genomeId]: {
     status: Status.OPEN,
     selectedTabName: SidebarTabName.OVERVIEW,
-    entities: {},
     sidebarModalView: null
   }
 });
@@ -199,40 +171,16 @@ const entityViewerSidebarSlice = createSlice({
       const { genomeId, fragment: newFragment } = action.payload;
       const oldStateFragment =
         state[genomeId] || buildInitialStateForGenome(genomeId)[genomeId];
-      const updatedFragment = merge({}, oldStateFragment, newFragment);
-      state[genomeId] = updatedFragment;
-    },
-    updateEntityUIState(
-      state,
-      action: PayloadAction<{
-        genomeId: string;
-        entityId: string;
-        fragment: Partial<EntityViewerSidebarUIState>;
-      }>
-    ) {
-      const { genomeId, entityId, fragment: newFragment } = action.payload;
-
-      if (!state[genomeId]) {
-        return; // this should never happen; but the action is meaningless if it does
-      }
-
-      // We need to overwrite the arrays instead of merging them so that it is easier to remove entries
-      const overwriteArray = (objValue: JSONValue, srcValue: JSONValue) => {
-        if (Array.isArray(objValue)) {
-          return srcValue;
-        }
+      const updatedFragment = {
+        ...oldStateFragment,
+        ...newFragment
       };
-
-      mergeWith(
-        state[genomeId].entities[entityId].uiState,
-        newFragment,
-        overwriteArray
-      );
+      state[genomeId] = updatedFragment;
     }
   }
 });
 
-export const { initializeSidebar, updateGenomeState, updateEntityUIState } =
+export const { initializeSidebar, updateGenomeState } =
   entityViewerSidebarSlice.actions;
 
 export default entityViewerSidebarSlice.reducer;


### PR DESCRIPTION
## Description

https://github.com/Ensembl/ensembl-client/pull/1316 resulted in a regression:

Interaction with the sidebar in Entity Viewer gene view (attempts to close the sidebar, or open gene search, etc.) produced the following error:

<img width="2539" height="335" alt="image" src="https://github.com/user-attachments/assets/b58f9077-55d6-4320-a0aa-63bbe7870d38" />

The problem turned out to be related to how the lodash's `merge` function attempts to merge two objects, one of which is wrapped in immer.

It is likely the consequence of a quiet update of `immer` that happened in [PR 1316](https://github.com/Ensembl/ensembl-client/pull/1316)

<img width="1017" height="194" alt="image" src="https://github.com/user-attachments/assets/c0d41bd3-5fee-4acd-af0d-51ff66e8df92" />

During investigation, it turned out that the `entities` part of the sidebar slice for genes and variants was no longer used anywhere; so I deleted it, and with it is gone the reliance on lodash's `merge` and `mergeWith` functions.

## Deployment URL(s)
http://fix-ev-sidebar.review.ensembl.org