### PR TITLE
Read annotations by plugin id without a lookup table

### DIFF
--- a/src/content/app/tools/vep/utils/annotations.ts
+++ b/src/content/app/tools/vep/utils/annotations.ts
@@ -14,83 +14,7 @@
  * limitations under the License.
  */
 
-import type {
-  Annotation,
-  CaddScores,
-  ClassificationWithScore,
-  ClinPredScore,
-  GencodePromoterData,
-  GnomadStructuralData,
-  ClinVarAnnotation,
-  ClinVarSvAnnotation,
-  DosageSensitivity,
-  FivePrimeUtrAnnotation,
-  GerpScore,
-  GoAnnotation,
-  HgvsNotations,
-  HgvsgRepresentation,
-  IntActAnnotation,
-  LoeufScore,
-  MaveDBAnnotation,
-  MutfuncAnnotation,
-  NearestExonJbData,
-  NearestGeneData,
-  NmdData,
-  OpenTargetsAssociation,
-  PopEve,
-  PopulationFrequencies,
-  ProteinData,
-  ProtVarAnnotation,
-  RevelScore,
-  RiboseqOrfsAnnotation,
-  SpdiRepresentation,
-  SpliceAiScores,
-  VariantPhenotypeData
-} from 'src/content/app/tools/vep/types/vepResultsResponse';
-
-/**
- * A map of plugin id -> shape of plugin annotation data
- */
-export type PluginDataMap = {
-  // transcript-scoped
-  mutfunc: MutfuncAnnotation;
-  mavedb: MaveDBAnnotation;
-  protvar: ProtVarAnnotation;
-  protein: ProteinData;
-  go: GoAnnotation;
-  spliceai: SpliceAiScores;
-  riboseq_orfs: RiboseqOrfsAnnotation;
-  hgvs: HgvsNotations;
-  dosage_sensitivity: DosageSensitivity;
-  intact: IntActAnnotation;
-  popeve: PopEve;
-  revel: RevelScore;
-  clinpred: ClinPredScore;
-  alphamissense: ClassificationWithScore;
-  eve: ClassificationWithScore;
-  utr_annotation: FivePrimeUtrAnnotation;
-  loeuf: LoeufScore;
-  nmd: NmdData;
-  nearest_exon_jb: NearestExonJbData;
-  clinvar: ClinVarAnnotation;
-  // allele-scoped
-  clinvar_sv: ClinVarSvAnnotation;
-  nearest_gene: NearestGeneData;
-  gencode_promoter: GencodePromoterData;
-  gnomad_exomes: PopulationFrequencies;
-  gnomad_genomes: PopulationFrequencies;
-  all_of_us: PopulationFrequencies;
-  gnomad_sv: GnomadStructuralData;
-  gnomad_cnv: GnomadStructuralData;
-  opentargets: OpenTargetsAssociation;
-  phenotype_data: VariantPhenotypeData;
-  cadd: CaddScores;
-  gerp: GerpScore;
-  spdi: SpdiRepresentation;
-  hgvsg: HgvsgRepresentation;
-};
-
-export type PluginId = keyof PluginDataMap;
+import type { Annotation } from 'src/content/app/tools/vep/types/vepResultsResponse';
 
 // Anything carrying the generic annotation list: a variant allele,
 // or a predicted transcript consequence.
@@ -101,13 +25,16 @@ export type AnnotatedEntity = {
 /**
  * Read the data of the given plugin's annotation
  * from the "annotated entity" (i.e. a variant allele, or a predicted transcript consequence object)
+ *
+ * The plugin id is a plain string, as it is on the wire and in the display spec.
+ * A caller that knows the shape it wants asks for it: getAnnotation<Foo>(...)
  */
-export const getAnnotation = <P extends PluginId>(
+export const getAnnotation = <Data = unknown>(
   entity: AnnotatedEntity | null | undefined,
-  plugin: P
-): PluginDataMap[P] | null => {
+  plugin: string
+): Data | null => {
   const entry = entity?.annotations?.find(
     (annotation) => annotation.plugin === plugin
   );
-  return entry ? (entry.data as PluginDataMap[P]) : null;
+  return entry ? (entry.data as Data) : null;
 };

--- a/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.tsx
@@ -79,7 +79,8 @@ import TextButton from 'src/shared/components/text-button/TextButton';
 import type { VepSubmissionWithoutInputFile } from 'src/content/app/tools/vep/types/vepSubmission';
 import type {
   VepResultsResponse,
-  AfSource
+  AfSource,
+  HgvsgRepresentation
 } from 'src/content/app/tools/vep/types/vepResultsResponse';
 import type { FormPanel } from 'src/content/app/tools/vep/types/vepFormConfig';
 import type { DisplaySpec } from 'src/content/app/tools/vep/types/vepDisplaySpec';
@@ -764,7 +765,7 @@ const VariantRow = (props: {
     // canonical minimal representation, which is exactly what ProtVar expects.
     // (When ProtVar is selected the backend forces HGVSg to be computed.)
     const protvarUrl = buildProtvarUrlFromHgvsg(
-      getAnnotation(allele, 'hgvsg')?.genomic
+      getAnnotation<HgvsgRepresentation>(allele, 'hgvsg')?.genomic
     );
     // This variant in OpenTargets' notation, for the link in its annotation
     // block. Built here rather than in the renderer because it comes from the

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-annotation-detail/displaySpecRenderer.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-annotation-detail/displaySpecRenderer.tsx
@@ -33,8 +33,7 @@ import {
 } from './annotationRows';
 import {
   getAnnotation,
-  type AnnotatedEntity,
-  type PluginId
+  type AnnotatedEntity
 } from 'src/content/app/tools/vep/utils/annotations';
 
 import QuestionButton from 'src/shared/components/question-button/QuestionButton';
@@ -184,7 +183,7 @@ const readPlugin = (
     spec.plugin_scopes[plugin] === 'allele'
       ? entities.allele
       : entities.consequence;
-  return getAnnotation(entity, plugin as PluginId);
+  return getAnnotation(entity, plugin);
 };
 
 /**


### PR DESCRIPTION
`PluginDataMap` had drifted badly and nothing noticed: four of its 34 keys named plugins that never appear in a payload, and four that do were missing — including `tss_distance`, the third most common annotation we serve. Nothing consulted it, which is why.

Only two call sites read an annotation. ProtVar names `hgvsg` literally and wants its shape; `readPlugin` in the display-spec renderer took the plugin id as a string, cast it to `PluginId` and returned `unknown`. Every other plugin travelled that second path, where the map typed nothing.

So `getAnnotation` is generic over the shape the caller asks for and takes the plugin id as the plain string it is on the wire. The renderer drops its cast, ProtVar names `HgvsgRepresentation` where it knows it, and there is no list left to fall out of date.

Tested locally against a spec covering all 34 plugins — results panel renders unchanged, ProtVar link included.

One deliberate trade: a typo in a plugin id now compiles and returns null. That was already the case, since the map never validated ids against what the backend sends — only the display spec knows the real names.