### PR TITLE
Rename species selector to genome selector, and species to genome

### DIFF
--- a/src/content/app/entity-viewer/interstitial/entity-viewer-interstitial-instructions/EntityViewerInterstitialInstructions.tsx
+++ b/src/content/app/entity-viewer/interstitial/entity-viewer-interstitial-instructions/EntityViewerInterstitialInstructions.tsx
@@ -41,10 +41,10 @@ const EntityViewerInterstitialInstructions = () => {
     <section className={styles.instructionsPanel}>
       <div className={styles.instructionsWrapper}>
         <div className={styles.stepWrapper}>
-          <Step count={1} label="Find and add a species">
+          <Step count={1} label="Find and add a genome">
             <div className={styles.description}>
               <SpeciesSelectorIcon />
-              <div className={styles.iconLabel}>Species Selector</div>
+              <div className={styles.iconLabel}>Genome Selector</div>
             </div>
           </Step>
         </div>

--- a/src/content/app/entity-viewer/interstitial/entity-viewer-interstitial-instructions/EntityViewerInterstitialInstructions.tsx
+++ b/src/content/app/entity-viewer/interstitial/entity-viewer-interstitial-instructions/EntityViewerInterstitialInstructions.tsx
@@ -44,7 +44,7 @@ const EntityViewerInterstitialInstructions = () => {
           <Step count={1} label="Find and add a genome">
             <div className={styles.description}>
               <SpeciesSelectorIcon />
-              <div className={styles.iconLabel}>Genome Selector</div>
+              <div className={styles.iconLabel}>Genome selector</div>
             </div>
           </Step>
         </div>
@@ -74,7 +74,7 @@ const EntityViewerInterstitialInstructions = () => {
           className={styles.speciesSelectorButton}
           onClick={goToSpeciesSelector}
         >
-          Go to Genome Selector
+          Go to Genome selector
         </PrimaryButton>
       </div>
     </section>

--- a/src/content/app/entity-viewer/interstitial/entity-viewer-interstitial-instructions/EntityViewerInterstitialInstructions.tsx
+++ b/src/content/app/entity-viewer/interstitial/entity-viewer-interstitial-instructions/EntityViewerInterstitialInstructions.tsx
@@ -74,7 +74,7 @@ const EntityViewerInterstitialInstructions = () => {
           className={styles.speciesSelectorButton}
           onClick={goToSpeciesSelector}
         >
-          Go to Species Selector
+          Go to Genome Selector
         </PrimaryButton>
       </div>
     </section>

--- a/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/EntityViewerSidebarModal.tsx
+++ b/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/EntityViewerSidebarModal.tsx
@@ -41,7 +41,7 @@ const entityViewerSidebarModals: Record<
 };
 
 const entityViewerSidebarModalTitles = {
-  [SidebarModalView.SEARCH]: 'Search this species',
+  [SidebarModalView.SEARCH]: 'Search this genome',
   [SidebarModalView.BOOKMARKS]: 'Previously viewed',
   [SidebarModalView.DOWNLOAD]: 'Download'
 };

--- a/src/content/app/genome-browser/components/browser-sidebar-modal/BrowserSidebarModal.tsx
+++ b/src/content/app/genome-browser/components/browser-sidebar-modal/BrowserSidebarModal.tsx
@@ -43,7 +43,7 @@ const browserSidebarModals: Record<string, ReturnType<typeof lazy>> = {
 };
 
 export const browserSidebarModalTitles: { [key: string]: string } = {
-  [BrowserSidebarModalView.SEARCH]: 'Search this species',
+  [BrowserSidebarModalView.SEARCH]: 'Search this genome',
   [BrowserSidebarModalView.BOOKMARKS]: 'Previously viewed',
   [BrowserSidebarModalView.SHARE]: 'Share',
   [BrowserSidebarModalView.DOWNLOAD]: 'Download'

--- a/src/content/app/genome-browser/components/interstitial/browser-interstitial-instructions/BrowserInterstitialInstructions.tsx
+++ b/src/content/app/genome-browser/components/interstitial/browser-interstitial-instructions/BrowserInterstitialInstructions.tsx
@@ -48,7 +48,7 @@ const BrowserInterstitialInstructions = () => {
           <Step count={1} label="Find and add a genome">
             <div className={styles.description}>
               <SpeciesSelectorIcon />
-              <div className={styles.iconLabel}>Genome Selector</div>
+              <div className={styles.iconLabel}>Genome selector</div>
             </div>
           </Step>
         </div>
@@ -57,7 +57,7 @@ const BrowserInterstitialInstructions = () => {
           <Step count={2} label="Return to this app">
             <div className={styles.description}>
               <GenomeBrowserIcon />
-              <div className={styles.iconLabel}>Genome Browser</div>
+              <div className={styles.iconLabel}>Genome browser</div>
             </div>
           </Step>
         </div>
@@ -79,7 +79,7 @@ const BrowserInterstitialInstructions = () => {
           className={styles.speciesSelectorButton}
           onClick={goToSpeciesSelector}
         >
-          Go to Genome Selector
+          Go to Genome selector
         </PrimaryButton>
       </div>
     </section>

--- a/src/content/app/genome-browser/components/interstitial/browser-interstitial-instructions/BrowserInterstitialInstructions.tsx
+++ b/src/content/app/genome-browser/components/interstitial/browser-interstitial-instructions/BrowserInterstitialInstructions.tsx
@@ -45,10 +45,10 @@ const BrowserInterstitialInstructions = () => {
     <section className={styles.instructionsPanel}>
       <div className={styles.instructionsWrapper}>
         <div className={styles.stepWrapper}>
-          <Step count={1} label="Find and add a species">
+          <Step count={1} label="Find and add a genome">
             <div className={styles.description}>
               <SpeciesSelectorIcon />
-              <div className={styles.iconLabel}>Species Selector</div>
+              <div className={styles.iconLabel}>Genome Selector</div>
             </div>
           </Step>
         </div>
@@ -79,7 +79,7 @@ const BrowserInterstitialInstructions = () => {
           className={styles.speciesSelectorButton}
           onClick={goToSpeciesSelector}
         >
-          Go to Species Selector
+          Go to Genome Selector
         </PrimaryButton>
       </div>
     </section>

--- a/src/content/app/help/components/help-landing/HelpLanding.tsx
+++ b/src/content/app/help/components/help-landing/HelpLanding.tsx
@@ -44,12 +44,12 @@ const AppsSection = () => {
           <div className={styles.appLabel}>
             <LabelledAppIcon app="speciesSelector" />
           </div>
-          Create &amp; manage your own species list
+          Create &amp; manage your own list of genomes
           <ul>
-            <li>opened from the launchbar at the top of every page</li>
-            <li>add as many species as you want</li>
-            <li>your species will then be available across all apps</li>
-            <li>use the species tabs to see information about each species</li>
+            <li>open from the launchbar at the top of every page</li>
+            <li>add as many genomes as you want</li>
+            <li>your genomes will then be available across all apps</li>
+            <li>use the genome tabs to see information about each genome</li>
           </ul>
         </div>
 
@@ -104,7 +104,7 @@ const StartUsingSection = () => {
       {isExpanded && (
         <div className={styles.stepsGrid}>
           <div>
-            <Step count={1} label="Find and add a species">
+            <Step count={1} label="Find and add a genome">
               <LabelledAppIcon app="speciesSelector" size="small" />
             </Step>
           </div>
@@ -146,11 +146,11 @@ const LastSection = () => {
           <div className={styles.appLabel}>
             <LabelledAppIcon app="blast" />
           </div>
-          Compare DNA or protein sequences across species
+          Compare DNA or protein sequences across genomes
           <ul>
             <li>opened from the launchbar at the top of every page</li>
-            <li>add up to 30 sequences and up to 25 species at a time</li>
-            <li>see significant sequence matches across species</li>
+            <li>add up to 30 sequences and up to 25 genomes at a time</li>
+            <li>see significant sequence matches across genomes</li>
             <li>results available for 7 days</li>
           </ul>
         </div>

--- a/src/content/app/help/components/labelled-app-icon/LabelledAppIcon.tsx
+++ b/src/content/app/help/components/labelled-app-icon/LabelledAppIcon.tsx
@@ -44,7 +44,7 @@ const appNameToIcon: Record<AppName, FunctionComponent> = {
 };
 
 const appNameToLabel: Record<AppName, string> = {
-  speciesSelector: 'Species selector',
+  speciesSelector: 'Genome selector',
   genomeBrowser: 'Genome browser',
   entityViewer: 'Feature explorer',
   blast: 'Blast'

--- a/src/content/app/regulatory-activity-viewer/RegulatoryActivityViewer.tsx
+++ b/src/content/app/regulatory-activity-viewer/RegulatoryActivityViewer.tsx
@@ -90,7 +90,7 @@ const ActivityViewer = () => {
     return (
       <div className={styles.container}>
         <ActivityViewerAppBar />
-        <div>Please select species.</div>
+        <div>Please select a genome.</div>
       </div>
     );
   } else if (

--- a/src/content/app/species-selector/SpeciesSelectorPage.tsx
+++ b/src/content/app/species-selector/SpeciesSelectorPage.tsx
@@ -26,8 +26,8 @@ import type { ServerFetch } from 'src/routes/routesConfig';
 
 const LazilyLoadedSpeciesSelector = lazy(() => import('./SpeciesSelector'));
 
-const pageTitle = 'Species selector — Ensembl';
-const pageDescription = 'Select one or more species to start using Ensembl';
+const pageTitle = 'Genome selector — Ensembl';
+const pageDescription = 'Select one or more genomes to start using Ensembl';
 
 const SpeciesSelectorPage = () => {
   const hasMounted = useHasMounted();
@@ -40,7 +40,7 @@ const SpeciesSelectorPage = () => {
         description: pageDescription
       })
     );
-  }, []);
+  }, [dispatch]);
 
   return hasMounted ? <LazilyLoadedSpeciesSelector /> : null;
 };

--- a/src/content/app/species-selector/components/species-search-field/AddSpecies.tsx
+++ b/src/content/app/species-selector/components/species-search-field/AddSpecies.tsx
@@ -34,7 +34,7 @@ const AddSpecies = (props: Props) => {
 
   return (
     <div className={styles.grid}>
-      <label className={styles.label}>Find a species</label>
+      <label className={styles.label}>Find a genome</label>
       <ShadedInput
         size="large"
         className={styles.input}

--- a/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx
+++ b/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx
@@ -58,7 +58,7 @@ export const SpeciesSearchField = (props: Props) => {
 const placeholderText = 'Common or scientific name...';
 
 const helpText = `
-Search for a genome using species common name, scientific name, assembly ID or GCA.
+Search for a genome using species common name, scientific name, taxon id, or assembly id.
 If no results are shown, please try a different spelling or attribute
 `;
 

--- a/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx
+++ b/src/content/app/species-selector/components/species-search-field/SpeciesSearchField.tsx
@@ -36,11 +36,11 @@ export const SpeciesSearchField = (props: Props) => {
   const { labelStyle = 'plain', ...otherProps } = props;
   const label =
     labelStyle === 'plain' ? (
-      'Find a species'
+      'Find a genome'
     ) : (
       <span className={styles.label}>
         <SpeciesSelectorIcon className={styles.icon} />
-        <span>Find a species</span>
+        <span>Find a genome</span>
       </span>
     );
 
@@ -58,7 +58,7 @@ export const SpeciesSearchField = (props: Props) => {
 const placeholderText = 'Common or scientific name...';
 
 const helpText = `
-Search for a species using a common name, scientific name, assembly ID or GCA.
+Search for a genome using species common name, scientific name, assembly ID or GCA.
 If no results are shown, please try a different spelling or attribute
 `;
 

--- a/src/content/app/species-selector/components/species-search-results-summary/SpeciesSearchResultsSummary.tsx
+++ b/src/content/app/species-selector/components/species-search-results-summary/SpeciesSearchResultsSummary.tsx
@@ -68,8 +68,8 @@ const SearchHelp = () => {
         suggest
       </p>
       <ul>
-        <li>only search for a species</li>
-        <li>use a full name where possible</li>
+        <li>only search for a genome</li>
+        <li>use the full name of a species where possible</li>
         <li>try a different name or identifier</li>
       </ul>
     </div>

--- a/src/content/app/species-selector/components/species-search-results-summary/SpeciesSearchResultsSummary.tsx
+++ b/src/content/app/species-selector/components/species-search-results-summary/SpeciesSearchResultsSummary.tsx
@@ -53,7 +53,7 @@ const NoResults = () => {
         </span>
       </div>
       <div className={styles.noMatchesMessage}>
-        Sorry, we don’t recognise, or may not have data for this species
+        Sorry, we don’t recognise, or may not have data for this genome
       </div>
       <SearchHelp />
     </div>

--- a/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
+++ b/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
@@ -36,7 +36,7 @@ import type { CommittedItem } from 'src/content/app/species-selector/types/commi
 import styles from './SpeciesSelectorAppBar.module.css';
 
 export const placeholderMessage =
-  'Find and add your favourite species to use them across the site';
+  'Find and add your favourite genomes to use them across the site';
 
 export const PlaceholderMessage = () => (
   <div className={styles.placeholderMessage}>{placeholderMessage}</div>
@@ -57,7 +57,7 @@ export const SpeciesSelectorAppBar = (props: { isSearchMode?: boolean }) => {
 
   return (
     <AppBar
-      topLeft={<AppName>Species Selector</AppName>}
+      topLeft={<AppName>Genome Selector</AppName>}
       topRight={<SpeciesManagerIndicator />}
       mainContent={mainContent}
       aside={<HelpPopupButton slug="species-selector-intro" />}
@@ -85,7 +85,7 @@ const AppBarMainContent = (props: {
         {props.isSearchMode && <CloseButtonWithLabel onClick={onSearchClose} />}
         {!props.isSearchMode && (
           <span className={styles.selectTabMessage}>
-            Select a tab to see a Species home page
+            Select a tab to see a Genome home page
           </span>
         )}
       </div>

--- a/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
+++ b/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
@@ -57,7 +57,7 @@ export const SpeciesSelectorAppBar = (props: { isSearchMode?: boolean }) => {
 
   return (
     <AppBar
-      topLeft={<AppName>Genome Selector</AppName>}
+      topLeft={<AppName>Genome selector</AppName>}
       topRight={<SpeciesManagerIndicator />}
       mainContent={mainContent}
       aside={<HelpPopupButton slug="species-selector-intro" />}

--- a/src/content/app/species-selector/components/species-selector-search-results-app-bar/SpeciesSelectorSearchResultsAppBar.tsx
+++ b/src/content/app/species-selector/components/species-selector-search-results-app-bar/SpeciesSelectorSearchResultsAppBar.tsx
@@ -43,7 +43,7 @@ const SpeciesSearchResultsAppBar = () => {
 
   return (
     <AppBar
-      topLeft={<AppName>Species Selector</AppName>}
+      topLeft={<AppName>Genome selector</AppName>}
       mainContent={mainContent}
       aside={<HelpPopupButton slug="species-selector-intro" />}
     />

--- a/src/content/app/species-selector/views/species-manager/SpeciesManager.tsx
+++ b/src/content/app/species-selector/views/species-manager/SpeciesManager.tsx
@@ -79,7 +79,7 @@ const MainContentTop = (props: {
           onClick={onAddSpeciesClick}
           className={styles.addSpeciesButton}
         >
-          Add a species
+          Add a genome
         </AddButton>
       </div>
     </div>

--- a/src/content/app/species-selector/views/species-manager/selected-genomes-table/SelectedGenomesTable.tsx
+++ b/src/content/app/species-selector/views/species-manager/selected-genomes-table/SelectedGenomesTable.tsx
@@ -147,7 +147,7 @@ const SelectedGenomesTable = (props: {
   );
 
   if (!allSelectedGenomes.length) {
-    return <div>You have not selected any species</div>;
+    return <div>You have not selected any genomes</div>;
   }
 
   const getLinkToSpeciesPage = (species: CommittedItem) => {
@@ -234,7 +234,7 @@ const SelectedGenomesTable = (props: {
     <Table stickyHeader={true} className={styles.table}>
       <thead>
         <tr>
-          <ColumnHead>Species home page</ColumnHead>
+          <ColumnHead>Genome home page</ColumnHead>
           <ColumnHead>Common name</ColumnHead>
           <ColumnHead>Scientific name</ColumnHead>
           <ColumnHead>Type</ColumnHead>
@@ -410,6 +410,6 @@ const ConfirmDeletion = (props: {
 };
 
 const removalWarning =
-  'Any configuration of views for this species will be lost if you remove it - do you wish to continue?';
+  'Any configuration of views for this genome will be lost if you remove it - do you wish to continue?';
 
 export default SelectedGenomesTable;

--- a/src/content/app/species-selector/views/species-manager/species-manager-app-bar/SpeciesManagerAppBar.tsx
+++ b/src/content/app/species-selector/views/species-manager/species-manager-app-bar/SpeciesManagerAppBar.tsx
@@ -36,7 +36,7 @@ export const SpeciesManagerAppBar = () => {
 
   const mainContent = <AppBarMainContent selectedSpecies={selectedSpecies} />;
 
-  const appName = <AppName>Species Selector</AppName>;
+  const appName = <AppName>Genome selector</AppName>;
 
   return (
     <AppBar

--- a/src/content/app/species-selector/views/species-selector-main-view/SpeciesSelectorMainView.test.tsx
+++ b/src/content/app/species-selector/views/species-selector-main-view/SpeciesSelectorMainView.test.tsx
@@ -18,6 +18,8 @@ import { MemoryRouter, type Location } from 'react-router-dom';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import * as urlFor from 'src/shared/helpers/urlHelper';
+
 import SpeciesSelectorMainView from './SpeciesSelectorMainView';
 import RouteChecker from 'tests/router/RouteChecker';
 
@@ -141,7 +143,7 @@ describe('<SpeciesSelectorMainView />', () => {
     expect(routerInfo.location?.pathname).toBe('/search/results');
     expect(routerInfo.location?.search).toBe('?query=BRCA2');
     expect(routerInfo.location?.state).toEqual({
-      returnTo: '/species-selector'
+      returnTo: urlFor.speciesSelector()
     });
   });
 });

--- a/src/content/app/species-selector/views/species-selector-main-view/SpeciesSelectorMainView.test.tsx
+++ b/src/content/app/species-selector/views/species-selector-main-view/SpeciesSelectorMainView.test.tsx
@@ -84,7 +84,7 @@ const renderMainView = () => {
   };
 
   render(
-    <MemoryRouter initialEntries={['/species-selector']}>
+    <MemoryRouter initialEntries={['/genome-selector']}>
       <SpeciesSelectorMainView />
       <RouteChecker
         setLocation={(location) => {

--- a/src/content/app/species/SpeciesPage.tsx
+++ b/src/content/app/species/SpeciesPage.tsx
@@ -40,8 +40,8 @@ const LazylyLoadedSpeciesPageContent = lazy(
   () => import('./SpeciesPageContent')
 );
 
-const defaultTitle = 'Species page — Ensembl';
-const defaultDescription = 'Species home page';
+const defaultTitle = 'Genome page — Ensembl';
+const defaultDescription = 'Genome home page';
 
 const buildPageTitle = (genomeInfo: BriefGenomeSummary) => {
   const speciesName = getDisplayName(genomeInfo);
@@ -68,7 +68,7 @@ const buildPageDescription = (genomeInfo: BriefGenomeSummary) => {
 
 const SpeciesPage = () => {
   const hasMounted = useHasMounted();
-  const params = useUrlParams<'genomeId'>(['/species/:genomeId']);
+  const params = useUrlParams<'genomeId'>(['/genome/:genomeId']);
   const dispatch = useAppDispatch();
   const { genomeId: genomeIdInUrl } = params;
 
@@ -101,7 +101,7 @@ export const serverFetch: ServerFetch = async (params) => {
   const { path, store } = params;
   const dispatch: AppDispatch = store.dispatch;
   const { genomeId: genomeIdFromUrl } = getPathParameters<'genomeId'>(
-    '/species/:genomeId/',
+    '/genome/:genomeId/',
     path
   ) as { genomeId: string };
 

--- a/src/content/app/species/SpeciesPageContent.tsx
+++ b/src/content/app/species/SpeciesPageContent.tsx
@@ -168,7 +168,7 @@ const TopBar = (props: { isSidebarOpen: boolean }) => {
           onClick={returnToSpeciesSelector}
           className={styles.addSpeciesButton}
         >
-          Add a species
+          Add a genome
         </AddButton>
         <CloseButtonWithLabel
           className={styles.closeButton}

--- a/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
+++ b/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
@@ -174,7 +174,7 @@ const SpeciesMainViewStats = () => {
   const activeGenomeId = useAppSelector(getActiveGenomeId);
   const genomeUIState = useAppSelector(getActiveGenomeUIState);
   const { genomeId: genomeIdForUrl } = useUrlParams<'genomeId'>(
-    '/species/:genomeId'
+    '/genome/:genomeId'
   ) as { genomeId: string };
   const species = useAppSelector((state: RootState) =>
     getCommittedSpeciesById(state, activeGenomeId)
@@ -225,7 +225,9 @@ const SpeciesMainViewStats = () => {
     isExpanded: boolean
   ) => {
     if (isExpanded) {
-      species && trackSpeciesStatsSectionOpen(species, section);
+      if (species) {
+        trackSpeciesStatsSectionOpen(species, section);
+      }
       dispatch(setActiveGenomeExpandedSections([...expandedSections, section]));
     } else {
       dispatch(

--- a/src/content/app/species/components/species-sidebar-modal/SpeciesSidebarModal.tsx
+++ b/src/content/app/species/components/species-sidebar-modal/SpeciesSidebarModal.tsx
@@ -38,7 +38,7 @@ const speciesSidebarModals: Record<string, ReturnType<typeof lazy>> = {
 };
 
 export const speciesSidebarModalTitles: { [key: string]: string } = {
-  [SpeciesSidebarModalView.SEARCH]: 'Search this species',
+  [SpeciesSidebarModalView.SEARCH]: 'Search this genome',
   [SpeciesSidebarModalView.BOOKMARKS]: 'Previously viewed',
   [SpeciesSidebarModalView.SHARE]: 'Share',
   [SpeciesSidebarModalView.DOWNLOAD]: 'Download'

--- a/src/content/app/species/components/species-sidebar-modal/modal-views/SpeciesSidebarSearch.tsx
+++ b/src/content/app/species/components/species-sidebar-modal/modal-views/SpeciesSidebarSearch.tsx
@@ -27,7 +27,7 @@ import SidebarSearch from 'src/shared/components/sidebar-search/SidebarSearch';
 const SpeciesSidebarSearch = () => {
   const activeGenomeId = useAppSelector(getActiveGenomeId);
   const { genomeId: genomeIdForUrl } =
-    useUrlParams<'genomeId'>('/species/:genomeId');
+    useUrlParams<'genomeId'>('/genome/:genomeId');
   const dispatch = useAppDispatch();
 
   const onSearchMatchNavigation = () => {

--- a/src/content/app/species/components/species-title-area/SpeciesTitleArea.tsx
+++ b/src/content/app/species/components/species-title-area/SpeciesTitleArea.tsx
@@ -144,7 +144,7 @@ const SpeciesTitleArea = () => {
         </div>
         {isRemoving && (
           <DeletionConfirmation
-            warningText="If you remove this species, any views you have configured will be lost — do you wish to continue?"
+            warningText="If you remove this genome, any views you have configured will be lost — do you wish to continue?"
             confirmText="Remove"
             cancelText="Do not remove"
             className={styles.speciesRemoveMessage}

--- a/src/content/app/species/components/species-title-area/species-usage-toggle/SpeciesUsageToggle.tsx
+++ b/src/content/app/species/components/species-title-area/species-usage-toggle/SpeciesUsageToggle.tsx
@@ -77,7 +77,7 @@ const SpeciesUsageToggle = () => {
   );
 };
 
-const helpMessage = `When 'Use' is selected, this species will appear in the species list in all apps.
-'Don't use' will disable this species in other apps, but will not remove it from your list in Species selector.`;
+const helpMessage = `When 'Use' is selected, this genome will appear in the genomes list in all apps.
+'Don't use' will disable this genome in other apps, but will not remove it from your list in Genome selector.`;
 
 export default SpeciesUsageToggle;

--- a/src/content/app/tools/blast/components/blast-selected-species-list/BlastSelectedSpeciesListHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-selected-species-list/BlastSelectedSpeciesListHeader.tsx
@@ -53,7 +53,7 @@ const BlastSelectedSpeciesListHeader = (props: Props) => {
         <span className={styles.title}>Blast against</span>
         <span className={styles.speciesCounter}>{selectedSpeciesCount}</span>
         <span className={styles.maxSpecies}>
-          of {maxSpeciesCount} species (max)
+          of {maxSpeciesCount} genomes (max)
         </span>
       </div>
       <AddButton
@@ -61,7 +61,7 @@ const BlastSelectedSpeciesListHeader = (props: Props) => {
         className={styles.addButton}
         onClick={onSpeciesAdd}
       >
-        Add a species
+        Add a genome
       </AddButton>
     </div>
   );

--- a/src/content/app/tools/blast/views/blast-form/BlastForm.tsx
+++ b/src/content/app/tools/blast/views/blast-form/BlastForm.tsx
@@ -56,11 +56,11 @@ const BlastForm = () => {
 
   useEffect(() => {
     dispatch(setBlastView('blast-form'));
-  }, []);
+  }, [dispatch]);
 
   useEffect(() => {
     dispatch(setBlastView('blast-form'));
-  }, [modalView]);
+  }, [dispatch, modalView]);
 
   if (!config) {
     return null;
@@ -174,7 +174,7 @@ const BlastFormStepToggle = () => {
         className={speciesButtonClass}
         onClick={onSwitchToSpecies}
       >
-        Select species
+        Select genomes
       </SecondaryButton>
     </div>
   );

--- a/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/single-blast-job-result/SingleBlastJobResult.tsx
@@ -138,7 +138,7 @@ const hitsTableColumns: DataTableColumns = [
   {
     columnId: 'genomic_location',
     title: 'Genomic location',
-    helpText: <span>Location of the hit in this species</span>,
+    helpText: <span>Location of the hit in this genome</span>,
     isSortable: true,
     renderer: (params) => {
       const cellData = params.cellData as TableCellStructuredData;
@@ -542,7 +542,7 @@ const HitsTable = (props: HitsTableProps) => {
         tableColumns[genomicLocationColumnIndex].downloadRenderer,
       sortFn: tableColumns[genomicLocationColumnIndex].sortFn,
       helpText: (
-        <span>Proteins in this species that contain sequence similarity</span>
+        <span>Proteins in this genome that contain sequence similarity</span>
       )
     };
   } else if (blastDatabase === 'cdna') {
@@ -556,7 +556,7 @@ const HitsTable = (props: HitsTableProps) => {
       sortFn: tableColumns[genomicLocationColumnIndex].sortFn,
       helpText: (
         <span>
-          Transcripts in this species that contain sequence similarity
+          Transcripts in this genome that contain sequence similarity
         </span>
       )
     };

--- a/src/content/app/tools/vep/VepPageContent.tsx
+++ b/src/content/app/tools/vep/VepPageContent.tsx
@@ -29,7 +29,7 @@ import styles from './VepPageContent.module.css';
 const VepPageContent = () => {
   return (
     <Routes>
-      <Route path="species-selector" element={<SpeciesSelectorWrapper />} />
+      <Route path="genome-selector" element={<SpeciesSelectorWrapper />} />
       <Route path="*" element={<MainWrapper />} />
     </Routes>
   );

--- a/src/content/app/tools/vep/views/vep-form/VepForm.tsx
+++ b/src/content/app/tools/vep/views/vep-form/VepForm.tsx
@@ -45,7 +45,7 @@ const VepForm = () => {
     }
     dispatch(initialiseVepForm());
     isInitialisedRef.current = true;
-  }, []);
+  }, [dispatch]);
 
   return (
     <div className={styles.outerContainer}>
@@ -57,7 +57,7 @@ const VepForm = () => {
 
         <FormSection>
           <div className={styles.topFormSectionRegularGrid}>
-            <div className={styles.topFormSectionName}>Species</div>
+            <div className={styles.topFormSectionName}>Genome</div>
             <VepFormSpecies className={styles.topFormSectionMain} />
             <VepSpeciesSelectorNavButton
               className={styles.topFormSectionToggle}

--- a/src/content/app/tools/vep/views/vep-form/vep-form-species-section/VepFormSpeciesSection.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-species-section/VepFormSpeciesSection.tsx
@@ -32,7 +32,7 @@ export const VepFormSpecies = (props: { className?: string }) => {
   const selectedSpecies = useAppSelector(getSelectedSpecies);
 
   if (!selectedSpecies) {
-    return <Link to={vepSpeciesSelectorUrl}>Select a genome / assembly</Link>;
+    return <Link to={vepSpeciesSelectorUrl}>Select a genome</Link>;
   }
 
   return (

--- a/src/content/app/tools/vep/views/vep-form/vep-form-species-section/VepFormSpeciesSection.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-species-section/VepFormSpeciesSection.tsx
@@ -32,7 +32,7 @@ export const VepFormSpecies = (props: { className?: string }) => {
   const selectedSpecies = useAppSelector(getSelectedSpecies);
 
   if (!selectedSpecies) {
-    return <Link to={vepSpeciesSelectorUrl}>Select a species / assembly</Link>;
+    return <Link to={vepSpeciesSelectorUrl}>Select a genome / assembly</Link>;
   }
 
   return (

--- a/src/content/home/Home.module.css
+++ b/src/content/home/Home.module.css
@@ -117,29 +117,24 @@
 }
 
 .appListItem .button {
-  display: block;
+  display: flex;
   position: relative;
+  align-items: center;
+  justify-content: center;
+  column-gap: 0.2rem;
   width: 221px;
   height: 40px;
+  padding-left: 16px; /* half the width of an app icon */
   background-color: var(--color-blue);
   color: var(--color-white);
   border-radius: 6px;
   text-align: center;
-  padding: 5px;
   font-size: 18px;
   font-weight: var(--font-weight-bold);
 }
 
-.appListItem .button span {
-  margin-left: -20px;
-}
-
 .appIconWrapper {
   font-size: 0;
-  position: absolute;
-  right: 20px;
-  top: 50%;
-  transform: translateY(-50%);
 }
 
 .appListItem .bottomText {

--- a/src/content/home/Home.tsx
+++ b/src/content/home/Home.tsx
@@ -16,6 +16,8 @@
 
 import { Link } from 'react-router-dom';
 
+import * as urlFor from 'src/shared/helpers/urlHelper';
+
 import useHomeAnalytics from 'src/content/home/hooks/useHomeAnalytics';
 
 import GenomeCounts from 'src/shared/components/genome-counts/GenomeCounts';
@@ -72,7 +74,7 @@ const Home = () => {
             <div className={styles.appListItem}>
               <div className={styles.buttonsContainer}>
                 <Link
-                  to="/species-selector"
+                  to={urlFor.speciesSelector()}
                   className={styles.button}
                   onClick={() => handleButtonClick('species-selector')}
                 >
@@ -84,7 +86,7 @@ const Home = () => {
               </div>
               <div className={styles.bottomTextContainer}>
                 <div className={styles.bottomText}>
-                  Create & manage your own species list
+                  Create & manage your own genomes list
                 </div>
               </div>
             </div>
@@ -92,7 +94,7 @@ const Home = () => {
             <div className={styles.appListItem}>
               <div className={styles.buttonsContainer}>
                 <Link
-                  to="/genome-browser"
+                  to={urlFor.browser()}
                   className={styles.button}
                   onClick={() => handleButtonClick('genome-browser')}
                 >
@@ -112,7 +114,7 @@ const Home = () => {
             <div className={styles.appListItem}>
               <div className={styles.buttonsContainer}>
                 <Link
-                  to="/feature-explorer"
+                  to={urlFor.entityViewer()}
                   className={styles.button}
                   onClick={() => handleButtonClick('entity-viewer')}
                 >

--- a/src/content/home/Home.tsx
+++ b/src/content/home/Home.tsx
@@ -78,7 +78,7 @@ const Home = () => {
                   className={styles.button}
                   onClick={() => handleButtonClick('species-selector')}
                 >
-                  <span>Species selector</span>
+                  <span>Genome selector</span>
                   <div className={styles.appIconWrapper}>
                     <SpeciesSelectorIcon />
                   </div>

--- a/src/global/globalConfig.ts
+++ b/src/global/globalConfig.ts
@@ -34,8 +34,8 @@ export type ScrollPosition = {
 
 export enum AppName {
   GENOME_BROWSER = 'Genome browser',
-  SPECIES_SELECTOR = 'Species selector',
-  SPECIES_PAGE = 'Species page',
+  SPECIES_SELECTOR = 'Genome selector',
+  SPECIES_PAGE = 'Genome page',
   ENTITY_VIEWER = 'Feature explorer',
   REGULATORY_ACTIVITY_VIEWER = 'Regulatory activity viewer',
   ALIGNMENTS_VIEWER = 'Alignments viewer',

--- a/src/header/launchbar/SpeciesSelectorLaunchbarButton.tsx
+++ b/src/header/launchbar/SpeciesSelectorLaunchbarButton.tsx
@@ -37,10 +37,10 @@ const SpeciesSelectorLaunchbarButton = () => {
   return (
     <LaunchbarButton
       path={urlHelper.speciesSelector()}
-      description="Species selector"
+      description="Genome selector"
       icon={SpeciesSelectorIcon}
       enabled={true}
-      isActive={['species', 'species-selector'].includes(firstPathnamePart)}
+      isActive={['genome', 'genome-selector'].includes(firstPathnamePart)}
       isClickableWhenActive={true}
     />
   );

--- a/src/routes/routesConfig.tsx
+++ b/src/routes/routesConfig.tsx
@@ -79,7 +79,7 @@ const routes: RouteConfig[] = [
     serverFetch: genomeBrowserPageServerFetch
   },
   {
-    path: '/species-selector/*',
+    path: '/genome-selector/*',
     element: <SpeciesSelectorPage />,
     serverFetch: speciesSelectorServerFetch
   },
@@ -89,7 +89,7 @@ const routes: RouteConfig[] = [
     serverFetch: searchPageServerFetch
   },
   {
-    path: '/species/:genomeId',
+    path: '/genome/:genomeId',
     element: <SpeciesPage />,
     serverFetch: speciesPageServerFetch
   },

--- a/src/server/middleware/redirectMiddleware.ts
+++ b/src/server/middleware/redirectMiddleware.ts
@@ -16,10 +16,12 @@
 
 import { Router } from 'express';
 
+import * as urlFor from 'src/shared/helpers/urlHelper';
+
 const router = Router();
 
-router.get('/species', (_, res) => {
-  res.redirect(301, '/species-selector');
+router.get('/genome', (_, res) => {
+  res.redirect(301, urlFor.speciesSelector());
 });
 
 router.get('/help/articles', (_, res) => {

--- a/src/server/static-files/robots.txt
+++ b/src/server/static-files/robots.txt
@@ -2,4 +2,4 @@ User-agent: *
 Disallow: /genome-browser/
 Disallow: /blast/
 Disallow: /vep/
-Disallow: /species-selector/search
+Disallow: /genome-selector/search

--- a/src/shared/components/error-screen/GeneralErrorScreen.tsx
+++ b/src/shared/components/error-screen/GeneralErrorScreen.tsx
@@ -84,7 +84,7 @@ const GeneralErrorScreen = () => {
             <div className={styles.resetOption}>
               <div>Unfortunately we need to reset everything</div>
               <div>
-                All your species, configuration of views &amp; history will be
+                All your genomes, configuration of views &amp; history will be
                 lost
               </div>
               <PrimaryButton onClick={resetSite}>Reset the site</PrimaryButton>

--- a/src/shared/components/error-screen/url-errors/MissingGenomeError.tsx
+++ b/src/shared/components/error-screen/url-errors/MissingGenomeError.tsx
@@ -82,7 +82,7 @@ const InvalidSpeciesError = (props: InvalidSpeciesErrorProps) => {
       <main className={styles.main}>
         <AlertButton className={styles.alertButton} />
         <div className={styles.errorMessage}>
-          This species is no longer available
+          This genome is no longer available
         </div>
         <div className={styles.suggestion}>
           Any invalid genomes and their site configurations will be removed

--- a/src/shared/components/species-manager-indicator/SpeciesManagerIndicator.tsx
+++ b/src/shared/components/species-manager-indicator/SpeciesManagerIndicator.tsx
@@ -70,7 +70,7 @@ const SpeciesInUse = ({
   return (
     <div className={styles.speciesInUse}>
       <span className={styles.label}>
-        <span className={styles.light}>Species</span> in use
+        <span className={styles.light}>Genomes</span> in use
       </span>
       <div className={styles.speciesInUsePill}>
         <span className={styles.speciesInUseNumerator}>

--- a/src/shared/helpers/urlHelper.ts
+++ b/src/shared/helpers/urlHelper.ts
@@ -53,12 +53,12 @@ type SpeciesSelectorSearchParams = {
 };
 
 export const speciesPage = (params: SpeciesPageUrlParams) => {
-  const speciesPageRootPath = '/species';
+  const speciesPageRootPath = '/genome';
 
   return `${speciesPageRootPath}/${params.genomeId}`;
 };
 
-const speciesSelectorPath = '/species-selector';
+const speciesSelectorPath = '/genome-selector';
 
 export const speciesSelector = () => speciesSelectorPath;
 
@@ -260,7 +260,7 @@ export const blastSubmission = (submissionId: string) =>
 
 export const vepForm = () => '/vep';
 
-export const vepSpeciesSelector = () => '/vep/species-selector';
+export const vepSpeciesSelector = () => '/vep/genome-selector';
 
 export const vepUnviewedSubmissionsList = () => '/vep/unviewed-submissions';
 


### PR DESCRIPTION
## Description
Rename "species" to "genome" in user-facing interface (UI and urls).

Specifically, species selector becomes genome selector (the url changes from `/species-selector` to `/genome-selector`), and species page becomes genome page (the url changes from `/species` to `/genome`).


**ALSO:**

Updated styles of the app buttons on the home page

Before:

<img width="3063" height="2430" alt="image" src="https://github.com/user-attachments/assets/cf7d7ad7-390c-42b9-83a9-5c44a0039add" />

After:

<img width="3063" height="2430" alt="image" src="https://github.com/user-attachments/assets/d3e3961b-d99e-402a-99ee-6ec24d751424" />



## Related JIRA Issue(s)
https://embl.atlassian.net/browse/ENSWBSITES-3009

## Deployment URL(s)
http://rename-species-selector.review.ensembl.org