### PR TITLE
Add pre-populated lists of genomes that can be selected for VEP

### DIFF
--- a/src/content/app/tools/vep/components/vep-app-bar/VepAppBar.tsx
+++ b/src/content/app/tools/vep/components/vep-app-bar/VepAppBar.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useMatch } from 'react-router';
+import { useMatch, useNavigate } from 'react-router';
 
 import { useAppDispatch, useAppSelector } from 'src/store';
 
@@ -23,7 +23,6 @@ import * as urlFor from 'src/shared/helpers/urlHelper';
 import useGenomeRemoval from 'src/content/app/species-selector/hooks/useGenomeRemoval';
 
 import { getEnabledCommittedSpecies } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors';
-import { getSelectedSpecies as getSelectedSpeciesForVep } from 'src/content/app/tools/vep/state/vep-form/vepFormSelectors';
 
 import { setSelectedSpecies } from 'src/content/app/tools/vep/state/vep-form/vepFormSlice';
 
@@ -51,15 +50,15 @@ const SpeciesTabs = () => {
   const vepFormPath = urlFor.vepForm();
   const isVepFormView = useMatch({ path: vepFormPath, end: true });
   const speciesList = useAppSelector(getEnabledCommittedSpecies);
-  const speciesSelectedForVep = useAppSelector(getSelectedSpeciesForVep);
   const { removeGenome } = useGenomeRemoval();
   const dispatch = useAppDispatch();
-
-  const hasSelectedSpeciesForVep = !!speciesSelectedForVep;
-  const shouldEnableSpeciesTabs = isVepFormView && !hasSelectedSpeciesForVep;
+  const navigate = useNavigate();
 
   const onSpeciesSelect = (species: CommittedItem) => {
     dispatch(setSelectedSpecies({ species }));
+    if (!isVepFormView) {
+      navigate(urlFor.vepForm());
+    }
   };
 
   const speciesTabs = speciesList.map((species) => (
@@ -67,8 +66,7 @@ const SpeciesTabs = () => {
       key={species.genome_id}
       species={species}
       onClick={onSpeciesSelect}
-      onRemove={shouldEnableSpeciesTabs ? removeGenome : undefined}
-      disabled={!shouldEnableSpeciesTabs}
+      onRemove={removeGenome}
     />
   ));
 

--- a/src/content/app/tools/vep/components/vep-app-bar/VepAppBar.tsx
+++ b/src/content/app/tools/vep/components/vep-app-bar/VepAppBar.tsx
@@ -23,6 +23,7 @@ import * as urlFor from 'src/shared/helpers/urlHelper';
 import useGenomeRemoval from 'src/content/app/species-selector/hooks/useGenomeRemoval';
 
 import { getEnabledCommittedSpecies } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors';
+import { getSelectedSpecies as getSelectedSpeciesForVep } from 'src/content/app/tools/vep/state/vep-form/vepFormSelectors';
 
 import { setSelectedSpecies } from 'src/content/app/tools/vep/state/vep-form/vepFormSlice';
 
@@ -49,7 +50,8 @@ const VepAppBar = () => {
 const SpeciesTabs = () => {
   const vepFormPath = urlFor.vepForm();
   const isVepFormView = useMatch({ path: vepFormPath, end: true });
-  const speciesList = useAppSelector(getEnabledCommittedSpecies);
+  const genomesList = useAppSelector(getEnabledCommittedSpecies);
+  const selectedGenome = useAppSelector(getSelectedSpeciesForVep);
   const { removeGenome } = useGenomeRemoval();
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
@@ -61,10 +63,11 @@ const SpeciesTabs = () => {
     }
   };
 
-  const speciesTabs = speciesList.map((species) => (
+  const speciesTabs = genomesList.map((genome) => (
     <SelectedSpecies
-      key={species.genome_id}
-      species={species}
+      key={genome.genome_id}
+      species={genome}
+      isActive={genome.genome_id === selectedGenome?.genome_id}
       onClick={onSpeciesSelect}
       onRemove={removeGenome}
     />

--- a/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
+++ b/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
@@ -41,10 +41,7 @@ import {
 
 const vepApiSlice = restApiSlice.injectEndpoints({
   endpoints: (builder) => ({
-    // Quick-select species for the form. Resolved by the backend against the
-    // current integrated release rather than shipped as hardcoded genome
-    // UUIDs, which are release-scoped and go stale silently.
-    vepSpeciesPresets: builder.query<VepSelectedSpecies[], void>({
+    vepGenomeSuggestions: builder.query<VepSelectedSpecies[], void>({
       query: () => ({
         url: `${config.toolsApiBaseUrl}/vep/species_presets`
       })
@@ -191,7 +188,7 @@ const prepareSubmissionFormData = (payload: VepSubmissionPayload) => {
 };
 
 export const {
-  useVepSpeciesPresetsQuery,
+  useVepGenomeSuggestionsQuery,
   useVepFormConfigQuery,
   useVepFormExampleInputQuery,
   useVepResultsQuery,

--- a/src/content/app/tools/vep/views/vep-form/vep-form-species-section/VepFormSpeciesSection.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-species-section/VepFormSpeciesSection.tsx
@@ -32,7 +32,7 @@ export const VepFormSpecies = (props: { className?: string }) => {
   const selectedSpecies = useAppSelector(getSelectedSpecies);
 
   if (!selectedSpecies) {
-    return <Link to={vepSpeciesSelectorUrl}>Select a genome</Link>;
+    return <Link to={vepSpeciesSelectorUrl}>Choose a genome</Link>;
   }
 
   return (

--- a/src/content/app/tools/vep/views/vep-species-selector/VepGenomesQuickList.module.css
+++ b/src/content/app/tools/vep/views/vep-species-selector/VepGenomesQuickList.module.css
@@ -33,4 +33,5 @@
   flex-direction: column;
   align-items: flex-start;
   row-gap: 1rem;
+  padding-left: 20px; /* same as for the label of genome search field */
 }

--- a/src/content/app/tools/vep/views/vep-species-selector/VepGenomesQuickList.module.css
+++ b/src/content/app/tools/vep/views/vep-species-selector/VepGenomesQuickList.module.css
@@ -1,0 +1,36 @@
+.container {
+  grid-row: results;
+  height: 100%;
+  padding-top: 4em;;
+  width: max-content;
+  overflow-y: hidden;
+}
+
+.scrollWrapper {
+  height: 100%;
+  overflow-y: auto;
+  display: flex;
+  padding-right: 1rem;
+  flex-direction: column;
+  row-gap: 2.5rem;
+  width: max-content;
+  padding-bottom: var(--global-padding-bottom);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  row-gap: 1rem;
+}
+
+.sectionTitle {
+  font-size: 14px;
+}
+
+.genomes {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  row-gap: 1rem;
+}

--- a/src/content/app/tools/vep/views/vep-species-selector/VepGenomesQuickList.tsx
+++ b/src/content/app/tools/vep/views/vep-species-selector/VepGenomesQuickList.tsx
@@ -1,0 +1,136 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useNavigate } from 'react-router';
+
+import { useAppSelector, useAppDispatch } from 'src/store';
+
+import * as urlFor from 'src/shared/helpers/urlHelper';
+
+import { getEnabledCommittedSpecies } from 'src/content/app/species-selector/state/species-selector-general-slice/speciesSelectorGeneralSelectors';
+
+import { setSelectedSpecies } from 'src/content/app/tools/vep/state/vep-form/vepFormSlice';
+import { useVepGenomeSuggestionsQuery } from 'src/content/app/tools/vep/state/vep-api/vepApiSlice';
+
+import TextButton from 'src/shared/components/text-button/TextButton';
+import SpeciesName from 'src/shared/components/species-name/SpeciesName';
+import { CircleLoader } from 'src/shared/components/loader';
+
+import type { VepSelectedSpecies } from 'src/content/app/tools/vep/types/vepSubmission';
+
+import styles from './VepGenomesQuickList.module.css';
+
+const VepGenomesQuickList = () => {
+  const storedGenomes = useAppSelector(getEnabledCommittedSpecies);
+  const { isFetching, data: popularVepGenomes } =
+    useVepGenomeSuggestionsQuery();
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+
+  const onGenomeSelected = (genome: VepSelectedSpecies) => {
+    dispatch(setSelectedSpecies({ species: genome }));
+    navigate(urlFor.vepForm());
+  };
+
+  if (isFetching) {
+    return (
+      <div className={styles.container}>
+        <CircleLoader />
+      </div>
+    );
+  } else if (!popularVepGenomes && !storedGenomes.length) {
+    return null;
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.scrollWrapper}>
+        {popularVepGenomes && (
+          <PopularVepGenomes
+            genomes={popularVepGenomes}
+            onGenomeSelected={onGenomeSelected}
+          />
+        )}
+        {!!storedGenomes.length && (
+          <StoredGenomes
+            genomes={storedGenomes}
+            onGenomeSelected={onGenomeSelected}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+const PopularVepGenomes = ({
+  genomes,
+  onGenomeSelected
+}: {
+  genomes: VepSelectedSpecies[];
+  onGenomeSelected: (genome: VepSelectedSpecies) => void;
+}) => {
+  const genomeElements = genomes.map((genome) => (
+    <Genome key={genome.genome_id} genome={genome} onClick={onGenomeSelected} />
+  ));
+
+  return (
+    <div className={styles.section}>
+      <div className={styles.sectionTitle}>Popular genomes</div>
+      <div className={styles.genomes}>{genomeElements}</div>
+    </div>
+  );
+};
+
+const StoredGenomes = ({
+  genomes,
+  onGenomeSelected
+}: {
+  genomes: VepSelectedSpecies[];
+  onGenomeSelected: (genome: VepSelectedSpecies) => void;
+}) => {
+  const sortedStroredGenomes = genomes.toSorted((g1, g2) => {
+    const name1 = g1.common_name ?? g1.scientific_name;
+    const name2 = g2.common_name ?? g2.scientific_name;
+    return name1.localeCompare(name2);
+  });
+
+  const genomeElements = sortedStroredGenomes.map((genome) => (
+    <Genome key={genome.genome_id} genome={genome} onClick={onGenomeSelected} />
+  ));
+
+  return (
+    <div className={styles.section}>
+      <div className={styles.sectionTitle}>Genomes from your list</div>
+      <div className={styles.genomes}>{genomeElements}</div>
+    </div>
+  );
+};
+
+const Genome = ({
+  genome,
+  onClick
+}: {
+  genome: VepSelectedSpecies;
+  onClick: (genome: VepSelectedSpecies) => void;
+}) => {
+  return (
+    <TextButton onClick={() => onClick(genome)}>
+      <SpeciesName species={genome} />
+    </TextButton>
+  );
+};
+
+export default VepGenomesQuickList;

--- a/src/content/app/tools/vep/views/vep-species-selector/VepSpeciesSelector.module.css
+++ b/src/content/app/tools/vep/views/vep-species-selector/VepSpeciesSelector.module.css
@@ -1,6 +1,6 @@
 .grid {
   display: grid;
-  grid-template-rows: auto auto 1fr;
+  grid-template-rows: auto auto [results] 1fr;
   margin-left: var(--global-padding-left);
   height: 100%;
 }

--- a/src/content/app/tools/vep/views/vep-species-selector/VepSpeciesSelector.tsx
+++ b/src/content/app/tools/vep/views/vep-species-selector/VepSpeciesSelector.tsx
@@ -150,7 +150,7 @@ const VepSpeciesSelector = () => {
           onClose={onClose}
         />
 
-        {data?.matches.length ? (
+        {!!data?.matches.length && (
           <SpeciesSearchResultsTableWrapper>
             <TableControlsSection>
               <PaginationWithPerPage
@@ -175,9 +175,9 @@ const VepSpeciesSelector = () => {
               />
             </TableSection>
           </SpeciesSearchResultsTableWrapper>
-        ) : (
-          <VepGenomesQuickList />
         )}
+
+        {!data && !isError && <VepGenomesQuickList />}
       </div>
     </ModalView>
   );

--- a/src/content/app/tools/vep/views/vep-species-selector/VepSpeciesSelector.tsx
+++ b/src/content/app/tools/vep/views/vep-species-selector/VepSpeciesSelector.tsx
@@ -51,6 +51,7 @@ import SpeciesSearchResultsTable from 'src/content/app/species-selector/componen
 import ModalView from 'src/shared/components/modal-view/ModalView';
 import { CircleLoader } from 'src/shared/components/loader';
 import PaginationWithPerPage from 'src/shared/components/pagination/PaginationWithPerPage';
+import VepGenomesQuickList from 'src/content/app/tools/vep/views/vep-species-selector/VepGenomesQuickList';
 
 import type { SpeciesSearchResponse } from 'src/content/app/species-selector/state/species-selector-api-slice/speciesSelectorApiSlice';
 import type { SortOrderWithNone } from 'src/shared/types/sort-order';
@@ -174,7 +175,9 @@ const VepSpeciesSelector = () => {
               />
             </TableSection>
           </SpeciesSearchResultsTableWrapper>
-        ) : null}
+        ) : (
+          <VepGenomesQuickList />
+        )}
       </div>
     </ModalView>
   );


### PR DESCRIPTION
## Description
Add a pre-populated list of genomes to VEP genome selector. The list consists of the genomes suggested by the tools api (this can be changed in the future to some call to the metadata api) and the common list of selected genomes. 

Also:
- Enable genome lozenges such that clicking them will add that genome to VEP form
- A genome lozenge whose associated genome is now selected in the form is marked as active

## Related JIRA Issue(s)
https://embl.atlassian.net/browse/ENSWBSITES-3057

## Deployment URL(s)
https://vep-prepopulated-genomes.review.ensembl.org
