### PR TITLE
Fix infinite loop error occurring on genome browser page

### DIFF
--- a/src/content/app/genome-browser/contexts/genome-browser-ids-context/useGenomeBrowserUrlValidator.ts
+++ b/src/content/app/genome-browser/contexts/genome-browser-ids-context/useGenomeBrowserUrlValidator.ts
@@ -181,17 +181,18 @@ const useGenomeBrowserUrlValidator = (params: Params) => {
   const runAfterValidation = useCallback(
     (fn: () => unknown) => {
       if (
-        !hasFocusObjectToValidate ||
-        (stateRef.current.doneValidating &&
-          !stateRef.current.isMissingFocusObject &&
-          !stateRef.current.isInvalidLocation)
+        genomeId &&
+        (!hasFocusObjectToValidate ||
+          (stateRef.current.doneValidating &&
+            !stateRef.current.isMissingFocusObject &&
+            !stateRef.current.isInvalidLocation))
       ) {
         fn();
       } else {
         postValidationQueueRef.current.push(fn);
       }
     },
-    [hasFocusObjectToValidate]
+    [hasFocusObjectToValidate, genomeId]
   );
 
   const resetValidator = () => {

--- a/src/content/app/genome-browser/state/browser-general/browserGeneralSlice.ts
+++ b/src/content/app/genome-browser/state/browser-general/browserGeneralSlice.ts
@@ -21,7 +21,6 @@ import {
   type PayloadAction,
   type ThunkAction
 } from '@reduxjs/toolkit';
-import { batch } from 'react-redux';
 import pickBy from 'lodash/pickBy';
 
 import browserStorageService from 'src/content/app/genome-browser/services/browserStorageService';
@@ -83,33 +82,33 @@ export const setDataFromUrlAndSave: ActionCreator<
   const currentActiveGenomeId = getBrowserActiveGenomeId(state);
   const currentActiveFocusObjectId = getBrowserActiveFocusObjectId(state);
 
-  batch(() => {
-    // update previously viewed objects before active genome id or active focus object id have changed
-    if (
-      activeGenomeId === currentActiveGenomeId &&
-      activeFocusObjectId !== currentActiveFocusObjectId
-    ) {
-      dispatch(updatePreviouslyViewedObjectsAndSave());
-    }
-    if (
-      activeFocusObjectId &&
-      activeFocusObjectId !== currentActiveFocusObjectId
-    ) {
-      dispatch(
-        updateTrackPanelTabForNewFocusObject({
-          genomeId: activeGenomeId,
-          focusObjectId: activeFocusObjectId
-        })
-      );
-    }
+  // update previously viewed objects before active genome id or active focus object id have changed
+  if (
+    activeGenomeId === currentActiveGenomeId &&
+    activeFocusObjectId !== currentActiveFocusObjectId
+  ) {
+    dispatch(updatePreviouslyViewedObjectsAndSave());
+  }
+  if (
+    activeFocusObjectId &&
+    activeFocusObjectId !== currentActiveFocusObjectId
+  ) {
+    dispatch(
+      updateTrackPanelTabForNewFocusObject({
+        genomeId: activeGenomeId,
+        focusObjectId: activeFocusObjectId
+      })
+    );
+  }
 
-    dispatch(browserGeneralSlice.actions.setDataFromUrl(payload));
-    dispatch(setInitialTrackPanelDataForGenome(payload));
-  });
+  dispatch(browserGeneralSlice.actions.setDataFromUrl(payload));
+  dispatch(setInitialTrackPanelDataForGenome(payload));
 
   browserStorageService.saveActiveGenomeId(activeGenomeId);
-  chrLocation &&
+
+  if (chrLocation) {
     browserStorageService.updateChrLocation({ [activeGenomeId]: chrLocation });
+  }
 
   if (activeFocusObjectId) {
     browserStorageService.updateActiveFocusObjectIds({

--- a/src/shared/components/close-button/CloseButton.tsx
+++ b/src/shared/components/close-button/CloseButton.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
+import { memo, type ComponentProps } from 'react';
 import classNames from 'classnames';
-import type { ComponentProps } from 'react';
 
 import CloseIcon from 'static/icons/icon_close.svg';
 
@@ -78,4 +78,4 @@ export const CloseButtonWithLabel = (
   );
 };
 
-export default CloseButton;
+export default memo(CloseButton);

--- a/src/shared/components/selected-species/SpeciesLozenge.tsx
+++ b/src/shared/components/selected-species/SpeciesLozenge.tsx
@@ -16,6 +16,7 @@
 
 import {
   useState,
+  useCallback,
   type DetailedHTMLProps,
   type ButtonHTMLAttributes
 } from 'react';
@@ -79,10 +80,10 @@ const RemoveButton = ({ onRemove }: { onRemove: Props['onRemove'] }) => {
     null
   );
 
-  const buttonRef = (element: HTMLButtonElement) => {
+  const buttonRef = useCallback((element: HTMLButtonElement) => {
     setButtonElement(element);
     return () => setButtonElement(null);
-  };
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
## Description
This is a temporary fix of errors that happened on the genome browser page when the genome id / genome tag was incorrect.

It resulted in the following error:

<img width="2048" height="603" alt="image" src="https://github.com/user-attachments/assets/79ddc957-1013-4340-934e-150b0c8fe0c8" />

Unwinding the error, it turned out:

- One (less important) cause of the infinite re-rendering was an uncached ref callback function in SpeciesLozenge.
- The actual reason for re-rendering was the `runAfterValidation` function, which did not fail validation when the genome id was incorrect.

The reason this fix is temporary is because I hope to address this code more closely in a subsequent PR and remove the `runAfterValidation` function altogether.

## Deployment URL(s)
http://fix-infinite-loop-error.review.ensembl.org
