### PR TITLE
Fix type imports

### DIFF
--- a/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/default-transcripts-list/transcripts-list-item-info/TranscriptsListItemInfo.tsx
@@ -38,7 +38,6 @@ import { InstantDownloadTranscript } from 'src/shared/components/instant-downloa
 import ViewInApp from 'src/shared/components/view-in-app/ViewInApp';
 import ShowHide from 'src/shared/components/show-hide/ShowHide';
 import ExternalReference from 'src/shared/components/external-reference/ExternalReference';
-import { TrackTranscriptDownloadPayload } from 'src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript';
 
 import {
   toggleTranscriptDownload,
@@ -46,6 +45,7 @@ import {
 } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 
 import { View } from 'src/content/app/entity-viewer/state/gene-view/view/geneViewViewSlice';
+import type { TrackTranscriptDownloadPayload } from 'src/shared/components/instant-download/instant-download-transcript/InstantDownloadTranscript';
 import type {
   DefaultEntityViewerGene,
   DefaultEntityViewerTranscript

--- a/src/content/app/entity-viewer/gene-view/components/gene-overview-image/GeneOverviewImage.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-overview-image/GeneOverviewImage.tsx
@@ -31,8 +31,8 @@ import {
 } from 'src/content/app/entity-viewer/gene-view/constants/geneViewConstants';
 
 import UnsplicedTranscript, {
-  UnsplicedTranscriptProps,
-  UNSPLICED_TRANSCRIPT_HEIGHT
+  UNSPLICED_TRANSCRIPT_HEIGHT,
+  type UnsplicedTranscriptProps
 } from 'src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript';
 import FeatureLengthRuler from 'src/shared/components/feature-length-ruler/FeatureLengthRuler';
 

--- a/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar-tabs/GeneViewSidebarTabs.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-sidebar-tabs/GeneViewSidebarTabs.tsx
@@ -32,7 +32,7 @@ import useEntityViewerAnalytics from 'src/content/app/entity-viewer/hooks/useEnt
 
 import { SidebarTabName } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSlice';
 
-import Tabs, { Tab } from 'src/shared/components/tabs/Tabs';
+import Tabs, { type Tab } from 'src/shared/components/tabs/Tabs';
 
 import styles from './GeneViewSidebarTabs.module.css';
 

--- a/src/content/app/entity-viewer/gene-view/components/gene-view-tabs/GeneViewTabs.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-tabs/GeneViewTabs.tsx
@@ -25,7 +25,7 @@ import {
 } from 'src/content/app/entity-viewer/state/gene-view/view/geneViewViewSelectors';
 import useEntityViewerAnalytics from 'src/content/app/entity-viewer/hooks/useEntityViewerAnalytics';
 
-import Tabs, { Tab } from 'src/shared/components/tabs/Tabs';
+import Tabs, { type Tab } from 'src/shared/components/tabs/Tabs';
 
 import {
   GeneViewTabName,

--- a/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/protein-domain-image/ProteinDomainImage.tsx
@@ -17,7 +17,7 @@
 import { useState, useRef, type TouchEvent, type MouseEvent } from 'react';
 
 import classNames from 'classnames';
-import { scaleLinear, ScaleLinear } from 'd3';
+import { scaleLinear, type ScaleLinear } from 'd3';
 
 import { Toolbox, ToolboxPosition } from 'src/shared/components/toolbox';
 import ExternalLink from 'src/shared/components/external-link/ExternalLink';

--- a/src/content/app/entity-viewer/gene-view/components/protein-features-count/ProteinFeaturesCount.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/protein-features-count/ProteinFeaturesCount.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ProteinStats } from 'src/content/app/entity-viewer/shared/rest/rest-data-fetchers/proteinData';
+import type { ProteinStats } from 'src/content/app/entity-viewer/shared/rest/rest-data-fetchers/proteinData';
 
 import structuresUrl from 'static/icons/icon_protein_structures.svg?url';
 import ligandsUrl from 'static/icons/icon_protein_ligands.svg?url';

--- a/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/proteins-list/proteins-list-item-info/ProteinsListItemInfo.tsx
@@ -29,7 +29,7 @@ import ProteinImage from 'src/content/app/entity-viewer/gene-view/components/pro
 import ProteinFeaturesCount from 'src/content/app/entity-viewer/gene-view/components/protein-features-count/ProteinFeaturesCount';
 import ExternalReference from 'src/shared/components/external-reference/ExternalReference';
 import InstantDownloadProtein, {
-  OnDownloadPayload
+  type OnDownloadPayload
 } from 'src/shared/components/instant-download/instant-download-protein/InstantDownloadProtein';
 import Chevron from 'src/shared/components/chevron/Chevron';
 
@@ -40,7 +40,7 @@ import {
 } from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
 import {
   fetchProteinSummaryStats,
-  ProteinStats
+  type ProteinStats
 } from 'src/content/app/entity-viewer/shared/rest/rest-data-fetchers/proteinData';
 
 import { GENE_IMAGE_WIDTH } from 'src/content/app/entity-viewer/gene-view/constants/geneViewConstants';

--- a/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter.tsx
@@ -29,13 +29,13 @@ import {
 import {
   setFilters,
   setSortingRule,
-  Filter,
-  Filters,
-  SortingRule
+  SortingRule,
+  type Filter,
+  type Filters
 } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 
 import RadioGroup, {
-  RadioOptions
+  type RadioOptions
 } from 'src/shared/components/radio-group/RadioGroup';
 
 import CheckboxWithLabel from 'src/shared/components/checkbox-with-label/CheckboxWithLabel';

--- a/src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript.tsx
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { ReactNode } from 'react';
 import classNames from 'classnames';
-import { scaleLinear, ScaleLinear } from 'd3';
+import { scaleLinear, type ScaleLinear } from 'd3';
+import type { ReactNode } from 'react';
 import type { Pick2, Pick3 } from 'ts-multipick';
 
 import type { FullTranscript } from 'src/shared/types/core-api/transcript';

--- a/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerDownload.tsx
+++ b/src/content/app/entity-viewer/shared/components/entity-viewer-sidebar/entity-viewer-sidebar-modal/modal-views/EntityViewerDownload.tsx
@@ -29,7 +29,7 @@ import { isProteinCodingGene } from 'src/content/app/entity-viewer/shared/helper
 import useEntityViewerAnalytics from 'src/content/app/entity-viewer/hooks/useEntityViewerAnalytics';
 
 import InstantDownloadGene, {
-  OnDownloadPayload
+  type OnDownloadPayload
 } from 'src/shared/components/instant-download/instant-download-gene/InstantDownloadGene';
 
 const EntityViewerSidebarDownload = () => {

--- a/src/content/app/entity-viewer/shared/helpers/transcripts-filter.ts
+++ b/src/content/app/entity-viewer/shared/helpers/transcripts-filter.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { Filters } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
-
 import { metadataFields } from '../../gene-view/components/transcripts-filter/TranscriptsFilter';
+
+import type { Filters } from 'src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSlice';
 
 type Transcript = {
   metadata: {

--- a/src/content/app/entity-viewer/shared/rest/rest-adaptors/rest-protein-adaptor.ts
+++ b/src/content/app/entity-viewer/shared/rest/rest-adaptors/rest-protein-adaptor.ts
@@ -15,8 +15,8 @@
  */
 
 import {
-  ProteinStatsInResponse,
-  ProteinStats
+  type ProteinStatsInResponse,
+  type ProteinStats
 } from '../rest-data-fetchers/proteinData';
 
 export const restProteinSummaryAdaptor = (

--- a/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
+++ b/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
@@ -57,8 +57,8 @@ import {
 } from './queries/geneHomologiesQuery';
 import {
   transcriptPageMetaQuery,
-  TranscriptPageMetaQueryResult,
-  TranscriptPageMeta
+  type TranscriptPageMetaQueryResult,
+  type TranscriptPageMeta
 } from './queries/transcriptPageMetaQuery';
 import {
   defaultTranscriptQuery,

--- a/src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSelectors.ts
+++ b/src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSelectors.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { RootState } from 'src/store';
+import type { RootState } from 'src/store';
 
 export const getAllPreviouslyViewedEntities = (state: RootState) =>
   state.entityViewer.bookmarks.previouslyViewed;

--- a/src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSlice.ts
+++ b/src/content/app/entity-viewer/state/bookmarks/entityViewerBookmarksSlice.ts
@@ -28,7 +28,7 @@ import {
 
 import { getPreviouslyViewedEntities } from './entityViewerBookmarksSelectors';
 
-import { RootState } from 'src/store';
+import type { RootState } from 'src/store';
 
 export type PreviouslyViewedEntity = {
   id: string;

--- a/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors.ts
+++ b/src/content/app/entity-viewer/state/gene-view/transcripts/geneViewTranscriptsSelectors.ts
@@ -21,11 +21,11 @@ import {
   getEntityViewerActiveEntityId
 } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors';
 
-import { RootState } from 'src/store';
+import type { RootState } from 'src/store';
 import {
-  TranscriptsStatePerGene,
-  Filters,
-  SortingRule
+  SortingRule,
+  type TranscriptsStatePerGene,
+  type Filters
 } from './geneViewTranscriptsSlice';
 
 const getSliceForGene = createSelector(

--- a/src/content/app/entity-viewer/state/gene-view/view/geneViewViewSelectors.ts
+++ b/src/content/app/entity-viewer/state/gene-view/view/geneViewViewSelectors.ts
@@ -19,13 +19,13 @@ import {
   getEntityViewerActiveEntityId
 } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors';
 
-import { RootState } from 'src/store';
+import type { RootState } from 'src/store';
 import {
-  View,
-  ViewStatePerGene,
-  GeneViewTabData,
   GeneViewTabMap,
-  SelectedTabViews
+  View,
+  type ViewStatePerGene,
+  type GeneViewTabData,
+  type SelectedTabViews
 } from './geneViewViewSlice';
 
 const getSliceForGene = (state: RootState): ViewStatePerGene | undefined => {

--- a/src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors.ts
+++ b/src/content/app/entity-viewer/state/general/entityViewerGeneralSelectors.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { RootState } from 'src/store';
+import type { RootState } from 'src/store';
 
 export const getEntityViewerActiveGenomeId = (state: RootState) =>
   state.entityViewer.general.activeGenomeId;

--- a/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors.ts
+++ b/src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSelectors.ts
@@ -20,8 +20,8 @@ import {
 } from '../general/entityViewerGeneralSelectors';
 
 import { Status } from 'src/shared/types/status';
-import { RootState } from 'src/store';
-import { EntityViewerSidebarGenomeState } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSlice';
+import type { RootState } from 'src/store';
+import type { EntityViewerSidebarGenomeState } from 'src/content/app/entity-viewer/state/sidebar/entityViewerSidebarSlice';
 
 export const getEntityViewerGenomeState = (state: RootState) => {
   const activeGenomeId = getEntityViewerActiveGenomeId(state);

--- a/src/content/app/entity-viewer/state/variant-view/transcriptConsequenceSlice.ts
+++ b/src/content/app/entity-viewer/state/variant-view/transcriptConsequenceSlice.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 type TranscriptConsequenceState = {
   [genomeId: string]: {

--- a/src/content/app/entity-viewer/transcript-view/components/gene-overview-image/GeneOverviewImage.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/gene-overview-image/GeneOverviewImage.tsx
@@ -30,8 +30,8 @@ import {
 } from 'src/content/app/entity-viewer/gene-view/constants/geneViewConstants';
 
 import UnsplicedTranscript, {
-  UnsplicedTranscriptProps,
-  UNSPLICED_TRANSCRIPT_HEIGHT
+  UNSPLICED_TRANSCRIPT_HEIGHT,
+  type UnsplicedTranscriptProps
 } from 'src/content/app/entity-viewer/gene-view/components/unspliced-transcript/UnsplicedTranscript';
 import FeatureLengthRuler, {
   type TicksAndScale

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-exons/useExonsData.ts
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-exons/useExonsData.ts
@@ -16,7 +16,7 @@
 
 import { useState } from 'react';
 
-import { AppDispatch, useAppDispatch } from 'src/store';
+import { useAppDispatch, type AppDispatch } from 'src/store';
 
 import { getSequenceSlice } from 'src/shared/helpers/sequenceHelpers';
 

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar-tabs/TranscriptViewSidebarTabs.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-view-sidebar-tabs/TranscriptViewSidebarTabs.tsx
@@ -32,7 +32,7 @@ import {
   getSidebarModalView
 } from 'src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSelectors';
 
-import Tabs, { Tab } from 'src/shared/components/tabs/Tabs';
+import Tabs, { type Tab } from 'src/shared/components/tabs/Tabs';
 
 import styles from './TranscriptViewSidebarTabs.module.css';
 

--- a/src/content/app/entity-viewer/variant-view/population-allele-frequencies/PopulationAlleleFrequencies.tsx
+++ b/src/content/app/entity-viewer/variant-view/population-allele-frequencies/PopulationAlleleFrequencies.tsx
@@ -19,7 +19,7 @@ import { useState } from 'react';
 import { createSmallNumberFormatter } from 'src/shared/helpers/formatters/numberFormatter';
 
 import usePopulationAlleleFrequenciesData, {
-  PreparedPopulationFrequencyData
+  type PreparedPopulationFrequencyData
 } from './usePopulationAlleleFrequenciesData';
 
 import { Panel, PanelHead, PanelBody } from 'src/shared/components/panel/Panel';

--- a/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-cds/TranscriptVariantCDS.tsx
+++ b/src/content/app/entity-viewer/variant-view/transcript-consequences/transcript-variant-cds/TranscriptVariantCDS.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { scaleLinear, interpolateRound, ScaleLinear } from 'd3';
+import { scaleLinear, interpolateRound, type ScaleLinear } from 'd3';
 import type { SVGAttributes } from 'react';
 import type { Pick2 } from 'ts-multipick';
 

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelGene.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/TrackPanelGene.tsx
@@ -33,7 +33,7 @@ import TrackPanelItemsExpandLozenge from './TrackPanelItemsExpandLozenge';
 import SimpleTrackPanelItemLayout from './track-panel-item-layout/SimpleTrackPanelItemLayout';
 
 import { Status } from 'src/shared/types/status';
-import { TrackActivityStatus } from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
+import type { TrackActivityStatus } from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
 
 import styles from './TrackPanelItem.module.css';
 

--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/track-panel-item-layout/SimpleTrackPanelItemLayout.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-list/track-panel-items/track-panel-item-layout/SimpleTrackPanelItemLayout.tsx
@@ -31,8 +31,8 @@ import VisibilityIcon from 'src/shared/components/visibility-icon/VisibilityIcon
 
 import Ellipsis from 'static/icons/icon_ellipsis.svg';
 
-import { TrackActivityStatus } from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
 import { Status } from 'src/shared/types/status';
+import type { TrackActivityStatus } from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
 
 import styles from './TrackPanelItemLayout.module.css';
 

--- a/src/content/app/genome-browser/components/track-settings-panel/track-settings-views/GeneTrackSettings.tsx
+++ b/src/content/app/genome-browser/components/track-settings-panel/track-settings-views/GeneTrackSettings.tsx
@@ -24,7 +24,7 @@ import SlideToggle from 'src/shared/components/slide-toggle/SlideToggle';
 
 import { getTrackSettingsForTrackId } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSelectors';
 
-import { GeneTrackSettings as GeneTrackSettingsType } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSlice';
+import type { GeneTrackSettings as GeneTrackSettingsType } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSlice';
 
 import ReorderTrack from 'static/icons/icon_move_tracks.svg';
 

--- a/src/content/app/genome-browser/components/zmenu/ZmenuContent.tsx
+++ b/src/content/app/genome-browser/components/zmenu/ZmenuContent.tsx
@@ -22,9 +22,9 @@ import * as urlFor from 'src/shared/helpers/urlHelper';
 import useGenomeBrowserIds from 'src/content/app/genome-browser/hooks/useGenomeBrowserIds';
 
 import {
-  ZmenuContentItem as ZmenuContentItemType,
   Markup,
-  ZmenuContent as ZmenuContentType
+  type ZmenuContentItem as ZmenuContentItemType,
+  type ZmenuContent as ZmenuContentType
 } from 'src/content/app/genome-browser/services/genome-browser-service/types/zmenu';
 
 import styles from './Zmenu.module.css';

--- a/src/content/app/genome-browser/helpers/browserHelper.ts
+++ b/src/content/app/genome-browser/helpers/browserHelper.ts
@@ -23,7 +23,7 @@ import {
   buildFocusObjectId
 } from 'src/shared/helpers/focusObjectHelpers';
 
-import { ChrLocation } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSlice';
+import type { ChrLocation } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSlice';
 
 type GenomeBrowserFocusIdConstituents = {
   genomeId: string;

--- a/src/content/app/genome-browser/services/track-settings/trackSettingsStorageService.ts
+++ b/src/content/app/genome-browser/services/track-settings/trackSettingsStorageService.ts
@@ -16,12 +16,12 @@
 
 import IndexedDB from 'src/services/indexeddb-service';
 
-import { TrackSettings } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSlice';
-
 import {
   GB_TRACK_SETTINGS_STORE_NAME,
   trackSettingFieldsMap
 } from './trackSettingsStorageConstants';
+
+import type { TrackSettings } from 'src/content/app/genome-browser/state/track-settings/trackSettingsSlice';
 
 // the combination of genome id and track id will be used as a composite key
 export type StoredTrack = {

--- a/src/content/app/genome-browser/state/drawer/drawer-sequence/drawerSequenceSlice.ts
+++ b/src/content/app/genome-browser/state/drawer/drawer-sequence/drawerSequenceSlice.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 import { changeDrawerViewForGenome } from 'src/content/app/genome-browser/state/drawer/drawerSlice';
 

--- a/src/content/app/genome-browser/state/focus-object/focusObjectSlice.ts
+++ b/src/content/app/genome-browser/state/focus-object/focusObjectSlice.ts
@@ -46,7 +46,7 @@ import type {
   FocusTranscript,
   FocusVariant
 } from 'src/shared/types/focus-object/focusObjectTypes';
-import { FullTranscript } from 'src/shared/types/core-api/transcript';
+import type { FullTranscript } from 'src/shared/types/core-api/transcript';
 
 export type FocusObjectsState = Readonly<{
   [focusObjectId: string]: {

--- a/src/content/app/genome-browser/state/focus-object/isGeneFocusObject.ts
+++ b/src/content/app/genome-browser/state/focus-object/isGeneFocusObject.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {
+import type {
   FocusObject,
   FocusGene
 } from 'src/shared/types/focus-object/focusObjectTypes';

--- a/src/content/app/genome-browser/state/track-panel/trackPanelSelectors.ts
+++ b/src/content/app/genome-browser/state/track-panel/trackPanelSelectors.ts
@@ -17,7 +17,7 @@
 import { getBrowserActiveGenomeId } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
 import { defaultTrackPanelStateForGenome } from 'src/content/app/genome-browser/state/track-panel/trackPanelSlice';
 
-import { RootState } from 'src/store';
+import type { RootState } from 'src/store';
 
 export const getActiveTrackPanel = (state: RootState) => {
   const activeGenomeId = getBrowserActiveGenomeId(state);

--- a/src/content/app/genome-browser/state/track-panel/trackPanelSlice.ts
+++ b/src/content/app/genome-browser/state/track-panel/trackPanelSlice.ts
@@ -27,11 +27,11 @@ import { parseFocusObjectId } from 'src/shared/helpers/focusObjectHelpers';
 
 import { getBrowserActiveGenomeId } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSelectors';
 import { getActiveTrackPanel } from './trackPanelSelectors';
-import { ParsedUrlPayload } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSlice';
 import { closeBrowserSidebarModal } from '../browser-sidebar-modal/browserSidebarModalSlice';
 
 import { TrackSet } from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
 
+import type { ParsedUrlPayload } from 'src/content/app/genome-browser/state/browser-general/browserGeneralSlice';
 import type { RootState } from 'src/store';
 
 export type TrackPanelStateForGenome = Readonly<{

--- a/src/content/app/help/Help.tsx
+++ b/src/content/app/help/Help.tsx
@@ -45,11 +45,11 @@ import Breadcrumbs from 'src/shared/components/breadcrumbs/Breadcrumbs';
 import HistoryButtons from 'src/shared/components/help-popup/HistoryButtons';
 import { NotFoundErrorScreen } from 'src/shared/components/error-screen';
 
-import {
+import type {
   Menu as MenuType,
   MenuItem
 } from 'src/shared/types/help-and-docs/menu';
-import {
+import type {
   TextArticleData,
   VideoArticleData
 } from 'src/shared/types/help-and-docs/article';

--- a/src/content/app/help/components/help-menu/HelpMenu.tsx
+++ b/src/content/app/help/components/help-menu/HelpMenu.tsx
@@ -23,7 +23,7 @@ import useHelpAppAnalytics from '../../hooks/useHelpAppAnalytics';
 import Chevron from 'src/shared/components/chevron/Chevron';
 import HelpMenuLink from './HelpMenuLink';
 
-import {
+import type {
   Menu as MenuType,
   MenuArticleItem,
   MenuItem

--- a/src/content/app/help/helpers/helpPageMetaHelpers.ts
+++ b/src/content/app/help/helpers/helpPageMetaHelpers.ts
@@ -16,7 +16,7 @@
 
 import { isHelpIndexRoute } from './isHelpIndexRoute';
 
-import {
+import type {
   TextArticleData,
   VideoArticleData
 } from 'src/shared/types/help-and-docs/article';

--- a/src/content/app/regulatory-activity-viewer/components/activity-viewer-popup/activity-viewer-popup-content/GenePopupContent.tsx
+++ b/src/content/app/regulatory-activity-viewer/components/activity-viewer-popup/activity-viewer-popup-content/GenePopupContent.tsx
@@ -21,7 +21,7 @@ import { getFormattedLocation } from 'src/shared/helpers/formatters/regionFormat
 
 import TextButton from 'src/shared/components/text-button/TextButton';
 
-import { Strand } from 'src/shared/types/core-api/strand';
+import type { Strand } from 'src/shared/types/core-api/strand';
 import type { GenePopupMessage } from '../activityViewerPopupMessageTypes';
 
 import styles from './AcrivityViewerPopupContent.module.css';

--- a/src/content/app/species-selector/state/speciesSelectorEpics.ts
+++ b/src/content/app/species-selector/state/speciesSelectorEpics.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { Epic } from 'redux-observable';
 import { map, tap, filter } from 'rxjs';
 import { isFulfilled, type Action } from '@reduxjs/toolkit';
+import type { Epic } from 'redux-observable';
 
 import { saveMultipleSelectedSpecies } from 'src/content/app/species-selector/services/speciesSelectorStorageService';
 

--- a/src/content/app/species/components/species-title-area/species-usage-toggle/SpeciesUsageToggle.tsx
+++ b/src/content/app/species/components/species-title-area/species-usage-toggle/SpeciesUsageToggle.tsx
@@ -25,7 +25,7 @@ import { toggleSpeciesUseAndSave } from 'src/content/app/species-selector/state/
 import SlideToggle from 'src/shared/components/slide-toggle/SlideToggle';
 import QuestionButton from 'src/shared/components/question-button/QuestionButton';
 
-import { RootState } from 'src/store';
+import type { RootState } from 'src/store';
 
 import styles from './SpeciesUsageToggle.module.css';
 

--- a/src/content/app/species/services/species-storage-service.ts
+++ b/src/content/app/species/services/species-storage-service.ts
@@ -15,11 +15,11 @@
  */
 
 import storageService, {
-  StorageServiceInterface,
-  StorageType
+  StorageType,
+  type StorageServiceInterface
 } from 'src/services/storage-service';
 
-import { UIState } from 'src/content/app/species/state/general/speciesGeneralSlice';
+import type { UIState } from 'src/content/app/species/state/general/speciesGeneralSlice';
 
 export enum StorageKeys {
   GENOME_UI_STATE = 'species.genomeUIState'

--- a/src/content/app/species/state/general/speciesGeneralHelper.ts
+++ b/src/content/app/species/state/general/speciesGeneralHelper.ts
@@ -17,11 +17,10 @@
 import * as urlFor from 'src/shared/helpers/urlHelper';
 import { formatNumber } from 'src/shared/helpers/formatters/numberFormatter';
 
-import { SpeciesStatsProps as IndividualStat } from 'src/content/app/species/components/species-stats/SpeciesStats';
-import { ExampleFocusObject } from 'src/shared/state/genome/genomeTypes';
-
 import { buildFocusIdForUrl } from 'src/shared/helpers/focusObjectHelpers';
 
+import type { ExampleFocusObject } from 'src/shared/state/genome/genomeTypes';
+import type { SpeciesStatsProps as IndividualStat } from 'src/content/app/species/components/species-stats/SpeciesStats';
 import type { LinksConfig } from 'src/shared/components/view-in-app/ViewInApp';
 import type { SpeciesStatistics } from 'src/content/app/species/state/api/speciesApiTypes';
 

--- a/src/content/app/species/state/general/speciesGeneralSelectors.ts
+++ b/src/content/app/species/state/general/speciesGeneralSelectors.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { RootState } from 'src/store';
+import type { RootState } from 'src/store';
 
 export const getActiveGenomeId = (state: RootState) =>
   state.speciesPage.general.activeGenomeId;

--- a/src/content/app/species/state/general/speciesGeneralSlice.ts
+++ b/src/content/app/species/state/general/speciesGeneralSlice.ts
@@ -24,8 +24,7 @@ import set from 'lodash/fp/set';
 import { getActiveGenomeId } from './speciesGeneralSelectors';
 import speciesStorageService from '../../services/species-storage-service';
 
-import { SpeciesStatsSection } from 'src/content/app/species/state/general/speciesGeneralHelper';
-
+import type { SpeciesStatsSection } from 'src/content/app/species/state/general/speciesGeneralHelper';
 import type { RootState } from 'src/store';
 
 export type GenomeUIState = {

--- a/src/content/app/species/state/sidebar/speciesSidebarSelectors.ts
+++ b/src/content/app/species/state/sidebar/speciesSidebarSelectors.ts
@@ -15,7 +15,8 @@
  */
 
 import { getActiveGenomeId } from 'src/content/app/species/state/general/speciesGeneralSelectors';
-import { RootState } from 'src/store';
+
+import type { RootState } from 'src/store';
 
 export const isSpeciesSidebarOpen = (state: RootState) => {
   const activeGenomeId = getActiveGenomeId(state);

--- a/src/content/app/tools/blast/state/blast-form/blastFormSelectors.ts
+++ b/src/content/app/tools/blast/state/blast-form/blastFormSelectors.ts
@@ -16,7 +16,7 @@
 
 import { createSelector } from 'reselect';
 
-import { RootState } from 'src/store';
+import type { RootState } from 'src/store';
 
 export const getSequences = (state: RootState) =>
   state.blast.blastForm.sequences;

--- a/src/content/app/tools/blast/state/blast-form/blastFormSlice.ts
+++ b/src/content/app/tools/blast/state/blast-form/blastFormSlice.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import cloneDeep from 'lodash/cloneDeep';
 
 import { guessSequenceType } from 'src/content/app/tools/blast/utils/sequenceTypeGuesser';

--- a/src/content/app/tools/blast/utils/blastFormValidator.ts
+++ b/src/content/app/tools/blast/utils/blastFormValidator.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ParsedInputSequence } from 'src/content/app/tools/blast/types/blastSequence';
+import type { ParsedInputSequence } from 'src/content/app/tools/blast/types/blastSequence';
 
 export const MAX_BLAST_SPECIES_COUNT = 25;
 export const MAX_BLAST_SEQUENCE_COUNT = 50;

--- a/src/content/app/tools/blast/utils/blastSubmisionTypeNarrowing.ts
+++ b/src/content/app/tools/blast/utils/blastSubmisionTypeNarrowing.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {
+import type {
   BlastSubmission,
   SuccessfulBlastSubmission,
   FailedBlastSubmission

--- a/src/content/app/tools/vep/components/vep-species-name/VepSpeciesName.tsx
+++ b/src/content/app/tools/vep/components/vep-species-name/VepSpeciesName.tsx
@@ -15,7 +15,8 @@
  */
 
 import SpeciesName from 'src/shared/components/species-name/SpeciesName';
-import { CommittedItem } from 'src/content/app/species-selector/types/committedItem';
+
+import type { CommittedItem } from 'src/content/app/species-selector/types/committedItem';
 
 import styles from './VepSpeciesName.module.css';
 

--- a/src/content/html/Html.tsx
+++ b/src/content/html/Html.tsx
@@ -21,7 +21,7 @@ import { CONFIG_FIELD_ON_WINDOW } from 'src/shared/constants/globals';
 import Meta from './Meta';
 import { HotjarScript } from './ThirdParty';
 
-import type JSONValue from 'src/shared/types/JSON';
+import type { JSONValue } from 'src/shared/types/JSON';
 import type { TransferredClientConfig } from 'src/server/helpers/getConfigForClient';
 
 type Props = {

--- a/src/content/unsupported-browser/UnsupportedBrowserHtml.tsx
+++ b/src/content/unsupported-browser/UnsupportedBrowserHtml.tsx
@@ -17,7 +17,7 @@
 import type { ReactNode } from 'react';
 
 import type { TransferredClientConfig } from 'src/server/helpers/getConfigForClient';
-import type JSONValue from 'src/shared/types/JSON';
+import type { JSONValue } from 'src/shared/types/JSON';
 
 type Props = {
   assets: Record<string, string>;

--- a/src/global/globalSelectors.ts
+++ b/src/global/globalSelectors.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import { RootState } from '../store';
-import { BreakpointWidth, ScrollPosition } from './globalConfig';
+import { BreakpointWidth, type ScrollPosition } from './globalConfig';
+
+import type { RootState } from '../store';
 
 export const getBrowserTabId = (state: RootState) =>
   state.global.browserTabId || '';

--- a/src/header/launchbar/LaunchbarButtonWithNotification.tsx
+++ b/src/header/launchbar/LaunchbarButtonWithNotification.tsx
@@ -17,7 +17,7 @@
 import { useMemo } from 'react';
 import classNames from 'classnames';
 
-import LaunchbarButton, { LaunchbarButtonProps } from './LaunchbarButton';
+import LaunchbarButton, { type LaunchbarButtonProps } from './LaunchbarButton';
 
 import styles from './Launchbar.module.css';
 

--- a/src/server/routes/viewsRouter.tsx
+++ b/src/server/routes/viewsRouter.tsx
@@ -29,7 +29,7 @@ import { getServerSideReduxStore } from '../serverSideReduxStore';
 import Html from 'src/content/html/Html';
 import Root from 'src/root/Root';
 
-import type JSONValue from 'src/shared/types/JSON';
+import type { JSONValue } from 'src/shared/types/JSON';
 
 const configForClient = getConfigForClient();
 

--- a/src/services/analytics-service.ts
+++ b/src/services/analytics-service.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { type AnalyticsOptions } from 'src/analyticsHelper';
-
 import config from 'config';
 
 import GoogleAnalytics, {
-  TrackEventParams
+  type TrackEventParams
 } from 'src/services/google-analytics';
+
+import type { AnalyticsOptions } from 'src/analyticsHelper';
 
 const { googleAnalyticsKey } = config;
 

--- a/src/services/api-service.ts
+++ b/src/services/api-service.ts
@@ -17,7 +17,7 @@
 import config from 'config';
 import LRUCache from 'src/shared/utils/lruCache';
 
-import JSONValue from 'src/shared/types/JSON';
+import type { JSONValue } from 'src/shared/types/JSON';
 
 export enum HTTPMethod {
   GET = 'GET',

--- a/src/services/google-analytics/index.ts
+++ b/src/services/google-analytics/index.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import { CustomDimensionsOptions } from 'src/analyticsHelper';
 import loadGoogleAnalytics from './loadGoogleAnalytics';
+
+import type { CustomDimensionsOptions } from 'src/analyticsHelper';
 
 type TrackPageView = {
   page_title?: string;

--- a/src/services/indexeddb-service.ts
+++ b/src/services/indexeddb-service.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { openDB, IDBPDatabase, type OpenDBCallbacks } from 'idb';
+import { openDB, type IDBPDatabase, type OpenDBCallbacks } from 'idb';
 
 import { GENERAL_STORE_NAME } from 'src/shared/services/generalStorageConstants';
 import { GENERAL_UI_STORE_NAME } from 'src/shared/services/generalUIStorageConstants';

--- a/src/services/storage-service.ts
+++ b/src/services/storage-service.ts
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-import windowService, {
-  WindowServiceInterface
-} from 'src/services/window-service';
 import mergeWith from 'lodash/mergeWith';
-import JSONValue, { PrimitiveValue, ArrayValue } from 'src/shared/types/JSON';
 import isArray from 'lodash/isArray';
 import unset from 'lodash/unset';
+
+import windowService, {
+  type WindowServiceInterface
+} from 'src/services/window-service';
+
+import type { JSONValue, PrimitiveValue, ArrayValue } from 'src/shared/types/JSON';
 
 export enum StorageType {
   LOCAL_STORAGE = 'localstorage',

--- a/src/shared/components/accordion/components/Accordion.tsx
+++ b/src/shared/components/accordion/components/Accordion.tsx
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 
-import { DivAttributes } from '../helpers/types';
-import { Consumer, Provider } from './AccordionContext';
-import { UUID } from './ItemContext';
-import defaultStyles from '../css/Accordion.module.css';
 import classNames from 'classnames';
+
+import { Consumer, Provider } from './AccordionContext';
+
+import type { DivAttributes } from '../helpers/types';
+import type { UUID } from './ItemContext';
+
+import defaultStyles from '../css/Accordion.module.css';
 
 type AccordionProps = Pick<
   DivAttributes,

--- a/src/shared/components/accordion/components/AccordionContext.tsx
+++ b/src/shared/components/accordion/components/AccordionContext.tsx
@@ -23,11 +23,11 @@ import {
 } from 'react';
 
 import AccordionStore, {
-  InjectedButtonAttributes,
-  InjectedHeadingAttributes,
-  InjectedPanelAttributes
+  type InjectedButtonAttributes,
+  type InjectedHeadingAttributes,
+  type InjectedPanelAttributes
 } from '../helpers/AccordionStore';
-import { UUID } from './ItemContext';
+import type { UUID } from './ItemContext';
 
 export interface ProviderProps {
   preExpanded?: UUID[];

--- a/src/shared/components/accordion/components/AccordionItem.tsx
+++ b/src/shared/components/accordion/components/AccordionItem.tsx
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import { Provider as ItemProvider, UUID } from './ItemContext';
 import classNames from 'classnames';
+
 import { generateId } from 'src/shared/helpers/generateId';
+
+import { Provider as ItemProvider, type UUID } from './ItemContext';
 
 import type { DivAttributes } from '../helpers/types';
 

--- a/src/shared/components/accordion/components/AccordionItemButton.tsx
+++ b/src/shared/components/accordion/components/AccordionItemButton.tsx
@@ -17,12 +17,12 @@
 import noop from 'lodash/noop';
 import classNames from 'classnames';
 
-import { Consumer as ItemConsumer, ItemContext } from './ItemContext';
+import { Consumer as ItemConsumer, type ItemContext } from './ItemContext';
 
 import Chevron from 'src/shared/components/chevron/Chevron';
 
-import { InjectedButtonAttributes } from '../helpers/AccordionStore';
-import { DivAttributes } from '../helpers/types';
+import type { InjectedButtonAttributes } from '../helpers/AccordionStore';
+import type { DivAttributes } from '../helpers/types';
 
 import defaultStyles from '../css/Accordion.module.css';
 

--- a/src/shared/components/accordion/components/AccordionItemHeading.tsx
+++ b/src/shared/components/accordion/components/AccordionItemHeading.tsx
@@ -15,9 +15,11 @@
  */
 
 import { useEffect, useRef } from 'react';
-import { InjectedHeadingAttributes } from '../helpers/AccordionStore';
-import { DivAttributes } from '../helpers/types';
-import { Consumer as ItemConsumer, ItemContext } from './ItemContext';
+
+import { Consumer as ItemConsumer, type ItemContext } from './ItemContext';
+
+import type { InjectedHeadingAttributes } from '../helpers/AccordionStore';
+import type { DivAttributes } from '../helpers/types';
 
 type Props = DivAttributes;
 

--- a/src/shared/components/accordion/components/AccordionItemPanel.tsx
+++ b/src/shared/components/accordion/components/AccordionItemPanel.tsx
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
-import { DivAttributes } from '../helpers/types';
-import { Consumer as ItemConsumer, ItemContext } from './ItemContext';
-import defaultStyles from '../css/Accordion.module.css';
 import classNames from 'classnames';
+
+import { Consumer as ItemConsumer, type ItemContext } from './ItemContext';
+
+import type { DivAttributes } from '../helpers/types';
+
+import defaultStyles from '../css/Accordion.module.css';
 
 type Props = DivAttributes & {
   extendDefaultStyles?: boolean;

--- a/src/shared/components/accordion/components/AccordionItemState.tsx
+++ b/src/shared/components/accordion/components/AccordionItemState.tsx
@@ -16,8 +16,8 @@
 
 import type { ReactNode } from 'react';
 
-import { DivAttributes } from '../helpers/types';
-import { Consumer as ItemConsumer, ItemContext } from './ItemContext';
+import type { DivAttributes } from '../helpers/types';
+import { Consumer as ItemConsumer, type ItemContext } from './ItemContext';
 
 type Props = Pick<DivAttributes, Exclude<keyof DivAttributes, 'children'>> & {
   children(args: Partial<{ expanded: boolean; disabled: boolean }>): ReactNode;

--- a/src/shared/components/accordion/components/ItemContext.tsx
+++ b/src/shared/components/accordion/components/ItemContext.tsx
@@ -16,14 +16,14 @@
 
 import { createContext, type ReactNode } from 'react';
 
-import {
+import type {
   InjectedButtonAttributes,
   InjectedHeadingAttributes,
   InjectedPanelAttributes
 } from '../helpers/AccordionStore';
 import {
-  AccordionContext,
-  Consumer as AccordionContextConsumer
+  Consumer as AccordionContextConsumer,
+  type AccordionContext
 } from './AccordionContext';
 
 export type UUID = string | number;

--- a/src/shared/components/accordion/helpers/AccordionStore.ts
+++ b/src/shared/components/accordion/helpers/AccordionStore.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { UUID } from '../components/ItemContext';
+import type { UUID } from '../components/ItemContext';
 
 export interface InjectedPanelAttributes {
   role: string | undefined;

--- a/src/shared/components/button-link/ButtonLink.tsx
+++ b/src/shared/components/button-link/ButtonLink.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { ReactNode } from 'react';
-import { NavLink, NavLinkProps } from 'react-router';
+import { type ReactNode } from 'react';
+import { NavLink, type NavLinkProps } from 'react-router';
 import classNames from 'classnames';
 
 import styles from './ButtonLink.module.css';

--- a/src/shared/components/data-table/dataTableReducer.ts
+++ b/src/shared/components/data-table/dataTableReducer.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { DataTableState, TableAction, AllTableActions } from './dataTableTypes';
+import { TableAction, type DataTableState, type AllTableActions } from './dataTableTypes';
 
 export const defaultDataTableState: DataTableState = {
   data: [],

--- a/src/shared/components/feature-length-ruler/FeatureLengthRuler.tsx
+++ b/src/shared/components/feature-length-ruler/FeatureLengthRuler.tsx
@@ -30,7 +30,7 @@ It follows the following rules for displaying labelled and unlabelled ticks
 */
 
 import { useEffect } from 'react';
-import { scaleLinear, ScaleLinear } from 'd3';
+import { scaleLinear, type ScaleLinear } from 'd3';
 
 import { getTicks } from './featureLengthRulerHelper';
 

--- a/src/shared/components/feature-length-ruler/featureLengthRulerHelper.ts
+++ b/src/shared/components/feature-length-ruler/featureLengthRulerHelper.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ScaleLinear } from 'd3';
+import type { ScaleLinear } from 'd3';
 
 export const getTicks = (scale: ScaleLinear<number, number>) => {
   // use d3 scale to get 'approximately' 10 ticks (exact number not guaranteed)

--- a/src/shared/components/feature-summary-strip/GeneSummaryStrip.tsx
+++ b/src/shared/components/feature-summary-strip/GeneSummaryStrip.tsx
@@ -20,8 +20,7 @@ import { getDisplayStableId } from 'src/shared/helpers/focusObjectHelpers';
 import { getFormattedLocation } from 'src/shared/helpers/formatters/regionFormatter';
 import { getStrandDisplayName } from 'src/shared/helpers/formatters/strandFormatter';
 
-import { FocusGene } from 'src/shared/types/focus-object/focusObjectTypes';
-
+import type { FocusGene } from 'src/shared/types/focus-object/focusObjectTypes';
 import type { Variety } from './types';
 
 import styles from './FeatureSummaryStrip.module.css';

--- a/src/shared/components/feature-summary-strip/LocationSummaryStrip.tsx
+++ b/src/shared/components/feature-summary-strip/LocationSummaryStrip.tsx
@@ -21,7 +21,7 @@ import { getFormattedLocation } from 'src/shared/helpers/formatters/regionFormat
 
 import styles from './FeatureSummaryStrip.module.css';
 
-import { FocusLocation } from 'src/shared/types/focus-object/focusObjectTypes';
+import type { FocusLocation } from 'src/shared/types/focus-object/focusObjectTypes';
 
 type Props = {
   location: FocusLocation;

--- a/src/shared/components/help-article/IndexArticle.tsx
+++ b/src/shared/components/help-article/IndexArticle.tsx
@@ -16,7 +16,7 @@
 
 import { Link } from 'react-router';
 
-import {
+import type {
   IndexArticleData,
   IndexArticleItem
 } from 'src/shared/types/help-and-docs/article';

--- a/src/shared/components/help-article/RelatedArticles.tsx
+++ b/src/shared/components/help-article/RelatedArticles.tsx
@@ -19,7 +19,7 @@ import classNames from 'classnames';
 
 import VideoIcon from 'static/icons/icon_video.svg';
 
-import { RelatedArticleData } from 'src/shared/types/help-and-docs/article';
+import type { RelatedArticleData } from 'src/shared/types/help-and-docs/article';
 
 import styles from './HelpArticle.module.css';
 

--- a/src/shared/components/help-article/TextArticle.tsx
+++ b/src/shared/components/help-article/TextArticle.tsx
@@ -18,7 +18,7 @@ import { useRef, useEffect, RefObject } from 'react';
 import classNames from 'classnames';
 import { useNavigate } from 'react-router';
 
-import { TextArticleData } from 'src/shared/types/help-and-docs/article';
+import type { TextArticleData } from 'src/shared/types/help-and-docs/article';
 
 import styles from './HelpArticle.module.css';
 import cssVariables from './helpArticleVariables.module.css';

--- a/src/shared/components/help-article/VideoArticle.tsx
+++ b/src/shared/components/help-article/VideoArticle.tsx
@@ -21,7 +21,7 @@ import useResizeObserver from 'src/shared/hooks/useResizeObserver';
 import { CircleLoader } from 'src/shared/components/loader';
 
 import { LoadingState } from 'src/shared/types/loading-state';
-import { VideoArticleData } from 'src/shared/types/help-and-docs/article';
+import type { VideoArticleData } from 'src/shared/types/help-and-docs/article';
 
 import styles from './HelpArticle.module.css';
 

--- a/src/shared/components/help-popup/HelpPopupBody.tsx
+++ b/src/shared/components/help-popup/HelpPopupBody.tsx
@@ -30,7 +30,7 @@ import { CircleLoader } from 'src/shared/components/loader';
 import HistoryButtons from './HistoryButtons';
 
 import { LoadingState } from 'src/shared/types/loading-state';
-import { SlugReference } from './types';
+import type { SlugReference } from './types';
 
 import styles from './HelpPopupBody.module.css';
 

--- a/src/shared/components/help-popup/helpPopupHistory.ts
+++ b/src/shared/components/help-popup/helpPopupHistory.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { SlugReference } from './types';
+import type { SlugReference } from './types';
 
 class HelpPopupHistory {
   private references: SlugReference[] = [];

--- a/src/shared/components/help-popup/useHelpArticle.ts
+++ b/src/shared/components/help-popup/useHelpArticle.ts
@@ -16,8 +16,8 @@
 
 import useApiService from 'src/shared/hooks/useApiService';
 
-import { SlugReference } from './types';
-import {
+import type { SlugReference } from './types';
+import type {
   TextArticleData,
   VideoArticleData
 } from 'src/shared/types/help-and-docs/article';

--- a/src/shared/components/pointer-box/pointer-box-inline-styles.ts
+++ b/src/shared/components/pointer-box/pointer-box-inline-styles.ts
@@ -15,7 +15,7 @@
  */
 
 import { Position } from './pointer-box-types';
-import { PointerBoxProps, InlineStylesState } from './PointerBox';
+import type { PointerBoxProps, InlineStylesState } from './PointerBox';
 
 type Params = Required<
   Pick<

--- a/src/shared/components/privacy-banner/privacy-banner-service.ts
+++ b/src/shared/components/privacy-banner/privacy-banner-service.ts
@@ -16,7 +16,7 @@
 
 import privacyConfig from './privacyConfig';
 import storageService, {
-  StorageServiceInterface
+  type StorageServiceInterface
 } from 'src/services/storage-service';
 
 export class PrivacyBannerService {

--- a/src/shared/components/search-match/VariantSearchMatches.tsx
+++ b/src/shared/components/search-match/VariantSearchMatches.tsx
@@ -28,8 +28,8 @@ import PointerBox, {
 } from 'src/shared/components/pointer-box/PointerBox';
 import TextButton from 'src/shared/components/text-button/TextButton';
 import ViewInApp from 'src/shared/components/view-in-app/ViewInApp';
-import { SearchResults } from 'src/shared/types/search-api/search-results';
 
+import type { SearchResults } from 'src/shared/types/search-api/search-results';
 import type { VariantSearchMatch as VariantSearchMatchType } from 'src/shared/types/search-api/search-match';
 import type { AppName as AppNameForViewInApp } from 'src/shared/components/view-in-app/ViewInApp';
 import type {

--- a/src/shared/components/textarea/ShadedTextarea.tsx
+++ b/src/shared/components/textarea/ShadedTextarea.tsx
@@ -16,7 +16,7 @@
 
 import classNames from 'classnames';
 
-import Textarea, { Props as TextareaProps } from './Textarea';
+import Textarea, { type Props as TextareaProps } from './Textarea';
 
 import styles from './Textarea.module.css';
 

--- a/src/shared/components/tooltip/Tooltip.tsx
+++ b/src/shared/components/tooltip/Tooltip.tsx
@@ -23,7 +23,7 @@ import PointerBox, {
   Position
 } from 'src/shared/components/pointer-box/PointerBox';
 
-import { TooltipPosition } from './tooltip-types';
+import type { TooltipPosition } from './tooltip-types';
 
 import styles from './Tooltip.module.css';
 import pointerBoxStyles from 'src/shared/components/pointer-box/PointerBox.module.css';

--- a/src/shared/components/view-in-app-popup/ViewInAppPopup.tsx
+++ b/src/shared/components/view-in-app-popup/ViewInAppPopup.tsx
@@ -19,7 +19,7 @@ import PointerBox, {
   Position
 } from 'src/shared/components/pointer-box/PointerBox';
 import ViewInApp, {
-  LinksConfig
+  type LinksConfig
 } from 'src/shared/components/view-in-app/ViewInApp';
 
 import styles from './ViewInAppPopup.module.css';

--- a/src/shared/components/visibility-icon/VisibilityIcon.tsx
+++ b/src/shared/components/visibility-icon/VisibilityIcon.tsx
@@ -17,7 +17,7 @@
 import classNames from 'classnames';
 
 import ImageButton, {
-  ImageButtonStatus
+  type ImageButtonStatus
 } from 'src/shared/components/image-button/ImageButton';
 
 import Eye from 'static/icons/icon_eye.svg';

--- a/src/shared/state/api-slices/refgetSlice.ts
+++ b/src/shared/state/api-slices/refgetSlice.ts
@@ -20,7 +20,7 @@ import restApiSlice from 'src/shared/state/api-slices/restSlice';
 
 import { getReverseComplement } from 'src/shared/helpers/sequenceHelpers';
 
-import { Strand } from 'src/shared/types/core-api/strand';
+import type { Strand } from 'src/shared/types/core-api/strand';
 
 export type SequenceQueryParams = {
   checksum: string;

--- a/src/shared/state/feature-search/featureSearchSlice.ts
+++ b/src/shared/state/feature-search/featureSearchSlice.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { type FeatureSearchAppName } from 'src/shared/helpers/featureSearchHelpers';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+import type { FeatureSearchAppName } from 'src/shared/helpers/featureSearchHelpers';
 
 type Queries = {
   gene: string;

--- a/src/shared/state/page-meta/pageMetaSlice.ts
+++ b/src/shared/state/page-meta/pageMetaSlice.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 /**
  * Every page should have a title and a description tag.

--- a/src/shared/types/JSON.ts
+++ b/src/shared/types/JSON.ts
@@ -18,8 +18,6 @@ export type PrimitiveValue = string | number | boolean | null | undefined;
 export type ArrayValue = PrimitiveValue[] | JSONValue[];
 export type PrimitiveOrArrayValue = PrimitiveValue | ArrayValue;
 
-type JSONValue = {
+export type JSONValue = {
   [key: string]: PrimitiveOrArrayValue | JSONValue;
 };
-
-export default JSONValue;

--- a/src/shared/types/core-api/product.ts
+++ b/src/shared/types/core-api/product.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { ExternalReference } from './externalReference';
-import { LocationWithinRegion } from './location';
-import { Sequence } from './sequence';
-import { Source } from './source';
+import type { ExternalReference } from './externalReference';
+import type { LocationWithinRegion } from './location';
+import type { Sequence } from './sequence';
+import type { Source } from './source';
 
 export enum ProductType {
   PROTEIN = 'Protein'

--- a/src/shared/types/core-api/transcript.ts
+++ b/src/shared/types/core-api/transcript.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { Slice } from './slice';
-import { SplicedExon } from './exon';
-import { FullProductGeneratingContext } from './productGeneratingContext';
-import { LocationWithinRegion } from './location';
-import { ExternalReference } from './externalReference';
-import { TranscriptMetadata } from './metadata';
-import { FullGene } from './gene';
+import type { Slice } from './slice';
+import type { SplicedExon } from './exon';
+import type { FullProductGeneratingContext } from './productGeneratingContext';
+import type { LocationWithinRegion } from './location';
+import type { ExternalReference } from './externalReference';
+import type { TranscriptMetadata } from './metadata';
+import type { FullGene } from './gene';
 
 export type FullTranscript = {
   type: 'Transcript';

--- a/src/shared/types/focus-object/focusObjectTypes.ts
+++ b/src/shared/types/focus-object/focusObjectTypes.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Strand } from 'src/shared/types/core-api/strand';
+import type { Strand } from 'src/shared/types/core-api/strand';
 
 export type FocusObjectLocation = {
   chromosome: string;


### PR DESCRIPTION
## Description
After an update, warnings started showing up about the missing `type` import annotations. This PR addresses these warnings.

## Deployment URL(s)
http://fix-type-imports.review.ensembl.org