### PR TITLE
Add a tab for transcripts table to FeatureExplorer gene view

### DIFF
--- a/src/content/app/entity-viewer/gene-view/GeneView.tsx
+++ b/src/content/app/entity-viewer/gene-view/GeneView.tsx
@@ -50,6 +50,7 @@ import GeneOverviewImage from './components/gene-overview-image/GeneOverviewImag
 import DefaultTranscriptsList from './components/default-transcripts-list/DefaultTranscriptsList';
 import GeneViewTabs from './components/gene-view-tabs/GeneViewTabs';
 import TranscriptsFilter from 'src/content/app/entity-viewer/gene-view/components/transcripts-filter/TranscriptsFilter';
+import GeneTranscriptsTable from './components/gene-transcripts-table/GeneTranscriptsTable';
 import GeneFunction from 'src/content/app/entity-viewer/gene-view/components/gene-function/GeneFunction';
 import GeneRelationships from 'src/content/app/entity-viewer/gene-view/components/gene-relationships/GeneRelationships';
 import ViewInApp from 'src/shared/components/view-in-app/ViewInApp';
@@ -213,6 +214,10 @@ const GeneViewWithData = (props: GeneViewWithDataProps) => {
           rulerTicks && (
             <DefaultTranscriptsList gene={props.gene} rulerTicks={rulerTicks} />
           )}
