### PR TITLE
Remove the flag for hiding genome categories in genome selector

### DIFF
--- a/src/content/app/species-selector/views/species-selector-main-view/SpeciesSelectorMainView.tsx
+++ b/src/content/app/species-selector/views/species-selector-main-view/SpeciesSelectorMainView.tsx
@@ -21,7 +21,6 @@ import useSpeciesSelectorAnalytics from 'src/content/app/species-selector/hooks/
 import { useAppSelector } from 'src/store';
 
 import * as urlFor from 'src/shared/helpers/urlHelper';
-import { isProductionEnvironment } from 'src/shared/helpers/environment';
 
 import { getCommittedSpecies } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors';
 import { useGenomeGroupCategoriesQuery } from 'src/content/app/species-selector/state/species-selector-api-slice/speciesSelectorApiSlice';
@@ -43,15 +42,11 @@ const SpeciesSelectorMainView = () => {
   const canSearchFeature = committedSpecies.length > 0;
   const { trackSpeciesSearchQuery } = useSpeciesSelectorAnalytics();
   const [activeTab, setActiveTab] = useState(popularSpeciesTab);
-  const shouldShowGenomeGroupTabs = !isProductionEnvironment();
   const { currentData: genomeGroupCategoriesData } =
-    useGenomeGroupCategoriesQuery(undefined, {
-      skip: !shouldShowGenomeGroupTabs
-    });
+    useGenomeGroupCategoriesQuery();
 
-  const genomeGroupCategories = shouldShowGenomeGroupTabs
-    ? (genomeGroupCategoriesData?.group_categories ?? [])
-    : [];
+  const genomeGroupCategories =
+    genomeGroupCategoriesData?.group_categories ?? [];
   const tabs = [
     popularSpeciesTab,
     ...genomeGroupCategories.map((category) => category.display_name)


### PR DESCRIPTION
## Description
Remove the flag that was hiding the genome categories tab in genome selector in production

## Deployment URL(s)
http://show-genome-categories.review.ensembl.org