### PR TITLE
Merge the viewed and the unviewed BLAST submission lists into a single one

### DIFF
--- a/src/content/app/tools/blast/BlastPage.tsx
+++ b/src/content/app/tools/blast/BlastPage.tsx
@@ -53,18 +53,14 @@ const BlastPage = () => {
         description: pageDescription
       })
     );
-  }, []);
+  }, [dispatch]);
 
   return hasMounted ? (
     <div className={styles.blastPage}>
       <Routes>
         <Route index element={<BlastForm />} />
-        <Route
-          path="unviewed-submissions"
-          element={<BlastSubmissions unviewed={true} />}
-        />
         <Route path="submissions">
-          <Route index={true} element={<BlastSubmissions unviewed={false} />} />
+          <Route index={true} element={<BlastSubmissions />} />
           <Route path=":submissionId" element={<BlastSubmissionResults />} />
         </Route>
         <Route path="*" element={<NotFoundErrorScreen />} />

--- a/src/content/app/tools/blast/components/blast-job-list-nav-button/BlastJobListNavButton.module.css
+++ b/src/content/app/tools/blast/components/blast-job-list-nav-button/BlastJobListNavButton.module.css
@@ -1,0 +1,3 @@
+.button {
+  align-self: start;
+}

--- a/src/content/app/tools/blast/components/blast-job-list-nav-button/BlastJobListNavButton.tsx
+++ b/src/content/app/tools/blast/components/blast-job-list-nav-button/BlastJobListNavButton.tsx
@@ -23,6 +23,8 @@ import { getBlastSubmissionsList } from 'src/content/app/tools/blast/state/blast
 
 import ButtonLink from 'src/shared/components/button-link/ButtonLink';
 
+import styles from './BlastJobListNavButton.module.css';
+
 const BlastJobListNavButton = () => {
   const blastSubmissions = useAppSelector(getBlastSubmissionsList);
 
@@ -30,6 +32,7 @@ const BlastJobListNavButton = () => {
     <ButtonLink
       to={urlFor.blastSubmissionsList()}
       isDisabled={!blastSubmissions.length}
+      className={styles.button}
     >
       Jobs list
     </ButtonLink>

--- a/src/content/app/tools/blast/components/blast-job-list-nav-button/BlastJobListNavButton.tsx
+++ b/src/content/app/tools/blast/components/blast-job-list-nav-button/BlastJobListNavButton.tsx
@@ -23,21 +23,17 @@ import { getBlastSubmissionsList } from 'src/content/app/tools/blast/state/blast
 
 import ButtonLink from 'src/shared/components/button-link/ButtonLink';
 
-import styles from './BlastJobListsNavigation.module.css';
-
-const BlastJobListsNavigation = () => {
+const BlastJobListNavButton = () => {
   const blastSubmissions = useAppSelector(getBlastSubmissionsList);
 
   return (
-    <div className={styles.actionButtons}>
-      <ButtonLink
-        to={urlFor.blastSubmissionsList()}
-        isDisabled={!blastSubmissions.length}
-      >
-        Jobs list
-      </ButtonLink>
-    </div>
+    <ButtonLink
+      to={urlFor.blastSubmissionsList()}
+      isDisabled={!blastSubmissions.length}
+    >
+      Jobs list
+    </ButtonLink>
   );
 };
 
-export default memo(BlastJobListsNavigation);
+export default memo(BlastJobListNavButton);

--- a/src/content/app/tools/blast/components/blast-job-list-nav-button/BlastJobListNavButton.tsx
+++ b/src/content/app/tools/blast/components/blast-job-list-nav-button/BlastJobListNavButton.tsx
@@ -19,30 +19,20 @@ import { memo } from 'react';
 import { useAppSelector } from 'src/store';
 import * as urlFor from 'src/shared/helpers/urlHelper';
 
-import {
-  getUnviewedBlastSubmissions,
-  getViewedBlastSubmissions
-} from 'src/content/app/tools/blast/state/blast-results/blastResultsSelectors';
+import { getBlastSubmissionsList } from 'src/content/app/tools/blast/state/blast-results/blastResultsSelectors';
 
 import ButtonLink from 'src/shared/components/button-link/ButtonLink';
 
 import styles from './BlastJobListsNavigation.module.css';
 
 const BlastJobListsNavigation = () => {
-  const unviewedBlastSubmissions = useAppSelector(getUnviewedBlastSubmissions);
-  const viewedBlastSubmissions = useAppSelector(getViewedBlastSubmissions);
+  const blastSubmissions = useAppSelector(getBlastSubmissionsList);
 
   return (
     <div className={styles.actionButtons}>
       <ButtonLink
-        to={urlFor.blastUnviewedSubmissions()}
-        isDisabled={!unviewedBlastSubmissions.length}
-      >
-        Unviewed jobs
-      </ButtonLink>
-      <ButtonLink
         to={urlFor.blastSubmissionsList()}
-        isDisabled={!viewedBlastSubmissions.length}
+        isDisabled={!blastSubmissions.length}
       >
         Jobs list
       </ButtonLink>

--- a/src/content/app/tools/blast/components/blast-job-lists-navigation/BlastJobListsNavigation.module.css
+++ b/src/content/app/tools/blast/components/blast-job-lists-navigation/BlastJobListsNavigation.module.css
@@ -1,5 +1,0 @@
-.actionButtons {
-  display: flex;
-  column-gap: 12px;
-  align-self: start;
-}

--- a/src/content/app/tools/blast/components/blast-job-submit/BlastJobSubmit.tsx
+++ b/src/content/app/tools/blast/components/blast-job-submit/BlastJobSubmit.tsx
@@ -74,7 +74,7 @@ const BlastJobSubmit = () => {
     const payload = createBlastSubmissionData(blastFormData);
     const submission = submitBlast(payload);
     submission.then(() => submission.reset());
-    navigate(urlFor.blastUnviewedSubmissions());
+    navigate(urlFor.blastSubmissionsList());
 
     dispatch(clearBlastForm());
   };

--- a/src/content/app/tools/blast/components/blast-settings/BlastSettings.tsx
+++ b/src/content/app/tools/blast/components/blast-settings/BlastSettings.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useState, type FormEvent, type ChangeEvent } from 'react';
+import { useEffect, useState, type InputEvent, type ChangeEvent } from 'react';
 import classNames from 'classnames';
 
 import { useAppSelector } from 'src/store';
@@ -27,7 +27,7 @@ import CheckboxWithLabel from 'src/shared/components/checkbox-with-label/Checkbo
 import SimpleSelect from 'src/shared/components/simple-select/SimpleSelect';
 import ShadedInput from 'src/shared/components/input/ShadedInput';
 import BlastJobSubmit from 'src/content/app/tools/blast/components/blast-job-submit/BlastJobSubmit';
-import BlastJobListsNavigation from '../blast-job-lists-navigation/BlastJobListsNavigation';
+import BlastJobListNavButton from '../blast-job-list-nav-button/BlastJobListNavButton';
 import Tooltip from 'src/shared/components/tooltip/Tooltip';
 
 import {
@@ -205,7 +205,7 @@ const BlastSettings = ({ config }: Props) => {
             <BlastJobSubmit />
           </div>
         </div>
-        <BlastJobListsNavigation />
+        <BlastJobListNavButton />
       </div>
       {parametersExpanded && (
         <div className={styles.bottomLevel}>
@@ -425,7 +425,7 @@ type BlastSelectProps = {
 };
 
 const BlastSelect = (setting: BlastSelectProps) => {
-  const onChange = (e: FormEvent<HTMLSelectElement>) => {
+  const onChange = (e: InputEvent<HTMLSelectElement>) => {
     const value = e.currentTarget.value;
     setting.onChange(value);
   };

--- a/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.tsx
+++ b/src/content/app/tools/blast/components/blast-submission-header/BlastSubmissionHeader.tsx
@@ -37,10 +37,7 @@ import {
   type SuccessfulBlastSubmission,
   type BlastSubmission
 } from 'src/content/app/tools/blast/state/blast-results/blastResultsSlice';
-import {
-  getUnviewedBlastSubmissions,
-  getViewedBlastSubmissions
-} from 'src/content/app/tools/blast/state/blast-results/blastResultsSelectors';
+import { getBlastSubmissionsList } from 'src/content/app/tools/blast/state/blast-results/blastResultsSelectors';
 import { getBlastView } from 'src/content/app/tools/blast/state/general/blastGeneralSelectors';
 
 import ButtonLink from 'src/shared/components/button-link/ButtonLink';
@@ -74,8 +71,7 @@ export const BlastSubmissionHeader = (props: Props) => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
 
-  const unviewedBlastSubmissions = useAppSelector(getUnviewedBlastSubmissions);
-  const viewedBlastSubmissions = useAppSelector(getViewedBlastSubmissions);
+  const blastSubmissions = useAppSelector(getBlastSubmissionsList);
   const blastView = useAppSelector(getBlastView);
 
   const blastProgram =
@@ -109,9 +105,7 @@ export const BlastSubmissionHeader = (props: Props) => {
     //if nothing more is left on the page after the submission is deleted, go to the new BLAST form (This might change depending on UX)
     if (
       blastView === 'submission-results' ||
-      (blastView === 'unviewed-submissions' &&
-        unviewedBlastSubmissions.length === 1) ||
-      (blastView === 'submissions-list' && viewedBlastSubmissions.length === 1)
+      (blastView === 'submissions-list' && blastSubmissions.length === 1)
     ) {
       navigate(urlFor.blastForm());
     }

--- a/src/content/app/tools/blast/components/blast-views-navigation/BlastViewsNavigation.tsx
+++ b/src/content/app/tools/blast/components/blast-views-navigation/BlastViewsNavigation.tsx
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
+import { memo } from 'react';
+
 import * as urlFor from 'src/shared/helpers/urlHelper';
 
 import ButtonLink from 'src/shared/components/button-link/ButtonLink';
-import BlastJobListsNavigation from '../blast-job-lists-navigation/BlastJobListsNavigation';
+import BlastJobListNavButton from '../blast-job-list-nav-button/BlastJobListNavButton';
 
 import styles from './BlastViewsNavigation.module.css';
 
@@ -34,15 +36,15 @@ const BlastViewsNavigation = () => {
       </div>
       <div className={styles.resultsAvailabilityNotice}>
         Results are only available for 7 days from submission. Submissions can
-        be rerun for 28 days.
+        be rerun for 28 days.
       </div>
       <div className={styles.rightColumn}>
         <div className={styles.wrapperRight}>
-          <BlastJobListsNavigation />
+          <BlastJobListNavButton />
         </div>
       </div>
     </div>
   );
 };
 
-export default BlastViewsNavigation;
+export default memo(BlastViewsNavigation);

--- a/src/content/app/tools/blast/components/listed-blast-submission/ListedBlastSubmission.tsx
+++ b/src/content/app/tools/blast/components/listed-blast-submission/ListedBlastSubmission.tsx
@@ -45,7 +45,7 @@ const ListedBlastSubmission = (props: Props) => {
   const sequences = submission.submittedData.sequences;
   const allJobs = getBlastJobsFromSubmission(submission);
   const isAnyJobRunning = allJobs.some((job) => job.status === 'RUNNING');
-  const { collapsedSubmissionIds } = uiState.unviewedJobsPage;
+  const { collapsedSubmissionIds } = uiState.submissionsPage;
 
   const isCurrentSubmissionCollapsed = collapsedSubmissionIds.includes(
     submission.id
@@ -81,7 +81,7 @@ const ListedBlastSubmission = (props: Props) => {
     dispatch(
       updateSubmissionUi({
         fragment: {
-          unviewedJobsPage: {
+          submissionsPage: {
             collapsedSubmissionIds: newCollapsedSubmissionIds
           }
         }

--- a/src/content/app/tools/blast/state/blast-results/blastResultsSelectors.ts
+++ b/src/content/app/tools/blast/state/blast-results/blastResultsSelectors.ts
@@ -15,34 +15,21 @@
  */
 
 import { createSelector } from '@reduxjs/toolkit';
-import {
-  isSuccessfulBlastSubmission,
-  isFailedBlastSubmission
-} from 'src/content/app/tools/blast/utils/blastSubmisionTypeNarrowing';
 
 import type { RootState } from 'src/store';
 import type { BlastSubmission } from 'src/content/app/tools/blast/state/blast-results/blastResultsSlice';
 
+// returns an object { [submissionId: string]: BlastSubmission; }
 export const getBlastSubmissions = (state: RootState) =>
   state.blast.blastResults.submissions;
 
 export const getBlastSubmissionsUi = (state: RootState) =>
   state.blast.blastResults.ui;
 
-export const getUnviewedBlastSubmissions = createSelector(
+// returns an array of BLAST submissions
+export const getBlastSubmissionsList = createSelector(
   (state: RootState) => getBlastSubmissions(state),
-  (submissions) =>
-    Object.values(submissions).filter(
-      (submission) => isFailedBlastSubmission(submission) || !submission.seen
-    )
-);
-
-export const getViewedBlastSubmissions = createSelector(
-  (state: RootState) => getBlastSubmissions(state),
-  (submissions) =>
-    Object.values(submissions).filter(
-      (submission) => isSuccessfulBlastSubmission(submission) && submission.seen
-    )
+  (submissions) => Object.values(submissions)
 );
 
 export const getBlastSubmissionById = (

--- a/src/content/app/tools/blast/state/blast-results/blastResultsSlice.ts
+++ b/src/content/app/tools/blast/state/blast-results/blastResultsSlice.ts
@@ -99,10 +99,7 @@ export type FailedBlastSubmission = {
 export type BlastSubmission = SuccessfulBlastSubmission | FailedBlastSubmission;
 
 export type BlastResultsUI = {
-  unviewedJobsPage: {
-    collapsedSubmissionIds: string[];
-  };
-  viewedJobsPage: {
+  submissionsPage: {
     collapsedSubmissionIds: string[];
   };
 };
@@ -140,10 +137,7 @@ export const markBlastSubmissionAsSeen = createAsyncThunk(
 export const initialBlastResultsState: BlastResultsState = {
   submissions: {},
   ui: {
-    unviewedJobsPage: {
-      collapsedSubmissionIds: []
-    },
-    viewedJobsPage: {
+    submissionsPage: {
       collapsedSubmissionIds: []
     }
   }

--- a/src/content/app/tools/blast/state/general/blastGeneralSlice.ts
+++ b/src/content/app/tools/blast/state/general/blastGeneralSlice.ts
@@ -32,7 +32,7 @@ import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 type BlastView =
   | 'blast-form' //new job form - form for submitting a new batch of BLASTS jobs
-  | 'submissions-list' //list of viewed BLAST submissions
+  | 'submissions-list' // list of BLAST submissions
   | 'submission-results'; //results of BLAST jobs in a single submission
 
 type BlastGeneralState = {

--- a/src/content/app/tools/blast/state/general/blastGeneralSlice.ts
+++ b/src/content/app/tools/blast/state/general/blastGeneralSlice.ts
@@ -26,13 +26,12 @@ import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
  * - A BLAST job is the result of running the BLAST program for one query sequence against one species
  *
  * Confusingly, the UI uses the terms "submission" and "job" interchangeably,
- * especially in the buttons "New job", "Unviewed jobs", "Jobs list", in order to save screen space
+ * especially in the buttons "New job" and "Jobs list", in order to save screen space
  *
  */
 
 type BlastView =
   | 'blast-form' //new job form - form for submitting a new batch of BLASTS jobs
-  | 'unviewed-submissions' //unviewed BLAST submissions - once the submission result are viewed they are moved to job list
   | 'submissions-list' //list of viewed BLAST submissions
   | 'submission-results'; //results of BLAST jobs in a single submission
 

--- a/src/content/app/tools/blast/views/blast-submission-results/components/missing-blast-submission-error/MissingBlastSubmissionError.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/missing-blast-submission-error/MissingBlastSubmissionError.tsx
@@ -17,10 +17,7 @@
 import { useAppSelector } from 'src/store';
 import * as urlFor from 'src/shared/helpers/urlHelper';
 
-import {
-  getViewedBlastSubmissions,
-  getUnviewedBlastSubmissions
-} from 'src/content/app/tools/blast/state/blast-results/blastResultsSelectors';
+import { getBlastSubmissionsList } from 'src/content/app/tools/blast/state/blast-results/blastResultsSelectors';
 
 import AlertButton from 'src/shared/components/alert-button/AlertButton';
 import ButtonLink from 'src/shared/components/button-link/ButtonLink';
@@ -32,16 +29,12 @@ type Props = {
 };
 
 const MissingBlastSubmissionError = (props: Props) => {
-  const viewedBlastSubmissions = useAppSelector(getViewedBlastSubmissions);
-  const unviewedBlastSubmissions = useAppSelector(getUnviewedBlastSubmissions);
-  const hasUnviewedBlastSubmissions = unviewedBlastSubmissions.length > 0;
-  const hasViewedBlastSubmissions = viewedBlastSubmissions.length > 0;
+  const blastSubmissions = useAppSelector(getBlastSubmissionsList);
+  const hasBlastSubmissions = blastSubmissions.length > 0;
 
   let buttonLink: string;
 
-  if (hasUnviewedBlastSubmissions) {
-    buttonLink = urlFor.blastUnviewedSubmissions();
-  } else if (hasViewedBlastSubmissions) {
+  if (hasBlastSubmissions) {
     buttonLink = urlFor.blastSubmissionsList();
   } else {
     buttonLink = urlFor.blastForm();

--- a/src/content/app/tools/blast/views/blast-submission-results/components/missing-blast-submission-error/MissingBlastSubmissionError.tsx
+++ b/src/content/app/tools/blast/views/blast-submission-results/components/missing-blast-submission-error/MissingBlastSubmissionError.tsx
@@ -64,9 +64,7 @@ const ErrorMessage = (props: { hasSubmissionParameters: boolean }) => {
       <p className={styles.errorText}>
         There are no results for this BLAST submission
       </p>
-      <p>
-        Any valid submissions can be found in your Unviewed jobs and Jobs lists
-      </p>
+      <p>Any valid submissions can be found in your Jobs list</p>
     </>
   );
 };

--- a/src/content/app/tools/blast/views/blast-submissions/BlastSubmissions.tsx
+++ b/src/content/app/tools/blast/views/blast-submissions/BlastSubmissions.tsx
@@ -18,10 +18,7 @@ import { useEffect } from 'react';
 
 import { useAppDispatch, useAppSelector } from 'src/store';
 
-import {
-  getUnviewedBlastSubmissions,
-  getViewedBlastSubmissions
-} from 'src/content/app/tools/blast/state/blast-results/blastResultsSelectors';
+import { getBlastSubmissionsList } from 'src/content/app/tools/blast/state/blast-results/blastResultsSelectors';
 
 import { useSubmitBlastMutation } from 'src/content/app/tools/blast/state/blast-api/blastApiSlice';
 import { setBlastView } from 'src/content/app/tools/blast/state/general/blastGeneralSlice';
@@ -36,18 +33,24 @@ import type { BlastSubmission } from 'src/content/app/tools/blast/state/blast-re
 
 import styles from './BlastSubmissions.module.css';
 
-type Props = {
-  unviewed: boolean;
-};
-
-const BlastSubmissions = (props: Props) => {
+const BlastSubmissions = () => {
+  const blastSubmissions = useAppSelector(getBlastSubmissionsList);
+  const [, formSubmissionResult] = useSubmitBlastMutation({
+    fixedCacheKey: 'submit-blast-form' // same as in BlastJobSubmit component
+  });
+  const { isLoading } = formSubmissionResult;
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    dispatch(
-      setBlastView(props.unviewed ? 'unviewed-submissions' : 'submissions-list')
-    );
-  }, []);
+    dispatch(setBlastView('submissions-list'));
+  }, [dispatch]);
+
+  // sort the submissions in reverse chronological order
+  const sortedSubmissions = getSortedSubmissions(blastSubmissions);
+
+  const submissionElements = sortedSubmissions.map((submission) => (
+    <ListedBlastSubmission key={submission.id} submission={submission} />
+  ));
 
   return (
     <div className={styles.submissionsContainer}>
@@ -55,54 +58,16 @@ const BlastSubmissions = (props: Props) => {
       <ToolsTopBar>
         <BlastViewsNavigation />
       </ToolsTopBar>
-      {props.unviewed ? (
-        <UnviewedBlastSubmissions />
-      ) : (
-        <ViewedBlastSubmissions />
-      )}
+      <div className={styles.container}>
+        {isLoading && (
+          <div className={styles.loaderContainer}>
+            <CircleLoader />
+          </div>
+        )}
+        {submissionElements}
+      </div>
     </div>
   );
-};
-
-// Notice that the unviewed submissions list also includes showing a spinner
-// if the BLAST form is still being submitted
-const UnviewedBlastSubmissions = () => {
-  const unviewedBlastSubmissions = useAppSelector(getUnviewedBlastSubmissions);
-  const [, formSubmissionResult] = useSubmitBlastMutation({
-    fixedCacheKey: 'submit-blast-form' // same as in BlastJobSubmit component
-  });
-  const { isLoading } = formSubmissionResult;
-
-  // sort the submissions in reverse chronological order
-  const sortedSubmissions = getSortedSubmissions(unviewedBlastSubmissions);
-
-  const submissionElements = sortedSubmissions.map((submission) => (
-    <ListedBlastSubmission key={submission.id} submission={submission} />
-  ));
-
-  return (
-    <main className={styles.container}>
-      {isLoading && (
-        <div className={styles.loaderContainer}>
-          <CircleLoader />
-        </div>
-      )}
-      {submissionElements}
-    </main>
-  );
-};
-
-const ViewedBlastSubmissions = () => {
-  const viewedBlastSubmissions = useAppSelector(getViewedBlastSubmissions);
-
-  // sort the submissions in reverse chronological order
-  const sortedSubmissions = getSortedSubmissions(viewedBlastSubmissions);
-
-  const submissionElements = sortedSubmissions.map((submission) => (
-    <ListedBlastSubmission key={submission.id} submission={submission} />
-  ));
-
-  return <main className={styles.container}>{submissionElements}</main>;
 };
 
 const getSortedSubmissions = (submissions: BlastSubmission[]) => {

--- a/src/header/launchbar/BlastLaunchbarButton.tsx
+++ b/src/header/launchbar/BlastLaunchbarButton.tsx
@@ -18,7 +18,7 @@ import { useAppSelector } from 'src/store';
 
 import { isSuccessfulBlastSubmission } from 'src/content/app/tools/blast/utils/blastSubmisionTypeNarrowing';
 
-import { getUnviewedBlastSubmissions } from 'src/content/app/tools/blast/state/blast-results/blastResultsSelectors';
+import { getBlastSubmissionsList } from 'src/content/app/tools/blast/state/blast-results/blastResultsSelectors';
 
 import useLastVisitedPath from './useLastVisitedPath';
 
@@ -28,22 +28,30 @@ import { BlastIcon } from 'src/shared/components/app-icon';
 const BLAST_APP_ROOT_PATH = '/tools/blast';
 
 const BlastLaunchbarButton = () => {
-  const unviewedSubmissions = useAppSelector(getUnviewedBlastSubmissions);
+  const blastSubmissions = useAppSelector(getBlastSubmissionsList);
   const blastAppPath = useLastVisitedPath({ rootPath: BLAST_APP_ROOT_PATH });
 
   const getNotification = () => {
-    if (unviewedSubmissions.length > 0) {
-      const isAnyJobRunning =
-        unviewedSubmissions.filter(
-          (submission) =>
-            isSuccessfulBlastSubmission(submission) &&
-            submission.results.some((job) => job.status === 'RUNNING')
-        ).length > 0;
+    const isAnyJobRunning = blastSubmissions.some((submission) => {
+      return (
+        isSuccessfulBlastSubmission(submission) &&
+        submission.results.some((job) => job.status === 'RUNNING')
+      );
+    });
 
-      return isAnyJobRunning ? 'red' : 'green';
-    } else {
-      return null;
+    if (isAnyJobRunning) {
+      return 'red';
     }
+
+    const hasUnviewedSubmissions = blastSubmissions.some((submission) => {
+      return isSuccessfulBlastSubmission(submission) && !submission.seen;
+    });
+
+    if (hasUnviewedSubmissions) {
+      return 'green';
+    }
+
+    return null;
   };
 
   return (

--- a/src/shared/helpers/urlHelper.ts
+++ b/src/shared/helpers/urlHelper.ts
@@ -251,9 +251,6 @@ export const structuralVariantsViewer = (params?: {
 
 export const blastForm = () => '/tools/blast';
 
-export const blastUnviewedSubmissions = () =>
-  '/tools/blast/unviewed-submissions';
-
 export const blastSubmissionsList = () => '/tools/blast/submissions';
 
 export const blastSubmission = (submissionId: string) =>


### PR DESCRIPTION
## Description
When the BLAST UI for Ensembl client was built, it separated BLAST submissions into two lists: a list of unviewed submissions (or "unviewed jobs", as the label says), and a list of viewed submissions (or "viewed jobs"). When the user opens a submission from a list of unviewed submissions, the submission becomes viewed, and is quietly moved from one list to another.

Multiple people have found this baffling; and so this PR merges the two submission lists into one.

**Before:**

<img width="3123" height="401" alt="image" src="https://github.com/user-attachments/assets/6a699cd6-c6c6-4f79-8428-c2cef9faaa62" />

**After:**

<img width="3198" height="401" alt="image" src="https://github.com/user-attachments/assets/74a87c5c-749f-4179-9b26-628344543c23" />


### For discussion
- How should the green circle in the BLAST launchbar button behave? What are the conditions for removing it?  


### Review from Codex
I gave this PR to gpt-5.4-mini, to review; and here is the result

```
The patch regresses user-visible behavior by dropping launchbar notifications for failed BLAST submissions, and it also removes the old submissions URL without an alias, which breaks existing links. These are discrete regressions that should be addressed before merging.

  Full review comments:

  - [P2] Keep failed BLAST submissions visible in the launchbar badge — ensembl-client/src/header/launchbar/BlastLaunchbarButton.tsx:46-52
    In src/header/launchbar/BlastLaunchbarButton.tsx#getNotification, the new green-state check only looks at successful submissions with seen === false, so a newly failed submission no longer produces any launchbar notification. Before this change, getUnviewedBlastSubmissions included failures, which meant users were
    prompted to review network/API failures as well; with the current logic those failures become completely silent unless the user opens BLAST manually.

  - [P3] Preserve the old BLAST submissions URL as an alias — ensembl-client/src/content/app/tools/blast/BlastPage.tsx:62-64
    Removing the unviewed-submissions route here means any existing bookmarks, browser history entries, or external links to /tools/blast/unviewed-submissions now fall through to the 404 screen instead of the BLAST submissions view. If this is a rename/consolidation rather than a hard deprecation, keeping a redirect/
    alias would avoid breaking previously shared links.
```

From what I can tell, none of the bot's concerns are important.


## Related JIRA Issue(s)
https://embl.atlassian.net/browse/ENSWBSITES-3025

## Deployment URL(s)
http://blast-merge-viewed-unviewed.review.ensembl.org
