### PR TITLE
Remove taxonomy/assembly params from form config request

### DIFF
--- a/WORK_NOTES.md
+++ b/WORK_NOTES.md
@@ -1,10 +1,5 @@
 # Need to review
 
-## API
-- The vepFormConfig endpoint (`/vep/form_config/:genome_id`) has been updated to take two optional parameters: `species_taxonomy_id` and `assembly_name`, alongside genome_id. But genome_id should be sufficient on its own for the backend to discover all the data that it needs.
-==> Can we remove these parameters from this endpoint
-
-
 ### The form config
 Explore the contract of the response
   - The purpose (and the name) of the `locked_children` field?
@@ -30,7 +25,6 @@ Note that the `hgvs` option is a single "boolean", but it is rendered as two che
 ## TODO
 - Add popular species?
 - Remove `expandCommand` from `VepFormOptionsPanel` (and from `VepFormOptionsSection`)
-- Remove requirement to pass `assembly_name` and `species_taxonomy_id` to requests for form config (see `vepFormSlice`)
 
 ## CHECK AND REMOVE?
 - Check if the logic of the `resultsPanels` function is still necessary

--- a/src/content/app/tools/vep/components/vep-top-bar/VepFormTopBar.tsx
+++ b/src/content/app/tools/vep/components/vep-top-bar/VepFormTopBar.tsx
@@ -62,9 +62,7 @@ const TranscriptSetSelector = () => {
   const vepFormParameters = useAppSelector(getVepFormParameters);
   const { currentData: vepFormConfig } = useVepFormConfigQuery(
     {
-      genome_id: selectedSpecies?.genome_id ?? '',
-      species_taxonomy_id: selectedSpecies?.species_taxonomy_id,
-      assembly_name: selectedSpecies?.assembly.name
+      genome_id: selectedSpecies?.genome_id ?? ''
     },
     {
       skip: !selectedSpecies

--- a/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
+++ b/src/content/app/tools/vep/state/vep-api/vepApiSlice.ts
@@ -53,27 +53,11 @@ const vepApiSlice = restApiSlice.injectEndpoints({
       VepFormConfig,
       {
         genome_id: string;
-        // Passed from the selected species so the tools API can decide which
-        // panels/options to show (e.g. human GRCh37/38).
-        species_taxonomy_id?: string;
-        assembly_name?: string;
       }
     >({
-      query: (params) => {
-        const search = new URLSearchParams();
-        if (params.species_taxonomy_id) {
-          search.set('species_taxonomy_id', params.species_taxonomy_id);
-        }
-        if (params.assembly_name) {
-          search.set('assembly_name', params.assembly_name);
-        }
-        const queryString = search.toString();
-        return {
-          url: `${config.toolsApiBaseUrl}/vep/form_config/${params.genome_id}${
-            queryString ? `?${queryString}` : ''
-          }`
-        };
-      }
+      query: ({ genome_id }) => ({
+        url: `${config.toolsApiBaseUrl}/vep/form_config/${genome_id}`
+      })
     }),
     vepFormExampleInput: builder.query<
       { vcfString?: string },

--- a/src/content/app/tools/vep/views/vep-form/useVepFormConfig.ts
+++ b/src/content/app/tools/vep/views/vep-form/useVepFormConfig.ts
@@ -52,9 +52,7 @@ const useVepFormConfig = () => {
   const areFormParametersEmpty = isObjectEmpty(vepFormParameters);
   const { currentData: vepFormConfig } = useVepFormConfigQuery(
     {
-      genome_id: selectedGenomeId ?? '',
-      species_taxonomy_id: selectedSpecies?.species_taxonomy_id,
-      assembly_name: selectedSpecies?.assembly.name
+      genome_id: selectedGenomeId ?? ''
     },
     {
       skip: !selectedGenomeId || !areFormParametersEmpty
@@ -71,7 +69,7 @@ const useVepFormConfig = () => {
     }
 
     dispatch(setDefaultParameters(vepFormConfig));
-  }, [vepFormConfig, areFormParametersEmpty]);
+  }, [vepFormConfig, areFormParametersEmpty, dispatch]);
 };
 
 const isObjectEmpty = (obj: Record<string, unknown>) => {

--- a/src/content/app/tools/vep/views/vep-form/vep-form-options-section/VepFormOptionsSection.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-options-section/VepFormOptionsSection.tsx
@@ -45,9 +45,7 @@ const VepFormOptionsSection = () => {
 
   const { currentData: formConfig, isFetching } = useVepFormConfigQuery(
     {
-      genome_id: selectedSpecies?.genome_id ?? '',
-      species_taxonomy_id: selectedSpecies?.species_taxonomy_id,
-      assembly_name: selectedSpecies?.assembly.name
+      genome_id: selectedSpecies?.genome_id ?? ''
     },
     {
       skip: !selectedSpecies

--- a/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.tsx
@@ -202,9 +202,7 @@ const VepSubmissionResults = () => {
   const pinnedPanels = vepResults?.metadata.display_panels ?? null;
   const { currentData: formConfig } = useVepFormConfigQuery(
     {
-      genome_id: species?.genome_id ?? '',
-      species_taxonomy_id: species?.species_taxonomy_id,
-      assembly_name: species?.assembly.name
+      genome_id: species?.genome_id ?? ''
     },
     // Wait for the results before deciding: a job with pinned panels needs no
     // form_config request at all, and one without gets it as soon as we know.


### PR DESCRIPTION
## Description
Remove the redundant `species_taxonomy_id` and `assembly_name` URL params from `/form_config/{genome_id}` endpoint.
Backend changes have already been implemented in [this commit](https://github.com/Ensembl/ensembl-web-tools-api/pull/61/changes/3ebd39f4faa51d43b0499d22ccf111b462448fd0) (backwards-compatible: ignores deprecated params).


## Related JIRA Issue(s)
[ENSWBSITES-3056](https://embl.atlassian.net/browse/ENSWBSITES-3056)

## Deployment URL(s)
https://vep2.review.ensembl.org