### PR TITLE
Drop the Impact row from the RiboSeqORFs fixture

### DIFF
--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-annotation-detail/displaySpec.fixture.ts
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-annotation-detail/displaySpec.fixture.ts
@@ -400,11 +400,6 @@ export const displaySpecFixture: DisplaySpec = {
               label: 'Consequences',
               from: 'riboseq_orfs.consequences',
               format: 'join'
-            },
-            {
-              key: 'imp',
-              label: 'Impact',
-              from: 'riboseq_orfs.impact'
             }
           ]
         }


### PR DESCRIPTION
Keeps the display fixture in step with the served spec, where the RiboSeqORFs Impact row is removed as redundant with the Consequences row above it (Ensembl/ensembl-web-tools-api#75).

The fixture is a capture of the served document, so it goes stale otherwise. No renderer or test changes — nothing pinned that row.