### PR TITLE
Render a split row's value as a link each

### DIFF
--- a/src/content/app/tools/vep/types/vepDisplaySpec.ts
+++ b/src/content/app/tools/vep/types/vepDisplaySpec.ts
@@ -63,6 +63,10 @@ export type DisplayRowSpec = {
    * Example when used: Geno2MP
    */
   link_from?: string | null;
+  /** One value packing several, each linked in its own right: a ClinVar custom
+   *  joins the records that matched one variant with `&`, and each has its own
+   *  page. Same separator vocabulary a list item's cell uses. */
+  split?: string | null;
   stars?: string | null; // string referring to a rating scale
   /**
    * An `item` is a row that itself contains a list of rows or cells,

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-annotation-detail/displaySpec.fixture.ts
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-annotation-detail/displaySpec.fixture.ts
@@ -502,6 +502,7 @@ export const displaySpecFixture: DisplaySpec = {
                 {
                   label: 'ClinVar variant ID',
                   from: 'clinvar.id',
+                  split: '&',
                   link: {
                     kind: 'external',
                     template:

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-annotation-detail/displaySpecRenderer.test.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-annotation-detail/displaySpecRenderer.test.tsx
@@ -1354,6 +1354,41 @@ describe('renderDisplayOption', () => {
     );
   });
 
+  test('ClinVar short: several matched records each get their own link', () => {
+    // A custom annotation joins every ClinVar record that matched the variant
+    // with `&`. One URL built from all of them points nowhere, so the row
+    // splits and links each id in its own right.
+    renderOption('phenotypes', {
+      consequence: {
+        annotations: [
+          annotation('clinvar', 'transcript', {
+            id: '2673364&2045211&3773565',
+            significance: ['Pathogenic', 'Pathogenic', 'Benign'],
+            classification_summary: [
+              {
+                type: 'Germline',
+                classification: 'Pathogenic',
+                review_status: 'no_assertion_criteria_provided',
+                rating_scale: 'clinvar_aggregate',
+                supporting: 1,
+                submissions: 1
+              }
+            ]
+          })
+        ]
+      }
+    });
+
+    for (const id of ['2673364', '2045211', '3773565']) {
+      expect(screen.getByRole('link', { name: id }).getAttribute('href')).toBe(
+        `https://www.ncbi.nlm.nih.gov/clinvar/variation/${id}/`
+      );
+    }
+
+    // ...and the separator is not left behind as text between them.
+    expect(screen.queryByText(/2673364&/)).toBeNull();
+  });
+
   test('ClinVar short: the variant-id row drops when there is no id', () => {
     renderOption('phenotypes', {
       consequence: {

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-annotation-detail/displaySpecRenderer.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-annotation-detail/displaySpecRenderer.tsx
@@ -316,6 +316,32 @@ const toRowSpec = (
     const href = row.link_from
       ? readField(row.link_from, spec, entities)
       : value;
+    // One value holding several, each its own link: a ClinVar custom joins the
+    // records that matched a variant with `&`, and one URL built from all of
+    // them points nowhere.
+    if (row.split && !isAbsent(value)) {
+      const template = row.link.template;
+      const parts = String(value).split(row.split).filter(Boolean);
+      return {
+        key: row.key ?? undefined,
+        label: rowLabel(row),
+        value,
+        valueNode: (
+          <span className={styles.splitLinks}>
+            {parts.map((part, index) => {
+              const url = interpolateUrl(template, { value: part });
+              return url ? (
+                <ExternalLink key={index} to={url}>
+                  {part}
+                </ExternalLink>
+              ) : (
+                <Fragment key={index}>{part}</Fragment>
+              );
+            })}
+          </span>
+        )
+      };
+    }
     const hrefString = interpolateUrl(row.link.template, {
       value: String(href)
     });


### PR DESCRIPTION
A ClinVar custom joins every record that matched a variant with `&`, so the variant-id row arrives as `2673364&2045211&3773565` and the single URL built from it points nowhere.

The `split` field already means this on a list item's cell; the row renderer had no equivalent. It now splits on the separator the spec names and links each part, falling back to plain text where a part makes no valid URL — the same shape `columnItem` uses.

Pairs with Ensembl/ensembl-web-tools-api#73, which adds `split` to the row model and sets it on the ClinVar variant ID row. Safe to merge in either order: without the backend change the field is simply never set.