### PR TITLE
Enable genome lozenges in genome manager and genome selector search results views

### DIFF
--- a/src/content/app/species-selector/SpeciesSelector.tsx
+++ b/src/content/app/species-selector/SpeciesSelector.tsx
@@ -26,27 +26,31 @@ import SpeciesManager from './views/species-manager/SpeciesManager';
 import styles from './SpeciesSelector.module.css';
 
 const SpeciesSelector = () => {
-  const appBar = (
+  return (
+    <div className={styles.grid}>
+      <AppBar />
+      <MainContent />
+    </div>
+  );
+};
+
+const AppBar = () => {
+  return (
     <Routes>
       <Route index element={<SpeciesSelectorAppBar />} />
       <Route path="/search" element={<SpeciesSearchResultsAppBar />} />
       <Route path="/manage" element={<SpeciesManagerAppBar />} />
     </Routes>
   );
+};
 
-  const body = (
+const MainContent = () => {
+  return (
     <Routes>
       <Route index element={<SpeciesSelectorMainView />} />
       <Route path="/search" element={<SpeciesSelectorResultsView />} />
       <Route path="/manage" element={<SpeciesManager />} />
     </Routes>
-  );
-
-  return (
-    <div className={styles.grid}>
-      {appBar}
-      {body}
-    </div>
   );
 };
 

--- a/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
+++ b/src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { useMemo } from 'react';
 import { useNavigate } from 'react-router';
 
 import { useAppSelector } from 'src/store';
@@ -29,7 +30,6 @@ import SpeciesManagerIndicator from 'src/shared/components/species-manager-indic
 import { HelpPopupButton } from 'src/shared/components/help-popup';
 import { SelectedSpecies } from 'src/shared/components/selected-species';
 import SpeciesTabsSlider from 'src/shared/components/species-tabs-slider/SpeciesTabsSlider';
-import { CloseButtonWithLabel } from 'src/shared/components/close-button/CloseButton';
 
 import type { CommittedItem } from 'src/content/app/species-selector/types/committedItem';
 
@@ -42,18 +42,13 @@ export const PlaceholderMessage = () => (
   <div className={styles.placeholderMessage}>{placeholderMessage}</div>
 );
 
-export const SpeciesSelectorAppBar = (props: { isSearchMode?: boolean }) => {
+export const SpeciesSelectorAppBar = () => {
   const enabledCommittedSpecies = useAppSelector(getEnabledCommittedSpecies);
   const hasEnabledSpecies = enabledCommittedSpecies.length > 0;
 
-  const mainContent = hasEnabledSpecies ? (
-    <AppBarMainContent
-      selectedSpecies={enabledCommittedSpecies}
-      isSearchMode={props.isSearchMode}
-    />
-  ) : (
-    <PlaceholderMessage />
-  );
+  const mainContent = useMemo(() => {
+    return hasEnabledSpecies ? <AppBarMainContent /> : <PlaceholderMessage />;
+  }, [hasEnabledSpecies]);
 
   return (
     <AppBar
@@ -65,65 +60,43 @@ export const SpeciesSelectorAppBar = (props: { isSearchMode?: boolean }) => {
   );
 };
 
-const AppBarMainContent = (props: {
-  selectedSpecies: CommittedItem[];
-  isSearchMode?: boolean;
-}) => {
-  const navigate = useNavigate();
-
-  const onSearchClose = () => {
-    navigate(-1);
-  };
-
+const AppBarMainContent = () => {
   return (
     <div className={styles.grid}>
-      <SelectedSpeciesList
-        selectedSpecies={props.selectedSpecies}
-        isSearchMode={props.isSearchMode}
-      />
+      <SelectedGenomes />
       <div className={styles.aside}>
-        {props.isSearchMode && <CloseButtonWithLabel onClick={onSearchClose} />}
-        {!props.isSearchMode && (
-          <span className={styles.selectTabMessage}>
-            Select a tab to see a Genome home page
-          </span>
-        )}
+        <span className={styles.selectTabMessage}>
+          Select a tab to see a Genome home page
+        </span>
       </div>
     </div>
   );
 };
 
-const SelectedSpeciesList = (props: {
-  selectedSpecies: CommittedItem[];
-  isSearchMode?: boolean;
-}) => {
+export const SelectedGenomes = () => {
+  const enabledCommittedGenomes = useAppSelector(getEnabledCommittedSpecies);
   const navigate = useNavigate();
   const { removeGenome } = useGenomeRemoval();
 
-  const showSpeciesPage = (species: CommittedItem) => {
-    const genomeIdForUrl = species.genome_tag ?? species.genome_id;
-    const speciesPageUrl = urlFor.speciesPage({
+  const openGenomePage = (genome: CommittedItem) => {
+    const genomeIdForUrl = genome.genome_tag ?? genome.genome_id;
+    const genomePageUrl = urlFor.speciesPage({
       genomeId: genomeIdForUrl
     });
 
-    navigate(speciesPageUrl);
+    navigate(genomePageUrl);
   };
 
-  const conditionalSpeciesProps = !props.isSearchMode
-    ? ({ theme: 'blue' } as const)
-    : ({ theme: 'grey', disabled: true } as const);
-
-  const selectedSpecies = props.selectedSpecies.map((species) => (
+  const selectedGenomes = enabledCommittedGenomes.map((genome) => (
     <SelectedSpecies
-      key={species.genome_id}
-      species={species}
-      onClick={() => showSpeciesPage(species)}
-      onRemove={!props.isSearchMode ? removeGenome : undefined}
-      {...conditionalSpeciesProps}
+      key={genome.genome_id}
+      species={genome}
+      onClick={() => openGenomePage(genome)}
+      onRemove={removeGenome}
     />
   ));
 
-  return <SpeciesTabsSlider>{selectedSpecies}</SpeciesTabsSlider>;
+  return <SpeciesTabsSlider>{selectedGenomes}</SpeciesTabsSlider>;
 };
 
 export default SpeciesSelectorAppBar;

--- a/src/content/app/species-selector/components/species-selector-search-results-app-bar/SpeciesSelectorSearchResultsAppBar.tsx
+++ b/src/content/app/species-selector/components/species-selector-search-results-app-bar/SpeciesSelectorSearchResultsAppBar.tsx
@@ -20,23 +20,14 @@ import { getEnabledCommittedSpecies } from 'src/content/app/species-selector/sta
 
 import AppBar, { AppName } from 'src/shared/components/app-bar/AppBar';
 import { HelpPopupButton } from 'src/shared/components/help-popup';
-import SpeciesTabsSlider from 'src/shared/components/species-tabs-slider/SpeciesTabsSlider';
-import { SelectedSpecies } from 'src/shared/components/selected-species';
 import { PlaceholderMessage } from 'src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar';
+import { SelectedGenomes } from 'src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar';
 
 const SpeciesSearchResultsAppBar = () => {
   const enabledCommittedSpecies = useAppSelector(getEnabledCommittedSpecies);
 
   const mainContent = enabledCommittedSpecies.length ? (
-    <SpeciesTabsSlider>
-      {enabledCommittedSpecies.map((species) => (
-        <SelectedSpecies
-          key={species.genome_id}
-          species={species}
-          disabled={true}
-        />
-      ))}
-    </SpeciesTabsSlider>
+    <SelectedGenomes />
   ) : (
     <PlaceholderMessage />
   );

--- a/src/content/app/species-selector/views/species-manager/species-manager-app-bar/SpeciesManagerAppBar.tsx
+++ b/src/content/app/species-selector/views/species-manager/species-manager-app-bar/SpeciesManagerAppBar.tsx
@@ -16,25 +16,17 @@
 
 import { useNavigate } from 'react-router';
 
-import { useAppSelector } from 'src/store';
-
-import { getCommittedSpecies } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors';
-
 import AppBar, { AppName } from 'src/shared/components/app-bar/AppBar';
 import SpeciesManagerIndicator from 'src/shared/components/species-manager-indicator/SpeciesManagerIndicator';
 import { HelpPopupButton } from 'src/shared/components/help-popup';
-import SpeciesTabsSlider from 'src/shared/components/species-tabs-slider/SpeciesTabsSlider';
-import { SelectedSpecies } from 'src/shared/components/selected-species';
-
-import type { CommittedItem } from 'src/content/app/species-selector/types/committedItem';
+import { SelectedGenomes } from 'src/content/app/species-selector/components/species-selector-app-bar/SpeciesSelectorAppBar';
 
 export const SpeciesManagerAppBar = () => {
-  const selectedSpecies = useAppSelector(getCommittedSpecies);
   const navigate = useNavigate();
 
   const onClose = () => navigate(-1);
 
-  const mainContent = <AppBarMainContent selectedSpecies={selectedSpecies} />;
+  const mainContent = <SelectedGenomes />;
 
   const appName = <AppName>Genome selector</AppName>;
 
@@ -45,22 +37,6 @@ export const SpeciesManagerAppBar = () => {
       mainContent={mainContent}
       aside={<HelpPopupButton slug="genome-selector-intro" />}
     />
-  );
-};
-
-const AppBarMainContent = (props: { selectedSpecies: CommittedItem[] }) => {
-  const selectedSpecies = props.selectedSpecies.map((species) => (
-    <SelectedSpecies
-      key={species.genome_id}
-      species={species}
-      disabled={true}
-    />
-  ));
-
-  return (
-    <div>
-      <SpeciesTabsSlider>{selectedSpecies}</SpeciesTabsSlider>
-    </div>
   );
 };
 


### PR DESCRIPTION
## Description
Enable genome lozenges in genome search results view, and in genome manager view.

Clicking a lozenge in either of these view will take the user to the corresponding genome page.

Before:

<img width="2559" height="1274" alt="image" src="https://github.com/user-attachments/assets/f5783d6a-070d-4b32-b62c-00e3b8305b9c" />

<img width="1909" height="1187" alt="image" src="https://github.com/user-attachments/assets/baf769dd-2deb-4198-abf7-80dd8f5dcf14" />


## Related JIRA Issue(s)
https://embl.atlassian.net/browse/ENSWBSITES-3022

## Deployment URL(s)
http://genome-lozenges-genome-selector.review.ensembl.org