### PR TITLE
Add an indeterminate state for Checkbox component

### DIFF
--- a/src/shared/components/checkbox/Checkbox.module.css
+++ b/src/shared/components/checkbox/Checkbox.module.css
@@ -6,14 +6,31 @@
     cursor: pointer;
     height: var(--checkbox-side-size, 13px);
     width: var(--checkbox-side-size, 13px);
-    transition: background-color 0.1s ease-in-out;
+    /* transition: background-color 0.1s ease-in-out; */
   }
   
   .checkbox:checked:not(:disabled) {
     background-color: var(--checkbox-checked-background-color, var(--color-green));
   }
+
+  .checkbox:indeterminate:not(:disabled) {
+    --_bg-color: var(--checkbox-background-color, var(--color-white));
+    --_color: var(--checkbox-checked-background-color, var(--color-green));
+    background: linear-gradient(
+      to bottom,
+      var(--_bg-color),
+      var(--_bg-color) 35%,
+      var(--_color) 35%,
+      var(--_color) 65%,
+      var(--_bg-color) 65%,
+      var(--_bg-color)
+    );
+    background-repeat: no-repeat;
+    background-size: calc(100% - 4px) 100%;
+    background-position: center;
+  }
   
-  .checkbox:not(:checked) {
+  .checkbox:not(:checked, :indeterminate, :disabled) {
     background-color: var(--checkbox-unchecked-background-color, var(--color-white));
   }
   

--- a/src/shared/components/checkbox/Checkbox.tsx
+++ b/src/shared/components/checkbox/Checkbox.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
+import { useLayoutEffect, useRef, type ComponentProps } from 'react';
 import classNames from 'classnames';
-import type { ComponentProps } from 'react';
 
 import styles from './Checkbox.module.css';
 
@@ -27,14 +27,57 @@ import styles from './Checkbox.module.css';
  * please use the CheckboxWithLabel component.
  */
 
-type Props = Omit<ComponentProps<'input'>, 'type'>; // the type of the input used in this comoponent is always 'checkbox'
+type CheckedState = boolean | 'indeterminate';
+
+// The type of the input used in this comoponent is always 'checkbox';
+// so the parent should have no reason to pass the "type" property to the component
+type Props = Omit<ComponentProps<'input'>, 'type' | 'checked'> & {
+  checked?: CheckedState;
+};
 
 const Checkbox = (props: Props) => {
-  const { className: classNameFromProps, ...otherProps } = props;
+  const {
+    className: classNameFromProps,
+    checked,
+    ref: refFromProps,
+    ...otherProps
+  } = props;
+
+  const localRef = useRef<HTMLInputElement>(null);
+
+  const setRef = (element: HTMLInputElement) => {
+    localRef.current = element;
+    let parentCleanup: void | (() => void);
+    if (typeof refFromProps === 'function') {
+      parentCleanup = refFromProps(element);
+    } else if (refFromProps) {
+      refFromProps.current = element;
+    }
+    return () => {
+      localRef.current = null;
+      parentCleanup?.();
+    };
+  };
+
+  useLayoutEffect(() => {
+    if (localRef.current) {
+      localRef.current.indeterminate = checked === 'indeterminate';
+    }
+  }, [checked]);
 
   const checkboxClasses = classNames(styles.checkbox, classNameFromProps);
 
-  return <input {...otherProps} type="checkbox" className={checkboxClasses} />;
+  const isChecked = checked === undefined ? undefined : checked === true;
+
+  return (
+    <input
+      {...otherProps}
+      type="checkbox"
+      className={checkboxClasses}
+      ref={setRef}
+      checked={isChecked}
+    />
+  );
 };
 
 export default Checkbox;

--- a/stories/shared-components/checkbox/Checkbox.stories.module.css
+++ b/stories/shared-components/checkbox/Checkbox.stories.module.css
@@ -17,6 +17,22 @@
   background-color: var(--color-black);
 }
 
