### PR TITLE
Convert flanking and intronic sequences in the exons table to lower case

### DIFF
--- a/src/content/app/entity-viewer/transcript-view/components/transcript-exons/exons-table/ExonsTable.tsx
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-exons/exons-table/ExonsTable.tsx
@@ -209,7 +209,7 @@ const FlankingSequenceRow = ({
       <td>{strand}</td>
       <td>
         <span className={classNames(styles.sequence, styles.light)}>
-          {sequence}
+          {sequence.toLowerCase()}
         </span>
       </td>
     </tr>
@@ -294,7 +294,7 @@ const IntronRow = ({
       <td>{intron.strand}</td>
       <td>
         <div className={classNames(styles.sequence, styles.light)}>
-          {sequence}
+          {sequence.toLowerCase()}
         </div>
       </td>
     </tr>

--- a/src/content/app/entity-viewer/transcript-view/components/transcript-exons/exons-table/exportExonsTable.ts
+++ b/src/content/app/entity-viewer/transcript-view/components/transcript-exons/exons-table/exportExonsTable.ts
@@ -91,7 +91,7 @@ const prepareFlankingSequenceRowData = ({
   return {
     name: title,
     strand,
-    sequence
+    sequence: sequence.toLowerCase()
   };
 };
 
@@ -118,7 +118,7 @@ const prepareIntronRowData = ({ intron }: { intron: Intron }): RowMap => {
     endPhase: '-',
     length: intron.length,
     strand: intron.strand,
-    sequence: intron.sequence
+    sequence: intron.sequence.toLowerCase()
   };
 };
 


### PR DESCRIPTION
## Description
This PR casts the flanking and intronic sequences In the transcript exons table to lower-case.

It uses javascript's `toLowerCase` instead of CSS `text-transform: lowercase` so that if the user selects and copies the sequence, it is copied with the desired letter case.

## Related JIRA Issue(s)
https://embl.atlassian.net/browse/ENSWBSITES-3064

## Deployment URL(s)
http://lower-case-introns.review.ensembl.org