### PR TITLE
Fix automatic positioning of the active genome lozenge

### DIFF
--- a/src/shared/components/selected-species/SelectedSpecies.tsx
+++ b/src/shared/components/selected-species/SelectedSpecies.tsx
@@ -59,7 +59,7 @@ const getSpeciesLozengeProps = (props: Props & { onRemove: () => void }) => {
     return {
       theme: 'grey',
       disabled: true,
-      'data-active': true
+      isActive: true
     } as const;
   }
 
@@ -67,7 +67,7 @@ const getSpeciesLozengeProps = (props: Props & { onRemove: () => void }) => {
     return {
       theme: 'black',
       disabled: true,
-      'data-active': true
+      isActive: true
     } as const;
   } else {
     return {

--- a/src/shared/components/selected-species/SpeciesLozenge.tsx
+++ b/src/shared/components/selected-species/SpeciesLozenge.tsx
@@ -41,6 +41,7 @@ export type Props = DetailedHTMLProps<
 > & {
   species: CommittedItem;
   theme: SpeciesLozengeTheme;
+  isActive?: boolean;
   withReleaseInfo?: boolean;
   onRemove?: () => void;
 };
@@ -49,6 +50,7 @@ const SpeciesLozenge = (props: Props) => {
   const {
     species,
     theme,
+    isActive,
     withReleaseInfo = false,
     onRemove,
     className: classNameFromProps,
@@ -62,7 +64,7 @@ const SpeciesLozenge = (props: Props) => {
   );
 
   return (
-    <div className={componentClasses}>
+    <div className={componentClasses} data-active={isActive}>
       <button className={styles.speciesButton} {...otherProps}>
         <div className={styles.inner}>
           <SpeciesName species={species} />

--- a/src/shared/components/species-tabs-slider/SpeciesTabsSlider.module.css
+++ b/src/shared/components/species-tabs-slider/SpeciesTabsSlider.module.css
@@ -10,6 +10,7 @@
   column-gap: 15px;
   width: 100%;
   overflow-x: auto;
+  overscroll-behavior-y: none;
   scrollbar-width: none;
   padding-top: var(--tabs-container-padding-top);
 }

--- a/src/shared/components/species-tabs-slider/SpeciesTabsSlider.tsx
+++ b/src/shared/components/species-tabs-slider/SpeciesTabsSlider.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useRef, memo, type ReactNode } from 'react';
+import { memo, type ReactNode, useCallback } from 'react';
 import classNames from 'classnames';
 
 import useSpeciesTabsSlider from './useSpeciesTabsSlider';
@@ -30,15 +30,29 @@ type Props = {
 };
 
 const SpeciesTabsSlider = (props: Props) => {
-  const tabsContainerRef = useRef<HTMLDivElement>(null);
+  const {
+    refCallback: hookRefCallback1,
+    canScrollLeft,
+    canScrollRight,
+    scrollLeft,
+    scrollRight
+  } = useSpeciesTabsSlider();
+  const { refCallback: hookRefCallback2 } = useSliderGestures();
+  const { refCallback: hookRefCallback3 } = useVisibleActiveSpecies();
 
-  const { canScrollLeft, canScrollRight, scrollLeft, scrollRight } =
-    useSpeciesTabsSlider({
-      containerRef: tabsContainerRef,
-      children: props.children
-    });
-  useSliderGestures(tabsContainerRef);
-  useVisibleActiveSpecies(tabsContainerRef);
+  const refCallback = useCallback(
+    (element: HTMLDivElement) => {
+      const cleanup1 = hookRefCallback1(element);
+      const cleanup2 = hookRefCallback2(element);
+      const cleanup3 = hookRefCallback3(element);
+      return () => {
+        cleanup1();
+        cleanup2();
+        cleanup3();
+      };
+    },
+    [hookRefCallback1, hookRefCallback2, hookRefCallback3]
+  );
 
   const areAllTabsInViewport = !canScrollLeft && !canScrollRight;
 
@@ -66,7 +80,7 @@ const SpeciesTabsSlider = (props: Props) => {
         </button>
       </div>
 
-      <div ref={tabsContainerRef} className={styles.tabsContainer}>
+      <div ref={refCallback} className={styles.tabsContainer}>
         {props.children}
       </div>
 

--- a/src/shared/components/species-tabs-slider/SpeciesTabsSlider.tsx
+++ b/src/shared/components/species-tabs-slider/SpeciesTabsSlider.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { memo, type ReactNode, useCallback } from 'react';
+import { useCallback, memo, type ReactNode } from 'react';
 import classNames from 'classnames';
 
 import useSpeciesTabsSlider from './useSpeciesTabsSlider';

--- a/src/shared/components/species-tabs-slider/useSliderGestures.ts
+++ b/src/shared/components/species-tabs-slider/useSliderGestures.ts
@@ -66,6 +66,11 @@ const createDragObservable = (element: HTMLElement) => {
       const startX = downEvent.clientX;
       const startScrollLeft = element.scrollLeft;
 
+      // NOTE: Although it is common, while setting up drag gestures using pointer events,
+      // to capture all pointer events into the element that started the gesture (i.e. emitted the pointerdown event)
+      // (i.e.: element.setPointerCapture(downEvent.pointerId)),
+      // this would not be suitable here, because it would prevent click events
+      // from being registered on genome lozenges.
       const pointerUp$ = fromEvent<PointerEvent>(document, 'pointerup').pipe(
         take(1)
       );

--- a/src/shared/components/species-tabs-slider/useSliderGestures.ts
+++ b/src/shared/components/species-tabs-slider/useSliderGestures.ts
@@ -54,30 +54,31 @@ const useSliderGestures = () => {
   };
 };
 
-const DRAG_THRESHOLD = 6; // consider a mouse event to be a drag gesture if the mouse moved this distance after mousedown
-
-// FIXME: change mouse to pointer
+const DRAG_THRESHOLD = 6; // consider a pointer event to be a drag gesture if the pointer has moved this distance after pointerdown
 
 const createDragObservable = (element: HTMLElement) => {
-  const mouseDown$ = fromEvent<MouseEvent>(element, 'mousedown', {
+  const pointerDown$ = fromEvent<PointerEvent>(element, 'pointerdown', {
     capture: true
   });
 
-  const pipeline = mouseDown$.pipe(
+  const pipeline = pointerDown$.pipe(
     exhaustMap((downEvent) => {
       const startX = downEvent.clientX;
       const startScrollLeft = element.scrollLeft;
 
-      const mouseUp$ = fromEvent<MouseEvent>(document, 'mouseup').pipe(take(1));
-      const mouseMove$ = fromEvent<MouseEvent>(document, 'mousemove').pipe(
-        takeUntil(mouseUp$)
+      const pointerUp$ = fromEvent<PointerEvent>(document, 'pointerup').pipe(
+        take(1)
       );
+      const pointerMove$ = fromEvent<PointerEvent>(
+        document,
+        'pointermove'
+      ).pipe(takeUntil(pointerUp$));
       const click$ = fromEvent<MouseEvent>(document, 'click', {
         capture: true,
         once: true
       }).pipe(take(1));
 
-      const deltaX$ = mouseMove$.pipe(
+      const deltaX$ = pointerMove$.pipe(
         map((moveEvent) => {
           return moveEvent.clientX - startX;
         }),

--- a/src/shared/components/species-tabs-slider/useSliderGestures.ts
+++ b/src/shared/components/species-tabs-slider/useSliderGestures.ts
@@ -15,7 +15,20 @@
  */
 
 import { useCallback } from 'react';
-import { fromEvent, switchMap, tap, takeUntil } from 'rxjs';
+import {
+  fromEvent,
+  map,
+  tap,
+  scan,
+  distinctUntilChanged,
+  take,
+  takeUntil,
+  share,
+  withLatestFrom,
+  merge,
+  exhaustMap,
+  ignoreElements
+} from 'rxjs';
 
 /**
  * The purpose of this hook is to enable interaction with the species tabs slider
@@ -30,15 +43,9 @@ const useSliderGestures = () => {
   const refCallback = useCallback((element: HTMLElement) => {
     const observable = createDragObservable(element);
     const subscription = observable.subscribe();
-    // element.addEventListener('mousedown', onMouseDown, { capture: true });
-    // element.addEventListener('click', onClick, { capture: true }); // to control whether to pass the click to the genome lozenge
-    // elementRef.current = element;
 
     return () => {
       subscription.unsubscribe();
-      // element.removeEventListener('mousedown', onMouseDown);
-      // element.removeEventListener('click', onClick);
-      // elementRef.current = null;
     };
   }, []);
 
@@ -47,7 +54,7 @@ const useSliderGestures = () => {
   };
 };
 
-// const DRAG_THRESHOLD = 6; // consider a mouse event to be a drag gesture if the mouse moved this distance after mousedown
+const DRAG_THRESHOLD = 6; // consider a mouse event to be a drag gesture if the mouse moved this distance after mousedown
 
 // FIXME: change mouse to pointer
 
@@ -57,20 +64,52 @@ const createDragObservable = (element: HTMLElement) => {
   });
 
   const pipeline = mouseDown$.pipe(
-    switchMap((downEvent) => {
+    exhaustMap((downEvent) => {
       const startX = downEvent.clientX;
       const startScrollLeft = element.scrollLeft;
 
-      const mouseMove$ = fromEvent<MouseEvent>(document, 'mousemove');
-      const mouseUp$ = fromEvent<MouseEvent>(document, 'mouseup');
-
-      return mouseMove$.pipe(
-        tap((moveEvent) => {
-          const deltaX = moveEvent.clientX - startX;
-          element.scrollLeft = startScrollLeft - deltaX;
-        }),
+      const mouseUp$ = fromEvent<MouseEvent>(document, 'mouseup').pipe(take(1));
+      const mouseMove$ = fromEvent<MouseEvent>(document, 'mousemove').pipe(
         takeUntil(mouseUp$)
       );
+      const click$ = fromEvent<MouseEvent>(document, 'click', {
+        capture: true,
+        once: true
+      }).pipe(take(1));
+
+      const deltaX$ = mouseMove$.pipe(
+        map((moveEvent) => {
+          return moveEvent.clientX - startX;
+        }),
+        share()
+      );
+      const dragStarted$ = deltaX$.pipe(
+        map((deltaX) => {
+          return Math.abs(deltaX) > DRAG_THRESHOLD;
+        }),
+        scan((isDragging, hasCrossedThreshold) => {
+          return isDragging || hasCrossedThreshold;
+        }),
+        distinctUntilChanged()
+      );
+      const suppressClick$ = click$.pipe(
+        withLatestFrom(dragStarted$),
+        tap(([event, isDragging]) => {
+          if (isDragging) {
+            event.stopPropagation();
+            event.preventDefault();
+          }
+        }),
+        ignoreElements()
+      );
+      const scrollUpdate$ = deltaX$.pipe(
+        tap((deltaX) => {
+          element.scrollLeft = startScrollLeft - deltaX;
+        }),
+        ignoreElements()
+      );
+
+      return merge(scrollUpdate$, suppressClick$);
     })
   );
 

--- a/src/shared/components/species-tabs-slider/useSliderGestures.ts
+++ b/src/shared/components/species-tabs-slider/useSliderGestures.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { useEffect, useRef, type RefObject } from 'react';
+import { useCallback } from 'react';
+import { fromEvent, switchMap, tap, takeUntil } from 'rxjs';
 
 /**
  * The purpose of this hook is to enable interaction with the species tabs slider
@@ -25,71 +26,55 @@ import { useEffect, useRef, type RefObject } from 'react';
  * - user should be able to scroll trough species tabs by using the mouse wheel
  */
 
-const useSliderGestures = (ref: RefObject<Element | null>) => {
-  const startXRef = useRef(0);
-  const startScrollLeftRef = useRef(0);
-  const currentXRef = useRef(0);
-  const isMouseDownRef = useRef(false);
-  const isDraggingRef = useRef(false);
-
-  useEffect(() => {
-    if (!ref.current) {
-      return; // should not happen
-    }
-
-    ref.current.addEventListener('mousedown', onMouseDown, { capture: true });
-    ref.current.addEventListener('click', onClick, { capture: true }); // to control whether to pass the click to the species lozenge
+const useSliderGestures = () => {
+  const refCallback = useCallback((element: HTMLElement) => {
+    const observable = createDragObservable(element);
+    const subscription = observable.subscribe();
+    // element.addEventListener('mousedown', onMouseDown, { capture: true });
+    // element.addEventListener('click', onClick, { capture: true }); // to control whether to pass the click to the genome lozenge
+    // elementRef.current = element;
 
     return () => {
-      ref.current?.removeEventListener('mousedown', onMouseDown);
-      ref.current?.removeEventListener('click', onClick);
+      subscription.unsubscribe();
+      // element.removeEventListener('mousedown', onMouseDown);
+      // element.removeEventListener('click', onClick);
+      // elementRef.current = null;
     };
   }, []);
 
-  const onMouseDown = (event: Event) => {
-    const target = event.currentTarget as HTMLElement;
-    startScrollLeftRef.current = target.scrollLeft;
-    const mouseEvent = event as MouseEvent;
-    isMouseDownRef.current = true;
-    startXRef.current = mouseEvent.clientX;
-
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
+  return {
+    refCallback
   };
+};
 
-  const onMouseMove = (event: Event) => {
-    if (!isMouseDownRef.current) {
-      return;
-    }
-    const mouseEvent = event as MouseEvent;
-    currentXRef.current = mouseEvent.clientX;
-    const deltaX = currentXRef.current - startXRef.current;
+// const DRAG_THRESHOLD = 6; // consider a mouse event to be a drag gesture if the mouse moved this distance after mousedown
 
-    if (Math.abs(deltaX) > 6 && !isDraggingRef.current) {
-      isDraggingRef.current = true;
-    }
+// FIXME: change mouse to pointer
 
-    (ref.current as HTMLElement).scrollLeft =
-      startScrollLeftRef.current - deltaX;
-  };
+const createDragObservable = (element: HTMLElement) => {
+  const mouseDown$ = fromEvent<MouseEvent>(element, 'mousedown', {
+    capture: true
+  });
 
-  const onMouseUp = () => {
-    isMouseDownRef.current = false;
-    setTimeout(() => (isDraggingRef.current = false), 0);
+  const pipeline = mouseDown$.pipe(
+    switchMap((downEvent) => {
+      const startX = downEvent.clientX;
+      const startScrollLeft = element.scrollLeft;
 
-    document.removeEventListener('mousemove', onMouseMove);
-    document.removeEventListener('mouseup', onMouseUp);
-  };
+      const mouseMove$ = fromEvent<MouseEvent>(document, 'mousemove');
+      const mouseUp$ = fromEvent<MouseEvent>(document, 'mouseup');
 
-  const onClick = (event: Event) => {
-    // If the user tries a "drag" gesture (mouse down followed by mouse move) while over a species lozenge,
-    // this will be interpreted as a click on the lozenge, and the species will change.
-    // This function prevents this from happening.
-    if (isDraggingRef.current) {
-      event.stopPropagation();
-      isDraggingRef.current = false;
-    }
-  };
+      return mouseMove$.pipe(
+        tap((moveEvent) => {
+          const deltaX = moveEvent.clientX - startX;
+          element.scrollLeft = startScrollLeft - deltaX;
+        }),
+        takeUntil(mouseUp$)
+      );
+    })
+  );
+
+  return pipeline;
 };
 
 export default useSliderGestures;

--- a/src/shared/components/species-tabs-slider/useSliderGestures.ts
+++ b/src/shared/components/species-tabs-slider/useSliderGestures.ts
@@ -66,11 +66,15 @@ const createDragObservable = (element: HTMLElement) => {
       const startX = downEvent.clientX;
       const startScrollLeft = element.scrollLeft;
 
-      // NOTE: Although it is common, while setting up drag gestures using pointer events,
-      // to capture all pointer events into the element that started the gesture (i.e. emitted the pointerdown event)
+      // Although pointer capture is commonly used for drag interactions,
       // (i.e.: element.setPointerCapture(downEvent.pointerId)),
-      // this would not be suitable here, because it would prevent click events
-      // from being registered on genome lozenges.
+      // it is not appropriate here, because:
+      // - It suppresses the change of the cursor shape to a pointer
+      //   when hovering over a genome lozenge right after mouse button is released
+      // - It immediately prevents clicks on genome lozenges
+      // Thus, the code below listens to events on the document object,
+      // instead of on the initial element after pointer capture.
+
       const pointerUp$ = fromEvent<PointerEvent>(document, 'pointerup').pipe(
         take(1)
       );

--- a/src/shared/components/species-tabs-slider/useSpeciesTabsSlider.ts
+++ b/src/shared/components/species-tabs-slider/useSpeciesTabsSlider.ts
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useReducer, type ReactNode, type RefObject } from 'react';
-
-type Params = {
-  containerRef: RefObject<HTMLDivElement | null>;
-  children: ReactNode;
-};
+import { useCallback, useRef, useReducer } from 'react';
 
 const initialScrollState = {
   canScrollLeft: false,
@@ -36,56 +31,14 @@ const scrollStateReducer = (
   };
 };
 
-const useSpeciesTabsSlider = (params: Params) => {
-  const { containerRef, children } = params;
+const useSpeciesTabsSlider = () => {
   const [scrollState, scrollStateDispatch] = useReducer(
     scrollStateReducer,
     initialScrollState
   );
 
-  // connect intersection observers to the first and the last species tabs
-  useEffect(() => {
-    const tabsContainer = containerRef.current;
-    if (!tabsContainer) {
-      return;
-    }
-
-    const speciesTabs = [...tabsContainer.children];
-    if (!speciesTabs.length) {
-      scrollStateDispatch({
-        canScrollLeft: false,
-        canScrollRight: false
-      });
-      return;
-    }
-
-    const firstSpeciesTab = speciesTabs.at(0) as HTMLElement;
-    const lastSpeciesTab = speciesTabs.at(-1) as HTMLElement;
-
-    const tabIntersectionObserverOptions = {
-      root: tabsContainer,
-      rootMargin: '1px', // to overcome rounding errors
-      threshold: 1
-    };
-
-    const firstTabIntersectionObserver = new IntersectionObserver(
-      updateScrollLeftState,
-      tabIntersectionObserverOptions
-    );
-
-    const lastTabIntersectionObserver = new IntersectionObserver(
-      updateScrollRightState,
-      tabIntersectionObserverOptions
-    );
-
-    firstTabIntersectionObserver.observe(firstSpeciesTab);
-    lastTabIntersectionObserver.observe(lastSpeciesTab);
-
-    return () => {
-      firstTabIntersectionObserver.disconnect();
-      lastTabIntersectionObserver.disconnect();
-    };
-  }, [children]);
+  const containerRef = useRef<HTMLElement>(null);
+  const intersectionObserverRefs = useRef<IntersectionObserver[]>([]);
 
   /**
    * NOTE for the two functions below:
@@ -172,8 +125,85 @@ const useSpeciesTabsSlider = (params: Params) => {
     tabsContainer.scrollTo({ left: scrollTo, behavior: 'smooth' });
   };
 
+  const clearIntersectionObservers = useCallback(() => {
+    // clear old intersection observers
+    intersectionObserverRefs.current.forEach((observer) => {
+      observer.disconnect();
+    });
+    intersectionObserverRefs.current = [];
+  }, []);
+
+  const setIntersectionObservers = useCallback(() => {
+    const container = containerRef.current as HTMLElement;
+    const genomeTabs = [...container.children];
+    if (!genomeTabs.length) {
+      scrollStateDispatch({
+        canScrollLeft: false,
+        canScrollRight: false
+      });
+      return;
+    }
+
+    const firstGenomeTab = genomeTabs.at(0) as HTMLElement;
+    const lastGenomeTab = genomeTabs.at(-1) as HTMLElement;
+
+    const tabIntersectionObserverOptions = {
+      root: container,
+      rootMargin: '1px', // to overcome rounding errors
+      threshold: 1
+    };
+
+    const firstTabIntersectionObserver = new IntersectionObserver(
+      updateScrollLeftState,
+      tabIntersectionObserverOptions
+    );
+
+    const lastTabIntersectionObserver = new IntersectionObserver(
+      updateScrollRightState,
+      tabIntersectionObserverOptions
+    );
+
+    firstTabIntersectionObserver.observe(firstGenomeTab);
+    lastTabIntersectionObserver.observe(lastGenomeTab);
+
+    intersectionObserverRefs.current = [
+      firstTabIntersectionObserver,
+      lastTabIntersectionObserver
+    ];
+  }, []);
+
+  const mutationObserverCallback: MutationCallback = useCallback(() => {
+    clearIntersectionObservers();
+    setIntersectionObservers();
+  }, [setIntersectionObservers, clearIntersectionObservers]);
+
+  const refCallback = useCallback(
+    (element: HTMLElement) => {
+      containerRef.current = element;
+      setIntersectionObservers();
+
+      // set up a mutation observer to react to changes
+      // in the number of genome lozenges
+      const mutationObserverConfig = { childList: true };
+      const mutationObserver = new MutationObserver(mutationObserverCallback);
+      mutationObserver.observe(element, mutationObserverConfig);
+
+      return () => {
+        mutationObserver.disconnect();
+        clearIntersectionObservers();
+        containerRef.current = null;
+      };
+    },
+    [
+      mutationObserverCallback,
+      setIntersectionObservers,
+      clearIntersectionObservers
+    ]
+  );
+
   return {
     ...scrollState,
+    refCallback,
     scrollLeft,
     scrollRight
   };

--- a/src/shared/components/species-tabs-slider/useVisibleActiveSpecies.ts
+++ b/src/shared/components/species-tabs-slider/useVisibleActiveSpecies.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useEffect, type RefObject } from 'react';
+import { useRef, useCallback } from 'react';
 
 /**
  * The purpose of this hook is to make sure that, when the SpeciesTabsSlider mounts,
@@ -24,89 +24,106 @@ import { useEffect, type RefObject } from 'react';
  * then it is scrolled to the nearest visible side of the container.
  */
 
-const useVisibleActiveSpecies = (ref: RefObject<HTMLDivElement | null>) => {
-  useEffect(() => {
-    if (!ref.current) {
-      return;
-    }
+const useVisibleActiveSpecies = () => {
+  const elementRef = useRef<HTMLElement>(null);
 
-    // set up a mutation observer to react to any of the species lozenges
-    // becoming active when user clicks on it
-    const mutationObserverConfig = { attributes: true, subtree: true };
-    const mutationObserver = new MutationObserver(mutationObserverCallback);
-    mutationObserver.observe(ref.current, mutationObserverConfig);
+  const scrollToActiveSpeciesTab = useCallback(
+    (
+      params: {
+        scrollOptions?: ScrollIntoViewOptions;
+      } = {}
+    ) => {
+      const { scrollOptions = {} } = params;
+      const container = elementRef.current as HTMLElement;
+      const activeSpeciesLozenge = container?.querySelector(
+        'button[data-active="true"]'
+      ) as HTMLElement | null;
 
-    updatePositionWhenFontsAreReady();
+      if (!container || !activeSpeciesLozenge) {
+        return;
+      }
 
-    return () => {
-      mutationObserver.disconnect();
-    };
-  }, []);
+      const elementBoundingClientRect =
+        activeSpeciesLozenge.getBoundingClientRect();
+      const containerBoundingClientRect = container.getBoundingClientRect();
+      const { x: elementX, width: elementWidth } = elementBoundingClientRect;
+      const { x: containerX, width: containerWidth } =
+        containerBoundingClientRect;
 
-  const mutationObserverCallback: MutationCallback = (mutationList) => {
-    const attributeChangeMutation = mutationList.find((mutation) => {
-      return (
-        mutation.type === 'attributes' &&
-        mutation.attributeName === 'data-active' &&
-        (mutation.target as HTMLElement).dataset.active
-      );
-    });
-    if (attributeChangeMutation) {
-      scrollToActiveSpeciesTab({ behavior: 'smooth' });
-    }
-  };
+      if (
+        elementX >= containerX &&
+        elementX + elementWidth <= containerX + containerWidth
+      ) {
+        // species lozenge is visible inside of the container
+        return;
+      }
+      let scrollTo: number;
+
+      if (elementX < containerX) {
+        // species lozenge is at least partly hidden behind the left corner
+        // of the container
+        scrollTo = Math.floor(
+          activeSpeciesLozenge.offsetLeft - container.offsetLeft
+        );
+      } else {
+        // species lozenge is at least partly hidden behind the right corner
+        // of the container
+        scrollTo = Math.ceil(
+          activeSpeciesLozenge.offsetLeft +
+            activeSpeciesLozenge.offsetWidth -
+            container.offsetWidth -
+            container.offsetLeft
+        );
+      }
+      container.scrollTo({ ...scrollOptions, left: scrollTo });
+    },
+    []
+  );
 
   // for proper calculation of tab positions, wait until fonts are ready
-  const updatePositionWhenFontsAreReady = async () => {
+  const updatePositionWhenFontsAreReady = useCallback(async () => {
     await document.fonts.ready;
     scrollToActiveSpeciesTab();
-  };
+  }, [scrollToActiveSpeciesTab]);
 
-  const scrollToActiveSpeciesTab = (
-    scrollOptions: ScrollIntoViewOptions = {}
-  ) => {
-    const container = ref.current;
-    const activeSpeciesLozenge = container?.querySelector(
-      'button[data-active="true"]'
-    ) as HTMLElement | null;
+  const mutationObserverCallback: MutationCallback = useCallback(
+    (mutationList) => {
+      const attributeChangeMutation = mutationList.find((mutation) => {
+        return (
+          mutation.type === 'attributes' &&
+          mutation.attributeName === 'data-active' &&
+          (mutation.target as HTMLElement).dataset.active
+        );
+      });
+      if (attributeChangeMutation) {
+        scrollToActiveSpeciesTab({ scrollOptions: { behavior: 'smooth' } });
+      }
+    },
+    [scrollToActiveSpeciesTab]
+  );
 
-    if (!container || !activeSpeciesLozenge) {
-      return;
-    }
+  const refCallback = useCallback(
+    (element: HTMLElement) => {
+      elementRef.current = element;
 
-    const elementBoundingClientRect =
-      activeSpeciesLozenge.getBoundingClientRect();
-    const containerBoundingClientRect = container.getBoundingClientRect();
-    const { x: elementX, width: elementWidth } = elementBoundingClientRect;
-    const { x: containerX, width: containerWidth } =
-      containerBoundingClientRect;
+      // set up a mutation observer to react to any of the species lozenges
+      // becoming active when user clicks on it
+      const mutationObserverConfig = { attributes: true, subtree: true };
+      const mutationObserver = new MutationObserver(mutationObserverCallback);
+      mutationObserver.observe(element, mutationObserverConfig);
 
-    if (
-      elementX >= containerX &&
-      elementX + elementWidth <= containerX + containerWidth
-    ) {
-      // species lozenge is visible inside of the container
-      return;
-    }
-    let scrollTo: number;
+      updatePositionWhenFontsAreReady();
 
-    if (elementX < containerX) {
-      // species lozenge is at least partly hidden behind the left corner
-      // of the container
-      scrollTo = Math.floor(
-        activeSpeciesLozenge.offsetLeft - container.offsetLeft
-      );
-    } else {
-      // species lozenge is at least partly hidden behind the right corner
-      // of the container
-      scrollTo = Math.ceil(
-        activeSpeciesLozenge.offsetLeft +
-          activeSpeciesLozenge.offsetWidth -
-          container.offsetWidth -
-          container.offsetLeft
-      );
-    }
-    container.scrollTo({ ...scrollOptions, left: scrollTo });
+      return () => {
+        mutationObserver.disconnect();
+        elementRef.current = null;
+      };
+    },
+    [mutationObserverCallback, updatePositionWhenFontsAreReady]
+  );
+
+  return {
+    refCallback
   };
 };
 

--- a/src/shared/components/species-tabs-slider/useVisibleActiveSpecies.ts
+++ b/src/shared/components/species-tabs-slider/useVisibleActiveSpecies.ts
@@ -27,6 +27,11 @@ import { useRef, useCallback } from 'react';
 const useVisibleActiveSpecies = () => {
   const elementRef = useRef<HTMLElement>(null);
 
+  // NOTE:
+  // When all our target browsers start supporting the container: "nearest" option
+  // of element.scrollIntoView method, the below function will become as easy as:
+  // activeSpeciesLozenge.scrollIntoView({ behavior: 'smooth', inline: 'nearest', container: 'nearest' })
+  // See https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
   const scrollToActiveSpeciesTab = useCallback(
     (
       params: {
@@ -36,46 +41,30 @@ const useVisibleActiveSpecies = () => {
       const { scrollOptions = {} } = params;
       const container = elementRef.current as HTMLElement;
       const activeSpeciesLozenge = container?.querySelector(
-        'button[data-active="true"]'
+        '[data-active="true"]'
       ) as HTMLElement | null;
 
       if (!container || !activeSpeciesLozenge) {
         return;
       }
 
-      const elementBoundingClientRect =
-        activeSpeciesLozenge.getBoundingClientRect();
-      const containerBoundingClientRect = container.getBoundingClientRect();
-      const { x: elementX, width: elementWidth } = elementBoundingClientRect;
-      const { x: containerX, width: containerWidth } =
-        containerBoundingClientRect;
+      const left = activeSpeciesLozenge.offsetLeft;
+      const right = left + activeSpeciesLozenge.offsetWidth;
 
-      if (
-        elementX >= containerX &&
-        elementX + elementWidth <= containerX + containerWidth
-      ) {
-        // species lozenge is visible inside of the container
-        return;
-      }
-      let scrollTo: number;
+      const visibleLeft = container.scrollLeft;
+      const visibleRight = visibleLeft + container.clientWidth;
 
-      if (elementX < containerX) {
-        // species lozenge is at least partly hidden behind the left corner
-        // of the container
-        scrollTo = Math.floor(
-          activeSpeciesLozenge.offsetLeft - container.offsetLeft
-        );
-      } else {
-        // species lozenge is at least partly hidden behind the right corner
-        // of the container
-        scrollTo = Math.ceil(
-          activeSpeciesLozenge.offsetLeft +
-            activeSpeciesLozenge.offsetWidth -
-            container.offsetWidth -
-            container.offsetLeft
-        );
+      if (left < visibleLeft) {
+        container.scrollTo({
+          left: left - container.offsetLeft,
+          ...scrollOptions
+        });
+      } else if (right > visibleRight) {
+        container.scrollTo({
+          left: right - container.offsetLeft - container.clientWidth,
+          ...scrollOptions
+        });
       }
-      container.scrollTo({ ...scrollOptions, left: scrollTo });
     },
     []
   );


### PR DESCRIPTION
## Description
Problems:
1. Select a lozenge that is outside the visible viewport, i.e. one that you have to scroll to select. Then refresh the page. Expectation: the selected lozenge should be visible after a page load. Observation: the selected lozenge is outside the viewport, and you have to scroll to find it.
2. When you select a partially hidden lozenge, the lozenge carousel scrolls all the way to the first (leftmost) lozenge

https://github.com/user-attachments/assets/4c12c676-4364-43f6-9a57-ad076345795b

**Cause:** The likely cause of this behaviour is a change to the DOM structure of the genome lozenge made when a delete button was added to the lozenge in [this PR](https://github.com/Ensembl/ensembl-client/pull/1317). This threw off the calculations made inside of the `useVisibleActiveSpecies` hook.

**After:**

https://github.com/user-attachments/assets/45675f03-e461-42ff-baa4-f13bab7163e9



As a part of this PR I also updated the three hooks powering the `SpeciesTabsSlider` —  `useSpeciesTabsSlider`, `useSliderGestures`, and `useVisibleActiveSpecies` — to make them return a ref callback instead of accepting a ref and running a useEffect on it. The hooks had various lint errors.

<details>

<summary>
lint errors
</summary>

```

ensembl-client/src/shared/components/species-tabs-slider/useSliderGestures.ts
  40:47  error    Error: Cannot access variable before it is declared

`onMouseDown` is accessed before it is declared, which prevents the earlier access from updating when this value changes over time.

ensembl-client/src/shared/components/species-tabs-slider/useSliderGestures.ts:40:47
  38 |     }
  39 |
> 40 |     ref.current.addEventListener('mousedown', onMouseDown, { capture: true });
     |                                               ^^^^^^^^^^^ `onMouseDown` accessed before it is declared
  41 |     ref.current.addEventListener('click', onClick, { capture: true }); // to control whether to pass the click to the species lozenge
  42 |
  43 |     return () => {

ensembl-client/src/shared/components/species-tabs-slider/useSliderGestures.ts:49:3
  47 |   }, []);
  48 |
> 49 |   const onMouseDown = (event: Event) => {
     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 50 |     const target = event.currentTarget as HTMLElement;
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 51 |     startScrollLeftRef.current = target.scrollLeft;
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 52 |     const mouseEvent = event as MouseEvent;
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 53 |     isMouseDownRef.current = true;
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 54 |     startXRef.current = mouseEvent.clientX;
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 55 |
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 56 |     document.addEventListener('mousemove', onMouseMove);
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 57 |     document.addEventListener('mouseup', onMouseUp);
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 58 |   };
     | ^^^^^ `onMouseDown` is declared here
  59 |
  60 |   const onMouseMove = (event: Event) => {
  61 |     if (!isMouseDownRef.current) {                                                                                                                                                                                                                                                                                                                 react-hooks/immutability
  41:43  error    Error: Cannot access variable before it is declared

`onClick` is accessed before it is declared, which prevents the earlier access from updating when this value changes over time.

ensembl-client/src/shared/components/species-tabs-slider/useSliderGestures.ts:41:43
  39 |
  40 |     ref.current.addEventListener('mousedown', onMouseDown, { capture: true });
> 41 |     ref.current.addEventListener('click', onClick, { capture: true }); // to control whether to pass the click to the species lozenge
     |                                           ^^^^^^^ `onClick` accessed before it is declared
  42 |
  43 |     return () => {
  44 |       ref.current?.removeEventListener('mousedown', onMouseDown);

ensembl-client/src/shared/components/species-tabs-slider/useSliderGestures.ts:84:3
  82 |   };
  83 |
> 84 |   const onClick = (event: Event) => {
     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 85 |     // If the user tries a "drag" gesture (mouse down followed by mouse move) while over a species lozenge,
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 86 |     // this will be interpreted as a click on the lozenge, and the species will change.
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 87 |     // This function prevents this from happening.
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 88 |     if (isDraggingRef.current) {
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 89 |       event.stopPropagation();
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 90 |       isDraggingRef.current = false;
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 91 |     }
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 92 |   };
     | ^^^^^ `onClick` is declared here
  93 | };
  94 |
  95 | export default useSliderGestures;  react-hooks/immutability
  45:11  warning  The ref value 'ref.current' will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by React, copy 'ref.current' to a variable inside the effect, and use that variable in the cleanup function                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       react-hooks/exhaustive-deps
  47:6   warning  React Hook useEffect has missing dependencies: 'onMouseDown' and 'ref'. Either include them or remove the dependency array                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  react-hooks/exhaustive-deps

ensembl-client/src/shared/components/species-tabs-slider/useSpeciesTabsSlider.ts
  72:7  error    Error: Cannot access variable before it is declared

`updateScrollLeftState` is accessed before it is declared, which prevents the earlier access from updating when this value changes over time.

ensembl-client/src/shared/components/species-tabs-slider/useSpeciesTabsSlider.ts:72:7
  70 |
  71 |     const firstTabIntersectionObserver = new IntersectionObserver(
> 72 |       updateScrollLeftState,
     |       ^^^^^^^^^^^^^^^^^^^^^ `updateScrollLeftState` accessed before it is declared
  73 |       tabIntersectionObserverOptions
  74 |     );
  75 |

ensembl-client/src/shared/components/species-tabs-slider/useSpeciesTabsSlider.ts:100:3
   98 |    */
   99 |
> 100 |   const updateScrollLeftState = (entries: IntersectionObserverEntry[]) => {
      |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 101 |     const intersectionEntry = entries.at(-1) as IntersectionObserverEntry;
      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 102 |     scrollStateDispatch({ canScrollLeft: !intersectionEntry.isIntersecting });
      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 103 |   };
      | ^^^^^ `updateScrollLeftState` is declared here
  104 |
  105 |   const updateScrollRightState = (entries: IntersectionObserverEntry[]) => {
  106 |     const intersectionEntry = entries.at(-1) as IntersectionObserverEntry;  react-hooks/immutability
  77:7  error    Error: Cannot access variable before it is declared

`updateScrollRightState` is accessed before it is declared, which prevents the earlier access from updating when this value changes over time.

ensembl-client/src/shared/components/species-tabs-slider/useSpeciesTabsSlider.ts:77:7
  75 |
  76 |     const lastTabIntersectionObserver = new IntersectionObserver(
> 77 |       updateScrollRightState,
     |       ^^^^^^^^^^^^^^^^^^^^^^ `updateScrollRightState` accessed before it is declared
  78 |       tabIntersectionObserverOptions
  79 |     );
  80 |

ensembl-client/src/shared/components/species-tabs-slider/useSpeciesTabsSlider.ts:105:3
  103 |   };
  104 |
> 105 |   const updateScrollRightState = (entries: IntersectionObserverEntry[]) => {
      |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 106 |     const intersectionEntry = entries.at(-1) as IntersectionObserverEntry;
      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 107 |     scrollStateDispatch({ canScrollRight: !intersectionEntry.isIntersecting });
      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 108 |   };
      | ^^^^^ `updateScrollRightState` is declared here
  109 |
  110 |   /**
  111 |    * NOTE: the reason the scroll functions below calculate scroll distance imperatively,                                                     react-hooks/immutability
  88:6  warning  React Hook useEffect has a missing dependency: 'containerRef'. Either include it or remove the dependency array                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          react-hooks/exhaustive-deps

ensembl-client/src/shared/components/species-tabs-slider/useVisibleActiveSpecies.ts
  36:51  error    Error: Cannot access variable before it is declared

`mutationObserverCallback` is accessed before it is declared, which prevents the earlier access from updating when this value changes over time.

ensembl-client/src/shared/components/species-tabs-slider/useVisibleActiveSpecies.ts:36:51
  34 |     // becoming active when user clicks on it
  35 |     const mutationObserverConfig = { attributes: true, subtree: true };
> 36 |     const mutationObserver = new MutationObserver(mutationObserverCallback);
     |                                                   ^^^^^^^^^^^^^^^^^^^^^^^^ `mutationObserverCallback` accessed before it is declared
  37 |     mutationObserver.observe(ref.current, mutationObserverConfig);
  38 |
  39 |     updatePositionWhenFontsAreReady();

ensembl-client/src/shared/components/species-tabs-slider/useVisibleActiveSpecies.ts:46:3
  44 |   }, []);
  45 |
> 46 |   const mutationObserverCallback: MutationCallback = (mutationList) => {
     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 47 |     const attributeChangeMutation = mutationList.find((mutation) => {
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 48 |       return (
     …
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 56 |     }
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 57 |   };
     | ^^^^^ `mutationObserverCallback` is declared here
  58 |
  59 |   // for proper calculation of tab positions, wait until fonts are ready
  60 |   const updatePositionWhenFontsAreReady = async () => {  react-hooks/immutability
  39:5   error    Error: Cannot access variable before it is declared

`updatePositionWhenFontsAreReady` is accessed before it is declared, which prevents the earlier access from updating when this value changes over time.

ensembl-client/src/shared/components/species-tabs-slider/useVisibleActiveSpecies.ts:39:5
  37 |     mutationObserver.observe(ref.current, mutationObserverConfig);
  38 |
> 39 |     updatePositionWhenFontsAreReady();
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `updatePositionWhenFontsAreReady` accessed before it is declared
  40 |
  41 |     return () => {
  42 |       mutationObserver.disconnect();

ensembl-client/src/shared/components/species-tabs-slider/useVisibleActiveSpecies.ts:60:3
  58 |
  59 |   // for proper calculation of tab positions, wait until fonts are ready
> 60 |   const updatePositionWhenFontsAreReady = async () => {
     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 61 |     await document.fonts.ready;
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 62 |     scrollToActiveSpeciesTab();
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 63 |   };
     | ^^^^^ `updatePositionWhenFontsAreReady` is declared here
  64 |
  65 |   const scrollToActiveSpeciesTab = (
  66 |     scrollOptions: ScrollIntoViewOptions = {}                                                                                                                                                                                                                                                                                                                                                                                   react-hooks/immutability
  44:6   warning  React Hook useEffect has missing dependencies: 'mutationObserverCallback', 'ref', and 'updatePositionWhenFontsAreReady'. Either include them or remove the dependency array                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         react-hooks/exhaustive-deps

✖ 10 problems (6 errors, 4 warnings)


```

</details>

The most radical change has been made to `useSliderGestures`, where I gave up on react apis (useCallback was causing circular dependencies between event handlers), and switched to rxjs instead.

## Deployment URL(s)
http://fix-genome-page-lozenges.review.ensembl.org