### PR TITLE
Fix VEP form submission in Safari

### DIFF
--- a/src/content/app/tools/vep/services/vepStorageService.ts
+++ b/src/content/app/tools/vep/services/vepStorageService.ts
@@ -22,6 +22,8 @@ import {
   TEMPORARY_VEP_SUBMISSION_STORAGE_DURATION
 } from './vepStorageServiceConstants';
 
+import { cloneFileRestoredFromIndexedDb } from 'src/shared/helpers/indexedDbHelpers';
+
 import type {
   VepSubmission,
   VepSubmissionWithoutInputFile
@@ -71,19 +73,16 @@ export const updateVepSubmission = async (
   }
 
   // The if block below is a hack due to IndexedDB (mis)behaviour in Safari.
-  // Safari seems to dislike it when you store a record one of whose fields is a file (i.e. a blob),
+  // Safari seems to dislike it when you store a record with a file (i.e. a blob),
   // and when you then retrieve that record from the db, change one of the fields that is not the file field,
   // and save it back to the db.
   // In such cases, IndexedDB in Safari (as recent as Safari 18) fails with an error:
   // 'UnknownError: Error preparing Blob/File data to be stored in object store'
   //
-  // The if block below clones the stored file into a new one. This is silly additional CPU work and memory pressure.
-  // TODO: observe in newer Safaris if this remains a problem, and remove this hack if no longer is.
+  // NOTE: this no longer seems to be a problem in Safari 26; but keeping this hack for now
   if (storedSubmission.inputFile) {
-    const fileClone = await storedSubmission.inputFile.arrayBuffer();
-    storedSubmission.inputFile = new File(
-      [fileClone],
-      storedSubmission.inputFile.name
+    storedSubmission.inputFile = await cloneFileRestoredFromIndexedDb(
+      storedSubmission.inputFile
     );
   }
 

--- a/src/content/app/tools/vep/state/vep-form/vepFormSlice.ts
+++ b/src/content/app/tools/vep/state/vep-form/vepFormSlice.ts
@@ -29,6 +29,8 @@ import {
   changeVepSubmissionId
 } from 'src/content/app/tools/vep/services/vepStorageService';
 
+import { cloneFileRestoredFromIndexedDb } from 'src/shared/helpers/indexedDbHelpers';
+
 import { getBrowserTabId } from 'src/global/globalSelectors';
 import {
   getTemporaryVepSubmissionId,
@@ -298,7 +300,9 @@ const prepareRequestPayload = async ({
         `Submission with id ${submissionId} does not exist in browser storage`
       );
     }
-    inputFile = storedSubmission.inputFile as File;
+    inputFile = await cloneFileRestoredFromIndexedDb(
+      storedSubmission.inputFile as File
+    );
   }
 
   return {

--- a/src/shared/helpers/indexedDbHelpers.ts
+++ b/src/shared/helpers/indexedDbHelpers.ts
@@ -1,0 +1,36 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * It appears that Safari has a bug related to files stored in IndexedDB.
+ * When the file is read back from the db and appended to FormData for submission to the server,
+ * Safari fails to send as a part of a multipart/form-data request;
+ * and instead sends a request whose content length is zero.
+ * This problem is briefly discussed in a StackOverflow issue in 2021:
+ * https://stackoverflow.com/questions/68555937/upload-file-from-safari-using-file-object-stored-in-indexed-db
+ * The bug is active for Safari 26 (as of July 2026).
+ *
+ * The hack around this problem is to create a new instance of the file object,
+ * copying into it the contents and the metadata of the original file.
+ */
+
+export const cloneFileRestoredFromIndexedDb = async (file: File) => {
+  const fileContentClone = await file.arrayBuffer();
+  return new File([fileContentClone], file.name, {
+    type: file.type,
+    lastModified: file.lastModified
+  });
+};


### PR DESCRIPTION
## Description
The Safari-related VEP form submission problem (see [Slack](https://genomes-ebi.slack.com/archives/CC2RKR525/p1783502598734479)) was due to what seems to be a genuine bug in Safari.

It appears that in Safari, if you save a file to indexedDB, as is done during VEP form submission, then read it back, append it to `FormData`, and submit it in a `multipart/form-data` request, Safari will send a request whose content-length is 0 bytes:

<img width="1303" height="739" alt="image" src="https://github.com/user-attachments/assets/88064c7a-7bda-423e-affa-3a2a094dbd3b" />

Yeah, that's crazy.

The temporary fix for this, until Apple fixes their browser, is to clone the file after reading it from IndexedDB and before appending it to `FormData`.

## Deployment URL(s)
http://fix-vep-form-submit-safari.review.ensembl.org