### PR TITLE
Add healthcheck endpoint and opentelemetry endpoint for collecting metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@ensembl/ensembl-elements-common": "0.0.5",
         "@ensembl/ensembl-genome-browser": "0.6.14",
         "@ensembl/ensembl-structural-variants": "0.0.11",
+        "@prometheus-io/client": "0.16.1",
         "@reduxjs/toolkit": "2.12.0",
         "@sentry/browser": "10.73.0",
         "classnames": "2.5.1",
@@ -4960,19 +4961,6 @@
         "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
-      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -5035,6 +5023,15 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
       "version": "0.127.0",
@@ -5959,6 +5956,19 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@prometheus-io/client": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@prometheus-io/client/-/client-0.16.1.tgz",
+      "integrity": "sha512-XkFPsGFGoSs/UMg/vh0QLDpanl/tsrOV5PLHdpGe8Ho+ir/Llhytr15j6y8ZwLrpIGzK9gTVVpIalA6C4UjUZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^22 || ^24 || >=26"
+      }
     },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.12.0",
@@ -12675,6 +12685,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.3.0",
@@ -25172,6 +25188,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.3.tgz",
+      "integrity": "sha512-zbRt+lT+/H4fRItHshczHErVCQnitJk8MfMT24MqFJf3YL7SJJPqGIGeuOdvxXxM/AHFzKBl7WoyaYwqO9s3Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/temp-dir": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@ensembl/ensembl-elements-common": "0.0.5",
     "@ensembl/ensembl-genome-browser": "0.6.14",
     "@ensembl/ensembl-structural-variants": "0.0.11",
+    "@prometheus-io/client": "0.16.1",
     "@reduxjs/toolkit": "2.12.0",
     "@sentry/browser": "10.73.0",
     "classnames": "2.5.1",

--- a/src/server/middleware/requestMetricsMiddleware.ts
+++ b/src/server/middleware/requestMetricsMiddleware.ts
@@ -1,0 +1,72 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Counter, Histogram } from '@prometheus-io/client';
+import type { NextFunction, Request, Response } from 'express';
+
+import { HEALTHCHECK_URL_PATH } from '../routes/healthcheckRouter';
+import { METRICS_URL_PATH } from '../routes/metricsRouter';
+
+const httpRequestsTotal = new Counter({
+  name: 'http_requests_total',
+  help: 'Total number of HTTP requests',
+  labelNames: ['method', 'route', 'status_code']
+});
+
+const httpRequestDurationSeconds = new Histogram({
+  name: 'http_request_duration_seconds',
+  help: 'HTTP request duration in seconds',
+  labelNames: ['method', 'route', 'status_code'],
+  buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5]
+});
+
+// Do not collect metrics from utility paths
+const ignoredMetricPaths = new Set([HEALTHCHECK_URL_PATH, METRICS_URL_PATH]);
+
+const getRouteTemplate = (req: Request) => {
+  const fullPathname = req.baseUrl + req.path;
+  const [first, second] = fullPathname.split('/');
+  return [first, second].filter((part) => Boolean(part)).join('/');
+};
+
+const requestMetricsMiddleware = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  if (ignoredMetricPaths.has(req.path)) {
+    next();
+    return;
+  }
+
+  const endRequestTimer = httpRequestDurationSeconds.startTimer();
+
+  res.on('finish', () => {
+    const route = getRouteTemplate(req);
+    const labels = {
+      method: req.method,
+      route,
+      status_code: String(res.statusCode)
+    };
+
+    httpRequestsTotal.inc(labels);
+    endRequestTimer(labels);
+  });
+
+  next();
+};
+
+export default requestMetricsMiddleware;

--- a/src/server/routes/healthcheckRouter.ts
+++ b/src/server/routes/healthcheckRouter.ts
@@ -1,0 +1,33 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Router } from 'express';
+
+const router = Router();
+
+/**
+ * So far, ensembl-client doesn't have a distinction
+ * between liveness and readiness probes;
+ * so both can be achieved via the same endpoint.
+ */
+
+export const HEALTHCHECK_URL_PATH = '/healthcheck';
+
+router.get(HEALTHCHECK_URL_PATH, (_, res) => {
+  res.send('All good');
+});
+
+export default router;

--- a/src/server/routes/metricsRouter.ts
+++ b/src/server/routes/metricsRouter.ts
@@ -1,0 +1,40 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Router } from 'express';
+import { collectDefaultMetrics, register } from '@prometheus-io/client';
+
+let defaultMetricsInitialized = false;
+
+if (!defaultMetricsInitialized) {
+  collectDefaultMetrics({ register });
+  defaultMetricsInitialized = true;
+}
+
+const router = Router();
+
+export const METRICS_URL_PATH = '/metrict';
+
+router.get(METRICS_URL_PATH, async (_req, res, next) => {
+  try {
+    res.setHeader('Content-Type', register.contentType);
+    res.send(await register.metrics());
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/src/server/routes/metricsRouter.ts
+++ b/src/server/routes/metricsRouter.ts
@@ -26,7 +26,7 @@ if (!defaultMetricsInitialized) {
 
 const router = Router();
 
-export const METRICS_URL_PATH = '/metrict';
+export const METRICS_URL_PATH = '/metrics';
 
 router.get(METRICS_URL_PATH, async (_req, res, next) => {
   try {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -18,11 +18,14 @@ import express from 'express';
 import morgan from 'morgan';
 
 import createProxyMiddleware from './middleware/proxyMiddleware';
+import requestMetricsMiddleware from './middleware/requestMetricsMiddleware';
 import staticMiddleware from './middleware/staticMiddleware';
 import redirectMiddleware from './middleware/redirectMiddleware';
 
 import getConfigForServer from './helpers/getConfigForServer';
 
+import healthcheckRouter from './routes/healthcheckRouter';
+import metricsRouter from './routes/metricsRouter';
 import viewsRouter from './routes/viewsRouter';
 import unsupportedBrowserRouter from './routes/unsupportedBrowserRouter';
 import seoRouter from './routes/seoRouter';
@@ -32,6 +35,7 @@ const serverConfig = getConfigForServer();
 
 app.disable('x-powered-by'); // no need to announce to the world that we are running on Express
 app.use(morgan('combined'));
+app.use(requestMetricsMiddleware);
 
 if (!serverConfig.isEnsemblDeployment) {
   const proxyMiddleware = createProxyMiddleware();
@@ -44,6 +48,8 @@ if (!serverConfig.isEnsemblDeployment) {
   }
 }
 
+app.use(healthcheckRouter);
+app.use(metricsRouter);
 app.use(redirectMiddleware);
 app.use(seoRouter);
 


### PR DESCRIPTION
## Description
- Add healthcheck endpoint to use as readiness and liveness probe
- Add opentelemetry metrics endpoint for prometheus

## Deployment URL(s)
http://try-prometheus.review.ensembl.org