### PR TITLE
DO NOT MERGE until Ensembl/ensembl-web-tools-api#68 lands — refactor(vep): take the results filter catalogue from the API

### DIFF
--- a/src/content/app/tools/vep/types/vepResultsFilters.test.ts
+++ b/src/content/app/tools/vep/types/vepResultsFilters.test.ts
@@ -17,7 +17,6 @@
 import { describe, it, expect } from 'vitest';
 
 import {
-  SCORE_FILTER_FIELDS,
   isResultsFilterActive,
   serializeResultsFilters
 } from './vepResultsFilters';
@@ -40,7 +39,7 @@ const parse = (conditions: ResultsFilterCondition[]) =>
 describe('score filters', () => {
   it('sends the threshold and the no-score choice', () => {
     expect(
-      parse([condition({ threshold: 20, includeMissing: false })])
+      parse([condition({ threshold: 20, include_missing: false })])
     ).toEqual([
       {
         field: 'cadd_phred',
@@ -50,15 +49,6 @@ describe('score filters', () => {
         include_missing: false
       }
     ]);
-  });
-
-  it('defaults to dropping variants with no score', () => {
-    // The opposite of the allele-frequency filter, which always keeps its
-    // unknowns, because absence means a different thing in each: no allele
-    // frequency is evidence of rarity, no impact score is evidence of nothing.
-    expect(parse([condition({ threshold: 20 })])[0].include_missing).toBe(
-      false
-    );
   });
 
   it('accepts a negative threshold', () => {
@@ -73,36 +63,6 @@ describe('score filters', () => {
     expect(
       parse([condition({ field: 'popeve', threshold: -3.4 })])[0].threshold
     ).toBe(-3.4);
-  });
-
-  it('treats every impact-prediction score as a numeric filter', () => {
-    // Each score is its own field on the wire, so a new one added to the menu
-    // has to serialise as a threshold rather than fall through to the
-    // value-list branch (which would silently send an empty condition).
-    for (const field of SCORE_FILTER_FIELDS) {
-      const [serialized] = parse([condition({ field, threshold: 0.5 })]);
-      expect(serialized).toEqual({
-        field,
-        operator: 'ge',
-        values: [],
-        threshold: 0.5,
-        include_missing: false
-      });
-    }
-  });
-
-  it('covers the splicing scores separately, one per event', () => {
-    // SpliceAI's deltas describe four different events at the same position
-    // plus the "any" roll-up, so they cannot share a single threshold.
-    expect(SCORE_FILTER_FIELDS).toEqual(
-      expect.arrayContaining([
-        'spliceai_ag',
-        'spliceai_al',
-        'spliceai_dg',
-        'spliceai_dl',
-        'spliceai_any'
-      ])
-    );
   });
 
   it('is inactive without a threshold, so it is not sent', () => {

--- a/src/content/app/tools/vep/types/vepResultsFilters.ts
+++ b/src/content/app/tools/vep/types/vepResultsFilters.ts
@@ -149,3 +149,55 @@ export const serializeResultsFilters = (
   });
   return active.length > 0 ? JSON.stringify(active) : undefined;
 };
+
+/**
+ * The filter catalogue the tools API serves on the results response: which
+ * fields the query builder offers, and what each one's editor needs.
+ *
+ * Only the keys an editor reads are sent, so a text field has no score groups
+ * and the allele-frequency field is three keys wide. Which of the offered
+ * scores and AF sources this job actually carries is separate, and arrives as
+ * `available_scores` / `available_af_sources`.
+ */
+export type FilterOption = {
+  value: string;
+  label: string;
+};
+
+export type FilterOptionGroup = {
+  label: string;
+  options: string[];
+};
+
+export type ScoreOption = {
+  value: ResultsFilterField;
+  label: string;
+  /** Range hint for the threshold input; differs per score. */
+  placeholder: string;
+};
+
+export type ScoreOptionGroup = {
+  title: string;
+  options: ScoreOption[];
+};
+
+export type FilterField = {
+  field: ResultsFilterField;
+  label: string;
+  /** Read between the field and its value. Absent where the editor chooses its
+   *  own operator, as the allele-frequency and score editors do. */
+  operator_label?: string;
+  editor: 'consequence' | 'text' | 'group' | 'af' | 'score';
+  /** Text editors. */
+  placeholder?: string;
+  mono?: boolean;
+  /** An editor that already takes many values is offered once, then withdrawn. */
+  single_instance?: boolean;
+  /** Consequence editor. */
+  option_groups?: FilterOptionGroup[];
+  /** Transcript-group editor. */
+  options?: FilterOption[];
+  /** Score editor. */
+  missing_label?: string;
+  score_groups?: ScoreOptionGroup[];
+};

--- a/src/content/app/tools/vep/types/vepResultsFilters.ts
+++ b/src/content/app/tools/vep/types/vepResultsFilters.ts
@@ -46,22 +46,6 @@ export type ResultsFilterField =
   | 'spliceai_dl'
   | 'spliceai_any';
 
-// The fields whose editor is a numeric comparison rather than a value list.
-export const SCORE_FILTER_FIELDS: ResultsFilterField[] = [
-  'cadd_phred',
-  'cadd_raw',
-  'alphamissense',
-  'revel',
-  'clinpred',
-  'eve',
-  'popeve',
-  'spliceai_ag',
-  'spliceai_al',
-  'spliceai_dg',
-  'spliceai_dl',
-  'spliceai_any'
-];
-
 // 'in' for set-membership fields; le/ge (<=, >=) for the numeric ones. There is
 // deliberately no '==': these are floats, so equality is a question the data can
 // rarely answer, and it was never the useful test for a frequency or a score.
@@ -89,21 +73,21 @@ export type ResultsFilterCondition = {
   // was never scored (out of that predictor's scope — a missense predictor has
   // nothing to say about a synonymous variant) and so implies nothing about how
   // damaging it is.
-  includeMissing?: boolean;
+  include_missing?: boolean;
 };
 
 // Whether a condition would actually filter anything (and so should be applied).
 export const isResultsFilterActive = (
   condition: ResultsFilterCondition
 ): boolean => {
-  if (condition.field === 'allele_frequency') {
+  if (condition.match !== undefined) {
     return (
       typeof condition.threshold === 'number' &&
       condition.threshold >= 0 &&
       condition.threshold <= 1
     );
   }
-  if (SCORE_FILTER_FIELDS.includes(condition.field)) {
+  if (condition.threshold !== undefined) {
     // No 0-1 bound here: not every score is a probability. CADD RAW is
     // unbounded and popEVE is negative throughout.
     return (
@@ -123,29 +107,9 @@ export const serializeResultsFilters = (
   conditions: ResultsFilterCondition[]
 ): string | undefined => {
   const active = conditions.filter(isResultsFilterActive).map((condition) => {
-    if (condition.field === 'allele_frequency') {
-      return {
-        field: condition.field,
-        operator: condition.operator,
-        values: condition.values,
-        threshold: condition.threshold,
-        match: condition.match ?? 'any'
-      };
-    }
-    if (SCORE_FILTER_FIELDS.includes(condition.field)) {
-      return {
-        field: condition.field,
-        operator: condition.operator,
-        values: [],
-        threshold: condition.threshold,
-        include_missing: condition.includeMissing ?? false
-      };
-    }
-    return {
-      field: condition.field,
-      operator: condition.operator,
-      values: condition.values
-    };
+    const wireCondition: Partial<ResultsFilterCondition> = { ...condition };
+    delete wireCondition.id;
+    return wireCondition;
   });
   return active.length > 0 ? JSON.stringify(active) : undefined;
 };
@@ -163,6 +127,11 @@ export type FilterOption = {
   value: string;
   label: string;
 };
+
+export type InitialFilterCondition = Omit<
+  ResultsFilterCondition,
+  'id' | 'field'
+>;
 
 export type FilterOptionGroup = {
   label: string;
@@ -188,9 +157,10 @@ export type FilterField = {
    *  own operator, as the allele-frequency and score editors do. */
   operator_label?: string;
   editor: 'consequence' | 'text' | 'group' | 'af' | 'score';
+  initial_condition: InitialFilterCondition;
+  operator_options?: FilterOption[];
   /** Text editors. */
   placeholder?: string;
-  mono?: boolean;
   /** An editor that already takes many values is offered once, then withdrawn. */
   single_instance?: boolean;
   /** Consequence editor. */

--- a/src/content/app/tools/vep/types/vepResultsResponse.ts
+++ b/src/content/app/tools/vep/types/vepResultsResponse.ts
@@ -16,6 +16,7 @@
 
 import type { FormPanel } from 'src/content/app/tools/vep/types/vepFormConfig';
 import type { DisplaySpec } from 'src/content/app/tools/vep/types/vepDisplaySpec';
+import type { FilterField } from 'src/content/app/tools/vep/types/vepResultsFilters';
 
 export type VepResultsResponse = {
   metadata: VepResultsResponseMetadata;
@@ -40,6 +41,12 @@ export type VepResultsResponseMetadata = {
    * columns nobody asked for.
    */
   available_scores?: string[];
+  /**
+   * The fields the query builder offers and how each is presented, from the
+   * job's pinned spec — gated to what this output can be filtered by. Absent
+   * for a job pinned before the catalogue existed.
+   */
+  filter_fields?: FilterField[] | null;
   /**
    * The option panels this job was submitted against, pinned by the tools API
    * at submission time. The results view lays itself out from these rather than

--- a/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.tsx
@@ -285,6 +285,9 @@ const VepSubmissionResults = () => {
   // above.
   const scoreFields = (vepResults?.metadata.available_scores ??
     []) as ResultsFilterField[];
+  // Which fields the query builder offers, and how each is presented. Absent on
+  // a job pinned before the catalogue existed, which then offers no filters.
+  const filterFields = vepResults?.metadata.filter_fields ?? [];
 
   return (
     <div className={styles.container}>
@@ -315,7 +318,7 @@ const VepSubmissionResults = () => {
             isDirty={isFiltersDirty}
             hasAppliedFilters={hasAppliedFilters}
             resultSummary={resultSummary}
-            species={submission.species}
+            filterFields={filterFields}
             afSources={afSources}
             scoreFields={scoreFields}
             appliedConditionIds={appliedConditionIds}

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/AlleleFrequencyInput.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/AlleleFrequencyInput.tsx
@@ -23,6 +23,7 @@ import CheckboxWithLabel from 'src/shared/components/checkbox-with-label/Checkbo
 import useOutsideClick from 'src/shared/hooks/useOutsideClick';
 
 import type {
+  FilterOption,
   ResultsFilterCondition,
   ResultsFilterOperator,
   AlleleFrequencyMatch
@@ -36,6 +37,7 @@ type Scope = 'any' | 'all' | 'specific';
 
 type Props = {
   operator: ResultsFilterOperator;
+  operatorOptions: FilterOption[];
   match: AlleleFrequencyMatch | undefined;
   values: string[];
   threshold: number | undefined;
@@ -49,15 +51,16 @@ const SCOPE_OPTIONS = [
   { value: 'specific', label: 'Specific selections' }
 ];
 
-// No '=': frequencies are floats, so equality is a question the data can rarely
-// answer, and it was never the useful test here.
-const OPERATOR_OPTIONS = [
-  { value: 'le', label: '≤' },
-  { value: 'ge', label: '≥' }
-];
-
 const AlleleFrequencyInput = (props: Props) => {
-  const { operator, match, values, threshold, sources, onChange } = props;
+  const {
+    operator,
+    operatorOptions,
+    match,
+    values,
+    threshold,
+    sources,
+    onChange
+  } = props;
   const [thresholdText, setThresholdText] = useState(
     threshold !== undefined ? String(threshold) : ''
   );
@@ -158,7 +161,7 @@ const AlleleFrequencyInput = (props: Props) => {
 
         <SimpleSelect
           className={styles.afOperatorSelect}
-          options={OPERATOR_OPTIONS}
+          options={operatorOptions}
           value={operator}
           onChange={() => undefined}
           onInput={(event) =>

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/ConsequenceMultiSelect.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/ConsequenceMultiSelect.tsx
@@ -21,18 +21,15 @@ import CheckboxWithLabel from 'src/shared/components/checkbox-with-label/Checkbo
 import VariantColour from 'src/shared/components/variant-color/VariantColor';
 import useOutsideClick from 'src/shared/hooks/useOutsideClick';
 
-import { CONSEQUENCE_OPTION_GROUPS } from './resultsFilterFields';
+import type { FilterOptionGroup } from 'src/content/app/tools/vep/types/vepResultsFilters';
 
 import styles from './VepResultsFilters.module.css';
 
 type Props = {
   values: string[];
   onChange: (values: string[]) => void;
+  optionGroups: FilterOptionGroup[];
 };
-
-// All consequence terms in vocabulary order, so a selection is always reported
-// in a stable order regardless of the order the user ticked them.
-const ALL_TERMS = CONSEQUENCE_OPTION_GROUPS.flatMap((group) => group.options);
 
 /**
  * The value editor for a consequence condition: a button summarising the current
@@ -43,7 +40,10 @@ const ALL_TERMS = CONSEQUENCE_OPTION_GROUPS.flatMap((group) => group.options);
  * inner scrollable list impossible to scroll.
  */
 const ConsequenceMultiSelect = (props: Props) => {
-  const { values, onChange } = props;
+  const { values, onChange, optionGroups } = props;
+  // All terms in catalogue order, so a selection is reported in a stable order
+  // regardless of the order the user ticked them.
+  const allTerms = optionGroups.flatMap((group) => group.options);
   const [isOpen, setIsOpen] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const selected = new Set(values);
@@ -51,7 +51,7 @@ const ConsequenceMultiSelect = (props: Props) => {
   useOutsideClick(wrapperRef, () => setIsOpen(false));
 
   const emit = (next: Set<string>) => {
-    onChange(ALL_TERMS.filter((term) => next.has(term)));
+    onChange(allTerms.filter((term) => next.has(term)));
   };
 
   const toggleValue = (value: string) => {
@@ -96,7 +96,7 @@ const ConsequenceMultiSelect = (props: Props) => {
       {isOpen && (
         <div className={styles.optionsPanel}>
           <div className={styles.optionGroups}>
-            {CONSEQUENCE_OPTION_GROUPS.map((group) => {
+            {optionGroups.map((group) => {
               const allSelected = group.options.every((option) =>
                 selected.has(option)
               );

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/ScoreInput.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/ScoreInput.tsx
@@ -21,12 +21,12 @@ import SimpleSelect from 'src/shared/components/simple-select/SimpleSelect';
 import CheckboxWithLabel from 'src/shared/components/checkbox-with-label/CheckboxWithLabel';
 
 import type {
+  FilterOption,
   ResultsFilterCondition,
   ResultsFilterField,
-  ResultsFilterOperator
+  ResultsFilterOperator,
+  ScoreOptionGroup
 } from 'src/content/app/tools/vep/types/vepResultsFilters';
-
-import type { ScoreOptionGroup } from 'src/content/app/tools/vep/types/vepResultsFilters';
 
 import styles from './VepResultsFilters.module.css';
 
@@ -36,6 +36,7 @@ type Props = {
   // is not offered again — one threshold per score.
   field: ResultsFilterField;
   scoreOptionGroups: ScoreOptionGroup[];
+  operatorOptions: FilterOption[];
   operator: ResultsFilterOperator;
   threshold: number | undefined;
   includeMissing: boolean;
@@ -43,11 +44,6 @@ type Props = {
   missingLabel: string;
   onChange: (patch: Partial<ResultsFilterCondition>) => void;
 };
-
-const OPERATOR_OPTIONS = [
-  { value: 'le', label: '≤' },
-  { value: 'ge', label: '≥' }
-];
 
 /**
  * The editor for a numeric score filter: a comparison, a threshold, and what to
@@ -77,6 +73,7 @@ const ScoreInput = (props: Props) => {
   const {
     field,
     scoreOptionGroups,
+    operatorOptions,
     operator,
     threshold,
     includeMissing,
@@ -121,7 +118,7 @@ const ScoreInput = (props: Props) => {
         />
         <SimpleSelect
           className={styles.afOperatorSelect}
-          options={OPERATOR_OPTIONS}
+          options={operatorOptions}
           value={operator}
           onInput={(event) =>
             onChange({
@@ -140,7 +137,7 @@ const ScoreInput = (props: Props) => {
         <CheckboxWithLabel
           label={missingLabel}
           checked={includeMissing}
-          onChange={(checked) => onChange({ includeMissing: checked })}
+          onChange={(checked) => onChange({ include_missing: checked })}
         />
       </div>
     </div>

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/ScoreInput.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/ScoreInput.tsx
@@ -25,9 +25,8 @@ import type {
   ResultsFilterField,
   ResultsFilterOperator
 } from 'src/content/app/tools/vep/types/vepResultsFilters';
-import { scoreFieldOption } from './resultsFilterFields';
 
-import type { ScoreFieldOptionGroup } from './resultsFilterFields';
+import type { ScoreOptionGroup } from 'src/content/app/tools/vep/types/vepResultsFilters';
 
 import styles from './VepResultsFilters.module.css';
 
@@ -36,7 +35,7 @@ type Props = {
   // category (genome wide / missense / splicing). A score taken by another row
   // is not offered again — one threshold per score.
   field: ResultsFilterField;
-  scoreOptionGroups: ScoreFieldOptionGroup[];
+  scoreOptionGroups: ScoreOptionGroup[];
   operator: ResultsFilterOperator;
   threshold: number | undefined;
   includeMissing: boolean;
@@ -84,7 +83,12 @@ const ScoreInput = (props: Props) => {
     missingLabel,
     onChange
   } = props;
-  const placeholder = scoreFieldOption(field)?.placeholder ?? '';
+  // The row's own score is always among the groups it is offered, so its range
+  // hint is here rather than needing the whole catalogue.
+  const placeholder =
+    scoreOptionGroups
+      .flatMap((group) => group.options)
+      .find((option) => option.value === field)?.placeholder ?? '';
   // Kept as text so a half-typed value ("-", "1.") survives; the number is only
   // reported once it parses.
   const [thresholdText, setThresholdText] = useState(

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/TokenListInput.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/TokenListInput.tsx
@@ -15,7 +15,6 @@
  */
 
 import { useState, memo, type InputEvent } from 'react';
-import classNames from 'classnames';
 
 import type { FilterField } from 'src/content/app/tools/vep/types/vepResultsFilters';
 
@@ -24,7 +23,7 @@ import styles from './VepResultsFilters.module.css';
 type Props = {
   values: string[];
   onChange: (values: string[]) => void;
-  config: Pick<FilterField, 'placeholder' | 'mono'>;
+  config: Pick<FilterField, 'placeholder'>;
 };
 
 // Split free text (comma / whitespace / newline separated) into unique tokens,
@@ -65,9 +64,7 @@ const TokenListInput = (props: Props) => {
     <div className={styles.tokenField}>
       <input
         type="text"
-        className={classNames(styles.tokenInput, {
-          [styles.tokenInputMono]: config.mono
-        })}
+        className={styles.tokenInput}
         value={text}
         onInput={onInput}
         placeholder={config.placeholder}

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/TokenListInput.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/TokenListInput.tsx
@@ -17,14 +17,14 @@
 import { useState, memo, type InputEvent } from 'react';
 import classNames from 'classnames';
 
-import type { TextInputConfig } from './resultsFilterFields';
+import type { FilterField } from 'src/content/app/tools/vep/types/vepResultsFilters';
 
 import styles from './VepResultsFilters.module.css';
 
 type Props = {
   values: string[];
   onChange: (values: string[]) => void;
-  config: TextInputConfig;
+  config: Pick<FilterField, 'placeholder' | 'mono'>;
 };
 
 // Split free text (comma / whitespace / newline separated) into unique tokens,
@@ -43,9 +43,7 @@ const parseTokens = (text: string): string[] => {
 
 /**
  * The value editor for a free-text token field (transcript / gene). Takes one or
- * more values separated by spaces, commas or newlines. When the field config
- * carries a `pattern`, non-matching tokens are flagged and excluded from the
- * applied filter rather than sent to the server.
+ * more values separated by spaces, commas or newlines.
  */
 const TokenListInput = (props: Props) => {
   const { values, onChange, config } = props;

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/TranscriptGroupSelect.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/TranscriptGroupSelect.tsx
@@ -16,12 +16,12 @@
 
 import CheckboxWithLabel from 'src/shared/components/checkbox-with-label/CheckboxWithLabel';
 
-import type { TranscriptGroupOption } from './resultsFilterFields';
+import type { FilterOption } from 'src/content/app/tools/vep/types/vepResultsFilters';
 
 import styles from './VepResultsFilters.module.css';
 
 type Props = {
-  options: TranscriptGroupOption[];
+  options: FilterOption[];
   values: string[];
   onChange: (values: string[]) => void;
 };

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/VepResultsFilters.module.css
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/VepResultsFilters.module.css
@@ -109,10 +109,6 @@
   font-size: 13px;
 }
 
-.tokenInputMono {
-  font-family: 'IBM Plex Mono', monospace;
-}
-
 .tokenError {
   color: var(--color-red);
   font-size: 11px;

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/VepResultsFilters.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/VepResultsFilters.tsx
@@ -29,23 +29,20 @@ import AlleleFrequencyInput, {
   type AfSourceOption
 } from './AlleleFrequencyInput';
 import {
-  FILTER_FIELDS,
   createCondition,
   availableFieldsForRow,
   availableScoresForRow,
   definitionForField,
   flattenScoreOptions,
   isScoreField,
-  nextAvailableField,
-  getTranscriptGroupOptions,
-  type FilterFieldDefinition
+  nextAvailableField
 } from './resultsFilterFields';
 
+import type { FilterField } from 'src/content/app/tools/vep/types/vepResultsFilters';
 import type {
   ResultsFilterCondition,
   ResultsFilterField
 } from 'src/content/app/tools/vep/types/vepResultsFilters';
-import type { VepSubmissionWithoutInputFile } from 'src/content/app/tools/vep/types/vepSubmission';
 
 import styles from './VepResultsFilters.module.css';
 
@@ -59,9 +56,10 @@ type Props = {
   hasAppliedFilters: boolean;
   // Filtered / total record counts from the last applied request, if any.
   resultSummary: { filtered: number; total: number } | null;
-  // The `species` property is needed to generate a list of transcript filters (e.g. MANE sets for human GRCh38).
-  // FIXME: this logic should be moved out of the client and to the server
-  species: VepSubmissionWithoutInputFile['species'];
+  // The fields this job can be filtered on, and how each is presented, from the
+  // results response. Which transcript groups it offers is decided there, from
+  // the columns the output has.
+  filterFields: FilterField[];
   // Allele-frequency sources chosen at input; the AF filter is only offered when
   // this is non-empty.
   afSources: AfSourceOption[];
@@ -76,8 +74,10 @@ type Props = {
 
 // Every score resolves to the one "Variant impact predictions" entry; which
 // score a row tests lives in the row, not in the field dropdown.
-const fieldDefinition = (field: ResultsFilterField): FilterFieldDefinition =>
-  definitionForField(field) ?? FILTER_FIELDS[0];
+const fieldDefinition = (
+  field: ResultsFilterField,
+  fields: FilterField[]
+): FilterField => definitionForField(field, fields) ?? fields[0];
 
 /**
  * The results filter query builder: rows of (field, operator, values) conditions
@@ -93,7 +93,7 @@ const VepResultsFilters = (props: Props) => {
     isDirty,
     hasAppliedFilters,
     resultSummary,
-    species,
+    filterFields,
     afSources,
     scoreFields,
     appliedConditionIds
@@ -116,9 +116,9 @@ const VepResultsFilters = (props: Props) => {
     // "Variant impact predictions" is one entry standing for several scores,
     // and its declared field is only the first of them. Landing on it would put
     // two rows on the same score, so take the first one still free.
-    const resolved = isScoreField(field)
+    const resolved = isScoreField(field, filterFields)
       ? (flattenScoreOptions(
-          availableScoresForRow(conditions, index, scoreFields)
+          availableScoresForRow(conditions, index, scoreFields, filterFields)
         ).find(
           (option) =>
             !conditions.some((c, i) => i !== index && c.field === option.value)
@@ -127,7 +127,7 @@ const VepResultsFilters = (props: Props) => {
     onChange(
       conditions.map((condition, i) =>
         i === index
-          ? { ...createCondition(resolved), id: condition.id }
+          ? { ...createCondition(resolved, filterFields), id: condition.id }
           : condition
       )
     );
@@ -138,14 +138,17 @@ const VepResultsFilters = (props: Props) => {
   };
 
   const addCondition = () => {
-    onChange([...conditions, createCondition(nextAvailableField(conditions))]);
+    onChange([
+      ...conditions,
+      createCondition(
+        nextAvailableField(conditions, filterFields),
+        filterFields
+      )
+    ]);
   };
 
-  // FIXME: This logic should not belong on the client; the client should not know anything about specific species or assemblies
-  const isHumanGRCh38 =
-    String(species?.species_taxonomy_id) === '9606' &&
-    (species?.assembly.name ?? '').startsWith('GRCh38');
-  const transcriptGroupOptions = getTranscriptGroupOptions(isHumanGRCh38);
+  const transcriptGroupOptions =
+    filterFields.find((f) => f.editor === 'group')?.options ?? [];
 
   return (
     <div className={styles.panel}>
@@ -157,7 +160,7 @@ const VepResultsFilters = (props: Props) => {
 
       <div className={styles.conditions}>
         {conditions.map((condition, index) => {
-          const definition = fieldDefinition(condition.field);
+          const definition = fieldDefinition(condition.field, filterFields);
           // The field (query type) locks once this row has been applied.
           const isFieldLocked = appliedConditionIds.has(condition.id);
           return (
@@ -165,7 +168,7 @@ const VepResultsFilters = (props: Props) => {
               {index > 0 && <span className={styles.conjunction}>and</span>}
               <SimpleSelect
                 className={styles.fieldSelect}
-                options={availableFieldsForRow(conditions, index)
+                options={availableFieldsForRow(conditions, index, filterFields)
                   .filter((field) => {
                     // A filter is only offered when the job carries the data it
                     // tests: AF sources and impact-prediction scores are both
@@ -179,8 +182,12 @@ const VepResultsFilters = (props: Props) => {
                       // are already dropped, so a non-empty list of groups
                       // means a genuinely available score.
                       return (
-                        availableScoresForRow(conditions, index, scoreFields)
-                          .length > 0
+                        availableScoresForRow(
+                          conditions,
+                          index,
+                          scoreFields,
+                          filterFields
+                        ).length > 0
                       );
                     }
                     return true;
@@ -192,7 +199,7 @@ const VepResultsFilters = (props: Props) => {
                 // A score row's value is its score, which is not a field option
                 // — point the select at the group entry instead.
                 value={
-                  isScoreField(condition.field)
+                  isScoreField(condition.field, filterFields)
                     ? definition.field
                     : condition.field
                 }
@@ -205,16 +212,16 @@ const VepResultsFilters = (props: Props) => {
                   )
                 }
               />
-              {definition.operatorLabel && (
+              {definition.operator_label && (
                 <span className={styles.operator}>
-                  {definition.operatorLabel}
+                  {definition.operator_label}
                 </span>
               )}
-              {definition.editor === 'text' && definition.textInput ? (
+              {definition.editor === 'text' ? (
                 <TokenListInput
                   values={condition.values}
                   onChange={(values) => updateCondition(index, { values })}
-                  config={definition.textInput}
+                  config={definition}
                 />
               ) : definition.editor === 'group' ? (
                 <TranscriptGroupSelect
@@ -228,12 +235,13 @@ const VepResultsFilters = (props: Props) => {
                   scoreOptionGroups={availableScoresForRow(
                     conditions,
                     index,
-                    scoreFields
+                    scoreFields,
+                    filterFields
                   )}
                   operator={condition.operator}
                   threshold={condition.threshold}
                   includeMissing={condition.includeMissing ?? false}
-                  missingLabel={definition.score?.missingLabel ?? ''}
+                  missingLabel={definition.missing_label ?? ''}
                   onChange={(patch) => updateCondition(index, patch)}
                 />
               ) : definition.editor === 'af' ? (
@@ -249,6 +257,7 @@ const VepResultsFilters = (props: Props) => {
                 <ConsequenceMultiSelect
                   values={condition.values}
                   onChange={(values) => updateCondition(index, { values })}
+                  optionGroups={definition.option_groups ?? []}
                 />
               )}
               <CloseButton

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/VepResultsFilters.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/VepResultsFilters.tsx
@@ -238,15 +238,17 @@ const VepResultsFilters = (props: Props) => {
                     scoreFields,
                     filterFields
                   )}
+                  operatorOptions={definition.operator_options ?? []}
                   operator={condition.operator}
                   threshold={condition.threshold}
-                  includeMissing={condition.includeMissing ?? false}
+                  includeMissing={condition.include_missing ?? false}
                   missingLabel={definition.missing_label ?? ''}
                   onChange={(patch) => updateCondition(index, patch)}
                 />
               ) : definition.editor === 'af' ? (
                 <AlleleFrequencyInput
                   operator={condition.operator}
+                  operatorOptions={definition.operator_options ?? []}
                   match={condition.match}
                   values={condition.values}
                   threshold={condition.threshold}

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/resultsFilterFields.test.ts
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/resultsFilterFields.test.ts
@@ -14,134 +14,140 @@
  * limitations under the License.
  */
 
-import { describe, it, expect } from 'vitest';
-
 import {
-  FILTER_FIELDS,
-  SCORE_FIELD_OPTIONS,
-  SCORE_FIELD_OPTION_GROUPS,
+  availableFieldsForRow,
   availableScoresForRow,
   createCondition,
-  definitionForField,
   flattenScoreOptions,
-  isScoreField,
-  scoreFieldOption
+  nextAvailableField
 } from './resultsFilterFields';
 
-import { SCORE_FILTER_FIELDS } from 'src/content/app/tools/vep/types/vepResultsFilters';
-
-import type {
-  ResultsFilterCondition,
-  ResultsFilterField
+import {
+  type FilterField,
+  type ResultsFilterCondition,
+  type ResultsFilterField,
+  type ScoreOptionGroup
 } from 'src/content/app/tools/vep/types/vepResultsFilters';
 
-const condition = (field: ResultsFilterField): ResultsFilterCondition =>
-  createCondition(field);
+/**
+ * What a row may offer, given what other rows have taken. The catalogue itself
+ * — which fields exist, their labels, which scores sit under which heading —
+ * comes from the API and is asserted there (tests/test_filter_spec.py); a
+ * fixture stands in for it here, so these tests describe the row logic and not
+ * the day's spec.
+ */
+const CATALOGUE: FilterField[] = [
+  {
+    field: 'consequence',
+    label: 'Predicted molecular consequence',
+    editor: 'consequence',
+    single_instance: true
+  },
+  { field: 'transcript', label: 'Transcript', editor: 'text' },
+  { field: 'allele_frequency', label: 'Allele frequency', editor: 'af' },
+  {
+    field: 'cadd_phred',
+    label: 'Variant impact predictions',
+    editor: 'score',
+    missing_label: 'Include variants with no score',
+    score_groups: [
+      {
+        title: 'Genome wide',
+        options: [
+          {
+            value: 'cadd_phred',
+            label: 'CADD (PHRED)',
+            placeholder: 'e.g. 20'
+          },
+          { value: 'cadd_raw', label: 'CADD (RAW)', placeholder: 'e.g. 3' }
+        ]
+      },
+      {
+        title: 'Missense',
+        options: [{ value: 'revel', label: 'REVEL', placeholder: 'e.g. 0.5' }]
+      },
+      {
+        title: 'Splicing',
+        options: [
+          {
+            value: 'spliceai_dl',
+            label: 'SpliceAI ΔS (donor loss)',
+            placeholder: 'e.g. 0.5'
+          }
+        ]
+      }
+    ]
+  }
+];
 
-const groupTitles = (groups: { title: string }[]) =>
+const condition = (field: ResultsFilterField): ResultsFilterCondition =>
+  createCondition(field, CATALOGUE);
+
+// The scores the catalogue offers, which is what "a score field" now means.
+const CATALOGUE_SCORES = (
+  CATALOGUE.find((f) => f.editor === 'score')?.score_groups ?? []
+).flatMap((group) => group.options.map((option) => option.value));
+
+const groupTitles = (groups: ScoreOptionGroup[]) =>
   groups.map((group) => group.title);
 
-describe('the score menu', () => {
-  it('offers the categories in the order the form uses', () => {
-    expect(groupTitles(SCORE_FIELD_OPTION_GROUPS)).toEqual([
-      'Genome wide',
-      'Missense',
-      'Splicing'
-    ]);
-  });
-
-  it('agrees with the score fields the filter type knows about', () => {
-    // The two lists are declared separately (one is the wire vocabulary, the
-    // other the menu), so a score added to one and not the other would either
-    // be unfilterable or unofferable.
-    expect(SCORE_FIELD_OPTIONS.map((option) => option.value).sort()).toEqual(
-      [...SCORE_FILTER_FIELDS].sort()
-    );
-    for (const field of SCORE_FILTER_FIELDS) {
-      expect(isScoreField(field)).toBe(true);
-    }
-  });
-
-  it('gives every score its own range hint', () => {
-    // The placeholder is a real hint at the expected range, not decoration:
-    // most scores are 0-1, CADD PHRED is ~0-99, and popEVE is negative.
-    expect(scoreFieldOption('cadd_phred')?.placeholder).toBe('e.g. 20');
-    expect(scoreFieldOption('cadd_raw')?.placeholder).toBe('e.g. 3');
-    expect(scoreFieldOption('revel')?.placeholder).toBe('e.g. 0.5');
-    expect(scoreFieldOption('popeve')?.placeholder).toBe('e.g. -3');
-    for (const option of SCORE_FIELD_OPTIONS) {
-      expect(option.placeholder).not.toBe('');
-    }
-  });
-
-  it('is reached from the one "Variant impact predictions" field entry', () => {
-    // Whichever score a row is on, the field dropdown shows the single grouped
-    // entry, named as the submission form's own panel is.
-    for (const field of SCORE_FILTER_FIELDS) {
-      expect(definitionForField(field)?.label).toBe(
-        'Variant impact predictions'
-      );
-    }
-    expect(
-      FILTER_FIELDS.filter((definition) => definition.editor === 'score')
-    ).toHaveLength(1);
-  });
-});
+const scoresIn = (groups: ScoreOptionGroup[]) =>
+  flattenScoreOptions(groups).map((option) => option.value);
 
 describe('availableScoresForRow', () => {
   it('offers only the scores the job carries, keeping them grouped', () => {
-    const groups = availableScoresForRow([], 0, ['cadd_phred', 'revel']);
+    const groups = availableScoresForRow(
+      [],
+      0,
+      ['cadd_phred', 'revel'],
+      CATALOGUE
+    );
     expect(groupTitles(groups)).toEqual(['Genome wide', 'Missense']);
-    expect(flattenScoreOptions(groups).map((option) => option.value)).toEqual([
-      'cadd_phred',
-      'revel'
-    ]);
+    expect(scoresIn(groups)).toEqual(['cadd_phred', 'revel']);
   });
 
   it('drops a category with no available scores rather than leaving it empty', () => {
     // An empty <optgroup> still renders its heading, so a category with nothing
     // under it would advertise scores this job does not have.
-    const groups = availableScoresForRow([], 0, ['spliceai_dl']);
+    const groups = availableScoresForRow([], 0, ['spliceai_dl'], CATALOGUE);
     expect(groupTitles(groups)).toEqual(['Splicing']);
   });
 
   it('returns nothing at all when the job carries no scores', () => {
     // This is what gates the whole entry out of the field dropdown.
-    expect(availableScoresForRow([], 0, [])).toEqual([]);
+    expect(availableScoresForRow([], 0, [], CATALOGUE)).toEqual([]);
   });
 
   it('does not offer a score another row has already taken', () => {
     const conditions = [condition('cadd_phred'), condition('revel')];
-    const groups = availableScoresForRow(conditions, 1, [
-      'cadd_phred',
-      'cadd_raw',
-      'revel'
-    ]);
-    expect(flattenScoreOptions(groups).map((option) => option.value)).toEqual([
-      'cadd_raw',
-      'revel'
-    ]);
+    const groups = availableScoresForRow(
+      conditions,
+      1,
+      ['cadd_phred', 'cadd_raw', 'revel'],
+      CATALOGUE
+    );
+    expect(scoresIn(groups)).toEqual(['cadd_raw', 'revel']);
     // And with the other row's score being the only genome-wide one, that
     // category disappears entirely.
     expect(
-      groupTitles(availableScoresForRow(conditions, 1, ['cadd_phred', 'revel']))
+      groupTitles(
+        availableScoresForRow(conditions, 1, ['cadd_phred', 'revel'], CATALOGUE)
+      )
     ).toEqual(['Missense']);
   });
 
   it('keeps the score the row is itself on', () => {
     // Otherwise a row would be pointing at an option that is not in its menu.
     const conditions = [condition('revel')];
-    const groups = availableScoresForRow(conditions, 0, ['revel']);
-    expect(flattenScoreOptions(groups).map((option) => option.value)).toEqual([
-      'revel'
-    ]);
+    const groups = availableScoresForRow(conditions, 0, ['revel'], CATALOGUE);
+    expect(scoresIn(groups)).toEqual(['revel']);
   });
 });
 
 describe('createCondition', () => {
   it('starts every score at >=, since the damaging end is what is asked for', () => {
-    for (const field of SCORE_FILTER_FIELDS) {
-      expect(createCondition(field).operator).toBe('ge');
+    for (const field of CATALOGUE_SCORES) {
+      expect(createCondition(field, CATALOGUE).operator).toBe('ge');
     }
   });
 
@@ -149,9 +155,35 @@ describe('createCondition', () => {
     // Unlike allele frequency, where absence implies the variant is very rare
     // and so is kept. A variant with no impact score was never judged, so
     // including it by default would dilute a hunt for damaging variants.
-    for (const field of SCORE_FILTER_FIELDS) {
-      expect(createCondition(field).includeMissing).toBe(false);
+    for (const field of CATALOGUE_SCORES) {
+      expect(createCondition(field, CATALOGUE).includeMissing).toBe(false);
     }
-    expect(createCondition('allele_frequency').includeMissing).toBeUndefined();
+    expect(
+      createCondition('allele_frequency', CATALOGUE).includeMissing
+    ).toBeUndefined();
+  });
+});
+
+describe('single-instance fields', () => {
+  it('withdraws a used one from the other rows', () => {
+    const conditions = [condition('consequence'), condition('transcript')];
+    const offered = availableFieldsForRow(conditions, 1, CATALOGUE).map(
+      (f) => f.field
+    );
+    expect(offered).not.toContain('consequence');
+  });
+
+  it('keeps it on the row that is using it', () => {
+    const conditions = [condition('consequence')];
+    const offered = availableFieldsForRow(conditions, 0, CATALOGUE).map(
+      (f) => f.field
+    );
+    expect(offered).toContain('consequence');
+  });
+
+  it('is skipped when choosing the field for a new row', () => {
+    expect(nextAvailableField([condition('consequence')], CATALOGUE)).toBe(
+      'transcript'
+    );
   });
 });

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/resultsFilterFields.test.ts
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/resultsFilterFields.test.ts
@@ -41,14 +41,43 @@ const CATALOGUE: FilterField[] = [
     field: 'consequence',
     label: 'Predicted molecular consequence',
     editor: 'consequence',
+    initial_condition: { operator: 'in', values: [] },
     single_instance: true
   },
-  { field: 'transcript', label: 'Transcript', editor: 'text' },
-  { field: 'allele_frequency', label: 'Allele frequency', editor: 'af' },
+  {
+    field: 'transcript',
+    label: 'Transcript',
+    editor: 'text',
+    initial_condition: { operator: 'in', values: [] }
+  },
+  {
+    field: 'allele_frequency',
+    label: 'Allele frequency',
+    editor: 'af',
+    initial_condition: {
+      operator: 'le',
+      values: [],
+      threshold: 0.05,
+      match: 'any'
+    },
+    operator_options: [
+      { value: 'le', label: '≤' },
+      { value: 'ge', label: '≥' }
+    ]
+  },
   {
     field: 'cadd_phred',
     label: 'Variant impact predictions',
     editor: 'score',
+    initial_condition: {
+      operator: 'ge',
+      values: [],
+      include_missing: false
+    },
+    operator_options: [
+      { value: 'le', label: '≤' },
+      { value: 'ge', label: '≥' }
+    ],
     missing_label: 'Include variants with no score',
     score_groups: [
       {
@@ -145,22 +174,32 @@ describe('availableScoresForRow', () => {
 });
 
 describe('createCondition', () => {
-  it('starts every score at >=, since the damaging end is what is asked for', () => {
+  it('uses the score initial condition from the catalogue', () => {
     for (const field of CATALOGUE_SCORES) {
-      expect(createCondition(field, CATALOGUE).operator).toBe('ge');
+      expect(createCondition(field, CATALOGUE)).toMatchObject({
+        field,
+        operator: 'ge',
+        values: [],
+        include_missing: false
+      });
     }
   });
 
-  it('starts every score excluding the unscored variants', () => {
-    // Unlike allele frequency, where absence implies the variant is very rare
-    // and so is kept. A variant with no impact score was never judged, so
-    // including it by default would dilute a hunt for damaging variants.
-    for (const field of CATALOGUE_SCORES) {
-      expect(createCondition(field, CATALOGUE).includeMissing).toBe(false);
-    }
-    expect(
-      createCondition('allele_frequency', CATALOGUE).includeMissing
-    ).toBeUndefined();
+  it('uses the allele-frequency initial condition from the catalogue', () => {
+    expect(createCondition('allele_frequency', CATALOGUE)).toMatchObject({
+      field: 'allele_frequency',
+      operator: 'le',
+      values: [],
+      threshold: 0.05,
+      match: 'any'
+    });
+  });
+
+  it('does not share the catalogue values array between rows', () => {
+    const first = createCondition('transcript', CATALOGUE);
+    const second = createCondition('transcript', CATALOGUE);
+    first.values.push('ENST1');
+    expect(second.values).toEqual([]);
   });
 });
 

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/resultsFilterFields.ts
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/resultsFilterFields.ts
@@ -14,246 +14,48 @@
  * limitations under the License.
  */
 
-import variantGroups from 'src/content/app/genome-browser/constants/variantGroups';
-
 import type {
+  FilterField,
   ResultsFilterCondition,
-  ResultsFilterField
+  ResultsFilterField,
+  ScoreOption,
+  ScoreOptionGroup
 } from 'src/content/app/tools/vep/types/vepResultsFilters';
 
-// Config for a free-text token editor (transcript / gene fields). When `pattern`
-// is set, tokens must match it to be applied; non-matching tokens are flagged.
-export type TextInputConfig = {
-  placeholder: string;
-  mono?: boolean;
-};
-
-// The fields the query builder can filter on. Adding a field here (plus, for a
-// text field, its input config) extends the builder.
-export type FilterFieldDefinition = {
-  field: ResultsFilterField;
-  label: string;
-  operatorLabel: string;
-  // Which value editor to render: the grouped consequence multi-select, a
-  // free-text token list, or the (species-dependent) transcript-group choices.
-  editor: 'consequence' | 'text' | 'group' | 'af' | 'score';
-  // Score editors only: what a variant with no score is called. The hint for
-  // the expected range is not here but on the score option, since it differs
-  // from score to score.
-  score?: { missingLabel: string };
-  textInput?: TextInputConfig;
-  // Fields whose editor is already multi-value (consequence, transcript group):
-  // a second condition would be redundant, so only one instance is allowed and
-  // the field is removed from other rows' field dropdowns once used.
-  singleInstance?: boolean;
-};
-
-// Transcript-group ids and their labels (must match the backend group ids).
-export type TranscriptGroupOption = { value: string; label: string };
-
-const TRANSCRIPT_GROUP_LABELS: Record<string, string> = {
-  mane_select: 'MANE Select',
-  mane_plus_clinical: 'MANE Plus Clinical',
-  gencode_primary: 'GENCODE Primary',
-  canonical: 'Canonical'
-};
-
 /**
- * Which transcript groups are offered for a species. Human GRCh38 has the MANE
- * sets plus GENCODE primary plus canonical; everything else has canonical only
- * (for now).
+ * Row-level bookkeeping for the query builder: which field a row may take, and
+ * what a new row should default to. Everything a field *is* — its label, editor
+ * and options — comes from the catalogue the API serves, and is passed in.
+ *
+ * The distinction is that this is interface state. What the user has already
+ * chosen in another row is not something the backend knows or should.
  */
-export const getTranscriptGroupOptions = (
-  isHumanGRCh38: boolean
-): TranscriptGroupOption[] => {
-  const ids = isHumanGRCh38
-    ? ['mane_select', 'mane_plus_clinical', 'gencode_primary', 'canonical']
-    : ['canonical'];
-  return ids.map((value) => ({ value, label: TRANSCRIPT_GROUP_LABELS[value] }));
-};
 
-export type ScoreFieldOption = {
-  value: ResultsFilterField;
-  label: string;
-  placeholder: string;
-};
+// Which of the offered scores exist at all, from the catalogue's score editor.
+const scoreOptions = (fields: FilterField[]): ScoreOption[] =>
+  fields.flatMap(
+    (field) => field.score_groups?.flatMap((group) => group.options) ?? []
+  );
 
-export type ScoreFieldOptionGroup = {
-  title: string;
-  options: ScoreFieldOption[];
-};
+export const isScoreField = (
+  field: ResultsFilterField,
+  fields: FilterField[]
+): boolean => scoreOptions(fields).some((option) => option.value === field);
 
-export const SCORE_FIELD_OPTION_GROUPS: ScoreFieldOptionGroup[] = [
-  {
-    title: 'Genome wide',
-    options: [
-      { value: 'cadd_phred', label: 'CADD (PHRED)', placeholder: 'e.g. 20' },
-      { value: 'cadd_raw', label: 'CADD (RAW)', placeholder: 'e.g. 3' }
-    ]
-  },
-  {
-    title: 'Missense',
-    options: [
-      {
-        value: 'alphamissense',
-        label: 'AlphaMissense',
-        placeholder: 'e.g. 0.5'
-      },
-      { value: 'revel', label: 'REVEL', placeholder: 'e.g. 0.5' },
-      { value: 'clinpred', label: 'ClinPred', placeholder: 'e.g. 0.5' },
-      { value: 'eve', label: 'EVE', placeholder: 'e.g. 0.5' },
-      // popEVE is a negative log-scale score (roughly -5.5 to -2.5 in the data
-      // we have), so its example threshold is negative where every other
-      // missense predictor's is a probability.
-      // TODO(popeve): popEVE also reports a gap frequency alongside the score.
-      // Offering a GAP-frequency filter is wanted, but it is a separate field
-      // with its own meaning rather than another entry in this menu, so it is
-      // deliberately not defined here yet.
-      { value: 'popeve', label: 'popEVE', placeholder: 'e.g. -3' }
-    ]
-  },
-  {
-    title: 'Splicing',
-    // Named the way the results name them: the source first, then "ΔS" — the
-    // same column heading the SpliceAI table uses for these very values, which
-    // are its `SpliceAI_pred_DS_*` delta scores. Spelling it "Delta score" here
-    // and "ΔS" there made the reader translate between the filter they set and
-    // the number they were looking at. The source prefix also leaves room for a
-    // second splicing predictor under this heading without either becoming
-    // ambiguous.
-    options: [
-      {
-        value: 'spliceai_ag',
-        label: 'SpliceAI ΔS (acceptor gain)',
-        placeholder: 'e.g. 0.5'
-      },
-      {
-        value: 'spliceai_al',
-        label: 'SpliceAI ΔS (acceptor loss)',
-        placeholder: 'e.g. 0.5'
-      },
-      {
-        value: 'spliceai_dg',
-        label: 'SpliceAI ΔS (donor gain)',
-        placeholder: 'e.g. 0.5'
-      },
-      {
-        value: 'spliceai_dl',
-        label: 'SpliceAI ΔS (donor loss)',
-        placeholder: 'e.g. 0.5'
-      },
-      {
-        value: 'spliceai_any',
-        label: 'SpliceAI ΔS (any)',
-        placeholder: 'e.g. 0.5'
-      }
-    ]
-  }
-];
-
-export const SCORE_FIELD_OPTIONS: ScoreFieldOption[] =
-  SCORE_FIELD_OPTION_GROUPS.flatMap((group) => group.options);
-
-const SCORE_FIELDS = new Set<ResultsFilterField>(
-  SCORE_FIELD_OPTIONS.map((option) => option.value)
-);
-
-// The placeholder (range hint) for a score, for the row's threshold input.
+/** The range hint for a score, for the row's threshold input. */
 export const scoreFieldOption = (
-  field: ResultsFilterField
-): ScoreFieldOption | undefined =>
-  SCORE_FIELD_OPTIONS.find((option) => option.value === field);
-
-export const isScoreField = (field: ResultsFilterField): boolean =>
-  SCORE_FIELDS.has(field);
-
-export const FILTER_FIELDS: FilterFieldDefinition[] = [
-  {
-    field: 'consequence',
-    label: 'Predicted molecular consequence',
-    operatorLabel: 'is any of',
-    editor: 'consequence',
-    singleInstance: true
-  },
-  {
-    field: 'transcript',
-    label: 'Transcript',
-    operatorLabel: 'is any of',
-    editor: 'text',
-    textInput: {
-      placeholder: 'e.g. ENST00000341065',
-      mono: true
-    }
-  },
-  {
-    field: 'gene_symbol',
-    label: 'Gene name',
-    operatorLabel: 'is any of',
-    editor: 'text',
-    textInput: {
-      placeholder: 'e.g. TP53'
-    }
-  },
-  {
-    field: 'gene_id',
-    label: 'Ensembl gene ID',
-    operatorLabel: 'is any of',
-    editor: 'text',
-    textInput: {
-      placeholder: 'e.g. ENSG00000141510',
-      mono: true
-    }
-  },
-  {
-    field: 'transcript_group',
-    label: 'Transcript group',
-    operatorLabel: 'is any of',
-    editor: 'group',
-    singleInstance: true
-  },
-  {
-    field: 'allele_frequency',
-    label: 'Allele frequency',
-    // The operator is chosen inside the AF editor, so no fixed operator label.
-    operatorLabel: '',
-    editor: 'af'
-  },
-  // One entry for every impact score, not one per score: the field dropdown
-  // offers "Variant impact predictions" (matching the submission form's panel
-  // of that name) and the score itself is chosen inside the row, the way the
-  // allele-frequency filter picks its sources. `field` holds the score actually
-  // chosen, so what goes to the API stays the real field.
-  {
-    field: 'cadd_phred',
-    label: 'Variant impact predictions',
-    operatorLabel: '',
-    editor: 'score',
-    score: {
-      missingLabel: 'Include variants with no score'
-    }
-  }
-];
-
-// Consequence terms offered in the multi-select, grouped as they are elsewhere
-// in the app (reusing the shared variant-consequence vocabulary as the single
-// source of terms and grouping).
-export type ConsequenceOptionGroup = {
-  label: string;
-  options: string[];
-};
-
-export const CONSEQUENCE_OPTION_GROUPS: ConsequenceOptionGroup[] =
-  variantGroups.map((group) => ({
-    label: group.label,
-    options: group.variant_types.map((type) => type.label)
-  }));
+  field: ResultsFilterField,
+  fields: FilterField[]
+): ScoreOption | undefined =>
+  scoreOptions(fields).find((option) => option.value === field);
 
 // A fresh condition on the given field, with a unique client-side id (used to
 // track which rows have been applied). Allele frequency starts on the requested
 // defaults: match any, <= (le), threshold 0.05.
 let conditionCounter = 0;
 export const createCondition = (
-  field: ResultsFilterField
+  field: ResultsFilterField,
+  fields: FilterField[]
 ): ResultsFilterCondition => {
   const id = `condition-${++conditionCounter}`;
   if (field === 'allele_frequency') {
@@ -266,7 +68,7 @@ export const createCondition = (
       threshold: 0.05
     };
   }
-  if (isScoreField(field)) {
+  if (isScoreField(field, fields)) {
     // `>=` by default
     return { id, field, operator: 'ge', values: [], includeMissing: false };
   }
@@ -275,29 +77,29 @@ export const createCondition = (
 
 // The single-instance fields already present in a set of conditions.
 const usedSingleInstanceFields = (
-  conditions: ResultsFilterCondition[]
+  conditions: ResultsFilterCondition[],
+  fields: FilterField[]
 ): Set<ResultsFilterField> => {
   const singleInstance = new Set(
-    FILTER_FIELDS.filter((f) => f.singleInstance).map((f) => f.field)
+    fields.filter((f) => f.single_instance).map((f) => f.field)
   );
   return new Set(
     conditions.map((c) => c.field).filter((field) => singleInstance.has(field))
   );
 };
 
-// Field options available to a given row: hide single-instance fields already
-// used by another row, but always keep the row's own current field.
 /**
  * The definition to render a condition with. Every score resolves to the one
  * "Variant impact predictions" entry, since which score it is lives in the row
  * rather than in the field dropdown.
  */
 export const definitionForField = (
-  field: ResultsFilterField
-): FilterFieldDefinition | undefined =>
-  isScoreField(field)
-    ? FILTER_FIELDS.find((f) => f.editor === 'score')
-    : FILTER_FIELDS.find((f) => f.field === field);
+  field: ResultsFilterField,
+  fields: FilterField[]
+): FilterField | undefined =>
+  isScoreField(field, fields)
+    ? fields.find((f) => f.editor === 'score')
+    : fields.find((f) => f.field === field);
 
 /**
  * Which scores this row may offer: those the job carries, minus the ones other
@@ -306,38 +108,44 @@ export const definitionForField = (
 export const availableScoresForRow = (
   conditions: ResultsFilterCondition[],
   rowIndex: number,
-  offered: ResultsFilterField[]
-): ScoreFieldOptionGroup[] => {
+  offered: ResultsFilterField[],
+  fields: FilterField[]
+): ScoreOptionGroup[] => {
   const takenElsewhere = new Set(
     conditions
-      .filter((c, i) => i !== rowIndex && isScoreField(c.field))
+      .filter((c, i) => i !== rowIndex && isScoreField(c.field, fields))
       .map((c) => c.field)
   );
-  const isAvailable = (option: ScoreFieldOption) =>
+  const isAvailable = (option: ScoreOption) =>
     offered.includes(option.value) &&
     (!takenElsewhere.has(option.value) ||
       conditions[rowIndex]?.field === option.value);
 
-  return SCORE_FIELD_OPTION_GROUPS.map((group) => ({
-    title: group.title,
-    options: group.options.filter(isAvailable)
-  })).filter((group) => group.options.length > 0);
+  const groups = fields.find((f) => f.editor === 'score')?.score_groups ?? [];
+  return groups
+    .map((group) => ({
+      title: group.title,
+      options: group.options.filter(isAvailable)
+    }))
+    .filter((group) => group.options.length > 0);
 };
 
 // The flat list of scores behind a grouped menu, for the places that only care
 // which scores are on offer rather than how they are presented.
 export const flattenScoreOptions = (
-  groups: ScoreFieldOptionGroup[]
-): ScoreFieldOption[] => groups.flatMap((group) => group.options);
+  groups: ScoreOptionGroup[]
+): ScoreOption[] => groups.flatMap((group) => group.options);
 
 export const availableFieldsForRow = (
   conditions: ResultsFilterCondition[],
-  rowIndex: number
-): FilterFieldDefinition[] => {
+  rowIndex: number,
+  fields: FilterField[]
+): FilterField[] => {
   const usedElsewhere = usedSingleInstanceFields(
-    conditions.filter((_, i) => i !== rowIndex)
+    conditions.filter((_, i) => i !== rowIndex),
+    fields
   );
-  return FILTER_FIELDS.filter(
+  return fields.filter(
     (f) =>
       !usedElsewhere.has(f.field) || conditions[rowIndex]?.field === f.field
   );
@@ -346,9 +154,10 @@ export const availableFieldsForRow = (
 // The field a newly-added condition should default to: the first field not
 // already blocked by a single-instance field being in use.
 export const nextAvailableField = (
-  conditions: ResultsFilterCondition[]
+  conditions: ResultsFilterCondition[],
+  fields: FilterField[]
 ): ResultsFilterField => {
-  const used = usedSingleInstanceFields(conditions);
-  const field = FILTER_FIELDS.find((f) => !used.has(f.field));
-  return (field ?? FILTER_FIELDS[0]).field;
+  const used = usedSingleInstanceFields(conditions, fields);
+  const field = fields.find((f) => !used.has(f.field));
+  return (field ?? fields[0]).field;
 };

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/resultsFilterFields.ts
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/resultsFilterFields.ts
@@ -50,29 +50,22 @@ export const scoreFieldOption = (
   scoreOptions(fields).find((option) => option.value === field);
 
 // A fresh condition on the given field, with a unique client-side id (used to
-// track which rows have been applied). Allele frequency starts on the requested
-// defaults: match any, <= (le), threshold 0.05.
+// track which rows have been applied) and API-provided initial wire values.
 let conditionCounter = 0;
 export const createCondition = (
   field: ResultsFilterField,
   fields: FilterField[]
 ): ResultsFilterCondition => {
-  const id = `condition-${++conditionCounter}`;
-  if (field === 'allele_frequency') {
-    return {
-      id,
-      field,
-      operator: 'le',
-      values: [],
-      match: 'any',
-      threshold: 0.05
-    };
+  const definition = definitionForField(field, fields);
+  if (!definition) {
+    throw new Error(`No filter definition for field '${field}'`);
   }
-  if (isScoreField(field, fields)) {
-    // `>=` by default
-    return { id, field, operator: 'ge', values: [], includeMissing: false };
-  }
-  return { id, field, operator: 'in', values: [] };
+  return {
+    id: `condition-${++conditionCounter}`,
+    field,
+    ...definition.initial_condition,
+    values: [...definition.initial_condition.values]
+  };
 };
 
 // The single-instance fields already present in a set of conditions.


### PR DESCRIPTION
> **Do not merge until Ensembl/ensembl-web-tools-api#68 is merged and deployed.** It deletes the catalogue the query builder is built from, so against a backend without #68 the filter panel offers no fields at all.

Which fields the query builder offers, their labels, editors, placeholders and option sets now arrive on the results response and are read from there. `resultsFilterFields.ts` goes from 354 lines to 155: what remains is per-row bookkeeping — which field a row may take, given what the others have — which is interface state rather than data.

`isHumanGRCh38` goes with it. Transcript groups come from the response, where they are decided from the columns the output has rather than from the species; the FIXME on that check said it belonged on the server. `species` is no longer a prop of the filter panel.

VEP no longer reads the genome browser's `variantGroups` constant for its consequence terms. That constant stays for its four other readers and the tools API carries its own copy for now — one source of truth for the grouping is worth its own change.

The tests keep the row-level cases and take a fixture catalogue rather than the constants they used to assert against. What those constants said — the score categories, each score's range hint, that every offered field is one the backend can compile — is asserted in #68, where the catalogue now lives.

`vitest` — 265 passed; `tsc --noEmit` clean. Also clears two comments describing the `pattern` validation removed in 626192e6.