### PR TITLE
Update gene track colour markers

### DIFF
--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.module.css
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.module.css
@@ -56,20 +56,6 @@
   padding: 10px 0 20px;
 }
 
-.trackPanelSectionLegend {
-  display: flex;
-  align-items: center;
-  column-gap: 12px;
-  padding: 4px 10px;
-}
-
-.trackPanelSectionLegendMarker {
-  width: 10px;
-  height: 10px;
-  background-color: var(--color-blue);
-  flex-shrink: 0;
-}
-
 .modalLinksWrapper {
   margin: 0 0 20px 10px;
   display: flex;

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.module.css
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.module.css
@@ -56,6 +56,20 @@
   padding: 10px 0 20px;
 }
 
+.trackPanelSectionLegend {
+  display: flex;
+  align-items: center;
+  column-gap: 12px;
+  padding: 4px 10px;
+}
+
+.trackPanelSectionLegendMarker {
+  width: 10px;
+  height: 10px;
+  background-color: var(--color-blue);
+  flex-shrink: 0;
+}
+
 .modalLinksWrapper {
   margin: 0 0 20px 10px;
   display: flex;

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
@@ -152,7 +152,6 @@ export const TrackPanelList = () => {
                       <TrackPanelRegularItem
                         {...track}
                         genomeId={activeGenomeId}
-                        category={category.track_category_id}
                         key={track.track_id}
                       />
                     ))}

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
@@ -147,17 +147,12 @@ export const TrackPanelList = () => {
                 <AccordionItemPanel
                   className={styles.trackPanelAccordionItemContent}
                 >
-                  {category.track_category_id === 'genes-transcripts' && (
-                    <div className={styles.trackPanelSectionLegend}>
-                      <span className={styles.trackPanelSectionLegendMarker} />
-                      <span>Genes & transcripts</span>
-                    </div>
-                  )}
                   <dl>
                     {category.track_list.map((track) => (
                       <TrackPanelRegularItem
                         {...track}
                         genomeId={activeGenomeId}
+                        category={category.track_category_id}
                         key={track.track_id}
                       />
                     ))}

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/TrackPanelList.tsx
@@ -147,12 +147,17 @@ export const TrackPanelList = () => {
                 <AccordionItemPanel
                   className={styles.trackPanelAccordionItemContent}
                 >
+                  {category.track_category_id === 'genes-transcripts' && (
+                    <div className={styles.trackPanelSectionLegend}>
+                      <span className={styles.trackPanelSectionLegendMarker} />
+                      <span>Genes & transcripts</span>
+                    </div>
+                  )}
                   <dl>
                     {category.track_list.map((track) => (
                       <TrackPanelRegularItem
                         {...track}
                         genomeId={activeGenomeId}
-                        category={category.track_category_id}
                         key={track.track_id}
                       />
                     ))}

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelItem.module.css
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelItem.module.css
@@ -39,12 +39,6 @@
   font-size: 11px;
 }
 
-.colourMarker {
-  display: inline-block;
-  width: 10px;
-  height: 10px;
-}
-
 .itemsCount {
   margin-right: 0.4rem;
 }

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelItem.module.css
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelItem.module.css
@@ -39,6 +39,12 @@
   font-size: 11px;
 }
 
