### PR TITLE
Fix 500 error on missing transcript pages

### DIFF
--- a/src/content/app/entity-viewer/EntityViewerForTranscript.tsx
+++ b/src/content/app/entity-viewer/EntityViewerForTranscript.tsx
@@ -14,14 +14,21 @@
  * limitations under the License.
  */
 
+import { useNavigate } from 'react-router';
+
 import { useAppSelector, useAppDispatch } from 'src/store';
+
+import * as urlFor from 'src/shared/helpers/urlHelper';
 
 import { getBreakpointWidth } from 'src/global/globalSelectors';
 
 import useTranscriptViewIds from 'src/content/app/entity-viewer/transcript-view/hooks/useTranscriptViewIds';
+import { useDefaultEntityViewerTranscriptQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
 
 import { getIsSidebarOpen } from 'src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSelectors';
+import { getGenomeById } from 'src/shared/state/genome/genomeSelectors';
 
+import { deleteActiveEntityIdAndSave } from 'src/content/app/entity-viewer/state/general/entityViewerGeneralSlice';
 import { toggleSidebar } from 'src/content/app/entity-viewer/state/transcript-view/sidebar/transcriptViewSidebarSlice';
 
 import { StandardAppLayout } from 'src/shared/components/layout';
@@ -30,14 +37,30 @@ import TranscriptView from './transcript-view/TranscriptView';
 import TranscriptViewSidebar from './transcript-view/components/transcript-view-sidebar/TranscriptViewSidebar';
 import TranscriptViewSidebarTabs from './transcript-view/components/transcript-view-sidebar-tabs/TranscriptViewSidebarTabs';
 import SidebarToolstrip from './transcript-view/components/transcript-view-sidebar/sidebar-toolstrip/SidebarToolstrip';
+import MissingFeatureError from 'src/shared/components/error-screen/url-errors/MissingFeatureError';
 
 const EntityViewerForTranscript = () => {
-  const { activeGenomeId, transcriptId } = useTranscriptViewIds();
+  const { activeGenomeId, genomeIdForUrl, transcriptId } =
+    useTranscriptViewIds();
   const isSidebarOpen = useAppSelector((state) =>
     getIsSidebarOpen(state, activeGenomeId ?? '', transcriptId ?? '')
   );
+  const genome = useAppSelector((state) =>
+    getGenomeById(state, activeGenomeId ?? '')
+  );
   const viewportWidth = useAppSelector(getBreakpointWidth);
   const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+
+  const { isFetching, isError } = useDefaultEntityViewerTranscriptQuery(
+    {
+      genomeId: activeGenomeId || '',
+      transcriptId: transcriptId || ''
+    },
+    {
+      skip: !activeGenomeId || !transcriptId
+    }
+  );
 
   const onSidebarToggle = () => {
     if (!activeGenomeId || !transcriptId) {
@@ -51,6 +74,26 @@ const EntityViewerForTranscript = () => {
       })
     );
   };
+
+  const openEntityViewerInterstitial = () => {
+    dispatch(deleteActiveEntityIdAndSave());
+    navigate(urlFor.entityViewer({ genomeId: genomeIdForUrl }));
+  };
+
+  if (isFetching) {
+    return null;
+  }
+
+  if (isError) {
+    return (
+      <MissingFeatureError
+        featureId={transcriptId as string}
+        genome={genome}
+        showTopBar={true}
+        onContinue={openEntityViewerInterstitial}
+      />
+    );
+  }
 
   return (
     <StandardAppLayout

--- a/src/content/app/entity-viewer/shared/server-fetch/entityViewerServerFetch.ts
+++ b/src/content/app/entity-viewer/shared/server-fetch/entityViewerServerFetch.ts
@@ -46,7 +46,10 @@ export const serverFetch: ServerFetch = async (params) => {
   const dispatch: AppDispatch = store.dispatch;
   const { genomeId: genomeIdFromUrl, entityId } = getPathParameters<
     'genomeId' | 'entityId'
-  >(['/feature-explorer/:genomeId', '/feature-explorer/:genomeId/:entityId'], path);
+  >(
+    ['/feature-explorer/:genomeId', '/feature-explorer/:genomeId/:entityId'],
+    path
+  );
 
   // If the url is just /feature-explorer, update page meta and exit
   if (!genomeIdFromUrl) {
@@ -187,7 +190,7 @@ const fetchTranscriptData = async ({
   pageMetaPromise.unsubscribe();
 
   if (pageMetaQueryResult?.error) {
-    if ((pageMetaQueryResult.error as any)?.meta?.data?.gene === null) {
+    if ((pageMetaQueryResult.error as any)?.meta?.data?.transcript === null) {
       // this is graphql's way of telling us that there is no such transcript
       throw new NotFoundError();
     } else {

--- a/src/shared/components/error-screen/url-errors/MissingFeatureError.tsx
+++ b/src/shared/components/error-screen/url-errors/MissingFeatureError.tsx
@@ -47,7 +47,7 @@ const MissingFeatureError = (props: Props) => {
           We do not recognise "{featureId}" in {speciesDisplayName}
         </div>
         <div className={styles.suggestion}>
-          Use Find a gene or the example gene link
+          Search for your feature or use one of the example links
         </div>
         <div className={styles.continueButtonWrapper}>
           <PrimaryButton onClick={onContinue}>Continue</PrimaryButton>


### PR DESCRIPTION
## Description
For missing transcripts, the server responds with a 500 error rather than a 404.

Examples:
- https://dev-2020.ensembl.org/feature-explorer/57bd559e-b255-48ef-9bff-d996d543e6d8/transcript:XM_064355627 — getting a 500 even though expecting a 404 (missing transcript)
- https://dev-2020.ensembl.org/feature-explorer/GCA_036323735.1/transcript:ENSRNOP00000073104

**Before:**

Mostly blank screen and a 500 response in the network tab

<img width="1511" height="951" alt="image" src="https://github.com/user-attachments/assets/28ad3d61-7b43-4627-a866-897fcded1140" />

**After:**

A screen with a message about a missing feature, and a 404 response in the network tab

<img width="757" height="456" alt="image" src="https://github.com/user-attachments/assets/66b6cc76-8e2f-409d-a2c0-56ac3fe43e5c" />



## Deployment URL(s)
- https://transcript-500-err.review.ensembl.org/feature-explorer/57bd559e-b255-48ef-9bff-d996d543e6d8/transcript:XM_064355627
- https://transcript-500-err.review.ensembl.org/feature-explorer/GCA_036323735.1/transcript:ENSRNOP00000073104