### PR TITLE
Remove track trigger dependencies

### DIFF
--- a/src/content/app/genome-browser/components/track-panel/components/track-panel-tabs/TrackPanelTabs.test.tsx
+++ b/src/content/app/genome-browser/components/track-panel/components/track-panel-tabs/TrackPanelTabs.test.tsx
@@ -56,8 +56,7 @@ const mockTrackCategories = {
       type: 'Genomic',
       track_list: [
         {
-          track_id: 'gene-pc-fwd',
-          trigger: ['track', 'gene-pc-fwd']
+          track_id: '238393ed-0f93-45ae-a91e-491b1c3a0b40'
         }
       ]
     }

--- a/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
@@ -207,20 +207,7 @@ const useGenomeBrowser = () => {
   };
 };
 
-/**
- * To toggle a genome browser track or its settings, the client has to generate
- * a "track path" — an array of strings that genome browser will use to identify the track.
- *
- * There are currently two types of genome browser tracks:
- *   - Older tracks with human-readable ids (e.g. protein-coding genes on the forward strand)
- *   - Newer tracks identified by uuids. They are registered by the genome browser
- *     using a mechanism called 'expansion'.
- *
- * Ideally, the client shouldn't know any of this. Ideally, tracks would be identified
- * Track API tracks are all registered through the common expansion node. Focus
- * controls are boot-only and retain their explicit path.
- */
-
+// Focus tracks have a hard-coded identifier path in genome browser.
 const getTrackPath = (trackId: string) => {
   if (trackId === 'focus') {
     return ['track', trackId];

--- a/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowser.ts
@@ -217,23 +217,15 @@ const useGenomeBrowser = () => {
  *     using a mechanism called 'expansion'.
  *
  * Ideally, the client shouldn't know any of this. Ideally, tracks would be identified
- * just by their ids. But, while this is not the case, the client will use a hack
- * as an easy option of generating a track path.
- *
- * The hack is: if track id is uuid-shaped, then it is an "expansion" track
- * that uses one path pattern; and in other cases, it is a "non-expansion" track,
- * which uses a different path pattern.
+ * Track API tracks are all registered through the common expansion node. Focus
+ * controls are boot-only and retain their explicit path.
  */
 
-const uuidRegex =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
 const getTrackPath = (trackId: string) => {
-  if (uuidRegex.test(trackId)) {
-    return ['track', 'expand', trackId];
-  } else {
+  if (trackId === 'focus') {
     return ['track', trackId];
   }
+  return ['track', 'expand', trackId];
 };
 
 export default useGenomeBrowser;

--- a/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
+++ b/src/content/app/genome-browser/hooks/useGenomeBrowserTracks.ts
@@ -236,9 +236,9 @@ const hasGenomicTrackSettings = (
   trackSettings: TrackSettingsPerTrack,
   trackCategories: GenomeTrackCategory[]
 ) => {
-  const firstGenomicTrackId = trackCategories
-    .find((category) => category.track_list.length > 0)
-    ?.track_list[0].trigger.at(-1);
+  const firstGenomicTrackId = trackCategories.find(
+    (category) => category.track_list.length > 0
+  )?.track_list[0].track_id;
 
   return !!firstGenomicTrackId && firstGenomicTrackId in trackSettings;
 };

--- a/src/content/app/genome-browser/state/api/genomeBrowserApiSlice.ts
+++ b/src/content/app/genome-browser/state/api/genomeBrowserApiSlice.ts
@@ -134,25 +134,9 @@ const genomeBrowserRestApiSlice = restApiSlice.injectEndpoints({
         url: `${config.tracksApiBaseUrl}/track_categories/${genomeId}`
       }),
       transformResponse: (response: GenomeTrackCategoriesResponse) => {
-        /**
-         * NOTE: the transformation inside of the map function below is rather disturbing,
-         * and should be replaced with something better.
-         * It is intended to fix the discrepancy between how the genome browser client identifies a track
-         * (it uses the path to the track that triggers the appropriate genome browser program),
-         * and how the track api identifies a track.
-         *
-         * Genome browser will report back to the browser chrome the tracks that it has enabled,
-         * using the ids from the track path (i.e. the last string in track trigger arrays).
-         * Browser chrome needs to be able to recognize these messages and to respond to them appropriately.
-         * For which purpose, we are here redefining track ids as the last string inside of track trigger array.
-         */
-        return response.track_categories.map((category) => ({
-          ...category,
-          track_list: category.track_list.map((track) => ({
-            ...track,
-            track_id: (track.track_id = track.trigger.at(-1) as string)
-          }))
-        }));
+        // Track API UUIDs are the browser and persistence identity for every
+        // visual track. The backend translates the UUID into an expansion.
+        return response.track_categories;
       }
     })
   })

