### PR TITLE
Genome browser fix: switch off non-focus tracks when switching between genomes

### DIFF
--- a/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
@@ -13,7 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useContext, useRef, useEffect, useCallback, useMemo } from 'react';
+import {
+  useState,
+  useContext,
+  useRef,
+  useEffect,
+  useCallback,
+  useMemo
+} from 'react';
 
 import config from 'config';
 import { useAppSelector } from 'src/store';
@@ -236,9 +243,25 @@ const useTrackIdToTrackPathMap = () => {
     }
   );
 
+  const [previousTrackCategories, setPreviousTrackCategories] = useState<
+    GenomeTrackCategory[]
+  >([]);
+  const [currentTrackCategoriesState, setCurrentTrackCategoriesState] =
+    useState(trackCategories);
+
+  if (
+    trackCategories.length &&
+    trackCategories !== currentTrackCategoriesState
+  ) {
+    setPreviousTrackCategories(currentTrackCategoriesState);
+    setCurrentTrackCategoriesState(trackCategories);
+  }
+
   const trackIdToPathMap = useMemo(() => {
-    return getTrackIdToTrackPathMap(trackCategories);
-  }, [trackCategories]);
+    return getTrackIdToTrackPathMap(
+      trackCategories.concat(previousTrackCategories)
+    );
+  }, [trackCategories, previousTrackCategories]);
 
   return trackIdToPathMap;
 };
@@ -254,5 +277,15 @@ const getTrackIdToTrackPathMap = (trackCategories: GenomeTrackCategory[]) => {
     {} as Record<string, string[]>
   );
 };
+
+// const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// const getTrackPath = (trackId: string) => {
+//   if (uuidRegex.test(trackId)) {
+//     return ['track', 'expand', trackId];
+//   } else {
+//     return ['track', trackId];
+//   }
+// };
 
 export default useGenomeBrowser;

--- a/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
@@ -13,14 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  useState,
-  useContext,
-  useRef,
-  useEffect,
-  useCallback,
-  useMemo
-} from 'react';
+import { useContext, useRef, useEffect, useCallback } from 'react';
 
 import config from 'config';
 import { useAppSelector } from 'src/store';
@@ -35,10 +28,8 @@ import * as genomeBrowserCommands from 'src/content/app/genome-browser/services/
 import { GenomeBrowserContext } from 'src/content/app/genome-browser/contexts/GenomeBrowserContext';
 
 import { getBrowserActiveGenomeId } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
-import { useGenomeTracksQuery } from 'src/content/app/genome-browser/state/api/genomeBrowserApiSlice';
 
 import type { ChrLocation } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSlice';
