### PR TITLE
Change urls for tools (BLAST and VEP)

### DIFF
--- a/src/content/app/tools/blast/components/listed-blast-submission/ListedBlastSubmission.test.tsx
+++ b/src/content/app/tools/blast/components/listed-blast-submission/ListedBlastSubmission.test.tsx
@@ -20,6 +20,8 @@ import { configureStore, combineReducers } from '@reduxjs/toolkit';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import * as urlFor from 'src/shared/helpers/urlHelper';
+
 import * as blastStorageService from 'src/content/app/tools/blast/services/blastStorageService';
 import { BLAST_RESULTS_AVAILABILITY_DURATION } from 'src/content/app/tools/blast/services/blastStorageServiceConstants';
 import { UNAVAILABLE_RESULTS_WARNING } from 'src/content/app/tools/shared/constants/displayedMessages';
@@ -201,7 +203,7 @@ describe('BlastSubmissionHeader', () => {
         expect(buttonLink).toBeTruthy();
         expect(buttonLink.tagName.toLowerCase()).toBe('a');
         expect(buttonLink.getAttribute('href')).toBe(
-          `/blast/submissions/${submission.id}`
+          urlFor.blastSubmission(submission.id)
         );
       });
     });

--- a/src/header/launchbar/BlastLaunchbarButton.tsx
+++ b/src/header/launchbar/BlastLaunchbarButton.tsx
@@ -25,7 +25,7 @@ import useLastVisitedPath from './useLastVisitedPath';
 import LaunchbarButtonWithNotification from './LaunchbarButtonWithNotification';
 import { BlastIcon } from 'src/shared/components/app-icon';
 
-const BLAST_APP_ROOT_PATH = '/blast';
+const BLAST_APP_ROOT_PATH = '/tools/blast';
 
 const BlastLaunchbarButton = () => {
   const unviewedSubmissions = useAppSelector(getUnviewedBlastSubmissions);

--- a/src/header/launchbar/VepLaunchbarButton.tsx
+++ b/src/header/launchbar/VepLaunchbarButton.tsx
@@ -25,7 +25,7 @@ import { VepIcon } from 'src/shared/components/app-icon';
 
 import type { VepSubmissionWithoutInputFile } from 'src/content/app/tools/vep/types/vepSubmission';
 
-const VEP_APP_ROOT_PATH = '/vep';
+const VEP_APP_ROOT_PATH = '/tools/vep';
 
 /**
  * Similarly to BlastLaunchbarButton, this button will show a dot

--- a/src/routes/routesConfig.tsx
+++ b/src/routes/routesConfig.tsx
@@ -108,12 +108,12 @@ const routes: RouteConfig[] = [
     element: <ActivityViewerPage />
   },
   {
-    path: '/blast/*',
+    path: '/tools/blast/*',
     element: <BlastPage />,
     serverFetch: blastServerFetch
   },
   {
-    path: '/vep/*',
+    path: '/tools/vep/*',
     element: <VepPage />,
     serverFetch: vepServerFetch
   },

--- a/src/server/static-files/robots.txt
+++ b/src/server/static-files/robots.txt
@@ -1,5 +1,4 @@
 User-agent: *
 Disallow: /genome-browser/
-Disallow: /blast/
-Disallow: /vep/
+Disallow: /tools/
 Disallow: /genome-selector/search

--- a/src/shared/helpers/urlHelper.ts
+++ b/src/shared/helpers/urlHelper.ts
@@ -249,25 +249,27 @@ export const structuralVariantsViewer = (params?: {
   return query ? `${pathname}?${query}` : pathname;
 };
 
-export const blastForm = () => '/blast';
+export const blastForm = () => '/tools/blast';
 
-export const blastUnviewedSubmissions = () => '/blast/unviewed-submissions';
+export const blastUnviewedSubmissions = () =>
+  '/tools/blast/unviewed-submissions';
 
-export const blastSubmissionsList = () => '/blast/submissions';
+export const blastSubmissionsList = () => '/tools/blast/submissions';
 
 export const blastSubmission = (submissionId: string) =>
-  `/blast/submissions/${submissionId}`;
+  `/tools/blast/submissions/${submissionId}`;
 
-export const vepForm = () => '/vep';
+export const vepForm = () => '/tools/vep';
 
-export const vepSpeciesSelector = () => '/vep/genome-selector';
+export const vepSpeciesSelector = () => '/tools/vep/genome-selector';
 
-export const vepUnviewedSubmissionsList = () => '/vep/unviewed-submissions';
+export const vepUnviewedSubmissionsList = () =>
+  '/tools/vep/unviewed-submissions';
 
-export const vepSubmissionsList = () => '/vep/submissions';
+export const vepSubmissionsList = () => '/tools/vep/submissions';
 
 export const vepResults = ({ submissionId }: { submissionId: string }) =>
-  `/vep/submissions/${submissionId}`;
+  `/tools/vep/submissions/${submissionId}`;
 
 type RefgetUrlParams = {
   checksum: string;


### PR DESCRIPTION
## Description
Changing urls for BLAST and tools
- For BLAST: from `/blast/*` to `/tools/blast/*`
- For VEP: from `/vep/*` to `/tools/vep/*`

The primary reason for the change is that `/vep` is a page on the old site that has links to documentation and source code, and needs to stay as is.

## Deployment URL(s)
http://change-tools-routes.review.ensembl.org
