### PR TITLE
Follow-up changes after VEP merge

### DIFF
--- a/src/content/app/tools/vep/types/vepFormConfig.ts
+++ b/src/content/app/tools/vep/types/vepFormConfig.ts
@@ -32,9 +32,7 @@ type SelectParameter = CommonParameterFields & {
 
 // --- Form panels (species-dependent) ---------------------------------------
 // The tools API's form_config endpoint returns a `panels` structure describing
-// which option panels/options to show for the selected species/assembly. Each
-// option `id` matches a submission parameter name, so selections round-trip
-// into the generated config.ini.
+// which option panels/options to show for the selected species/assembly.
 
 /** A sub-option revealed when its parent option is checked. */
 export type FormPanelSubOption =
@@ -59,36 +57,23 @@ export type FormPanelSubOption =
       min?: number;
       max?: number;
     }
-  // A labelled group of nested options (e.g. gnomAD exomes' genetic-ancestry
-  // groups, each with its own sex sub-options). Has no id of its own — it's a
-  // heading + nested `FormPanelOption`s that carry the parameters.
+  // A labelled group of nested options has no id of its own
   | {
       type: 'group';
       label?: string;
       options: FormPanelOption[];
     };
 
-/** A resource link shown inside an option's help tooltip. */
 export type OptionHelpLink = {
   href: string;
-  /** Visible link text; a generic label is used when omitted. */
   label?: string;
 };
 
-/**
- * Structured help text for a form option, shown in a tooltip via a
- * question-mark icon. Plain strings + link descriptors rather than JSX, because
- * form_config supplies it: it is authored in the annotation spec's `help`
- * section, alongside the label and panel that decide where the option appears.
- */
 export type OptionHelp = {
-  /** Description text. A `*span*` is rendered emphasised (a small markdown
-   *  subset, so the string stays serialisable). A `{version}` is replaced with
-   *  the version in the option's own label, so one description can serve an
-   *  option id that appears at different versions per assembly; it collapses
-   *  cleanly when the label carries no version. */
+  /** Description text may include asterisks to mark up fragments of text
+   * that have to be emphasised (i.e. *text* -> <em>text</em>)
+   */
   description: string;
-  /** Zero or more resource links rendered after the description. */
   links?: OptionHelpLink[];
 };
 
@@ -99,15 +84,10 @@ export type FormPanelOption = {
   default: boolean;
   category?: string; // Optional label used to group options within a panel.
   sub_options?: FormPanelSubOption[];
-  /** Help text for the option, from the spec. Optional: an option with none —
-   *  `updownstream_distance`, say — simply shows no tooltip. */
   help?: OptionHelp;
   /**
-   * The option cannot run with none of its sub-options selected. mutfunc does
-   * everything when told nothing, so a config line naming no sub-flag already
-   * means *all* of them — "none" is not a state the plugin can be asked for.
-   * Unticking the last sub-option therefore switches the option itself off, and
-   * switching it back on restores them all.
+   * The option cannot run with none of its sub-options selected.
+   * E.g. mutfunc
    */
   requires_any_sub_option?: boolean;
 };

--- a/src/content/app/tools/vep/types/vepResultsFilters.ts
+++ b/src/content/app/tools/vep/types/vepResultsFilters.ts
@@ -14,26 +14,6 @@
  * limitations under the License.
  */
 
-export type ResultsFilterField =
-  | 'consequence'
-  | 'transcript'
-  | 'gene_symbol'
-  | 'gene_id'
-  | 'transcript_group'
-  | 'allele_frequency'
-  | 'cadd_phred'
-  | 'cadd_raw'
-  | 'alphamissense'
-  | 'revel'
-  | 'clinpred'
-  | 'eve'
-  | 'popeve'
-  | 'spliceai_ag'
-  | 'spliceai_al'
-  | 'spliceai_dg'
-  | 'spliceai_dl'
-  | 'spliceai_any';
-
 // 'in' for set-membership fields; le/ge (<=, >=) for the numeric ones. There is
 // deliberately no '==': these are floats, so equality is a question the data can
 // rarely answer, and it was never the useful test for a frequency or a score.