+.colourMarker {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+}
+
 .itemsCount {
   margin-right: 0.4rem;
 }

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelRegularItem.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelRegularItem.tsx
@@ -39,7 +39,6 @@ import styles from './TrackPanelItem.module.css';
 
 type Props = GenomicTrack & {
   genomeId: string;
-  category: string;
 };
 
 const TrackPanelRegularItem = (props: Props) => {

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelRegularItem.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelRegularItem.tsx
@@ -39,12 +39,10 @@ import styles from './TrackPanelItem.module.css';
 
 type Props = GenomicTrack & {
   genomeId: string;
-  category: string;
 };
 
 const TrackPanelRegularItem = (props: Props) => {
   const { genomeId, track_id } = props;
-  const showColourMarker = props.category === 'genes-transcripts';
   const isTrackVisible = useAppSelector((state: RootState) =>
     getTrackVisibility(state, track_id)
   );
@@ -80,13 +78,6 @@ const TrackPanelRegularItem = (props: Props) => {
     );
   };
 
-  const colourMarker = (
-    <span
-      className={styles.colourMarker}
-      style={{ backgroundColor: '#0099FF' }}
-    />
-  );
-
   return (
     <SimpleTrackPanelItemLayout
       visibilityStatus={isTrackVisible ? Status.SELECTED : Status.UNSELECTED}
@@ -94,7 +85,6 @@ const TrackPanelRegularItem = (props: Props) => {
       onShowMore={onShowMore}
     >
       <div className={styles.label}>
-        {showColourMarker ? colourMarker : null}
         <span className={styles.labelText}>{props.label}</span>
         {props.additional_info ? (
           <span className={styles.labelTextSecondary}>

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelRegularItem.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelRegularItem.tsx
@@ -44,6 +44,7 @@ type Props = GenomicTrack & {
 
 const TrackPanelRegularItem = (props: Props) => {
   const { genomeId, track_id } = props;
+  const showColourMarker = props.category === 'genes-transcripts';
   const isTrackVisible = useAppSelector((state: RootState) =>
     getTrackVisibility(state, track_id)
   );
@@ -79,6 +80,13 @@ const TrackPanelRegularItem = (props: Props) => {
     );
   };
 
+  const colourMarker = (
+    <span
+      className={styles.colourMarker}
+      style={{ backgroundColor: '#0099FF' }}
+    />
+  );
+
   return (
     <SimpleTrackPanelItemLayout
       visibilityStatus={isTrackVisible ? Status.SELECTED : Status.UNSELECTED}
@@ -86,6 +94,7 @@ const TrackPanelRegularItem = (props: Props) => {
       onShowMore={onShowMore}
     >
       <div className={styles.label}>
+        {showColourMarker ? colourMarker : null}
         <span className={styles.labelText}>{props.label}</span>
         {props.additional_info ? (
           <span className={styles.labelTextSecondary}>

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelRegularItem.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelRegularItem.tsx
@@ -39,6 +39,7 @@ import styles from './TrackPanelItem.module.css';
 
 type Props = GenomicTrack & {
   genomeId: string;
+  category: string;
 };
 
 const TrackPanelRegularItem = (props: Props) => {

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelRegularItem.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelRegularItem.tsx
@@ -79,11 +79,6 @@ const TrackPanelRegularItem = (props: Props) => {
     );
   };
 
-  const color = props.colour ? colorMap[props.colour] : undefined;
-  const colourMarker = color ? (
-    <span className={styles.colourMarker} style={{ backgroundColor: color }} />
-  ) : null;
-
   return (
     <SimpleTrackPanelItemLayout
       visibilityStatus={isTrackVisible ? Status.SELECTED : Status.UNSELECTED}
@@ -91,7 +86,6 @@ const TrackPanelRegularItem = (props: Props) => {
       onShowMore={onShowMore}
     >
       <div className={styles.label}>
-        {colourMarker}
         <span className={styles.labelText}>{props.label}</span>
         {props.additional_info ? (
           <span className={styles.labelTextSecondary}>
@@ -101,11 +95,6 @@ const TrackPanelRegularItem = (props: Props) => {
       </div>
     </SimpleTrackPanelItemLayout>
   );
-};
-
-const colorMap: Record<string, string> = {
-  DARK_GREY: '#6f8190',
-  GREY: '#b7c0c8'
 };
 
 export default TrackPanelRegularItem;

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelTranscript.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelTranscript.tsx
@@ -21,7 +21,6 @@ import useGenomeBrowserAnalytics from 'src/content/app/genome-browser/hooks/useG
 import { changeDrawerViewForGenome } from 'src/content/app/genome-browser/state/drawer/drawerSlice';
 
 import { getTranscriptMetadata as getTranscriptSupportLevel } from 'src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel';
-import { isProteinCodingTranscript } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
 
 import SimpleTrackPanelItemLayout from './track-panel-item-layout/SimpleTrackPanelItemLayout';
 
@@ -89,25 +88,11 @@ const TrackPanelTranscript = (props: Props) => {
       onShowMore={onShowMore}
     >
       <div className={styles.label}>
-        <span
-          className={styles.colourMarker}
-          style={{ backgroundColor: getTranscriptColor(transcript) }}
-        />
         <span className={styles.labelText}>{currentTranscriptId}</span>
         {secondaryLabel}
       </div>
     </SimpleTrackPanelItemLayout>
   );
-};
-
-const getTranscriptColor = (transcript: TrackPanelTranscriptType) => {
-  if (transcript.metadata.canonical?.value) {
-    return '#0099ff'; // blue
-  } else if (isProteinCodingTranscript(transcript)) {
-    return '#6f8190'; // dark grey
-  } else {
-    return '#b7c0c8'; // regular grey
-  }
 };
 
 export default TrackPanelTranscript;

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelTranscript.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelTranscript.tsx
@@ -88,10 +88,6 @@ const TrackPanelTranscript = (props: Props) => {
       onShowMore={onShowMore}
     >
       <div className={styles.label}>
-        <span
-          className={styles.colourMarker}
-          style={{ backgroundColor: '#0099FF' }}
-        />
         <span className={styles.labelText}>{currentTranscriptId}</span>
         {secondaryLabel}
       </div>

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelTranscript.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelTranscript.tsx
@@ -21,7 +21,6 @@ import useGenomeBrowserAnalytics from 'src/content/app/genome-browser/hooks/useG
 import { changeDrawerViewForGenome } from 'src/content/app/genome-browser/state/drawer/drawerSlice';
 
 import { getTranscriptMetadata as getTranscriptSupportLevel } from 'src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel';
-import { isProteinCodingTranscript } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
 
 import SimpleTrackPanelItemLayout from './track-panel-item-layout/SimpleTrackPanelItemLayout';
 
@@ -91,23 +90,13 @@ const TrackPanelTranscript = (props: Props) => {
       <div className={styles.label}>
         <span
           className={styles.colourMarker}
-          style={{ backgroundColor: getTranscriptColor(transcript) }}
+          style={{ backgroundColor: '#0099FF' }}
         />
         <span className={styles.labelText}>{currentTranscriptId}</span>
         {secondaryLabel}
       </div>
     </SimpleTrackPanelItemLayout>
   );
-};
-
-const getTranscriptColor = (transcript: TrackPanelTranscriptType) => {
-  if (transcript.metadata.canonical?.value) {
-    return '#0099ff'; // blue
-  } else if (isProteinCodingTranscript(transcript)) {
-    return '#6f8190'; // dark grey
-  } else {
-    return '#b7c0c8'; // regular grey
-  }
 };
 
 export default TrackPanelTranscript;

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelTranscript.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelTranscript.tsx
@@ -21,6 +21,7 @@ import useGenomeBrowserAnalytics from 'src/content/app/genome-browser/hooks/useG
 import { changeDrawerViewForGenome } from 'src/content/app/genome-browser/state/drawer/drawerSlice';
 
 import { getTranscriptMetadata as getTranscriptSupportLevel } from 'src/content/app/entity-viewer/shared/components/default-transcript-label/TranscriptQualityLabel';
+import { isProteinCodingTranscript } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
 
 import SimpleTrackPanelItemLayout from './track-panel-item-layout/SimpleTrackPanelItemLayout';
 
@@ -88,11 +89,25 @@ const TrackPanelTranscript = (props: Props) => {
       onShowMore={onShowMore}
     >
       <div className={styles.label}>
+        <span
+          className={styles.colourMarker}
+          style={{ backgroundColor: getTranscriptColor(transcript) }}
+        />
         <span className={styles.labelText}>{currentTranscriptId}</span>
         {secondaryLabel}
       </div>
     </SimpleTrackPanelItemLayout>
   );
+};
+
+const getTranscriptColor = (transcript: TrackPanelTranscriptType) => {
+  if (transcript.metadata.canonical?.value) {
+    return '#0099ff'; // blue
+  } else if (isProteinCodingTranscript(transcript)) {
+    return '#6f8190'; // dark grey
+  } else {
+    return '#b7c0c8'; // regular grey
+  }
 };
 
 export default TrackPanelTranscript;

--- a/src/content/app/genome-browser/state/types/tracks.ts
+++ b/src/content/app/genome-browser/state/types/tracks.ts
@@ -44,7 +44,6 @@ export type GenomicTrack = {
   type: GenomicTrackType;
   trigger: string[]; // <-- see the note about triggers above
   label: string;
-  colour: string; // NOTE: the backend will want to get rid of this field
   additional_info: string;
   description: string;
   on_by_default: boolean;

--- a/tests/fixtures/genomes.ts
+++ b/tests/fixtures/genomes.ts
@@ -50,7 +50,6 @@ const createTrack = (): GenomicTrack => {
     trigger: ['track', 'gene-pc-fwd'],
     type: 'gene',
     additional_info: faker.lorem.words(),
-    colour: 'DARK_GREY',
     label: faker.lorem.words(),
     on_by_default: true,
     display_order: 1,


### PR DESCRIPTION
## Description
This PR ~changes~ removes all gene track colour markers in the right-hand panel, to match the [updates in Genome browser](https://github.com/Ensembl/ensembl-dauphin-style-compiler/pull/149).

## Related JIRA Issue(s)
[ENSWBSITES-2973](https://embl.atlassian.net/browse/ENSWBSITES-2973)

## Deployment URL(s)
http://blue-genes.review.ensembl.org


## Views affected
Genome Browser view