--- a/src/content/app/genome-browser/state/api/genomeBrowserApiSlice.ts
+++ b/src/content/app/genome-browser/state/api/genomeBrowserApiSlice.ts
@@ -134,8 +134,6 @@ const genomeBrowserRestApiSlice = restApiSlice.injectEndpoints({
         url: `${config.tracksApiBaseUrl}/track_categories/${genomeId}`
       }),
       transformResponse: (response: GenomeTrackCategoriesResponse) => {
-        // Track API UUIDs are the browser and persistence identity for every
-        // visual track. The backend translates the UUID into an expansion.
         return response.track_categories;
       }
     })

--- a/src/content/app/genome-browser/state/types/tracks.ts
+++ b/src/content/app/genome-browser/state/types/tracks.ts
@@ -16,33 +16,11 @@
 
 import { TrackSet } from 'src/content/app/genome-browser/components/track-panel/trackPanelConfig';
 
-/**
- * NOTE ON THE TRIGGER FIELD ON THE GenomicTrack TYPE
- *
- * Tracks are stored in genome browser's memory in a tree-like structure,
- * and a trigger is an array that represents the path to a given track node.
- * Sadly, the client needs to be aware of this implementation detail,
- * because it needs to use this trigger to toggle a track, or its settings
- * (which are represented as tree nodes inside the track node) on and off.
- *
- * The contents of a trigger array for a given track are vaguely predictable,
- * but not certain. For some tracks, the trigger to toggle the track on/off
- * will be ["track", track_id]. For other tracks, it will be ["track", expansion_node, track_id].
- * Since there is no way for the client to know which is which, it has
- * to rely on track api to tell it.
- *
- * The content of trigger arrays for track settings is predictable,
- * and consist of the contents of the track trigger followed by
- * the name of the setting. Thus, triggers for settings can be generated
- * on the client.
- */
-
 type GenomicTrackType = 'gene' | 'variant' | 'regular';
 
 export type GenomicTrack = {
   track_id: string;
   type: GenomicTrackType;
-  trigger: string[]; // <-- see the note about triggers above
   label: string;
   additional_info: string;
   description: string;

--- a/tests/fixtures/genomes.ts
+++ b/tests/fixtures/genomes.ts
@@ -46,8 +46,7 @@ export const createGenomeCategories = (): GenomeTrackCategory[] => [
 
 const createTrack = (): GenomicTrack => {
   return {
-    track_id: 'gene-pc-fwd',
-    trigger: ['track', 'gene-pc-fwd'],
+    track_id: '238393ed-0f93-45ae-a91e-491b1c3a0b40',
     type: 'gene',
     additional_info: faker.lorem.words(),
     label: faker.lorem.words(),


### PR DESCRIPTION
## Description
This PR removes the dependency on track "trigger" values, instead using track IDs for identifying all tracks.
Depends on the backend update in [this PR](https://github.com/Ensembl/ensembl-dauphin-style-compiler/pull/154).


## Related JIRA Issue(s)
[ENSWBSITES-2404](https://embl.atlassian.net/browse/ENSWBSITES-2404)

## Deployment URL(s)
http://migrate-legacy-tracks.review.ensembl.org


## Views affected
All genome browser tracks