### PR TITLE
Prevent component unmount when genome data is loaded

### DIFF
--- a/src/content/app/species/SpeciesPageContent.tsx
+++ b/src/content/app/species/SpeciesPageContent.tsx
@@ -106,8 +106,6 @@ const SpeciesPageContent = () => {
     );
   }
 
-  const isDataReady = genomeSummary && speciesDetails;
-
   return (
     <div className={styles.speciesPage}>
       <SpeciesAppBar onSpeciesSelect={changeGenomeId} />
@@ -115,16 +113,10 @@ const SpeciesPageContent = () => {
       <StandardAppLayout
         mainContent={<SpeciesMainView />}
         sidebarContent={
-          isDataReady ? (
-            <SidebarContent
-              genomeSummary={genomeSummary}
-              speciesDetails={speciesDetails}
-            />
-          ) : (
-            <Sidebar>
-              <SidebarLoader />
-            </Sidebar>
-          )
+          <SidebarContent
+            genomeSummary={genomeSummary}
+            speciesDetails={speciesDetails}
+          />
         }
         sidebarNavigation={null}
         topbarContent={<TopBar isSidebarOpen={sidebarStatus} />}
@@ -139,19 +131,32 @@ const SpeciesPageContent = () => {
   );
 };
 
-const SidebarContent = (props: {
-  genomeSummary: BriefGenomeSummary;
-  speciesDetails: GenomeInfo;
+const SidebarContent = ({
+  genomeSummary,
+  speciesDetails
+}: {
+  genomeSummary: BriefGenomeSummary | undefined;
+  speciesDetails: GenomeInfo | undefined;
 }) => {
+  const isDataReady = genomeSummary && speciesDetails;
   const isSpeciesSidebarModalOpened = useAppSelector(
     getIsSpeciesSidebarModalOpened
   );
+
+  if (!isDataReady) {
+    return (
+      <Sidebar>
+        <SidebarLoader />
+      </Sidebar>
+    );
+  }
+
   return isSpeciesSidebarModalOpened ? (
     <SpeciesSidebarModal />
   ) : (
     <SpeciesPageSidebar
-      data={props.speciesDetails}
-      genomeSuppressionMessage={props.genomeSummary.suppression_details}
+      data={speciesDetails}
+      genomeSuppressionMessage={genomeSummary.suppression_details}
     />
   );
 };

--- a/src/content/app/species/SpeciesPageContent.tsx
+++ b/src/content/app/species/SpeciesPageContent.tsx
@@ -43,6 +43,8 @@ import SpeciesSidebarModal from './components/species-sidebar-modal/SpeciesSideb
 import SpeciesSidebarToolstrip from './components/species-sidebar-toolstrip/SpeciesSidebarToolstrip';
 import AddButton from 'src/shared/components/add-button/AddButton';
 import { CloseButtonWithLabel } from 'src/shared/components/close-button/CloseButton';
+import Sidebar from 'src/shared/components/layout/sidebar/Sidebar';
+import { SidebarLoader } from 'src/shared/components/loader';
 
 import { BreakpointWidth } from 'src/global/globalConfig';
 import type { CommittedItem } from 'src/content/app/species-selector/types/committedItem';
@@ -104,9 +106,7 @@ const SpeciesPageContent = () => {
     );
   }
 
-  if (!genomeSummary || !speciesDetails) {
-    return null; // TODO: consider some kind of a spinner?
-  }
+  const isDataReady = genomeSummary && speciesDetails;
 
   return (
     <div className={styles.speciesPage}>
@@ -115,10 +115,16 @@ const SpeciesPageContent = () => {
       <StandardAppLayout
         mainContent={<SpeciesMainView />}
         sidebarContent={
-          <SidebarContent
-            genomeSummary={genomeSummary}
-            speciesDetails={speciesDetails}
-          />
+          isDataReady ? (
+            <SidebarContent
+              genomeSummary={genomeSummary}
+              speciesDetails={speciesDetails}
+            />
+          ) : (
+            <Sidebar>
+              <SidebarLoader />
+            </Sidebar>
+          )
         }
         sidebarNavigation={null}
         topbarContent={<TopBar isSidebarOpen={sidebarStatus} />}

--- a/src/content/app/species/components/species-main-view/SpeciesMainView.module.css
+++ b/src/content/app/species/components/species-main-view/SpeciesMainView.module.css
@@ -17,6 +17,12 @@
   padding: 5px 20px var(--global-padding-bottom) 140px;
 }
 
+.statsLoading {
+  display: flex;
+  justify-content: center;
+  padding: var(--standard-gutter);
+}
+
 .pointerBox {
   padding: 6px 12px;
   background: var(--color-black);

--- a/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
+++ b/src/content/app/species/components/species-main-view/SpeciesMainViewStats.tsx
@@ -204,7 +204,9 @@ const SpeciesMainViewStats = () => {
   if (isFetchingStatistics) {
     return (
       <div className={styles.statsWrapper}>
-        <CircleLoader />
+        <div className={styles.statsLoading}>
+          <CircleLoader />
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Description

There was an early return in the SpeciesPageContent component, which returned `null` if genome data was not yet ready:

```
  if (!genomeSummary || !speciesDetails) {
    return null; // TODO: consider some kind of a spinner?
  }
```

This results in the unmounting and remounting of the full species page component, which produces a visual flash, but more importantly, rewinds the list of selected genomes to the beginning, which is annoying and disorienting:

https://github.com/user-attachments/assets/7883cf5e-722f-4541-a89b-82bb75afc01d

## Deployment URL(s)
http://fix-genome-page-lozenges.review.ensembl.org