+
+        {selectedTabs.primaryTab === GeneViewTabName.TRANSCRIPTS_TABLE && (
+          <GeneTranscriptsTable />
+        )}
 
         {selectedTabs.primaryTab === GeneViewTabName.GENE_FUNCTION && (
           <GeneFunction gene={props.gene} />

--- a/src/content/app/entity-viewer/gene-view/components/gene-transcripts-table/GeneTranscriptsTable.module.css
+++ b/src/content/app/entity-viewer/gene-view/components/gene-transcripts-table/GeneTranscriptsTable.module.css
@@ -15,25 +15,25 @@
 
 /* contains the table and control elements above it */
 .container {
-  container-type: inline-size;
   display: grid;
   grid-template-rows: auto 1fr;
   height: 100%;
   width: 100%;
-  height: 100%;
+  max-width: max-content;
   row-gap: calc(var(--standard-gutter) / 2);
   padding-top: calc(var(--standard-gutter) / 2);
 }
 
 .tableWrapper {
   height: 100%;
-  width: 100cqi;
+  width: fit-content;
   overflow: auto;
 }
 
 .controlsSection {
   display: flex;
   justify-content: flex-end;
+  padding-right: 16px;
 }
 
 .table {

--- a/src/content/app/entity-viewer/gene-view/components/gene-transcripts-table/GeneTranscriptsTable.module.css
+++ b/src/content/app/entity-viewer/gene-view/components/gene-transcripts-table/GeneTranscriptsTable.module.css
@@ -1,0 +1,60 @@
+.panelBody {
+  color: var(--color-black);
+}
+
+.panelHead {
+  position: sticky;
+  top: -5px;
+  color: var(--color-black);
+  padding: 0 var(--standard-gutter);
+}
+
+.selectedTab {
+  font-weight: var(--font-weight-bold);
+}
+
+/* contains the table and control elements above it */
+.container {
+  container-type: inline-size;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  height: 100%;
+  width: 100%;
+  height: 100%;
+  row-gap: calc(var(--standard-gutter) / 2);
+  padding-top: calc(var(--standard-gutter) / 2);
+}
+
+.tableWrapper {
+  height: 100%;
+  width: 100cqi;
+  overflow: auto;
+}
+
+.controlsSection {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.table {
+  --table-height: calc(100% - 28px); /* the calc is a hack: apparently, the data table isn't laid out as a grid, so the height of the table portion isn't calculated automatically */
+  height: 100%;
+  margin-left: var(--standard-gutter);
+  margin-bottom: var(--global-padding-bottom);
+}
+
+.table tr {
+  background-color: var(--color-white);
+}
+
+.table td {
+  vertical-align: top;
+}
+
+.transcriptFlags {
+  --info-pill-color: var(--color-dark-grey);
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: 1ch;
+  row-gap: 0.6rem;
+}

--- a/src/content/app/entity-viewer/gene-view/components/gene-transcripts-table/GeneTranscriptsTable.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-transcripts-table/GeneTranscriptsTable.tsx
@@ -20,7 +20,7 @@ import * as urlFor from 'src/shared/helpers/urlHelper';
 
 import useGeneViewIds from 'src/content/app/entity-viewer/gene-view/hooks/useGeneViewIds';
 
-import { useDefaultEntityViewerGeneQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
+import { useDefaultEntityViewerGeneWithAllTranscriptsQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
 
 import { formatNumber } from 'src/shared/helpers/formatters/numberFormatter';
 import {
@@ -69,16 +69,16 @@ const GeneTranscriptsTable = () => {
 const MainContent = () => {
   const { activeGenomeId, geneId, genomeIdForUrl } = useGeneViewIds();
 
-  // FIXME: change the query to load all gene transcripts
-  const { currentData, isFetching } = useDefaultEntityViewerGeneQuery(
-    {
-      geneId: geneId as string,
-      genomeId: activeGenomeId as string
-    },
-    {
-      skip: !geneId || !activeGenomeId
-    }
-  );
+  const { currentData, isFetching } =
+    useDefaultEntityViewerGeneWithAllTranscriptsQuery(
+      {
+        geneId: geneId as string,
+        genomeId: activeGenomeId as string
+      },
+      {
+        skip: !geneId || !activeGenomeId
+      }
+    );
 
   if (isFetching) {
     return <CircleLoader />;

--- a/src/content/app/entity-viewer/gene-view/components/gene-transcripts-table/GeneTranscriptsTable.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-transcripts-table/GeneTranscriptsTable.tsx
@@ -1,0 +1,281 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState } from 'react';
+
+import * as urlFor from 'src/shared/helpers/urlHelper';
+
+import useGeneViewIds from 'src/content/app/entity-viewer/gene-view/hooks/useGeneViewIds';
+
+import { useDefaultEntityViewerGeneQuery } from 'src/content/app/entity-viewer/state/api/entityViewerThoasSlice';
+
+import { formatNumber } from 'src/shared/helpers/formatters/numberFormatter';
+import {
+  isProteinCodingTranscript,
+  getSplicedRNALength,
+  getProductAminoAcidLength
+} from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
+import { buildFocusIdForUrl } from 'src/shared/helpers/focusObjectHelpers';
+import {
+  getCCDSXref,
+  getNCBITranscriptData,
+  getTranscriptBiotype,
+  getTranscriptFlags,
+  getUniprotXref
+} from './transcriptTableHelpers';
+import { downloadTextAsFile } from 'src/shared/helpers/downloadAsFile';
+import { getDownloadableTranscriptTable } from './geneTranscriptsTableDownload';
+
+import { Panel, PanelHead, PanelBody } from 'src/shared/components/panel/Panel';
+import { Table, ColumnHead } from 'src/shared/components/table';
+import { CircleLoader } from 'src/shared/components/loader';
+import ExternalLink from 'src/shared/components/external-link/ExternalLink';
+import InfoPill from 'src/shared/components/info-pill/InfoPill';
+import ViewInAppPopup from 'src/shared/components/view-in-app-popup/ViewInAppPopup';
+import { ControlledDownloadButton } from 'src/shared/components/download-button/DownloadButton';
+
+import { LoadingState } from 'src/shared/types/loading-state';
+
+import type { DefaultEntityViewerTranscript } from 'src/content/app/entity-viewer/state/api/queries/defaultGeneQuery';
+
+import styles from './GeneTranscriptsTable.module.css';
+
+const GeneTranscriptsTable = () => {
+  return (
+    <Panel>
+      <PanelHead className={styles.panelHead}>
+        <span className={styles.selectedTab}>Proteins</span>
+      </PanelHead>
+      <PanelBody className={styles.panelBody}>
+        <MainContent />
+      </PanelBody>
+    </Panel>
+  );
+};
+
+const MainContent = () => {
+  const { activeGenomeId, geneId, genomeIdForUrl } = useGeneViewIds();
+
+  // FIXME: change the query to load all gene transcripts
+  const { currentData, isFetching } = useDefaultEntityViewerGeneQuery(
+    {
+      geneId: geneId as string,
+      genomeId: activeGenomeId as string
+    },
+    {
+      skip: !geneId || !activeGenomeId
+    }
+  );
+
+  if (isFetching) {
+    return <CircleLoader />;
+  }
+  if (!currentData) {
+    return null;
+  }
+
+  const gene = currentData.gene;
+  const transcripts = gene.transcripts;
+
+  return (
+    <div className={styles.container}>
+      <ControlsSection geneId={gene.stable_id} transcripts={transcripts} />
+      <div className={styles.tableWrapper}>
+        <Table stickyHeader={true} className={styles.table}>
+          <thead>
+            <tr>
+              <ColumnHead>Transcript</ColumnHead>
+              <ColumnHead>cDNA length</ColumnHead>
+              <ColumnHead>Protein length</ColumnHead>
+              <ColumnHead>Biotype</ColumnHead>
+              <ColumnHead>CCDS</ColumnHead>
+              <ColumnHead>UniProt match</ColumnHead>
+              <ColumnHead>RefSeq match</ColumnHead>
+              <ColumnHead>Flags</ColumnHead>
+            </tr>
+          </thead>
+          <tbody>
+            {transcripts.map((transcript) => (
+              <tr key={transcript.stable_id}>
+                <td>
+                  <TranscriptStableId
+                    genomeIdForUrl={genomeIdForUrl as string}
+                    transcriptId={transcript.stable_id}
+                  />
+                </td>
+                <td>{formatNumber(getSplicedRNALength(transcript))}</td>
+                <td>
+                  {isProteinCodingTranscript(transcript)
+                    ? formatNumber(getProductAminoAcidLength(transcript))
+                    : '—'}
+                </td>
+                <td>{getTranscriptBiotype(transcript)}</td>
+                <td>
+                  <CCDSLink transcript={transcript} />
+                </td>
+                <td>
+                  <UniprotLink transcript={transcript} />
+                </td>
+                <td>
+                  <RefSeqLink transcript={transcript} />
+                </td>
+                <td>
+                  <TranscriptFlags transcript={transcript} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      </div>
+    </div>
+  );
+};
+
+const ControlsSection = ({
+  transcripts,
+  geneId
+}: {
+  geneId: string;
+  transcripts: DefaultEntityViewerTranscript[];
+}) => {
+  const [buttonStatus, setButtonStatus] = useState(LoadingState.NOT_REQUESTED);
+  const fileName = `${geneId} transcripts.csv`;
+
+  const onDownloadClick = () => {
+    const tableCSV = getDownloadableTranscriptTable({ transcripts });
+
+    downloadTextAsFile(tableCSV, fileName);
+    setButtonStatus(LoadingState.SUCCESS);
+
+    setTimeout(() => {
+      setButtonStatus(LoadingState.NOT_REQUESTED);
+    }, 1000);
+  };
+
+  return (
+    <div className={styles.controlsSection}>
+      <ControlledDownloadButton
+        onClick={onDownloadClick}
+        status={buttonStatus}
+      />
+    </div>
+  );
+};
+
+const TranscriptStableId = ({
+  genomeIdForUrl,
+  transcriptId
+}: {
+  genomeIdForUrl: string;
+  transcriptId: string;
+}) => {
+  const focusIdForUrl = buildFocusIdForUrl({
+    type: 'transcript',
+    objectId: transcriptId
+  });
+
+  const genomeBrowserUrl = urlFor.browser({
+    genomeId: genomeIdForUrl,
+    focus: focusIdForUrl
+  });
+
+  const featureExplorerUrl = urlFor.entityViewer({
+    genomeId: genomeIdForUrl,
+    entityId: focusIdForUrl
+  });
+
+  return (
+    <ViewInAppPopup
+      links={{
+        genomeBrowser: {
+          url: genomeBrowserUrl
+        },
+        entityViewer: {
+          url: featureExplorerUrl
+        }
+      }}
+    >
+      {transcriptId}
+    </ViewInAppPopup>
+  );
+};
+
+const CCDSLink = ({
+  transcript
+}: {
+  transcript: Pick<DefaultEntityViewerTranscript, 'external_references'>;
+}) => {
+  const data = getCCDSXref(transcript);
+  if (!data?.url) {
+    return '—';
+  }
+
+  return (
+    <ExternalLink to={data.url} nowrap={true}>
+      <span className={styles.externalRefLink}>{data.accession_id}</span>
+    </ExternalLink>
+  );
+};
+
+const UniprotLink = ({
+  transcript
+}: {
+  transcript: Parameters<typeof getUniprotXref>[0];
+}) => {
+  const data = getUniprotXref(transcript);
+  if (!data?.url) {
+    return '—';
+  }
+
+  return (
+    <ExternalLink to={data.url} nowrap={true}>
+      <span className={styles.externalRefLink}>{data.accession_id}</span>
+    </ExternalLink>
+  );
+};
+
+const RefSeqLink = ({
+  transcript
+}: {
+  transcript: Parameters<typeof getNCBITranscriptData>[0];
+}) => {
+  const ncbiTranscript = getNCBITranscriptData(transcript);
+  if (!ncbiTranscript?.url) {
+    return '—';
+  }
+
+  return (
+    <ExternalLink to={ncbiTranscript.url} nowrap={true}>
+      <span className={styles.externalRefLink}>{ncbiTranscript.id}</span>
+    </ExternalLink>
+  );
+};
+
+const TranscriptFlags = ({
+  transcript
+}: {
+  transcript: Pick<DefaultEntityViewerTranscript, 'metadata'>;
+}) => {
+  const flags = getTranscriptFlags(transcript);
+
+  const flagElements = flags.map((flag) => (
+    <InfoPill key={flag}>{flag}</InfoPill>
+  ));
+
+  return <div className={styles.transcriptFlags}>{flagElements}</div>;
+};
+
+export default GeneTranscriptsTable;

--- a/src/content/app/entity-viewer/gene-view/components/gene-transcripts-table/GeneTranscriptsTable.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-transcripts-table/GeneTranscriptsTable.tsx
@@ -57,7 +57,7 @@ const GeneTranscriptsTable = () => {
   return (
     <Panel>
       <PanelHead className={styles.panelHead}>
-        <span className={styles.selectedTab}>Proteins</span>
+        <span className={styles.selectedTab}>All transcripts</span>
       </PanelHead>
       <PanelBody className={styles.panelBody}>
         <MainContent />

--- a/src/content/app/entity-viewer/gene-view/components/gene-transcripts-table/geneTranscriptsTableDownload.ts
+++ b/src/content/app/entity-viewer/gene-view/components/gene-transcripts-table/geneTranscriptsTableDownload.ts
@@ -1,0 +1,70 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  getSplicedRNALength,
+  getProductAminoAcidLength
+} from 'src/content/app/entity-viewer/shared/helpers/entity-helpers';
+import {
+  getCCDSXref,
+  getNCBITranscriptData,
+  getTranscriptBiotype,
+  getTranscriptFlags,
+  getUniprotXref
+} from './transcriptTableHelpers';
+import { formatCSV } from 'src/shared/helpers/formatters/tabularFileFormatter';
+
+import type { DefaultEntityViewerTranscript } from 'src/content/app/entity-viewer/state/api/queries/defaultGeneQuery';
+
+export const getDownloadableTranscriptTable = ({
+  transcripts
+}: {
+  transcripts: DefaultEntityViewerTranscript[];
+}) => {
+  const tableHead = [
+    'Transcript',
+    'cDNA length',
+    'Protein length',
+    'Biotype',
+    'CCDS',
+    'UniProt match',
+    'RefSeq match',
+    'Flags'
+  ];
+
+  const rows = transcripts.map((transcript) => {
+    const ccdsXref = getCCDSXref(transcript);
+    const uniprotXref = getUniprotXref(transcript);
+    const ncbiTranscript = getNCBITranscriptData(transcript);
+    const transcriptFlags = getTranscriptFlags(transcript).join(', ');
+    const escapedTranscriptFlagsString = transcriptFlags
+      ? `"${transcriptFlags}"`
+      : '';
+
+    return [
+      transcript.stable_id,
+      getSplicedRNALength(transcript),
+      getProductAminoAcidLength(transcript),
+      getTranscriptBiotype(transcript),
+      ccdsXref?.accession_id ?? '-',
+      uniprotXref?.accession_id ?? '-',
+      ncbiTranscript?.id ?? '-',
+      escapedTranscriptFlagsString
+    ];
+  });
+
+  return formatCSV([tableHead, ...rows]);
+};

--- a/src/content/app/entity-viewer/gene-view/components/gene-transcripts-table/transcriptTableHelpers.ts
+++ b/src/content/app/entity-viewer/gene-view/components/gene-transcripts-table/transcriptTableHelpers.ts
@@ -1,0 +1,84 @@
+/**
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Pick2, Pick3 } from 'ts-multipick';
+
+import type {
+  DefaultEntityViewerTranscript,
+  ExternalReferenceInProduct
+} from 'src/content/app/entity-viewer/state/api/queries/defaultGeneQuery';
+
+export const getTranscriptBiotype = (
+  transcript: Pick3<
+    DefaultEntityViewerTranscript,
+    'metadata',
+    'biotype',
+    'label'
+  >
+) => {
+  return transcript.metadata.biotype.label;
+};
+
+export const getCCDSXref = (
+  transcript: Pick<DefaultEntityViewerTranscript, 'external_references'>
+) => {
+  return transcript.external_references.find(
+    (xref) => xref.source.name === 'CCDS'
+  );
+};
+
+export const getNCBITranscriptData = (
+  transcript: Pick2<DefaultEntityViewerTranscript, 'metadata', 'mane'>
+) => {
+  return transcript.metadata.mane?.ncbi_transcript;
+};
+
+export const getUniprotXref = (transcript: {
+  product_generating_contexts: Array<{
+    product_type: string;
+    product: {
+      external_references: ExternalReferenceInProduct[];
+    } | null;
+  }>;
+}) => {
+  const productGeneratingContext = transcript.product_generating_contexts.find(
+    (context) => context.product_type === 'product'
+  );
+  if (!productGeneratingContext) {
+    return null;
+  }
+  const xrefs = productGeneratingContext.product!.external_references;
+  return xrefs.find((xref) => xref.source.id === 'Uniprot/SWISSPROT');
+};
+
+export const getTranscriptFlags = (
+  transcript: Pick<DefaultEntityViewerTranscript, 'metadata'>
+) => {
+  const isCanonical = !!transcript.metadata.canonical?.value;
+  const canonicalLabel = isCanonical ? 'Ensembl canonical' : undefined;
+  const maneLabel = transcript.metadata.mane?.label;
+  const gencodeBasicLabel = transcript.metadata.gencode_basic?.label;
+  const apprisLabel = transcript.metadata.appris?.label;
+  const tslLabel = transcript.metadata.tsl?.label;
+
+  return [
+    canonicalLabel,
+    maneLabel,
+    gencodeBasicLabel,
+    apprisLabel,
+    tslLabel
+  ].filter((label) => !!label) as string[];
+};

--- a/src/content/app/entity-viewer/gene-view/components/gene-view-tabs/GeneViewTabs.tsx
+++ b/src/content/app/entity-viewer/gene-view/components/gene-view-tabs/GeneViewTabs.tsx
@@ -36,6 +36,7 @@ import styles from './GeneViewTabs.module.css';
 
 const tabsData: Tab[] = [
   { title: 'Transcripts' },
+  { title: 'Transcripts table' },
   { title: 'Gene function' },
   { title: 'Gene relationships' }
 ];
@@ -64,7 +65,9 @@ const GeneViewTabs = (props: Props) => {
 
   const onTabChange = (selectedTabName: string) => {
     let view = View.TRANSCRIPTS;
-    if (selectedTabName === GeneViewTabName.GENE_FUNCTION) {
+    if (selectedTabName === GeneViewTabName.TRANSCRIPTS_TABLE) {
+      view = View.TRANSCRIPTS_TABLE;
+    } else if (selectedTabName === GeneViewTabName.GENE_FUNCTION) {
       view = selectedTabViews?.geneFunctionTab || View.PROTEIN;
     } else if (selectedTabName === GeneViewTabName.GENE_RELATIONSHIPS) {
       view = selectedTabViews?.geneRelationshipsTab || View.HOMOLOGY;

--- a/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
+++ b/src/content/app/entity-viewer/state/api/entityViewerThoasSlice.ts
@@ -27,6 +27,7 @@ import {
 } from './queries/genePageMetaQuery';
 import {
   defaultGeneQuery,
+  defaultGeneWithAllTranscriptsQuery,
   type DefaultEntityViewerGeneQueryResult,
   type DefaultEntityViewerGeneWithTranscriptsPage
 } from './queries/defaultGeneQuery';
@@ -138,6 +139,16 @@ const entityViewerThoasSlice = graphqlApiSlice.injectEndpoints({
       }) => {
         return transformGeneInResponse(response);
       }
+    }),
+    defaultEntityViewerGeneWithAllTranscripts: builder.query<
+      DefaultEntityViewerGeneQueryResult,
+      GeneQueryParams
+    >({
+      query: (params) => ({
+        url: config.coreApiUrl,
+        body: defaultGeneWithAllTranscriptsQuery,
+        variables: params
+      })
     }),
     geneSummary: builder.query<GeneSummaryQueryResult, GeneQueryParams>({
       query: (params) => ({
@@ -374,6 +385,7 @@ const addAlleleUrlId = <
 export const {
   useGenePageMetaQuery,
   useDefaultEntityViewerGeneQuery,
+  useDefaultEntityViewerGeneWithAllTranscriptsQuery,
   useGeneSummaryQuery,
   useGeneOverviewQuery,
   useGeneExternalReferencesQuery,

--- a/src/content/app/entity-viewer/state/api/queries/defaultGeneQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/defaultGeneQuery.ts
@@ -161,6 +161,34 @@ export const defaultGeneQuery = gql`
   ${transcriptFieldsFragment}
 `;
 
+// Instead of requesting transcripts in pages, as defaultGeneQuery does,
+// this query requests all gene transcripts at once
+// TODO: extract gene fields (shared with defaultGeneQuery) into a fragment?
+export const defaultGeneWithAllTranscriptsQuery = gql`
+  query DefaultEntityViewerGene($genomeId: String!, $geneId: String!) {
+    gene(by_id: { genome_id: $genomeId, stable_id: $geneId }) {
+      stable_id
+      symbol
+      unversioned_stable_id
+      version
+      slice {
+        location {
+          start
+          end
+          length
+        }
+        strand {
+          code
+        }
+      }
+      transcripts {
+        ...transcriptFields
+      }
+    }
+  }
+  ${transcriptFieldsFragment}
+`;
+
 type GeneFields = Pick<
   FullGene,
   'stable_id' | 'unversioned_stable_id' | 'symbol' | 'version'

--- a/src/content/app/entity-viewer/state/api/queries/defaultGeneQuery.ts
+++ b/src/content/app/entity-viewer/state/api/queries/defaultGeneQuery.ts
@@ -83,6 +83,7 @@ export const transcriptFieldsFragment = gql`
           accession_id
           name
           description
+          url
           source {
             id
           }
@@ -188,9 +189,9 @@ type ProductOnDefaultTranscript = Pick<
   external_references: ExternalReferenceInProduct[];
 };
 
-type ExternalReferenceInProduct = Pick<
+export type ExternalReferenceInProduct = Pick<
   Product['external_references'][number],
-  'accession_id' | 'name' | 'description'
+  'accession_id' | 'name' | 'description' | 'url'
 > &
   Pick2<Product['external_references'][number], 'source', 'id'>;
 

--- a/src/content/app/entity-viewer/state/gene-view/view/geneViewViewSlice.ts
+++ b/src/content/app/entity-viewer/state/gene-view/view/geneViewViewSlice.ts
@@ -30,12 +30,14 @@ import type { RootState } from 'src/store';
 
 export enum View {
   TRANSCRIPTS = 'transcripts',
+  TRANSCRIPTS_TABLE = 'transcripts_table',
   PROTEIN = 'protein',
   HOMOLOGY = 'homology'
 }
 
 export enum GeneViewTabName {
   TRANSCRIPTS = 'Transcripts',
+  TRANSCRIPTS_TABLE = 'Transcripts table',
   GENE_FUNCTION = 'Gene function',
   GENE_RELATIONSHIPS = 'Gene relationships'
 }
@@ -59,6 +61,11 @@ export const GeneViewTabMap: Map<View, GeneViewTabData> = new Map();
 GeneViewTabMap.set(View.TRANSCRIPTS, {
   view: View.TRANSCRIPTS,
   primaryTab: GeneViewTabName.TRANSCRIPTS,
+  secondaryTab: null
+});
+GeneViewTabMap.set(View.TRANSCRIPTS_TABLE, {
+  view: View.TRANSCRIPTS_TABLE,
+  primaryTab: GeneViewTabName.TRANSCRIPTS_TABLE,
   secondaryTab: null
 });
 GeneViewTabMap.set(View.PROTEIN, {

--- a/src/shared/components/external-link/ExternalLink.module.css
+++ b/src/shared/components/external-link/ExternalLink.module.css
@@ -1,14 +1,20 @@
-.icon {
-  position: relative;
-  bottom: -1px;
-  display: inline-block;
-  margin-right: var(--external-link-icon-offset, 5px);
-  fill: var(--external-link-icon-offset, var(--color-orange));
-  height: var(--external-link-icon-size, 12px);
-  aspect-ratio: 1;
-}
+@layer components {
+  .icon {
+    position: relative;
+    bottom: -1px;
+    display: inline-block;
+    margin-right: var(--external-link-icon-offset, 5px);
+    fill: var(--external-link-icon-offset, var(--color-orange));
+    height: var(--external-link-icon-size, 12px);
+    aspect-ratio: 1;
+  }
 
-.link {
-  display: inline-block;
-  font-size: 12px; /* seems to be Andrea's default for external links; can be overridden by wrapping the child in a span with its own styles */
+  .link {
+    display: inline-block;
+    font-size: 12px; /* seems to be Andrea's default for external links; can be overridden by wrapping the child in a span with its own styles */
+  }
+
+  .nowrap {
+    white-space: nowrap;
+  }
 }

--- a/src/shared/components/external-link/ExternalLink.tsx
+++ b/src/shared/components/external-link/ExternalLink.tsx
@@ -26,10 +26,15 @@ export type ExternalLinkProps = {
   children: ReactNode;
   className?: string;
   onClick?: () => void;
+  nowrap?: boolean;
 };
 
 const ExternalLink = (props: ExternalLinkProps) => {
-  const componentClasses = classNames(styles.link, props.className);
+  const componentClasses = classNames(
+    styles.link,
+    { [styles.nowrap]: props.nowrap },
+    props.className
+  );
 
   return (
     <a


### PR DESCRIPTION
## Description
Add a transcripts table to Feature explorer's gene view

- A new tab opens up the view with the table (it was decided that the transcripts diagram is still the default view)
- The table displays the data in a similar way to the old Ensembl site
- Transcript ids, when clicked, show a "view in app" popup to let the transcript be viewed in either the genome browser or feature explorer
- The table can be downloaded as a .csv file
- The transcripts in the table reuse the same filtering and sorting rules as in the default transcripts view (the one with diagrams)
- The table shows all transcripts of a gene, rather than just the first 100. 

## Related JIRA Issue(s)
https://embl.atlassian.net/browse/ENSWBSITES-3065

## Deployment URL(s)
http://transcripts-table.review.ensembl.org