### PR TITLE
Clear locally stored VEP data to avoid backwards incompatibility issues

### DIFF
--- a/src/services/indexeddb-migrations/vepStoreMigrations.test.ts
+++ b/src/services/indexeddb-migrations/vepStoreMigrations.test.ts
@@ -1,0 +1,78 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'fake-indexeddb/auto';
+import { openDB } from 'idb';
+import times from 'lodash/times';
+import { faker } from '@faker-js/faker';
+
+import { VEP_SUBMISSIONS_STORE_NAME } from 'src/content/app/tools/vep/services/vepStorageServiceConstants';
+
+import { migrateVepStore } from 'src/services/indexeddb-migrations/vepStoreMigrations';
+
+describe('v9 -> v10 migration', () => {
+  // During migration to version 10,
+  // all locally stored VEP submissions should be deleted
+  // due to backwards incompatibility of the new VEP release
+
+  const oldVersion = 9;
+  const newVersion = 10;
+
+  test('cleanin up VEP storage', async () => {
+    // Create a db using the old db version
+    const oldDb = await openDB('test-db', oldVersion, {
+      upgrade(db) {
+        db.createObjectStore(VEP_SUBMISSIONS_STORE_NAME);
+      }
+    });
+
+    // It doesn't really matter what we fill the db store with
+    // The point of the test is to verify that the store gets cleared
+
+    const mockSubmissionsCount = 3;
+    const mockVepSubmissions = times(mockSubmissionsCount, () => {
+      return {
+        id: faker.string.uuid(),
+        foo: faker.lorem.sentence()
+      };
+    });
+
+    // Save mock data into the database
+    for (const submission of mockVepSubmissions) {
+      await oldDb.put(VEP_SUBMISSIONS_STORE_NAME, submission, submission.id);
+    }
+
+    // confirm that the VEP store has some data
+    const storedVepData = await oldDb.getAll(VEP_SUBMISSIONS_STORE_NAME);
+    expect(storedVepData.length).toBe(mockSubmissionsCount);
+
+    oldDb.close();
+
+    // Now run the db migration
+    const newDb = await openDB('test-db', newVersion, {
+      upgrade(db, oldVersion, __, transaction) {
+        migrateVepStore({
+          oldVersion,
+          transaction
+        });
+      }
+    });
+
+    // Confirm that the store is now empty
+    const vepData = await newDb.getAll(VEP_SUBMISSIONS_STORE_NAME);
+    expect(vepData.length).toBe(0);
+  });
+});

--- a/src/services/indexeddb-migrations/vepStoreMigrations.ts
+++ b/src/services/indexeddb-migrations/vepStoreMigrations.ts
@@ -1,0 +1,43 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { VEP_SUBMISSIONS_STORE_NAME } from 'src/content/app/tools/vep/services/vepStorageServiceConstants';
+
+import type { IDBPTransaction } from 'idb';
+
+export const migrateVepStore = ({
+  oldVersion,
+  transaction
+}: {
+  oldVersion: number;
+  transaction: IDBPTransaction<unknown, string[], 'versionchange'>;
+}) => {
+  if (oldVersion <= 9) {
+    clearVepSubmissions({ transaction });
+  }
+};
+
+const clearVepSubmissions = async ({
+  transaction
+}: {
+  transaction: IDBPTransaction<unknown, string[], 'versionchange'>;
+}) => {
+  // use the 'versionchange' transaction to access VEP submissions store
+  const vepSubmissionsStore = transaction.objectStore(
+    VEP_SUBMISSIONS_STORE_NAME
+  );
+  await vepSubmissionsStore.clear();
+};

--- a/src/services/indexeddb-service.ts
+++ b/src/services/indexeddb-service.ts
@@ -32,7 +32,7 @@ import { migrateSpeciesStore } from './indexeddb-migrations/speciesStoreMigratio
 import { migrateVepStore } from './indexeddb-migrations/vepStoreMigrations';
 
 const DB_NAME = 'ensembl-website';
-const DB_VERSION = 9;
+const DB_VERSION = 10;
 
 const getDbPromise = (params?: {
   onBlocking?: OpenDBCallbacks<unknown>['blocking'];

--- a/src/services/indexeddb-service.ts
+++ b/src/services/indexeddb-service.ts
@@ -29,6 +29,7 @@ import { NOTIFICATIONS_STORE_NAME } from 'src/shared/services/notificationsStora
 import { IndexedDBUpdateScheduler } from './indexeddb-migrations/dbUpdateScheduler';
 
 import { migrateSpeciesStore } from './indexeddb-migrations/speciesStoreMigrations';
+import { migrateVepStore } from './indexeddb-migrations/vepStoreMigrations';
 
 const DB_NAME = 'ensembl-website';
 const DB_VERSION = 9;
@@ -65,6 +66,11 @@ const getDbPromise = (params?: {
       }
       if (!db.objectStoreNames.contains(VEP_SUBMISSIONS_STORE_NAME)) {
         db.createObjectStore(VEP_SUBMISSIONS_STORE_NAME);
+      } else {
+        migrateVepStore({
+          oldVersion,
+          transaction
+        });
       }
       if (!db.objectStoreNames.contains(PREVIOUSLY_VIEWED_OBJECTS_STORE_NAME)) {
         db.createObjectStore(PREVIOUSLY_VIEWED_OBJECTS_STORE_NAME);


### PR DESCRIPTION
## Description
As part of migration to the next version of VEP, clear the old VEP data that might be stored in indexedDB 

## Deployment URL(s)
not relevant (there would be nothing to test in a new deployment)
