### PR TITLE
Increase transcripts opacity in Feature explorer gene view

### DIFF
--- a/src/content/app/entity-viewer/gene-view/components/gene-overview-image/GeneOverviewImage.module.css
+++ b/src/content/app/entity-viewer/gene-view/components/gene-overview-image/GeneOverviewImage.module.css
@@ -18,7 +18,7 @@
 .transcript rect {
   stroke: var(--color-dark-grey);
   fill: var(--color-dark-grey);
-  opacity: 0.3;
+  opacity: var(--transcript-opacity); /* Set by the javascript code of the component */
 }
 
 .geneId {

--- a/src/content/app/entity-viewer/gene-view/components/gene-overview-image/GeneOverviewImage.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-overview-image/GeneOverviewImage.tsx
@@ -15,6 +15,7 @@
  */
 
 import { scaleLinear } from 'd3';
+import type { CSSProperties } from 'react';
 import type { Pick3 } from 'ts-multipick';
 
 import {
@@ -80,6 +81,7 @@ const GeneOverviewImage = (props: GeneOverviewImageProps) => {
 
 export const GeneImage = (props: GeneOverviewImageProps) => {
   const { start: geneStart, end: geneEnd } = getFeatureCoordinates(props.gene);
+  const transcriptsCount = props.gene.transcripts.length || 1; // not that there can be zero transcripts, but why not play it safe
 
   // FIXME: use the "length" property of the gene when it is added to payload;
   // (it will help with drawing genes of circular chromosomes)
@@ -111,11 +113,14 @@ export const GeneImage = (props: GeneOverviewImageProps) => {
 
   const viewBox = `0 0 ${GENE_IMAGE_WIDTH} ${GENE_IMAGE_HEIGHT}`;
 
+  const transcriptOpacity = Math.max(Math.min(1, 1.5 / transcriptsCount), 0.3);
+
   return (
     <svg
       className={styles.containerSVG}
       viewBox={viewBox}
       width={GENE_IMAGE_WIDTH}
+      style={{ '--transcript-opacity': transcriptOpacity } as CSSProperties}
     >
       {renderedTranscripts}
     </svg>


### PR DESCRIPTION
## Description
In the gene view of Feature Explorer, In the gene visualisation (the diagram at the top), I previously used `opacity: 0.3` for transcripts regardless of how many there are. As a result, if a gene has only one transcript, the transcript looks very faint.

This PR varies transcript opacity based on the number of transcript in a gene (higher opacity when there are few transcripts; lower opacity when there are many transcripts).

## Related JIRA Issue(s)
https://embl.atlassian.net/browse/ENSWBSITES-3024

## Deployment URL(s)
http://increase-transcripts-opacity.review.ensembl.org

**Examples**
- gene with one transcript: [prod](https://www.ensembl.org/feature-explorer/GCA_000001405.29/gene:ENSG00000302448?view=transcripts) vs [this branch](https://increase-transcripts-opacity.review.ensembl.org/feature-explorer/GCA_000001405.29/gene:ENSG00000302448?view=transcripts)
- another gene (from a bacteria) with one transcript: [prod](https://www.ensembl.org/feature-explorer/a73351f7-93e7-11ec-a39d-005056b38ce3/gene:b2992?view=transcripts) vs [this branch](https://increase-transcripts-opacity.review.ensembl.org/feature-explorer/a73351f7-93e7-11ec-a39d-005056b38ce3/gene:b2992?view=transcripts)
- gene with two transcripts: [prod](https://www.ensembl.org/feature-explorer/GCA_000001405.29/gene:ENSG00000189167?view=transcripts) vs [this branch](https://increase-transcripts-opacity.review.ensembl.org/feature-explorer/GCA_000001405.29/gene:ENSG00000189167?view=transcripts)
- gene with three transcripts: [prod](https://www.ensembl.org/feature-explorer/GCA_000001405.29/gene:ENSG00000133105?view=transcripts) vs [this branch](https://increase-transcripts-opacity.review.ensembl.org/feature-explorer/GCA_000001405.29/gene:ENSG00000133105?view=transcripts)
- gene with many transcripts: [prod](https://www.ensembl.org/feature-explorer/GCA_000001405.29/gene:ENSG00000073910?view=transcripts) vs [this branch](https://increase-transcripts-opacity.review.ensembl.org/feature-explorer/GCA_000001405.29/gene:ENSG00000073910?view=transcripts)