-import type { GenomeTrackCategory } from 'src/content/app/genome-browser/state/types/tracks';
 
 const useMandatoryGenomeBrowserContext = () => {
   const genomeBrowserContext = useContext(GenomeBrowserContext);
@@ -54,8 +45,6 @@ const useMandatoryGenomeBrowserContext = () => {
 const useGenomeBrowser = () => {
   const genomeBrowserContext = useMandatoryGenomeBrowserContext();
   const activeGenomeId = useAppSelector(getBrowserActiveGenomeId);
-
-  const trackIdToPathMap = useTrackIdToTrackPathMap();
 
   const {
     genomeBrowser,
@@ -159,7 +148,7 @@ const useGenomeBrowser = () => {
         return;
       }
       const { trackId, isEnabled } = params;
-      const trackPath = trackIdToPathMap[trackId] ?? ['track', trackId];
+      const trackPath = getTrackPath(trackId);
 
       genomeBrowserCommands.toggleTrack({
         genomeBrowser,
@@ -167,7 +156,7 @@ const useGenomeBrowser = () => {
         isEnabled
       });
     },
-    [genomeBrowser, trackIdToPathMap]
+    [genomeBrowser]
   );
 
   // At the moment, most track settings are just a boolean flag. Will this continue to be the case? Who knows.
@@ -177,7 +166,7 @@ const useGenomeBrowser = () => {
         return;
       }
       const { trackId, setting, isEnabled } = params;
-      const trackPath = trackIdToPathMap[trackId] ?? ['track', trackId];
+      const trackPath = getTrackPath(trackId);
 
       genomeBrowserCommands.toggleTrackSetting({
         genomeBrowser,
@@ -186,7 +175,7 @@ const useGenomeBrowser = () => {
         isEnabled
       });
     },
-    [genomeBrowser, trackIdToPathMap]
+    [genomeBrowser]
   );
 
   const updateFocusGeneTranscripts = useCallback(
@@ -219,73 +208,32 @@ const useGenomeBrowser = () => {
 };
 
 /**
- * There is, currently, a disconnect between what information genome browser needs
- * to toggle a track on or off (it needs a full "path" to the track, expressed in
- * the "trigger" field of track payload), and what the genome browser sends back
- * in its message about which tracks are being displayed (it only sends the last part
- * of the path, i.e. the last string of the "trigger" array).
+ * To toggle a genome browser track or its settings, the client has to generate
+ * a "track path" — an array of strings that genome browser will use to identify the track.
  *
- * This hook creates a map between a track id and the trigger required for
- * messages to the genome browser. The map includes non-focus tracks
- * for the currently active genome, as well as for the previous active genome.
- * The reason for storing information about tracks of the previous active genome
- * is to be able to turn off previous genome's tracks that don't even exist
- * for the currently active genome (e.g. a variation track may exist for human,
- * but not for some bacterium).
+ * There are currently two types of genome browser tracks:
+ *   - Older tracks with human-readable ids (e.g. protein-coding genes on the forward strand)
+ *   - Newer tracks identified by uuids. They are registered by the genome browser
+ *     using a mechanism called 'expansion'.
+ *
+ * Ideally, the client shouldn't know any of this. Ideally, tracks would be identified
+ * just by their ids. But, while this is not the case, the client will use a hack
+ * as an easy option of generating a track path.
+ *
+ * The hack is: if track id is uuid-shaped, then it is an "expansion" track
+ * that uses one path pattern; and in other cases, it is a "non-expansion" track,
+ * which uses a different path pattern.
  */
-const useTrackIdToTrackPathMap = () => {
-  const activeGenomeId = useAppSelector(getBrowserActiveGenomeId);
 
-  const { currentData: trackCategories = [] } = useGenomeTracksQuery(
-    activeGenomeId ?? '',
-    {
-      skip: !activeGenomeId
-    }
-  );
+const uuidRegex =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-  const [previousTrackCategories, setPreviousTrackCategories] = useState<
-    GenomeTrackCategory[]
-  >([]);
-  const [currentTrackCategoriesState, setCurrentTrackCategoriesState] =
-    useState(trackCategories);
-
-  if (
-    trackCategories.length &&
-    trackCategories !== currentTrackCategoriesState
-  ) {
-    setPreviousTrackCategories(currentTrackCategoriesState);
-    setCurrentTrackCategoriesState(trackCategories);
+const getTrackPath = (trackId: string) => {
+  if (uuidRegex.test(trackId)) {
+    return ['track', 'expand', trackId];
+  } else {
+    return ['track', trackId];
   }
-
-  const trackIdToPathMap = useMemo(() => {
-    return getTrackIdToTrackPathMap(
-      trackCategories.concat(previousTrackCategories)
-    );
-  }, [trackCategories, previousTrackCategories]);
-
-  return trackIdToPathMap;
 };
-
-const getTrackIdToTrackPathMap = (trackCategories: GenomeTrackCategory[]) => {
-  const tracks = trackCategories.flatMap(({ track_list }) => track_list);
-
-  return tracks.reduce(
-    (accumulator, track) => {
-      accumulator[track.track_id] = track.trigger;
-      return accumulator;
-    },
-    {} as Record<string, string[]>
-  );
-};
-
-// const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-// const getTrackPath = (trackId: string) => {
-//   if (uuidRegex.test(trackId)) {
-//     return ['track', 'expand', trackId];
-//   } else {
-//     return ['track', trackId];
-//   }
-// };
 
 export default useGenomeBrowser;

--- a/src/content/app/genome-browser/hooks/useGenomicTracks.ts
+++ b/src/content/app/genome-browser/hooks/useGenomicTracks.ts
@@ -37,6 +37,11 @@ import type { TrackSettingsPerTrack } from 'src/content/app/genome-browser/state
  * Only one copy of this hook should be run.
  */
 
+type TrackIdsList = {
+  trackId: string;
+  isEnabled: boolean;
+}[];
+
 const useGenomicTracks = () => {
   const { activeGenomeId } = useGenomeBrowserIds();
   const trackSettingsForGenome = useAppSelector((state) =>
@@ -44,6 +49,8 @@ const useGenomicTracks = () => {
   );
   const { genomeBrowser, ...genomeBrowserMethods } = useGenomeBrowser();
   const genomeIdInitialisedRef = useRef('');
+
+  const previousTrackIdsRef = useRef<TrackIdsList>([]);
 
   const { data: genomeTrackCategories } = useGenomeTracksQuery(
     activeGenomeId as string,
@@ -62,12 +69,16 @@ const useGenomicTracks = () => {
       return;
     }
 
-    const trackIdsList = prepareTrackIdsList(
-      genomeTrackCategories ?? [],
-      trackSettingsForGenome ?? {}
-    );
+    const trackIdsList = prepareTrackIdsList({
+      trackGroups: genomeTrackCategories ?? [],
+      trackSettings: trackSettingsForGenome ?? [],
+      previousTrackIdsList: previousTrackIdsRef.current
+    });
+
     trackIdsList.forEach(genomeBrowserMethods.toggleTrack);
     genomeIdInitialisedRef.current = activeGenomeId as string;
+
+    previousTrackIdsRef.current = trackIdsList;
 
     return () => {
       genomeIdInitialisedRef.current = '';
@@ -84,22 +95,21 @@ const useGenomicTracks = () => {
     if (!genomeBrowser || !trackSettingsForGenome) {
       return;
     }
-
     sendTrackSettings(trackSettingsForGenome, genomeBrowserMethods);
   }, [trackSettingsForGenome, genomeBrowser, genomeBrowserMethods]);
 };
 
-type TrackIdsList = {
-  trackId: string;
-  isEnabled: boolean;
-}[];
-
 // Create a list of tracks to enable in the genome browser.
 // Assume that all tracks should be enabled by default
-const prepareTrackIdsList = (
-  trackGroups: GenomeTrackCategory[],
-  trackSettings: TrackSettingsPerTrack
-): TrackIdsList => {
+const prepareTrackIdsList = ({
+  trackGroups,
+  trackSettings,
+  previousTrackIdsList
+}: {
+  trackGroups: GenomeTrackCategory[];
+  trackSettings: TrackSettingsPerTrack;
+  previousTrackIdsList: TrackIdsList;
+}): TrackIdsList => {
   const trackIdsList = trackGroups
     .flatMap(({ track_list }) => track_list)
     .map(({ track_id, on_by_default }) => {
@@ -112,7 +122,21 @@ const prepareTrackIdsList = (
         isEnabled: isVisibleTrack
       };
     });
-  return trackIdsList;
+
+  // Find if there are any tracks from the previous render
+  // that are not included in the new list of ids
+  // (such as what happens when user switches from one genome to another),
+  // and prepare a payload to tell the genome browser to switch them off.
+  const outdatedTrackIds = previousTrackIdsList
+    .filter(({ trackId }) => {
+      return !trackIdsList.find((track) => track.trackId === trackId);
+    })
+    .map((track) => ({
+      ...track,
+      isEnabled: false
+    }));
+
+  return trackIdsList.concat(outdatedTrackIds);
 };
 
 const sendTrackSettings = (


### PR DESCRIPTION
## Description
**Problem:** when switching from one genome to another, non-focus tracks from one genome are carried over to another genome.

For example, in screen capture below, human repeatmasker track and dbSNP short variants track are still visible in the genome browser after switching to zebrafish. You can also see that these human tracks do not have corresponding cogs in zebrafish view

https://github.com/user-attachments/assets/6dad45d0-bb60-4240-8c3e-5c44ccb4b467


**Cause:** The client should instruct the genome browser to turn off previous genome's tracks after switching to a new genome, but is not currently doing so.

## Related JIRA Issue(s)
https://embl.atlassian.net/browse/EBD-121

## Deployment URL(s)
http://fix-gb-non-focus-tracks.review.ensembl.org