+.indeterminateCheckboxStory {
+  label {
+    display: inline-flex;
+    column-gap: 1rem;
+    align-items: center;
+  }
+
+  .subordinateCheckboxes {
+    padding-left: 1rem;
+    padding-top: 0.5rem;
+    display: flex;
+    flex-direction: column;
+  }
+}
+
+
 .controlledCheckboxesStory {
   display: flex;
   flex-direction: column;

--- a/stories/shared-components/checkbox/Checkbox.stories.tsx
+++ b/stories/shared-components/checkbox/Checkbox.stories.tsx
@@ -30,6 +30,58 @@ const CheckboxesWithoutLabel = () => (
   </div>
 );
 
+const IndeterminateCheckbox = () => {
+  const [firstCheckboxChecked, setFirstCheckboxChecked] = useState(false);
+  const [secondCheckboxChecked, setSecondCheckboxChecked] = useState(false);
+
+  const masterCheckboxCheckedState =
+    firstCheckboxChecked && secondCheckboxChecked
+      ? true
+      : [firstCheckboxChecked, secondCheckboxChecked].some(
+            (isChecked) => isChecked
+          )
+        ? 'indeterminate'
+        : false;
+
+  const onMasterCheckboxChange = () => {
+    if (firstCheckboxChecked && secondCheckboxChecked) {
+      setFirstCheckboxChecked(false);
+      setSecondCheckboxChecked(false);
+    } else {
+      setFirstCheckboxChecked(true);
+      setSecondCheckboxChecked(true);
+    }
+  };
+
+  return (
+    <div className={styles.indeterminateCheckboxStory}>
+      <label>
+        <Checkbox
+          onChange={onMasterCheckboxChange}
+          checked={masterCheckboxCheckedState}
+        />
+        Select all
+      </label>
+      <div className={styles.subordinateCheckboxes}>
+        <label>
+          First
+          <Checkbox
+            checked={firstCheckboxChecked}
+            onChange={() => setFirstCheckboxChecked(!firstCheckboxChecked)}
+          />
+        </label>
+        <label>
+          Second
+          <Checkbox
+            checked={secondCheckboxChecked}
+            onChange={() => setSecondCheckboxChecked(!secondCheckboxChecked)}
+          />
+        </label>
+      </div>
+    </div>
+  );
+};
+
 const ControlledCheckboxes = () => {
   const [firstChecked, setFirtsChecked] = useState(false);
   const [secondChecked, setSecondChecked] = useState(false);
@@ -67,6 +119,11 @@ const ControlledCheckboxes = () => {
 export const DefaultCheckboxStory = {
   name: 'default',
   render: () => <CheckboxesWithoutLabel />
+};
+
+export const IndeterminateCheckboxStory = {
+  name: 'indeterminate checkbox',
+  render: () => <IndeterminateCheckbox />
 };
 
 export const ControlledCheckboxesStory = {


### PR DESCRIPTION
## Description
It seems that we are starting to use a pattern in which one checkbox can control multiple subordinate checkboxes to select/deselect all. Thus, such a checkbox can be in one of three states:
- All subordinate checkboxes are checked --> the "select all" checkbox is also checked
- All subordinate checkboxes are unchecked --> the "select all" checkbox is also unchecked
- Some subordinate checkboxes are checked, others are not --> what should the state of the "select all" checkbox be?

It is a common practice to represent this third state as an "indeterminate" state. This is so common that the indeterminate state is part of the native DOM input element.

This PR adds an indeterminate state to the checkbox. It has **not** been deliberately designed and officially blessed by Andrea.


https://github.com/user-attachments/assets/6c543ecc-b416-453f-8839-de696fd3492c


### Docs and design systems:
- MDN [docs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/indeterminate) about the indeterminate state of the input element
- [Web Awesome's checkbox component](https://webawesome.com/docs/components/checkbox/#indeterminate)
- [Material UI's checkbox component](https://mui.com/material-ui/react-checkbox/#indeterminate)

### Prior art
Github notifications

<img width="407" height="251" alt="image" src="https://github.com/user-attachments/assets/581b23a0-315f-4d5d-9b6d-a77e698bd0e5" />

Gitlab packages

<img width="383" height="352" alt="image" src="https://github.com/user-attachments/assets/aae7c7bb-d92d-48e0-ba43-c034ef36c6ee" />

### Notable exceptions

NCBI doesn't seem to use this pattern. [Example](https://www.ncbi.nlm.nih.gov/datasets/gene/GCF_000001405.40/)

## Deployment URL(s)
Not relevant. The changes made are in Storybook
