### PR TITLE
Do not use lodash to update species general redux slice

### DIFF
--- a/src/content/app/species/state/general/speciesGeneralSlice.ts
+++ b/src/content/app/species/state/general/speciesGeneralSlice.ts
@@ -88,15 +88,13 @@ const speciesGeneralSlice = createSlice({
         expandedSections: SpeciesStatsSection[];
       }>
     ) {
-      const stateToUpdate = state.uiState[action.payload.genomeId]
-        ? state
-        : set(action.payload.genomeId, { expandedSections: [] }, state);
+      const { genomeId, expandedSections } = action.payload;
 
-      return set(
-        `uiState.${action.payload.genomeId}.expandedSections`,
-        action.payload.expandedSections,
-        stateToUpdate
-      );
+      if (!state.uiState[genomeId]) {
+        state.uiState[genomeId] = { expandedSections: [] };
+      }
+
+      state.uiState[genomeId].expandedSections = expandedSections;
     },
 
     restoreUI(state) {


### PR DESCRIPTION
## Description
A bug with the same cause as https://github.com/Ensembl/ensembl-client/pull/1321, but now affecting species general slice.

Steps to reproduce: try opening any of the stats accordions on the species page.

<img width="2560" height="485" alt="image" src="https://github.com/user-attachments/assets/c4781102-6e9c-45f3-93fc-85b3d6efddfe" />


## Deployment URL(s)
http://fix-species-expandable-sections.review.ensembl.org