@@ -45,7 +25,7 @@ export type ResultsFilterCondition = {
   // Stable client-side id, used to track which draft rows have been applied.
   // Not part of the wire format — stripped before serialising to the API.
   id: string;
-  field: ResultsFilterField;
+  field: string;
   operator: ResultsFilterOperator;
   values: string[];
   threshold?: number;
@@ -107,7 +87,7 @@ export type FilterOptionGroup = {
 };
 
 export type ScoreOption = {
-  value: ResultsFilterField;
+  value: string;
   label: string;
   /** Range hint for the threshold input; differs per score. */
   placeholder: string;
@@ -119,7 +99,7 @@ export type ScoreOptionGroup = {
 };
 
 export type FilterField = {
-  field: ResultsFilterField;
+  field: string;
   label: string;
   /** Text to show between the field and its value.
    * Absent where the editor chooses its own operator,

--- a/src/content/app/tools/vep/types/vepResultsFilters.ts
+++ b/src/content/app/tools/vep/types/vepResultsFilters.ts
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-// A results query-builder condition. Conditions are AND-combined server-side.
-// The shape matches the tools API's ResultsFilter (field/operator/values), so it
-// serialises straight into the `filters` query param.
-
 export type ResultsFilterField =
   | 'consequence'
   | 'transcript'
@@ -25,14 +21,6 @@ export type ResultsFilterField =
   | 'gene_id'
   | 'transcript_group'
   | 'allele_frequency'
-  // Every variant-impact prediction is its own field, even where several come
-  // from one tool, because each carries its own scale and a threshold means
-  // nothing without knowing which scale it is on. CADD PHRED is ~0-99 and
-  // scaled for interpretation while CADD RAW is unbounded around -7 to +35;
-  // the missense predictors are 0-1 probabilities except popEVE, which is a
-  // negative log-scale score; and SpliceAI's four delta scores describe four
-  // different events at the same position, so they cannot share one threshold
-  // either.
   | 'cadd_phred'
   | 'cadd_raw'
   | 'alphamissense'
@@ -60,19 +48,9 @@ export type ResultsFilterCondition = {
   field: ResultsFilterField;
   operator: ResultsFilterOperator;
   values: string[];
-  // Numeric fields only: the comparison threshold. Allele frequency also
-  // carries the any/all match mode across its columns; a score filter tests one
-  // column, so it has no equivalent.
   threshold?: number;
   match?: AlleleFrequencyMatch;
-  // Score filters only: whether entries with no score are kept. Defaults to
-  // dropping them, unlike the allele-frequency filter, which always keeps its
-  // unknowns. The paradigm differs: a missing allele frequency implies the
-  // variant is absent from the reference set and so very rare, which is usually
-  // what the query is after, whereas a missing impact score means the variant
-  // was never scored (out of that predictor's scope — a missense predictor has
-  // nothing to say about a synonymous variant) and so implies nothing about how
-  // damaging it is.
+  // Score filters only: whether entries with no score are kept.
   include_missing?: boolean;
 };
 
@@ -98,10 +76,9 @@ export const isResultsFilterActive = (
 };
 
 /**
- * Serialise conditions into the `filters` query param (a JSON array), keeping
- * only active conditions and dropping the client-only `id`. Allele-frequency
- * conditions also carry threshold/match. Returns undefined when nothing is
- * active, so the request omits the param and takes the fast unfiltered path.
+ * Serialise conditions into the `filters` query param,
+ * keeping only active conditions and dropping the client-only `id`.
+ * Allele-frequency conditions also carry threshold/match.
  */
 export const serializeResultsFilters = (
   conditions: ResultsFilterCondition[]
@@ -114,15 +91,6 @@ export const serializeResultsFilters = (
   return active.length > 0 ? JSON.stringify(active) : undefined;
 };
 
-/**
- * The filter catalogue the tools API serves on the results response: which
- * fields the query builder offers, and what each one's editor needs.
- *
- * Only the keys an editor reads are sent, so a text field has no score groups
- * and the allele-frequency field is three keys wide. Which of the offered
- * scores and AF sources this job actually carries is separate, and arrives as
- * `available_scores` / `available_af_sources`.
- */
 export type FilterOption = {
   value: string;
   label: string;
@@ -153,21 +121,21 @@ export type ScoreOptionGroup = {
 export type FilterField = {
   field: ResultsFilterField;
   label: string;
-  /** Read between the field and its value. Absent where the editor chooses its
-   *  own operator, as the allele-frequency and score editors do. */
+  /** Text to show between the field and its value.
+   * Absent where the editor chooses its own operator,
+   * as the allele-frequency and score editors do. */
   operator_label?: string;
   editor: 'consequence' | 'text' | 'group' | 'af' | 'score';
   initial_condition: InitialFilterCondition;
   operator_options?: FilterOption[];
-  /** Text editors. */
+  // used in the text editor
   placeholder?: string;
-  /** An editor that already takes many values is offered once, then withdrawn. */
   single_instance?: boolean;
-  /** Consequence editor. */
+  // used in the consequence editor
   option_groups?: FilterOptionGroup[];
-  /** Transcript-group editor. */
+  // used in the transcript-group editor
   options?: FilterOption[];
-  /** Score editor. */
+  // used in the score editor
   missing_label?: string;
   score_groups?: ScoreOptionGroup[];
 };

--- a/src/content/app/tools/vep/utils/annotations.ts
+++ b/src/content/app/tools/vep/utils/annotations.ts
@@ -25,9 +25,6 @@ export type AnnotatedEntity = {
 /**
  * Read the data of the given plugin's annotation
  * from the "annotated entity" (i.e. a variant allele, or a predicted transcript consequence object)
- *
- * The plugin id is a plain string, as it is on the wire and in the display spec.
- * A caller that knows the shape it wants asks for it: getAnnotation<Foo>(...)
  */
 export const getAnnotation = <Data = unknown>(
   entity: AnnotatedEntity | null | undefined,

--- a/src/content/app/tools/vep/utils/groupByCategory.ts
+++ b/src/content/app/tools/vep/utils/groupByCategory.ts
@@ -22,10 +22,7 @@ export type OptionGroup = {
 };
 
 /**
- * Cluster a panel's options by their `category`, preserving first-seen order.
- * Options without a category fall into a single unlabelled group. Shared by the
- * form's job-options panels and the results annotation detail so both render the
- * form_config panel -> category -> option hierarchy identically.
+ * Group a panel's options by their category
  */
 export const groupByCategory = (options: FormPanelOption[]): OptionGroup[] => {
   const groups: OptionGroup[] = [];

--- a/src/content/app/tools/vep/views/vep-form/vep-form-options-section/vep-form-options-panel/OptionHelpText.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-options-section/vep-form-options-panel/OptionHelpText.tsx
@@ -23,9 +23,7 @@ import type { OptionHelp } from 'src/content/app/tools/vep/types/vepFormConfig';
 
 const DEFAULT_LINK_LABEL = 'More information';
 
-// Render a description string, turning each `*span*` into emphasised text. This
-// restricted markdown subset lets the description stay a plain string
-// in the data layer while still supporting inline emphasis.
+// Render a description string, turning each `*span*` into emphasised text.
 const renderDescription = (description: string): ReactNode[] =>
   description
     .split(/(\*[^*]+\*)/g)

--- a/src/content/app/tools/vep/views/vep-form/vep-form-options-section/vep-form-options-panel/VepFormOptionsPanel.module.css
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-options-section/vep-form-options-panel/VepFormOptionsPanel.module.css
@@ -22,7 +22,6 @@
 
 .groupLabel {
   font-weight: var(--font-weight-bold);
-  color: var(--color-dark-grey);
 }
 
 .optionsGrid {

--- a/src/content/app/tools/vep/views/vep-form/vep-form-options-section/vep-form-options-panel/VepFormOptionsPanel.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-options-section/vep-form-options-panel/VepFormOptionsPanel.tsx
@@ -54,10 +54,9 @@ type Props = {
 };
 
 /**
- * An option carrying a nested group — the gnomAD / All of Us allele-frequency
- * sources, each with its own ancestry (or subset) matrix. These need more room
- * than a standard 200px option column, so a group of them is laid out in wider
- * columns (see `optionsGridSources`).
+ * An option carrying a nested group.
+ * Examples: gnomAD / All of Us allele-frequency sources,
+ * each with its own ancestry (or subset) matrix.
  */
 const isSourceOption = (option: FormPanelOption) =>
   !!option.sub_options?.some((subOption) => subOption.type === 'group');
@@ -94,9 +93,6 @@ const VepFormOptionsPanel = (props: Props) => {
     }
   }, [hasSelectedOption]);
 
-  // Open/close on the section toggle's command. Keyed on the nonce, not on
-  // `expanded`, so clicking the section toggle twice back to the same value
-  // still lands — and so a re-render never reopens a panel the user just closed.
   const lastExpandNonce = useRef(expandCommand?.nonce);
   useEffect(() => {
     if (expandCommand && expandCommand.nonce !== lastExpandNonce.current) {
@@ -117,9 +113,6 @@ const VepFormOptionsPanel = (props: Props) => {
   const toggleSelectAll = () =>
     dispatch(updateParameters(panelSelectionUpdates(panel, !allSelected)));
 
-  // renderSubOption and renderOption are mutually recursive (a 'group'
-  // sub-option renders nested options, which may themselves have sub-options).
-  // Declared as hoisted functions so the forward reference is clean.
   /**
    * Whether a sub-option shows while a source is uncustomised. Only selections
    * are hidden: a setting like the SV overlap cutoff is part of the suggested
@@ -139,9 +132,9 @@ const VepFormOptionsPanel = (props: Props) => {
     return boolValue(option.id, option.default);
   }
 
-  // `owner` is the top-level option a boolean sub-option belongs to, passed
-  // only from the direct-children call site: it is what lets unticking the last
-  // sub-option switch the option itself off (see subOptionToggleUpdates).
+  // renderSubOption and renderOption are mutually recursive (a 'group'
+  // sub-option renders nested options, which may themselves have sub-options).
+
   function renderSubOption(
     subOption: FormPanelSubOption,
     showAll = true,

--- a/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.tsx
+++ b/src/content/app/tools/vep/views/vep-form/vep-form-variants-section/VepFormVariantsSection.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState, useEffect, type FormEvent, type ReactNode } from 'react';
+import { useState, type ChangeEvent, type ReactNode } from 'react';
 import classNames from 'classnames';
 
 import { useAppDispatch, useAppSelector } from 'src/store';
@@ -32,7 +32,6 @@ import {
   updateInputCommittedFlag
 } from 'src/content/app/tools/vep/state/vep-form/vepFormSlice';
 import { useVepFormExampleInputQuery } from 'src/content/app/tools/vep/state/vep-api/vepApiSlice';
-// input check (remove this import + the block in onCommitInput + error UI to disable)
 import { checkVepInput } from './checkVepInput';
 
 import FormSection from 'src/content/app/tools/vep/components/form-section/FormSection';
@@ -64,14 +63,20 @@ const VepFormVariantsSection = () => {
     }
   );
 
-  useEffect(() => {
+  const [prevIsGenomeSelected, setPrevIsGenomeSelected] = useState(
+    Boolean(selectedSpecies)
+  );
+
+  if (
+    (selectedSpecies && !prevIsGenomeSelected) ||
+    (!selectedSpecies && prevIsGenomeSelected)
+  ) {
     // Automatically expand this section once a species has been selected, so the
     // user can go straight to entering variants. If the species is cleared
     // (e.g. the form is reset), collapse the section again.
-    setIsExpanded(!!selectedSpecies);
-  }, [selectedSpecies]);
-
-  // TODO: create a useEffect for component unmount, which will update stored VEP form
+    setPrevIsGenomeSelected(Boolean(selectedSpecies));
+    setIsExpanded(Boolean(selectedSpecies));
+  }
 
   const toggleExpanded = () => {
     setIsExpanded(!isExpanded);
@@ -177,7 +182,7 @@ const ExpandedContents = ({
   const [inputError, setInputError] = useState<string | null>(null);
   const dispatch = useAppDispatch();
 
-  const onTextareaContentChange = (event: FormEvent<HTMLTextAreaElement>) => {
+  const onTextareaContentChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
     setInputError(null); // input check: clear error while editing
     setInputString(event.currentTarget.value);
   };

--- a/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.module.css
+++ b/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.module.css
@@ -170,13 +170,6 @@
   font-size: 11px;
 }
 
-
-/* The annotation panel spans the full width between the row division lines.
-   The shared Table's own `td` rule outranks a plain class selector here (its
-   selector carries an element as well), so a bare `padding: 0` on this class
-   silently did nothing — the horizontal inset has to come off through the
-   variables that component exposes for the purpose. Vertical padding stays:
-   it separates the panel from the rows above and below. */
 .detailCell {
   --table-cell-padding-left: 0;
   --table-cell-padding-right: 0;

--- a/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.test.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.test.tsx
@@ -22,8 +22,6 @@ import {
 import type { VepResultsTableRowData } from './useVepVariantTabularData';
 import type { FormPanel } from 'src/content/app/tools/vep/types/vepFormConfig';
 
-// planLeadingCells only reads the variant/allele/gene "markers"; the consequence
-// is irrelevant to it, so build minimal rows carrying just those markers.
 const makeRow = (
   markers: Partial<
     Pick<VepResultsTableRowData, 'variant' | 'alternativeAllele' | 'gene'>
@@ -89,9 +87,7 @@ describe('planLeadingCells', () => {
     expect(collapsed[0].allele?.rowSpan).toBe(1);
     expect(collapsed[0].gene?.rowSpan).toBe(1);
 
-    // The panel spans the full row, so nothing can sit beside it: expanding
-    // leaves every leading cell covering its own row only, rather than
-    // stretching over the injected one.
+    // The panel spans the full row, so nothing can sit beside it
     const expanded = planLeadingCells(rows, new Set([0]));
     expect(expanded[0].variant?.rowSpan).toBe(1);
     expect(expanded[0].allele?.rowSpan).toBe(1);
@@ -113,10 +109,10 @@ describe('planLeadingCells', () => {
     expect(plan[1].gene?.data.stableId).toBe('geneB');
   });
 
-  it('restarts the identity cells below a panel that interrupts their group', () => {
-    // Expanding gene-1 injects the panel between the two gene rows. Every
-    // leading cell stops above it and is re-emitted on the gene-2 row — the
-    // variant is stated twice, which is the price of the full-width panel.
+  it('restarts shared cells below an expanded row', () => {
+    // The the row that has gene-1 expands the annotation panel,
+    // and thus the panel is injected between the row with gene-1 and the row with gene-2.
+    // The variant is repeated twice.
     const plan = planLeadingCells(twoGeneRows(), new Set([0]));
 
     expect(plan[0].variant?.rowSpan).toBe(1);
@@ -130,9 +126,9 @@ describe('planLeadingCells', () => {
     expect(plan[1].gene?.data.stableId).toBe('geneB');
   });
 
-  it('keeps one identity cell when the panel opens on the group’s last row', () => {
-    // Nothing is interrupted: the panel lands after the group, so the identity
-    // still spans both rows and is emitted once.
+  it('keeps shared cells spanning the group when the detail panel opens on the last row', () => {
+    // Neither variant, gene, or transcript is interrupted
+    // by the expanded details panel.
     const plan = planLeadingCells(twoGeneRows(), new Set([1]));
 
     expect(plan[0].variant?.rowSpan).toBe(2);
@@ -142,7 +138,7 @@ describe('planLeadingCells', () => {
     expect(plan[1].gene?.rowSpan).toBe(1);
   });
 
-  it('splits every leading cell around a panel on a middle transcript', () => {
+  it('splits shared cells around a detail panel in the middle of a group', () => {
     // Three transcripts of one gene; expand the middle one.
     const plan = planLeadingCells(singleGeneRows(3), new Set([1]));
 
@@ -161,10 +157,11 @@ describe('planLeadingCells', () => {
     expect(plan[2].gene?.rowSpan).toBe(1);
   });
 
-  it('splits at each of several open panels', () => {
+  it('splits shared cells when multiple panels are open', () => {
+    // The details panel is opened after the first and the second row
     const plan = planLeadingCells(singleGeneRows(3), new Set([0, 1]));
 
-    // A panel after each of the first two rows leaves every run one row long.
+    // Confirm that features in every row aren't trying to span across more than one row.
     for (const index of [0, 1, 2]) {
       expect(plan[index].variant?.rowSpan).toBe(1);
       expect(plan[index].allele?.rowSpan).toBe(1);
@@ -182,8 +179,8 @@ const transcriptRow = (altAlleleSequence: string): VepResultsTableRowData => ({
   } as VepResultsTableRowData['consequence']
 });
 
-// An intergenic row: its alt allele lives on the row's alternativeAllele marker
-// (present only on the allele's first intergenic row, as getTabularData emits).
+// An intergenic row: its alt allele lives on the row's alternativeAllele field
+// (unlike transcript rows, this row does not carry altAlleleSequence inside consequence)
 const intergenicRow = (altAlleleSequence?: string): VepResultsTableRowData => ({
   ...makeRow(
     altAlleleSequence
@@ -204,20 +201,18 @@ describe('detailBearingRowIndices', () => {
     expect(indices).toEqual([0, 1]);
   });
 
-  it('includes an intergenic row via its own alt-allele marker', () => {
+  it('includes an intergenic row by checking its alternativeAllele field', () => {
     const rows = [intergenicRow('T')];
     expect(detailBearingRowIndices(rows, () => true)).toEqual([0]);
   });
 
-  it('skips a row whose allele is not among those carrying annotations', () => {
+  it('skips transcript rows whose alt allele has no annotations', () => {
     const rows = [transcriptRow('T'), transcriptRow('X')];
     const indices = detailBearingRowIndices(rows, (seq) => seq === 'T');
     expect(indices).toEqual([0]);
   });
 
-  it('skips an intergenic row with no alt-allele marker (a later same-allele row)', () => {
-    // getTabularData sets the alt-allele marker only on the first intergenic row
-    // of an allele; a follow-on row has none and offers no detail toggle.
+  it('skips an intergenic row with no data in alternativeAllele field', () => {
     const rows = [intergenicRow('T'), intergenicRow()];
     expect(detailBearingRowIndices(rows, () => true)).toEqual([0]);
   });
@@ -241,8 +236,6 @@ describe('hasAnySelectedOption', () => {
   ] as unknown as FormPanel[];
 
   it('is false when the job ran no annotation option', () => {
-    // A submission with nothing ticked: every detail section is gated on an
-    // option, so the panel would open empty -- no chevron is offered.
     expect(hasAnySelectedOption(panels, {})).toBe(false);
     expect(
       hasAnySelectedOption(panels, { tss_distance: false, cadd: false })
@@ -255,9 +248,6 @@ describe('hasAnySelectedOption', () => {
   });
 
   it('ignores parameters that are not options of a panel', () => {
-    // `parameters` also carries settings that produce no annotation -- the
-    // up/downstream distance value, and the sub-option values of an option that
-    // is itself off. Neither should make the panel look worth opening.
     expect(
       hasAnySelectedOption(panels, {
         updownstream_distance_bp: 5000,
@@ -265,11 +255,5 @@ describe('hasAnySelectedOption', () => {
         species: 'homo_sapiens'
       })
     ).toBe(false);
-  });
-
-  it('keeps the chevron for a job with no pinned panels', () => {
-    // Submitted before panels were pinned: the options it ran cannot be
-    // enumerated, so it behaves as it always did rather than losing its detail.
-    expect(hasAnySelectedOption(undefined, {})).toBe(true);
   });
 });

--- a/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.tsx
@@ -82,8 +82,7 @@ import type { FormPanel } from 'src/content/app/tools/vep/types/vepFormConfig';
 import type { DisplaySpec } from 'src/content/app/tools/vep/types/vepDisplaySpec';
 import {
   serializeResultsFilters,
-  type ResultsFilterCondition,
-  type ResultsFilterField
+  type ResultsFilterCondition
 } from 'src/content/app/tools/vep/types/vepResultsFilters';
 
 import styles from './VepSubmissionResults.module.css';
@@ -240,8 +239,7 @@ const VepSubmissionResults = () => {
       label: formatAfSourceLabel(source)
     })
   );
-  const scoreFields = (vepResults?.metadata.available_scores ??
-    []) as ResultsFilterField[];
+  const scoreFields = vepResults?.metadata.available_scores ?? [];
   // Which fields the query builder offers, and how each is presented. Absent on
   // a job pinned before the catalogue existed, which then offers no filters.
   const filterFields = vepResults?.metadata.filter_fields ?? [];

--- a/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/VepSubmissionResults.tsx
@@ -510,6 +510,8 @@ export const hasAnySelectedOption = (
     panel.options.some((option) => Boolean(parameters[option.id]))
   );
 
+// Finds indices of rows that have content that can go into the expandable
+// detailed annotations panel
 export const detailBearingRowIndices = (
   rows: VepResultsTableRowData[],
   hasAllele: (sequence: string) => boolean

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-allele/VepResultsAllele.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-allele/VepResultsAllele.tsx
@@ -16,8 +16,6 @@
 
 import { useState } from 'react';
 
-import useRefWithRerender from 'src/shared/hooks/useRefWithRerender';
-
 import TextButton from 'src/shared/components/text-button/TextButton';
 import { Toolbox, ToolboxPosition } from 'src/shared/components/toolbox';
 import Copy from 'src/shared/components/copy/Copy';
@@ -39,7 +37,7 @@ const MAX_DISPLAY_LENGTH = 5;
 const isStructuralAllele = (sequence: string) => sequence.startsWith('<');
 
 const AlleleSequence = ({ sequence, structuralVariantDetail }: Props) => {
-  const [anchorRef, setAnchorRef] = useRefWithRerender<HTMLElement>(null);
+  const [anchorElement, setAnchorElement] = useState<HTMLElement | null>(null);
   const [shouldShowTooltip, setShouldShowTooltip] = useState(false);
 
   if (isStructuralAllele(sequence)) {
@@ -61,6 +59,11 @@ const AlleleSequence = ({ sequence, structuralVariantDetail }: Props) => {
     setShouldShowTooltip(!shouldShowTooltip);
   };
 
+  const setAnchorRef = (element: HTMLElement) => {
+    setAnchorElement(element);
+    return () => setAnchorElement(null);
+  };
+
   const onOutsideClick = () => {
     setShouldShowTooltip(false);
   };
@@ -79,10 +82,10 @@ const AlleleSequence = ({ sequence, structuralVariantDetail }: Props) => {
       </span>
 
       <div className={styles.sequenceLength}>{sequence.length}</div>
-      {anchorRef.current && shouldShowTooltip && (
+      {anchorElement && shouldShowTooltip && (
         <Toolbox
           onOutsideClick={onOutsideClick}
-          anchor={anchorRef.current}
+          anchor={anchorElement}
           position={ToolboxPosition.RIGHT}
         >
           <div className={styles.toolboxContents}>

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-annotation-detail/VepResultsAnnotationDetail.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-annotation-detail/VepResultsAnnotationDetail.tsx
@@ -37,11 +37,6 @@ import { groupByCategory } from 'src/content/app/tools/vep/utils/groupByCategory
 import { subOptionRan as didSubOptionRun } from 'src/content/app/tools/vep/utils/subOptionRan';
 import styles from './VepResultsAnnotationDetail.module.css';
 
-/**
- * Question: why does this component have allele frequency, protvar url,
- * and opentargets variant id as distinct properties?
- */
-
 const VepResultsAnnotationDetail = (props: {
   genomeId: string;
   consequence: PredictedMolecularConsequence;

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-annotation-detail/annotationRows.test.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-annotation-detail/annotationRows.test.tsx
@@ -122,9 +122,6 @@ describe('renderRows', () => {
     expect(screen.getByText('0.6')).toBeDefined();
   });
 
-  // A plain result is bolded so the answer, not the label naming it, is what
-  // the eye lands on. Which values qualify is decided here rather than at each
-  // call site, so these are the tests of that rule.
   describe('bolding the result', () => {
     it('bolds a plain formatted value', () => {
       renderSpecs([

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/AlleleFrequencyInput.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/AlleleFrequencyInput.tsx
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { useState, useRef } from 'react';
-import type { FormEvent } from 'react';
+import { useState, useRef, type InputEvent } from 'react';
 import classNames from 'classnames';
 
 import SimpleSelect from 'src/shared/components/simple-select/SimpleSelect';
@@ -68,9 +67,6 @@ const AlleleFrequencyInput = (props: Props) => {
   const sourcesRef = useRef<HTMLDivElement>(null);
   useOutsideClick(sourcesRef, () => setIsSourcesOpen(false));
 
-  // Scope is explicit local state: "specific" with no picks yet can't be derived
-  // from the condition (values would be empty, reading as "any"), so tracking it
-  // separately keeps the specific selector visible while the user chooses.
   const [scope, setScope] = useState<Scope>(
     values.length > 0 ? 'specific' : match === 'all' ? 'all' : 'any'
   );
@@ -82,7 +78,6 @@ const AlleleFrequencyInput = (props: Props) => {
     } else if (next === 'all') {
       onChange({ match: 'all', values: [] });
     } else {
-      // Specific: match across the chosen subset is "any"; keep any picks made.
       onChange({ match: 'any' });
     }
   };
@@ -99,7 +94,7 @@ const AlleleFrequencyInput = (props: Props) => {
     });
   };
 
-  const onThresholdInput = (event: FormEvent<HTMLInputElement>) => {
+  const onThresholdInput = (event: InputEvent<HTMLInputElement>) => {
     const text = event.currentTarget.value;
     setThresholdText(text);
     const parsed = Number.parseFloat(text);

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/ConsequenceMultiSelect.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/ConsequenceMultiSelect.tsx
@@ -31,18 +31,8 @@ type Props = {
   optionGroups: FilterOptionGroup[];
 };
 
-/**
- * The value editor for a consequence condition: a button summarising the current
- * selection that opens a scrollable panel of grouped consequence checkboxes.
- *
- * Uses a self-managed dropdown rather than the shared PointerBox: PointerBox
- * closes itself on any scroll (to reposition against its anchor), which makes an
- * inner scrollable list impossible to scroll.
- */
 const ConsequenceMultiSelect = (props: Props) => {
   const { values, onChange, optionGroups } = props;
-  // All terms in catalogue order, so a selection is reported in a stable order
-  // regardless of the order the user ticked them.
   const allTerms = optionGroups.flatMap((group) => group.options);
   const [isOpen, setIsOpen] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/ScoreInput.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/ScoreInput.tsx
@@ -23,7 +23,6 @@ import CheckboxWithLabel from 'src/shared/components/checkbox-with-label/Checkbo
 import type {
   FilterOption,
   ResultsFilterCondition,
-  ResultsFilterField,
   ResultsFilterOperator,
   ScoreOptionGroup
 } from 'src/content/app/tools/vep/types/vepResultsFilters';
@@ -34,7 +33,7 @@ type Props = {
   // Which score this row tests, and the ones still free to choose, grouped by
   // category (genome wide / missense / splicing). A score taken by another row
   // is not offered again — one threshold per score.
-  field: ResultsFilterField;
+  field: string;
   scoreOptionGroups: ScoreOptionGroup[];
   operatorOptions: FilterOption[];
   operator: ResultsFilterOperator;
@@ -112,7 +111,7 @@ const ScoreInput = (props: Props) => {
           value={field}
           onInput={(event) =>
             onChange({
-              field: event.currentTarget.value as ResultsFilterField
+              field: event.currentTarget.value
             })
           }
         />

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/VepResultsFilters.module.css
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/VepResultsFilters.module.css
@@ -42,11 +42,6 @@
   font-size: 13px;
 }
 
-/* The value editor trigger button (opens the consequence / AF-source popover).
-   Styled to read as the same control as the field dropdown beside it, which is
-   the shared SimpleSelect: same blue border, square corners, same padding, and
-   the same arrowhead below. It cannot simply *be* a SimpleSelect — that wraps a
-   native <select>, and this opens a panel of checkboxes. */
 .valueTrigger {
   display: inline-flex;
   align-items: center;
@@ -55,11 +50,7 @@
   justify-content: space-between;
   position: relative;
 
-  /* Right padding matches SimpleSelect's, to clear the arrowhead. The vertical
-     padding stays at 6px rather than its 3px: a native select is taller than a
-     button at the same padding (28px against 21px measured here), so copying
-     that number exactly would leave the two controls visibly different heights
-     side by side. 6px brings the button to 27px, which is what it was before. */
+  /* Right padding matches SimpleSelect's, to clear the arrowhead */
   padding: 6px 25px 6px 10px;
   background-color: var(--color-white);
   border: 1px solid var(--color-blue);
@@ -67,11 +58,7 @@
   font-size: 13px;
 }
 
-/* SimpleSelect's arrowhead. Geometry and colour are copied from
-   `simple-select/SimpleSelect.module.css`, which stays the source of truth — a
-   CSS-module class is scoped to its own file, and that one is bound to the
-   native-select markup, so it can't be shared directly. If the arrow changes
-   there, change it here too. */
+/* The arrowhead. Geometry and colour are copied from SimpleSelect */
 .valueTrigger::after {
   content: '';
   position: absolute;
@@ -84,8 +71,6 @@
   clip-path: polygon(100% 0%, 0 0%, 50% 100%);
 }
 
-/* The one thing a native select can't do, kept: the same arrowhead turned over
-   while the panel is open, so the control still shows its state. */
 .valueTriggerOpen::after {
   transform: translateY(-25%) rotate(180deg);
 }
@@ -144,10 +129,6 @@
   min-width: 56px;
 }
 
-/* Sized in `ch` (the advance of one digit in the monospace face) plus the
-   horizontal padding and borders, since box-sizing is border-box. 9 characters
-   fits the longest placeholder, "e.g. 0.5", with room for a typed value like
-   "-5.4712"; a fixed 80px cut the last character off the decimal placeholders. */
 .afThreshold {
   width: calc(9ch + 22px);
   padding: 6px 10px;
@@ -164,8 +145,6 @@
   flex: none;
 }
 
-/* Self-managed consequence dropdown (see ConsequenceMultiSelect for why it
-   doesn't use the shared PointerBox). */
 .multiSelect {
   position: relative;
 }
@@ -181,7 +160,6 @@
   box-shadow: 0 2px 6px var(--shadow-color, rgb(0 0 0 / 0.25));
 }
 
-/* A consequence option: colour swatch + term, matching the results table. */
 .optionLabel {
   display: inline-flex;
   align-items: center;

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/VepResultsFilters.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/VepResultsFilters.tsx
@@ -54,21 +54,18 @@ type Props = {
   onClear: () => void;
   isDirty: boolean;
   hasAppliedFilters: boolean;
-  // Filtered / total record counts from the last applied request, if any.
   resultSummary: { filtered: number; total: number } | null;
   // The fields this job can be filtered on, and how each is presented, from the
-  // results response. Which transcript groups it offers is decided there, from
-  // the columns the output has.
+  // results response.
   filterFields: FilterField[];
   // Allele-frequency sources chosen at input; the AF filter is only offered when
   // this is non-empty.
   afSources: AfSourceOption[];
   // Impact-prediction scores chosen at input ('cadd_phred', 'revel',
-  // 'spliceai_dl', …); a score is only offered in the row's menu when it is
+  // 'spliceai_dl', etc.); a score is only offered in the row's menu when it is
   // among them.
   scoreFields: ResultsFilterField[];
-  // Ids of conditions already applied; their field (query type) select is frozen
-  // so the applied filter type can't change — only its values stay editable.
+  // Ids of conditions already applied
   appliedConditionIds: Set<string>;
 };
 

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/VepResultsFilters.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/VepResultsFilters.tsx
@@ -38,10 +38,9 @@ import {
   nextAvailableField
 } from './resultsFilterFields';
 
-import type { FilterField } from 'src/content/app/tools/vep/types/vepResultsFilters';
 import type {
-  ResultsFilterCondition,
-  ResultsFilterField
+  FilterField,
+  ResultsFilterCondition
 } from 'src/content/app/tools/vep/types/vepResultsFilters';
 
 import styles from './VepResultsFilters.module.css';
@@ -64,17 +63,15 @@ type Props = {
   // Impact-prediction scores chosen at input ('cadd_phred', 'revel',
   // 'spliceai_dl', etc.); a score is only offered in the row's menu when it is
   // among them.
-  scoreFields: ResultsFilterField[];
+  scoreFields: string[];
   // Ids of conditions already applied
   appliedConditionIds: Set<string>;
 };
 
 // Every score resolves to the one "Variant impact predictions" entry; which
 // score a row tests lives in the row, not in the field dropdown.
-const fieldDefinition = (
-  field: ResultsFilterField,
-  fields: FilterField[]
-): FilterField => definitionForField(field, fields) ?? fields[0];
+const fieldDefinition = (field: string, fields: FilterField[]): FilterField =>
+  definitionForField(field, fields) ?? fields[0];
 
 /**
  * The results filter query builder: rows of (field, operator, values) conditions
@@ -109,7 +106,7 @@ const VepResultsFilters = (props: Props) => {
 
   // Replace a whole condition (used on field change, so field-specific defaults
   // apply cleanly and stale fields from the previous field don't linger).
-  const changeField = (index: number, field: ResultsFilterField) => {
+  const changeField = (index: number, field: string) => {
     // "Variant impact predictions" is one entry standing for several scores,
     // and its declared field is only the first of them. Landing on it would put
     // two rows on the same score, so take the first one still free.
@@ -203,10 +200,7 @@ const VepResultsFilters = (props: Props) => {
                 disabled={isFieldLocked}
                 onChange={() => undefined}
                 onInput={(event) =>
-                  changeField(
-                    index,
-                    event.currentTarget.value as ResultsFilterField
-                  )
+                  changeField(index, event.currentTarget.value)
                 }
               />
               {definition.operator_label && (

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/VepResultsFilters.tsx
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/VepResultsFilters.tsx
@@ -104,12 +104,7 @@ const VepResultsFilters = (props: Props) => {
     );
   };
 
-  // Replace a whole condition (used on field change, so field-specific defaults
-  // apply cleanly and stale fields from the previous field don't linger).
   const changeField = (index: number, field: string) => {
-    // "Variant impact predictions" is one entry standing for several scores,
-    // and its declared field is only the first of them. Landing on it would put
-    // two rows on the same score, so take the first one still free.
     const resolved = isScoreField(field, filterFields)
       ? (flattenScoreOptions(
           availableScoresForRow(conditions, index, scoreFields, filterFields)
@@ -164,17 +159,10 @@ const VepResultsFilters = (props: Props) => {
                 className={styles.fieldSelect}
                 options={availableFieldsForRow(conditions, index, filterFields)
                   .filter((field) => {
-                    // A filter is only offered when the job carries the data it
-                    // tests: AF sources and impact-prediction scores are both
-                    // gated on what was actually selected at input.
                     if (field.field === 'allele_frequency') {
                       return afSources.length > 0;
                     }
                     if (field.editor === 'score') {
-                      // The group is offered while any of its scores, in any
-                      // category, is still free for this row. Empty categories
-                      // are already dropped, so a non-empty list of groups
-                      // means a genuinely available score.
                       return (
                         availableScoresForRow(
                           conditions,
@@ -190,8 +178,6 @@ const VepResultsFilters = (props: Props) => {
                     label: field.label,
                     value: field.field
                   }))}
-                // A score row's value is its score, which is not a field option
-                // — point the select at the group entry instead.
                 value={
                   isScoreField(condition.field, filterFields)
                     ? definition.field

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/resultsFilterFields.test.ts
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/resultsFilterFields.test.ts
@@ -25,7 +25,6 @@ import {
 import {
   type FilterField,
   type ResultsFilterCondition,
-  type ResultsFilterField,
   type ScoreOptionGroup
 } from 'src/content/app/tools/vep/types/vepResultsFilters';
 
@@ -109,7 +108,7 @@ const CATALOGUE: FilterField[] = [
   }
 ];
 
-const condition = (field: ResultsFilterField): ResultsFilterCondition =>
+const condition = (field: string): ResultsFilterCondition =>
   createCondition(field, CATALOGUE);
 
 // The scores the catalogue offers, which is what "a score field" now means.

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/resultsFilterFields.ts
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/resultsFilterFields.ts
@@ -17,7 +17,6 @@
 import type {
   FilterField,
   ResultsFilterCondition,
-  ResultsFilterField,
   ScoreOption,
   ScoreOptionGroup
 } from 'src/content/app/tools/vep/types/vepResultsFilters';
@@ -37,14 +36,12 @@ const scoreOptions = (fields: FilterField[]): ScoreOption[] =>
     (field) => field.score_groups?.flatMap((group) => group.options) ?? []
   );
 
-export const isScoreField = (
-  field: ResultsFilterField,
-  fields: FilterField[]
-): boolean => scoreOptions(fields).some((option) => option.value === field);
+export const isScoreField = (field: string, fields: FilterField[]): boolean =>
+  scoreOptions(fields).some((option) => option.value === field);
 
 /** The range hint for a score, for the row's threshold input. */
 export const scoreFieldOption = (
-  field: ResultsFilterField,
+  field: string,
   fields: FilterField[]
 ): ScoreOption | undefined =>
   scoreOptions(fields).find((option) => option.value === field);
@@ -53,7 +50,7 @@ export const scoreFieldOption = (
 // track which rows have been applied) and API-provided initial wire values.
 let conditionCounter = 0;
 export const createCondition = (
-  field: ResultsFilterField,
+  field: string,
   fields: FilterField[]
 ): ResultsFilterCondition => {
   const definition = definitionForField(field, fields);
@@ -72,7 +69,7 @@ export const createCondition = (
 const usedSingleInstanceFields = (
   conditions: ResultsFilterCondition[],
   fields: FilterField[]
-): Set<ResultsFilterField> => {
+): Set<string> => {
   const singleInstance = new Set(
     fields.filter((f) => f.single_instance).map((f) => f.field)
   );
@@ -87,7 +84,7 @@ const usedSingleInstanceFields = (
  * rather than in the field dropdown.
  */
 export const definitionForField = (
-  field: ResultsFilterField,
+  field: string,
   fields: FilterField[]
 ): FilterField | undefined =>
   isScoreField(field, fields)
@@ -101,7 +98,7 @@ export const definitionForField = (
 export const availableScoresForRow = (
   conditions: ResultsFilterCondition[],
   rowIndex: number,
-  offered: ResultsFilterField[],
+  offered: string[],
   fields: FilterField[]
 ): ScoreOptionGroup[] => {
   const takenElsewhere = new Set(
@@ -149,7 +146,7 @@ export const availableFieldsForRow = (
 export const nextAvailableField = (
   conditions: ResultsFilterCondition[],
   fields: FilterField[]
-): ResultsFilterField => {
+): string => {
   const used = usedSingleInstanceFields(conditions, fields);
   const field = fields.find((f) => !used.has(f.field));
   return (field ?? fields[0]).field;

--- a/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/resultsFilterFields.ts
+++ b/src/content/app/tools/vep/views/vep-submission-results/components/vep-results-filters/resultsFilterFields.ts
@@ -21,16 +21,6 @@ import type {
   ScoreOptionGroup
 } from 'src/content/app/tools/vep/types/vepResultsFilters';
 
-/**
- * Row-level bookkeeping for the query builder: which field a row may take, and
- * what a new row should default to. Everything a field *is* — its label, editor
- * and options — comes from the catalogue the API serves, and is passed in.
- *
- * The distinction is that this is interface state. What the user has already
- * chosen in another row is not something the backend knows or should.
- */
-
-// Which of the offered scores exist at all, from the catalogue's score editor.
 const scoreOptions = (fields: FilterField[]): ScoreOption[] =>
   fields.flatMap(
     (field) => field.score_groups?.flatMap((group) => group.options) ?? []
@@ -39,15 +29,14 @@ const scoreOptions = (fields: FilterField[]): ScoreOption[] =>
 export const isScoreField = (field: string, fields: FilterField[]): boolean =>
   scoreOptions(fields).some((option) => option.value === field);
 
-/** The range hint for a score, for the row's threshold input. */
 export const scoreFieldOption = (
   field: string,
   fields: FilterField[]
 ): ScoreOption | undefined =>
   scoreOptions(fields).find((option) => option.value === field);
 
-// A fresh condition on the given field, with a unique client-side id (used to
-// track which rows have been applied) and API-provided initial wire values.
+// A fresh condition on the given field, with a unique client-side id
+// (used to track which rows have been applied)
 let conditionCounter = 0;
 export const createCondition = (
   field: string,
@@ -65,7 +54,6 @@ export const createCondition = (
   };
 };
 
-// The single-instance fields already present in a set of conditions.
 const usedSingleInstanceFields = (
   conditions: ResultsFilterCondition[],
   fields: FilterField[]
@@ -78,11 +66,6 @@ const usedSingleInstanceFields = (
   );
 };
 
-/**
- * The definition to render a condition with. Every score resolves to the one
- * "Variant impact predictions" entry, since which score it is lives in the row
- * rather than in the field dropdown.
- */
 export const definitionForField = (
   field: string,
   fields: FilterField[]
@@ -120,8 +103,6 @@ export const availableScoresForRow = (
     .filter((group) => group.options.length > 0);
 };
 
-// The flat list of scores behind a grouped menu, for the places that only care
-// which scores are on offer rather than how they are presented.
 export const flattenScoreOptions = (
   groups: ScoreOptionGroup[]
 ): ScoreOption[] => groups.flatMap((group) => group.options);


### PR DESCRIPTION
## Description
- Continue removing or updating Claude comments (remove when they don't contribute anything to the code; update when they are too grandiloquent.
- Replace the specific enumeration of filter id strings with a single `string` type.
- Update colour of category headings in VEP options section of the submission form (dark grey -> black)

### TODO
- Move `vepResultsFilters` file out of the `types` directory
- Check for all remaining FIXME comments
- Check whether anything in the payload still has a `mono` field to signal the use of monospace font

## Related JIRA Issue(s)
- https://embl.atlassian.net/browse/ENSWBSITES-3033
- https://embl.atlassian.net/browse/ENSWBSITES-3032

## Deployment URL(s)
http://vep-follow-up.review.ensembl.org