### PR TITLE
Add ftp link to the genomes table

### DIFF
--- a/src/content/app/species-selector/components/species-search-results-table/SpeciesSearchResultsTable.module.css
+++ b/src/content/app/species-selector/components/species-search-results-table/SpeciesSearchResultsTable.module.css
@@ -25,11 +25,6 @@
   font-style: italic;
 }
 
-.disabled {
-  --dot-solid-color: var(--color-medium-light-grey);
-  color: var(--color-medium-dark-grey);
-}
-
 .centered {
   text-align: center;
 }

--- a/src/content/app/species-selector/components/species-search-results-table/SpeciesSearchResultsTable.tsx
+++ b/src/content/app/species-selector/components/species-search-results-table/SpeciesSearchResultsTable.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import classNames from 'classnames';
-
 import { formatNumber } from 'src/shared/helpers/formatters/numberFormatter';
 
 import { Table, ColumnHead } from 'src/shared/components/table';
@@ -23,7 +21,6 @@ import Checkbox from 'src/shared/components/checkbox/Checkbox';
 import SolidDot from 'src/shared/components/table/dot/SolidDot';
 import EmptyDot from 'src/shared/components/table/dot/EmptyDot';
 import ExternalLink from 'src/shared/components/external-link/ExternalLink';
-import DisabledExternalLink from 'src/shared/components/external-link/DisabledExternalLink';
 import {
   CommonName,
   ScientificName,
@@ -213,12 +210,7 @@ const SpeciesSearchResultsTable = (props: Props) => {
       </thead>
       <tbody>
         {results.map((searchMatch) => (
-          <tr
-            key={searchMatch.genome_id}
-            className={classNames({
-              [styles.disabled]: shouldDisableRow(searchMatch, canAddToStaged)
-            })}
-          >
+          <tr key={searchMatch.genome_id}>
             <td>
               <Checkbox
                 disabled={shouldDisableRow(searchMatch, canAddToStaged)}
@@ -247,18 +239,12 @@ const SpeciesSearchResultsTable = (props: Props) => {
               <GenomeReleaseType release={searchMatch.release} />
             </td>
             <td className={styles.assemblyAccessionId}>
-              {!shouldDisableRow(searchMatch, canAddToStaged) ? (
-                <ExternalLink
-                  to={searchMatch.assembly.url}
-                  className={styles.externalLink}
-                >
-                  <AssemblyAccessionId {...searchMatch} />
-                </ExternalLink>
-              ) : (
-                <DisabledExternalLink>
-                  <AssemblyAccessionId {...searchMatch} />
-                </DisabledExternalLink>
-              )}
+              <ExternalLink
+                to={searchMatch.assembly.url}
+                className={styles.externalLink}
+              >
+                <AssemblyAccessionId {...searchMatch} />
+              </ExternalLink>
             </td>
 
             <td>

--- a/src/content/app/species-selector/components/species-search-results-table/SpeciesSearchResultsTable.tsx
+++ b/src/content/app/species-selector/components/species-search-results-table/SpeciesSearchResultsTable.tsx
@@ -159,6 +159,8 @@ const SpeciesSearchResultsTable = (props: Props) => {
             Assembly accession
           </ColumnHead>
 
+          <ColumnHead>Get data</ColumnHead>
+
           <ColumnHead
             sortOrder={getSortOrderForColumn('coding_genes_count', sortRule)}
             onSortOrderChange={(newOrder) =>
@@ -257,6 +259,15 @@ const SpeciesSearchResultsTable = (props: Props) => {
                   <AssemblyAccessionId {...searchMatch} />
                 </DisabledExternalLink>
               )}
+            </td>
+
+            <td>
+              <ExternalLink
+                to={searchMatch.ftp_url}
+                className={styles.externalLink}
+              >
+                FTP
+              </ExternalLink>
             </td>
 
             <td>{formatNumber(searchMatch.coding_genes_count)}</td>

--- a/src/content/app/species-selector/types/speciesSearchMatch.ts
+++ b/src/content/app/species-selector/types/speciesSearchMatch.ts
@@ -31,6 +31,7 @@ export type SpeciesSearchMatch = Pick<
   GenomeInfo,
   SearchMatchFieldsFromGenomeInfo
 > & {
+  ftp_url: string;
   coding_genes_count: number;
   contig_n50: number | null; // E.coli doesn't have contig n50 in species stats
   has_variation: boolean;


### PR DESCRIPTION
## Description
Add ftp link to the genomes table.

**ALSO:**
- Do not grey out the whole selected genome row — only disable the checkbox in the row

[Reference XD](https://xd.adobe.com/view/ec719eb2-a3c1-4dc0-97e8-15751315c6e7-b922/screen/31a960cb-8d04-4f04-9099-224d648aabca?fullscreen)

### For later discussion
- Consider whether to change FTP links column name (it now says "Get data", which is a bit weird for a table column name)
- Consider whether to hide some of the columns in tools genome selector (e.g. ftp link, the pips, gene counts, etc.)  

## Deployment URL(s)
http://genomes-table-ftp-link.review.ensembl.org
